### PR TITLE
docs: add wildcard-field report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -12,6 +12,7 @@
 - [Lucene 10 Upgrade](opensearch/lucene-10-upgrade.md)
 - [Merge & Segment Settings](opensearch/merge-segment-settings.md)
 - [Stream Input/Output](opensearch/stream-inputoutput.md)
+- [Wildcard Field](opensearch/wildcard-field.md)
 
 ## opensearch-dashboards
 

--- a/docs/features/opensearch/wildcard-field.md
+++ b/docs/features/opensearch/wildcard-field.md
@@ -1,0 +1,157 @@
+# Wildcard Field
+
+## Summary
+
+The wildcard field type is a specialized string field designed for efficient wildcard (`*`), prefix, and regular expression queries on arbitrary substrings. Unlike standard `text` fields that tokenize content, wildcard fields use n-gram indexing to enable fast pattern matching without token boundaries, making them ideal for log analysis, code search, and other use cases where substring matching is required.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Indexing"
+        Input[Input String] --> Tokenizer[WildcardFieldTokenizer]
+        Tokenizer --> NGrams[3-gram Tokens]
+        NGrams --> Index[Inverted Index]
+    end
+    
+    subgraph "Querying"
+        Query[Wildcard Query] --> Extract[Extract Required N-grams]
+        Extract --> Candidate[Candidate Document Filter]
+        Candidate --> Verify[Second-Phase Verification]
+        Verify --> Results[Final Results]
+    end
+    
+    Index --> Candidate
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Document] --> B[Wildcard Field Mapper]
+    B --> C[N-gram Tokenizer]
+    C --> D[Index Terms]
+    
+    E[Search Query] --> F[Pattern Analysis]
+    F --> G[N-gram Extraction]
+    G --> H[Index Lookup]
+    H --> I[Candidate Docs]
+    I --> J[Pattern Verification]
+    J --> K[Results]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `WildcardFieldMapper` | Main field mapper that handles indexing and query building |
+| `WildcardFieldTokenizer` | Custom tokenizer that generates 3-gram tokens with anchors |
+| `WildcardFieldType` | Field type implementation with query methods |
+| `WildcardMatchingQuery` | Two-phase query with approximation and verification |
+
+### How It Works
+
+1. **Indexing**: Input strings are split into overlapping 3-character sequences (trigrams) with special anchor characters (null bytes) marking string boundaries
+2. **Query Processing**: Search patterns are analyzed to extract required n-grams
+3. **Two-Phase Search**: 
+   - First phase: Fast index lookup for candidate documents containing required n-grams
+   - Second phase: Exact pattern matching against source values to filter false positives
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `doc_values` | Enable doc values for aggregations/sorting | `false` |
+| `ignore_above` | Maximum string length to index | `2147483647` |
+| `normalizer` | Normalizer for preprocessing (e.g., `lowercase`) | none |
+| `null_value` | Value to use for null fields | `null` |
+
+### Usage Example
+
+Create an index with a wildcard field:
+
+```json
+PUT logs
+{
+  "mappings": {
+    "properties": {
+      "log_line": {
+        "type": "wildcard",
+        "fields": {
+          "lower": {
+            "type": "wildcard",
+            "normalizer": "lowercase"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Index documents:
+
+```json
+POST logs/_bulk
+{"index": {"_id": 1}}
+{"log_line": "org.opensearch.transport.NodeDisconnectedException: [node_s0] disconnected"}
+{"index": {"_id": 2}}
+{"log_line": "[2024-06-08T06:31:37,443][INFO] cluster-manager node failed"}
+```
+
+Search with wildcard patterns:
+
+```json
+GET logs/_search
+{
+  "query": {
+    "wildcard": {
+      "log_line": {
+        "value": "*Exception*disconnected*"
+      }
+    }
+  }
+}
+```
+
+Case-insensitive search using the normalized sub-field:
+
+```json
+GET logs/_search
+{
+  "query": {
+    "wildcard": {
+      "log_line.lower": {
+        "value": "*exception*"
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- **Exact match queries**: `term` and `terms` queries are less efficient on wildcard fields compared to `keyword` fields
+- **Short patterns**: Patterns with fewer than 3 consecutive non-wildcard characters may result in broader index scans
+- **Storage overhead**: While optimized in v3.0.0, wildcard fields still require more storage than keyword fields due to n-gram indexing
+- **Not for full-text search**: Wildcard fields don't support full-text analysis; use `text` fields for natural language content
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17349](https://github.com/opensearch-project/OpenSearch/pull/17349) | Optimize to 3-gram only indexing |
+| v2.15.0 | Initial | Wildcard field type introduction |
+
+## References
+
+- [Wildcard Field Documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/wildcard/): Official documentation
+- [Issue #17099](https://github.com/opensearch-project/OpenSearch/issues/17099): 3-gram optimization feature request with benchmarks
+- [OpenSearch 2.15 Blog](https://opensearch.org/blog/diving-into-opensearch-2-15/): Initial feature announcement
+
+## Change History
+
+- **v3.0.0** (2025): Changed indexing strategy from 1-3 gram to 3-gram only, reducing index size by ~20% and improving write throughput by 5-30%
+- **v2.15.0** (2024): Initial introduction of wildcard field type with 1-3 gram indexing

--- a/docs/releases/v3.0.0/features/opensearch/wildcard-field.md
+++ b/docs/releases/v3.0.0/features/opensearch/wildcard-field.md
@@ -1,0 +1,129 @@
+# Wildcard Field 3-gram Indexing Optimization
+
+## Summary
+
+OpenSearch v3.0.0 optimizes the wildcard field type by changing the indexing strategy from 1-3 gram to 3-gram only. This reduces index size by approximately 20% and improves write throughput by 5-25%, while maintaining equivalent search performance for wildcard, prefix, and regexp queries.
+
+## Details
+
+### What's New in v3.0.0
+
+The wildcard field type now indexes only 3-grams (trigrams) instead of the previous 1-3 gram approach. This optimization was driven by benchmark results showing that single and double character n-grams create long posting lists that don't significantly improve search performance but substantially increase storage requirements.
+
+### Technical Changes
+
+#### Indexing Strategy Change
+
+```mermaid
+flowchart LR
+    subgraph "Previous (1-3 gram)"
+        A1[Input: 'lucene'] --> B1[Tokens: l, lu, luc, u, uc, uce, c, ce, cen, e, en, ene, n, ne, e]
+    end
+    subgraph "New (3-gram only)"
+        A2[Input: 'lucene'] --> B2[Tokens: luc, uce, cen, ene + anchors]
+    end
+```
+
+#### Token Generation
+
+For the string "lucene", the new tokenizer emits:
+- `[0, 0, 'l']` - prefix anchor
+- `[0, 'l', 'u']` - prefix anchor
+- `['l', 'u', 'c']` - trigram
+- `['u', 'c', 'e']` - trigram
+- `['c', 'e', 'n']` - trigram
+- `['e', 'n', 'e']` - trigram
+- `['n', 'e', 0]` - suffix anchor
+- `['e', 0, 0]` - suffix anchor
+
+The `NGRAM_SIZE` constant is set to 3, and all tokens are now exactly 3 characters with zero-valued anchors for prefix/suffix boundaries.
+
+#### Modified Components
+
+| Component | Description |
+|-----------|-------------|
+| `WildcardFieldMapper.java` | Core mapper with updated tokenizer logic |
+| `WildcardFieldTokenizer` | Simplified to emit only 3-grams |
+| `getRequiredNGrams()` | Updated query term extraction for 3-gram matching |
+
+#### Query Behavior Changes
+
+When searching with patterns containing fewer than 3 non-wildcard characters, the query falls back to an existence check rather than attempting to match short n-grams:
+
+```java
+if (findNonWildcardSequence(value, 0) != value.length() || value.length() == 0 || value.contains("?")) {
+    approximation = this.existsQuery(context);
+}
+```
+
+### Performance Improvements
+
+Based on benchmark testing from Issue #17099:
+
+| Metric | 1-3 gram | 3-gram only | Improvement |
+|--------|----------|-------------|-------------|
+| Write throughput (http_logs) | 194,174 docs/s | 206,403 docs/s | +6.3% |
+| Write throughput (treccovid) | 1,130 docs/s | 1,469 docs/s | +30% |
+| Index size (doc files) | 9 GB | 4.69 GB | -48% |
+| Total index size | 22.1 GB | 17.7 GB | -20% |
+
+Search performance remains comparable, with some queries showing slight improvements due to shorter posting lists.
+
+### Usage Example
+
+The wildcard field type usage remains unchanged:
+
+```json
+PUT logs
+{
+  "mappings": {
+    "properties": {
+      "log_line": {
+        "type": "wildcard"
+      }
+    }
+  }
+}
+```
+
+Queries work the same way:
+
+```json
+GET logs/_search
+{
+  "query": {
+    "wildcard": {
+      "log_line": {
+        "value": "*Exception*"
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- **Breaking Change**: Indexes created with v3.0.0 use the new 3-gram only format
+- **Rolling Upgrade**: The PR includes rolling upgrade tests to ensure compatibility during cluster upgrades
+- Existing indexes created with previous versions will continue to work but won't benefit from the storage reduction until reindexed
+
+## Limitations
+
+- Search patterns with fewer than 3 consecutive non-wildcard characters may have slightly different performance characteristics
+- The optimization is most beneficial for longer strings; very short field values may not see significant storage savings
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17349](https://github.com/opensearch-project/OpenSearch/pull/17349) | Wildcard field use only 3-gram to index |
+
+## References
+
+- [Issue #17099](https://github.com/opensearch-project/OpenSearch/issues/17099): Feature request with benchmark data
+- [Wildcard Field Documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/wildcard/): Official documentation
+- [OpenSearch 2.15 Blog](https://opensearch.org/blog/diving-into-opensearch-2-15/): Initial wildcard field introduction
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/wildcard-field.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -12,6 +12,7 @@
 - [Lucene 10 Upgrade](features/opensearch/lucene-10-upgrade.md)
 - [Merge & Segment Settings](features/opensearch/merge-segment-settings.md)
 - [Stream Input/Output](features/opensearch/stream-inputoutput.md)
+- [Wildcard Field](features/opensearch/wildcard-field.md)
 
 ## opensearch-dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Wildcard Field 3-gram indexing optimization in OpenSearch v3.0.0.

## Changes

### Release Report
- `docs/releases/v3.0.0/features/opensearch/wildcard-field.md`
  - Documents the change from 1-3 gram to 3-gram only indexing
  - Includes performance benchmarks showing ~20% storage reduction and 5-30% write throughput improvement
  - Technical details on tokenizer changes and query behavior

### Feature Report
- `docs/features/opensearch/wildcard-field.md`
  - Comprehensive documentation of the wildcard field type
  - Architecture diagrams showing indexing and query flow
  - Configuration options and usage examples
  - Change history tracking the evolution from v2.15.0 to v3.0.0

## Related
- Closes #256
- PR: opensearch-project/OpenSearch#17349
- Issue: opensearch-project/OpenSearch#17099