### PR TITLE
docs: add SQL/PPL Documentation report for v3.0.0

### DIFF
--- a/docs/features/sql/sql-ppl-breaking-changes.md
+++ b/docs/features/sql/sql-ppl-breaking-changes.md
@@ -117,6 +117,7 @@ POST /_plugins/_sql
 | v3.0.0 | [#3367](https://github.com/opensearch-project/sql/pull/3367) | Deprecate OpenSearch DSL format |
 | v3.0.0 | [#3439](https://github.com/opensearch-project/sql/pull/3439) | Support CAST function with Calcite |
 | v3.0.0 | [#3473](https://github.com/opensearch-project/sql/pull/3473) | Add datetime functions |
+| v3.0.0 | [#3488](https://github.com/opensearch-project/sql/pull/3488) | Documentation for PPL V3 engine and limitations |
 
 ## References
 
@@ -124,7 +125,9 @@ POST /_plugins/_sql
 - [Breaking Changes](https://docs.opensearch.org/3.0/breaking-changes/): v3.0.0 breaking changes
 - [OpenSearch 3.0 Blog](https://opensearch.org/blog/opensearch-3-0-what-to-expect/): What to expect in OpenSearch 3.0
 - [SQL Plugin Repository](https://github.com/opensearch-project/sql): Source code
+- [PPL V3 Engine Limitations](https://docs.opensearch.org/3.0/search-plugins/sql/limitation/): V3 engine limitations
+- [Enhanced Log Analysis Blog](https://opensearch.org/blog/enhanced-log-analysis-with-opensearch-ppl-introducing-lookup-join-and-subsearch/): New PPL commands (join, lookup, subsearch)
 
 ## Change History
 
-- **v3.0.0** (2025): Major breaking changes - removed SparkSQL, DELETE statement, DSL format, scroll API, opendistro settings/endpoints; added Calcite-based functions and unified PPL data types
+- **v3.0.0** (2025): Major breaking changes - removed SparkSQL, DELETE statement, DSL format, scroll API, opendistro settings/endpoints; added Calcite-based functions, unified PPL data types, and documentation for V3 engine with new commands (join, lookup, subquery)

--- a/docs/releases/v3.0.0/features/sql/sql-ppl-documentation.md
+++ b/docs/releases/v3.0.0/features/sql/sql-ppl-documentation.md
@@ -1,0 +1,137 @@
+# SQL/PPL Documentation
+
+## Summary
+
+This release item adds comprehensive documentation for the PPL V3 engine and its limitations in OpenSearch 3.0.0 Beta. The documentation covers the new Apache Calcite-based query engine architecture, new PPL commands (join, lookup, subquery), breaking changes from V2, and the fallback mechanism for unsupported queries.
+
+## Details
+
+### What's New in v3.0.0
+
+This PR introduces developer and user documentation for the experimental PPL V3 engine, which integrates Apache Calcite for enhanced query processing capabilities.
+
+### Technical Changes
+
+#### New Documentation Files
+
+| File | Description |
+|------|-------------|
+| `docs/dev/intro-v3-architecture.md` | V3 engine architecture overview with Calcite integration |
+| `docs/dev/intro-v3-engine.md` | V3 engine features, limitations, and breaking changes |
+| `docs/user/ppl/cmd/join.rst` | JOIN command documentation |
+| `docs/user/ppl/cmd/lookup.rst` | LOOKUP command documentation |
+| `docs/user/ppl/cmd/subquery.rst` | Subquery (subsearch) command documentation |
+
+#### V3 Engine Architecture
+
+The V3 engine integrates Apache Calcite to address key pain points:
+
+1. **Complex Query Support**: Calcite provides industry-standard SQL parsing and optimization
+2. **Unified PPL Experience**: Bridges the gap between PPL-on-OpenSearch and PPL-on-Spark
+3. **Query Optimization**: Built-in RBO (Rule-Based Optimizer) and CBO (Cost-Based Optimizer)
+4. **Robustness**: Leverages Calcite's mature, well-tested codebase
+
+#### Query Processing Flow
+
+```mermaid
+flowchart LR
+    PPL[PPL Query] --> ANTLR[ANTLR Parser]
+    ANTLR --> AST[AST]
+    AST --> RelNode[RelNode/Calcite]
+    RelNode --> Enum[EnumerableRel]
+    Enum --> OSRel[OpenSearchEnumerableRel]
+    OSRel --> API[OpenSearch API]
+```
+
+#### New PPL Commands
+
+| Command | Description | Syntax |
+|---------|-------------|--------|
+| `join` | Combines two datasets | `[joinType] JOIN left=l right=r ON <criteria> <dataset>` |
+| `lookup` | Enriches data from lookup index | `LOOKUP <index> <mappingField> [REPLACE\|APPEND] <fields>` |
+| `subquery` | Nested queries (InSubquery, ExistsSubquery, ScalarSubquery) | `where <field> [not] in [ source=... ]` |
+
+#### Breaking Changes (V2 → V3)
+
+| Item | V2 | V3 |
+|------|-----|-----|
+| Return type of `timestampdiff` | timestamp | int |
+| Return type of `regexp` | int | boolean |
+| Return type of `count`, `dc`, `distinct_count` | int | bigint |
+| Return type of `ceiling`, `floor`, `sign` | int | same type as input |
+| `like(firstname, 'Ambe_')` on "Amber JOHnny" | true | false |
+| `cast(firstname as boolean)` | false | null |
+| Sum of multiple `null` values (pushdown enabled) | 0 | null |
+
+#### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.calcite.enabled` | Enable V3 Calcite engine | `false` |
+
+### Usage Example
+
+Enable Calcite engine:
+```bash
+curl -H 'Content-Type: application/json' -X PUT localhost:9200/_plugins/_query/settings -d '{
+  "transient": {
+    "plugins.calcite.enabled": true
+  }
+}'
+```
+
+JOIN example:
+```
+source = state_country
+| inner join left=a right=b ON a.name = b.name occupation
+| stats avg(salary) by span(age, 10) as age_span, b.country
+```
+
+LOOKUP example:
+```
+source = worker
+| LOOKUP work_information uid AS id REPLACE department
+| fields id, name, occupation, country, salary, department
+```
+
+Subquery example:
+```
+source = outer | where a in [ source = inner | fields b ]
+```
+
+### Migration Notes
+
+- V3 engine is experimental in 3.0.0-beta and disabled by default
+- Unsupported queries automatically fall back to V2 engine
+- Check OpenSearch logs for "Fallback to V2 query engine since..." messages
+- Review breaking changes table before upgrading production workloads
+
+## Limitations
+
+The following functionalities fall back to V2 engine:
+- All SQL queries (PPL only in V3)
+- `trendline`, `top`, `rare`, `fillnull`, `patterns`
+- `describe`, `explain`, `show datasource`
+- `dedup` with `consecutive=true`
+- Search-relevant commands (AD, ML, Kmeans)
+- Commands with `fetch_size` parameter
+- Queries with metadata fields (`_id`, `_doc`, etc.)
+- JSON functions (`cast to json`, `json`, `json_valid`)
+- Search functions (`match`, `match_phrase`, `query_string`, etc.)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3488](https://github.com/opensearch-project/sql/pull/3488) | Documentation for PPL new engine (V3) and limitations of 3.0.0 Beta |
+
+## References
+
+- [Issue #3431](https://github.com/opensearch-project/sql/issues/3431): Documentation request for PPL V3 engine
+- [SQL and PPL Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/index/): Official documentation
+- [PPL V3 Engine Limitations](https://docs.opensearch.org/3.0/search-plugins/sql/limitation/): V3 limitations documentation
+- [Enhanced Log Analysis Blog](https://opensearch.org/blog/enhanced-log-analysis-with-opensearch-ppl-introducing-lookup-join-and-subsearch/): Blog post on new PPL commands
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/sql/sql-ppl-breaking-changes.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -54,6 +54,7 @@
 ## sql
 
 - [SQL/PPL v3.0.0 Breaking Changes](features/sql/sql-ppl-v3-breaking-changes.md)
+- [SQL/PPL Documentation](features/sql/sql-ppl-documentation.md)
 
 ## asynchronous-search
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the SQL/PPL V3 engine documentation release item (Issue #191).

## Changes

### Release Report
- Created `docs/releases/v3.0.0/features/sql/sql-ppl-documentation.md`
- Documents the PPL V3 engine architecture with Apache Calcite integration
- Covers new PPL commands: join, lookup, subquery
- Lists breaking changes from V2 to V3
- Documents limitations and fallback mechanism

### Feature Report Update
- Updated `docs/features/sql/sql-ppl-breaking-changes.md`
- Added PR #3488 to related PRs
- Added new references for V3 documentation
- Updated change history

### Release Index
- Added link to new release report in `docs/releases/v3.0.0/index.md`

## Related Issue
Closes #191