### PR TITLE
docs: add asynchronous-search report for v3.0.0

### DIFF
--- a/docs/features/asynchronous-search/asynchronous-search.md
+++ b/docs/features/asynchronous-search/asynchronous-search.md
@@ -1,0 +1,169 @@
+# Asynchronous Search
+
+## Summary
+
+Asynchronous search is an OpenSearch plugin that enables running search requests in the background for large volumes of data. It allows users to submit long-running queries, monitor their progress, retrieve partial results as they become available, and save completed results for later examination. This is particularly useful when searching across warm nodes or multiple remote clusters where queries may take significant time to complete.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph Client
+        A[Search Request]
+    end
+    
+    subgraph "OpenSearch Cluster"
+        B[Coordinator Node]
+        C[Async Search Service]
+        D[Search Execution]
+        E[Result Store]
+        
+        subgraph "Data Nodes"
+            F[Shard 1]
+            G[Shard 2]
+            H[Shard N]
+        end
+    end
+    
+    A -->|POST _plugins/_asynchronous_search| B
+    B --> C
+    C --> D
+    D --> F
+    D --> G
+    D --> H
+    F --> D
+    G --> D
+    H --> D
+    D -->|Partial Results| C
+    C -->|Store| E
+    C -->|Response with ID| A
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Submit Search] --> B{Wait Timeout?}
+    B -->|Yes| C[Return Partial Results + ID]
+    B -->|No| D[Return Complete Results]
+    C --> E[Poll for Updates]
+    E --> F{Search Complete?}
+    F -->|No| E
+    F -->|Yes| G[Get Final Results]
+    G --> H{Keep Results?}
+    H -->|Yes| I[Store in Cluster]
+    H -->|No| J[Cleanup]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Async Search Service | Manages asynchronous search lifecycle and state |
+| Result Store | Persists search results in the cluster for later retrieval |
+| Stats Collector | Tracks metrics for submitted, running, and completed searches |
+| Security Integration | Provides role-based access control for async searches |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `wait_for_completion_timeout` | Time to wait for initial results (max 300s) | 1 second |
+| `keep_on_completion` | Whether to save results after search completes | `false` |
+| `keep_alive` | Duration to retain saved results | 12 hours |
+
+### API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `_plugins/_asynchronous_search` | POST | Submit an asynchronous search |
+| `_plugins/_asynchronous_search/<ID>` | GET | Get partial/complete results |
+| `_plugins/_asynchronous_search/<ID>` | DELETE | Cancel search or delete results |
+| `_plugins/_asynchronous_search/stats` | GET | Get async search statistics |
+
+### Search States
+
+| State | Description |
+|-------|-------------|
+| `RUNNING` | Search is still executing |
+| `SUCCEEDED` | Search completed successfully |
+| `FAILED` | Search completed with failure |
+| `PERSISTING` | Results are being persisted |
+| `PERSIST_SUCCEEDED` | Results successfully persisted |
+| `PERSIST_FAILED` | Result persistence failed |
+| `CLOSED` | Search was closed/cancelled |
+| `STORE_RESIDENT` | Results are stored and available |
+
+### Usage Example
+
+```json
+// Submit an asynchronous search
+POST _plugins/_asynchronous_search/?wait_for_completion_timeout=1ms&keep_on_completion=true
+{
+  "query": {
+    "match_all": {}
+  },
+  "aggs": {
+    "city": {
+      "terms": {
+        "field": "city",
+        "size": 10
+      }
+    }
+  }
+}
+
+// Response includes an ID for polling
+{
+  "id": "FklfVlU4eFdIUTh1Q1hyM3ZnT19fUVEUd29KLWZYUUI3TzRpdU5wMjRYOHgAAAAAAAAABg==",
+  "state": "RUNNING",
+  "start_time_in_millis": 1599833301297,
+  "expiration_time_in_millis": 1600265301297,
+  "response": {
+    "took": 15,
+    "_shards": {
+      "total": 21,
+      "successful": 4
+    }
+  }
+}
+
+// Poll for results
+GET _plugins/_asynchronous_search/FklfVlU4eFdIUTh1Q1hyM3ZnT19fUVEUd29KLWZYUUI3TzRpdU5wMjRYOHgAAAAAAAAABg==
+```
+
+### Security Roles
+
+| Role | Description |
+|------|-------------|
+| `asynchronous_search_full_access` | Full access to all async search operations |
+| `asynchronous_search_read_access` | Read-only access to async search results |
+
+## Limitations
+
+- Maximum `wait_for_completion_timeout` is 300 seconds
+- Results are automatically deleted after `keep_alive` period expires
+- Query execution time counts against `keep_alive` duration
+- Users can only access their own async searches (with security enabled)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#724](https://github.com/opensearch-project/asynchronous-search/pull/724) | Version increment for 3.0.0 GA |
+| v3.0.0 | [#698](https://github.com/opensearch-project/asynchronous-search/pull/698) | JDK23 support and Gradle 8.10.2 |
+| v3.0.0 | [#582](https://github.com/opensearch-project/asynchronous-search/pull/582) | JDK21 baseline for 3.0 |
+
+## References
+
+- [Asynchronous Search Documentation](https://docs.opensearch.org/3.0/search-plugins/async/index/)
+- [Asynchronous Search Security](https://docs.opensearch.org/3.0/search-plugins/async/security/)
+- [Asynchronous Search Settings](https://docs.opensearch.org/3.0/search-plugins/async/settings/)
+- [GitHub Repository](https://github.com/opensearch-project/asynchronous-search)
+
+## Change History
+
+- **v3.0.0** (2025): GA release preparation - JDK21 baseline, Gradle 8.10.2, JDK23 support
+- **v1.0.0** (2021): Initial release with OpenSearch

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -52,3 +52,7 @@
 ## sql
 
 - [SQL/PPL Breaking Changes](sql/sql-ppl-breaking-changes.md)
+
+## asynchronous-search
+
+- [Asynchronous Search](asynchronous-search/asynchronous-search.md)

--- a/docs/releases/v3.0.0/features/asynchronous-search/ga-release-preparation.md
+++ b/docs/releases/v3.0.0/features/asynchronous-search/ga-release-preparation.md
@@ -1,0 +1,62 @@
+# Asynchronous Search GA Release Preparation
+
+## Summary
+
+This release item covers the version increment and release preparation for the asynchronous-search plugin for OpenSearch 3.0.0 GA. The changes are maintenance-focused, updating the plugin version from `3.0.0-beta1-SNAPSHOT` to `3.0.0-SNAPSHOT` to align with the OpenSearch 3.0.0 GA release.
+
+## Details
+
+### What's New in v3.0.0
+
+The asynchronous-search plugin for v3.0.0 includes:
+
+- **Version alignment**: Updated plugin version to match OpenSearch 3.0.0 GA release
+- **JDK 21 baseline**: The plugin now requires JDK 21 as the minimum Java version (set in earlier 3.0 preparation)
+- **Gradle 8.10.2**: Build system updated to use Gradle 8.10.2
+- **JDK 23 support**: Added support for building with JDK 23
+
+### Technical Changes
+
+#### Build Configuration
+
+| Setting | Previous Value | New Value |
+|---------|----------------|-----------|
+| `opensearch_version` | `3.0.0-beta1-SNAPSHOT` | `3.0.0-SNAPSHOT` |
+
+#### Compatibility
+
+The asynchronous-search plugin maintains full compatibility with OpenSearch 3.0.0 and continues to provide the same functionality:
+
+- Background search execution for long-running queries
+- Partial results retrieval during search execution
+- Search result persistence for later examination
+- Stats monitoring for asynchronous searches
+
+### No Feature Changes
+
+This release item contains no new features or API changes. The asynchronous-search plugin functionality remains unchanged from previous versions.
+
+## Limitations
+
+- No new features introduced in this release
+- This is a maintenance release for GA version alignment
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#724](https://github.com/opensearch-project/asynchronous-search/pull/724) | Increment version to 3.0.0-SNAPSHOT |
+| [#714](https://github.com/opensearch-project/asynchronous-search/pull/714) | Add 3.0.0.0-alpha1 release notes |
+| [#698](https://github.com/opensearch-project/asynchronous-search/pull/698) | Update main branch for 3.0.0.0-alpha1 / gradle 8.10.2 / JDK23 |
+| [#582](https://github.com/opensearch-project/asynchronous-search/pull/582) | Set JDK21 as the baseline for the 3.0 major version |
+
+## References
+
+- [Asynchronous Search Documentation](https://docs.opensearch.org/3.0/search-plugins/async/index/)
+- [Asynchronous Search Security](https://docs.opensearch.org/3.0/search-plugins/async/security/)
+- [Asynchronous Search Settings](https://docs.opensearch.org/3.0/search-plugins/async/settings/)
+- [Issue #318](https://github.com/opensearch-project/asynchronous-search/issues/318): 3.0.0 release tracking
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/asynchronous-search/asynchronous-search.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -53,3 +53,7 @@
 ## sql
 
 - [SQL/PPL v3.0.0 Breaking Changes](features/sql/sql-ppl-v3-breaking-changes.md)
+
+## asynchronous-search
+
+- [GA Release Preparation](features/asynchronous-search/ga-release-preparation.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the asynchronous-search plugin for OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/asynchronous-search/ga-release-preparation.md`
- Feature report: `docs/features/asynchronous-search/asynchronous-search.md`

### Key Findings

The asynchronous-search plugin for v3.0.0 is a **maintenance release** with no new features:

- Version increment from `3.0.0-beta1-SNAPSHOT` to `3.0.0-SNAPSHOT` for GA release
- JDK 21 baseline requirement
- Gradle 8.10.2 build system
- JDK 23 support added

### Related PRs Investigated
- [#724](https://github.com/opensearch-project/asynchronous-search/pull/724): Version increment for GA
- [#714](https://github.com/opensearch-project/asynchronous-search/pull/714): Release notes
- [#698](https://github.com/opensearch-project/asynchronous-search/pull/698): JDK23/Gradle update
- [#582](https://github.com/opensearch-project/asynchronous-search/pull/582): JDK21 baseline

### Resources Used
- [Asynchronous Search Documentation](https://docs.opensearch.org/3.0/search-plugins/async/index/)

Closes #196