### PR TITLE
docs: add remote-metadata-store-documentation report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -65,3 +65,7 @@
 ## multi-plugin
 
 - [CVE Fixes & Dependency Updates](multi-plugin/cve-fixes-dependency-updates.md)
+
+## opensearch-remote-metadata-sdk
+
+- [Remote Metadata SDK](opensearch-remote-metadata-sdk/remote-metadata-sdk.md)

--- a/docs/features/opensearch-remote-metadata-sdk/remote-metadata-sdk.md
+++ b/docs/features/opensearch-remote-metadata-sdk/remote-metadata-sdk.md
@@ -1,0 +1,142 @@
+# OpenSearch Remote Metadata SDK
+
+## Summary
+
+The OpenSearch Remote Metadata SDK enables plugin developers to build stateless OpenSearch plugins by abstracting metadata storage to external data stores. Instead of storing metadata in local system indices within the OpenSearch cluster, plugins can use remote storage solutions like other OpenSearch clusters, Amazon OpenSearch Service, or Amazon DynamoDB. This approach improves scalability, reduces resource contention, and enables multi-tenancy support.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Cluster"
+        Plugin[OpenSearch Plugin]
+        SdkClient[SdkClient]
+    end
+    
+    subgraph "Remote Storage Options"
+        RemoteOS[Remote OpenSearch Cluster]
+        AOS[Amazon OpenSearch Service]
+        DDB[Amazon DynamoDB]
+    end
+    
+    Plugin --> SdkClient
+    SdkClient --> RemoteOS
+    SdkClient --> AOS
+    SdkClient --> DDB
+    
+    DDB -.->|Zero-ETL Replication| AOS
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Plugin Request] --> B[SdkClient]
+    B --> C{Storage Type}
+    C -->|RemoteOpenSearch| D[Remote OS Cluster]
+    C -->|AWSOpenSearchService| E[AOS/AOSS]
+    C -->|AWSDynamoDB| F[DynamoDB]
+    F -->|Search Only| E
+    D --> G[Response]
+    E --> G
+    G --> H[Plugin Response]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SdkClient` | Main client interface for remote metadata operations |
+| `SdkClientFactory` | Factory class to instantiate appropriate client based on configuration |
+| `PutDataObjectRequest` | SDK wrapper for index operations |
+| `GetDataObjectRequest` | SDK wrapper for get operations |
+| `UpdateDataObjectRequest` | SDK wrapper for update operations |
+| `DeleteDataObjectRequest` | SDK wrapper for delete operations |
+| `SearchDataObjectRequest` | SDK wrapper for search operations |
+| `SdkClientUtils` | Utility class with completion wrappers for async operations |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `remote_metadata_type` | Storage backend type: `RemoteOpenSearch`, `AWSDynamoDB`, `AWSOpenSearchService` | - |
+| `remote_metadata_endpoint` | Remote storage endpoint URL | - |
+| `remote_metadata_region` | AWS region for remote storage | - |
+| `remote_metadata_service_name` | Service name for remote storage | - |
+| `multi_tenancy_enabled` | Enable multi-tenancy support | `false` |
+
+### Supported Storage Backends
+
+| Backend | Client Module | Use Case |
+|---------|---------------|----------|
+| Remote OpenSearch | `remote-client` | Self-managed remote OpenSearch cluster |
+| Amazon OpenSearch Service | `aos-client` | AWS managed OpenSearch or Serverless |
+| Amazon DynamoDB | `ddb-client` | DynamoDB for CRUD with zero-ETL to AOS for search |
+
+### Usage Example
+
+```groovy
+// build.gradle dependencies
+implementation ("org.opensearch:opensearch-remote-metadata-sdk:${opensearch_build}")
+// For DynamoDB backend:
+implementation ("org.opensearch:opensearch-remote-metadata-sdk-ddb-client:${opensearch_build}")
+```
+
+```java
+// Initialize in createComponents()
+SdkClient sdkClient = SdkClientFactory.createSdkClient(
+    client,
+    xContentRegistry,
+    Map.ofEntries(
+        Map.entry(REMOTE_METADATA_TYPE_KEY, REMOTE_METADATA_TYPE.get(settings)),
+        Map.entry(REMOTE_METADATA_ENDPOINT_KEY, REMOTE_METADATA_ENDPOINT.get(settings)),
+        Map.entry(REMOTE_METADATA_REGION_KEY, REMOTE_METADATA_REGION.get(settings)),
+        Map.entry(REMOTE_METADATA_SERVICE_NAME_KEY, REMOTE_METADATA_SERVICE_NAME.get(settings)),
+        Map.entry(TENANT_AWARE_KEY, "true"),
+        Map.entry(TENANT_ID_FIELD_KEY, TENANT_ID_FIELD)
+    ),
+    client.threadPool().executor(ThreadPool.Names.GENERIC)
+);
+
+// Use SDK client for operations
+GetDataObjectRequest request = GetDataObjectRequest.builder()
+    .index(indexName)
+    .id(documentId)
+    .tenantId(tenantId)  // For multi-tenancy
+    .build();
+sdkClient.getDataObjectAsync(request)
+    .whenComplete(SdkClientUtils.wrapGetCompletion(actionListener));
+```
+
+### Supported Plugins
+
+The following plugins support multi-tenancy with remote metadata storage:
+
+- **ML Commons**: Connectors, model groups, externally hosted models, agents, tasks
+- **Flow Framework**: Workflow configurations and state
+
+## Limitations
+
+- Indices (OpenSearch) or tables (DynamoDB) must be created manually before use
+- Thread pool parameter currently unused but reserved for future implementations
+- DynamoDB backend requires zero-ETL replication setup for search operations
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#124](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/124) | Add a developer guide |
+
+## References
+
+- [PR #124](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/124): Add a developer guide
+- [DEVELOPER_GUIDE.md](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/blob/main/DEVELOPER_GUIDE.md): Full developer guide
+- [Plugin as a Service Documentation](https://docs.opensearch.org/3.0/developer-documentation/plugin-as-a-service/index/): Official OpenSearch documentation
+- [SDK Client Repository](https://github.com/opensearch-project/opensearch-remote-metadata-sdk): Source repository
+- [Zero-ETL Replication](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/OpenSearchIngestionForDynamoDB.html): DynamoDB to OpenSearch replication
+
+## Change History
+
+- **v3.0.0** (2025-04-02): Added developer guide with migration instructions (PR #124)

--- a/docs/releases/v3.0.0/features/opensearch-remote-metadata-sdk/remote-metadata-store-documentation.md
+++ b/docs/releases/v3.0.0/features/opensearch-remote-metadata-sdk/remote-metadata-store-documentation.md
@@ -1,0 +1,99 @@
+# Remote Metadata Store Documentation
+
+## Summary
+
+This release item adds a comprehensive developer guide to the OpenSearch Remote Metadata SDK repository. The guide provides step-by-step instructions for plugin developers to integrate the SDK, enabling stateless OpenSearch plugins that use external data stores instead of local system indices.
+
+## Details
+
+### What's New in v3.0.0
+
+PR #124 introduces a new `DEVELOPER_GUIDE.md` file that documents how to use the Remote Metadata SDK in OpenSearch plugins. This documentation fills a critical gap for developers looking to migrate their plugins to use remote metadata storage.
+
+### Technical Changes
+
+#### New Documentation
+
+The developer guide covers six key integration steps:
+
+| Step | Description |
+|------|-------------|
+| 1. Declare Dependencies | Add SDK dependencies to `build.gradle` |
+| 2. Initialize SDK Client | Use `SdkClientFactory` in `createComponents()` |
+| 3. Inject Client | Use `@Inject` to pass `SdkClient` to classes |
+| 4. Migrate API Calls | Replace NodeClient requests with SDK equivalents |
+| 5. Update Exception Handling | Expand exception checks for remote storage |
+| 6. Handle Multitenancy | Optional tenant ID handling |
+
+#### Supported Remote Storage Backends
+
+| Client | Description |
+|--------|-------------|
+| `remote-client` | Remote OpenSearch cluster |
+| `aos-client` | Amazon OpenSearch Service (AOS) or Serverless (AOSS) |
+| `ddb-client` | DynamoDB with zero-ETL replication to AOS/AOSS |
+
+#### API Migration Reference
+
+| NodeClient | SDK Client |
+|------------|------------|
+| `IndexRequest` | `PutDataObjectRequest` |
+| `GetRequest` | `GetDataObjectRequest` |
+| `UpdateRequest` | `UpdateDataObjectRequest` |
+| `DeleteRequest` | `DeleteDataObjectRequest` |
+| `SearchRequest` | `SearchDataObjectRequest` |
+
+### Usage Example
+
+```java
+// Initialize SDK Client
+SdkClient sdkClient = SdkClientFactory.createSdkClient(
+    client,
+    xContentRegistry,
+    Map.ofEntries(
+        Map.entry(REMOTE_METADATA_TYPE_KEY, REMOTE_METADATA_TYPE.get(settings)),
+        Map.entry(REMOTE_METADATA_ENDPOINT_KEY, REMOTE_METADATA_ENDPOINT.get(settings)),
+        Map.entry(REMOTE_METADATA_REGION_KEY, REMOTE_METADATA_REGION.get(settings)),
+        Map.entry(REMOTE_METADATA_SERVICE_NAME_KEY, REMOTE_METADATA_SERVICE_NAME.get(settings)),
+        Map.entry(TENANT_AWARE_KEY, "true"),
+        Map.entry(TENANT_ID_FIELD_KEY, TENANT_ID_FIELD)
+    ),
+    client.threadPool().executor(ThreadPool.Names.GENERIC)
+);
+
+// Migrate get operation
+GetDataObjectRequest getDataObjectRequest = GetDataObjectRequest.builder()
+    .index(indexName)
+    .id(documentId)
+    .build();
+sdkClient.getDataObjectAsync(getDataObjectRequest)
+    .whenComplete(SdkClientUtils.wrapGetCompletion(actionListener));
+```
+
+### Migration Notes
+
+- The SDK client does not automatically create indices (OpenSearch) or tables (DynamoDB) - these must be created manually
+- Exception handling should be expanded to check both specific exceptions and generic `OpenSearchException` status codes
+- For multitenancy, extract tenant ID from REST request headers and add `.tenantId(tenantId)` to request objects
+
+## Limitations
+
+- Manual index/table creation required before using the SDK
+- Currently unused thread pool parameter may be needed in future implementations
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#124](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/124) | Add a developer guide |
+
+## References
+
+- [PR #124](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/124): Add a developer guide
+- [DEVELOPER_GUIDE.md](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/blob/main/DEVELOPER_GUIDE.md): Full developer guide
+- [Plugin as a Service Documentation](https://docs.opensearch.org/3.0/developer-documentation/plugin-as-a-service/index/): Official OpenSearch documentation
+- [SDK Client Repository](https://github.com/opensearch-project/opensearch-remote-metadata-sdk): Source repository
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-remote-metadata-sdk/remote-metadata-sdk.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -66,3 +66,7 @@
 ## multi-plugin
 
 - [CVE Fixes & Dependency Updates](features/multi-plugin/cve-fixes-dependency-updates.md)
+
+## opensearch-remote-metadata-sdk
+
+- [Remote Metadata Store Documentation](features/opensearch-remote-metadata-sdk/remote-metadata-store-documentation.md)


### PR DESCRIPTION
## Summary

This PR adds documentation reports for the Remote Metadata Store Documentation release item (v3.0.0).

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch-remote-metadata-sdk/remote-metadata-store-documentation.md`
- Feature report: `docs/features/opensearch-remote-metadata-sdk/remote-metadata-sdk.md`

### Key Changes in v3.0.0
- Added comprehensive developer guide (`DEVELOPER_GUIDE.md`) to the opensearch-remote-metadata-sdk repository
- Documents step-by-step integration process for plugin developers
- Covers SDK client initialization, API migration, exception handling, and multi-tenancy support

### Resources Used
- PR: opensearch-project/opensearch-remote-metadata-sdk#124
- Docs: https://docs.opensearch.org/3.0/developer-documentation/plugin-as-a-service/index/

Closes #192