### PR TITLE
docs: add segment-warmer report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -20,6 +20,7 @@
 - [Merge & Segment Settings](opensearch/merge-segment-settings.md)
 - [Nodes Info API](opensearch/nodes-info-api.md)
 - [Search Backpressure](opensearch/search-backpressure.md)
+- [Segment Warmer](opensearch/segment-warmer.md)
 - [Stream Input/Output](opensearch/stream-inputoutput.md)
 - [Wildcard Field](opensearch/wildcard-field.md)
 

--- a/docs/features/opensearch/segment-warmer.md
+++ b/docs/features/opensearch/segment-warmer.md
@@ -1,0 +1,134 @@
+# Segment Warmer
+
+## Summary
+
+Segment Warmer is an optimization feature for segment replication that pre-copies merged segments to replica shards before the primary shard's refresh completes. By leveraging Lucene's `IndexWriter.IndexReaderWarmer` interface, this feature significantly reduces the visibility delay between primary and replica shards, improving data consistency and search freshness in segment replication deployments.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Primary Shard"
+        IW[IndexWriter]
+        SM[SegmentMerger]
+        MSW[MergedSegmentWarmer]
+    end
+    
+    subgraph "MergedSegmentWarmerFactory"
+        MF[Factory]
+        LSW[LocalMergedSegmentWarmer]
+        RSW[RemoteStoreMergedSegmentWarmer]
+    end
+    
+    subgraph "Replication Targets"
+        R1[Replica Shard 1]
+        R2[Replica Shard N]
+        RS[Remote Store]
+    end
+    
+    SM -->|merge complete| IW
+    IW -->|warm callback| MSW
+    MF -->|local segrep| LSW
+    MF -->|remote store| RSW
+    LSW -->|node-to-node| R1
+    LSW -->|node-to-node| R2
+    RSW -->|upload| RS
+    RS -.->|fetch| R1
+    RS -.->|fetch| R2
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Without Pre-copy"
+        A1[Merge] --> A2[Refresh]
+        A2 --> A3[Segment Replication]
+        A3 --> A4[Replica Visible]
+    end
+    
+    subgraph "With Pre-copy"
+        B1[Merge] --> B2[Pre-copy to Replicas]
+        B2 --> B3[Refresh]
+        B3 --> B4[Segment Replication]
+        B4 --> B5[Replica Visible]
+        B2 -.->|files already present| B4
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `MergedSegmentWarmerFactory` | Factory that creates appropriate `IndexReaderWarmer` implementations based on index replication settings |
+| `MergedSegmentWarmer` | Unified implementation handling both local and remote segment warming |
+| `LocalMergedSegmentWarmer` | Handles node-to-node segment transfer for local segment replication |
+| `RemoteStoreMergedSegmentWarmer` | Handles segment upload to remote store for remote-backed indexes |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `opensearch.experimental.feature.merged_segment_warmer.enabled` | Feature flag to enable merged segment warmer | `false` |
+| `index.replication.type` | Must be set to `SEGMENT` for segment warmer to activate | `DOCUMENT` |
+
+### Usage Example
+
+Enable the feature flag in `opensearch.yml`:
+
+```yaml
+opensearch.experimental.feature.merged_segment_warmer.enabled: true
+```
+
+Create an index with segment replication:
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "replication.type": "SEGMENT",
+      "number_of_replicas": 1
+    }
+  }
+}
+```
+
+### How Pre-copy Works
+
+1. **Standard Segment Replication Flow**: Without pre-copy, merged segments wait for the next refresh cycle before being replicated to replicas, causing visibility delays proportional to segment size
+
+2. **Pre-copy Flow**:
+   - Primary shard completes segment merge
+   - `IndexWriter` invokes `IndexReaderWarmer.warm()` callback
+   - `MergedSegmentWarmer` initiates segment transfer to replicas
+   - Replicas receive segment files before primary refresh
+   - On refresh, segment replication finds files already present on replicas
+   - Replication completes with minimal network transfer
+
+3. **Failover**: If pre-copy fails or times out, the system falls back to standard segment replication behavior
+
+## Limitations
+
+- Requires segment replication (`replication.type: SEGMENT`)
+- Experimental feature requiring explicit feature flag enablement
+- Increases network utilization during merge operations
+- Not applicable to document replication indexes
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17881](https://github.com/opensearch-project/OpenSearch/pull/17881) | Initial implementation - MergedSegmentWarmerFactory infrastructure |
+
+## References
+
+- [Issue #17528](https://github.com/opensearch-project/OpenSearch/issues/17528): RFC - Introduce Pre-copy Merged Segment into Segment Replication
+- [Issue #1694](https://github.com/opensearch-project/OpenSearch/issues/1694): Original Segment Replication feature request
+- [Segment Replication Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/segment-replication/index/): Official docs
+
+## Change History
+
+- **v3.0.0** (2025-04-15): Initial implementation - introduced `MergedSegmentWarmerFactory` with `LocalMergedSegmentWarmer` and `RemoteStoreMergedSegmentWarmer` infrastructure

--- a/docs/releases/v3.0.0/features/opensearch/segment-warmer.md
+++ b/docs/releases/v3.0.0/features/opensearch/segment-warmer.md
@@ -1,0 +1,126 @@
+# Segment Warmer
+
+## Summary
+
+OpenSearch v3.0.0 introduces `MergedSegmentWarmerFactory`, an extensible framework for pre-copying merged segments to replica shards during segment replication. This feature significantly reduces replica visibility delay by allowing merged segments to be transferred to replicas before the primary shard's refresh completes, reducing lag time by over 20x in benchmarks.
+
+## Details
+
+### What's New in v3.0.0
+
+This release introduces the foundational infrastructure for merged segment pre-copy in segment replication scenarios. The feature leverages Lucene's `IndexWriter.IndexReaderWarmer` interface to initiate segment transfer to replicas immediately after merge completion, rather than waiting for the standard segment replication cycle.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Primary Shard"
+        IW[IndexWriter]
+        MSW[MergedSegmentWarmer]
+        MF[MergedSegmentWarmerFactory]
+    end
+    
+    subgraph "Segment Replication"
+        LSW[LocalMergedSegmentWarmer]
+        RSW[RemoteStoreMergedSegmentWarmer]
+    end
+    
+    subgraph "Replica Shards"
+        R1[Replica 1]
+        R2[Replica N]
+    end
+    
+    subgraph "Remote Store"
+        RS[Remote Storage]
+    end
+    
+    IW -->|merge complete| MSW
+    MF -->|creates| LSW
+    MF -->|creates| RSW
+    LSW -->|node-to-node| R1
+    LSW -->|node-to-node| R2
+    RSW -->|upload| RS
+    RS -->|fetch| R1
+    RS -->|fetch| R2
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `MergedSegmentWarmerFactory` | Factory class that creates appropriate `IndexReaderWarmer` based on replication type (local segment replication, remote store, or document replication) |
+| `LocalMergedSegmentWarmer` | Implementation for local on-disk segment replication - transfers segments directly to replicas via node-to-node communication |
+| `RemoteStoreMergedSegmentWarmer` | Implementation for remote store - uploads merged segments to remote storage for replica consumption |
+| `MergedSegmentWarmer` | Unified warmer implementation (in main branch) that handles both local and remote scenarios |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `opensearch.experimental.feature.merged_segment_warmer.enabled` | Feature flag to enable merged segment warmer functionality | `false` |
+
+### How It Works
+
+1. **Merge Completion**: When `IndexWriter` completes a segment merge, it invokes the configured `IndexReaderWarmer`
+2. **Warmer Selection**: `MergedSegmentWarmerFactory` selects the appropriate warmer based on index settings:
+   - Local segment replication → `LocalMergedSegmentWarmer`
+   - Remote store enabled → `RemoteStoreMergedSegmentWarmer`
+   - Document replication → No warmer (returns null)
+3. **Pre-copy Execution**: The warmer initiates segment transfer to replicas before the merged segment becomes visible
+4. **Segment Replication**: When the primary refreshes, replicas can reuse pre-copied segment files, dramatically reducing replication lag
+
+### Usage Example
+
+Enable the experimental feature flag in `opensearch.yml`:
+
+```yaml
+opensearch.experimental.feature.merged_segment_warmer.enabled: true
+```
+
+Create an index with segment replication:
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "replication.type": "SEGMENT",
+      "number_of_replicas": 1
+    }
+  }
+}
+```
+
+### Performance Results
+
+Benchmarks using the `nyc_taxis` workload with 2 primary shards and 1 replica showed:
+
+| Metric | Without Pre-copy | With Pre-copy | Improvement |
+|--------|------------------|---------------|-------------|
+| Maximum Replica Lag | 66 seconds | 2.9 seconds | **>20x reduction** |
+| CPU Utilization | Baseline | No significant change | Neutral |
+| P99 Read Latency | Baseline | No significant change | Neutral |
+
+## Limitations
+
+- **Experimental Feature**: Requires enabling the feature flag; not enabled by default
+- **Segment Replication Only**: Only applicable to indexes using segment replication (`replication.type: SEGMENT`)
+- **Implementation Pending**: The `warm()` methods in `LocalMergedSegmentWarmer` and `RemoteStoreMergedSegmentWarmer` contain TODO placeholders in v3.0.0; full implementation is ongoing
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17881](https://github.com/opensearch-project/OpenSearch/pull/17881) | Introducing MergedSegmentWarmerFactory to support the extension of IndexWriter.IndexReaderWarmer |
+
+## References
+
+- [Issue #17528](https://github.com/opensearch-project/OpenSearch/issues/17528): RFC - Introduce Pre-copy Merged Segment into Segment Replication
+- [Issue #1694](https://github.com/opensearch-project/OpenSearch/issues/1694): Original Segment Replication feature request
+- [Segment Replication Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/segment-replication/index/): Official docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/segment-warmer.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -20,6 +20,7 @@
 - [Merge & Segment Settings](features/opensearch/merge-segment-settings.md)
 - [Nodes Info API Changes](features/opensearch/nodes-info-api-changes.md)
 - [Search Backpressure](features/opensearch/search-backpressure.md)
+- [Segment Warmer](features/opensearch/segment-warmer.md)
 - [Stream Input/Output](features/opensearch/stream-inputoutput.md)
 - [Wildcard Field](features/opensearch/wildcard-field.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Segment Warmer feature introduced in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/segment-warmer.md`
- Feature report: `docs/features/opensearch/segment-warmer.md`

### Key Changes in v3.0.0
- Introduced `MergedSegmentWarmerFactory` to support extension of `IndexWriter.IndexReaderWarmer`
- Added `LocalMergedSegmentWarmer` for local on-disk segment replication
- Added `RemoteStoreMergedSegmentWarmer` for remote store scenarios
- New experimental feature flag: `opensearch.experimental.feature.merged_segment_warmer.enabled`

### Resources Used
- PR: [#17881](https://github.com/opensearch-project/OpenSearch/pull/17881)
- Issue: [#17528](https://github.com/opensearch-project/OpenSearch/issues/17528)
- Docs: [Segment Replication](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/segment-replication/index/)

Closes #245