### PR TITLE
docs: add cluster-manager-throttling report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -7,6 +7,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
+- [Cluster Manager Task Throttling](opensearch/cluster-manager-throttling.md)
 - [Dependency Management](opensearch/dependency-management.md)
 - [Locale Provider](opensearch/locale-provider.md)
 - [HTTP API](opensearch/http-api.md)

--- a/docs/features/opensearch/cluster-manager-throttling.md
+++ b/docs/features/opensearch/cluster-manager-throttling.md
@@ -1,0 +1,131 @@
+# Cluster Manager Task Throttling
+
+## Summary
+
+Cluster manager task throttling is a built-in protection mechanism that prevents the cluster manager from being overwhelmed by excessive task submissions. When nodes submit tasks like index creation, mapping updates, or snapshot operations, these tasks queue up on the cluster manager. Without throttling, spikes in task submissions can flood the cluster manager's pending task queue, degrading performance and potentially affecting cluster availability.
+
+The throttling mechanism evaluates incoming tasks based on their type and rejects tasks when the number of pending tasks of the same type exceeds a configurable threshold. Rejected tasks are retried by the submitting node with exponential backoff.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Data Nodes"
+        DN1[Data Node 1]
+        DN2[Data Node 2]
+        DN3[Data Node N]
+    end
+    
+    subgraph "Cluster Manager"
+        CMT[ClusterManagerTaskThrottler]
+        PTQ[Pending Task Queue]
+        CMS[ClusterManagerService]
+    end
+    
+    DN1 -->|Submit Task| CMT
+    DN2 -->|Submit Task| CMT
+    DN3 -->|Submit Task| CMT
+    
+    CMT -->|Check Threshold| PTQ
+    CMT -->|Accept| CMS
+    CMT -->|Reject| DN1
+    CMT -->|Reject| DN2
+    CMT -->|Reject| DN3
+    
+    CMS --> PTQ
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Task Submitted] --> B{Throttling Enabled?}
+    B -->|No| C[Add to Queue]
+    B -->|Yes| D{Count < Threshold?}
+    D -->|Yes| C
+    D -->|No| E[Reject Task]
+    E --> F[Client Retry with Backoff]
+    F --> A
+    C --> G[Process Task]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ClusterManagerTaskThrottler` | Core throttling logic that tracks task counts and enforces thresholds |
+| `ClusterManagerTask` | Enum defining all task types with their keys and default thresholds |
+| `ThrottlingKey` | Identifier for a registered task type used during throttling checks |
+| `ClusterManagerThrottlingStats` | Statistics tracking for throttled tasks |
+| `ClusterManagerService` | Service that processes cluster state updates and integrates with throttling |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster_manager.throttling.thresholds.<task-type>.value` | Maximum pending tasks of this type before throttling | Task-type specific (see below) |
+| `cluster_manager.throttling.retry.base_delay` | Base delay for retry backoff | 1s |
+| `cluster_manager.throttling.retry.max_delay` | Maximum delay for retry backoff | 30s |
+
+### Default Thresholds by Task Type
+
+| Task Type | Threshold | Rationale |
+|-----------|-----------|-----------|
+| Most operations (create-index, delete-index, etc.) | 50 | Standard operations with moderate frequency |
+| `auto-create` | 200 | Higher frequency due to automatic index creation |
+| `rollover-index` | 200 | Higher frequency in time-series workloads |
+| `index-aliases` | 200 | Common operation in alias-based routing |
+| `put-mapping` | 10000 | Very high frequency in dynamic mapping scenarios |
+| `update-snapshot-state` | 5000 | High frequency during snapshot operations |
+
+### Usage Example
+
+```yaml
+# opensearch.yml - Static configuration
+cluster_manager.throttling.retry.base_delay: 2s
+cluster_manager.throttling.retry.max_delay: 60s
+```
+
+```json
+// Dynamic configuration via API
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster_manager.throttling.thresholds": {
+      "create-index": {
+        "value": 100
+      },
+      "put-mapping": {
+        "value": 5000
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Throttling is evaluated per task type, not globally across all task types
+- Thresholds are cluster-wide settings and cannot be configured per-node
+- When a task is rejected, the entire batch of tasks in that submission is rejected
+- Throttling statistics are reset when the cluster manager node changes
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.4.0 | [#4986](https://github.com/opensearch-project/OpenSearch/pull/4986) | Initial cluster manager task throttling implementation |
+| v3.0.0 | [#17711](https://github.com/opensearch-project/OpenSearch/pull/17711) | Enabled default throttling for all tasks |
+
+## References
+
+- [Issue #17685](https://github.com/opensearch-project/OpenSearch/issues/17685): Feature request for default throttling in v3.0.0
+- [Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/cluster-manager-task-throttling/): Official cluster manager task throttling documentation
+- [OpenSearch 2.4.0 Blog](https://opensearch.org/blog/opensearch-2-4-is-available-today/): Introduction of cluster manager task throttling
+
+## Change History
+
+- **v3.0.0** (2025): Enabled default throttling for all task types with predefined thresholds; introduced `ClusterManagerTask` enum
+- **v2.4.0** (2022): Initial implementation of cluster manager task throttling (disabled by default)

--- a/docs/releases/v3.0.0/features/opensearch/cluster-manager-throttling.md
+++ b/docs/releases/v3.0.0/features/opensearch/cluster-manager-throttling.md
@@ -1,0 +1,143 @@
+# Cluster Manager Throttling
+
+## Summary
+
+OpenSearch v3.0.0 enables default throttling for all tasks submitted to the cluster manager. Previously, throttling was disabled by default and required manual configuration. This change provides out-of-the-box protection against cluster manager overload by applying predefined throttling thresholds based on task type.
+
+## Details
+
+### What's New in v3.0.0
+
+- **Default throttling enabled**: All cluster manager tasks now have throttling enabled by default with predefined thresholds
+- **Task-type-based thresholds**: Different task types have different default thresholds based on their typical usage patterns
+- **New `ClusterManagerTask` enum**: Replaces the old `ClusterManagerTaskKeys` class with a type-safe enum that includes both task keys and their default thresholds
+- **Automatic threshold application**: When a task is registered for throttling, its default threshold is automatically applied if not explicitly configured
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.0.0"
+        A1[Task Submission] --> B1[ClusterManagerTaskThrottler]
+        B1 --> C1{Threshold Configured?}
+        C1 -->|No| D1[No Throttling]
+        C1 -->|Yes| E1[Apply Threshold]
+    end
+    
+    subgraph "v3.0.0"
+        A2[Task Submission] --> B2[ClusterManagerTaskThrottler]
+        B2 --> C2{Custom Threshold?}
+        C2 -->|No| D2[Apply Default from ClusterManagerTask]
+        C2 -->|Yes| E2[Apply Custom Threshold]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ClusterManagerTask` | New enum that defines all cluster manager task types with their keys and default thresholds |
+| `registerClusterManagerTask(ClusterManagerTask, boolean)` | Updated method signature that accepts the enum instead of a string key |
+
+#### Default Throttling Thresholds
+
+| Task Type | Default Threshold |
+|-----------|-------------------|
+| `create-index` | 50 |
+| `update-settings` | 50 |
+| `cluster-update-settings` | 50 |
+| `delete-index` | 50 |
+| `delete-dangling-index` | 50 |
+| `create-data-stream` | 50 |
+| `remove-data-stream` | 50 |
+| `create-index-template` | 50 |
+| `remove-index-template` | 50 |
+| `create-component-template` | 50 |
+| `remove-component-template` | 50 |
+| `create-index-template-v2` | 50 |
+| `remove-index-template-v2` | 50 |
+| `put-pipeline` | 50 |
+| `delete-pipeline` | 50 |
+| `put-search-pipeline` | 50 |
+| `delete-search-pipeline` | 50 |
+| `create-persistent-task` | 50 |
+| `finish-persistent-task` | 50 |
+| `remove-persistent-task` | 50 |
+| `update-task-state` | 50 |
+| `create-query-group` | 50 |
+| `delete-query-group` | 50 |
+| `update-query-group` | 50 |
+| `put-script` | 50 |
+| `delete-script` | 50 |
+| `put-repository` | 50 |
+| `delete-repository` | 50 |
+| `create-snapshot` | 50 |
+| `delete-snapshot` | 50 |
+| `restore-snapshot` | 50 |
+| `cluster-reroute-api` | 50 |
+| `auto-create` | 200 |
+| `rollover-index` | 200 |
+| `index-aliases` | 200 |
+| `put-mapping` | 10000 |
+| `update-snapshot-state` | 5000 |
+
+### Usage Example
+
+Throttling is now enabled by default. To customize a threshold:
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster_manager.throttling.thresholds": {
+      "put-mapping": {
+        "value": 5000
+      }
+    }
+  }
+}
+```
+
+To disable throttling for a specific task type, set the threshold to `-1`:
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster_manager.throttling.thresholds": {
+      "create-index": {
+        "value": -1
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- **Breaking change for custom configurations**: If you previously relied on throttling being disabled by default, you may need to explicitly disable it for specific task types
+- **Existing custom thresholds preserved**: Any custom thresholds configured via cluster settings will continue to override the defaults
+- **No action required for most users**: The default thresholds are designed to provide reasonable protection without impacting normal operations
+
+## Limitations
+
+- Throttling thresholds are cluster-wide and cannot be configured per-node
+- The default thresholds are based on general usage patterns and may need tuning for specific workloads
+- When throttled, tasks are rejected and must be retried by the client with exponential backoff
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17711](https://github.com/opensearch-project/OpenSearch/pull/17711) | Enabled default throttling for all tasks submitted to cluster manager |
+
+## References
+
+- [Issue #17685](https://github.com/opensearch-project/OpenSearch/issues/17685): Feature request for default throttling
+- [Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/cluster-manager-task-throttling/): Cluster manager task throttling
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/cluster-manager-throttling.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -7,6 +7,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)
+- [Cluster Manager Throttling](features/opensearch/cluster-manager-throttling.md)
 - [Dependency Bumps](features/opensearch/dependency-bumps.md)
 - [Locale Provider Changes](features/opensearch/locale-provider-changes.md)
 - [HTTP API Improvements](features/opensearch/http-api-improvements.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Cluster Manager Throttling feature in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/cluster-manager-throttling.md`
- Feature report: `docs/features/opensearch/cluster-manager-throttling.md`

### Key Changes in v3.0.0
- Default throttling enabled for all cluster manager tasks
- New `ClusterManagerTask` enum with predefined thresholds per task type
- Task-type-based default thresholds (50 for most operations, higher for frequent operations like `put-mapping`)

### Resources Used
- PR: [#17711](https://github.com/opensearch-project/OpenSearch/pull/17711)
- Issue: [#17685](https://github.com/opensearch-project/OpenSearch/issues/17685)
- Docs: https://docs.opensearch.org/3.0/tuning-your-cluster/cluster-manager-task-throttling/

Closes #247