### PR TITLE
docs: add Lucene 10 Upgrade report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -7,3 +7,4 @@
 ## opensearch
 
 - [Java Runtime & JPMS](opensearch/java-runtime-and-jpms.md)
+- [Lucene 10 Upgrade](opensearch/lucene-10-upgrade.md)

--- a/docs/features/opensearch/lucene-10-upgrade.md
+++ b/docs/features/opensearch/lucene-10-upgrade.md
@@ -1,0 +1,112 @@
+# Lucene 10 Upgrade
+
+## Summary
+
+Apache Lucene is the core search library that powers OpenSearch's indexing and search capabilities. The Lucene 10 upgrade brings major performance improvements in I/O operations, search parallelism, sparse indexing, and vector search. This upgrade is foundational to OpenSearch 3.0 and enables future performance optimizations.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Stack"
+        API[REST API]
+        Core[OpenSearch Core]
+        Lucene[Apache Lucene]
+        Storage[Storage Layer]
+    end
+    
+    subgraph "Lucene 10 Features"
+        AsyncIO[Async I/O API]
+        SegPart[Segment Partitioning]
+        Sparse[Sparse Indexing]
+        Vector[Vector Search]
+    end
+    
+    API --> Core
+    Core --> Lucene
+    Lucene --> Storage
+    
+    Lucene --> AsyncIO
+    Lucene --> SegPart
+    Lucene --> Sparse
+    Lucene --> Vector
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Indexing"
+        Doc[Document] --> Analyzer
+        Analyzer --> Index[Lucene Index]
+    end
+    
+    subgraph "Search (Lucene 10)"
+        Query[Query] --> Parser
+        Parser --> Segments
+        Segments --> |Parallel| Results
+    end
+    
+    Index --> Segments
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Lucene Core | Core indexing and search library |
+| Async I/O API | Enables asynchronous data fetching for improved disk I/O |
+| Segment Partitioning | Logical partitions within segments for parallel search |
+| Sparse Indexing | Block-based indexing with min/max values for query optimization |
+| Vector Search | Improved HNSW implementation for k-NN searches |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| N/A | Lucene version is bundled with OpenSearch | Lucene 10.1.0 |
+
+The Lucene upgrade is transparent to users - no configuration changes are required.
+
+### Usage Example
+
+```bash
+# Verify Lucene version via cluster info
+curl -X GET "localhost:9200"
+
+# Response includes lucene_version
+{
+  "version": {
+    "number": "3.0.0",
+    "lucene_version": "10.1.0",
+    ...
+  }
+}
+```
+
+## Limitations
+
+- Requires JDK 21 or later as minimum runtime
+- Some Snowball stemmers removed: `dutch_kp`, `lovins` (use alternatives)
+- `german2` stemmer merged into `german` stemmer
+- Plugins using Lucene APIs directly may require updates
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#16366](https://github.com/opensearch-project/OpenSearch/pull/16366) | Update to Apache Lucene 10 for 3.0.0 |
+
+## References
+
+- [Issue #11415](https://github.com/opensearch-project/OpenSearch/issues/11415): Original feature request
+- [Lucene 10.0.0 Release Notes](https://cwiki.apache.org/confluence/display/LUCENE/Release+Notes+10.0.0): Official release notes
+- [Lucene 10 Changelog](https://lucene.apache.org/core/10_0_0/changes/Changes.html#v10.0.0): Detailed changes
+- [OpenSearch 3.0 Blog](https://opensearch.org/blog/opensearch-3-0-what-to-expect/): Overview of 3.0 features
+- [JDK 21 Dependency](https://github.com/opensearch-project/OpenSearch/issues/14011): JDK 21 requirement tracking
+
+## Change History
+
+- **v3.0.0** (2025-01-22): Upgraded from Lucene 9.12.1 to Lucene 10.1.0

--- a/docs/releases/v3.0.0/features/opensearch/lucene-10-upgrade.md
+++ b/docs/releases/v3.0.0/features/opensearch/lucene-10-upgrade.md
@@ -1,0 +1,118 @@
+# Lucene 10 Upgrade
+
+## Summary
+
+OpenSearch 3.0.0 upgrades from Apache Lucene 9.x to Lucene 10.1.0, bringing significant performance improvements in I/O parallelism, search execution, and vector search capabilities. This major dependency upgrade is a key driver for the OpenSearch 3.0 release and requires JDK 21 as the minimum runtime version.
+
+## Details
+
+### What's New in v3.0.0
+
+The upgrade to Apache Lucene 10 introduces several foundational improvements:
+
+- **I/O Parallelism**: New API for asynchronous data fetching enables more efficient disk operations
+- **Search Parallelism**: Logical partitions within segments replace segment grouping for parallel searches
+- **Sparse Indexing**: Primary-key indexing organizes data into blocks with min/max values, allowing queries to skip non-relevant blocks
+- **k-NN/Vector Search**: Improved parallelized execution and vector indexing optimizations
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "OpenSearch 3.0.0"
+        OS[OpenSearch Core]
+        L10[Lucene 10.1.0]
+        JDK21[JDK 21+]
+    end
+    
+    subgraph "Lucene 10 Improvements"
+        IO[Async I/O API]
+        SP[Segment Partitioning]
+        SI[Sparse Indexing]
+        VS[Vector Search]
+    end
+    
+    OS --> L10
+    L10 --> JDK21
+    L10 --> IO
+    L10 --> SP
+    L10 --> SI
+    L10 --> VS
+```
+
+#### Key Version Changes
+
+| Component | Previous | New |
+|-----------|----------|-----|
+| Apache Lucene | 9.12.1 | 10.1.0 |
+| Minimum JDK | 11 | 21 |
+| Build JDK | 17 | 21 |
+
+#### API Changes
+
+Lucene 10 introduces breaking API changes that affect OpenSearch internals:
+
+- `TotalHits.value` changed to `TotalHits.value()` (field to method)
+- `TotalHits.relation` changed to `TotalHits.relation()` (field to method)
+- `TimeLimitingCollector` global timer methods removed
+- `LUCENE_8_0_0` constant removed (use `Version.fromBits(8, 0, 0)`)
+
+#### Removed Stemmers
+
+The following Snowball stemmers were removed in Lucene 10:
+
+| Stemmer | Status |
+|---------|--------|
+| `dutch_kp` / `kp` | Removed |
+| `lovins` | Removed |
+| `german2` | Merged into `german` |
+
+#### Build System Changes
+
+- Minimum compiler version: 21 (was 17)
+- Minimum runtime version: 21 (was 11)
+- CI matrix updated to test JDK 21 and 23 only
+- Multi-release JAR support for Java 20+ removed (now baseline)
+- Shadow plugin updated to `com.gradleup.shadow:shadow-gradle-plugin:8.3.5`
+
+### Usage Example
+
+No configuration changes required for end users. The Lucene upgrade is transparent at the API level, though plugin developers may need to update code that directly uses Lucene APIs.
+
+```yaml
+# opensearch.yml - no changes needed for Lucene 10
+# Ensure JDK 21+ is installed
+```
+
+### Migration Notes
+
+1. **JDK Requirement**: Upgrade to JDK 21 or later before upgrading to OpenSearch 3.0.0
+2. **Index Compatibility**: Indices created with Lucene 9.x are compatible with Lucene 10
+3. **Plugin Updates**: Plugins using Lucene APIs directly may require updates for API changes
+4. **Stemmer Changes**: If using `dutch_kp`, `lovins`, or `german2` stemmers, migrate to alternatives
+
+## Limitations
+
+- Rolling upgrades from OpenSearch 2.x require careful planning due to JDK version requirements
+- Some Snowball stemmers (`dutch_kp`, `lovins`) are no longer available
+- Plugins compiled against Lucene 9.x APIs may need recompilation
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16366](https://github.com/opensearch-project/OpenSearch/pull/16366) | Update to Apache Lucene 10 for 3.0.0 |
+
+## References
+
+- [Issue #11415](https://github.com/opensearch-project/OpenSearch/issues/11415): Feature request for Lucene 10 upgrade
+- [Lucene 10.0.0 Release Notes](https://cwiki.apache.org/confluence/display/LUCENE/Release+Notes+10.0.0): Official Lucene changelog
+- [Lucene 10.1.0 Changes](https://lucene.apache.org/core/10_0_0/changes/Changes.html#v10.0.0): Detailed change log
+- [OpenSearch 3.0 Blog](https://opensearch.org/blog/opensearch-3-0-what-to-expect/): Overview of 3.0 features and breaking changes
+- [Breaking Changes Guide](https://github.com/opensearch-project/opensearch-build/issues/5243): 2.x to 3.0 migration guide
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/lucene-10-upgrade.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -7,3 +7,4 @@
 ## opensearch
 
 - [Java Runtime & JPMS](features/opensearch/java-runtime-and-jpms.md)
+- [Lucene 10 Upgrade](features/opensearch/lucene-10-upgrade.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Lucene 10 Upgrade feature in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/lucene-10-upgrade.md`
- Feature report: `docs/features/opensearch/lucene-10-upgrade.md`

### Key Changes in v3.0.0
- Upgraded from Apache Lucene 9.12.1 to Lucene 10.1.0
- Minimum JDK requirement changed from 11 to 21
- I/O parallelism improvements with async data fetching API
- Search parallelism via logical segment partitioning
- Sparse indexing for query optimization
- Enhanced k-NN/vector search performance

### Resources Used
- PR: opensearch-project/OpenSearch#16366
- Issue: opensearch-project/OpenSearch#11415
- Blog: https://opensearch.org/blog/opensearch-3-0-what-to-expect/

Closes #123