### PR TITLE
docs: add geospatial-plugin report for v3.0.0

### DIFF
--- a/docs/features/geospatial/geospatial-plugin.md
+++ b/docs/features/geospatial/geospatial-plugin.md
@@ -1,0 +1,81 @@
+# Geospatial Plugin
+
+## Summary
+
+The OpenSearch Geospatial plugin provides geospatial data processing capabilities including the IP2Geo processor for enriching documents with geographic information based on IP addresses. The plugin supports various geospatial queries and data types for location-based search and analysis.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Geospatial Plugin"
+        IP2Geo[IP2Geo Processor]
+        GeoQuery[Geospatial Queries]
+        GeoTypes[Geospatial Types]
+    end
+    
+    subgraph "Build & Release"
+        Gradle[Gradle Build]
+        Maven[Maven Publishing]
+        POM[POM Metadata]
+    end
+    
+    Gradle --> Maven
+    Maven --> POM
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| IP2Geo Processor | Ingest processor that adds geographic information based on IP addresses |
+| Geospatial Queries | Query DSL support for geographic and xy queries |
+| Geospatial Types | Field types for storing geographic data |
+| Geospatial Client | Java client library for geospatial operations |
+
+### Installation
+
+```bash
+./bin/opensearch-plugin install opensearch-geospatial
+```
+
+### Maven Artifacts
+
+The plugin publishes the following artifacts to Maven Central:
+
+| Artifact | Group ID | Description |
+|----------|----------|-------------|
+| opensearch-geospatial | org.opensearch | Main plugin artifact |
+| geospatial-client | org.opensearch | Java client library |
+| geospatial | org.opensearch.plugin | Plugin distribution |
+
+### Build Configuration
+
+The plugin uses Gradle for building and Maven for artifact publishing. POM files include:
+- Apache License 2.0
+- OpenSearch developer information
+- Project description and inception year (2021)
+
+## Limitations
+
+- IP2Geo processor requires external GeoIP data sources
+- Search performance may be impacted when using IP2Geo processor due to index lookups
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#732](https://github.com/opensearch-project/geospatial/pull/732) | Persist licenses and developer fields in pom file |
+
+## References
+
+- [Issue #731](https://github.com/opensearch-project/geospatial/issues/731): Maven POM metadata bug report
+- [IP2Geo Documentation](https://docs.opensearch.org/3.0/ingest-pipelines/processors/ip2geo/): Official IP2Geo processor docs
+- [Installing Plugins](https://docs.opensearch.org/3.0/install-and-configure/plugins/): Plugin installation guide
+- [Geospatial Repository](https://github.com/opensearch-project/geospatial): Source code
+
+## Change History
+
+- **v3.0.0** (2025-03-24): Fixed Maven POM metadata to include license, description, and developer information for all published artifacts

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -56,3 +56,7 @@
 ## asynchronous-search
 
 - [Asynchronous Search](asynchronous-search/asynchronous-search.md)
+
+## geospatial
+
+- [Geospatial Plugin](geospatial/geospatial-plugin.md)

--- a/docs/releases/v3.0.0/features/geospatial/maven-pom-metadata.md
+++ b/docs/releases/v3.0.0/features/geospatial/maven-pom-metadata.md
@@ -1,0 +1,103 @@
+# Maven POM Metadata Fix
+
+## Summary
+
+This bugfix ensures that license, description, and developer information are properly persisted in Maven POM files when publishing the Geospatial plugin artifacts to Maven Central. Previously, these required metadata fields were missing, causing Nexus staging validation failures.
+
+## Details
+
+### What's New in v3.0.0
+
+The Geospatial plugin's Gradle build configuration was updated to properly include required Maven Central metadata in all published POM files.
+
+### Technical Changes
+
+#### Problem
+
+When publishing to Maven Central, the Nexus staging rules require POM files to include:
+- Project description
+- License information
+- Developer information
+
+The existing build configuration only applied these fields to specific publications, not all artifacts.
+
+#### Solution
+
+Changed the publication configuration from `pluginZip(MavenPublication)` to `all` clause, ensuring metadata is applied to all published artifacts. The fix uses `pom.withXml` to append XML nodes for:
+
+- `inceptionYear`: 2021
+- `licenses`: Apache License 2.0
+- `developers`: OpenSearch project information
+
+#### Affected Artifacts
+
+| Artifact | Group ID |
+|----------|----------|
+| opensearch-geospatial | org.opensearch |
+| geospatial-client | org.opensearch |
+| geospatial | org.opensearch.plugin |
+| opensearch-geospatial | org.opensearch.plugin |
+
+#### Build Configuration Changes
+
+```groovy
+// Before: Only applied to pluginZip publication
+publications {
+    pluginZip(MavenPublication) {
+        pom {
+            licenses { ... }
+            developers { ... }
+        }
+    }
+}
+
+// After: Applied to all publications via withXml
+publications {
+    all {
+        pom {
+            name = pluginName
+            description = pluginDescription
+        }
+        pom.withXml { XmlProvider xml ->
+            Node node = xml.asNode()
+            node.appendNode('inceptionYear', '2021')
+            
+            Node license = node.appendNode('licenses').appendNode('license')
+            license.appendNode('name', "The Apache License, Version 2.0")
+            license.appendNode('url', "http://www.apache.org/licenses/LICENSE-2.0.txt")
+            
+            Node developer = node.appendNode('developers').appendNode('developer')
+            developer.appendNode('name', 'OpenSearch')
+            developer.appendNode('url', 'https://github.com/opensearch-project/geospatial')
+        }
+    }
+}
+```
+
+### Verification
+
+After the fix, the following POM files contain proper metadata:
+- `~/.m2/repository/org/opensearch/opensearch-geospatial/{version}/opensearch-geospatial-{version}.pom`
+- `~/.m2/repository/org/opensearch/geospatial-client/{version}/geospatial-client-{version}.pom`
+- `~/.m2/repository/org/opensearch/plugin/geospatial/{version}/geospatial-{version}.pom`
+- `~/.m2/repository/org/opensearch/plugin/opensearch-geospatial/{version}/opensearch-geospatial-{version}.pom`
+
+## Limitations
+
+- This is a build/release infrastructure fix with no runtime impact
+- Only affects Maven artifact publishing
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#732](https://github.com/opensearch-project/geospatial/pull/732) | Persist licenses and developer fields in pom file |
+
+## References
+
+- [Issue #731](https://github.com/opensearch-project/geospatial/issues/731): Missing necessary license, description, developer information in maven pom
+- [Job Scheduler build.gradle](https://github.com/opensearch-project/job-scheduler/blob/main/build.gradle): Reference implementation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/geospatial/geospatial-plugin.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -57,3 +57,7 @@
 ## asynchronous-search
 
 - [GA Release Preparation](features/asynchronous-search/ga-release-preparation.md)
+
+## geospatial
+
+- [Maven POM Metadata Fix](features/geospatial/maven-pom-metadata.md)


### PR DESCRIPTION
## Summary

Adds documentation for the Geospatial plugin Maven POM metadata fix in v3.0.0.

## Changes

- Release report: `docs/releases/v3.0.0/features/geospatial/maven-pom-metadata.md`
- Feature report: `docs/features/geospatial/geospatial-plugin.md`
- Updated release and feature indexes

## Related Issue

Closes #195

## Investigation Summary

This bugfix ensures that license, description, and developer information are properly persisted in Maven POM files when publishing the Geospatial plugin artifacts to Maven Central. The fix changes the Gradle publication configuration from `pluginZip(MavenPublication)` to `all` clause with `pom.withXml` to apply metadata to all published artifacts.

### Key Changes in v3.0.0
- Fixed Maven POM metadata for all Geospatial plugin artifacts
- Added inceptionYear, licenses, and developers XML nodes to POM files
- Resolved Nexus staging validation failures