### PR TITLE
docs: add Dashboards CI/CD & Documentation report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -11,6 +11,7 @@
 
 ## opensearch-dashboards
 
+- [Dashboards CI/CD & Documentation](opensearch-dashboards/dashboards-ci-cd-documentation.md)
 - [Dashboards Cypress Testing](opensearch-dashboards/dashboards-cypress-testing.md)
 
 ## sql

--- a/docs/features/opensearch-dashboards/dashboards-ci-cd-documentation.md
+++ b/docs/features/opensearch-dashboards/dashboards-ci-cd-documentation.md
@@ -1,0 +1,115 @@
+# Dashboards CI/CD & Documentation
+
+## Summary
+
+OpenSearch Dashboards CI/CD & Documentation encompasses the continuous integration pipeline improvements, automated documentation generation, and developer documentation for the OpenSearch Dashboards project. These improvements ensure code quality through automated checks, maintain up-to-date developer documentation, and provide comprehensive guides for features like Discover 2.0.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph "CI/CD Pipeline"
+        PR[Pull Request] --> LC[Lockfile Check]
+        LC --> LV[License Validation]
+        LV --> DD[Dev Docs Check]
+        DD --> BT[Build & Test]
+        BT --> M[Merge]
+    end
+    
+    subgraph "Pre-commit Hooks"
+        C[Commit] --> GH[Git Hook]
+        GH --> DG[Generate Dev Docs]
+        DG --> VS[Validate Staged]
+    end
+    
+    subgraph "Documentation"
+        D2[Discover 2.0 Docs]
+        DE[Docker Environment]
+        TP[Triaging Process]
+        OA[OpenAPI Docs]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Lockfile Validation | CI check ensuring yarn.lock is synchronized with package.json |
+| License Validation | Automated validation of dependency licenses during CI |
+| Dev Docs Generator | Script to generate developer documentation sidebar |
+| Pre-commit Hook | Git hook to ensure developer docs are always updated |
+| Discover 2.0 Docs | Developer documentation for Discover 2.0 architecture and usage |
+| Docker Dev Environment | Alternative Docker setup for Cypress testing |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `yarn docs:generateDevDocs` | Command to generate developer documentation | N/A |
+| Pre-commit hook | Automatically runs on git commit | Enabled |
+
+### CI Checks
+
+The CI pipeline includes the following validation steps:
+
+1. **Lockfile Sync Check**: Ensures `yarn.lock` matches `package.json` dependencies
+2. **License Validation**: Validates that all dependencies comply with allowed licenses
+3. **Developer Docs Check**: Verifies developer documentation is current
+4. **Build and Test**: Standard build and test workflows
+
+### Usage Example
+
+```bash
+# Generate developer documentation
+yarn docs:generateDevDocs
+
+# The pre-commit hook automatically:
+# 1. Runs docs:generateDevDocs
+# 2. Checks if generated files are staged
+# 3. Fails commit if unstaged changes exist
+
+# To manually validate lockfile
+yarn install --frozen-lockfile
+```
+
+### Docker Development Environment
+
+For Cypress testing, an alternative Docker development environment is available:
+
+```bash
+# Follow DEVELOPER_GUIDE.md for Docker setup
+# This environment supports:
+# - Creating datasources
+# - Populating test data
+# - Running Cypress tests
+```
+
+## Limitations
+
+- Pre-commit hooks require Node.js to be installed
+- Docker development environment is optimized for Cypress testing scenarios
+- License validation may require updates when adding new dependencies
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#9064](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9064) | CI hardening: lockfile, license validation, actions bump |
+| v3.0.0 | [#8885](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8885) | Fix OpenAPI documentation |
+| v3.0.0 | [#9291](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9291) | Add triaging process documentation |
+| v3.0.0 | [#9325](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9325) | Add 2.19 Release Notes |
+| v3.0.0 | [#9362](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9362) | Docker development environment for Cypress |
+| v3.0.0 | [#9463](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9463) | Understanding Discover 2.0 documentation |
+| v3.0.0 | [#9467](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9467) | Add Joey Liu as maintainer |
+| v3.0.0 | [#9525](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9525) | Getting started with Discover 2.0 |
+| v3.0.0 | [#6585](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6585) | Pre-commit hook for developer docs |
+
+## References
+
+- [OpenSearch Dashboards Repository](https://github.com/opensearch-project/OpenSearch-Dashboards)
+
+## Change History
+
+- **v3.0.0** (2025): CI/CD hardening, Discover 2.0 documentation, Docker development environment, pre-commit hooks for developer docs

--- a/docs/releases/v3.0.0/features/opensearch-dashboards/dashboards-ci-cd-documentation.md
+++ b/docs/releases/v3.0.0/features/opensearch-dashboards/dashboards-ci-cd-documentation.md
@@ -1,0 +1,101 @@
+# Dashboards CI/CD & Documentation
+
+## Summary
+
+OpenSearch Dashboards v3.0.0 includes significant improvements to CI/CD pipelines and developer documentation. These changes enhance build reliability through lockfile validation and dependency license checks, add comprehensive documentation for Discover 2.0, and improve the developer experience with Docker-based development environments and automated documentation generation.
+
+## Details
+
+### What's New in v3.0.0
+
+This release consolidates multiple CI/CD and documentation improvements:
+
+1. **CI Pipeline Hardening**: Enhanced PR validation with lockfile sync checks and dependency license validation
+2. **Discover 2.0 Documentation**: New developer guides for understanding and getting started with Discover 2.0
+3. **Docker Development Environment**: Alternative Docker setup documentation for Cypress testing
+4. **Developer Documentation Automation**: Git pre-commit hooks to ensure developer docs stay updated
+5. **OpenAPI Documentation Fixes**: Corrected HTTP methods for bulk saved object APIs
+6. **Triaging Process Documentation**: Added documentation for issue triaging workflow
+7. **Maintainer Updates**: Added Joey Liu (@Maosaic) as a maintainer
+
+### Technical Changes
+
+#### CI/CD Improvements
+
+```mermaid
+flowchart LR
+    subgraph "PR Validation Pipeline"
+        A[PR Submitted] --> B[Lockfile Check]
+        B --> C[License Validation]
+        C --> D[Dev Docs Check]
+        D --> E[Build & Test]
+    end
+```
+
+| Check | Description |
+|-------|-------------|
+| Lockfile Sync | Validates yarn.lock is in sync with package.json |
+| License Validation | Ensures dependencies comply with licensing requirements |
+| Dev Docs | Verifies developer documentation is up-to-date |
+| Actions Bump | Updated GitHub Actions to latest versions |
+
+#### Developer Documentation
+
+| Document | Description |
+|----------|-------------|
+| Understanding Discover 2.0 | Architecture and onboarding guide for new data types and languages |
+| Getting Started with Discover 2.0 | Quick start guide for Discover 2.0 features |
+| Docker Development Setup | Alternative Docker environment for Cypress testing |
+| Triaging Process | Issue triaging workflow documentation |
+
+#### Pre-commit Hook
+
+The new pre-commit hook automatically runs `yarn docs:generateDevDocs` and validates that changes are staged:
+
+```bash
+# Hook validates:
+# 1. Developer docs are generated
+# 2. Generated changes are staged
+# 3. Fails if unstaged changes exist
+```
+
+### Usage Example
+
+To set up the development environment with Docker for Cypress testing:
+
+```bash
+# Follow the alternative Docker development environment documentation
+# This allows creating datasources and filling data for Cypress tests
+```
+
+### Migration Notes
+
+- Existing PRs may fail CI if lockfile is out of sync - run `yarn` to update
+- Developer documentation changes now require staging the generated sidebar updates
+
+## Limitations
+
+- Pre-commit hook requires Node.js environment
+- Docker development setup is specific to Cypress testing scenarios
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9064](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9064) | Improve CI checks: lockfile sync, license validation, actions bump |
+| [#8885](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8885) | Fix OpenAPI documentation for bulk saved object APIs |
+| [#9291](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9291) | Add triaging process documentation |
+| [#9325](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9325) | Add 2.19 Release Notes |
+| [#9362](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9362) | Add Docker development environment documentation for Cypress |
+| [#9463](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9463) | Initial version of Understanding Discover 2.0 |
+| [#9467](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9467) | Add Joey Liu as maintainer |
+| [#9525](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9525) | Getting started with Discover 2.0 |
+| [#6585](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6585) | Add git pre-commit hook for developer docs |
+
+## References
+
+- [OpenSearch Dashboards Repository](https://github.com/opensearch-project/OpenSearch-Dashboards)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/dashboards-ci-cd-documentation.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -11,6 +11,7 @@
 
 ## opensearch-dashboards
 
+- [Dashboards CI/CD & Documentation](features/opensearch-dashboards/dashboards-ci-cd-documentation.md)
 - [Dashboards Cypress Testing](features/opensearch-dashboards/dashboards-cypress-testing.md)
 
 ## sql


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dashboards CI/CD & Documentation improvements in OpenSearch Dashboards v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch-dashboards/dashboards-ci-cd-documentation.md`
- Feature report: `docs/features/opensearch-dashboards/dashboards-ci-cd-documentation.md`

### Key Changes in v3.0.0
- CI pipeline hardening with lockfile sync and license validation checks
- Discover 2.0 documentation (Understanding and Getting Started guides)
- Docker development environment documentation for Cypress testing
- Git pre-commit hooks for automated developer documentation generation
- OpenAPI documentation fixes
- Triaging process documentation
- New maintainer addition (Joey Liu)

### Related PRs
- #9064: CI hardening
- #8885: OpenAPI documentation fix
- #9291: Triaging process documentation
- #9325: 2.19 Release Notes
- #9362: Docker development environment
- #9463: Understanding Discover 2.0
- #9467: Add Joey Liu as maintainer
- #9525: Getting started with Discover 2.0
- #6585: Pre-commit hook for developer docs

Closes #286