### PR TITLE
docs: add CI/CD & Build Fixes report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -11,6 +11,7 @@
 
 ## opensearch-dashboards
 
+- [CI/CD & Build Fixes](opensearch-dashboards/ci-cd-build-fixes.md)
 - [Dashboards CI/CD & Documentation](opensearch-dashboards/dashboards-ci-cd-documentation.md)
 - [Dashboards Cypress Testing](opensearch-dashboards/dashboards-cypress-testing.md)
 - [Dashboards UI/UX Fixes](opensearch-dashboards/dashboards-ui-ux-fixes.md)

--- a/docs/features/opensearch-dashboards/ci-cd-build-fixes.md
+++ b/docs/features/opensearch-dashboards/ci-cd-build-fixes.md
@@ -1,0 +1,104 @@
+# CI/CD & Build Fixes
+
+## Summary
+
+This feature tracks CI/CD pipeline improvements and build system fixes for OpenSearch Dashboards. It includes GitHub Actions workflow updates, permission configurations, and cross-platform build compatibility enhancements.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "GitHub Actions Workflows"
+        CY[Cypress Workflow]
+        PT[Performance Testing]
+    end
+    
+    subgraph "Build System"
+        FS[fs.ts - File Operations]
+        CP[cross-platform Package]
+    end
+    
+    CY --> |uses| Cache[actions/cache@v4]
+    PT --> |requires| Perms[PR Write Permissions]
+    FS --> |uses| CP
+    FS --> |handles| WinPath[Windows Long Paths]
+    FS --> |implements| Retry[Retry Logic]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `cypress_workflow.yml` | Cypress test workflow with caching |
+| `performance_testing.yml` | Bundle analyzer and performance CI |
+| `src/dev/build/lib/fs.ts` | File system operations for build |
+| `@osd/cross-platform` | Cross-platform path utilities |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `actions/cache` version | GitHub Actions cache action version | v4 |
+| `pull-requests` permission | PR comment write access | write |
+| Retry attempts | File deletion retry count | 3 |
+| Retry delay | Wait time between retries | 1000ms |
+
+### Usage Example
+
+#### Workflow Permissions Configuration
+
+```yaml
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+```
+
+#### File Deletion with Retry
+
+```typescript
+import { standardize } from '@osd/cross-platform';
+
+async function deleteWithRetry(folder: string, log: ToolingLog) {
+  if (process.platform === 'win32') {
+    folder = standardize(folder, false, false, true);
+  }
+
+  for (let i = 0; i < 3; i++) {
+    try {
+      await rm(folder, { force: true, recursive: true });
+      return;
+    } catch (err) {
+      if (i === 2) throw err;
+      log.debug(`Retry ${i + 1}/3 on ${folder}, waiting for 1000ms`);
+      await new Promise((resolve) => setTimeout(resolve, 1000));
+    }
+  }
+}
+```
+
+## Limitations
+
+- Retry logic may add latency to builds (up to 3 seconds per failed deletion)
+- Windows long path support requires extended path prefix (`\\?\`)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#9366](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9366) | Update actions/cache from v1 to v4 |
+| v3.0.0 | [#9534](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9534) | Add PR write permission |
+| v3.0.0 | [#9581](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9581) | Fix bundler performance testing permissions |
+| v3.0.0 | [#9561](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9561) | Windows longpath support with retry |
+
+## References
+
+- [Issue #9397](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9397): Windows build failure
+- [Issue #3747](https://github.com/opensearch-project/opensearch-build/issues/3747): opensearch-build Windows issue
+- [GitHub Actions Cache](https://github.com/actions/cache): Official cache action
+
+## Change History
+
+- **v3.0.0** (2025-03): Initial implementation with cache update, workflow permissions, and Windows build fixes

--- a/docs/releases/v3.0.0/features/opensearch-dashboards/ci-cd-build-fixes.md
+++ b/docs/releases/v3.0.0/features/opensearch-dashboards/ci-cd-build-fixes.md
@@ -1,0 +1,94 @@
+# CI/CD & Build Fixes
+
+## Summary
+
+OpenSearch Dashboards v3.0.0 includes several CI/CD and build system fixes that improve workflow reliability, address GitHub Actions deprecation warnings, and resolve Windows build issues. These changes ensure stable continuous integration pipelines and cross-platform build compatibility.
+
+## Details
+
+### What's New in v3.0.0
+
+This release addresses four key areas:
+
+1. **GitHub Actions Cache Update**: Updated `actions/cache` from deprecated v1 to v4
+2. **Workflow Permissions**: Added proper write permissions for PR comments in performance testing
+3. **Windows Build Stability**: Implemented retry logic with long path support for file deletion
+
+### Technical Changes
+
+#### GitHub Actions Updates
+
+The Cypress workflow was updated to use `actions/cache@v4` instead of the deprecated v1:
+
+```yaml
+- name: Cache Cypress
+  id: cache-cypress
+  uses: actions/cache@v4
+  with:
+    path: ~/.cache/Cypress
+    key: cypress-cache-v2-${{ runner.os }}-${{ hashFiles('**/package.json') }}
+```
+
+#### Workflow Permissions
+
+The performance testing workflow now includes explicit permissions for PR interactions:
+
+```yaml
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+```
+
+#### Windows Long Path Support
+
+The build system now handles Windows long paths and includes retry logic for file deletion:
+
+```typescript
+// src/dev/build/lib/fs.ts
+if (process.platform === 'win32') {
+  folder = standardize(folder, false, false, true); // extended long path
+}
+
+for (let i = 0; i < 3; i++) {
+  try {
+    await rm(folder, { force: true, recursive: true });
+    return;
+  } catch (err) {
+    if (i === 2) throw err;
+    log.debug(`Retry ${i + 1}/3 on ${folder}, waiting for 1000ms`);
+    await new Promise((resolveSleep) => setTimeout(resolveSleep, 1000));
+  }
+}
+```
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `.github/workflows/cypress_workflow.yml` | Updated actions/cache v1 → v4 |
+| `.github/workflows/performance_testing.yml` | Added PR write permissions |
+| `src/dev/build/lib/fs.ts` | Added retry logic and Windows long path support |
+
+## Limitations
+
+- Retry logic adds up to 3 seconds delay per failed deletion attempt
+- Windows long path support requires the `@osd/cross-platform` package
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9366](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9366) | Update actions/cache from v1 to v4 |
+| [#9534](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9534) | Add PR write permission for performance testing |
+| [#9581](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9581) | Fix permissions for bundler performance testing CI |
+| [#9561](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9561) | Retry on file/folder deletion with Windows longpath support |
+
+## References
+
+- [Issue #9397](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9397): Windows build failure discussion
+- [Issue #3747](https://github.com/opensearch-project/opensearch-build/issues/3747): opensearch-build Windows issue
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/ci-cd-build-fixes.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -11,6 +11,7 @@
 
 ## opensearch-dashboards
 
+- [CI/CD & Build Fixes](features/opensearch-dashboards/ci-cd-build-fixes.md)
 - [Dashboards CI/CD & Documentation](features/opensearch-dashboards/dashboards-ci-cd-documentation.md)
 - [Dashboards Cypress Testing](features/opensearch-dashboards/dashboards-cypress-testing.md)
 - [Dashboards UI/UX Fixes](features/opensearch-dashboards/dashboards-ui-ux-fixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for CI/CD & Build Fixes in OpenSearch Dashboards v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch-dashboards/ci-cd-build-fixes.md`
- Feature report: `docs/features/opensearch-dashboards/ci-cd-build-fixes.md`

### Key Changes in v3.0.0
- Updated `actions/cache` from deprecated v1 to v4 in Cypress workflow
- Added PR write permissions for performance testing workflow
- Implemented retry logic with Windows long path support for file deletion

### PRs Investigated
- #9366: Update actions/cache from v1 to v4
- #9534: Add PR write permission for performance testing
- #9581: Fix permissions for bundler performance testing CI
- #9561: Retry on file/folder deletion with Windows longpath support

Closes #284