### PR TITLE
docs: add Java Runtime & JPMS report for v3.0.0

### DIFF
--- a/docs/releases/v3.0.0/features/opensearch/java-runtime-and-jpms.md
+++ b/docs/releases/v3.0.0/features/opensearch/java-runtime-and-jpms.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-OpenSearch 3.0 introduces two major breaking changes: JDK 21 as the minimum supported Java runtime and Phase-0 JPMS (Java Platform Module System) support. These changes modernize the codebase, eliminate split packages, and prepare OpenSearch for future modularization while enabling performance improvements from modern JVM features.
+OpenSearch 3.0.0 introduces two major breaking changes to the Java runtime environment: JDK 21 becomes the minimum supported runtime, and the codebase has been refactored to eliminate split packages in preparation for Java Platform Module System (JPMS) support. These changes enable OpenSearch to leverage modern Java features and prepare for future modularization.
 
 ## Details
 
@@ -10,99 +10,120 @@ OpenSearch 3.0 introduces two major breaking changes: JDK 21 as the minimum supp
 
 #### JDK 21 Minimum Requirement
 
-OpenSearch 3.0 requires JDK 21 as the minimum supported Java runtime, a significant upgrade from JDK 11 in OpenSearch 2.x. This enables:
-- Virtual threads for improved concurrency
-- Pattern matching for `switch` statements
-- Sequenced collections
-- MemorySegment API for improved mmap performance (finalized from JDK 19+ preview APIs)
-- Better overall performance (benchmarks showed JDK 17+ significantly outperformed earlier versions)
+OpenSearch 3.0.0 requires JDK 21 as the minimum supported Java runtime. This is a breaking change from previous versions that supported JDK 11+. The upgrade was driven by:
 
-#### JPMS Phase-0: Split Package Elimination
+- Apache Lucene 10.x requiring JDK 21
+- Access to modern Java features including virtual threads, pattern matching, and improved garbage collection
+- JDK 21 being a Long-Term Support (LTS) release with support until 2031
 
-The codebase has been refactored to eliminate top-level split packages, preparing for full JPMS support:
+#### JPMS Phase 0 - Split Package Elimination
 
-| Original Package | New Package | Module |
-|-----------------|-------------|--------|
-| `org.opensearch.bootstrap` | `org.opensearch.common.bootstrap` | `:libs:opensearch-common` |
-| `org.opensearch.cli` | `org.opensearch.common.cli` | `:server` |
-| `org.opensearch.client` | `org.opensearch.transport.client` | `:server` |
-| `org.opensearch.common.settings` | `org.opensearch.cli.keystore` | `:distribution:tools:keystore-cli` |
-| `org.apache.lucene.*` | `org.opensearch.lucene.*` | `:server` |
+The codebase has been refactored to eliminate top-level split packages, which is a prerequisite for JPMS support. Split packages occur when the same package exists in multiple JAR files, which is incompatible with the Java module system.
 
 ### Technical Changes
 
-#### Package Refactoring
+#### Architecture Changes
 
-1. **Bootstrap Package** ([#17117](https://github.com/opensearch-project/OpenSearch/pull/17117)): Moved from `:libs:opensearch-common` and `:server` split to unified `org.opensearch.common.bootstrap`
-
-2. **CLI Package** ([#17153](https://github.com/opensearch-project/OpenSearch/pull/17153)): 
-   - Refactored `:server` module's `org.opensearch.cli` to `org.opensearch.common.cli`
-   - Removed unused `LoggingAwareCommand.java`
-   - Moved common CLI tests from `:server` to `:libs`
-   - Refactored `plugin-cli` to `org.opensearch.tools.cli.plugin`
-   - Refactored `upgrade-cli` to `org.opensearch.tools.cli.upgrade`
-   - Removed `:libs:plugin-classloader`, moved `ExtendedPluginsClassLoader` to `:server`
-
-3. **Client Package** ([#17272](https://github.com/opensearch-project/OpenSearch/pull/17272)): Refactored `org.opensearch.client` to `org.opensearch.transport.client` to resolve split package with REST client
-
-4. **Lucene Package** ([#17241](https://github.com/opensearch-project/OpenSearch/pull/17241)): Refactored `org.apache.lucene` classes to `org.opensearch.lucene`:
-   - Removed `OneMergeHelper.java`, merged into `OpenSearchConcurrentMergeScheduler`
-   - Moved `Packed64` implementation directly to `CuckooFilter`
-   - Updated `ShuffleForcedMergePolicy` to use `addDiagnostics`
-   - Added `MinimizationOperations` with new `Automaton` class from Lucene
-   - Updated `QueryStringQueryParser` from `XQueryParser` to standard `QueryParser`
-   - Updated `CustomFieldHighlighter` with `getFieldOffsetStrategy` method
-
-#### MMap Preview API Support
-
-When running with JDK 19+, OpenSearch can use the MemorySegment API for improved mmap performance ([#5151](https://github.com/opensearch-project/OpenSearch/pull/5151)):
-
-```bash
-# Enable preview features for MemorySegment API
-OPENSEARCH_JAVA_OPTS="--enable-preview" ./bin/opensearch
+```mermaid
+graph TB
+    subgraph "Before v3.0.0"
+        A1[":server module"] --> B1["org.opensearch.bootstrap"]
+        A2[":libs:opensearch-common"] --> B1
+        A3[":server module"] --> C1["org.opensearch.cli"]
+        A4[":libs:opensearch-cli"] --> C1
+        A5[":server module"] --> D1["org.opensearch.client"]
+        A6[":client module"] --> D1
+    end
+    
+    subgraph "After v3.0.0"
+        E1[":server module"] --> F1["org.opensearch.bootstrap"]
+        E2[":libs:opensearch-common"] --> F2["org.opensearch.common.bootstrap"]
+        E3[":server module"] --> G1["org.opensearch.common.cli"]
+        E4[":libs:opensearch-cli"] --> G2["org.opensearch.cli"]
+        E5[":server module"] --> H1["org.opensearch.transport.client"]
+        E6[":client module"] --> H2["org.opensearch.client"]
+    end
 ```
 
-With `--enable-preview`:
-```
-[INFO] Using MemorySegmentIndexInput with Java 21
-```
+#### Package Refactoring Summary
 
-Without `--enable-preview`:
-```
-[WARN] You are running with Java 21. To make full use of MMapDirectory, please pass '--enable-preview' to the Java command line.
-```
+| Original Package | New Package | Module |
+|-----------------|-------------|--------|
+| `org.opensearch.bootstrap` (libs) | `org.opensearch.common.bootstrap` | `:libs:opensearch-common` |
+| `org.opensearch.cli` (server) | `org.opensearch.common.cli` | `:server` |
+| `org.opensearch.client` (server) | `org.opensearch.transport.client` | `:server` |
+| `org.opensearch.common.settings` (keystore-cli) | `org.opensearch.tools.cli.keystore` | `:distribution:tools:keystore-cli` |
+| `org.opensearch.plugins` (plugin-cli) | `org.opensearch.tools.cli.plugin` | `:distribution:tools:plugin-cli` |
+| `org.apache.lucene.*` (server) | `org.opensearch.lucene.*` | `:server` |
+
+#### Key Class Relocations
+
+| Class | Old Location | New Location |
+|-------|--------------|--------------|
+| `JarHell` | `org.opensearch.bootstrap` | `org.opensearch.common.bootstrap` |
+| `JdkJarHellCheck` | `org.opensearch.bootstrap` | `org.opensearch.common.bootstrap` |
+| `KeyStoreCli` | `org.opensearch.common.settings` | `org.opensearch.tools.cli.keystore` |
+| `PluginCli` | `org.opensearch.plugins` | `org.opensearch.tools.cli.plugin` |
+| `KeyStoreAwareCommand` | `org.opensearch.cli` | `org.opensearch.tools.cli.keystore` |
+
+#### Removed Components
+
+- `LoggingAwareCommand.java` from `:server` module (unused)
+- `libs/plugin-classloader` module (refactored into `:server`)
+- `OneMergeHelper.java` (merged into `OpenSearchConcurrentMergeScheduler`)
 
 ### Migration Notes
 
-1. **Upgrade JDK**: Ensure JDK 21 or later is installed
-2. **Update Dependencies**: Plugins using affected packages must update imports:
-   - `org.opensearch.cli.*` → `org.opensearch.common.cli.*`
-   - `org.opensearch.client.*` → `org.opensearch.transport.client.*`
-   - `org.opensearch.bootstrap.*` → `org.opensearch.common.bootstrap.*`
-3. **Java High-Level REST Client**: No longer supports JDK 8
-4. **Environment Variables**: Use `OPENSEARCH_JAVA_HOME` to specify JDK path (takes precedence over `JAVA_HOME`)
+#### For Users
+
+1. **Upgrade JDK**: Ensure your runtime environment uses JDK 21 or later
+2. **Update JAVA_HOME**: Set `JAVA_HOME` or `OPENSEARCH_JAVA_HOME` to point to JDK 21+
+3. **Bundled JDK**: OpenSearch distributions include a bundled JDK 21, which is used by default
+
+#### For Plugin Developers
+
+1. **Update imports**: If your plugin references any relocated classes, update the import statements:
+   ```java
+   // Before
+   import org.opensearch.bootstrap.JarHell;
+   import org.opensearch.cli.KeyStoreAwareCommand;
+   
+   // After
+   import org.opensearch.common.bootstrap.JarHell;
+   import org.opensearch.tools.cli.keystore.KeyStoreAwareCommand;
+   ```
+
+2. **Compile with JDK 21**: Update your build configuration to use JDK 21
+3. **Test thoroughly**: Verify plugin compatibility with the new package structure
+
+### JDK Memory Mapping Improvements
+
+OpenSearch 3.0.0 can leverage JDK 21's `MemorySegment` API for memory-mapped files in Lucene, providing:
+- Improved performance for large indexes
+- Better memory management
+- No need for `--enable-preview` flag (was required in JDK 19-20)
 
 ## Limitations
 
-- Full JPMS modularization (Phase 1+) is still in progress
-- Some `org.apache.lucene` packages remain (codecs, index, search.grouping) pending Star Tree implementation
+- **No JDK 8/11 support**: Applications requiring older JDK versions cannot use OpenSearch 3.0.0
+- **Plugin compatibility**: Plugins compiled against older OpenSearch versions may need updates
+- **JPMS not fully enabled**: Phase 0 only eliminates split packages; full module descriptors are planned for future releases
 
 ## Related PRs
 
 | PR | Description |
 |----|-------------|
-| [#5151](https://github.com/opensearch-project/OpenSearch/pull/5151) | Allow mmap to use JDK-19 preview APIs |
-| [#17117](https://github.com/opensearch-project/OpenSearch/pull/17117) | Refactor `:libs` bootstrap package |
-| [#17153](https://github.com/opensearch-project/OpenSearch/pull/17153) | Refactor CLI and plugin packages |
-| [#17241](https://github.com/opensearch-project/OpenSearch/pull/17241) | Refactor `org.apache.lucene` packages |
-| [#17272](https://github.com/opensearch-project/OpenSearch/pull/17272) | Refactor `org.opensearch.client` package |
+| [#17153](https://github.com/opensearch-project/OpenSearch/pull/17153) | Refactor codebase to eliminate top level split packages for JPMS support |
+| [#17117](https://github.com/opensearch-project/OpenSearch/pull/17117) | Refactor `:libs` module `bootstrap` package |
+| [#17241](https://github.com/opensearch-project/OpenSearch/pull/17241) | Refactor `org.apache.lucene` codebase |
+| [#17272](https://github.com/opensearch-project/OpenSearch/pull/17272) | Refactor `org.opensearch.client` from `:server` module |
+| [#5151](https://github.com/opensearch-project/OpenSearch/pull/5151) | Allow mmap to use JDK-19 preview APIs in Lucene 9.4+ |
 
 ## References
 
 - [Issue #8110](https://github.com/opensearch-project/OpenSearch/issues/8110): META - Split and modularize the server monolith
-- [Breaking Changes](https://docs.opensearch.org/3.0/breaking-changes/): JDK 21 requirement documentation
-- [OpenSearch 3.0 Blog](https://opensearch.org/blog/opensearch-3-0-what-to-expect/): What to expect in OpenSearch 3.0
-- [Java Runtime Blog](https://opensearch.org/blog/opensearch-java-runtime/): Using different Java runtimes with OpenSearch
+- [Breaking Changes Documentation](https://docs.opensearch.org/3.0/breaking-changes/): Official breaking changes for v3.0.0
+- [Using Different Java Runtimes with OpenSearch](https://opensearch.org/blog/opensearch-java-runtime/): Blog post on Java runtime options
 
 ## Related Feature Report
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Java Runtime & JPMS changes in OpenSearch v3.0.0.

### Key Changes in v3.0.0

- **JDK 21 Minimum Requirement**: OpenSearch 3.0.0 requires JDK 21 as the minimum supported runtime
- **JPMS Phase 0**: Codebase refactored to eliminate split packages in preparation for Java module system support
- **Package Relocations**: Multiple packages moved to eliminate split package conflicts

### Reports Created

- Release report: `docs/releases/v3.0.0/features/opensearch/java-runtime-and-jpms.md`
- Feature report: `docs/features/opensearch/java-runtime-and-jpms.md`

### Related PRs

- [#17153](https://github.com/opensearch-project/OpenSearch/pull/17153): Refactor codebase for JPMS support
- [#17117](https://github.com/opensearch-project/OpenSearch/pull/17117): Refactor bootstrap package
- [#17241](https://github.com/opensearch-project/OpenSearch/pull/17241): Refactor Lucene packages
- [#17272](https://github.com/opensearch-project/OpenSearch/pull/17272): Refactor client package

Closes #136