### PR TITLE
docs: add Search Backpressure report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -15,6 +15,7 @@
 - [Lucene Similarity](opensearch/lucene-similarity.md)
 - [Merge & Segment Settings](opensearch/merge-segment-settings.md)
 - [Nodes Info API](opensearch/nodes-info-api.md)
+- [Search Backpressure](opensearch/search-backpressure.md)
 - [Stream Input/Output](opensearch/stream-inputoutput.md)
 - [Wildcard Field](opensearch/wildcard-field.md)
 

--- a/docs/features/opensearch/search-backpressure.md
+++ b/docs/features/opensearch/search-backpressure.md
@@ -1,0 +1,135 @@
+# Search Backpressure
+
+## Summary
+
+Search Backpressure is a mechanism that identifies resource-intensive search requests and cancels them when a node is under duress. It monitors CPU usage, heap usage, and elapsed time for search tasks, applying configurable thresholds to protect cluster stability. The feature operates at both the coordinator (search task) and shard (search shard task) levels.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Search Request Flow"
+        Client[Client] --> Coordinator[Coordinator Node]
+        Coordinator --> Shard1[Shard Task 1]
+        Coordinator --> Shard2[Shard Task 2]
+        Coordinator --> ShardN[Shard Task N]
+    end
+    
+    subgraph "Search Backpressure Service"
+        Observer[Observer Thread] --> NodeDuress{Node Under Duress?}
+        NodeDuress -->|Yes| TaskEval[Evaluate Tasks]
+        NodeDuress -->|No| Continue[Continue Monitoring]
+        TaskEval --> Score[Calculate Cancellation Score]
+        Score --> Cancel[Cancel Resource-Intensive Tasks]
+    end
+    
+    Shard1 -.-> Observer
+    Shard2 -.-> Observer
+    ShardN -.-> Observer
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Resource Tracking"
+        CPU[CPU Usage Tracker]
+        Heap[Heap Usage Tracker]
+        Time[Elapsed Time Tracker]
+    end
+    
+    subgraph "Decision Making"
+        Threshold[Threshold Check]
+        Variance[Variance Check]
+        Score[Cancellation Score]
+    end
+    
+    subgraph "Actions"
+        Cancel[Task Cancellation]
+        Stats[Stats Collection]
+    end
+    
+    CPU --> Threshold
+    Heap --> Threshold
+    Time --> Threshold
+    Threshold --> Variance
+    Variance --> Score
+    Score --> Cancel
+    Score --> Stats
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SearchBackpressureService` | Main service that coordinates backpressure monitoring and task cancellation |
+| `SearchTaskStats` | Statistics for coordinator-level search tasks |
+| `SearchShardTaskStats` | Statistics for shard-level search tasks |
+| `CpuUsageTracker` | Tracks CPU time consumed by search tasks |
+| `HeapUsageTracker` | Tracks heap memory usage by search tasks |
+| `ElapsedTimeTracker` | Tracks elapsed wall-clock time for search tasks |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `search_backpressure.mode` | Operating mode: `monitor_only`, `enforced`, or `disabled` | `monitor_only` |
+| `search_backpressure.node_duress.cpu_threshold` | CPU usage threshold for node duress | 90% |
+| `search_backpressure.node_duress.heap_threshold` | Heap usage threshold for node duress | 70% |
+| `search_backpressure.node_duress.num_successive_breaches` | Successive breaches before node is considered under duress | 3 |
+| `search_backpressure.search_task.elapsed_time_millis_threshold` | Elapsed time threshold for search tasks | 45,000ms |
+| `search_backpressure.search_task.heap_percent_threshold` | Heap usage threshold for search tasks | 2% |
+| `search_backpressure.search_task.cpu_time_millis_threshold` | CPU time threshold for search tasks | 30,000ms |
+| `search_backpressure.search_shard_task.elapsed_time_millis_threshold` | Elapsed time threshold for shard tasks | 30,000ms |
+| `search_backpressure.search_shard_task.heap_percent_threshold` | Heap usage threshold for shard tasks | 0.5% |
+| `search_backpressure.search_shard_task.cpu_time_millis_threshold` | CPU time threshold for shard tasks | 15,000ms |
+
+### Usage Example
+
+```bash
+# Get search backpressure stats
+GET _nodes/stats/search_backpressure
+
+# Configure search backpressure mode
+PUT /_cluster/settings
+{
+  "persistent": {
+    "search_backpressure": {
+      "mode": "enforced"
+    }
+  }
+}
+
+# Adjust thresholds
+PUT /_cluster/settings
+{
+  "persistent": {
+    "search_backpressure.search_task.elapsed_time_millis_threshold": 60000,
+    "search_backpressure.search_shard_task.cpu_time_millis_threshold": 20000
+  }
+}
+```
+
+## Limitations
+
+- Operates in `monitor_only` mode by default; must be explicitly set to `enforced` to cancel tasks
+- Cancellation may result in partial search results
+- Statistics are reset on node restart
+- Mixed-version clusters may have inconsistent stats reporting
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#10028](https://github.com/opensearch-project/OpenSearch/pull/10028) | Add task completion count in search backpressure stats API |
+
+## References
+
+- [Issue #8698](https://github.com/opensearch-project/OpenSearch/issues/8698): Add total successful task count in nodeStats API
+- [Search Backpressure Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/search-backpressure/): Official documentation
+
+## Change History
+
+- **v3.0.0** (2026-01-08): Added `completion_count` field to stats API for calculating cancellation percentages

--- a/docs/releases/v3.0.0/features/opensearch/search-backpressure.md
+++ b/docs/releases/v3.0.0/features/opensearch/search-backpressure.md
@@ -1,0 +1,91 @@
+# Search Backpressure Stats Enhancement
+
+## Summary
+
+This release adds task completion count (`completion_count`) to the Search Backpressure Stats API response. This new metric enables operators to calculate cancellation percentages and supports auto-tuning of heap-based cancellation thresholds.
+
+## Details
+
+### What's New in v3.0.0
+
+The Search Backpressure Stats API (`/_nodes/stats/search_backpressure`) now includes a `completion_count` field for both `search_task` and `search_shard_task` statistics. This field tracks the total number of successfully completed search tasks since the node last restarted.
+
+### Technical Changes
+
+#### New Response Field
+
+The `completion_count` field is added to both `SearchTaskStats` and `SearchShardTaskStats` classes:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `completion_count` | long | Total number of successfully completed tasks since node restart |
+
+#### API Response Changes
+
+The stats API response now includes `completion_count` in both task types:
+
+```json
+{
+  "search_backpressure": {
+    "search_task": {
+      "resource_tracker_stats": { ... },
+      "completion_count": 1000,
+      "cancellation_stats": {
+        "cancellation_count": 10,
+        "cancellation_limit_reached_count": 2
+      }
+    },
+    "search_shard_task": {
+      "resource_tracker_stats": { ... },
+      "completion_count": 5000,
+      "cancellation_stats": {
+        "cancellation_count": 50,
+        "cancellation_limit_reached_count": 5
+      }
+    },
+    "mode": "monitor_only"
+  }
+}
+```
+
+#### Version Compatibility
+
+The `completion_count` field is only serialized for OpenSearch 3.0.0 and later. When communicating with older nodes:
+- Reading from older nodes: `completion_count` defaults to `-1`
+- Writing to older nodes: `completion_count` is not included in the response
+
+### Usage Example
+
+Calculate the cancellation percentage for search shard tasks:
+
+```bash
+# Get search backpressure stats
+curl "localhost:9200/_nodes/stats/search_backpressure?pretty"
+
+# Calculate cancellation percentage
+# cancellation_percentage = cancellation_count / (completion_count + cancellation_count) * 100
+```
+
+### Migration Notes
+
+No migration required. The new field is automatically available after upgrading to v3.0.0.
+
+## Limitations
+
+- The `completion_count` is reset when the node restarts
+- When querying mixed-version clusters, nodes running versions prior to 3.0.0 will return `-1` for `completion_count`
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10028](https://github.com/opensearch-project/OpenSearch/pull/10028) | Add task completion count in search backpressure stats API |
+
+## References
+
+- [Issue #8698](https://github.com/opensearch-project/OpenSearch/issues/8698): Original feature request
+- [Search Backpressure Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/search-backpressure/): Official docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/search-backpressure.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -15,6 +15,7 @@
 - [Lucene Similarity](features/opensearch/lucene-similarity.md)
 - [Merge & Segment Settings](features/opensearch/merge-segment-settings.md)
 - [Nodes Info API Changes](features/opensearch/nodes-info-api-changes.md)
+- [Search Backpressure](features/opensearch/search-backpressure.md)
 - [Stream Input/Output](features/opensearch/stream-inputoutput.md)
 - [Wildcard Field](features/opensearch/wildcard-field.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Search Backpressure Stats API enhancement in OpenSearch v3.0.0.

### Changes
- Added `completion_count` field to the Search Backpressure Stats API response
- Enables calculation of cancellation percentages for search tasks
- Supports auto-tuning of heap-based cancellation thresholds

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/search-backpressure.md`
- Feature report: `docs/features/opensearch/search-backpressure.md`

### Related
- PR: [opensearch-project/OpenSearch#10028](https://github.com/opensearch-project/OpenSearch/pull/10028)
- Issue: [opensearch-project/OpenSearch#8698](https://github.com/opensearch-project/OpenSearch/issues/8698)