### PR TITLE
Add semantic field documentation for v3.0.0

### DIFF
--- a/docs/features/neural-search/semantic-field.md
+++ b/docs/features/neural-search/semantic-field.md
@@ -1,0 +1,130 @@
+# Semantic Field
+
+## Summary
+
+The semantic field type is a new field mapper in the neural-search plugin that simplifies semantic search workflows. It automatically handles text-to-vector transformations using ML models, eliminating the need for separate ingest pipelines while preserving the original text for traditional search capabilities.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Semantic Field Mapper"
+        SFM[SemanticFieldMapper]
+        SFT[SemanticFieldType]
+        SP[SemanticParameters]
+    end
+    
+    subgraph "Delegate Field Mappers"
+        TFM[TextFieldMapper]
+        KFM[KeywordFieldMapper]
+        MOTFM[MatchOnlyTextFieldMapper]
+        WFM[WildcardFieldMapper]
+    end
+    
+    subgraph "ML Integration"
+        Model[ML Model]
+        Embeddings[Vector Embeddings]
+    end
+    
+    SFM --> SP
+    SFM --> SFT
+    SFM -->|delegates to| TFM
+    SFM -->|delegates to| KFM
+    SFM -->|delegates to| MOTFM
+    SFM -->|delegates to| WFM
+    SFM -->|inference| Model
+    Model --> Embeddings
+```
+
+### Components
+
+| Component | Description | Since |
+|-----------|-------------|-------|
+| SemanticFieldMapper | Main field mapper handling semantic field configuration | v3.0.0 |
+| SemanticFieldType | Field type extending FilterFieldType for delegate wrapping | v3.0.0 |
+| SemanticParameters | DTO holding model_id, search_model_id, raw_field_type, semantic_info_field_name | v3.0.0 |
+| FeatureFlagUtil | Controls semantic field feature availability | v3.0.0 |
+
+### Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|--------|
+| `model_id` | ML model ID for embedding generation at index time | Required |
+| `search_model_id` | ML model ID for query inference (optional) | Uses `model_id` |
+| `raw_field_type` | Underlying field type for raw data | `text` |
+| `semantic_info_field_name` | Custom name for semantic info field | Auto-generated |
+
+### Supported Raw Field Types
+
+| Type | Use Case |
+|------|----------|
+| `text` | Full-text search with analysis (default) |
+| `keyword` | Exact matching, aggregations |
+| `match_only_text` | Space-efficient text without scoring |
+| `wildcard` | Pattern matching queries |
+| `token_count` | Token counting |
+| `binary` | Binary data storage |
+
+### Usage Example
+
+```json
+// Create index with semantic field
+PUT /semantic-index
+{
+  "mappings": {
+    "properties": {
+      "description": {
+        "type": "semantic",
+        "model_id": "sentence-transformers/all-MiniLM-L6-v2",
+        "search_model_id": "sentence-transformers/all-MiniLM-L6-v2",
+        "raw_field_type": "text"
+      }
+    }
+  }
+}
+
+// Index document (embedding generated automatically)
+POST /semantic-index/_doc
+{
+  "description": "OpenSearch is a distributed search and analytics engine."
+}
+
+// Get mapping shows semantic field configuration
+GET /semantic-index/_mapping
+{
+  "semantic-index": {
+    "mappings": {
+      "properties": {
+        "description": {
+          "type": "semantic",
+          "model_id": "sentence-transformers/all-MiniLM-L6-v2",
+          "search_model_id": "sentence-transformers/all-MiniLM-L6-v2",
+          "raw_field_type": "text"
+        }
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Feature is disabled by default (requires `semantic_field_enabled` feature flag)
+- Cannot change `raw_field_type` after index creation
+- Cannot change `semantic_info_field_name` after index creation
+- Public documentation pending
+
+## References
+
+- [Issue #803](https://github.com/opensearch-project/neural-search/issues/803): Neural Search field type proposal
+- [Issue #1226](https://github.com/opensearch-project/neural-search/issues/1226): Semantic field implementation tracking
+- [PR #1225](https://github.com/opensearch-project/neural-search/pull/1225): Add semantic field mapper
+- [Semantic Search Documentation](https://docs.opensearch.org/3.0/vector-search/ai-search/semantic-search/): Related semantic search concepts
+
+## Change History
+
+| Version | Changes |
+|---------|--------|
+| v3.0.0 | Initial semantic field mapper implementation (feature-flagged) |

--- a/docs/releases/v3.0.0/features/neural-search/semantic-field.md
+++ b/docs/releases/v3.0.0/features/neural-search/semantic-field.md
@@ -1,0 +1,91 @@
+# Semantic Field
+
+## Summary
+
+OpenSearch 3.0 introduces the semantic field type in the neural-search plugin. This new field mapper simplifies semantic search by automatically handling text-to-vector transformations at index time, eliminating the need for separate ingest pipelines.
+
+## Details
+
+### What's New in v3.0.0
+
+#### Semantic Field Mapper
+
+The semantic field type allows users to define fields that automatically generate embeddings using ML models:
+
+- Supports multiple raw field types: `text`, `keyword`, `match_only_text`, `wildcard`, `token_count`, `binary`
+- Configurable ML models for indexing and search
+- Automatic delegation to underlying field type for storage and queries
+
+### Configuration Parameters
+
+| Parameter | Description | Required | Default |
+|-----------|-------------|----------|--------|
+| `model_id` | ML model ID for generating embeddings at index time | Yes | - |
+| `search_model_id` | ML model ID for query text inference (uses `model_id` if not set) | No | `model_id` |
+| `raw_field_type` | Underlying field type for raw data storage | No | `text` |
+| `semantic_info_field_name` | Custom field name for semantic information | No | Auto-generated |
+
+### Supported Raw Field Types
+
+| Type | Description |
+|------|-------------|
+| `text` | Full-text searchable content (default) |
+| `keyword` | Exact match strings |
+| `match_only_text` | Space-optimized text without scoring |
+| `wildcard` | Wildcard pattern matching |
+| `token_count` | Token count storage |
+| `binary` | Binary data storage |
+
+### Usage Example
+
+```json
+PUT /my-index
+{
+  "mappings": {
+    "properties": {
+      "content": {
+        "type": "semantic",
+        "model_id": "my-embedding-model",
+        "raw_field_type": "text"
+      }
+    }
+  }
+}
+```
+
+### Technical Implementation
+
+The semantic field mapper uses a delegate pattern:
+
+1. **SemanticFieldMapper**: Main mapper handling semantic parameters
+2. **Delegate Field Mapper**: Handles raw data parsing and queries based on `raw_field_type`
+3. **SemanticFieldType**: Extends `FilterFieldType` to wrap delegate field type
+
+### Feature Flag
+
+The semantic field is currently gated behind a feature flag:
+
+```java
+FeatureFlagUtil.SEMANTIC_FIELD_ENABLED = false  // Default: disabled
+```
+
+## Limitations
+
+- Feature is disabled by default (requires feature flag)
+- Documentation not yet available in public docs
+- API specification companion PR pending
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1225](https://github.com/opensearch-project/neural-search/pull/1225) | Add semantic field mapper |
+
+## References
+
+- [Issue #803](https://github.com/opensearch-project/neural-search/issues/803): Neural Search field type proposal
+- [Issue #1226](https://github.com/opensearch-project/neural-search/issues/1226): Related semantic field implementation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/neural-search/semantic-field.md)


### PR DESCRIPTION
## Summary

Add documentation for the Semantic Field feature introduced in OpenSearch v3.0.0.

## Changes

- Created release report: `docs/releases/v3.0.0/features/neural-search/semantic-field.md`
- Created feature report: `docs/features/neural-search/semantic-field.md`

## Feature Overview

The semantic field type is a new field mapper in the neural-search plugin that simplifies semantic search by:
- Automatically handling text-to-vector transformations using ML models
- Supporting multiple raw field types (text, keyword, match_only_text, wildcard, token_count, binary)
- Eliminating the need for separate ingest pipelines

## Related PRs

- [opensearch-project/neural-search#1225](https://github.com/opensearch-project/neural-search/pull/1225): Add semantic field mapper

## Related Issues

- [opensearch-project/neural-search#803](https://github.com/opensearch-project/neural-search/issues/803): Neural Search field type proposal

Resolves #289