### PR TITLE
docs: add gRPC Transport & Services report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -7,6 +7,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
+- [gRPC Transport & Services](opensearch/grpc-transport--services.md)
 - [Mapping Transformer](opensearch/mapping-transformer.md)
 - [Cluster Manager Task Throttling](opensearch/cluster-manager-throttling.md)
 - [Dependency Management](opensearch/dependency-management.md)

--- a/docs/features/opensearch/grpc-transport--services.md
+++ b/docs/features/opensearch/grpc-transport--services.md
@@ -1,0 +1,246 @@
+# gRPC Transport & Services
+
+## Summary
+
+gRPC Transport & Services provides an alternative communication protocol for OpenSearch, enabling high-performance, binary-encoded API access using protocol buffers over gRPC. This feature allows client applications in Java, Go, Python, and other languages to interact with OpenSearch using native gRPC stubs, offering lower latency and higher throughput compared to traditional HTTP REST APIs for high-volume workloads.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Client Applications"
+        JavaClient[Java Client]
+        GoClient[Go Client]
+        PythonClient[Python Client]
+        OtherClient[Other gRPC Clients]
+    end
+    
+    subgraph "OpenSearch Cluster"
+        subgraph "Node 1"
+            HTTP1[HTTP Transport<br/>Port 9200]
+            GRPC1[gRPC Transport<br/>Port 9400]
+            Core1[OpenSearch Core]
+        end
+        
+        subgraph "Node 2"
+            HTTP2[HTTP Transport<br/>Port 9200]
+            GRPC2[gRPC Transport<br/>Port 9400]
+            Core2[OpenSearch Core]
+        end
+    end
+    
+    subgraph "gRPC Services"
+        DocService[DocumentService<br/>- Bulk]
+        SearchService[SearchService<br/>- Search]
+    end
+    
+    JavaClient -->|Protocol Buffers| GRPC1
+    GoClient -->|Protocol Buffers| GRPC1
+    PythonClient -->|Protocol Buffers| GRPC2
+    OtherClient -->|Protocol Buffers| GRPC2
+    
+    GRPC1 --> DocService
+    GRPC1 --> SearchService
+    GRPC2 --> DocService
+    GRPC2 --> SearchService
+    
+    DocService --> Core1
+    DocService --> Core2
+    SearchService --> Core1
+    SearchService --> Core2
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Client
+        Proto[Protocol Buffer<br/>Message]
+    end
+    
+    subgraph "gRPC Transport"
+        Serialize[Serialize to<br/>Binary]
+        TLS[TLS Encryption<br/>Optional]
+        Deserialize[Deserialize<br/>Response]
+    end
+    
+    subgraph "OpenSearch"
+        Service[gRPC Service<br/>Handler]
+        Execute[Execute<br/>Operation]
+        Response[Build<br/>Response]
+    end
+    
+    Proto --> Serialize
+    Serialize --> TLS
+    TLS -->|HTTP/2| Service
+    Service --> Execute
+    Execute --> Response
+    Response -->|HTTP/2| Deserialize
+    Deserialize --> Client
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `transport-grpc` | Plugin providing gRPC server transport capability |
+| `Netty4GrpcServerTransport` | Base gRPC server implementation using Netty4 |
+| `SecureNetty4GrpcServerTransport` | TLS-enabled gRPC transport for secure connections |
+| `DocumentService` | gRPC service handling document operations (Bulk API) |
+| `SearchService` | gRPC service handling search operations (Search API) |
+| `opensearch-protobufs` | Protocol buffer definitions for OpenSearch APIs |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `grpc.port` | Port for gRPC server to listen on | `9400` |
+| `grpc.publish_port` | Port published for external connections | Same as `grpc.port` |
+| `grpc.bind_host` | Network interface to bind gRPC server | Network host setting |
+| `grpc.publish_host` | Host address published for gRPC | Network host setting |
+
+### Supported Services
+
+#### DocumentService
+
+The DocumentService provides the Bulk API for batch document operations:
+
+| Operation | Description |
+|-----------|-------------|
+| `index` | Index a document (creates or replaces) |
+| `create` | Create a new document (fails if exists) |
+| `update` | Partially update an existing document |
+| `delete` | Delete a document by ID |
+
+**Request Fields:**
+- `request_body`: List of bulk operations
+- `index`: Default index for operations
+- `pipeline`: Ingest pipeline ID
+- `refresh`: Refresh behavior after indexing
+- `routing`: Custom routing value
+- `timeout`: Operation timeout
+
+#### SearchService
+
+The SearchService provides the Search API for querying documents:
+
+**Supported Query Types:**
+- `match_all`: Match all documents
+- `term`: Exact term matching on a field
+- `terms`: Match any of multiple terms
+- `match_none`: Match no documents
+
+**Request Fields:**
+- `index`: Target indexes
+- `request_body`: Search request with query DSL
+- `source`: Control `_source` field return
+- `from`/`size`: Pagination
+- `sort`: Result ordering
+- `timeout`: Query timeout
+
+### Usage Example
+
+**Installing the Plugin:**
+
+```bash
+bin/opensearch-plugin install transport-grpc
+```
+
+**Java Client Example:**
+
+```java
+import org.opensearch.protobufs.*;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+import com.google.protobuf.ByteString;
+
+// Create channel
+ManagedChannel channel = ManagedChannelBuilder
+    .forAddress("localhost", 9400)
+    .usePlaintext()
+    .build();
+
+// Bulk indexing
+DocumentServiceGrpc.DocumentServiceBlockingStub docStub = 
+    DocumentServiceGrpc.newBlockingStub(channel);
+
+BulkRequest bulkRequest = BulkRequest.newBuilder()
+    .setIndex("my-index")
+    .addRequestBody(BulkRequestBody.newBuilder()
+        .setIndex(IndexOperation.newBuilder()
+            .setId("1")
+            .build())
+        .setDoc(ByteString.copyFromUtf8("{\"title\": \"Document 1\"}"))
+        .build())
+    .build();
+
+BulkResponse bulkResponse = docStub.bulk(bulkRequest);
+
+// Search
+SearchServiceGrpc.SearchServiceBlockingStub searchStub = 
+    SearchServiceGrpc.newBlockingStub(channel);
+
+SearchRequest searchRequest = SearchRequest.newBuilder()
+    .addIndex("my-index")
+    .setRequestBody(SearchRequestBody.newBuilder()
+        .setQuery(QueryContainer.newBuilder()
+            .setTerm(TermQuery.newBuilder()
+                .putTerm("title", TermQueryField.newBuilder()
+                    .setValue(FieldValue.newBuilder()
+                        .setStringValue("Document")
+                        .build())
+                    .build())
+                .build())
+            .build())
+        .setSize(10)
+        .build())
+    .build();
+
+SearchResponse searchResponse = searchStub.search(searchRequest);
+
+channel.shutdown();
+```
+
+**Document Encoding:**
+
+Documents in gRPC requests must be Base64 encoded:
+
+```json
+// Original document
+{"title": "Inception", "year": 2010}
+
+// Base64 encoded for gRPC
+"eyJ0aXRsZSI6ICJJbmNlcHRpb24iLCAieWVhciI6IDIwMTB9"
+```
+
+## Limitations
+
+- **Experimental status**: Feature is experimental and not recommended for production
+- **Limited query support**: Only basic queries (match_all, term, terms, match_none) supported
+- **No aggregations**: Aggregation support not yet available
+- **Limited services**: Only Bulk and Search endpoints implemented
+- **Plugin required**: Must install transport-grpc plugin separately
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17796](https://github.com/opensearch-project/OpenSearch/pull/17796) | Enable TLS for Netty4GrpcServerTransport |
+| v3.0.0 | [#17727](https://github.com/opensearch-project/OpenSearch/pull/17727) | Add DocumentService and Bulk gRPC endpoint v1 |
+| v3.0.0 | [#17830](https://github.com/opensearch-project/OpenSearch/pull/17830) | SearchService and Search gRPC endpoint v1 |
+| v3.0.0 | [#17888](https://github.com/opensearch-project/OpenSearch/pull/17888) | Add terms query support in Search gRPC endpoint |
+
+## References
+
+- [Issue #16787](https://github.com/opensearch-project/OpenSearch/issues/16787): gRPC Transport tracking issue
+- [gRPC APIs Documentation](https://docs.opensearch.org/3.0/api-reference/grpc-apis/index/): Official documentation
+- [Bulk (gRPC) API](https://docs.opensearch.org/3.0/api-reference/grpc-apis/bulk/): Bulk endpoint reference
+- [Search (gRPC) API](https://docs.opensearch.org/3.0/api-reference/grpc-apis/search/): Search endpoint reference
+- [opensearch-protobufs](https://github.com/opensearch-project/opensearch-protobufs): Protocol buffer definitions
+- [Additional Plugins](https://docs.opensearch.org/3.0/install-and-configure/additional-plugins/index/): Plugin installation guide
+
+## Change History
+
+- **v3.0.0** (2025-03): Initial implementation with DocumentService (Bulk) and SearchService (Search), TLS support

--- a/docs/releases/v3.0.0/features/opensearch/grpc-transport--services.md
+++ b/docs/releases/v3.0.0/features/opensearch/grpc-transport--services.md
@@ -1,0 +1,177 @@
+# gRPC Transport & Services
+
+## Summary
+
+OpenSearch 3.0.0 introduces experimental gRPC transport support as an alternative to the traditional HTTP REST API. The transport-grpc plugin enables high-performance, binary-encoded communication using protocol buffers, providing efficient client integrations for Java, Go, Python, and other languages with native gRPC stubs. This release includes TLS security support and initial implementations of DocumentService (Bulk) and SearchService (Search) endpoints.
+
+## Details
+
+### What's New in v3.0.0
+
+- **gRPC Transport Plugin**: New `transport-grpc` plugin providing gRPC server transport on port 9400 (default)
+- **TLS Support**: SecureNetty4GrpcServerTransport enables encrypted gRPC connections
+- **DocumentService**: Bulk API endpoint for batch document operations (index, create, update, delete)
+- **SearchService**: Search API endpoint supporting match_all, term, terms, and match_none queries
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Client Applications"
+        Java[Java Client]
+        Go[Go Client]
+        Python[Python Client]
+    end
+    
+    subgraph "OpenSearch Node"
+        subgraph "Transport Layer"
+            HTTP[HTTP REST API<br/>Port 9200]
+            GRPC[gRPC Transport<br/>Port 9400]
+        end
+        
+        subgraph "Services"
+            DocSvc[DocumentService]
+            SearchSvc[SearchService]
+        end
+        
+        Core[OpenSearch Core]
+    end
+    
+    Java -->|Protocol Buffers| GRPC
+    Go -->|Protocol Buffers| GRPC
+    Python -->|Protocol Buffers| GRPC
+    
+    GRPC --> DocSvc
+    GRPC --> SearchSvc
+    DocSvc --> Core
+    SearchSvc --> Core
+    HTTP --> Core
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `Netty4GrpcServerTransport` | Base gRPC server transport using Netty4 |
+| `SecureNetty4GrpcServerTransport` | TLS-enabled gRPC transport |
+| `DocumentService` | gRPC service for document operations (Bulk) |
+| `SearchService` | gRPC service for search operations |
+| `opensearch-protobufs` | Protocol buffer definitions for OpenSearch APIs |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `grpc.port` | Port for gRPC server | `9400` |
+| `grpc.publish_port` | Published port for gRPC | Same as `grpc.port` |
+| `grpc.bind_host` | Host to bind gRPC server | Network host |
+| `grpc.publish_host` | Host to publish for gRPC | Network host |
+
+#### API Changes
+
+**DocumentService - Bulk Endpoint**
+
+The gRPC Bulk API mirrors the REST Bulk API with protocol buffer encoding:
+
+- Operations: `index`, `create`, `update`, `delete`
+- Documents provided as Base64-encoded bytes
+- Supports routing, pipeline, refresh options
+
+**SearchService - Search Endpoint**
+
+The gRPC Search API supports basic query types:
+
+- `match_all`: Returns all documents
+- `term`: Exact term matching
+- `terms`: Multiple term matching with terms lookup support
+- `match_none`: Returns no documents
+
+### Usage Example
+
+**Java gRPC Client - Bulk Request:**
+
+```java
+import org.opensearch.protobufs.*;
+import io.grpc.ManagedChannel;
+import io.grpc.ManagedChannelBuilder;
+
+ManagedChannel channel = ManagedChannelBuilder
+    .forAddress("localhost", 9400)
+    .usePlaintext()
+    .build();
+
+DocumentServiceGrpc.DocumentServiceBlockingStub stub = 
+    DocumentServiceGrpc.newBlockingStub(channel);
+
+IndexOperation indexOp = IndexOperation.newBuilder()
+    .setIndex("my-index")
+    .setId("1")
+    .build();
+
+BulkRequestBody body = BulkRequestBody.newBuilder()
+    .setIndex(indexOp)
+    .setDoc(ByteString.copyFromUtf8("{\"field\": \"value\"}"))
+    .build();
+
+BulkRequest request = BulkRequest.newBuilder()
+    .addRequestBody(body)
+    .build();
+
+BulkResponse response = stub.bulk(request);
+```
+
+**Java gRPC Client - Search Request:**
+
+```java
+SearchServiceGrpc.SearchServiceBlockingStub searchStub = 
+    SearchServiceGrpc.newBlockingStub(channel);
+
+SearchRequest searchRequest = SearchRequest.newBuilder()
+    .addIndex("my-index")
+    .setRequestBody(SearchRequestBody.newBuilder()
+        .setQuery(QueryContainer.newBuilder()
+            .setMatchAll(MatchAllQuery.newBuilder().build())
+            .build())
+        .setSize(10)
+        .build())
+    .build();
+
+SearchResponse searchResponse = searchStub.search(searchRequest);
+```
+
+### Migration Notes
+
+1. **Install the plugin**: The transport-grpc plugin must be installed separately
+2. **Obtain protobufs**: Client applications need protocol buffer definitions from [opensearch-protobufs](https://github.com/opensearch-project/opensearch-protobufs)
+3. **Port configuration**: gRPC uses port 9400 by default (separate from HTTP 9200)
+4. **TLS setup**: For secure connections, configure TLS certificates for gRPC transport
+
+## Limitations
+
+- **Experimental feature**: Not recommended for production use
+- **Limited query support**: Only `match_all`, `term`, `terms`, and `match_none` queries supported in v3.0.0
+- **Limited service coverage**: Only Bulk and Search endpoints available initially
+- **No aggregations**: Aggregation support not yet implemented in gRPC Search API
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17796](https://github.com/opensearch-project/OpenSearch/pull/17796) | Enable TLS for Netty4GrpcServerTransport |
+| [#17727](https://github.com/opensearch-project/OpenSearch/pull/17727) | Add DocumentService and Bulk gRPC endpoint v1 |
+| [#17830](https://github.com/opensearch-project/OpenSearch/pull/17830) | SearchService and Search gRPC endpoint v1 |
+| [#17888](https://github.com/opensearch-project/OpenSearch/pull/17888) | Add terms query support in Search gRPC endpoint |
+
+## References
+
+- [Issue #16787](https://github.com/opensearch-project/OpenSearch/issues/16787): gRPC Transport tracking issue
+- [gRPC APIs Documentation](https://docs.opensearch.org/3.0/api-reference/grpc-apis/index/): Official docs
+- [Bulk (gRPC) Documentation](https://docs.opensearch.org/3.0/api-reference/grpc-apis/bulk/): Bulk API reference
+- [Search (gRPC) Documentation](https://docs.opensearch.org/3.0/api-reference/grpc-apis/search/): Search API reference
+- [Additional Plugins - transport-grpc](https://docs.opensearch.org/3.0/install-and-configure/additional-plugins/index/): Plugin installation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/grpc-transport--services.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -7,6 +7,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)
+- [gRPC Transport & Services](features/opensearch/grpc-transport--services.md)
 - [Mapping Transformer](features/opensearch/mapping-transformer.md)
 - [Cluster Manager Throttling](features/opensearch/cluster-manager-throttling.md)
 - [Dependency Bumps](features/opensearch/dependency-bumps.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the gRPC Transport & Services feature introduced in OpenSearch v3.0.0.

## Reports Created

- **Release report**: `docs/releases/v3.0.0/features/opensearch/grpc-transport--services.md`
- **Feature report**: `docs/features/opensearch/grpc-transport--services.md`

## Key Changes in v3.0.0

- New `transport-grpc` plugin providing gRPC server transport on port 9400
- TLS support via SecureNetty4GrpcServerTransport
- DocumentService with Bulk API endpoint (index, create, update, delete operations)
- SearchService with Search API endpoint (match_all, term, terms, match_none queries)

## Related PRs

- [#17796](https://github.com/opensearch-project/OpenSearch/pull/17796): Enable TLS for Netty4GrpcServerTransport
- [#17727](https://github.com/opensearch-project/OpenSearch/pull/17727): Add DocumentService and Bulk gRPC endpoint v1
- [#17830](https://github.com/opensearch-project/OpenSearch/pull/17830): SearchService and Search gRPC endpoint v1
- [#17888](https://github.com/opensearch-project/OpenSearch/pull/17888): Add terms query support in Search gRPC endpoint

Closes #241