### PR TITLE
docs: add HTTP API Improvements report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -7,6 +7,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
+- [HTTP API](opensearch/http-api.md)
 - [Source Field Matching](opensearch/source-field-matching.md)
 - [Cryptography & Security Libraries](opensearch/cryptography-security-libraries.md)
 - [Gradle Build System](opensearch/gradle-build-system.md)

--- a/docs/features/opensearch/http-api.md
+++ b/docs/features/opensearch/http-api.md
@@ -1,0 +1,120 @@
+# HTTP API
+
+## Summary
+
+OpenSearch provides a RESTful HTTP API for all cluster operations. The HTTP layer handles request parsing, authentication, and response formatting. Proper HTTP status codes and configurable limits ensure reliable client-server communication and support for modern authentication mechanisms.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "HTTP Layer"
+        HTTP[HTTP Server]
+        Parser[Request Parser]
+        Handler[Request Handler]
+        Response[Response Builder]
+    end
+    
+    subgraph "Error Handling"
+        EH[ExceptionsHelper]
+        SE[SettingsException]
+        CSE[ConcurrentSnapshotException]
+        NXE[NotXContentException]
+    end
+    
+    Client[Client] --> HTTP
+    HTTP --> Parser
+    Parser --> Handler
+    Handler --> Response
+    Response --> Client
+    
+    Handler --> EH
+    EH --> SE
+    EH --> CSE
+    EH --> NXE
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `HttpTransportSettings` | Defines HTTP transport configuration settings including max header size |
+| `ExceptionsHelper` | Maps exceptions to appropriate HTTP status codes |
+| `SettingsException` | Exception for settings validation errors, returns 400 Bad Request |
+| `ConcurrentSnapshotExecutionException` | Exception for snapshot conflicts, returns 409 Conflict |
+| `NotXContentException` | Exception for invalid content format, returns 400 Bad Request |
+| `AbstractScopedSettings` | Validates cluster and index settings, throws `SettingsException` for invalid settings |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `http.max_header_size` | Maximum size of HTTP request headers | 16KB |
+| `http.max_content_length` | Maximum size of HTTP request body | 100MB |
+| `http.max_initial_line_length` | Maximum length of the initial HTTP request line | 4KB |
+
+### HTTP Status Code Mapping
+
+| Exception Type | HTTP Status | Description |
+|----------------|-------------|-------------|
+| `NotXContentException` | 400 Bad Request | Invalid content format in request body |
+| `SettingsException` | 400 Bad Request | Invalid settings in request |
+| `IllegalArgumentException` | 400 Bad Request | Invalid argument in request |
+| `ConcurrentSnapshotExecutionException` | 409 Conflict | Concurrent snapshot operation conflict |
+| `OpenSearchRejectedExecutionException` | 429 Too Many Requests | Request rejected due to overload |
+| Other exceptions | 500 Internal Server Error | Unexpected server errors |
+
+### Usage Example
+
+```yaml
+# opensearch.yml - HTTP configuration
+http.max_header_size: 16kb
+http.max_content_length: 100mb
+http.max_initial_line_length: 4kb
+```
+
+Example API responses with proper status codes:
+
+```bash
+# Invalid JSON in create index request - returns 400
+curl -X PUT "localhost:9200/test-index" -H 'Content-Type: application/json' -d'invalid'
+# Response: {"error":{"type":"not_x_content_exception",...},"status":400}
+
+# Invalid settings update - returns 400
+curl -X PUT "localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d'
+{
+  "transient": {"unknown.setting": "value"}
+}'
+# Response: {"error":{"type":"settings_exception",...},"status":400}
+
+# Concurrent snapshot conflict - returns 409
+# When attempting to create a snapshot while another is in progress
+# Response: {"error":{"type":"concurrent_snapshot_execution_exception",...},"status":409}
+```
+
+## Limitations
+
+- `http.max_header_size` is a node-level setting requiring restart to change
+- Header size increases may impact memory usage under high load
+- Status code changes may affect existing client error handling logic
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#4773](https://github.com/opensearch-project/OpenSearch/pull/4773) | Change HTTP code on create index API with bad input from 500 to 400 |
+| v3.0.0 | [#4792](https://github.com/opensearch-project/OpenSearch/pull/4792) | Improve summary error message for invalid setting updates |
+| v3.0.0 | [#8986](https://github.com/opensearch-project/OpenSearch/pull/8986) | Return 409 Conflict instead of 503 for concurrent snapshot execution |
+| v3.0.0 | [#18024](https://github.com/opensearch-project/OpenSearch/pull/18024) | Change default max header size from 8KB to 16KB |
+
+## References
+
+- [Issue #2756](https://github.com/opensearch-project/OpenSearch/issues/2756): Wrong HTTP code returned from create index API
+- [Issue #4745](https://github.com/opensearch-project/OpenSearch/issues/4745): Update AbstractScopedSettings to throw OpenSearchExceptions
+- [Issue #18022](https://github.com/opensearch-project/OpenSearch/issues/18022): Increase http.max_header_size default to 16KB
+
+## Change History
+
+- **v3.0.0** (2025): HTTP status code improvements and increased default max header size from 8KB to 16KB

--- a/docs/releases/v3.0.0/features/opensearch/http-api-improvements.md
+++ b/docs/releases/v3.0.0/features/opensearch/http-api-improvements.md
@@ -1,0 +1,96 @@
+# HTTP API Improvements
+
+## Summary
+
+OpenSearch v3.0.0 introduces several improvements to HTTP API error handling and configuration. These changes provide more accurate HTTP status codes for various error conditions and increase the default maximum header size to better support modern authentication mechanisms like JWT tokens.
+
+## Details
+
+### What's New in v3.0.0
+
+This release includes four key improvements to the HTTP API layer:
+
+1. **Create Index API Error Code Fix**: Changed HTTP response code from 500 to 400 when invalid input raises `NotXContentException`
+2. **Settings Error Messages**: Improved error messages for invalid setting updates by using `SettingsException` instead of `IllegalArgumentException`
+3. **Snapshot Conflict Status**: Changed HTTP status from 503 to 409 for concurrent snapshot execution failures
+4. **Increased Max Header Size**: Changed default `http.max_header_size` from 8KB to 16KB
+
+### Technical Changes
+
+#### HTTP Status Code Corrections
+
+| Scenario | Before | After | Rationale |
+|----------|--------|-------|-----------|
+| Create index with invalid content | 500 Internal Server Error | 400 Bad Request | Client error, not server error |
+| Invalid settings update | 500 Internal Server Error | 400 Bad Request | Proper `SettingsException` with BAD_REQUEST status |
+| Concurrent snapshot execution | 503 Service Unavailable | 409 Conflict | Resource conflict, not service unavailability |
+
+#### New Configuration Default
+
+| Setting | Description | Old Default | New Default |
+|---------|-------------|-------------|-------------|
+| `http.max_header_size` | Maximum size of HTTP request headers | 8KB | 16KB |
+
+### Usage Example
+
+The increased header size is particularly beneficial for JWT token-based authentication:
+
+```yaml
+# opensearch.yml - no change needed for most use cases
+# The new default of 16KB accommodates larger JWT tokens
+
+# If you need even larger headers (not recommended):
+http.max_header_size: 32kb
+```
+
+Example of improved error response for invalid index creation:
+
+```bash
+# Before v3.0.0: Returns 500 Internal Server Error
+# After v3.0.0: Returns 400 Bad Request
+curl -X PUT "localhost:9200/test-index" -H 'Content-Type: application/json' -d'invalid-json'
+
+# Response (v3.0.0):
+{
+  "error": {
+    "root_cause": [{
+      "type": "not_x_content_exception",
+      "reason": "Compressor detection can only be called on some xcontent bytes or compressed xcontent bytes"
+    }],
+    "type": "not_x_content_exception",
+    "reason": "Compressor detection can only be called on some xcontent bytes or compressed xcontent bytes"
+  },
+  "status": 400
+}
+```
+
+### Migration Notes
+
+- **No action required** for most users - these are backward-compatible improvements
+- Applications relying on specific HTTP status codes (500, 503) for error handling may need updates
+- The increased header size default benefits JWT authentication without configuration changes
+
+## Limitations
+
+- The `http.max_header_size` setting is a node-level setting and requires a node restart to change
+- Very large headers (>16KB) still require explicit configuration
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4773](https://github.com/opensearch-project/OpenSearch/pull/4773) | Change HTTP code on create index API with bad input from 500 to 400 |
+| [#4792](https://github.com/opensearch-project/OpenSearch/pull/4792) | Improve summary error message for invalid setting updates |
+| [#8986](https://github.com/opensearch-project/OpenSearch/pull/8986) | Return 409 Conflict instead of 503 for concurrent snapshot execution |
+| [#18024](https://github.com/opensearch-project/OpenSearch/pull/18024) | Change default max header size from 8KB to 16KB |
+
+## References
+
+- [Issue #2756](https://github.com/opensearch-project/OpenSearch/issues/2756): Wrong HTTP code returned from create index API with bad input
+- [Issue #4745](https://github.com/opensearch-project/OpenSearch/issues/4745): Update AbstractScopedSettings to throw OpenSearchExceptions
+- [Issue #18022](https://github.com/opensearch-project/OpenSearch/issues/18022): Increase http.max_header_size default to 16KB
+- [Security Dashboards Plugin Issue #1311](https://github.com/opensearch-project/security-dashboards-plugin/issues/1311): JWT header size issues
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/http-api.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -7,6 +7,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)
+- [HTTP API Improvements](features/opensearch/http-api-improvements.md)
 - [Source Field Matching](features/opensearch/source-field-matching.md)
 - [Cryptography & Security Libraries](features/opensearch/cryptography-security-libraries.md)
 - [Gradle Build System](features/opensearch/gradle-build-system.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for HTTP API Improvements in OpenSearch v3.0.0.

### Changes in v3.0.0

1. **Create Index API Error Code Fix** (PR #4773): Changed HTTP response code from 500 to 400 when invalid input raises `NotXContentException`
2. **Settings Error Messages** (PR #4792): Improved error messages for invalid setting updates by using `SettingsException` instead of `IllegalArgumentException`
3. **Snapshot Conflict Status** (PR #8986): Changed HTTP status from 503 to 409 for concurrent snapshot execution failures
4. **Increased Max Header Size** (PR #18024): Changed default `http.max_header_size` from 8KB to 16KB

### Files Added/Modified

- `docs/releases/v3.0.0/features/opensearch/http-api-improvements.md` (new)
- `docs/features/opensearch/http-api.md` (new)
- `docs/releases/v3.0.0/index.md` (updated)
- `docs/features/index.md` (updated)

Closes #250