### PR TITLE
docs: add mapping-transformer report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -7,6 +7,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
+- [Mapping Transformer](opensearch/mapping-transformer.md)
 - [Cluster Manager Task Throttling](opensearch/cluster-manager-throttling.md)
 - [Dependency Management](opensearch/dependency-management.md)
 - [Locale Provider](opensearch/locale-provider.md)

--- a/docs/features/opensearch/mapping-transformer.md
+++ b/docs/features/opensearch/mapping-transformer.md
@@ -1,0 +1,207 @@
+# Mapping Transformer
+
+## Summary
+
+Mapping Transformer is an extensibility feature in OpenSearch that allows plugins to intercept and transform index mappings during index creation, mapping updates, and index template operations. This enables plugins to automatically generate or modify field mappings based on custom logic, simplifying complex configuration workflows.
+
+The primary use case is the neural-search plugin's semantic field feature, which uses mapping transformers to automatically generate knn_vector or rank_feature fields based on model IDs defined in semantic fields.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Plugin Layer"
+        P1[Plugin 1]
+        P2[Plugin 2]
+        PN[Plugin N]
+    end
+    
+    subgraph "Core - Mapper Module"
+        MT[MappingTransformer Interface]
+        MTR[MappingTransformerRegistry]
+    end
+    
+    subgraph "Core - Transport Actions"
+        TCI[TransportCreateIndexAction]
+        TPM[TransportPutMappingAction]
+        TPI[TransportPutIndexTemplateAction]
+        TPC[TransportPutComponentTemplateAction]
+        TPCI[TransportPutComposableIndexTemplateAction]
+    end
+    
+    subgraph "Core - Metadata Services"
+        MCI[MetadataCreateIndexService]
+        MMS[MetadataMappingService]
+        MITS[MetadataIndexTemplateService]
+    end
+    
+    P1 --> MT
+    P2 --> MT
+    PN --> MT
+    MT --> MTR
+    
+    TCI --> MTR
+    TPM --> MTR
+    TPI --> MTR
+    TPC --> MTR
+    TPCI --> MTR
+    
+    TCI --> MCI
+    TPM --> MMS
+    TPI --> MITS
+    TPC --> MITS
+    TPCI --> MITS
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Client Request] --> B[Transport Action]
+    B --> C{Has Mapping?}
+    C -->|No| G[Proceed to Service]
+    C -->|Yes| D[MappingTransformerRegistry]
+    D --> E[Apply Transformers Sequentially]
+    E --> F[Validate Transformed Mapping]
+    F --> G
+    G --> H[Persist to Cluster State]
+```
+
+### Components
+
+| Component | Package | Description |
+|-----------|---------|-------------|
+| `MappingTransformer` | `org.opensearch.index.mapper` | Interface for implementing custom mapping transformation logic |
+| `MappingTransformerRegistry` | `org.opensearch.index.mapper` | Collects transformers from all MapperPlugins and applies them sequentially |
+| `MappingTransformer.TransformContext` | `org.opensearch.index.mapper` | Context object for transformation (reserved for future use) |
+| `MapperPlugin.getMappingTransformers()` | `org.opensearch.plugins` | Extension point for plugins to register transformers |
+
+### Configuration
+
+This feature does not have any cluster or index settings. Transformers are registered programmatically by plugins.
+
+### Usage Example
+
+#### Implementing a MappingTransformer
+
+```java
+public class SemanticFieldTransformer implements MappingTransformer {
+    
+    private final ModelService modelService;
+    
+    public SemanticFieldTransformer(ModelService modelService) {
+        this.modelService = modelService;
+    }
+    
+    @Override
+    public void transform(
+        final Map<String, Object> mapping,
+        final TransformContext context,
+        @NonNull final ActionListener<Void> listener
+    ) {
+        try {
+            Map<String, Object> properties = (Map<String, Object>) mapping.get("properties");
+            if (properties == null) {
+                listener.onResponse(null);
+                return;
+            }
+            
+            // Find semantic fields and generate corresponding vector fields
+            for (Map.Entry<String, Object> entry : new HashMap<>(properties).entrySet()) {
+                Map<String, Object> fieldConfig = (Map<String, Object>) entry.getValue();
+                if ("semantic".equals(fieldConfig.get("type"))) {
+                    String modelId = (String) fieldConfig.get("model_id");
+                    int dimension = modelService.getModelDimension(modelId);
+                    
+                    // Add generated knn_vector field
+                    properties.put(entry.getKey() + "_embedding", Map.of(
+                        "type", "knn_vector",
+                        "dimension", dimension
+                    ));
+                }
+            }
+            
+            listener.onResponse(null);
+        } catch (Exception e) {
+            listener.onFailure(e);
+        }
+    }
+}
+```
+
+#### Registering in a Plugin
+
+```java
+public class NeuralSearchPlugin extends Plugin implements MapperPlugin {
+    
+    private final SemanticFieldTransformer transformer;
+    
+    public NeuralSearchPlugin() {
+        this.transformer = new SemanticFieldTransformer(new ModelService());
+    }
+    
+    @Override
+    public List<MappingTransformer> getMappingTransformers() {
+        return List.of(transformer);
+    }
+}
+```
+
+#### Example Transformation
+
+Original mapping:
+```json
+{
+  "properties": {
+    "title": { "type": "text" },
+    "content": { 
+      "type": "semantic",
+      "model_id": "my-embedding-model"
+    }
+  }
+}
+```
+
+Transformed mapping (after semantic field transformer):
+```json
+{
+  "properties": {
+    "title": { "type": "text" },
+    "content": { 
+      "type": "semantic",
+      "model_id": "my-embedding-model"
+    },
+    "content_embedding": {
+      "type": "knn_vector",
+      "dimension": 768
+    }
+  }
+}
+```
+
+## Limitations
+
+- Transformers are executed sequentially, which may impact performance if many transformers are registered
+- No ordering guarantee between transformers from different plugins
+- The `TransformContext` is currently empty; index settings and action type information are not yet available
+- Transformers modify mappings in place; there's no transaction or rollback mechanism
+- Async transformer execution requires careful error handling to avoid request timeouts
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17635](https://github.com/opensearch-project/OpenSearch/pull/17635) | Initial implementation of mapping transformer |
+
+## References
+
+- [Issue #17500](https://github.com/opensearch-project/OpenSearch/issues/17500): RFC - Introduce Mapping Transformer
+- [Issue #803](https://github.com/opensearch-project/neural-search/issues/803): Proposal to support semantic field in neural search
+- [Issue #1211](https://github.com/opensearch-project/neural-search/issues/1211): HLD of the semantic field
+- [Issue #1212](https://github.com/opensearch-project/neural-search/issues/1212): LLD of the semantic field
+
+## Change History
+
+- **v3.0.0** (2025-04-15): Initial implementation - introduced MappingTransformer interface, MappingTransformerRegistry, and integration with index/template transport actions

--- a/docs/releases/v3.0.0/features/opensearch/mapping-transformer.md
+++ b/docs/releases/v3.0.0/features/opensearch/mapping-transformer.md
@@ -1,0 +1,172 @@
+# Mapping Transformer
+
+## Summary
+
+OpenSearch 3.0.0 introduces the Mapping Transformer feature, a plugin extension point that allows plugins to transform index mappings during index creation/update and index template creation/update operations. This feature enables plugins to automatically generate or modify field mappings based on custom logic, simplifying complex setup workflows like neural search configuration.
+
+## Details
+
+### What's New in v3.0.0
+
+The Mapping Transformer feature introduces a new extensibility mechanism in the OpenSearch core that allows plugins to intercept and transform index mappings at the transport layer before they are persisted.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Client Request"
+        A[Create Index / Update Mapping / Put Template]
+    end
+    
+    subgraph "Transport Layer"
+        B[Transport Action]
+        C[MappingTransformerRegistry]
+        D[MappingTransformer 1]
+        E[MappingTransformer 2]
+        F[MappingTransformer N]
+    end
+    
+    subgraph "Cluster State"
+        G[MetadataCreateIndexService]
+        H[MetadataMappingService]
+        I[MetadataIndexTemplateService]
+    end
+    
+    A --> B
+    B --> C
+    C --> D
+    D --> E
+    E --> F
+    F --> B
+    B --> G
+    B --> H
+    B --> I
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `MappingTransformer` | Interface for plugins to implement custom mapping transformation logic |
+| `MappingTransformerRegistry` | Registry that collects and applies all registered transformers sequentially |
+| `TransformContext` | Context object for future extensibility (currently empty, reserved for index settings, action type, etc.) |
+
+#### New Plugin Extension Point
+
+The `MapperPlugin` interface now includes a new method for registering mapping transformers:
+
+```java
+public interface MapperPlugin {
+    // Existing methods...
+    
+    /**
+     * Returns mapper transformer implementations added by this plugin.
+     */
+    default List<MappingTransformer> getMappingTransformers() {
+        return Collections.emptyList();
+    }
+}
+```
+
+#### Supported Operations
+
+The mapping transformer is applied to the following transport actions:
+
+| Action | Class |
+|--------|-------|
+| Create Index | `TransportCreateIndexAction` |
+| Put Mapping | `TransportPutMappingAction` |
+| Put Index Template | `TransportPutIndexTemplateAction` |
+| Put Component Template | `TransportPutComponentTemplateAction` |
+| Put Composable Index Template | `TransportPutComposableIndexTemplateAction` |
+
+### Usage Example
+
+Plugins can implement the `MappingTransformer` interface to transform mappings:
+
+```java
+public class MyMappingTransformer implements MappingTransformer {
+    @Override
+    public void transform(
+        final Map<String, Object> mapping,
+        final TransformContext context,
+        @NonNull final ActionListener<Void> listener
+    ) {
+        // Modify the mapping in place
+        Map<String, Object> properties = (Map<String, Object>) mapping.get("properties");
+        if (properties != null && properties.containsKey("my_custom_field")) {
+            // Add generated fields based on custom field configuration
+            properties.put("generated_field", Map.of("type", "keyword"));
+        }
+        listener.onResponse(null);
+    }
+}
+```
+
+Register the transformer in your plugin:
+
+```java
+public class MyPlugin extends Plugin implements MapperPlugin {
+    @Override
+    public List<MappingTransformer> getMappingTransformers() {
+        return List.of(new MyMappingTransformer());
+    }
+}
+```
+
+### Processing Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant TransportAction
+    participant Registry as MappingTransformerRegistry
+    participant Transformer as MappingTransformer
+    participant Service as MetadataService
+    
+    Client->>TransportAction: Create Index Request
+    TransportAction->>Registry: applyTransformers(mapping, context, listener)
+    Registry->>Registry: Parse mapping to Map
+    loop For each transformer
+        Registry->>Transformer: transform(mapping, context, listener)
+        Transformer->>Transformer: Modify mapping in place
+        Transformer->>Registry: onResponse(null)
+        Registry->>Registry: Validate transformed mapping
+    end
+    Registry->>TransportAction: onResponse(transformedMappingString)
+    TransportAction->>Service: Create index with transformed mapping
+    Service->>Client: Response
+```
+
+### Error Handling
+
+The `MappingTransformerRegistry` includes built-in error handling:
+
+- Validates mapping JSON after each transformer to catch corruption early
+- Identifies the faulty transformer if mapping becomes invalid
+- Propagates transformer failures to the original request listener
+
+## Limitations
+
+- Transformers are applied sequentially, not in parallel
+- The `TransformContext` is currently empty; future versions may include index settings and action type information
+- Transformers modify mappings in place; there's no rollback mechanism if a later transformer fails
+- No ordering guarantee between transformers from different plugins
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17635](https://github.com/opensearch-project/OpenSearch/pull/17635) | Introduce mapping transformer to allow transform mappings during index create/update or index template create/update |
+
+## References
+
+- [Issue #17500](https://github.com/opensearch-project/OpenSearch/issues/17500): RFC - Introduce Mapping Transformer
+- [Issue #803](https://github.com/opensearch-project/neural-search/issues/803): Proposal to support semantic field in neural search
+- [Issue #1211](https://github.com/opensearch-project/neural-search/issues/1211): HLD of the semantic field
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/mapping-transformer.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -7,6 +7,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)
+- [Mapping Transformer](features/opensearch/mapping-transformer.md)
 - [Cluster Manager Throttling](features/opensearch/cluster-manager-throttling.md)
 - [Dependency Bumps](features/opensearch/dependency-bumps.md)
 - [Locale Provider Changes](features/opensearch/locale-provider-changes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Mapping Transformer feature introduced in OpenSearch v3.0.0.

## Changes

- Added release report: `docs/releases/v3.0.0/features/opensearch/mapping-transformer.md`
- Added feature report: `docs/features/opensearch/mapping-transformer.md`
- Updated release index and features index

## Feature Overview

Mapping Transformer is an extensibility feature that allows plugins to intercept and transform index mappings during index creation, mapping updates, and index template operations. The primary use case is the neural-search plugin's semantic field feature.

### Key Components
- `MappingTransformer` interface for plugins to implement
- `MappingTransformerRegistry` to collect and apply transformers
- Integration with 5 transport actions (CreateIndex, PutMapping, PutIndexTemplate, PutComponentTemplate, PutComposableIndexTemplate)

## Related
- Closes #244
- PR: opensearch-project/OpenSearch#17635
- Issue: opensearch-project/OpenSearch#17500