### PR TITLE
docs: add refresh-task-scheduling report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -20,6 +20,7 @@
 - [Lucene Similarity](opensearch/lucene-similarity.md)
 - [Merge & Segment Settings](opensearch/merge-segment-settings.md)
 - [Nodes Info API](opensearch/nodes-info-api.md)
+- [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)
 - [Search Backpressure](opensearch/search-backpressure.md)
 - [Segment Warmer](opensearch/segment-warmer.md)
 - [Stream Input/Output](opensearch/stream-inputoutput.md)

--- a/docs/features/opensearch/refresh-task-scheduling.md
+++ b/docs/features/opensearch/refresh-task-scheduling.md
@@ -1,0 +1,129 @@
+# Refresh Task Scheduling
+
+## Summary
+
+Refresh Task Scheduling is a feature that provides deterministic timing for index refresh operations in OpenSearch. By tracking actual refresh execution times and dynamically calculating sleep durations, this feature ensures consistent intervals between refreshes regardless of how long each refresh operation takes. This is particularly important for remote store indexes where predictable data freshness is critical.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Cluster Settings"
+        ClusterSettings[ClusterSettings]
+        Setting[CLUSTER_REFRESH_FIXED_INTERVAL_SCHEDULE_ENABLED_SETTING]
+    end
+    
+    subgraph "IndicesService"
+        IS[IndicesService]
+        IS --> |stores| Enabled[fixedRefreshIntervalSchedulingEnabled]
+        IS --> |provides supplier| IndexModule
+    end
+    
+    subgraph "Index Level"
+        IndexModule --> IndexService
+        IndexService --> AsyncRefreshTask
+    end
+    
+    subgraph "Task Execution"
+        AsyncRefreshTask --> |extends| BaseAsyncTask
+        BaseAsyncTask --> |extends| AbstractAsyncTask
+        AbstractAsyncTask --> |calculates| SleepDuration[getSleepDuration]
+    end
+    
+    ClusterSettings --> Setting
+    Setting --> IS
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Refresh Cycle"
+        A[Task Scheduled] --> B[run called]
+        B --> C[Record lastRunStartTimeNs]
+        C --> D[Execute runInternal]
+        D --> E[rescheduleIfNecessary]
+        E --> F[getSleepDuration]
+        F --> G{Fixed Interval Enabled?}
+        G -->|No| H[Return configured interval]
+        G -->|Yes| I{First Run?}
+        I -->|Yes| J[Return random staggered delay]
+        I -->|No| K[Calculate dynamic sleep]
+        K --> L{Elapsed >= Interval?}
+        L -->|Yes| M[Return ZERO]
+        L -->|No| N[Return remaining time]
+    end
+```
+
+### Components
+
+| Component | Class | Description |
+|-----------|-------|-------------|
+| Cluster Setting | `IndicesService.CLUSTER_REFRESH_FIXED_INTERVAL_SCHEDULE_ENABLED_SETTING` | Boolean setting to enable/disable fixed interval scheduling |
+| Task Base Class | `AbstractAsyncTask` | Enhanced to track last run time and calculate dynamic sleep durations |
+| Index Task | `IndexService.AsyncRefreshTask` | Refresh task that uses the fixed interval scheduling supplier |
+| Sleep Calculator | `AbstractAsyncTask.getSleepDuration()` | Method that determines the next sleep duration |
+
+### Configuration
+
+| Setting | Description | Default | Scope |
+|---------|-------------|---------|-------|
+| `cluster.index.refresh.fixed_interval_scheduling.enabled` | Enables fixed interval scheduling for refresh tasks | `false` | Cluster (Dynamic) |
+
+### Usage Example
+
+Enable fixed interval refresh scheduling:
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.index.refresh.fixed_interval_scheduling.enabled": true
+  }
+}
+```
+
+Combine with custom refresh interval per index:
+
+```json
+PUT /my-index/_settings
+{
+  "index": {
+    "refresh_interval": "5s"
+  }
+}
+```
+
+### Behavior Comparison
+
+| Scenario | Without Fixed Interval | With Fixed Interval |
+|----------|----------------------|---------------------|
+| Refresh takes 200ms, interval 1s | Next refresh in 1s (total 1.2s) | Next refresh in 800ms (total 1s) |
+| Refresh takes 1.5s, interval 1s | Next refresh in 1s (total 2.5s) | Next refresh immediately (total 1.5s) |
+| Initial refresh | Starts immediately | Starts with random delay (0 to interval) |
+
+## Limitations
+
+- Cluster-wide setting only; cannot be configured per-index
+- No backpressure when refreshes consistently exceed the interval
+- Staggered start applies only to initial refresh after task creation
+- Does not address the underlying cause of slow refreshes
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17777](https://github.com/opensearch-project/OpenSearch/pull/17777) | Implement fixed interval refresh task scheduling |
+
+## References
+
+- [Issue #17776](https://github.com/opensearch-project/OpenSearch/issues/17776): META - Improve Data Freshness for Remote Store Indexes
+- [Blog: Optimize OpenSearch Refresh Interval](https://opensearch.org/blog/optimize-refresh-interval/): Background on refresh interval concepts
+- [Blog: Adaptive refresh for resilient segment replication](https://opensearch.org/blog/adaptive-refresh-for-resilient-segment-replication/): Related refresh improvements for segment replication
+- [Refresh Index API](https://docs.opensearch.org/3.0/api-reference/index-apis/refresh/): Official documentation on refresh operations
+
+## Change History
+
+- **v3.0.0** (2025-04-03): Initial implementation with cluster-level setting and dynamic sleep duration calculation

--- a/docs/releases/v3.0.0/features/opensearch/refresh-task-scheduling.md
+++ b/docs/releases/v3.0.0/features/opensearch/refresh-task-scheduling.md
@@ -1,0 +1,116 @@
+# Refresh Task Scheduling
+
+## Summary
+
+OpenSearch v3.0.0 introduces fixed interval refresh task scheduling, a feature that ensures consistent intervals between index refreshes. This enhancement addresses the problem of variable refresh timing caused by the duration of refresh operations themselves, improving data freshness predictability for remote store indexes.
+
+## Details
+
+### What's New in v3.0.0
+
+This release adds a new cluster-level setting that enables deterministic refresh scheduling. When enabled, the system calculates dynamic sleep durations based on actual refresh execution time, ensuring that refreshes occur at consistent intervals regardless of how long each refresh takes.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Refresh Task Scheduling"
+        Setting[cluster.index.refresh.fixed_interval_scheduling.enabled]
+        Setting --> IndicesService
+        IndicesService --> IndexService
+        IndexService --> AsyncRefreshTask
+        AsyncRefreshTask --> AbstractAsyncTask
+    end
+    
+    subgraph "AbstractAsyncTask Enhancements"
+        AbstractAsyncTask --> LastRunTime[Track lastRunStartTimeNs]
+        AbstractAsyncTask --> SleepCalc[Calculate Dynamic Sleep Duration]
+        SleepCalc --> StaggeredStart[Staggered Initial Start]
+        SleepCalc --> DynamicInterval[Dynamic Interval Adjustment]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `CLUSTER_REFRESH_FIXED_INTERVAL_SCHEDULE_ENABLED_SETTING` | New cluster setting in `IndicesService` to enable fixed interval scheduling |
+| `fixedIntervalSchedulingEnabled` supplier | Supplier passed through `IndexModule` → `IndexService` → `AsyncRefreshTask` |
+| `getSleepDuration()` method | New method in `AbstractAsyncTask` that calculates dynamic sleep duration |
+| `lastRunStartTimeNs` field | Tracks the start time of the last task execution |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.index.refresh.fixed_interval_scheduling.enabled` | Enables fixed interval scheduling for refresh tasks | `false` |
+
+### How It Works
+
+The fixed interval scheduling works by tracking when each refresh starts and calculating the appropriate sleep duration for the next refresh:
+
+1. **Initial Staggered Start**: On first execution, a random sleep duration within the interval is used to prevent concurrent refreshes across multiple shards (dense shard packing scenario)
+
+2. **Dynamic Sleep Calculation**: After each refresh, the system calculates:
+   - Time elapsed since last refresh started
+   - If elapsed time >= configured interval → schedule immediately (`TimeValue.ZERO`)
+   - If elapsed time < configured interval → sleep for remaining time
+
+```java
+// Simplified logic from AbstractAsyncTask.getSleepDuration()
+if (lastRunStartTimeNs == -1) {
+    // Stagger initial start with random delay
+    return TimeValue.timeValueNanos(random.nextLong(interval.nanos()));
+}
+
+long timeSinceLastRunNs = System.nanoTime() - lastRunStartTimeNs;
+if (timeSinceLastRunNs >= interval.nanos()) {
+    return TimeValue.ZERO;  // Refresh took longer than interval
+} else {
+    return TimeValue.timeValueNanos(interval.nanos() - timeSinceLastRunNs);
+}
+```
+
+### Usage Example
+
+Enable fixed interval refresh scheduling cluster-wide:
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.index.refresh.fixed_interval_scheduling.enabled": true
+  }
+}
+```
+
+### Migration Notes
+
+- This feature is disabled by default for backward compatibility
+- Enable it on clusters where consistent refresh timing is important
+- Particularly beneficial for remote store indexes where data freshness is critical
+- No index-level changes required; the setting applies cluster-wide
+
+## Limitations
+
+- The setting is cluster-wide and cannot be configured per-index
+- When refresh duration exceeds the configured interval, refreshes are scheduled immediately (no backpressure mechanism)
+- Staggered start only applies to the initial refresh; subsequent refreshes follow the calculated schedule
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17777](https://github.com/opensearch-project/OpenSearch/pull/17777) | Implement fixed interval refresh task scheduling |
+
+## References
+
+- [Issue #17776](https://github.com/opensearch-project/OpenSearch/issues/17776): META - Improve Data Freshness for Remote Store Indexes
+- [Blog: Optimize OpenSearch Refresh Interval](https://opensearch.org/blog/optimize-refresh-interval/): Background on refresh interval optimization
+- [Blog: Adaptive refresh for resilient segment replication](https://opensearch.org/blog/adaptive-refresh-for-resilient-segment-replication/): Related refresh improvements
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/refresh-task-scheduling.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -20,6 +20,7 @@
 - [Lucene Similarity](features/opensearch/lucene-similarity.md)
 - [Merge & Segment Settings](features/opensearch/merge-segment-settings.md)
 - [Nodes Info API Changes](features/opensearch/nodes-info-api-changes.md)
+- [Refresh Task Scheduling](features/opensearch/refresh-task-scheduling.md)
 - [Search Backpressure](features/opensearch/search-backpressure.md)
 - [Segment Warmer](features/opensearch/segment-warmer.md)
 - [Stream Input/Output](features/opensearch/stream-inputoutput.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Refresh Task Scheduling feature introduced in OpenSearch v3.0.0.

## Changes

- **Release Report**: `docs/releases/v3.0.0/features/opensearch/refresh-task-scheduling.md`
- **Feature Report**: `docs/features/opensearch/refresh-task-scheduling.md`
- Updated release and feature indexes

## Feature Overview

Fixed interval refresh task scheduling ensures consistent intervals between index refreshes by:
- Tracking actual refresh execution times
- Dynamically calculating sleep durations
- Staggering initial refresh starts to prevent concurrent refreshes across shards

## Related

- Closes #243
- OpenSearch PR: opensearch-project/OpenSearch#17777
- Meta Issue: opensearch-project/OpenSearch#17776