### PR TITLE
docs: add Merge & Segment Settings report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -8,6 +8,7 @@
 
 - [Java Runtime & JPMS](opensearch/java-runtime-and-jpms.md)
 - [Lucene 10 Upgrade](opensearch/lucene-10-upgrade.md)
+- [Merge & Segment Settings](opensearch/merge-segment-settings.md)
 
 ## opensearch-dashboards
 

--- a/docs/features/opensearch/merge-segment-settings.md
+++ b/docs/features/opensearch/merge-segment-settings.md
@@ -1,0 +1,144 @@
+# Merge & Segment Settings
+
+## Summary
+
+OpenSearch uses Apache Lucene's TieredMergePolicy to manage segment merging during indexing. Segment merging is crucial for maintaining query performance by consolidating smaller segments into larger ones. This feature covers the configurable settings that control merge behavior, including floor segment size, maximum segments per merge, and force merge thread allocation.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Index Writer"
+        IW[Index Writer]
+    end
+    
+    subgraph "Merge Policy"
+        TMP[TieredMergePolicy]
+        FS[Floor Segment Size]
+        MM[Max Merge At Once]
+        SPT[Segments Per Tier]
+    end
+    
+    subgraph "Thread Pools"
+        MT[Merge Threads]
+        FMT[Force Merge Threads]
+    end
+    
+    subgraph "Segments"
+        S1[Small Segments]
+        S2[Medium Segments]
+        S3[Large Segments]
+    end
+    
+    IW --> TMP
+    TMP --> FS
+    TMP --> MM
+    TMP --> SPT
+    TMP --> MT
+    TMP --> FMT
+    MT --> S1
+    MT --> S2
+    FMT --> S3
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[New Documents] --> B[Index Buffer]
+    B --> C[Flush to Segment]
+    C --> D{Segment Size}
+    D -->|< Floor Size| E[Queue for Merge]
+    D -->|>= Floor Size| F[Keep Segment]
+    E --> G[Merge Policy Evaluation]
+    G --> H{Segments to Merge}
+    H -->|<= maxMergeAtOnce| I[Single Merge]
+    H -->|> maxMergeAtOnce| J[Multiple Merges]
+    I --> K[Merged Segment]
+    J --> K
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `TieredMergePolicy` | Default merge policy that organizes segments into tiers based on size |
+| `TieredMergePolicyProvider` | OpenSearch wrapper that manages merge policy configuration |
+| `IndexSettings` | Manages index-level settings including merge policy parameters |
+| `IndicesService` | Manages cluster-level settings and propagates changes to indexes |
+| `ThreadPool.FORCE_MERGE` | Dedicated thread pool for force merge operations |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.merge.policy.floor_segment` | Segments smaller than this are merged more aggressively | 16MB |
+| `index.merge.policy.max_merge_at_once` | Maximum number of segments merged at once | 30 |
+| `index.merge.policy.max_merged_segment` | Maximum size of a merged segment | 5GB |
+| `index.merge.policy.segments_per_tier` | Target number of segments per tier | 10 |
+| `index.merge.policy.expunge_deletes_allowed` | Percentage of deleted docs allowed before merge | 10% |
+| `cluster.default.index.max_merge_at_once` | Cluster-level default for max merge at once | 30 |
+
+### Usage Example
+
+```yaml
+# Index creation with custom merge settings
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "merge": {
+        "policy": {
+          "floor_segment": "32mb",
+          "max_merge_at_once": 20,
+          "max_merged_segment": "10gb"
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+// Cluster-level merge settings
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.default.index.max_merge_at_once": 25
+  }
+}
+```
+
+```bash
+# Force merge an index to reduce segments
+POST /my-index/_forcemerge?max_num_segments=1
+```
+
+## Limitations
+
+- Merge settings cannot be changed on closed indexes without reopening
+- Force merge is resource-intensive and should be used during low-traffic periods
+- Very large `max_merge_at_once` values may cause memory pressure
+- Force merge thread pool size is fixed at node startup
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17255](https://github.com/opensearch-project/OpenSearch/pull/17255) | Increase force merge threads to 1/8th of cores |
+| v3.0.0 | [#17699](https://github.com/opensearch-project/OpenSearch/pull/17699) | Increase floor segment size to 16MB |
+| v3.0.0 | [#17774](https://github.com/opensearch-project/OpenSearch/pull/17774) | Increase default maxMergeAtOnce to 30 |
+
+## References
+
+- [Issue #17051](https://github.com/opensearch-project/OpenSearch/issues/17051): Increase maxMergeAtOnce parameter in OpenSearch 3.0
+- [Issue #16935](https://github.com/opensearch-project/OpenSearch/issues/16935): OpenSearch 3.0 Core Release Tracker
+- [Lucene TieredMergePolicy](https://lucene.apache.org/core/10_0_0/core/org/apache/lucene/index/TieredMergePolicy.html): Lucene documentation
+- [Index Settings Documentation](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/index-settings/): Official docs
+- [Force Merge API](https://docs.opensearch.org/3.0/api-reference/index-apis/force-merge/): Force merge documentation
+
+## Change History
+
+- **v3.0.0** (2025-04): Floor segment size increased to 16MB, maxMergeAtOnce increased to 30, force merge threads scaled to 1/8th of cores, new cluster-level setting added

--- a/docs/releases/v3.0.0/features/opensearch/merge-segment-settings.md
+++ b/docs/releases/v3.0.0/features/opensearch/merge-segment-settings.md
@@ -1,0 +1,117 @@
+# Merge & Segment Settings
+
+## Summary
+
+OpenSearch 3.0.0 introduces optimized default settings for segment merging, improving indexing performance out of the box. These changes align with recent Lucene recommendations and include increased floor segment size, higher max merge at once limit, and more force merge threads.
+
+## Details
+
+### What's New in v3.0.0
+
+Three key merge-related defaults have been updated to improve indexing performance:
+
+1. **Floor segment size increased from 2MB to 16MB** - Smaller segments are now merged more aggressively
+2. **maxMergeAtOnce increased from 10 to 30** - More segments can be merged in a single operation
+3. **Force merge thread pool scaled to 1/8th of CPU cores** - Force merge operations now utilize more CPU resources
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Merge Policy (TieredMergePolicy)"
+        FS[Floor Segment: 16MB]
+        MM[Max Merge At Once: 30]
+    end
+    
+    subgraph "Thread Pool"
+        FM[Force Merge Threads: cores/8]
+    end
+    
+    subgraph "Benefits"
+        B1[Fewer Segments]
+        B2[Faster Merges]
+        B3[Better Query Performance]
+    end
+    
+    FS --> B1
+    MM --> B2
+    FM --> B2
+    B1 --> B3
+    B2 --> B3
+```
+
+#### New Configuration
+
+| Setting | Old Default | New Default | Description |
+|---------|-------------|-------------|-------------|
+| `index.merge.policy.floor_segment` | 2MB | 16MB | Minimum segment size before merging |
+| `index.merge.policy.max_merge_at_once` | 10 | 30 | Maximum segments merged in one operation |
+| `cluster.default.index.max_merge_at_once` | N/A | 30 | New cluster-level setting for max merge at once |
+| Force merge thread pool size | 1 | cores/8 (min 1) | Thread pool for force merge operations |
+
+#### New Cluster Setting
+
+A new dynamic cluster setting `cluster.default.index.max_merge_at_once` has been introduced:
+
+- Allows cluster-wide tuning of the `maxMergeAtOnce` parameter
+- Applies to all indexes without an explicit index-level override
+- Can be updated dynamically without cluster restart
+- Minimum value: 2
+
+### Usage Example
+
+```json
+// Set cluster-level default for maxMergeAtOnce
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.default.index.max_merge_at_once": 20
+  }
+}
+
+// Override at index level if needed
+PUT /my-index/_settings
+{
+  "index.merge.policy.max_merge_at_once": 15
+}
+
+// Remove index-level override to use cluster default
+PUT /my-index/_settings
+{
+  "index.merge.policy.max_merge_at_once": null
+}
+```
+
+### Migration Notes
+
+- These are default value changes; existing indexes retain their current settings
+- New indexes automatically use the optimized defaults
+- No action required for most users
+- Users who previously tuned these settings should evaluate if custom values are still needed
+
+## Limitations
+
+- Force merge thread pool size is calculated at node startup and cannot be changed dynamically
+- The `cluster.default.index.max_merge_at_once` setting only affects indexes without explicit index-level overrides
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17255](https://github.com/opensearch-project/OpenSearch/pull/17255) | Increase force merge threads to 1/8th of cores |
+| [#17699](https://github.com/opensearch-project/OpenSearch/pull/17699) | Increase floor segment size to 16MB |
+| [#17774](https://github.com/opensearch-project/OpenSearch/pull/17774) | Increase default maxMergeAtOnce to 30 and add cluster setting |
+
+## References
+
+- [Issue #17051](https://github.com/opensearch-project/OpenSearch/issues/17051): Increase maxMergeAtOnce parameter in OpenSearch 3.0
+- [Issue #16935](https://github.com/opensearch-project/OpenSearch/issues/16935): OpenSearch 3.0 Core Release Tracker
+- [Lucene PR #266](https://github.com/apache/lucene/pull/266): Lucene maxMergeAtOnce increase
+- [Lucene PR #14189](https://github.com/apache/lucene/pull/14189): Lucene floor segment size increase
+- [Index Settings Documentation](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/index-settings/): Official docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/merge-segment-settings.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -8,6 +8,7 @@
 
 - [Java Runtime & JPMS](features/opensearch/java-runtime-and-jpms.md)
 - [Lucene 10 Upgrade](features/opensearch/lucene-10-upgrade.md)
+- [Merge & Segment Settings](features/opensearch/merge-segment-settings.md)
 
 ## opensearch-dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Merge & Segment Settings improvements in OpenSearch v3.0.0.

## Changes

### Release Report
- `docs/releases/v3.0.0/features/opensearch/merge-segment-settings.md`

### Feature Report
- `docs/features/opensearch/merge-segment-settings.md`

## Key Changes in v3.0.0

1. **Floor segment size increased from 2MB to 16MB** - Aligns with Lucene defaults for more aggressive small segment merging
2. **maxMergeAtOnce increased from 10 to 30** - Allows more segments to be merged in a single operation
3. **Force merge thread pool scaled to 1/8th of CPU cores** - Better utilization of available CPU resources
4. **New cluster setting `cluster.default.index.max_merge_at_once`** - Dynamic cluster-level control over merge behavior

## Related PRs
- opensearch-project/OpenSearch#17255
- opensearch-project/OpenSearch#17699
- opensearch-project/OpenSearch#17774

Closes #260