### PR TITLE
docs: add workspace improvements report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -15,6 +15,7 @@
 - [Dashboards CI/CD & Documentation](opensearch-dashboards/dashboards-ci-cd-documentation.md)
 - [Dashboards Cypress Testing](opensearch-dashboards/dashboards-cypress-testing.md)
 - [Dashboards UI/UX Fixes](opensearch-dashboards/dashboards-ui-ux-fixes.md)
+- [Workspace](opensearch-dashboards/workspace.md)
 
 ## sql
 

--- a/docs/features/opensearch-dashboards/workspace.md
+++ b/docs/features/opensearch-dashboards/workspace.md
@@ -1,0 +1,143 @@
+# Workspace
+
+## Summary
+
+Workspace is a feature in OpenSearch Dashboards that enables users to tailor their environment with use-case-specific configurations. It provides isolated storage for visual assets like dashboards and visualizations, allowing teams to organize and manage their resources independently.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        WS[Workspace Service]
+        WC[Workspace Client]
+        WV[Workspace Validation Service]
+        SO[Saved Objects]
+    end
+    
+    subgraph "Workspace Features"
+        ACL[Access Control Lists]
+        UC[Use Cases]
+        RI[Recent Items]
+    end
+    
+    WS --> WC
+    WS --> WV
+    WC --> SO
+    WV --> WC
+    SO --> ACL
+    WS --> UC
+    WS --> RI
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[User Request] --> B[Workspace URL Parser]
+    B --> C{Workspace ID?}
+    C -->|Yes| D[Enter Workspace]
+    C -->|No| E[Global Context]
+    D --> F[Workspace Validation]
+    F -->|Valid| G[Load Workspace Context]
+    F -->|Invalid| H[Error Page]
+    G --> I[Filter Saved Objects]
+    I --> J[Render Dashboard]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `WorkspacesService` | Core service managing workspace state and lifecycle |
+| `WorkspaceClient` | Client for workspace CRUD operations |
+| `WorkspaceValidationService` | Validates workspace state during initialization |
+| `RecentWorkspaceManager` | Manages recently accessed workspaces |
+| `WorkspaceError` | Enum defining workspace error types |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `workspace.enabled` | Enable workspace feature | `false` |
+| `home:useNewHomePage` | Use new home page with workspace support | `false` |
+| `opensearch_security.multitenancy.enabled` | Must be disabled when using workspaces | `true` |
+
+### Workspace Data Model
+
+```typescript
+interface Workspace {
+  id: string;
+  name: string;
+  description?: string;
+  features?: string[];  // Use case IDs
+  color: string;
+  uiSettings: Record<string, unknown>;
+}
+```
+
+### Use Cases
+
+Workspaces support predefined use cases that limit functionality:
+
+- `use-case-observability`
+- `use-case-security-analytics`
+- `use-case-search`
+- `use-case-essentials`
+- `use-case-all`
+
+### Saved Object Association
+
+Saved objects can be associated with workspaces via the `workspaces` attribute:
+
+```json
+{
+  "type": "dashboard",
+  "id": "da123f20-6680-11ee-93fa-df944ec23359",
+  "workspaces": ["M5NqCu"]
+}
+```
+
+### Usage Example
+
+Enable workspaces in `opensearch_dashboards.yml`:
+
+```yaml
+workspace.enabled: true
+uiSettings:
+  overrides:
+    "home:useNewHomePage": true
+
+# If security plugin is installed
+opensearch_security.multitenancy.enabled: false
+```
+
+## Limitations
+
+- Multi-tenancy must be disabled when using workspaces (conflicts with similar functionality)
+- Not all saved objects are workspace-aware; some operate globally
+- Stale workspace state requires manual navigation back to home page
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#9420](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9420) | Fix saved objects find returning all workspaces |
+| v3.0.0 | [#9346](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9346) | Filter out recent items with errors |
+| v3.0.0 | [#9478](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9478) | Add error handling page for stale workspace state |
+
+## References
+
+- [Workspace Documentation](https://docs.opensearch.org/3.0/dashboards/workspace/workspace/): Official workspace feature documentation
+- [Getting Started with Workspaces](https://docs.opensearch.org/3.0/dashboards/workspace/index/): Introduction to workspaces
+- [Create a Workspace](https://docs.opensearch.org/3.0/dashboards/workspace/create-workspace/): How to create workspaces
+- [Manage Workspaces](https://docs.opensearch.org/3.0/dashboards/workspace/manage-workspace/): Workspace management guide
+- [Workspace ACLs](https://docs.opensearch.org/3.0/dashboards/workspace/workspace-acl/): Access control documentation
+- [Workspaces APIs](https://docs.opensearch.org/3.0/dashboards/workspace/apis/): API reference
+
+## Change History
+
+- **v3.0.0** (2025): Bug fixes for saved object isolation, recent items error filtering, and stale workspace error handling
+- **v2.18.0**: Initial workspace feature introduction

--- a/docs/releases/v3.0.0/features/opensearch-dashboards/workspace-improvements.md
+++ b/docs/releases/v3.0.0/features/opensearch-dashboards/workspace-improvements.md
@@ -1,0 +1,104 @@
+# Workspace Improvements
+
+## Summary
+
+OpenSearch Dashboards v3.0.0 includes several bug fixes for the Workspace feature that improve stability and user experience. These fixes address issues with saved object isolation, error handling for deleted items in recent lists, and stale workspace state handling.
+
+## Details
+
+### What's New in v3.0.0
+
+Three key bug fixes improve workspace reliability:
+
+1. **Saved Objects Isolation Fix**: The `_find` API now correctly returns only saved objects within the current workspace context
+2. **Recent Items Error Filtering**: Deleted or inaccessible items are filtered out from the recent items list
+3. **Stale Workspace Error Handling**: Users are redirected to an error page instead of getting stuck in a loading state when accessing a stale workspace
+
+### Technical Changes
+
+#### Saved Objects Find API Fix (PR #9420)
+
+Previously, when querying saved objects within a workspace context without explicit `workspace` query parameters, the API would return all saved objects across all workspaces. This was a security and usability issue.
+
+**Root Cause**: The endpoint passed `workspace: undefined` when no workspace parameter was provided, bypassing workspace filtering.
+
+**Fix**: Modified `src/plugins/saved_objects_management/server/routes/find.ts` to only include the `workspaces` property when explicitly provided:
+
+```typescript
+// Before
+workspaces: req.query.workspaces ? Array<string>().concat(req.query.workspaces) : undefined,
+
+// After
+...(req.query.workspaces
+  ? {
+      workspaces: Array<string>().concat(req.query.workspaces),
+    }
+  : {}),
+```
+
+#### Recent Items Error Filtering (PR #9346)
+
+The recent items component now filters out saved objects that have errors (e.g., deleted objects) before displaying them.
+
+**Changed File**: `src/core/public/chrome/ui/header/recent_items.tsx`
+
+```typescript
+const formatDetailedSavedObjects = res
+  .filter((obj) => !obj.error) // filter out saved objects with errors
+  .map((obj) => {
+    // ... formatting logic
+  });
+```
+
+#### Stale Workspace Error Handling (PR #9478)
+
+A new `WorkspaceValidationService` handles workspace state validation and redirects users to an error page when the workspace is stale.
+
+```mermaid
+flowchart LR
+    A[User enters workspace URL] --> B{Workspace exists?}
+    B -->|Yes| C[Load workspace]
+    B -->|No| D[Show error page]
+    C --> E{Workspace stale?}
+    E -->|Yes| D
+    E -->|No| F[Display workspace]
+```
+
+**New Components**:
+
+| Component | Description |
+|-----------|-------------|
+| `WorkspaceValidationService` | Validates workspace state during initialization |
+| `WorkspaceError` enum | Defines workspace error types (e.g., `WORKSPACE_IS_STALE`) |
+| `workspaceError$` | Observable stream for workspace errors |
+
+**Error Flow**:
+1. User navigates to workspace URL
+2. `WorkspaceValidationService` checks workspace validity
+3. If workspace is stale or not found, `workspaceError$` emits error
+4. Plugin redirects to `WORKSPACE_FATAL_ERROR_APP_ID` with error message
+
+### Migration Notes
+
+No migration required. These are bug fixes that improve existing behavior.
+
+## Limitations
+
+- The stale workspace error page requires manual navigation back to the home page
+- Recent items filtering only removes items with errors; it does not automatically clean up the recent items storage
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9420](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9420) | Fix saved objects find returning all workspaces |
+| [#9346](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9346) | Filter out recent items with errors |
+| [#9478](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9478) | Add error handling page for stale workspace state |
+
+## References
+
+- [Workspace Documentation](https://docs.opensearch.org/3.0/dashboards/workspace/workspace/): Official workspace feature documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/workspace.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -16,6 +16,7 @@
 - [Dashboards Cypress Testing](features/opensearch-dashboards/dashboards-cypress-testing.md)
 - [Dashboards UI/UX Fixes](features/opensearch-dashboards/dashboards-ui-ux-fixes.md)
 - [UI/UX Improvements](features/opensearch-dashboards/ui-ux-improvements.md)
+- [Workspace Improvements](features/opensearch-dashboards/workspace-improvements.md)
 
 ## sql
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Workspace Improvements bugfix in OpenSearch Dashboards v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch-dashboards/workspace-improvements.md`
- Feature report: `docs/features/opensearch-dashboards/workspace.md` (new)

### Key Changes in v3.0.0
- **Saved Objects Isolation Fix** (PR #9420): The `_find` API now correctly returns only saved objects within the current workspace context
- **Recent Items Error Filtering** (PR #9346): Deleted or inaccessible items are filtered out from the recent items list
- **Stale Workspace Error Handling** (PR #9478): Users are redirected to an error page instead of getting stuck in a loading state when accessing a stale workspace

### Resources Used
- PR: #9420, #9346, #9478
- Docs: https://docs.opensearch.org/3.0/dashboards/workspace/workspace/

Closes #282