### PR TITLE
docs: add Nodes Info API Changes report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -14,6 +14,7 @@
 - [Lucene 10 Upgrade](opensearch/lucene-10-upgrade.md)
 - [Lucene Similarity](opensearch/lucene-similarity.md)
 - [Merge & Segment Settings](opensearch/merge-segment-settings.md)
+- [Nodes Info API](opensearch/nodes-info-api.md)
 - [Stream Input/Output](opensearch/stream-inputoutput.md)
 - [Wildcard Field](opensearch/wildcard-field.md)
 

--- a/docs/features/opensearch/nodes-info-api.md
+++ b/docs/features/opensearch/nodes-info-api.md
@@ -1,0 +1,140 @@
+# Nodes Info API
+
+## Summary
+
+The Nodes Info API provides static information about cluster nodes, including host system details, JVM configuration, thread pool settings, installed plugins, and more. Starting from v3.0.0, the API introduces a "default metrics" concept that excludes certain metrics (like `search_pipelines`) from the default response to optimize response size.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Client Request"
+        REST[REST API]
+        Java[Java Client]
+    end
+    
+    subgraph "NodesInfoRequest"
+        Default[Default Metrics]
+        All[All Metrics]
+        Custom[Custom Selection]
+    end
+    
+    subgraph "Metric Groups"
+        Core[Core Metrics<br/>settings, os, process,<br/>jvm, thread_pool]
+        Network[Network Metrics<br/>transport, http]
+        Plugin[Plugin Metrics<br/>plugins, ingest]
+        Search[Search Metrics<br/>search_pipelines]
+        Other[Other Metrics<br/>aggregations, indices]
+    end
+    
+    REST --> Default
+    REST --> All
+    Java --> Default
+    Java --> Custom
+    
+    Default --> Core
+    Default --> Network
+    Default --> Plugin
+    Default --> Other
+    
+    All --> Core
+    All --> Network
+    All --> Plugin
+    All --> Search
+    All --> Other
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `NodesInfoRequest` | Request class for nodes info API with metric selection |
+| `NodesInfoRequest.Metric` | Enum defining available metric groups |
+| `defaultMetrics()` | Returns default set of metrics (excludes `search_pipelines`) |
+| `allMetrics()` | Returns all available metrics |
+
+### Configuration
+
+The Nodes Info API does not require configuration. Metric selection is done per-request.
+
+| Request Type | Metrics Returned |
+|--------------|------------------|
+| `GET /_nodes` | Default metrics (11 metrics) |
+| `GET /_nodes/_all` | All metrics (12 metrics) |
+| `GET /_nodes/<metric>` | Specified metric(s) only |
+
+### Available Metrics
+
+| Metric | Description | Default |
+|--------|-------------|---------|
+| `settings` | Node settings from config file and dynamic updates | ✓ |
+| `os` | OS name, version, architecture, processors | ✓ |
+| `process` | Process ID, refresh interval, mlockall status | ✓ |
+| `jvm` | JVM version, memory, GC info, arguments | ✓ |
+| `thread_pool` | Thread pool configurations | ✓ |
+| `transport` | Transport layer addresses and profiles | ✓ |
+| `http` | HTTP layer addresses and content length | ✓ |
+| `plugins` | Installed plugins and modules | ✓ |
+| `ingest` | Ingest pipelines and processors | ✓ |
+| `aggregations` | Available aggregation types | ✓ |
+| `indices` | Static index settings at node level | ✓ |
+| `search_pipelines` | Search pipeline information | ✗ |
+
+### Usage Example
+
+```bash
+# Get default node info
+GET /_nodes
+
+# Get all metrics including search_pipelines
+GET /_nodes/_all
+
+# Get specific metrics
+GET /_nodes/jvm,thread_pool
+
+# Get search_pipelines only
+GET /_nodes/search_pipelines
+
+# Filter by node
+GET /_nodes/node1,node2/jvm
+```
+
+Java client example:
+
+```java
+// Default metrics request
+NodesInfoRequest defaultRequest = new NodesInfoRequest();
+
+// All metrics request
+NodesInfoRequest allRequest = new NodesInfoRequest().all();
+
+// Clear and add specific metrics
+NodesInfoRequest customRequest = new NodesInfoRequest()
+    .clear()
+    .addMetric(NodesInfoRequest.Metric.JVM.metricName())
+    .addMetric(NodesInfoRequest.Metric.SEARCH_PIPELINES.metricName());
+```
+
+## Limitations
+
+- The `search_pipelines` metric is not included in default responses (v3.0.0+)
+- Metric selection is per-request; there is no cluster-level default configuration
+- Some metrics may have performance implications when requested frequently
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#12497](https://github.com/opensearch-project/OpenSearch/pull/12497) | Breaking change: Do not request search_pipelines by default |
+
+## References
+
+- [Nodes Info API Documentation](https://docs.opensearch.org/3.0/api-reference/nodes-apis/nodes-info/): Official API reference
+- [PR #12497](https://github.com/opensearch-project/OpenSearch/pull/12497): Implementation PR
+- [PR #10296](https://github.com/opensearch-project/OpenSearch/pull/10296): Related - Add optional section of node analyzers
+
+## Change History
+
+- **v3.0.0** (2024-03-12): Breaking change - `search_pipelines` metric excluded from default metrics set

--- a/docs/releases/v3.0.0/features/opensearch/nodes-info-api-changes.md
+++ b/docs/releases/v3.0.0/features/opensearch/nodes-info-api-changes.md
@@ -1,0 +1,103 @@
+# Nodes Info API Changes
+
+## Summary
+
+OpenSearch 3.0.0 introduces a breaking change to the Nodes Info API: the `search_pipelines` metric is no longer included in the default set of metrics returned by `NodesInfoRequest`. This change reduces the default response size by excluding metrics that are typically only needed for specific use cases.
+
+## Details
+
+### What's New in v3.0.0
+
+The `NodesInfoRequest` class now uses a "default metrics" set instead of "all metrics" by default. The `search_pipelines` metric is excluded from this default set, meaning clients must explicitly request it when needed.
+
+### Technical Changes
+
+#### API Behavior Change
+
+| Aspect | Before v3.0.0 | v3.0.0+ |
+|--------|---------------|---------|
+| Default metrics | All 12 metrics | 11 metrics (excludes `search_pipelines`) |
+| `GET /_nodes` response | Includes `search_pipelines` | Does NOT include `search_pipelines` |
+| Explicit request required | No | Yes, for `search_pipelines` |
+
+#### New Methods in NodesInfoRequest
+
+| Method | Description |
+|--------|-------------|
+| `defaultMetrics()` | Returns the default set of metrics (excludes `search_pipelines`) |
+| `all()` | Returns all available metrics (includes `search_pipelines`) |
+
+#### Available Metrics
+
+The Nodes Info API supports the following metrics:
+
+| Metric | Included in Default | Description |
+|--------|---------------------|-------------|
+| `settings` | ✓ | Node settings |
+| `os` | ✓ | Operating system info |
+| `process` | ✓ | Process information |
+| `jvm` | ✓ | JVM details |
+| `thread_pool` | ✓ | Thread pool settings |
+| `transport` | ✓ | Transport layer info |
+| `http` | ✓ | HTTP layer info |
+| `plugins` | ✓ | Installed plugins |
+| `ingest` | ✓ | Ingest pipelines info |
+| `aggregations` | ✓ | Available aggregations |
+| `indices` | ✓ | Index settings |
+| `search_pipelines` | ✗ | Search pipelines info |
+
+### Usage Example
+
+To explicitly request `search_pipelines` metrics:
+
+```bash
+# Request only search_pipelines metric
+GET /_nodes/search_pipelines
+
+# Request all metrics including search_pipelines
+GET /_nodes/_all
+```
+
+For Java clients:
+
+```java
+// Default request (excludes search_pipelines)
+NodesInfoRequest request = new NodesInfoRequest();
+
+// Request all metrics including search_pipelines
+NodesInfoRequest allRequest = new NodesInfoRequest().all();
+
+// Request only search_pipelines
+NodesInfoRequest pipelinesRequest = new NodesInfoRequest()
+    .clear()
+    .addMetric(NodesInfoRequest.Metric.SEARCH_PIPELINES.metricName());
+```
+
+### Migration Notes
+
+If your application relies on `search_pipelines` information from the Nodes Info API:
+
+1. Update API calls to explicitly request the `search_pipelines` metric
+2. Use `GET /_nodes/search_pipelines` for REST API calls
+3. For Java clients, use `.all()` or explicitly add the metric
+
+## Limitations
+
+- This is a **breaking change** - existing clients expecting `search_pipelines` in default responses will need updates
+- The change affects both REST API and Java transport client behavior
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#12497](https://github.com/opensearch-project/OpenSearch/pull/12497) | Do not request "search_pipelines" metrics by default in NodesInfoRequest |
+
+## References
+
+- [PR #12497](https://github.com/opensearch-project/OpenSearch/pull/12497): Main implementation
+- [PR #10296](https://github.com/opensearch-project/OpenSearch/pull/10296): Related - Add optional section of node analyzers into NodeInfo
+- [Nodes Info API Documentation](https://docs.opensearch.org/3.0/api-reference/nodes-apis/nodes-info/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/nodes-info-api.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -14,6 +14,7 @@
 - [Lucene 10 Upgrade](features/opensearch/lucene-10-upgrade.md)
 - [Lucene Similarity](features/opensearch/lucene-similarity.md)
 - [Merge & Segment Settings](features/opensearch/merge-segment-settings.md)
+- [Nodes Info API Changes](features/opensearch/nodes-info-api-changes.md)
 - [Stream Input/Output](features/opensearch/stream-inputoutput.md)
 - [Wildcard Field](features/opensearch/wildcard-field.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Nodes Info API Changes feature in OpenSearch v3.0.0.

### Key Changes in v3.0.0

- **Breaking Change**: The `search_pipelines` metric is no longer included in the default set of metrics returned by `NodesInfoRequest`
- The `NodesInfoRequest` class now uses `defaultMetrics()` instead of `allMetrics()` by default
- Clients must explicitly request `search_pipelines` metric when needed

### Reports Created

- Release report: `docs/releases/v3.0.0/features/opensearch/nodes-info-api-changes.md`
- Feature report: `docs/features/opensearch/nodes-info-api.md`

### Resources Used

- PR: [opensearch-project/OpenSearch#12497](https://github.com/opensearch-project/OpenSearch/pull/12497)
- Related PR: [opensearch-project/OpenSearch#10296](https://github.com/opensearch-project/OpenSearch/pull/10296)
- Docs: [Nodes Info API](https://docs.opensearch.org/3.0/api-reference/nodes-apis/nodes-info/)

Closes #252