### PR TITLE
docs: add dashboards-dependencies report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -34,6 +34,7 @@
 - [Dashboards CI/CD & Documentation](opensearch-dashboards/dashboards-ci-cd-documentation.md)
 - [Dashboards Cypress Testing](opensearch-dashboards/dashboards-cypress-testing.md)
 - [Dashboards UI/UX Fixes](opensearch-dashboards/dashboards-ui-ux-fixes.md)
+- [DOMPurify Sanitization](opensearch-dashboards/dompurify-sanitization.md)
 - [Workspace](opensearch-dashboards/workspace.md)
 
 ## security

--- a/docs/features/opensearch-dashboards/dompurify-sanitization.md
+++ b/docs/features/opensearch-dashboards/dompurify-sanitization.md
@@ -1,0 +1,97 @@
+# DOMPurify Sanitization
+
+## Summary
+
+DOMPurify is a critical security library used in OpenSearch Dashboards to sanitize HTML, MathML, and SVG content before rendering. It protects against cross-site scripting (XSS) attacks by removing malicious code from user-provided content while preserving safe markup.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart LR
+    subgraph Input
+        A[User HTML Content]
+    end
+    subgraph Sanitization
+        B[DOMPurify]
+        C[DOM Parser]
+        D[Sanitization Rules]
+    end
+    subgraph Output
+        E[Safe HTML]
+    end
+    A --> B
+    B --> C
+    C --> D
+    D --> E
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| DOMPurify | Core sanitization library from Cure53 |
+| DOM Parser | Browser's native DOM parsing engine |
+| Sanitization Rules | Configurable allowlists for tags and attributes |
+
+### Usage in OpenSearch Dashboards
+
+DOMPurify is used throughout OpenSearch Dashboards to sanitize:
+
+- Table visualization cell content with URL formatting
+- Markdown content in visualizations
+- Custom HTML in dashboard panels
+- User-provided labels and descriptions
+
+### Configuration
+
+DOMPurify can be configured with various options:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| ALLOWED_TAGS | HTML tags permitted in output | Standard safe tags |
+| ALLOWED_ATTR | Attributes permitted on elements | Standard safe attributes |
+| FORBID_TAGS | Tags explicitly forbidden | Script, style, etc. |
+| FORBID_ATTR | Attributes explicitly forbidden | Event handlers |
+
+### Usage Example
+
+```typescript
+import DOMPurify from 'dompurify';
+
+// Basic sanitization
+const cleanHTML = DOMPurify.sanitize(dirtyHTML);
+
+// With custom configuration
+const cleanHTML = DOMPurify.sanitize(dirtyHTML, {
+  ALLOWED_TAGS: ['b', 'i', 'em', 'strong', 'a'],
+  ALLOWED_ATTR: ['href', 'title']
+});
+```
+
+## Limitations
+
+- Sanitization adds processing overhead for large HTML content
+- Some legitimate HTML patterns may be stripped if they resemble attack vectors
+- Configuration must balance security with functionality
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#9447](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9447) | Bump dompurify from 3.1.6 to 3.2.4 (CVE-2025-26791) |
+| v2.17.1 | [#8346](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8346) | Bump dompurify from 3.0.11 to 3.1.6 (CVE-2024-45801) |
+| v2.5.0 | [#2918](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/2918) | Initial DOMPurify integration for table visualization |
+
+## References
+
+- [DOMPurify GitHub](https://github.com/cure53/DOMPurify): Official DOMPurify repository
+- [CVE-2025-26791](https://nvd.nist.gov/vuln/detail/CVE-2025-26791): mXSS vulnerability in template literal regex
+- [CVE-2024-45801](https://nvd.nist.gov/vuln/detail/CVE-2024-45801): Nesting-based mXSS vulnerability
+
+## Change History
+
+- **v3.0.0** (2025-02-26): Updated to 3.2.4 to fix CVE-2025-26791 (mXSS via template literal regex)
+- **v2.17.1** (2024-09-25): Updated to 3.1.6 to fix CVE-2024-45801 (nesting-based mXSS)
+- **v2.5.0** (2022-12-15): Initial integration for table visualization URL formatting

--- a/docs/releases/v3.0.0/features/opensearch-dashboards/dashboards-dependencies.md
+++ b/docs/releases/v3.0.0/features/opensearch-dashboards/dashboards-dependencies.md
@@ -1,0 +1,54 @@
+# Dashboards Dependencies
+
+## Summary
+
+This release updates the DOMPurify dependency from version 3.1.6 to 3.2.4 in OpenSearch Dashboards to address CVE-2025-26791, a mutation cross-site scripting (mXSS) vulnerability caused by an incorrect template literal regular expression.
+
+## Details
+
+### What's New in v3.0.0
+
+The DOMPurify library has been updated to fix a security vulnerability that could allow attackers to bypass XSS sanitization through specially crafted input.
+
+### Technical Changes
+
+#### Security Fix
+
+| CVE | Severity | Description |
+|-----|----------|-------------|
+| CVE-2025-26791 | Medium | Mutation XSS vulnerability due to incorrect template literal regex |
+
+#### Dependency Update
+
+| Package | Previous Version | New Version |
+|---------|------------------|-------------|
+| dompurify | 3.1.6 | 3.2.4 |
+
+### Background
+
+DOMPurify is a DOM-only, super-fast, uber-tolerant XSS sanitizer for HTML, MathML, and SVG. OpenSearch Dashboards uses DOMPurify to sanitize user-provided HTML content before rendering, protecting against cross-site scripting attacks.
+
+The vulnerability (CVE-2025-26791) existed in versions before 3.2.4 where an incorrect template literal regular expression could lead to mutation XSS (mXSS) attacks. In mXSS attacks, malicious content that appears safe during initial sanitization can mutate into executable code when the browser parses the DOM.
+
+### Migration Notes
+
+No migration steps required. The dependency update is transparent to users and administrators.
+
+## Limitations
+
+None specific to this update.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9447](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9447) | Bump dompurify from 3.1.6 to 3.2.4 |
+
+## References
+
+- [CVE-2025-26791 - NVD](https://nvd.nist.gov/vuln/detail/CVE-2025-26791): Official CVE entry
+- [DOMPurify GitHub](https://github.com/cure53/DOMPurify): DOMPurify library repository
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/dompurify-sanitization.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -33,6 +33,7 @@
 - [CI/CD & Build Fixes](features/opensearch-dashboards/ci-cd-build-fixes.md)
 - [Dashboards CI/CD & Documentation](features/opensearch-dashboards/dashboards-ci-cd-documentation.md)
 - [Dashboards Cypress Testing](features/opensearch-dashboards/dashboards-cypress-testing.md)
+- [Dashboards Dependencies](features/opensearch-dashboards/dashboards-dependencies.md)
 - [Dashboards UI/UX Fixes](features/opensearch-dashboards/dashboards-ui-ux-fixes.md)
 - [UI/UX Improvements](features/opensearch-dashboards/ui-ux-improvements.md)
 - [Workspace Improvements](features/opensearch-dashboards/workspace-improvements.md)


### PR DESCRIPTION
## Summary

Adds documentation for the DOMPurify dependency update in OpenSearch Dashboards v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch-dashboards/dashboards-dependencies.md`
- Feature report: `docs/features/opensearch-dashboards/dompurify-sanitization.md`

### Key Changes in v3.0.0
- DOMPurify updated from 3.1.6 to 3.2.4
- Fixes CVE-2025-26791 (mutation XSS via incorrect template literal regex)

### Related Issue
Closes #193