### PR TITLE
docs: add Automata & Regex Optimization report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -6,6 +6,7 @@
 
 ## opensearch
 
+- [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
 - [Cryptography & Security Libraries](opensearch/cryptography-security-libraries.md)
 - [Gradle Build System](opensearch/gradle-build-system.md)
 - [Java Runtime & JPMS](opensearch/java-runtime-and-jpms.md)

--- a/docs/features/opensearch/automata-regex-optimization.md
+++ b/docs/features/opensearch/automata-regex-optimization.md
@@ -1,0 +1,169 @@
+# Automata & Regex Optimization
+
+## Summary
+
+OpenSearch uses finite automata internally to process case-insensitive queries, wildcard queries, and regular expression queries. This feature tracks optimizations to automaton processing that improve memory efficiency and prevent out-of-memory errors when handling complex pattern matching queries.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Query Processing"
+        Q[Query with case_insensitive=true]
+        AQ[AutomatonQueries]
+        A[Automaton]
+    end
+    
+    subgraph "Automaton Operations"
+        CI[toCaseInsensitiveChar]
+        CS[toCaseInsensitiveString]
+        CW[toCaseInsensitiveWildcardAutomaton]
+        DET[Operations.determinize]
+        CONCAT[Operations.concatenate]
+    end
+    
+    subgraph "Query Execution"
+        AQR[AutomatonQuery]
+        CRA[CharacterRunAutomaton]
+        MATCH[Term Matching]
+    end
+    
+    Q --> AQ
+    AQ --> CI
+    AQ --> CS
+    AQ --> CW
+    CI --> CONCAT
+    CS --> CONCAT
+    CW --> CONCAT
+    CONCAT --> A
+    A --> DET
+    DET --> AQR
+    AQR --> CRA
+    CRA --> MATCH
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Input
+        TERM["'SearchTerm'"]
+        FLAG["case_insensitive=true"]
+    end
+    
+    subgraph "Character Processing"
+        C1["'S' → [Ss]"]
+        C2["'e' → [Ee]"]
+        C3["..."]
+    end
+    
+    subgraph "Automaton Building"
+        UNION["Union per char"]
+        CONCAT["Concatenate all"]
+        DFA["Deterministic FA"]
+    end
+    
+    subgraph Output
+        QUERY["AutomatonQuery"]
+    end
+    
+    TERM --> C1
+    FLAG --> C1
+    C1 --> UNION
+    C2 --> UNION
+    C3 --> UNION
+    UNION --> CONCAT
+    CONCAT --> DFA
+    DFA --> QUERY
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `AutomatonQueries` | Helper class for building case-insensitive automaton queries |
+| `Operations.determinize()` | Lucene method to convert NFA to DFA |
+| `Operations.concatenate()` | Lucene method to concatenate automata |
+| `CharacterRunAutomaton` | Compiled automaton for efficient string matching |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `max_determinized_states` | Maximum automaton states for regexp queries | 10,000 |
+
+### Usage Example
+
+Case-insensitive term query:
+
+```json
+GET /my-index/_search
+{
+  "query": {
+    "term": {
+      "status": {
+        "value": "Active",
+        "case_insensitive": true
+      }
+    }
+  }
+}
+```
+
+Case-insensitive wildcard query:
+
+```json
+GET /my-index/_search
+{
+  "query": {
+    "wildcard": {
+      "user.name": {
+        "value": "john*",
+        "case_insensitive": true
+      }
+    }
+  }
+}
+```
+
+Case-insensitive prefix query:
+
+```json
+GET /my-index/_search
+{
+  "query": {
+    "prefix": {
+      "product.name": {
+        "value": "open",
+        "case_insensitive": true
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Case-insensitive matching only works with ASCII characters (codepoints ≤ 128)
+- Complex regular expressions may still hit the `max_determinized_states` limit
+- The `case_insensitive` parameter is not available for all query types
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17268](https://github.com/opensearch-project/OpenSearch/pull/17268) | Remove MinimizationOperations to fix memory exhaustion |
+
+## References
+
+- [Issue #16975](https://github.com/opensearch-project/OpenSearch/issues/16975): Bug report - Memory exhaustion with case-insensitive term queries
+- [Regexp Query Documentation](https://docs.opensearch.org/3.0/query-dsl/term/regexp/): Official docs on regexp queries
+- [Term Query Documentation](https://docs.opensearch.org/3.0/query-dsl/term/term/): Official docs on term queries with `case_insensitive`
+- [Wildcard Query Documentation](https://docs.opensearch.org/3.0/query-dsl/term/wildcard/): Official docs on wildcard queries
+- [Prefix Query Documentation](https://docs.opensearch.org/3.0/query-dsl/term/prefix/): Official docs on prefix queries
+
+## Change History
+
+- **v3.0.0** (2025-02-10): Removed `MinimizationOperations` class; stopped minimizing automata for case-insensitive matches to prevent memory exhaustion

--- a/docs/releases/v3.0.0/features/opensearch/automata-regex-optimization.md
+++ b/docs/releases/v3.0.0/features/opensearch/automata-regex-optimization.md
@@ -1,0 +1,98 @@
+# Automata & Regex Optimization
+
+## Summary
+
+OpenSearch v3.0.0 removes the `MinimizationOperations` class and stops minimizing automata used for case-insensitive matches. This change fixes a memory exhaustion bug where case-insensitive term queries on large strings could easily run out of memory due to exponential state explosion during automaton minimization.
+
+## Details
+
+### What's New in v3.0.0
+
+The `MinimizationOperations.minimize()` calls have been removed from case-insensitive query processing. Instead, the code now uses `Operations.determinize()` where needed, or relies on the fact that the constructed automata are already deterministic.
+
+### Technical Changes
+
+#### Background: The Memory Problem
+
+Case-insensitive queries in OpenSearch work by converting the query string into a finite automaton. For example, a case-insensitive term query for `abc` behaves like a regexp query for `[Aa][Bb][Cc]`:
+
+```mermaid
+stateDiagram-v2
+    direction LR
+    [*] --> s1: [Aa]
+    s1 --> s2: [Bb]
+    s2 --> [*]: [Cc]
+```
+
+The previous implementation called `MinimizationOperations.minimize()` with `Integer.MAX_VALUE` as the work limit, which could cause exponential memory consumption for long strings (100+ characters).
+
+#### Changes Made
+
+| Component | Before | After |
+|-----------|--------|-------|
+| `AutomatonQueries.caseInsensitivePrefix()` | `MinimizationOperations.minimize(a, Integer.MAX_VALUE)` | `assert a.isDeterministic()` |
+| `AutomatonQueries.toCaseInsensitiveString()` | `MinimizationOperations.minimize(a, maxDeterminizedStates)` | `Operations.concatenate(list)` |
+| `AutomatonQueries.toCaseInsensitiveChar()` | `MinimizationOperations.minimize(result, maxDeterminizedStates)` | Direct union without minimization |
+| `ReindexValidator.buildRemoteAllowlist()` | `MinimizationOperations.minimize()` | `Operations.determinize()` |
+| `SystemIndices.buildCharacterRunAutomaton()` | `MinimizationOperations.minimize()` | `Operations.determinize()` |
+
+#### Removed Components
+
+| Component | Description |
+|-----------|-------------|
+| `MinimizationOperations.java` | 374-line class implementing Hopcroft's minimization algorithm |
+| `package-info.java` | Package documentation for `org.opensearch.lucene.util.automaton` |
+
+#### API Changes
+
+The `maxDeterminizedStates` parameter has been removed from several methods in `AutomatonQueries`:
+
+| Method | Old Signature | New Signature |
+|--------|---------------|---------------|
+| `toCaseInsensitiveChar` | `toCaseInsensitiveChar(int codepoint, int maxDeterminizedStates)` | `toCaseInsensitiveChar(int codepoint)` |
+| `toCaseInsensitiveString` | `toCaseInsensitiveString(String s, int maxDeterminizedStates)` | `toCaseInsensitiveString(String s)` |
+| `toCaseInsensitiveWildcardAutomaton` | `toCaseInsensitiveWildcardAutomaton(Term wildcardquery, int maxDeterminizedStates)` | `toCaseInsensitiveWildcardAutomaton(Term wildcardquery)` |
+
+### Usage Example
+
+Case-insensitive queries continue to work the same way from a user perspective:
+
+```json
+GET /my-index/_search
+{
+  "query": {
+    "term": {
+      "field": {
+        "value": "SearchTerm",
+        "case_insensitive": true
+      }
+    }
+  }
+}
+```
+
+The difference is internal - the query now executes more safely without risk of memory exhaustion.
+
+### Migration Notes
+
+- **No user action required**: This is an internal optimization with no API changes
+- **Plugin developers**: If your plugin directly calls `AutomatonQueries.toCaseInsensitiveString()` or similar methods with the `maxDeterminizedStates` parameter, update to use the new signatures without that parameter
+
+## Limitations
+
+- The optimization applies only to case-insensitive queries; regexp queries still use the `max_determinized_states` parameter for controlling complexity
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17268](https://github.com/opensearch-project/OpenSearch/pull/17268) | Remove MinimizationOperations |
+
+## References
+
+- [Issue #16975](https://github.com/opensearch-project/OpenSearch/issues/16975): Bug report - Can (easily) run out of memory with case-insensitive term queries
+- [Regexp Query Documentation](https://docs.opensearch.org/3.0/query-dsl/term/regexp/): Official docs on regexp queries and `case_insensitive` parameter
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/automata-regex-optimization.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -6,6 +6,7 @@
 
 ## opensearch
 
+- [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)
 - [Cryptography & Security Libraries](features/opensearch/cryptography-security-libraries.md)
 - [Gradle Build System](features/opensearch/gradle-build-system.md)
 - [Java Runtime & JPMS](features/opensearch/java-runtime-and-jpms.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Automata & Regex Optimization feature in OpenSearch v3.0.0.

### Changes

- **Release report**: `docs/releases/v3.0.0/features/opensearch/automata-regex-optimization.md`
- **Feature report**: `docs/features/opensearch/automata-regex-optimization.md`
- Updated index files

### Key Points

- Removes `MinimizationOperations` class that was causing memory exhaustion
- Fixes bug where case-insensitive term queries on large strings (100+ chars) could run out of memory
- Replaces `MinimizationOperations.minimize()` with `Operations.determinize()` or removes minimization entirely
- No user-facing API changes - internal optimization only

### Related

- Closes #254
- OpenSearch PR: [#17268](https://github.com/opensearch-project/OpenSearch/pull/17268)
- OpenSearch Issue: [#16975](https://github.com/opensearch-project/OpenSearch/issues/16975)