### PR TITLE
docs: add Stream Input/Output report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -10,6 +10,7 @@
 - [Java Runtime & JPMS](opensearch/java-runtime-and-jpms.md)
 - [Lucene 10 Upgrade](opensearch/lucene-10-upgrade.md)
 - [Merge & Segment Settings](opensearch/merge-segment-settings.md)
+- [Stream Input/Output](opensearch/stream-inputoutput.md)
 
 ## opensearch-dashboards
 

--- a/docs/features/opensearch/stream-inputoutput.md
+++ b/docs/features/opensearch/stream-inputoutput.md
@@ -1,0 +1,150 @@
+# Stream Input/Output
+
+## Summary
+
+`StreamInput` and `StreamOutput` are core OpenSearch classes that handle binary serialization and deserialization of data for inter-node communication. These classes provide methods to read and write various data types efficiently across the cluster, including primitives, collections, enums, and custom `Writeable` objects.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Node Communication"
+        N1[Node 1] -->|StreamOutput| Wire[Network Wire]
+        Wire -->|StreamInput| N2[Node 2]
+    end
+    
+    subgraph "StreamOutput"
+        SO[StreamOutput] --> WP[Write Primitives]
+        SO --> WC[Write Collections]
+        SO --> WE[Write Enums/EnumSets]
+        SO --> WW[Write Writeables]
+    end
+    
+    subgraph "StreamInput"
+        SI[StreamInput] --> RP[Read Primitives]
+        SI --> RC[Read Collections]
+        SI --> RE[Read Enums/EnumSets]
+        SI --> RW[Read Writeables]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Serialization
+        A[Java Object] --> B[StreamOutput]
+        B --> C[Byte Stream]
+    end
+    
+    subgraph Network
+        C --> D[Transport Layer]
+    end
+    
+    subgraph Deserialization
+        D --> E[StreamInput]
+        E --> F[Java Object]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `StreamInput` | Abstract class for reading binary data from a stream |
+| `StreamOutput` | Abstract class for writing binary data to a stream |
+| `BytesStreamOutput` | Concrete implementation writing to a byte array |
+| `InputStreamStreamInput` | Concrete implementation reading from an InputStream |
+| `Writeable` | Interface for objects that can serialize themselves |
+| `NamedWriteable` | Extension of Writeable with a name for registry lookup |
+
+### Configuration
+
+Stream classes are internal infrastructure and do not have user-configurable settings. They are used automatically by OpenSearch for all inter-node communication.
+
+### Key Methods
+
+#### Primitive Types
+
+| StreamOutput | StreamInput | Description |
+|--------------|-------------|-------------|
+| `writeByte(byte)` | `readByte()` | Single byte |
+| `writeInt(int)` | `readInt()` | 4-byte integer |
+| `writeVInt(int)` | `readVInt()` | Variable-length integer |
+| `writeLong(long)` | `readLong()` | 8-byte long |
+| `writeString(String)` | `readString()` | UTF-8 string |
+| `writeBoolean(boolean)` | `readBoolean()` | Boolean value |
+
+#### Collections
+
+| StreamOutput | StreamInput | Description |
+|--------------|-------------|-------------|
+| `writeStringCollection(Collection)` | `readStringList()` | String collection |
+| `writeList(List)` | `readList(Reader)` | Generic list |
+| `writeMap(Map, Writer, Writer)` | `readMap(Reader, Reader)` | Generic map |
+| `writeEnumSet(EnumSet)` | `readEnumSet(Class)` | EnumSet |
+| `writeOptionalEnumSet(EnumSet)` | `readOptionalEnumSet(Class)` | Optional EnumSet (v3.0.0+) |
+
+#### Optional Values
+
+| StreamOutput | StreamInput | Description |
+|--------------|-------------|-------------|
+| `writeOptionalString(String)` | `readOptionalString()` | Nullable string |
+| `writeOptionalInt(Integer)` | `readOptionalInt()` | Nullable integer |
+| `writeOptionalWriteable(Writeable)` | `readOptionalWriteable(Reader)` | Nullable writeable |
+| `writeOptionalEnumSet(EnumSet)` | `readOptionalEnumSet(Class)` | Nullable EnumSet (v3.0.0+) |
+
+### Usage Example
+
+```java
+// Implementing Writeable interface
+public class MyRequest implements Writeable {
+    private final String name;
+    private final EnumSet<MyOption> options;
+    
+    public MyRequest(StreamInput in) throws IOException {
+        this.name = in.readString();
+        this.options = in.readOptionalEnumSet(MyOption.class);
+    }
+    
+    @Override
+    public void writeTo(StreamOutput out) throws IOException {
+        out.writeString(name);
+        out.writeOptionalEnumSet(options);
+    }
+}
+
+// Using BytesStreamOutput for testing
+BytesStreamOutput out = new BytesStreamOutput();
+out.writeString("test");
+out.writeOptionalEnumSet(EnumSet.of(MyOption.A, MyOption.B));
+
+StreamInput in = out.bytes().streamInput();
+String name = in.readString();
+EnumSet<MyOption> options = in.readOptionalEnumSet(MyOption.class);
+```
+
+## Limitations
+
+- Stream classes are designed for internal use and are not part of the public REST API
+- Version compatibility must be maintained when adding new serialization methods
+- The `readOptionalEnumSet` method returns an empty EnumSet (not null) when null/empty was written
+- Enum class must be provided at read time due to Java type erasure
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17556](https://github.com/opensearch-project/OpenSearch/pull/17556) | Add optional enum set read/write functionality |
+
+## References
+
+- [StreamInput.java](https://github.com/opensearch-project/OpenSearch/blob/main/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamInput.java): Source code
+- [StreamOutput.java](https://github.com/opensearch-project/OpenSearch/blob/main/libs/core/src/main/java/org/opensearch/core/common/io/stream/StreamOutput.java): Source code
+- [ml-commons MLStatsInput](https://github.com/opensearch-project/ml-commons/blob/main/plugin/src/main/java/org/opensearch/ml/stats/MLStatsInput.java): Example usage in plugin
+
+## Change History
+
+- **v3.0.0** (2025-03-13): Added `writeOptionalEnumSet` and `readOptionalEnumSet` methods for optional EnumSet serialization

--- a/docs/releases/v3.0.0/features/opensearch/stream-inputoutput.md
+++ b/docs/releases/v3.0.0/features/opensearch/stream-inputoutput.md
@@ -1,0 +1,135 @@
+# Stream Input/Output
+
+## Summary
+
+OpenSearch v3.0.0 adds optional EnumSet read/write methods to `StreamInput` and `StreamOutput` classes. This enhancement provides a standardized way to serialize and deserialize optional `EnumSet` collections across the cluster, eliminating the need for plugin-specific helper methods.
+
+## Details
+
+### What's New in v3.0.0
+
+Two new methods have been added to the core streaming API:
+
+- `StreamInput.readOptionalEnumSet(Class<E> enumClass)` - Reads an optional EnumSet from the stream
+- `StreamOutput.writeOptionalEnumSet(EnumSet<E> enumSet)` - Writes an optional EnumSet to the stream
+
+### Technical Changes
+
+#### New API Methods
+
+| Class | Method | Description |
+|-------|--------|-------------|
+| `StreamInput` | `readOptionalEnumSet(Class<E> enumClass)` | Reads an optional EnumSet; returns empty set if null/empty was written |
+| `StreamOutput` | `writeOptionalEnumSet(EnumSet<E> enumSet)` | Writes an optional EnumSet; writes `false` for null or empty sets |
+
+#### Serialization Format
+
+```mermaid
+flowchart LR
+    subgraph Write
+        A[EnumSet] --> B{null or empty?}
+        B -->|Yes| C[Write false]
+        B -->|No| D[Write true]
+        D --> E[Write EnumSet via writeEnumSet]
+    end
+    
+    subgraph Read
+        F[Read boolean] --> G{true?}
+        G -->|Yes| H[Read EnumSet via readEnumSet]
+        G -->|No| I[Return empty EnumSet]
+    end
+```
+
+#### Implementation Details
+
+The implementation follows the existing pattern for optional collection serialization:
+
+**StreamOutput.writeOptionalEnumSet:**
+```java
+public <E extends Enum<E>> void writeOptionalEnumSet(@Nullable EnumSet<E> enumSet) throws IOException {
+    if (enumSet != null && enumSet.size() > 0) {
+        writeBoolean(true);
+        writeEnumSet(enumSet);
+    } else {
+        writeBoolean(false);
+    }
+}
+```
+
+**StreamInput.readOptionalEnumSet:**
+```java
+public <E extends Enum<E>> EnumSet<E> readOptionalEnumSet(Class<E> enumClass) throws IOException {
+    if (readBoolean()) {
+        return readEnumSet(enumClass);
+    } else {
+        return EnumSet.noneOf(enumClass);
+    }
+}
+```
+
+### Usage Example
+
+```java
+// Define an enum
+public enum NodeStat {
+    CPU,
+    MEMORY,
+    DISK,
+    NETWORK
+}
+
+// Writing optional EnumSet
+EnumSet<NodeStat> stats = EnumSet.of(NodeStat.CPU, NodeStat.MEMORY);
+streamOutput.writeOptionalEnumSet(stats);
+
+// Writing null/empty
+streamOutput.writeOptionalEnumSet(null);  // writes false
+streamOutput.writeOptionalEnumSet(EnumSet.noneOf(NodeStat.class));  // writes false
+
+// Reading optional EnumSet
+EnumSet<NodeStat> readStats = streamInput.readOptionalEnumSet(NodeStat.class);
+// Returns EnumSet with values if present, or empty EnumSet if null/empty was written
+```
+
+### Migration Notes
+
+Plugins that previously implemented custom helper methods for optional EnumSet serialization can now use the core API methods:
+
+**Before (plugin-specific):**
+```java
+// ml-commons MLStatsInput pattern
+private void writeOptionalEnumSet(StreamOutput out, EnumSet<?> set) {
+    if (set != null && !set.isEmpty()) {
+        out.writeBoolean(true);
+        out.writeEnumSet(set);
+    } else {
+        out.writeBoolean(false);
+    }
+}
+```
+
+**After (using core API):**
+```java
+out.writeOptionalEnumSet(enumSet);
+EnumSet<MyEnum> result = in.readOptionalEnumSet(MyEnum.class);
+```
+
+## Limitations
+
+- When reading a null or empty EnumSet, the method returns an empty `EnumSet.noneOf(enumClass)` rather than `null`. This is consistent with other optional collection readers in OpenSearch.
+- The enum class must be provided when reading, as Java's type erasure prevents runtime type inference.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17556](https://github.com/opensearch-project/OpenSearch/pull/17556) | Add read and write optional enum sets methods to stream input and output |
+
+## References
+
+- [ml-commons MLStatsInput](https://github.com/opensearch-project/ml-commons/blob/main/plugin/src/main/java/org/opensearch/ml/stats/MLStatsInput.java#L142): Example of plugin-specific implementation being consolidated
+- [neural-search NeuralStatsInput PR](https://github.com/opensearch-project/neural-search/pull/1208): Related use case in neural-search plugin
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/stream-inputoutput.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -10,6 +10,7 @@
 - [Java Runtime & JPMS](features/opensearch/java-runtime-and-jpms.md)
 - [Lucene 10 Upgrade](features/opensearch/lucene-10-upgrade.md)
 - [Merge & Segment Settings](features/opensearch/merge-segment-settings.md)
+- [Stream Input/Output](features/opensearch/stream-inputoutput.md)
 
 ## opensearch-dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Stream Input/Output enhancement in OpenSearch v3.0.0.

### Changes

- **Release report**: `docs/releases/v3.0.0/features/opensearch/stream-inputoutput.md`
- **Feature report**: `docs/features/opensearch/stream-inputoutput.md`
- Updated release and feature indexes

### Feature Overview

OpenSearch v3.0.0 adds optional EnumSet read/write methods to `StreamInput` and `StreamOutput` classes:

- `StreamInput.readOptionalEnumSet(Class<E> enumClass)`
- `StreamOutput.writeOptionalEnumSet(EnumSet<E> enumSet)`

This provides a standardized way to serialize optional EnumSet collections, eliminating the need for plugin-specific helper methods (previously used in ml-commons, neural-search, etc.).

### Related

- PR: [opensearch-project/OpenSearch#17556](https://github.com/opensearch-project/OpenSearch/pull/17556)
- Issue: #258