### PR TITLE
docs: add Gradle Build System report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -6,6 +6,7 @@
 
 ## opensearch
 
+- [Gradle Build System](opensearch/gradle-build-system.md)
 - [Java Runtime & JPMS](opensearch/java-runtime-and-jpms.md)
 - [Lucene 10 Upgrade](opensearch/lucene-10-upgrade.md)
 - [Merge & Segment Settings](opensearch/merge-segment-settings.md)

--- a/docs/features/opensearch/gradle-build-system.md
+++ b/docs/features/opensearch/gradle-build-system.md
@@ -1,0 +1,137 @@
+# Gradle Build System
+
+## Summary
+
+The Gradle Build System feature modernizes OpenSearch's dependency management by migrating from the legacy `buildSrc/version.properties` file to Gradle's native version catalog (`gradle/libs.versions.toml`). This enables automated dependency updates via Dependabot, centralizes version management, and simplifies build configurations across the project.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Version Catalog System"
+        VC[gradle/libs.versions.toml]
+        
+        subgraph "Sections"
+            VS[versions]
+            LB[libraries]
+            BN[bundles]
+        end
+        
+        VC --> VS
+        VC --> LB
+        VC --> BN
+    end
+    
+    subgraph "Consumers"
+        SRV[server/build.gradle]
+        PLG[plugins/*/build.gradle]
+        MOD[modules/*/build.gradle]
+    end
+    
+    subgraph "Automation"
+        DB[Dependabot]
+        PR[Auto PRs]
+    end
+    
+    LB --> SRV
+    LB --> PLG
+    LB --> MOD
+    BN --> SRV
+    BN --> PLG
+    BN --> MOD
+    
+    VC --> DB
+    DB --> PR
+    PR --> VC
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Dependency Update Flow"
+        DB[Dependabot] -->|Scans| VC[libs.versions.toml]
+        VC -->|New version found| PR[Pull Request]
+        PR -->|Merged| VC
+        VC -->|Provides versions| BG[build.gradle]
+        BG -->|Downloads| DEP[Dependencies]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `gradle/libs.versions.toml` | Central version catalog file in TOML format |
+| `[versions]` section | Defines version variables for dependencies |
+| `[libraries]` section | Defines library coordinates with version references |
+| `[bundles]` section | Groups related libraries for convenient import |
+| Dependabot | GitHub's automated dependency update service |
+
+### Configuration
+
+The version catalog (`gradle/libs.versions.toml`) structure:
+
+| Section | Purpose | Example |
+|---------|---------|---------|
+| `[versions]` | Define version variables | `netty = "4.2.9.Final"` |
+| `[libraries]` | Define library coordinates | `netty-buffer = { group = "io.netty", name = "netty-buffer", version.ref = "netty" }` |
+| `[bundles]` | Group related libraries | `netty = ["netty-buffer", "netty-codec", ...]` |
+
+### Usage Example
+
+Version catalog definition:
+```toml
+[versions]
+netty = "4.2.9.Final"
+reactor_netty = "1.3.1"
+
+[libraries]
+netty-buffer = { group = "io.netty", name = "netty-buffer", version.ref = "netty" }
+netty-codec = { group = "io.netty", name = "netty-codec", version.ref = "netty" }
+reactor-netty-core = { group = "io.projectreactor.netty", name = "reactor-netty-core", version.ref = "reactor_netty" }
+
+[bundles]
+netty = ["netty-buffer", "netty-codec"]
+```
+
+Using in build.gradle:
+```groovy
+dependencies {
+    // Single library
+    api libs.netty.buffer
+    
+    // Bundle (multiple libraries)
+    api libs.bundles.netty
+    
+    // Test dependencies
+    testImplementation libs.reactor.test
+}
+```
+
+## Limitations
+
+- Incremental migration: Not all modules have been converted to use the version catalog
+- Some dependencies may still reference `buildSrc/version.properties`
+- Dependabot only monitors dependencies in the version catalog, not legacy properties files
+- Bundle changes require updating both the catalog and consuming build files
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17233](https://github.com/opensearch-project/OpenSearch/pull/17233) | Convert transport-reactor-netty4 to use gradle version catalog |
+| v2.19.0 | [#16284](https://github.com/opensearch-project/OpenSearch/pull/16284) | Initial implementation of Gradle version catalog |
+
+## References
+
+- [Issue #3782](https://github.com/opensearch-project/OpenSearch/issues/3782): Original feature request for Dependabot support
+- [Gradle Version Catalogs](https://docs.gradle.org/current/userguide/platforms.html): Official Gradle documentation
+- [Dependabot Gradle Support](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#gradle): GitHub Dependabot configuration
+
+## Change History
+
+- **v3.0.0** (2025-02-06): Added Netty and Reactor Netty bundles, converted transport-reactor-netty4 plugin
+- **v2.19.0** (2024-10-28): Initial implementation of Gradle version catalog, migrated core dependencies from buildSrc/version.properties

--- a/docs/releases/v3.0.0/features/opensearch/gradle-build-system.md
+++ b/docs/releases/v3.0.0/features/opensearch/gradle-build-system.md
@@ -1,0 +1,125 @@
+# Gradle Build System
+
+## Summary
+
+This release item continues the migration of OpenSearch modules to use the Gradle version catalog (`gradle/libs.versions.toml`) instead of the legacy `buildSrc/version.properties` file. Specifically, PR #17233 converts the `transport-reactor-netty4` plugin to use the version catalog, adding Netty and Reactor dependencies to the centralized catalog.
+
+## Details
+
+### What's New in v3.0.0
+
+The `transport-reactor-netty4` plugin has been migrated to use the Gradle version catalog, which:
+
+- Adds Netty library bundles to the version catalog
+- Adds Reactor Netty dependencies to the catalog
+- Simplifies the plugin's `build.gradle` by using catalog references
+- Enables Dependabot to monitor and create automated dependency update PRs for these libraries
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before (Legacy)"
+        VP[buildSrc/version.properties]
+        BG1[build.gradle files]
+        VP --> BG1
+    end
+    
+    subgraph "After (Version Catalog)"
+        VC[gradle/libs.versions.toml]
+        BG2[build.gradle files]
+        DB[Dependabot]
+        VC --> BG2
+        VC --> DB
+        DB -->|Auto PRs| VC
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `libs.bundles.netty` | Bundle containing all Netty dependencies |
+| `libs.bundles.reactornetty` | Bundle containing Reactor Netty core and HTTP |
+| `libs.log4jslf4jimpl` | Log4j SLF4J implementation reference |
+| `libs.reactor.test` | Reactor test library reference |
+
+#### New Configuration
+
+The following entries were added to `gradle/libs.versions.toml`:
+
+| Setting | Description | Version |
+|---------|-------------|---------|
+| `netty-buffer` | Netty buffer library | `${netty}` |
+| `netty-codec` | Netty codec library | `${netty}` |
+| `netty-codec-dns` | Netty DNS codec | `${netty}` |
+| `netty-codec-http` | Netty HTTP codec | `${netty}` |
+| `netty-codec-http2` | Netty HTTP/2 codec | `${netty}` |
+| `netty-common` | Netty common utilities | `${netty}` |
+| `netty-handler` | Netty handler | `${netty}` |
+| `netty-resolver-dns` | Netty DNS resolver | `${netty}` |
+| `netty-resolver` | Netty resolver | `${netty}` |
+| `netty-transport` | Netty transport | `${netty}` |
+| `netty-transport-native-unix-common` | Netty Unix transport | `${netty}` |
+| `reactor-netty-core` | Reactor Netty core | `${reactor_netty}` |
+| `reactor-netty-http` | Reactor Netty HTTP | `${reactor_netty}` |
+| `reactor-test` | Reactor test utilities | `${reactor}` |
+| `log4jslf4jimpl` | Log4j SLF4J implementation | `${log4j}` |
+
+### Usage Example
+
+Before (legacy approach):
+```groovy
+dependencies {
+  api "io.netty:netty-buffer:${versions.netty}"
+  api "io.netty:netty-codec:${versions.netty}"
+  api "io.netty:netty-codec-http:${versions.netty}"
+  // ... many more individual declarations
+  api "io.projectreactor.netty:reactor-netty-http:${versions.reactor_netty}"
+  api "io.projectreactor.netty:reactor-netty-core:${versions.reactor_netty}"
+}
+```
+
+After (version catalog):
+```groovy
+dependencies {
+  api libs.bundles.netty
+  api libs.bundles.reactornetty
+  testImplementation libs.log4jslf4jimpl
+  javaRestTestImplementation libs.reactor.test
+}
+```
+
+### Migration Notes
+
+For plugin developers migrating to the version catalog:
+
+1. Add library entries to `gradle/libs.versions.toml` under `[libraries]`
+2. Create bundles under `[bundles]` for related dependencies
+3. Replace version string references with `libs.<library-name>` or `libs.bundles.<bundle-name>`
+4. Remove corresponding entries from `buildSrc/version.properties` if no longer needed
+
+## Limitations
+
+- The migration is incremental; not all modules have been converted yet
+- Some dependencies may still use the legacy `versions.properties` approach
+- Dependabot can only monitor dependencies listed in the version catalog
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17233](https://github.com/opensearch-project/OpenSearch/pull/17233) | Convert transport-reactor-netty4 to use gradle version catalog |
+| [#16284](https://github.com/opensearch-project/OpenSearch/pull/16284) | Initial implementation of Gradle version catalog |
+
+## References
+
+- [Issue #3782](https://github.com/opensearch-project/OpenSearch/issues/3782): Original feature request for Dependabot support
+- [Gradle Version Catalogs](https://docs.gradle.org/current/userguide/platforms.html): Official Gradle documentation
+- [Dependabot Gradle Support](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#gradle): GitHub Dependabot configuration
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/gradle-build-system.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -6,6 +6,7 @@
 
 ## opensearch
 
+- [Gradle Build System](features/opensearch/gradle-build-system.md)
 - [Java Runtime & JPMS](features/opensearch/java-runtime-and-jpms.md)
 - [Lucene 10 Upgrade](features/opensearch/lucene-10-upgrade.md)
 - [Merge & Segment Settings](features/opensearch/merge-segment-settings.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Gradle Build System feature in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/gradle-build-system.md`
- Feature report: `docs/features/opensearch/gradle-build-system.md`

### Key Changes in v3.0.0
- Converted `transport-reactor-netty4` plugin to use Gradle version catalog
- Added Netty library bundles to the version catalog
- Added Reactor Netty dependencies to the catalog
- Enables Dependabot to monitor and create automated dependency update PRs

### Related Issue
Closes #259