### PR TITLE
docs: add flow-framework-templates report for v3.0.0

### DIFF
--- a/docs/features/flow-framework/text-to-visualization-templates.md
+++ b/docs/features/flow-framework/text-to-visualization-templates.md
@@ -1,0 +1,164 @@
+# Text-to-Visualization Templates
+
+## Summary
+
+Text-to-Visualization Templates are Flow Framework workflow templates that automate the setup of AI agents for generating visualizations from natural language in OpenSearch Dashboards. These templates configure the necessary connectors, models, tools, and agents to enable the Dashboards Assistant's text-to-visualization feature.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph "User Interface"
+        UI[OpenSearch Dashboards Assistant]
+    end
+    
+    subgraph "Flow Framework"
+        T[Workflow Template]
+        T --> C[Claude Connector]
+        T --> M[Claude Model]
+        T --> TL[Text2Vega Tools]
+        T --> AG[Flow Agents]
+    end
+    
+    subgraph "ML Commons"
+        C --> M
+        M --> TL
+        TL --> AG
+    end
+    
+    subgraph "External"
+        BR[AWS Bedrock - Claude Haiku]
+    end
+    
+    UI --> AG
+    AG --> TL
+    TL --> M
+    M --> C
+    C --> BR
+```
+
+### Data Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Dashboard as Dashboards Assistant
+    participant Agent as t2vega Agent
+    participant Tool as Text2Vega Tool
+    participant Model as Claude Model
+    participant Bedrock as AWS Bedrock
+    
+    User->>Dashboard: Natural language query
+    Dashboard->>Agent: Execute with parameters
+    Agent->>Tool: Process with prompt template
+    Tool->>Model: Generate Vega-Lite spec
+    Model->>Bedrock: API call
+    Bedrock-->>Model: Response
+    Model-->>Tool: Vega-Lite JSON
+    Tool-->>Agent: Result
+    Agent-->>Dashboard: Visualization spec
+    Dashboard-->>User: Rendered visualization
+```
+
+### Components
+
+| Component | Type | Description |
+|-----------|------|-------------|
+| Claude Connector | `create_connector` | AWS Bedrock connector for Claude Haiku model with SigV4 authentication |
+| Claude Model | `register_remote_model` | Deployed remote model using the connector |
+| Text2Vega Tool | `create_tool` (MLModelTool) | Rule-based tool with detailed Vega-Lite generation prompts |
+| Instruction-Based Text2Vega Tool | `create_tool` (MLModelTool) | Example-based tool supporting user styling instructions |
+| t2vega Agent | `register_agent` (flow) | Flow agent for rule-based visualization generation |
+| t2vega Instruction-Based Agent | `register_agent` (flow) | Flow agent supporting custom visualization instructions |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `create_connector.credential.access_key` | AWS access key | Required |
+| `create_connector.credential.secret_key` | AWS secret key | Required |
+| `create_connector.credential.session_token` | AWS session token | Required |
+| `create_connector.parameters.endpoint` | Bedrock endpoint | bedrock-runtime.us-east-1.amazonaws.com |
+| `create_connector.parameters.region` | AWS region | us-east-1 |
+| `create_connector.parameters.max_tokens_to_sample` | Max response tokens | 8000 |
+| `create_connector.parameters.temperature` | Model temperature | 0.0000 |
+
+### Tool Prompt Types
+
+The templates include two types of prompts for Vega-Lite generation:
+
+#### Rule-Based Prompt (t2vega)
+Uses entrance codes based on metric/dimension/date counts to select visualization types:
+- Type 1: `<1, 1, 0>` → Bar chart
+- Type 2: `<1, 2, 0>` → Grouped bar chart
+- Type 3: `<3, 1, 0>` → Bubble chart
+- Type 4: `<2, 1, 0>` → Scatter plot
+- Type 5-9: Various temporal and layered charts
+- Type 10: Table fallback
+
+#### Instruction-Based Prompt (t2vega_instruction_based)
+Uses example-based learning with common visualization patterns:
+- Bar charts, histograms, pie charts
+- Scatter plots, line charts, heatmaps
+- Layered and faceted visualizations
+
+### Usage Example
+
+```yaml
+# Enable text-to-visualization in opensearch_dashboards.yml
+assistant.text2viz.enabled: true
+```
+
+```bash
+# Create and provision the workflow
+POST /_plugins/_flow_framework/workflow?provision=true
+{
+  "name": "Text to visualization agents",
+  "description": "This template is to create all Agents required for text to visualization",
+  "use_case": "REGISTER_AGENTS",
+  "version": {
+    "template": "1.0.0",
+    "compatibility": ["2.18.0", "3.0.0"]
+  },
+  "workflows": {
+    "provision": {
+      "nodes": [...]
+    }
+  }
+}
+
+# Configure root agent
+POST /.plugins-ml-config/_doc/os_text2vega
+{
+  "type": "os_chat_root_agent",
+  "configuration": {
+    "agent_id": "<AGENT_ID>"
+  }
+}
+```
+
+## Limitations
+
+- Only supports Claude Haiku model via AWS Bedrock
+- Requires valid AWS credentials with Bedrock access
+- Text-to-visualization feature is experimental
+- Generated Vega-Lite specs may require manual refinement for complex visualizations
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#936](https://github.com/opensearch-project/flow-framework/pull/936) | Add text to visualization agent template |
+
+## References
+
+- [Text to visualization documentation](https://docs.opensearch.org/3.0/dashboards/dashboards-assistant/text-to-visualization/)
+- [Workflow templates documentation](https://docs.opensearch.org/3.0/automating-configurations/workflow-templates/)
+- [Flow agents documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/agents/flow/)
+- [OpenSearch Assistant Toolkit](https://docs.opensearch.org/3.0/ml-commons-plugin/opensearch-assistant/)
+
+## Change History
+
+- **v3.0.0** (2024-11-19): Added text-to-visualization sample templates for Claude Haiku model

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -50,6 +50,10 @@
 
 - [Backward Compatibility](dashboards-flow-framework/backward-compatibility.md)
 
+## flow-framework
+
+- [Text-to-Visualization Templates](flow-framework/text-to-visualization-templates.md)
+
 ## sql
 
 - [SQL/PPL Breaking Changes](sql/sql-ppl-breaking-changes.md)

--- a/docs/releases/v3.0.0/features/flow-framework/flow-framework-templates.md
+++ b/docs/releases/v3.0.0/features/flow-framework/flow-framework-templates.md
@@ -1,0 +1,120 @@
+# Flow Framework Templates
+
+## Summary
+
+This bugfix adds sample templates for the text-to-visualization feature in Flow Framework. The templates enable the OpenSearch Dashboards Assistant to create visualizations from natural language instructions by configuring the necessary agents and tools.
+
+## Details
+
+### What's New in v3.0.0
+
+PR #936 adds two new sample template files to the Flow Framework plugin:
+- `text-to-visualization-claude.json`
+- `text-to-visualization-claude.yml`
+
+These templates automate the setup of all components required for the text-to-visualization feature in OpenSearch Dashboards.
+
+### Technical Changes
+
+#### Workflow Architecture
+
+```mermaid
+flowchart TB
+    subgraph "Text-to-Visualization Workflow"
+        A[Create Claude Connector] --> B[Register Claude Model]
+        B --> C[Create Text2Vega Tool]
+        B --> D[Create Instruction-Based Text2Vega Tool]
+        C --> E[Register t2vega Agent]
+        D --> F[Register t2vega Instruction-Based Agent]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `create_claude_connector` | Creates AWS Bedrock connector for Claude Haiku model |
+| `register_claude_model` | Registers and deploys the Claude model |
+| `create_t2vega_tool` | Creates MLModelTool with rule-based Vega-Lite generation prompts |
+| `create_instruction_based_t2vega_tool` | Creates MLModelTool with example-based prompts for user instructions |
+| `t2vega_agent` | Flow agent for rule-based visualization generation |
+| `t2vega_instruction_based_agent` | Flow agent supporting user styling instructions |
+
+#### Template Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `name` | Template name | Text to visualization agents |
+| `use_case` | Template use case | REGISTER_AGENTS |
+| `version.template` | Template version | 1.0.0 |
+| `version.compatibility` | Compatible OpenSearch versions | 2.18.0, 3.0.0 |
+
+#### Connector Configuration
+
+The templates configure an AWS Bedrock connector for Claude Haiku:
+
+| Parameter | Value |
+|-----------|-------|
+| `endpoint` | bedrock-runtime.us-east-1.amazonaws.com |
+| `model` | anthropic.claude-3-haiku-20240307-v1:0 |
+| `protocol` | aws_sigv4 |
+| `max_tokens_to_sample` | 8000 |
+| `temperature` | 0.0000 |
+
+### Usage Example
+
+To use these templates, provision the workflow via the Flow Framework API:
+
+```bash
+# Create workflow from template
+POST /_plugins/_flow_framework/workflow
+{
+  "name": "Text to visualization agents",
+  "description": "This template is to create all Agents required for text to visualization",
+  "use_case": "REGISTER_AGENTS",
+  ...
+}
+
+# Provision the workflow
+POST /_plugins/_flow_framework/workflow/<workflow_id>/_provision
+```
+
+After provisioning, configure the root agent in the ML config index:
+
+```bash
+POST /.plugins-ml-config/_doc/os_text2vega
+{
+  "type": "os_chat_root_agent",
+  "configuration": {
+    "agent_id": "<ROOT_AGENT_ID>"
+  }
+}
+```
+
+### Migration Notes
+
+- Requires AWS credentials with access to Amazon Bedrock
+- The `assistant.text2viz.enabled: true` setting must be enabled in `opensearch_dashboards.yml`
+- Templates are compatible with both OpenSearch 2.18.0 and 3.0.0
+
+## Limitations
+
+- Currently only supports Claude Haiku model via AWS Bedrock
+- Requires valid AWS credentials (access_key, secret_key, session_token)
+- The text-to-visualization feature is experimental
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#936](https://github.com/opensearch-project/flow-framework/pull/936) | Add text to visualization agent template |
+
+## References
+
+- [Text to visualization documentation](https://docs.opensearch.org/3.0/dashboards/dashboards-assistant/text-to-visualization/)
+- [Workflow templates documentation](https://docs.opensearch.org/3.0/automating-configurations/workflow-templates/)
+- [Flow agents documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/agents/flow/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/flow-framework/text-to-visualization-templates.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -51,6 +51,10 @@
 
 - [Dashboards BWC](features/dashboards-flow-framework/dashboards-bwc.md)
 
+## flow-framework
+
+- [Flow Framework Templates](features/flow-framework/flow-framework-templates.md)
+
 ## sql
 
 - [SQL/PPL v3.0.0 Breaking Changes](features/sql/sql-ppl-v3-breaking-changes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Flow Framework Templates bugfix in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/flow-framework/flow-framework-templates.md`
- Feature report: `docs/features/flow-framework/text-to-visualization-templates.md`

### Key Changes in v3.0.0
- Added sample templates for text-to-visualization feature
- Templates configure Claude Haiku model via AWS Bedrock
- Creates t2vega agents for rule-based and instruction-based visualization generation
- Compatible with OpenSearch 2.18.0 and 3.0.0

### Related Issue
Closes #189

### Resources Used
- PR: [#936](https://github.com/opensearch-project/flow-framework/pull/936)
- Docs: [Text to visualization](https://docs.opensearch.org/3.0/dashboards/dashboards-assistant/text-to-visualization/)
- Docs: [Workflow templates](https://docs.opensearch.org/3.0/automating-configurations/workflow-templates/)