### PR TITLE
docs: add java-runtime-and-jpms report for v3.0.0

### DIFF
--- a/docs/features/opensearch/java-runtime-and-jpms.md
+++ b/docs/features/opensearch/java-runtime-and-jpms.md
@@ -42,8 +42,9 @@ graph TB
 
 | Setting | Description | Default |
 |---------|-------------|---------|
+| `OPENSEARCH_JAVA_HOME` | Path to JDK 21+ installation (takes precedence over JAVA_HOME) | None |
+| `JAVA_HOME` | Fallback path to JDK installation | System default |
 | `OPENSEARCH_JAVA_OPTS` | JVM options including `--enable-preview` for MemorySegment | None |
-| `JAVA_HOME` | Path to JDK 21+ installation | System default |
 
 ### Package Mapping
 
@@ -60,6 +61,9 @@ graph TB
 # Verify JDK version
 java -version
 # openjdk version "21.0.x" ...
+
+# Set OpenSearch-specific Java home
+export OPENSEARCH_JAVA_HOME=/path/to/jdk21
 
 # Start OpenSearch with MemorySegment API enabled
 OPENSEARCH_JAVA_OPTS="--enable-preview" ./bin/opensearch
@@ -87,6 +91,8 @@ OPENSEARCH_JAVA_OPTS="--enable-preview" ./bin/opensearch
 - [PR #17241](https://github.com/opensearch-project/OpenSearch/pull/17241): Lucene package refactor
 - [PR #17272](https://github.com/opensearch-project/OpenSearch/pull/17272): Client package refactor
 - [Breaking Changes](https://docs.opensearch.org/3.0/breaking-changes/): Official documentation
+- [OpenSearch 3.0 Blog](https://opensearch.org/blog/opensearch-3-0-what-to-expect/): What to expect in OpenSearch 3.0
+- [Java Runtime Blog](https://opensearch.org/blog/opensearch-java-runtime/): Using different Java runtimes with OpenSearch
 
 ## Change History
 


### PR DESCRIPTION
## Summary

Updated investigation report for Java Runtime & JPMS feature in OpenSearch v3.0.0.

### Reports Updated
- Release report: `docs/releases/v3.0.0/features/opensearch/java-runtime-and-jpms.md`
- Feature report: `docs/features/opensearch/java-runtime-and-jpms.md`

### Key Changes in v3.0.0
- JDK 21 minimum requirement (breaking change from JDK 11)
- JPMS Phase-0: Split package elimination
- Package refactoring for module system compatibility
- MemorySegment API support for improved mmap performance

### Resources Used
- Issue #8110: META - Split and modularize the server monolith
- PRs: #5151, #17117, #17153, #17241, #17272
- Docs: https://docs.opensearch.org/3.0/breaking-changes/
- Blog: https://opensearch.org/blog/opensearch-3-0-what-to-expect/