### PR TITLE
docs: add Dashboards Cypress Testing report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -9,6 +9,10 @@
 - [Java Runtime & JPMS](opensearch/java-runtime-and-jpms.md)
 - [Lucene 10 Upgrade](opensearch/lucene-10-upgrade.md)
 
+## opensearch-dashboards
+
+- [Dashboards Cypress Testing](opensearch-dashboards/dashboards-cypress-testing.md)
+
 ## sql
 
 - [SQL/PPL Breaking Changes](sql/sql-ppl-breaking-changes.md)

--- a/docs/features/opensearch-dashboards/dashboards-cypress-testing.md
+++ b/docs/features/opensearch-dashboards/dashboards-cypress-testing.md
@@ -1,0 +1,148 @@
+# Dashboards Cypress Testing
+
+## Summary
+
+OpenSearch Dashboards uses Cypress for end-to-end integration testing. The Cypress test suite provides comprehensive coverage for key Dashboards functionality including Discover, saved searches, visualizations, and query features. These tests ensure UI functionality works correctly across different scenarios and help catch regressions early.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Cypress Test Framework"
+        Runner[Cypress Test Runner]
+        Specs[Test Specs]
+        Commands[Custom Commands]
+        Fixtures[Test Fixtures]
+    end
+    
+    subgraph "Test Categories"
+        Discover[Discover Tests]
+        Dashboard[Dashboard Tests]
+        Query[Query Tests]
+        Sidebar[Sidebar Tests]
+    end
+    
+    subgraph "OpenSearch Dashboards"
+        OSD[OSD Server]
+        UI[UI Components]
+        API[REST APIs]
+    end
+    
+    Runner --> Specs
+    Specs --> Commands
+    Specs --> Fixtures
+    Specs --> Discover
+    Specs --> Dashboard
+    Specs --> Query
+    Specs --> Sidebar
+    Discover --> UI
+    Dashboard --> UI
+    Query --> API
+    Sidebar --> UI
+```
+
+### Test Categories
+
+| Category | Description | Key Tests |
+|----------|-------------|----------|
+| Discover | Discover page functionality | Sidebar, table canvas, inspect |
+| Dashboard | Dashboard integration | Saved searches, visualizations |
+| Query | Query features | Recent queries, query editor, auto-update |
+| Sharing | Share functionality | Share menu, export |
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Test Specs | Individual test files (`.spec.js`) |
+| Custom Commands | Reusable Cypress commands |
+| Fixtures | Test data and configurations |
+| Support Files | Setup and helper functions |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `baseUrl` | OSD server URL | `http://localhost:5601` |
+| `defaultCommandTimeout` | Command timeout | `10000` |
+| `viewportWidth` | Browser viewport width | `1680` |
+| `viewportHeight` | Browser viewport height | `900` |
+
+### Usage Example
+
+```bash
+# Install dependencies
+yarn install
+
+# Start OpenSearch Dashboards
+yarn start
+
+# Open Cypress test runner (interactive mode)
+yarn run cypress open
+
+# Run all tests headlessly
+yarn run cypress run
+
+# Run specific test spec
+yarn run cypress run --spec "cypress/integration/discover/sidebar.spec.js"
+```
+
+### Writing Tests
+
+```javascript
+// Example test spec
+describe('Discover Sidebar', () => {
+  before(() => {
+    // Setup test data
+    cy.setupTestData();
+  });
+
+  beforeEach(() => {
+    cy.visit('/app/discover');
+  });
+
+  it('should filter fields by type', () => {
+    cy.getElementByTestId('fieldFilterTypes')
+      .click();
+    cy.getElementByTestId('typeFilter-keyword')
+      .click();
+    cy.get('[data-test-subj="field-category"]')
+      .should('be.visible');
+  });
+
+  after(() => {
+    // Cleanup
+    cy.cleanupTestData();
+  });
+});
+```
+
+## Limitations
+
+- Tests require a running OpenSearch Dashboards instance
+- Some tests may be flaky due to timing issues (mitigated with retry mechanisms)
+- Test data setup may be required before running certain test suites
+- Tests are primarily designed for Discover 2.0 features
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#9154](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9154) | Refactor sidebar spec |
+| v3.0.0 | [#9285](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9285) | Table canvas tests |
+| v3.0.0 | [#9288](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9288) | Saved searches tests |
+| v3.0.0 | [#9292](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9292) | Inspect functionality tests |
+| v3.0.0 | [#9386](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9386) | Top values and filter tests |
+| v3.0.0 | [#9433](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9433) | Fix flaky tests |
+
+## References
+
+- [Cypress Documentation](https://docs.cypress.io/)
+- [OpenSearch Dashboards Repository](https://github.com/opensearch-project/OpenSearch-Dashboards)
+- [Issue #8946](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8946): Discover 2.0 testing initiative
+
+## Change History
+
+- **v3.0.0** (2025): Major expansion of Cypress test coverage for Discover 2.0, including sidebar tests, saved search tests, inspect functionality, query editor tests, and flaky test fixes (18 PRs)

--- a/docs/releases/v3.0.0/features/opensearch-dashboards/dashboards-cypress-testing.md
+++ b/docs/releases/v3.0.0/features/opensearch-dashboards/dashboards-cypress-testing.md
@@ -1,0 +1,95 @@
+# Dashboards Cypress Testing
+
+## Summary
+
+OpenSearch Dashboards v3.0.0 includes significant improvements to Cypress end-to-end testing coverage. This release adds 18 PRs focused on expanding test coverage for Discover 2.0 features, fixing flaky tests, and improving test infrastructure reliability.
+
+## Details
+
+### What's New in v3.0.0
+
+This release introduces comprehensive Cypress test coverage for key Dashboards functionality:
+
+- **Discover Page Testing**: New tests for sidebar functionality, top values, field filtering by type, and table canvas
+- **Dashboard Integration**: Tests for saved searches in dashboards
+- **Inspect Functionality**: Integration tests for inspect feature in Discover and Dashboards pages
+- **Query Features**: Tests for recent queries, query editor display, and auto query updates on dataset switch
+- **Test Reliability**: Fixes for flaky tests, retry mechanisms, and improved test data handling
+
+### Technical Changes
+
+#### New Test Suites
+
+| Test Suite | Description | PR |
+|------------|-------------|----|
+| Sidebar Tests | Top values, field filtering by type | [#9386](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9386) |
+| Saved Search Tests | Saved searches in dashboards | [#9288](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9288) |
+| Inspect Tests | Inspect functionality for Discover/Dashboards | [#9292](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9292), [#9331](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9331) |
+| Histogram Tests | Histogram interaction tests | [#9290](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9290) |
+| Recent Queries Tests | All recent queries functionality | [#9307](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9307) |
+| Table Canvas Tests | Table canvas in discover | [#9285](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9285) |
+| Query Editor Tests | Query editor display | [#9398](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9398) |
+| Dataset Switch Tests | Auto query updates on dataset switch | [#9322](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9322) |
+
+#### Test Infrastructure Improvements
+
+| Improvement | Description | PR |
+|-------------|-------------|----|
+| Flaky Test Fixes | General flakiness fixes | [#9433](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9433) |
+| Retry Mechanism | Retry for flaky share menu test | [#9352](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9352) |
+| Test Data Updates | Random IDs, missing value fields, unique fields | [#9321](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9321) |
+| Performance | Use before/after hooks to speed up tests | [#9439](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9439) |
+| Cleanup | Remove unnecessary reload in saved_search test | [#9396](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9396) |
+| S3 Integration | Clear session storage in S3 integ test | [#9490](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9490) |
+| Re-enabled Tests | Re-enable saved search cypress tests | [#9628](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9628) |
+
+### Usage Example
+
+Run Cypress tests with:
+
+```bash
+# Open Cypress test runner
+yarn run cypress open
+
+# Run specific test spec
+yarn run cypress run --spec "cypress/integration/discover/sidebar.spec.js"
+```
+
+## Limitations
+
+- Some tests may require specific test data setup
+- Tests are designed for Discover 2.0 features and may not cover legacy Discover
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9154](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9154) | Refactor TESTID-140 sidebar spec and clean up |
+| [#9285](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9285) | Add tests for table canvas in discover |
+| [#9288](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9288) | Add tests for saved searches in dashboards |
+| [#9290](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9290) | Add histogram interaction tests |
+| [#9292](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9292) | Add inspect functionality tests |
+| [#9307](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9307) | Add all recent queries tests |
+| [#9314](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9314) | Test sort in language_specific_display |
+| [#9321](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9321) | Update cypress data |
+| [#9322](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9322) | Add cypress test for auto query updates |
+| [#9331](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9331) | Add inspect functionality tests |
+| [#9352](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9352) | Add retry mechanism for flaky share menu test |
+| [#9386](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9386) | Add Top Values and Filter Sidebar Fields testing |
+| [#9396](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9396) | Remove unnecessary reload in saved_search test |
+| [#9398](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9398) | Add tests for query editor display |
+| [#9433](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9433) | Fix flakiness in cypress tests |
+| [#9439](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9439) | Use before/after to speed up test |
+| [#9490](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9490) | Clear session storage in S3 integ test |
+| [#9628](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9628) | Reenable saved search cypress tests |
+
+## References
+
+- [Issue #8946](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8946): TESTID-140 Sidebar testing
+- [Issue #8954](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8954): Sharing spec testing
+- [Issue #8955](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8955): Inspect functionality testing
+- [Issue #8959](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8959): Saved searches testing
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/dashboards-cypress-testing.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -9,6 +9,10 @@
 - [Java Runtime & JPMS](features/opensearch/java-runtime-and-jpms.md)
 - [Lucene 10 Upgrade](features/opensearch/lucene-10-upgrade.md)
 
+## opensearch-dashboards
+
+- [Dashboards Cypress Testing](features/opensearch-dashboards/dashboards-cypress-testing.md)
+
 ## sql
 
 - [SQL/PPL v3.0.0 Breaking Changes](features/sql/sql-ppl-v3-breaking-changes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dashboards Cypress Testing improvements in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch-dashboards/dashboards-cypress-testing.md`
- Feature report: `docs/features/opensearch-dashboards/dashboards-cypress-testing.md`

### Key Changes in v3.0.0
- New Cypress test suites for Discover 2.0 features (sidebar, table canvas, inspect functionality)
- Tests for saved searches in dashboards
- Query feature tests (recent queries, query editor, auto-update on dataset switch)
- Test infrastructure improvements (flaky test fixes, retry mechanisms, performance optimizations)

### PRs Covered
18 PRs from OpenSearch-Dashboards repository focused on Cypress testing improvements.

Closes #287