### PR TITLE
docs: add source-field-matching report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -7,6 +7,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
+- [Source Field Matching](opensearch/source-field-matching.md)
 - [Cryptography & Security Libraries](opensearch/cryptography-security-libraries.md)
 - [Gradle Build System](opensearch/gradle-build-system.md)
 - [Java Runtime & JPMS](opensearch/java-runtime-and-jpms.md)

--- a/docs/features/opensearch/source-field-matching.md
+++ b/docs/features/opensearch/source-field-matching.md
@@ -1,0 +1,125 @@
+# Source Field Matching
+
+## Summary
+
+Source field matching is the mechanism OpenSearch uses to filter which fields from the `_source` document are returned in search responses. The `_source` field contains the original JSON document that was indexed, and source filtering allows you to selectively include or exclude specific fields to reduce network transfer and improve performance.
+
+In v3.0.0, OpenSearch introduced a significant performance optimization that uses HashSet-based matching for simple field names, avoiding the overhead of automaton-based pattern matching.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph "Search Request"
+        A[_source filtering<br/>includes/excludes]
+    end
+    
+    subgraph "XContentMapValues.filter()"
+        B{Field pattern<br/>analysis}
+        C[HashSet Filter<br/>O(1) lookup]
+        D[Automaton Filter<br/>Pattern matching]
+    end
+    
+    subgraph "Output"
+        E[Filtered _source]
+    end
+    
+    A --> B
+    B -->|Simple names| C
+    B -->|Wildcards/dots| D
+    C --> E
+    D --> E
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Document _source] --> B[Filter Function]
+    C[Include Fields] --> B
+    D[Exclude Fields] --> B
+    B --> E{For each field}
+    E --> F{In includes?}
+    F -->|Yes| G{In excludes?}
+    F -->|No| H[Skip field]
+    G -->|No| I[Keep field]
+    G -->|Yes| H
+    I --> J[Filtered Result]
+    H --> E
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `XContentMapValues` | Utility class for filtering and extracting values from XContent maps |
+| `filter()` | Main entry point that selects the appropriate filtering strategy |
+| `hasNoWildcardsOrDots()` | Checks if field names are simple (no `*` or `.` characters) |
+| `createSetBasedFilter()` | Creates efficient HashSet-based filter for simple field names |
+| `createAutomatonFilter()` | Creates automaton-based filter for complex patterns |
+
+### Configuration
+
+Source filtering is configured at query time through the `_source` parameter:
+
+| Parameter | Description | Example |
+|-----------|-------------|---------|
+| `_source` | Boolean to enable/disable source | `"_source": false` |
+| `_source.includes` | Fields to include | `["title", "author"]` |
+| `_source.excludes` | Fields to exclude | `["password", "internal_*"]` |
+
+### Usage Example
+
+```json
+// Disable _source entirely
+GET /index/_search
+{
+  "_source": false,
+  "query": { "match_all": {} }
+}
+```
+
+```json
+// Include specific fields (uses HashSet optimization)
+GET /index/_search
+{
+  "_source": ["title", "author", "price"],
+  "query": { "match_all": {} }
+}
+```
+
+```json
+// Include/exclude with patterns (uses automaton matching)
+GET /index/_search
+{
+  "_source": {
+    "includes": ["user.*"],
+    "excludes": ["user.password"]
+  },
+  "query": { "match_all": {} }
+}
+```
+
+## Limitations
+
+- HashSet optimization only applies when all field names are simple (no wildcards or dots)
+- Disabling `_source` in index mappings affects features like `update`, `update_by_query`, and `reindex`
+- Dots in field names are treated as sub-objects (e.g., including `a` will also include `a.b`)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17160](https://github.com/opensearch-project/OpenSearch/pull/17160) | Add HashSet based filtering optimization to XContentMapValues |
+
+## References
+
+- [Issue #17114](https://github.com/opensearch-project/OpenSearch/issues/17114): Bug report - Fetching source uses automata even for simple matching
+- [Source Field Documentation](https://docs.opensearch.org/3.0/field-types/metadata-fields/source/): Official `_source` field documentation
+- [Retrieve Specific Fields](https://docs.opensearch.org/3.0/search-plugins/searching-data/retrieve-specific-fields/): Source filtering documentation
+
+## Change History
+
+- **v3.0.0** (2025-02-07): Added HashSet-based filtering optimization for simple field names to prevent TooComplexToDeterminizeException

--- a/docs/releases/v3.0.0/features/opensearch/source-field-matching.md
+++ b/docs/releases/v3.0.0/features/opensearch/source-field-matching.md
@@ -1,0 +1,108 @@
+# Source Field Matching
+
+## Summary
+
+This release introduces a performance optimization for source field filtering in OpenSearch. When filtering `_source` fields using simple field names (without wildcards or dot-paths), OpenSearch now uses a HashSet-based matching approach instead of the more complex automaton-based matching. This prevents `TooComplexToDeterminizeException` errors when processing documents with many long field names.
+
+## Details
+
+### What's New in v3.0.0
+
+The `XContentMapValues.filter()` method now intelligently selects between two filtering strategies:
+
+1. **HashSet-based filtering**: Used when field names are simple (no wildcards `*` or dots `.`)
+2. **Automaton-based filtering**: Used for complex patterns with wildcards or dot-paths
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+flowchart TB
+    subgraph "Before v3.0.0"
+        A1[Source Filter Request] --> B1[Automaton Matching]
+        B1 --> C1[TooComplexToDeterminizeException<br/>with many fields]
+    end
+    
+    subgraph "v3.0.0+"
+        A2[Source Filter Request] --> D{Has wildcards<br/>or dots?}
+        D -->|Yes| B2[Automaton Matching]
+        D -->|No| E[HashSet Matching]
+        B2 --> F[Filtered Result]
+        E --> F
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `hasNoWildcardsOrDots()` | Helper method to check if field names contain wildcards or dots |
+| `createSetBasedFilter()` | Creates a HashSet-based filter for exact field name matching |
+| `createAutomatonFilter()` | Creates an automaton-based filter for complex pattern matching |
+
+#### Implementation Details
+
+The optimization works by:
+
+1. Checking if all include/exclude field names are simple (no `*` or `.` characters)
+2. If simple: Creating `HashSet` collections for O(1) lookup performance
+3. If complex: Falling back to the existing automaton-based approach
+
+For document keys containing dots, the filter extracts the prefix before the first dot to match against the include/exclude sets, preserving the existing behavior where dots in field names are treated as sub-objects.
+
+### Usage Example
+
+```json
+// Search request with simple field names - uses HashSet optimization
+GET /my_index/_search
+{
+  "_source": {
+    "includes": ["title", "author", "price"],
+    "excludes": ["internal_id"]
+  },
+  "query": {
+    "match_all": {}
+  }
+}
+```
+
+```json
+// Search request with wildcards - uses automaton matching
+GET /my_index/_search
+{
+  "_source": {
+    "includes": ["user.*", "meta.tags"],
+    "excludes": ["*.internal"]
+  },
+  "query": {
+    "match_all": {}
+  }
+}
+```
+
+### Migration Notes
+
+This is a transparent optimization with no API changes. Existing queries will automatically benefit from the improved performance when using simple field names.
+
+## Limitations
+
+- The HashSet optimization only applies when **all** include and exclude field names are simple (no wildcards or dots)
+- If any field name contains a wildcard (`*`) or dot (`.`), the automaton-based approach is used for all fields
+- Documents with dotted field names in their keys still work correctly, but the optimization checks the prefix before the first dot
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17160](https://github.com/opensearch-project/OpenSearch/pull/17160) | Add HashSet based filtering optimization to XContentMapValues |
+
+## References
+
+- [Issue #17114](https://github.com/opensearch-project/OpenSearch/issues/17114): Original bug report - Fetching source uses automata even for simple matching
+- [Source Field Documentation](https://docs.opensearch.org/3.0/field-types/metadata-fields/source/): Official documentation for `_source` field
+- [Retrieve Specific Fields](https://docs.opensearch.org/3.0/search-plugins/searching-data/retrieve-specific-fields/): Documentation on source filtering
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/source-field-matching.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -7,6 +7,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)
+- [Source Field Matching](features/opensearch/source-field-matching.md)
 - [Cryptography & Security Libraries](features/opensearch/cryptography-security-libraries.md)
 - [Gradle Build System](features/opensearch/gradle-build-system.md)
 - [Java Runtime & JPMS](features/opensearch/java-runtime-and-jpms.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Source Field Matching optimization introduced in OpenSearch v3.0.0.

### Changes

- Added release report: `docs/releases/v3.0.0/features/opensearch/source-field-matching.md`
- Added feature report: `docs/features/opensearch/source-field-matching.md`
- Updated release index and features index

### Feature Overview

OpenSearch v3.0.0 introduces a performance optimization for `_source` field filtering. When filtering source fields using simple field names (without wildcards or dot-paths), OpenSearch now uses a HashSet-based matching approach instead of automaton-based matching. This prevents `TooComplexToDeterminizeException` errors when processing documents with many long field names.

### Related

- Resolves Issue #253
- OpenSearch PR: [#17160](https://github.com/opensearch-project/OpenSearch/pull/17160)
- OpenSearch Issue: [#17114](https://github.com/opensearch-project/OpenSearch/issues/17114)