### PR TITLE
docs: add reporting-ci-workflow report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -43,6 +43,7 @@
 ## reporting
 
 - [AUTO Version Management](reporting/auto-version-management.md)
+- [CI/CD Workflow](reporting/ci-workflow.md)
 
 ## sql
 

--- a/docs/features/reporting/ci-workflow.md
+++ b/docs/features/reporting/ci-workflow.md
@@ -1,0 +1,81 @@
+# CI/CD Workflow
+
+## Summary
+
+The dashboards-reporting plugin uses GitHub Actions for continuous integration and delivery. The CI/CD infrastructure includes workflows for testing, building, linting, and end-to-end testing across multiple platforms (Linux, Windows, macOS).
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "GitHub Actions Workflows"
+        A[Pull Request] --> B[Lint Workflow]
+        A --> C[Test & Build Workflow]
+        A --> D[Link Checker]
+        
+        C --> E[Linux Build]
+        C --> F[Windows/macOS Build Matrix]
+        
+        G[Push to Main] --> H[Cypress E2E Tests]
+        G --> I[FTR E2E Tests]
+    end
+    
+    subgraph "Artifacts"
+        E --> J[Linux Artifact]
+        F --> K[Windows Artifact]
+        F --> L[macOS Artifact]
+    end
+```
+
+### Workflow Files
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `dashboards-reports-test-and-build-workflow.yml` | Push/PR | Build and test on Linux, Windows, macOS |
+| `cypress-e2e-reporting-test.yml` | Push to main | Cypress end-to-end tests |
+| `ftr-e2e-reporting-test.yml` | Push to main | Functional test runner E2E tests |
+| `lint.yml` | Pull request | Code linting |
+| `link-checker.yml` | Push/PR to main | Check for broken links |
+| `verify-binary-installation.yml` | Manual/scheduled | Verify binary installation |
+
+### Build Matrix Configuration
+
+The test and build workflow uses a matrix strategy for cross-platform builds:
+
+```yaml
+windows-mac-builds:
+  runs-on: ${{ matrix.os }}
+  strategy:
+    matrix:
+      os: [windows-latest, macos-latest]
+```
+
+### Key Dependencies
+
+| Dependency | Source |
+|------------|--------|
+| Node.js version | Read from `OpenSearch-Dashboards/.nvmrc` |
+| Yarn version | Read from `OpenSearch-Dashboards/package.json` |
+| OpenSearch Dashboards | Checked out as sibling directory |
+
+## Limitations
+
+- E2E tests only run on push to main branch, not on pull requests
+- Windows builds require `core.longpaths` git configuration
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#548](https://github.com/opensearch-project/dashboards-reporting/pull/548) | CI updates and workflow fixes |
+
+## References
+
+- [dashboards-reporting repository](https://github.com/opensearch-project/dashboards-reporting): Source repository
+- [GitHub Actions documentation](https://docs.github.com/en/actions): GitHub Actions reference
+
+## Change History
+
+- **v3.0.0** (2025-03-13): Upgraded actions/checkout to v4, consolidated Windows/macOS builds into matrix job, fixed documentation links

--- a/docs/releases/v3.0.0/features/reporting/ci-workflow-fixes.md
+++ b/docs/releases/v3.0.0/features/reporting/ci-workflow-fixes.md
@@ -1,0 +1,96 @@
+# CI/Workflow Fixes
+
+## Summary
+
+This release item includes minor CI updates and workflow fixes for the dashboards-reporting plugin. The changes modernize GitHub Actions workflows by upgrading to newer action versions, consolidating duplicate build jobs, and fixing documentation links.
+
+## Details
+
+### What's New in v3.0.0
+
+The PR introduces several maintenance improvements to the CI/CD infrastructure:
+
+1. **GitHub Actions Version Upgrades**: Updated `actions/checkout` from v1/v2/v3 to v4 across all workflow files
+2. **Build Job Consolidation**: Merged separate Windows and macOS build jobs into a single matrix-based job
+3. **Documentation Fixes**: Corrected broken links in README and DEVELOPER_GUIDE
+4. **Maintainer Updates**: Updated maintainer GitHub handle
+
+### Technical Changes
+
+#### Workflow Files Modified
+
+| File | Changes |
+|------|---------|
+| `cypress-e2e-reporting-test.yml` | Upgraded checkout actions to v4, removed invalid filter parameter |
+| `dashboards-reports-test-and-build-workflow.yml` | Consolidated Windows/macOS builds into matrix job, fixed path references |
+| `ftr-e2e-reporting-test.yml` | Upgraded checkout actions to v4, removed invalid filter parameter |
+| `link-checker.yml` | Upgraded checkout action to v4, formatting cleanup |
+| `lint.yml` | Upgraded checkout actions to v4, formatting cleanup |
+| `verify-binary-installation.yml` | Upgraded checkout action to v4 |
+
+#### Build Job Consolidation
+
+Before v3.0.0, Windows and macOS builds were separate jobs with duplicated configuration:
+
+```yaml
+# Before: Separate jobs
+windows-build:
+  runs-on: windows-latest
+  steps: [...]
+
+macos-build:
+  runs-on: macos-latest
+  steps: [...]
+```
+
+After v3.0.0, they are consolidated using a matrix strategy:
+
+```yaml
+# After: Matrix-based job
+windows-mac-builds:
+  runs-on: ${{ matrix.os }}
+  strategy:
+    matrix:
+      os: [windows-latest, macos-latest]
+  steps: [...]
+```
+
+#### Path Reference Fixes
+
+Fixed incorrect path references in the build workflow:
+
+| Setting | Before | After |
+|---------|--------|-------|
+| node-version-file | `'../OpenSearch-Dashboards/.nvmrc'` | `'OpenSearch-Dashboards/.nvmrc'` |
+| yarn version path | `'../OpenSearch-Dashboards/package.json'` | `'./OpenSearch-Dashboards/package.json'` |
+| bootstrap command | `yarn osd bootstrap` | `cd OpenSearch-Dashboards && yarn osd bootstrap` |
+
+#### Documentation Fixes
+
+| File | Fix |
+|------|-----|
+| `README.md` | Fixed cypress code link path |
+| `README.md` | Removed outdated Notifications integration section |
+| `DEVELOPER_GUIDE.md` | Fixed backport.yml link to use absolute URL |
+| `MAINTAINERS.md` | Updated vamsi-amazon handle to vamsimanohar |
+
+## Limitations
+
+- These are infrastructure-only changes with no impact on plugin functionality
+- The changes are specific to the dashboards-reporting repository CI/CD
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#548](https://github.com/opensearch-project/dashboards-reporting/pull/548) | Minor CI updates and workflow fixes |
+| [#547](https://github.com/opensearch-project/dashboards-reporting/pull/547) | Related: Upgrade dashboards-reporting to node version 20 (closed, not merged) |
+
+## References
+
+- [PR #548](https://github.com/opensearch-project/dashboards-reporting/pull/548): Main implementation
+- [dashboards-reporting repository](https://github.com/opensearch-project/dashboards-reporting): Source repository
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/reporting/ci-workflow.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -40,6 +40,7 @@
 ## reporting
 
 - [AUTO Version Increment](features/reporting/auto-version-increment.md)
+- [CI/Workflow Fixes](features/reporting/ci-workflow-fixes.md)
 
 ## security
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the CI/Workflow fixes in the dashboards-reporting plugin for OpenSearch v3.0.0.

## Changes

### Release Report
- `docs/releases/v3.0.0/features/reporting/ci-workflow-fixes.md`

### Feature Report
- `docs/features/reporting/ci-workflow.md`

## Key Findings

The PR #548 in dashboards-reporting includes:
- GitHub Actions version upgrades (checkout v1/v2/v3 → v4)
- Build job consolidation (separate Windows/macOS jobs → matrix-based job)
- Documentation link fixes (README, DEVELOPER_GUIDE)
- Maintainer handle update

## Related Issue
Closes #198