### PR TITLE
docs: add locale-provider-changes report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -7,6 +7,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
+- [Locale Provider](opensearch/locale-provider.md)
 - [HTTP API](opensearch/http-api.md)
 - [Source Field Matching](opensearch/source-field-matching.md)
 - [Cryptography & Security Libraries](opensearch/cryptography-security-libraries.md)

--- a/docs/features/opensearch/locale-provider.md
+++ b/docs/features/opensearch/locale-provider.md
@@ -1,0 +1,111 @@
+# Locale Provider
+
+## Summary
+
+OpenSearch uses the Java locale provider system to handle internationalization and localization of date/time formatting, number formatting, and other locale-sensitive operations. The locale provider determines the source of locale data used throughout the application.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "JVM Locale System"
+        LP[Locale Providers]
+        SPI[SPI Provider]
+        CLDR[CLDR Provider]
+    end
+    
+    subgraph "OpenSearch"
+        JVM[JVM Options]
+        DT[Date/Time Parsing]
+        FMT[Formatting]
+    end
+    
+    JVM -->|java.locale.providers| LP
+    LP --> SPI
+    LP --> CLDR
+    SPI --> DT
+    CLDR --> DT
+    DT --> FMT
+```
+
+### Locale Provider Types
+
+| Provider | Description | Status |
+|----------|-------------|--------|
+| SPI | Service Provider Interface for custom locale data | Active |
+| CLDR | Unicode Common Locale Data Repository | Default (JDK 9+) |
+| COMPAT | JDK 8 compatibility locale data | Deprecated |
+
+### Configuration
+
+OpenSearch sets the locale provider via JVM system property:
+
+```
+-Djava.locale.providers=SPI,CLDR
+```
+
+This configuration is applied in:
+- `distribution/tools/launchers/src/main/java/org/opensearch/tools/launchers/SystemJvmOptions.java`
+- `buildSrc/src/main/java/org/opensearch/gradle/OpenSearchTestBasePlugin.java`
+- `gradle/ide.gradle`
+
+### CLDR vs COMPAT Differences
+
+CLDR locale data follows Unicode standards and may differ from legacy COMPAT data:
+
+| Locale | Element | COMPAT | CLDR |
+|--------|---------|--------|------|
+| de (German) | Short weekday | `Mi` | `Mi.` |
+| de (German) | Short month | `Dez` | `Dez.` |
+
+### Usage Example
+
+When using locale-specific date formats in OpenSearch:
+
+```json
+PUT /my-index
+{
+  "mappings": {
+    "properties": {
+      "date_field": {
+        "type": "date",
+        "format": "E, d MMM yyyy HH:mm:ss Z",
+        "locale": "de"
+      }
+    }
+  }
+}
+```
+
+With CLDR provider, German dates should include periods:
+
+```json
+POST /my-index/_doc
+{
+  "date_field": "Mi., 06 Dez. 2000 02:55:00 -0800"
+}
+```
+
+## Limitations
+
+- Locale data differences between CLDR and COMPAT may affect date parsing
+- Custom date formats using locale-specific names require testing when upgrading
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#14345](https://github.com/opensearch-project/OpenSearch/pull/14345) | Changed locale provider from COMPAT to CLDR |
+
+## References
+
+- [Issue #11550](https://github.com/opensearch-project/OpenSearch/issues/11550): Original feature request
+- [JDK-8305402](https://bugs.openjdk.org/browse/JDK-8305402): COMPAT locale provider removal notice
+- [CLDR Supported Locales (JDK 11)](https://www.oracle.com/java/technologies/javase/jdk11-suported-locales.html): Oracle documentation
+- [Blog: How to start contributing to OpenSearch](https://opensearch.org/blog/how-to-start-contributing-to-opensearch-a-beginners-guide-based-on-my-journey/): Contributor journey
+
+## Change History
+
+- **v3.0.0** (2024-06-15): Changed locale provider from COMPAT to CLDR to address JDK 21+ deprecation warnings

--- a/docs/releases/v3.0.0/features/opensearch/locale-provider-changes.md
+++ b/docs/releases/v3.0.0/features/opensearch/locale-provider-changes.md
@@ -1,0 +1,78 @@
+# Locale Provider Changes
+
+## Summary
+
+OpenSearch v3.0.0 changes the default locale provider from COMPAT to CLDR (Common Locale Data Repository). This change prepares OpenSearch for future JDK versions where the COMPAT provider will be removed, and aligns with the JDK's default behavior since JDK 9.
+
+## Details
+
+### What's New in v3.0.0
+
+The locale provider setting `java.locale.providers` has been changed from `SPI,COMPAT` to `SPI,CLDR` across all OpenSearch components:
+
+- JVM options for OpenSearch runtime
+- Gradle test configuration
+- IDE run configurations
+
+### Technical Changes
+
+#### Background
+
+Starting from JDK 21, a deprecation warning appears when using the COMPAT locale provider:
+
+```
+WARNING: COMPAT locale provider will be removed in a future release
+```
+
+The COMPAT provider was maintained for backward compatibility with JDK 8's locale data. Since JDK 9, CLDR has been the default locale data source.
+
+#### Changed Files
+
+| File | Change |
+|------|--------|
+| `SystemJvmOptions.java` | Changed `-Djava.locale.providers=SPI,COMPAT` to `SPI,CLDR` |
+| `OpenSearchTestBasePlugin.java` | Updated test system property to use CLDR |
+| `gradle/ide.gradle` | Updated IntelliJ run configuration |
+
+#### Locale Data Differences
+
+CLDR locale data has minor differences from COMPAT. For example, German (`de`) locale short names for days and months include periods in CLDR:
+
+| Format | COMPAT | CLDR |
+|--------|--------|------|
+| Wednesday (short) | `Mi` | `Mi.` |
+| Thursday (short) | `Do` | `Do.` |
+| December (short) | `Dez` | `Dez.` |
+
+### Migration Notes
+
+If your application uses locale-specific date parsing with custom formats, you may need to update date patterns to account for CLDR formatting differences:
+
+```java
+// Before (COMPAT format for German locale)
+"Mi, 06 Dez 2000 02:55:00 -0800"
+
+// After (CLDR format for German locale)
+"Mi., 06 Dez. 2000 02:55:00 -0800"
+```
+
+## Limitations
+
+- Applications relying on exact locale-specific string matching may need updates
+- Custom date formats using locale-specific day/month names should be tested
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#14345](https://github.com/opensearch-project/OpenSearch/pull/14345) | Changed locale provider from COMPAT to CLDR |
+
+## References
+
+- [Issue #11550](https://github.com/opensearch-project/OpenSearch/issues/11550): COMPAT locale provider deprecation warning
+- [JDK-8305402](https://bugs.openjdk.org/browse/JDK-8305402): COMPAT locale provider removal notice
+- [Blog: How to start contributing to OpenSearch](https://opensearch.org/blog/how-to-start-contributing-to-opensearch-a-beginners-guide-based-on-my-journey/): Contributor journey including this fix
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/locale-provider.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -7,6 +7,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)
+- [Locale Provider Changes](features/opensearch/locale-provider-changes.md)
 - [HTTP API Improvements](features/opensearch/http-api-improvements.md)
 - [Source Field Matching](features/opensearch/source-field-matching.md)
 - [Cryptography & Security Libraries](features/opensearch/cryptography-security-libraries.md)


### PR DESCRIPTION
## Summary

Documents the locale provider change from COMPAT to CLDR in OpenSearch v3.0.0.

## Changes

- Release report: `docs/releases/v3.0.0/features/opensearch/locale-provider-changes.md`
- Feature report: `docs/features/opensearch/locale-provider.md`
- Updated release and feature indexes

## Key Points

- Changed `java.locale.providers` from `SPI,COMPAT` to `SPI,CLDR`
- Addresses JDK 21+ deprecation warning for COMPAT provider
- Minor locale data differences (e.g., German short day/month names include periods in CLDR)

## Related

- Closes #249
- PR: opensearch-project/OpenSearch#14345
- Issue: opensearch-project/OpenSearch#11550