### PR TITLE
docs: add ML Commons Blueprints & Tutorials report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -69,3 +69,7 @@
 ## opensearch-remote-metadata-sdk
 
 - [Remote Metadata SDK](opensearch-remote-metadata-sdk/remote-metadata-sdk.md)
+
+## ml-commons
+
+- [ML Commons Connector Blueprints](ml-commons/ml-commons-blueprints.md)

--- a/docs/features/ml-commons/ml-commons-blueprints.md
+++ b/docs/features/ml-commons/ml-commons-blueprints.md
@@ -1,0 +1,158 @@
+# ML Commons Connector Blueprints
+
+## Summary
+
+ML Commons connector blueprints provide pre-configured templates for connecting OpenSearch to external machine learning models and services. Blueprints define the parameters, credentials, and actions needed to integrate with various ML platforms including Amazon Bedrock, OpenAI, Cohere, Azure OpenAI, and Amazon SageMaker.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph OpenSearch
+        ML[ML Commons Plugin]
+        Connector[Connector]
+        Blueprint[Blueprint Template]
+    end
+    
+    subgraph "External ML Services"
+        Bedrock[Amazon Bedrock]
+        OpenAI[OpenAI API]
+        Cohere[Cohere API]
+        Azure[Azure OpenAI]
+        SageMaker[Amazon SageMaker]
+    end
+    
+    Blueprint --> Connector
+    Connector --> ML
+    ML --> Bedrock
+    ML --> OpenAI
+    ML --> Cohere
+    ML --> Azure
+    ML --> SageMaker
+```
+
+### Blueprint Types
+
+OpenSearch provides two types of connector blueprints:
+
+| Type | Description | Recommended For |
+|------|-------------|-----------------|
+| **Standard Blueprints** | Pass input directly to model without pre/post processing | OpenSearch 2.14+ |
+| **Legacy Blueprints** | Include pre/post processing functions for custom transformations | Existing implementations |
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `name` | Connector name identifier |
+| `description` | Human-readable description |
+| `version` | Blueprint version number |
+| `protocol` | Connection protocol (`aws_sigv4` for AWS, `http` for others) |
+| `credential` | Authentication credentials (encrypted with AES/GCM/NoPadding) |
+| `parameters` | Default connector parameters (endpoint, model, region) |
+| `actions` | Defines predict actions with URL, method, headers, request body |
+| `client_config` | Optional connection and retry settings |
+
+### Supported Connectors
+
+#### Amazon Bedrock
+- Titan Embedding (v1, v2)
+- Titan Multimodal Embedding
+- Cohere Embed English/Multilingual v3
+- Claude 3.5, 3.7 (standard and extended thinking modes)
+
+#### OpenAI
+- text-embedding-ada-002
+- GPT-4o (chat completions)
+
+#### Cohere
+- embed-english-v3.0/v2.0
+- embed-multimodal-v3.0/v2.0
+
+#### Azure OpenAI
+- text-embedding-ada-002
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `max_connection` | Maximum concurrent connections | Unlimited |
+| `retry_backoff_millis` | Base backoff time for retries | 200 |
+| `retry_timeout_seconds` | Timeout for retry attempts | 30 |
+
+### Usage Example
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "Amazon Bedrock Connector: embedding",
+  "description": "Connector to Bedrock Titan embedding model",
+  "version": 1,
+  "protocol": "aws_sigv4",
+  "parameters": {
+    "region": "us-east-1",
+    "service_name": "bedrock",
+    "model": "amazon.titan-embed-text-v1"
+  },
+  "credential": {
+    "access_key": "<ACCESS_KEY>",
+    "secret_key": "<SECRET_KEY>"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/invoke",
+      "headers": {
+        "content-type": "application/json",
+        "x-amz-content-sha256": "required"
+      },
+      "request_body": "{ \"inputText\": \"${parameters.inputText}\" }"
+    }
+  ]
+}
+```
+
+### Built-in Processing Functions
+
+| Function | Purpose |
+|----------|---------|
+| `connector.pre_process.openai.embedding` | Preprocess for OpenAI embedding models |
+| `connector.post_process.openai.embedding` | Post-process OpenAI embedding responses |
+| `connector.pre_process.cohere.embedding` | Preprocess for Cohere embedding models |
+| `connector.post_process.cohere.embedding` | Post-process Cohere embedding responses |
+| `connector.pre_process.default.embedding` | Default preprocessing for neural search |
+| `connector.post_process.default.embedding` | Default post-processing for neural search |
+
+## Limitations
+
+- Credentials are encrypted but stored in OpenSearch system index
+- Standard blueprints require ML inference processor for input/output mapping
+- Some models require specific inference profile IDs (e.g., Claude 3.7)
+- Maximum connection limits may need tuning for high-throughput scenarios
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#3659](https://github.com/opensearch-project/ml-commons/pull/3659) | Add standard blueprint for vector search |
+| v3.0.0 | [#3584](https://github.com/opensearch-project/ml-commons/pull/3584) | Add blueprint for Claude 3.7 on Bedrock |
+| v3.0.0 | [#3725](https://github.com/opensearch-project/ml-commons/pull/3725) | Add standard blueprint for Azure embedding ada2 |
+| v3.0.0 | [#3612](https://github.com/opensearch-project/ml-commons/pull/3612) | Fix template query link |
+| v3.0.0 | [#2975](https://github.com/opensearch-project/ml-commons/pull/2975) | Add tutorial for RAG of OpenAI and Bedrock |
+
+## References
+
+- [Connector Blueprints Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/blueprints/)
+- [Supported Connectors](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/supported-connectors/)
+- [Connectors Overview](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/connectors/)
+- [ML Commons Cluster Settings](https://docs.opensearch.org/3.0/ml-commons-plugin/cluster-settings/)
+- [Issue #3619](https://github.com/opensearch-project/ml-commons/issues/3619): Standard blueprints feature request
+
+## Change History
+
+- **v3.0.0** (2025-03): Added standard blueprints for vector search, Claude 3.7 blueprint, Azure OpenAI blueprint, RAG tutorials
+- **v2.14.0**: Introduced ML inference processor support for standard blueprints
+- **v2.9.0**: Initial connector blueprints feature

--- a/docs/releases/v3.0.0/features/ml-commons/ml-commons-blueprints-tutorials.md
+++ b/docs/releases/v3.0.0/features/ml-commons/ml-commons-blueprints-tutorials.md
@@ -1,0 +1,124 @@
+# ML Commons Blueprints & Tutorials
+
+## Summary
+
+This release item adds new connector blueprints and tutorials to ML Commons for v3.0.0. The changes include standard blueprints for vector search (without pre/post processing functions), a blueprint for Claude 3.7 on Bedrock, Azure OpenAI embedding blueprint, and RAG tutorials for OpenAI and Bedrock.
+
+## Details
+
+### What's New in v3.0.0
+
+This release introduces several documentation and blueprint improvements:
+
+1. **Standard Blueprints for Vector Search** - New simplified blueprints that work with ML inference processor for input/output mapping (recommended for OpenSearch 2.14+)
+2. **Claude 3.7 Blueprint** - Support for Anthropic's first hybrid reasoning model on Amazon Bedrock
+3. **Azure OpenAI Embedding Blueprint** - Standard blueprint for text-embedding-ada-002 on Azure
+4. **RAG Tutorials** - Comprehensive tutorials for conversational search with OpenAI and Bedrock Claude
+
+### Technical Changes
+
+#### New Standard Blueprints
+
+Standard blueprints are designed for connectors that pass input directly to the model without requiring pre/post processing functions. These are recommended for OpenSearch 2.14+.
+
+| Blueprint | Provider | Model |
+|-----------|----------|-------|
+| Bedrock Titan Embedding | AWS | amazon.titan-embed-text-v1/v2 |
+| Bedrock Titan Multimodal | AWS | amazon.titan-embed-image-v1 |
+| Bedrock Cohere English | AWS | cohere.embed-english-v3 |
+| Bedrock Cohere Multilingual | AWS | cohere.embed-multilingual-v3 |
+| Cohere Text Embedding | Cohere | embed-english-v3.0/v2.0 |
+| Cohere Image Embedding | Cohere | embed-multimodal-v3.0/v2.0 |
+| OpenAI Embedding | OpenAI | text-embedding-ada-002 |
+| Azure OpenAI Embedding | Azure | text-embedding-ada-002 |
+
+#### Claude 3.7 Blueprint Features
+
+Claude 3.7 Sonnet supports two modes:
+- **Standard mode**: Regular inference with configurable temperature and max tokens
+- **Extended thinking mode**: Enables deeper reasoning with `budget_tokens` parameter
+
+```json
+// Extended thinking mode connector
+{
+  "parameters": {
+    "model": "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+    "budget_tokens": 1024
+  },
+  "request_body": "{ \"thinking\": {\"type\": \"enabled\", \"budget_tokens\": ${parameters.budget_tokens} } }"
+}
+```
+
+#### RAG Tutorial Highlights
+
+The new tutorials demonstrate:
+- Conversational search with memory persistence
+- Search pipeline configuration with RAG processor
+- Both Bedrock Converse API and Invoke API approaches
+- OpenAI GPT-4o integration for conversational search
+
+### Usage Example
+
+Creating a standard blueprint connector (no pre/post processing):
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "Cohere Embed Model",
+  "description": "Standard connector for Cohere embedding",
+  "version": "1",
+  "protocol": "http",
+  "credential": {
+    "cohere_key": "<API_KEY>"
+  },
+  "parameters": {
+    "model": "embed-english-v3.0",
+    "input_type": "search_document",
+    "truncate": "END"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://api.cohere.ai/v1/embed",
+      "headers": {
+        "Authorization": "Bearer ${credential.cohere_key}"
+      },
+      "request_body": "{ \"texts\": ${parameters.texts}, \"model\": \"${parameters.model}\" }"
+    }
+  ]
+}
+```
+
+### Migration Notes
+
+- Standard blueprints are recommended for new implementations on OpenSearch 2.14+
+- Legacy blueprints with pre/post processing functions remain available for existing implementations
+- Claude 3.7 requires inference profile ID (e.g., `us.anthropic.claude-3-7-sonnet-20250219-v1:0`)
+
+## Limitations
+
+- Claude 3.7 extended thinking mode requires additional token budget configuration
+- Standard blueprints require ML inference processor for input/output mapping
+- Azure OpenAI requires proper endpoint and deployment name configuration
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3659](https://github.com/opensearch-project/ml-commons/pull/3659) | Add standard blueprint for vector search |
+| [#3584](https://github.com/opensearch-project/ml-commons/pull/3584) | Add blueprint for Claude 3.7 on Bedrock |
+| [#3725](https://github.com/opensearch-project/ml-commons/pull/3725) | Add standard blueprint for Azure embedding ada2 |
+| [#3612](https://github.com/opensearch-project/ml-commons/pull/3612) | Fix template query link |
+| [#2975](https://github.com/opensearch-project/ml-commons/pull/2975) | Add tutorial for RAG of OpenAI and Bedrock |
+
+## References
+
+- [Issue #3619](https://github.com/opensearch-project/ml-commons/issues/3619): Standard blueprints feature request
+- [Connector Blueprints Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/blueprints/)
+- [Supported Connectors](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/supported-connectors/)
+- [AWS Blog: Claude 3.7 on Bedrock](https://aws.amazon.com/blogs/aws/anthropics-claude-3-7-sonnet-the-first-hybrid-reasoning-model-is-now-available-in-amazon-bedrock/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/ml-commons/ml-commons-blueprints.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -71,3 +71,7 @@
 ## opensearch-remote-metadata-sdk
 
 - [Remote Metadata Store Documentation](features/opensearch-remote-metadata-sdk/remote-metadata-store-documentation.md)
+
+## ml-commons
+
+- [ML Commons Blueprints & Tutorials](features/ml-commons/ml-commons-blueprints-tutorials.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for ML Commons Blueprints & Tutorials for OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/ml-commons/ml-commons-blueprints-tutorials.md`
- Feature report: `docs/features/ml-commons/ml-commons-blueprints.md`

### Key Changes in v3.0.0
- Standard blueprints for vector search (without pre/post processing functions)
- Blueprint for Claude 3.7 on Amazon Bedrock (standard and extended thinking modes)
- Azure OpenAI embedding blueprint for text-embedding-ada-002
- RAG tutorials for conversational search with OpenAI and Bedrock Claude
- Documentation link fix for template query

### Related PRs
- [#3659](https://github.com/opensearch-project/ml-commons/pull/3659): Add standard blueprint for vector search
- [#3584](https://github.com/opensearch-project/ml-commons/pull/3584): Add blueprint for Claude 3.7 on Bedrock
- [#3725](https://github.com/opensearch-project/ml-commons/pull/3725): Add standard blueprint for Azure embedding ada2
- [#3612](https://github.com/opensearch-project/ml-commons/pull/3612): Fix template query link
- [#2975](https://github.com/opensearch-project/ml-commons/pull/2975): Add tutorial for RAG of OpenAI and Bedrock

Closes #190