### PR TITLE
docs: add security bugfixes report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -36,6 +36,10 @@
 - [Dashboards UI/UX Fixes](opensearch-dashboards/dashboards-ui-ux-fixes.md)
 - [Workspace](opensearch-dashboards/workspace.md)
 
+## security
+
+- [Security Configuration](security/security-configuration.md)
+
 ## sql
 
 - [SQL/PPL Breaking Changes](sql/sql-ppl-breaking-changes.md)

--- a/docs/features/security/security-configuration.md
+++ b/docs/features/security/security-configuration.md
@@ -1,0 +1,149 @@
+# Security Configuration
+
+## Summary
+
+The OpenSearch Security plugin provides comprehensive security features including TLS encryption, authentication backends, data masking, audit logging, and role-based access control. The security configuration system manages how these features are configured and upgraded across OpenSearch versions.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Security Configuration"
+        YAML[Security YAML Files]
+        Index[.opendistro_security Index]
+        Loader[ConfigurationLoader]
+    end
+    
+    subgraph "Configuration Types"
+        Config[config.yml]
+        Roles[roles.yml]
+        RolesMapping[roles_mapping.yml]
+        InternalUsers[internal_users.yml]
+        ActionGroups[action_groups.yml]
+        Tenants[tenants.yml]
+        Allowlist[allowlist.yml]
+        Audit[audit.yml]
+        Nodesdn[nodes_dn.yml]
+    end
+    
+    YAML --> Loader
+    Loader --> Index
+    Config --> YAML
+    Roles --> YAML
+    RolesMapping --> YAML
+    InternalUsers --> YAML
+    ActionGroups --> YAML
+    Tenants --> YAML
+    Allowlist --> YAML
+    Audit --> YAML
+    Nodesdn --> YAML
+```
+
+### Configuration Version Model
+
+The Security plugin uses versioned configuration models:
+
+| Version | Description | OpenSearch Version |
+|---------|-------------|-------------------|
+| v6 | Legacy format | Pre-2.18 |
+| v7 | Current format | 2.18+ |
+
+Starting with OpenSearch 2.18, the plugin automatically converts v6 configurations to v7 format. In OpenSearch 3.0.0, the default assumption for configurations without explicit `_meta` version is v7.
+
+### Configuration File Structure
+
+Each security configuration file should include a `_meta` section:
+
+```yaml
+_meta:
+  type: "config"
+  config_version: 2
+
+config:
+  dynamic:
+    # configuration options
+```
+
+### Authentication Handling
+
+The Security plugin supports various authentication backends including:
+
+- Internal user database
+- LDAP/Active Directory
+- OIDC (OpenID Connect)
+- SAML
+- Kerberos
+- JWT
+
+#### OIDC Username Handling
+
+OIDC providers may send usernames with special characters. The plugin handles pipe characters (`|`) by escaping them in the ThreadContext to prevent parsing issues.
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| ConfigurationLoader | Loads and validates security configurations |
+| SecurityAdmin | CLI tool for managing security configurations |
+| Installer | Demo configuration installer |
+| ThreadContext | Stores user information during request processing |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.config_index_name` | Name of the security index | `.opendistro_security` |
+| `plugins.security.allow_default_init_securityindex` | Allow default initialization | `false` |
+| `plugins.security.audit.type` | Audit log type | `internal_opensearch` |
+
+### Usage Example
+
+```yaml
+# config.yml - Basic authentication configuration
+_meta:
+  type: "config"
+  config_version: 2
+
+config:
+  dynamic:
+    authc:
+      basic_internal_auth_domain:
+        http_enabled: true
+        transport_enabled: true
+        order: 1
+        http_authenticator:
+          type: basic
+          challenge: true
+        authentication_backend:
+          type: internal
+```
+
+## Limitations
+
+- Configuration changes require either a cluster restart or use of the Security Admin tool
+- Some configuration options are not hot-reloadable
+- OIDC usernames with escaped pipe characters may need special handling in downstream systems
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#5193](https://github.com/opensearch-project/security/pull/5193) | Default to v7 models if _meta not present |
+| v3.0.0 | [#5175](https://github.com/opensearch-project/security/pull/5175) | Escape pipe character for injected users |
+| v3.0.0 | [#5157](https://github.com/opensearch-project/security/pull/5157) | Fix version matcher in demo config installer |
+| v2.18.0 | [#4753](https://github.com/opensearch-project/security/pull/4753) | Auto-convert security config models from v6 to v7 |
+
+## References
+
+- [Issue #5191](https://github.com/opensearch-project/security/issues/5191): Upgrade failure from 2.19 to 3.0.0-alpha1
+- [Issue #2756](https://github.com/opensearch-project/security/issues/2756): Username cannot have '|' in the security plugin
+- [Documentation: Configuration APIs](https://docs.opensearch.org/3.0/api-reference/security/configuration/index/)
+- [Documentation: Upgrade Perform API](https://docs.opensearch.org/3.0/api-reference/security/configuration/upgrade-perform/)
+- [Documentation: Rolling Upgrade](https://docs.opensearch.org/3.0/install-and-configure/upgrade-opensearch/rolling-upgrade/)
+
+## Change History
+
+- **v3.0.0** (2025): Default to v7 models, escape pipe characters in usernames, fix demo config version matcher
+- **v2.18.0** (2024): Auto-convert security config models from v6 to v7

--- a/docs/releases/v3.0.0/features/security/release-3-0-bugfixes.md
+++ b/docs/releases/v3.0.0/features/security/release-3-0-bugfixes.md
@@ -1,0 +1,79 @@
+# Security Plugin Bugfixes for Release 3.0
+
+## Summary
+
+OpenSearch 3.0.0 includes several important bugfixes for the Security plugin that address upgrade compatibility issues, authentication handling, and configuration management. These fixes ensure smooth upgrades from 2.x versions and improve support for OIDC authentication scenarios.
+
+## Details
+
+### What's New in v3.0.0
+
+This release addresses critical bugs that affected users upgrading from OpenSearch 2.x to 3.0.0 and improves authentication handling for OIDC use cases.
+
+### Technical Changes
+
+#### Key Bugfixes
+
+| PR | Title | Description |
+|----|-------|-------------|
+| [#5193](https://github.com/opensearch-project/security/pull/5193) | Assume default of v7 models if _meta portion is not present | Fixes upgrade failures from 2.19 to 3.0.0 when security YAML files lack `_meta` section |
+| [#5175](https://github.com/opensearch-project/security/pull/5175) | Escape pipe character for injected users | Enables OIDC usernames containing pipe characters |
+| [#5157](https://github.com/opensearch-project/security/pull/5157) | Fix version matcher string in demo config installer | Corrects version parsing for new security packages |
+
+#### Upgrade Compatibility Fix (PR #5193)
+
+The most significant bugfix addresses an upgrade blocker from OpenSearch 2.19 to 3.0.0-alpha1. When security YAML configuration files (like `whitelist.yml`) did not include a `_meta` portion with `config_version: 2`, the system incorrectly assumed v6 format models, causing startup failures.
+
+**Error before fix:**
+```
+[ERROR] java.io.IOException: Config version 1 is not supported; config type: WHITELIST
+```
+
+**Solution:** The default assumption was changed from v6 to v7 models, leveraging the auto-conversion logic introduced in OpenSearch 2.18 that automatically converts v6 to v7 format.
+
+#### OIDC Username Pipe Character Support (PR #5175)
+
+Fixed an issue where OIDC providers sending usernames with pipe characters (e.g., `idp-provider|email@test.com|tenant-id|user-id`) would fail authentication with:
+
+```
+java.lang.IllegalStateException: Username cannot have '|' in the security plugin.
+```
+
+The fix properly escapes pipe characters in usernames, roles, and tenants when setting UserInfo in ThreadContext.
+
+#### Demo Config Version Matcher Fix (PR #5157)
+
+Fixed a bug in `Installer.java` where the version matcher incorrectly parsed package names. With new packages like `opensearch-security-client` and `opensearch-security-common`, the matcher would extract `common-3.0.0.0` instead of `3.0.0.0`.
+
+### Migration Notes
+
+When upgrading from OpenSearch 2.x to 3.0.0:
+
+1. **No action required** for the v7 model default change - the fix handles this automatically
+2. **OIDC users** with pipe characters in usernames will now work without configuration changes
+3. **Demo installations** will correctly detect the security plugin version
+
+## Limitations
+
+- The pipe character escaping is applied at the ThreadContext level; downstream systems should handle escaped values appropriately
+- Users with custom security configurations should verify compatibility after upgrade
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5193](https://github.com/opensearch-project/security/pull/5193) | Default to v7 models for security config |
+| [#5175](https://github.com/opensearch-project/security/pull/5175) | Escape pipe character for injected users |
+| [#5157](https://github.com/opensearch-project/security/pull/5157) | Fix version matcher in demo config installer |
+| [#4753](https://github.com/opensearch-project/security/pull/4753) | Auto-convert security config models from v6 to v7 (2.18) |
+
+## References
+
+- [Issue #5191](https://github.com/opensearch-project/security/issues/5191): Upgrade OS from 2.19.0 to 3.0.0-alpha1 failure
+- [Issue #2756](https://github.com/opensearch-project/security/issues/2756): Username cannot have '|' in the security plugin
+- [Documentation: Configuration APIs](https://docs.opensearch.org/3.0/api-reference/security/configuration/index/)
+- [Documentation: Upgrade Perform API](https://docs.opensearch.org/3.0/api-reference/security/configuration/upgrade-perform/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/security-configuration.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -37,6 +37,10 @@
 - [UI/UX Improvements](features/opensearch-dashboards/ui-ux-improvements.md)
 - [Workspace Improvements](features/opensearch-dashboards/workspace-improvements.md)
 
+## security
+
+- [Security Plugin Bugfixes for Release 3.0](features/security/release-3-0-bugfixes.md)
+
 ## sql
 
 - [SQL/PPL v3.0.0 Breaking Changes](features/sql/sql-ppl-v3-breaking-changes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for security plugin bugfixes in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/security/release-3-0-bugfixes.md`
- Feature report: `docs/features/security/security-configuration.md`

### Key Changes Documented

1. **Upgrade Compatibility Fix (PR #5193)**: Fixed upgrade failures from 2.19 to 3.0.0 when security YAML files lack `_meta` section by defaulting to v7 models
2. **OIDC Username Support (PR #5175)**: Enabled OIDC usernames containing pipe characters by properly escaping them
3. **Demo Config Fix (PR #5157)**: Corrected version parsing for new security packages

### Related Issue
Closes #200