### PR TITLE
docs: add tiered-caching report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -24,6 +24,7 @@
 - [Search Backpressure](opensearch/search-backpressure.md)
 - [Segment Warmer](opensearch/segment-warmer.md)
 - [Stream Input/Output](opensearch/stream-inputoutput.md)
+- [Tiered Caching](opensearch/tiered-caching.md)
 - [Wildcard Field](opensearch/wildcard-field.md)
 
 ## opensearch-dashboards

--- a/docs/features/opensearch/tiered-caching.md
+++ b/docs/features/opensearch/tiered-caching.md
@@ -1,0 +1,131 @@
+# Tiered Caching
+
+## Summary
+
+Tiered caching is a multi-level caching mechanism in OpenSearch that combines an on-heap cache tier with a disk-based cache tier. This approach balances performance and capacity, allowing larger datasets to be cached without consuming valuable heap memory. When items are evicted from the faster on-heap tier, they spill over to the larger disk tier, reducing cache misses and improving query performance for repeated queries.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Tiered Spillover Cache"
+        Query[Incoming Query] --> Check{Cache Lookup}
+        Check -->|Hit| OnHeap[On-Heap Cache]
+        Check -->|Miss in Heap| Disk[Disk Cache]
+        Disk -->|Hit| Return[Return Result]
+        Disk -->|Miss| Compute[Compute Query]
+        Compute --> PolicyCheck{Took-Time Policy}
+        PolicyCheck -->|Pass| OnHeap
+        PolicyCheck -->|Fail| Skip[Skip Caching]
+        OnHeap -->|Eviction| DiskPolicy{Disk Policy}
+        DiskPolicy -->|Pass| Disk
+        DiskPolicy -->|Fail| Evict[Evict]
+    end
+    
+    subgraph "Disk Cache Manager"
+        DCM[EhcacheDiskCacheManager] --> CM[Single PersistentCacheManager]
+        CM --> C1[Cache Segment 1]
+        CM --> C2[Cache Segment 2]
+        CM --> CN[Cache Segment N]
+        CM --> TP[Shared Thread Pool]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    Q[Query] --> HP{Heap Policy}
+    HP -->|Pass| HC[Heap Cache]
+    HP -->|Fail| Skip1[No Cache]
+    HC -->|Eviction| DP{Disk Policy}
+    DP -->|Pass| DC[Disk Cache]
+    DP -->|Fail| Skip2[Evict]
+    DC --> Storage[(SSD/NVMe)]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `TieredSpilloverCache` | Main cache implementation that coordinates between heap and disk tiers |
+| `TieredSpilloverCacheSegment` | Individual cache segment with its own read/write lock for concurrency |
+| `EhcacheDiskCacheManager` | Singleton manager that creates and manages disk caches via a single `PersistentCacheManager` |
+| `TookTimePolicy` | Policy that filters cache entries based on query execution time |
+| `OpenSearchOnHeapCache` | Built-in on-heap cache implementation |
+| `EhcacheDiskCache` | Disk cache implementation using Ehcache library |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `indices.requests.cache.store.name` | Cache store implementation | `opensearch_onheap` |
+| `indices.requests.cache.tiered_spillover.onheap.store.name` | On-heap tier implementation | `opensearch_onheap` |
+| `indices.requests.cache.tiered_spillover.disk.store.name` | Disk tier implementation | `ehcache_disk` |
+| `indices.requests.cache.tiered_spillover.onheap.store.size` | On-heap cache size | 1% of heap |
+| `indices.requests.cache.tiered_spillover.disk.store.size` | Disk cache size | 1 GB |
+| `indices.requests.cache.tiered_spillover.segments` | Number of cache segments | `2^(ceil(log2(CPU_CORES * 1.5)))` |
+| `indices.requests.cache.tiered_spillover.policies.took_time.threshold` | Min query time to enter cache | `0ms` |
+| `indices.requests.cache.tiered_spillover.disk.store.policies.took_time.threshold` | Min query time to enter disk tier | `10ms` |
+| `indices.requests.cache.tiered_spillover.disk.store.enabled` | Enable/disable disk tier dynamically | `true` |
+| `indices.requests.cache.ehcache_disk.max_size_in_bytes` | Disk cache size in bytes | 1 GB |
+| `indices.requests.cache.ehcache_disk.segments` | Disk cache segments | 16 |
+| `indices.requests.cache.ehcache_disk.min_threads` | Min disk write threads | 2 |
+| `indices.requests.cache.ehcache_disk.max_threads` | Max disk write threads | 1.5 × CPU cores |
+
+### Usage Example
+
+```yaml
+# opensearch.yml - Enable tiered caching
+indices.requests.cache.store.name: tiered_spillover
+indices.requests.cache.tiered_spillover.onheap.store.name: opensearch_onheap
+indices.requests.cache.tiered_spillover.disk.store.name: ehcache_disk
+
+# Configure cache sizes
+indices.requests.cache.tiered_spillover.onheap.store.size: 2%
+indices.requests.cache.tiered_spillover.disk.store.size: 5gb
+
+# Configure took-time policies
+indices.requests.cache.tiered_spillover.policies.took_time.threshold: 0ms
+indices.requests.cache.tiered_spillover.disk.store.policies.took_time.threshold: 10ms
+```
+
+Check cache statistics:
+```bash
+GET /_nodes/stats/caches/request_cache?level=tier
+```
+
+## Limitations
+
+- Currently only supported for the request cache (not query cache)
+- Experimental feature - not recommended for production use
+- Requires `cache-ehcache` plugin installation for disk tier
+- Disk cache data is not persisted between process restarts
+- Minimum disk cache size is 10 MB
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17513](https://github.com/opensearch-project/OpenSearch/pull/17513) | Single cache manager for all ehcache disk caches |
+| v3.0.0 | [#17190](https://github.com/opensearch-project/OpenSearch/pull/17190) | Took-time threshold guards heap tier as well as disk tier |
+| v2.19.0 | - | Disk cache partitioning for improved concurrency |
+| v2.14.0 | - | Initial tiered caching support (experimental) |
+| v2.13.0 | - | cache-ehcache plugin introduced |
+
+## References
+
+- [Issue #16162](https://github.com/opensearch-project/OpenSearch/issues/16162): RFC - Optimize caching policy for Request cache
+- [Issue #10024](https://github.com/opensearch-project/OpenSearch/issues/10024): Tiered caching tracking issue
+- [Tiered Cache Documentation](https://docs.opensearch.org/3.0/search-plugins/caching/tiered-cache/)
+- [Tiered Caching Blog](https://opensearch.org/blog/tiered-cache/)
+- [Request Cache Documentation](https://docs.opensearch.org/3.0/search-plugins/caching/request-cache/)
+
+## Change History
+
+- **v3.0.0** (2025): Single cache manager for disk caches reduces CPU overhead; took-time policy extended to guard heap tier
+- **v2.19.0** (2024): Disk cache partitioning with read/write locks for improved concurrency
+- **v2.14.0** (2024): Initial experimental tiered caching support for request cache
+- **v2.13.0** (2024): cache-ehcache plugin introduced for disk cache implementation

--- a/docs/releases/v3.0.0/features/opensearch/tiered-caching.md
+++ b/docs/releases/v3.0.0/features/opensearch/tiered-caching.md
@@ -1,0 +1,99 @@
+# Tiered Caching
+
+## Summary
+
+OpenSearch v3.0.0 introduces two key improvements to tiered caching: a unified cache manager for disk caches and an extended took-time policy that now guards both heap and disk tiers. These changes reduce CPU overhead from excessive thread pools and prevent the heap tier from being flooded with cheap queries.
+
+## Details
+
+### What's New in v3.0.0
+
+1. **Single Cache Manager for Disk Caches** ([#17513](https://github.com/opensearch-project/OpenSearch/pull/17513)): Previously, creating N ehcache disk caches resulted in N separate cache managers, each with its own disk write thread pool. This caused CPU spikes when tiered caching was enabled. The new implementation uses a single cache manager for all disk caches per cache type, with a shared thread pool sized between 2 and 1.5× CPU cores.
+
+2. **Took-Time Policy Extended to Heap Tier** ([#17190](https://github.com/opensearch-project/OpenSearch/pull/17190)): The minimum took-time threshold policy now guards both the heap tier and disk tier, not just the disk tier. This prevents cheap queries from flooding the heap cache when caching size > 0 queries.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.0.0"
+        Q1[Query] --> HC1[Heap Cache]
+        HC1 -->|Eviction| DC1[Disk Cache]
+        DC1 -->|Disk Policy| DP1[Took-Time Check]
+    end
+    
+    subgraph "v3.0.0"
+        Q2[Query] --> CP[Cache Policy]
+        CP -->|Took-Time Check| HC2[Heap Cache]
+        HC2 -->|Eviction + Disk Policy| DC2[Disk Cache]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `EhcacheDiskCacheManager` | Singleton manager per cache type that creates and manages all disk caches via a single `PersistentCacheManager` |
+| `TookTimePolicy` (extended) | Now accepts a target setting parameter to support both heap and disk tier policies |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `indices.requests.cache.tiered_spillover.policies.took_time.threshold` | Minimum query execution time to enter the cache (heap tier) | `0ms` |
+| `indices.requests.cache.tiered_spillover.disk.store.policies.took_time.threshold` | Minimum query execution time to enter the disk tier | `10ms` |
+
+The disk tier setting key remains unchanged for backwards compatibility.
+
+#### Thread Pool Changes
+
+| Setting | Old Default | New Default |
+|---------|-------------|-------------|
+| `ehcache_disk.min_threads` | 2 | 2 |
+| `ehcache_disk.max_threads` | 2 | 1.5 × CPU cores (search thread pool size) |
+
+### Usage Example
+
+```yaml
+# opensearch.yml - Enable tiered caching with custom policies
+indices.requests.cache.store.name: tiered_spillover
+indices.requests.cache.tiered_spillover.onheap.store.name: opensearch_onheap
+indices.requests.cache.tiered_spillover.disk.store.name: ehcache_disk
+
+# Set heap tier threshold to 5ms (queries taking <5ms won't be cached)
+indices.requests.cache.tiered_spillover.policies.took_time.threshold: 5ms
+
+# Set disk tier threshold to 15ms (queries taking <15ms won't spill to disk)
+indices.requests.cache.tiered_spillover.disk.store.policies.took_time.threshold: 15ms
+```
+
+### Migration Notes
+
+- The disk took-time policy setting key (`tiered_spillover.disk.store.policies.took_time.threshold`) is unchanged for backwards compatibility
+- The new heap tier policy defaults to `0ms`, maintaining previous behavior where all queries could enter the heap cache
+- Existing configurations will continue to work without modification
+
+## Limitations
+
+- Tiered caching is still experimental and not recommended for production use
+- Only supported for the request cache (not query cache)
+- The `cache-ehcache` plugin must be installed for disk tier functionality
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17513](https://github.com/opensearch-project/OpenSearch/pull/17513) | Single cache manager for all ehcache disk caches |
+| [#17190](https://github.com/opensearch-project/OpenSearch/pull/17190) | Took-time threshold guards heap tier as well as disk tier |
+
+## References
+
+- [Issue #16162](https://github.com/opensearch-project/OpenSearch/issues/16162): RFC - Optimize caching policy for Request cache
+- [Tiered Cache Documentation](https://docs.opensearch.org/3.0/search-plugins/caching/tiered-cache/)
+- [Tiered Caching Blog](https://opensearch.org/blog/tiered-cache/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/tiered-caching.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -24,6 +24,7 @@
 - [Search Backpressure](features/opensearch/search-backpressure.md)
 - [Segment Warmer](features/opensearch/segment-warmer.md)
 - [Stream Input/Output](features/opensearch/stream-inputoutput.md)
+- [Tiered Caching](features/opensearch/tiered-caching.md)
 - [Wildcard Field](features/opensearch/wildcard-field.md)
 
 ## opensearch-dashboards


### PR DESCRIPTION
## Summary

This PR adds documentation for the Tiered Caching feature improvements in OpenSearch v3.0.0.

### Changes in v3.0.0

1. **Single Cache Manager for Disk Caches** ([#17513](https://github.com/opensearch-project/OpenSearch/pull/17513))
   - Previously, creating N ehcache disk caches resulted in N separate cache managers with their own thread pools
   - Now uses a single cache manager per cache type with a shared thread pool (2 to 1.5× CPU cores)
   - Reduces CPU overhead when tiered caching is enabled

2. **Took-Time Policy Extended to Heap Tier** ([#17190](https://github.com/opensearch-project/OpenSearch/pull/17190))
   - The minimum took-time threshold policy now guards both heap and disk tiers
   - Prevents cheap queries from flooding the heap cache
   - New setting: `indices.requests.cache.tiered_spillover.policies.took_time.threshold` (default: 0ms)
   - Existing disk tier setting unchanged for backwards compatibility

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/tiered-caching.md`
- Feature report: `docs/features/opensearch/tiered-caching.md`

### References
- [Issue #16162](https://github.com/opensearch-project/OpenSearch/issues/16162): RFC - Optimize caching policy for Request cache
- [Tiered Cache Documentation](https://docs.opensearch.org/3.0/search-plugins/caching/tiered-cache/)