### PR TITLE
docs: add Lucene Similarity report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -10,6 +10,7 @@
 - [Gradle Build System](opensearch/gradle-build-system.md)
 - [Java Runtime & JPMS](opensearch/java-runtime-and-jpms.md)
 - [Lucene 10 Upgrade](opensearch/lucene-10-upgrade.md)
+- [Lucene Similarity](opensearch/lucene-similarity.md)
 - [Merge & Segment Settings](opensearch/merge-segment-settings.md)
 - [Stream Input/Output](opensearch/stream-inputoutput.md)
 - [Wildcard Field](opensearch/wildcard-field.md)

--- a/docs/features/opensearch/lucene-similarity.md
+++ b/docs/features/opensearch/lucene-similarity.md
@@ -1,0 +1,164 @@
+# Lucene Similarity
+
+## Summary
+
+OpenSearch uses similarity algorithms to calculate relevance scores for text search. The similarity algorithm determines how documents are ranked based on term frequency, document length, and inverse document frequency. Starting with v3.0.0, OpenSearch defaults to Lucene's native `BM25Similarity` instead of the custom `LegacyBM25Similarity`.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Query Processing"
+        Q[Search Query] --> A[Analyzer]
+        A --> T[Terms]
+    end
+    
+    subgraph "Similarity Calculation"
+        T --> S[Similarity Algorithm]
+        S --> IDF[IDF: Inverse Document Frequency]
+        S --> TF[TF: Term Frequency]
+        S --> DL[Document Length Normalization]
+        IDF --> Score
+        TF --> Score
+        DL --> Score
+    end
+    
+    subgraph "Available Algorithms"
+        BM25[BM25Similarity - Default]
+        Legacy[LegacyBM25Similarity]
+        Bool[BooleanSimilarity]
+        DFR[DFR Similarity]
+        IB[IB Similarity]
+    end
+    
+    Score --> R[Ranked Results]
+```
+
+### Similarity Types
+
+| Type | Description | Use Case |
+|------|-------------|----------|
+| `BM25` | Lucene's native BM25 implementation (default since v3.0.0) | General text search |
+| `LegacyBM25` | OpenSearch's previous BM25 implementation | Backward compatibility with v2.x |
+| `boolean` | Returns constant scores (1 or 0) | When only matching matters, not relevance |
+| `DFR` | Divergence from Randomness | Specialized ranking needs |
+| `IB` | Information-Based model | Specialized ranking needs |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `k1` | Controls term frequency saturation | `1.2` |
+| `b` | Controls document length normalization | `0.75` |
+| `discount_overlaps` | Whether to discount overlapping tokens | `true` |
+
+### BM25 Parameters
+
+- **k1**: Higher values increase the impact of term frequency. Range: 0 to 3 (typical)
+- **b**: Higher values penalize longer documents more. Range: 0 to 1
+  - `b=0`: No length normalization
+  - `b=1`: Full length normalization
+
+### Usage Example
+
+#### Default BM25 (v3.0.0+)
+
+```json
+PUT /my-index
+{
+  "mappings": {
+    "properties": {
+      "content": {
+        "type": "text"
+      }
+    }
+  }
+}
+```
+
+#### Custom BM25 Parameters
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "similarity": {
+        "custom_bm25": {
+          "type": "BM25",
+          "k1": 1.5,
+          "b": 0.8,
+          "discount_overlaps": false
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "content": {
+        "type": "text",
+        "similarity": "custom_bm25"
+      }
+    }
+  }
+}
+```
+
+#### Legacy BM25 (for v2.x compatibility)
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "similarity": {
+        "default": {
+          "type": "LegacyBM25",
+          "k1": 1.2,
+          "b": 0.75
+        }
+      }
+    }
+  }
+}
+```
+
+#### Boolean Similarity
+
+```json
+PUT /my-index
+{
+  "mappings": {
+    "properties": {
+      "tags": {
+        "type": "text",
+        "similarity": "boolean"
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Similarity settings are defined at index creation time and cannot be changed for existing fields
+- Different similarity algorithms produce different score ranges, making cross-index score comparison difficult
+- `LegacyBM25Similarity` is deprecated and may be removed in future versions
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17306](https://github.com/opensearch-project/OpenSearch/pull/17306) | Use Lucene `BM25Similarity` as default |
+
+## References
+
+- [Issue #17315](https://github.com/opensearch-project/OpenSearch/issues/17315): Original feature request
+- [Similarity Documentation](https://docs.opensearch.org/3.0/field-types/mapping-parameters/similarity/): Official OpenSearch docs
+- [Keyword Search Documentation](https://docs.opensearch.org/3.0/search-plugins/keyword-search/): BM25 configuration guide
+
+## Change History
+
+- **v3.0.0** (2025-02-12): Changed default similarity from `LegacyBM25Similarity` to Lucene's `BM25Similarity`. Added `LegacyBM25` type for backward compatibility.

--- a/docs/releases/v3.0.0/features/opensearch/lucene-similarity.md
+++ b/docs/releases/v3.0.0/features/opensearch/lucene-similarity.md
@@ -1,0 +1,124 @@
+# Lucene Similarity
+
+## Summary
+
+OpenSearch v3.0.0 changes the default similarity algorithm from `LegacyBM25Similarity` to Lucene's native `BM25Similarity`. This aligns OpenSearch with the upstream Lucene implementation and provides a cleaner, more standardized scoring approach. Users who need the previous behavior can explicitly configure `LegacyBM25` similarity.
+
+## Details
+
+### What's New in v3.0.0
+
+The default similarity for text fields has been switched from OpenSearch's `LegacyBM25Similarity` to Lucene's `BM25Similarity`. This change:
+
+- Adopts Lucene's modern BM25 implementation as the default
+- Deprecates `LegacyBM25Similarity` while keeping it available for backward compatibility
+- Introduces a new `LegacyBM25` similarity type for users who need the previous behavior
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "v2.x Default"
+        A[Text Field] --> B[LegacyBM25Similarity]
+        B --> C[Score Calculation]
+    end
+    
+    subgraph "v3.0.0 Default"
+        D[Text Field] --> E[BM25Similarity]
+        E --> F[Score Calculation]
+    end
+    
+    subgraph "v3.0.0 Optional"
+        G[Text Field] --> H[LegacyBM25 Config]
+        H --> I[LegacyBM25Similarity]
+        I --> J[Score Calculation]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `BM25Similarity` | Lucene's native BM25 implementation, now the default |
+| `LegacyBM25` type | New similarity type to explicitly use the legacy implementation |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.similarity.default.type` | Similarity algorithm for the index | `BM25` |
+| `LegacyBM25` type | Use legacy BM25 implementation | N/A |
+
+### Usage Example
+
+To use the legacy BM25 similarity (previous default behavior):
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "similarity": {
+        "default": {
+          "type": "LegacyBM25",
+          "k1": 1.2,
+          "b": 0.75
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "content": {
+        "type": "text"
+      }
+    }
+  }
+}
+```
+
+To use the new default (Lucene BM25), no configuration is needed:
+
+```json
+PUT /my-index
+{
+  "mappings": {
+    "properties": {
+      "content": {
+        "type": "text"
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- **New indexes**: Will automatically use `BM25Similarity` (Lucene's implementation)
+- **Existing indexes**: Retain their configured similarity settings
+- **Score differences**: While the core ranking behavior is similar, exact scores may differ slightly between implementations
+- **Explicit configuration**: If you need consistent scoring with v2.x, explicitly set `LegacyBM25` as the similarity type
+
+## Limitations
+
+- Exact relevance scores may differ between `BM25Similarity` and `LegacyBM25Similarity`
+- The `LegacyBM25Similarity` class is marked as deprecated and may be removed in future versions
+- Mixed clusters during rolling upgrades may produce inconsistent scores if indexes use different defaults
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17306](https://github.com/opensearch-project/OpenSearch/pull/17306) | Use Lucene `BM25Similarity` as default |
+
+## References
+
+- [Issue #17315](https://github.com/opensearch-project/OpenSearch/issues/17315): Deprecate `LegacyBM25Similarity` and default to `BM25Similarity`
+- [Lucene Issue #9609](https://github.com/apache/lucene/issues/9609): Related Lucene discussion
+- [Similarity Documentation](https://docs.opensearch.org/3.0/field-types/mapping-parameters/similarity/): Official OpenSearch docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/lucene-similarity.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -10,6 +10,7 @@
 - [Gradle Build System](features/opensearch/gradle-build-system.md)
 - [Java Runtime & JPMS](features/opensearch/java-runtime-and-jpms.md)
 - [Lucene 10 Upgrade](features/opensearch/lucene-10-upgrade.md)
+- [Lucene Similarity](features/opensearch/lucene-similarity.md)
 - [Merge & Segment Settings](features/opensearch/merge-segment-settings.md)
 - [Stream Input/Output](features/opensearch/stream-inputoutput.md)
 - [Wildcard Field](features/opensearch/wildcard-field.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Lucene Similarity feature in OpenSearch v3.0.0.

### Changes
- **Release report**: `docs/releases/v3.0.0/features/opensearch/lucene-similarity.md`
- **Feature report**: `docs/features/opensearch/lucene-similarity.md`
- Updated index files

### Key Points
- OpenSearch v3.0.0 changes the default similarity from `LegacyBM25Similarity` to Lucene's native `BM25Similarity`
- Users can still use `LegacyBM25` type for backward compatibility
- The change aligns OpenSearch with upstream Lucene implementation

### Related
- Closes #255
- PR: opensearch-project/OpenSearch#17306
- Issue: opensearch-project/OpenSearch#17315