### PR TITLE
docs: add CVE Fixes & Dependency Updates report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -60,3 +60,7 @@
 ## geospatial
 
 - [Geospatial Plugin](geospatial/geospatial-plugin.md)
+
+## multi-plugin
+
+- [CVE Fixes & Dependency Updates](multi-plugin/cve-fixes-dependency-updates.md)

--- a/docs/features/multi-plugin/cve-fixes-dependency-updates.md
+++ b/docs/features/multi-plugin/cve-fixes-dependency-updates.md
@@ -1,0 +1,110 @@
+# CVE Fixes & Dependency Updates
+
+## Summary
+
+OpenSearch maintains security and stability through regular CVE fixes and dependency updates across its plugin ecosystem. This feature tracks security vulnerability remediation and dependency management across multiple repositories including alerting, security, anomaly-detection, reporting, index-management, and notifications plugins.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Plugin Ecosystem"
+        subgraph "Backend Plugins"
+            A[alerting]
+            IM[index-management]
+        end
+        subgraph "Dashboard Plugins"
+            SD[security-dashboards]
+            AD[anomaly-detection-dashboards]
+            R[dashboards-reporting]
+            N[dashboards-notifications]
+        end
+    end
+    
+    subgraph "Dependency Categories"
+        SEC[Security Libraries]
+        BUILD[Build Tools]
+        TEST[Testing Frameworks]
+        UI[UI Libraries]
+    end
+    
+    A --> SEC
+    A --> BUILD
+    IM --> BUILD
+    SD --> SEC
+    AD --> UI
+    R --> UI
+    R --> TEST
+    N --> TEST
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Security Libraries | axios, elliptic, dompurify - handle authentication, cryptography, and sanitization |
+| Build Tools | Gradle plugins (nebula.ospackage, detekt), ktlint |
+| Testing Frameworks | cypress, babel-jest |
+| UI Libraries | jspdf, @babel/runtime, @babel/helpers |
+
+### Common CVE Categories
+
+| Category | Description | Typical Fix |
+|----------|-------------|-------------|
+| SSRF | Server-Side Request Forgery | Upgrade HTTP client libraries |
+| XSS | Cross-Site Scripting | Upgrade sanitization libraries |
+| Cryptographic | Weak cryptographic implementations | Upgrade crypto libraries |
+| Prototype Pollution | JavaScript prototype manipulation | Upgrade affected packages |
+| Arbitrary Code Execution | Remote code execution risks | Upgrade affected packages |
+
+### Dependency Management Strategy
+
+```mermaid
+flowchart LR
+    A[Dependabot/Mend Alert] --> B{Security CVE?}
+    B -->|Yes| C[Priority Fix]
+    B -->|No| D[Regular Update]
+    C --> E[Create PR]
+    D --> E
+    E --> F[CI/CD Tests]
+    F --> G{Tests Pass?}
+    G -->|Yes| H[Merge]
+    G -->|No| I[Fix Compatibility]
+    I --> F
+```
+
+### Configuration
+
+No user configuration required. Dependency updates are applied automatically during plugin installation.
+
+## Limitations
+
+- Dependency versions may be constrained by OpenSearch Dashboards compatibility requirements
+- Some security fixes require coordinated updates across multiple plugins
+- Dev dependencies (cypress, babel-jest) may be removed rather than updated to reduce attack surface
+
+## Related PRs
+
+| Version | PR | Repository | Description |
+|---------|-----|------------|-------------|
+| v3.0.0 | [#1802](https://github.com/opensearch-project/alerting/pull/1802) | alerting | Bump logback to 1.5.16 |
+| v3.0.0 | [#993](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/993) | anomaly-detection | Update @babel/runtime (CVE-2025-27789) |
+| v3.0.0 | [#529](https://github.com/opensearch-project/dashboards-reporting/pull/529) | reporting | Bump jspdf to 3.0 (CVE-2025-26791) |
+| v3.0.0 | [#555](https://github.com/opensearch-project/dashboards-reporting/pull/555) | reporting | Bump jspdf to 3.0.1 (CVE-2025-29907) |
+| v3.0.0 | [#550](https://github.com/opensearch-project/dashboards-reporting/pull/550) | reporting | CVE fix for elliptic |
+| v3.0.0 | [#558](https://github.com/opensearch-project/dashboards-reporting/pull/558) | reporting | CVE fix for babel/helpers |
+| v3.0.0 | [#1374](https://github.com/opensearch-project/index-management/pull/1374) | index-management | Bump nebula.ospackage |
+| v3.0.0 | [#338](https://github.com/opensearch-project/dashboards-notifications/pull/338) | notifications | Bump cypress |
+
+## References
+
+- [CVE-2025-27789](https://nvd.nist.gov/vuln/detail/CVE-2025-27789): @babel/runtime vulnerability
+- [CVE-2025-26791](https://nvd.nist.gov/vuln/detail/CVE-2025-26791): jspdf vulnerability
+- [CVE-2025-29907](https://nvd.nist.gov/vuln/detail/CVE-2025-29907): jspdf vulnerability
+- [GHSA-vjh7-7g9h-fjfh](https://github.com/advisories/GHSA-vjh7-7g9h-fjfh): elliptic vulnerability
+
+## Change History
+
+- **v3.0.0** (2025-04): Multiple CVE fixes across alerting, security, anomaly-detection, reporting, index-management, and notifications plugins

--- a/docs/releases/v3.0.0/features/multi-plugin/cve-fixes-dependency-updates.md
+++ b/docs/releases/v3.0.0/features/multi-plugin/cve-fixes-dependency-updates.md
@@ -1,0 +1,107 @@
+# CVE Fixes & Dependency Updates
+
+## Summary
+
+OpenSearch v3.0.0 includes critical security fixes and dependency updates across multiple plugins to address known CVEs and maintain compatibility with the latest library versions. These changes span alerting, security, anomaly-detection, reporting, index-management, and notifications plugins.
+
+## Details
+
+### What's New in v3.0.0
+
+This release addresses multiple security vulnerabilities and updates dependencies to their latest secure versions across the OpenSearch plugin ecosystem.
+
+### Technical Changes
+
+#### CVEs Addressed
+
+| CVE | Description | Affected Component | Fix |
+|-----|-------------|-------------------|-----|
+| CVE-2025-27789 | @babel/runtime vulnerability | anomaly-detection, reporting | Upgrade to >=7.26.10 |
+| CVE-2025-26791 | jspdf vulnerability | reporting | Upgrade to 3.0.0 |
+| CVE-2025-29907 | jspdf vulnerability | reporting | Upgrade to 3.0.1 |
+| GHSA-vjh7-7g9h-fjfh | elliptic vulnerability | reporting | Remove vulnerable dependency |
+| N/A | logback vulnerability | alerting | Upgrade to 1.5.16 |
+| N/A | axios SSRF vulnerability | security | Upgrade to 1.8.2 |
+
+#### Dependency Updates by Repository
+
+##### Alerting
+| Dependency | Old Version | New Version |
+|------------|-------------|-------------|
+| logback | < 1.5.16 | 1.5.16 |
+| ktlint | (CVE fix) | Updated |
+
+##### Anomaly Detection Dashboards
+| Dependency | Old Version | New Version |
+|------------|-------------|-------------|
+| @babel/runtime | < 7.26.10 | >=7.26.10 |
+
+##### Security Dashboards
+| Dependency | Old Version | New Version |
+|------------|-------------|-------------|
+| axios | < 1.8.2 | 1.8.2 |
+
+##### Dashboards Reporting
+| Dependency | Old Version | New Version |
+|------------|-------------|-------------|
+| dompurify | 3.2.4 | 3.0.11 (match OSD) |
+| jspdf | < 3.0 | 3.0.1 |
+| @babel/helpers | (CVE fix) | Updated |
+| @babel/runtime | (CVE fix) | Updated |
+| elliptic | 6.6.0 | Removed |
+| cypress | (dev) | Removed |
+| babel-jest | (dev) | Removed |
+
+##### Index Management
+| Dependency | Old Version | New Version |
+|------------|-------------|-------------|
+| com.netflix.nebula.ospackage | 11.10.1 | 11.11.1 |
+| commons-beanutils | (security fix) | Updated |
+| io.gitlab.arturbosch.detekt | (updated) | Updated |
+| micromatch | (updated) | Updated |
+
+##### Dashboards Notifications
+| Dependency | Old Version | New Version |
+|------------|-------------|-------------|
+| cypress | < 13.6.0 | ^13.6.0 |
+
+### Migration Notes
+
+These are dependency-only changes with no breaking API changes. Users upgrading to v3.0.0 will automatically benefit from these security fixes.
+
+## Limitations
+
+- Some dependency updates (like dompurify in reporting) were aligned to match OpenSearch Dashboards versions rather than using the latest available version to avoid build conflicts.
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#1802](https://github.com/opensearch-project/alerting/pull/1802) | alerting | Bump logback to 1.5.16 |
+| [#1223](https://github.com/opensearch-project/alerting/pull/1223) | alerting | CVE fix for ktlint |
+| [#991](https://github.com/opensearch-project/security-dashboards-plugin/pull/991) | security | Upgrade axios to 1.8.2 (SSRF fix) |
+| [#993](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/993) | anomaly-detection | Update @babel/runtime to >=7.26.10 |
+| [#516](https://github.com/opensearch-project/dashboards-reporting/pull/516) | reporting | Change dompurify to 3.0.11 |
+| [#529](https://github.com/opensearch-project/dashboards-reporting/pull/529) | reporting | Bump jspdf to 3.0 (CVE-2025-26791) |
+| [#550](https://github.com/opensearch-project/dashboards-reporting/pull/550) | reporting | CVE fix for elliptic |
+| [#555](https://github.com/opensearch-project/dashboards-reporting/pull/555) | reporting | Bump jspdf to 3.0.1 (CVE-2025-29907) |
+| [#558](https://github.com/opensearch-project/dashboards-reporting/pull/558) | reporting | CVE fix for babel/helpers and babel/runtime |
+| [#559](https://github.com/opensearch-project/dashboards-reporting/pull/559) | reporting | Remove cypress and babel-jest |
+| [#1374](https://github.com/opensearch-project/index-management/pull/1374) | index-management | Bump nebula.ospackage 11.10.1 → 11.11.1 |
+| [#1375](https://github.com/opensearch-project/index-management/pull/1375) | index-management | Bump commons-beanutils |
+| [#1381](https://github.com/opensearch-project/index-management/pull/1381) | index-management | Bump detekt-gradle-plugin |
+| [#1273](https://github.com/opensearch-project/index-management/pull/1273) | index-management | Update micromatch |
+| [#338](https://github.com/opensearch-project/dashboards-notifications/pull/338) | notifications | Bump cypress to ^13.6.0 |
+
+## References
+
+- [CVE-2025-27789](https://nvd.nist.gov/vuln/detail/CVE-2025-27789): @babel/runtime vulnerability
+- [CVE-2025-26791](https://nvd.nist.gov/vuln/detail/CVE-2025-26791): jspdf vulnerability
+- [CVE-2025-29907](https://nvd.nist.gov/vuln/detail/CVE-2025-29907): jspdf vulnerability
+- [GHSA-vjh7-7g9h-fjfh](https://github.com/advisories/GHSA-vjh7-7g9h-fjfh): elliptic vulnerability
+- [Issue #150](https://github.com/opensearch-project/dashboards-reporting/issues/150): Reporting elliptic CVE tracking
+- [Issue #305](https://github.com/opensearch-project/dashboards-notifications/issues/305): Notifications cypress update tracking
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/multi-plugin/cve-fixes-dependency-updates.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -61,3 +61,7 @@
 ## geospatial
 
 - [Maven POM Metadata Fix](features/geospatial/maven-pom-metadata.md)
+
+## multi-plugin
+
+- [CVE Fixes & Dependency Updates](features/multi-plugin/cve-fixes-dependency-updates.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for CVE fixes and dependency updates in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/multi-plugin/cve-fixes-dependency-updates.md`
- Feature report: `docs/features/multi-plugin/cve-fixes-dependency-updates.md`

### Key Changes in v3.0.0
- CVE-2025-27789: @babel/runtime vulnerability fix (anomaly-detection, reporting)
- CVE-2025-26791 & CVE-2025-29907: jspdf vulnerability fixes (reporting)
- GHSA-vjh7-7g9h-fjfh: elliptic vulnerability fix (reporting)
- logback upgrade to 1.5.16 (alerting)
- axios upgrade to 1.8.2 for SSRF fix (security)
- Multiple Gradle plugin updates (index-management)
- cypress version bump (notifications)

### Repositories Affected
- alerting
- security-dashboards-plugin
- anomaly-detection-dashboards-plugin
- dashboards-reporting
- index-management
- dashboards-notifications

Closes #194