### PR TITLE
docs: add semantic field report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -1,5 +1,9 @@
 # OpenSearch Features
 
+## neural-search
+
+- [Semantic Field](neural-search/semantic-field.md)
+
 ## opensearch
 
 - [Java Runtime & JPMS](opensearch/java-runtime-and-jpms.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -1,5 +1,9 @@
 # OpenSearch v3.0.0 Release Features
 
+## neural-search
+
+- [Semantic Field](features/neural-search/semantic-field.md)
+
 ## opensearch
 
 - [Java Runtime & JPMS](features/opensearch/java-runtime-and-jpms.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Semantic Field feature introduced in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/neural-search/semantic-field.md`
- Feature report: `docs/features/neural-search/semantic-field.md`

### Key Changes in v3.0.0
- New `semantic` field type in neural-search plugin
- Automatic text-to-vector transformation at index time
- Supports multiple raw field types: text, keyword, match_only_text, wildcard, token_count, binary
- Configurable ML models via `model_id` and `search_model_id` parameters
- Feature gated behind `semantic_field_enabled` flag (disabled by default)

### Resources Used
- PR: [#1225](https://github.com/opensearch-project/neural-search/pull/1225)
- Issue: [#803](https://github.com/opensearch-project/neural-search/issues/803)
- Docs: https://docs.opensearch.org/3.0/vector-search/ai-search/semantic-search/
- Blog: https://opensearch.org/blog/the-new-semantic-field-simplifying-semantic-search-in-opensearch/

Closes #289