### PR TITLE
docs: add dual cluster gradle run report for v3.0.0

### DIFF
--- a/docs/features/anomaly-detection/dual-cluster-development.md
+++ b/docs/features/anomaly-detection/dual-cluster-development.md
@@ -1,0 +1,156 @@
+# Dual Cluster Development Environment
+
+## Summary
+
+The Anomaly Detection plugin provides a dual cluster development environment that allows developers to run two independent OpenSearch clusters locally with a single Gradle command. This feature simplifies testing of cross-cluster functionality such as cross-cluster replication, remote cluster queries, and multi-cluster anomaly detection scenarios.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Development Environment"
+        DEV[Developer Machine]
+        
+        subgraph "Gradle Build System"
+            GR[./gradlew :run -PdualCluster=true]
+        end
+        
+        subgraph "Leader Cluster"
+            LC[OpenSearch Node]
+            LC_AD[Anomaly Detection Plugin]
+            LC_JS[Job Scheduler Plugin]
+            LC --> LC_AD
+            LC --> LC_JS
+        end
+        
+        subgraph "Follower Cluster"
+            FC[OpenSearch Node]
+            FC_AD[Anomaly Detection Plugin]
+            FC_JS[Job Scheduler Plugin]
+            FC --> FC_AD
+            FC --> FC_JS
+        end
+        
+        DEV --> GR
+        GR --> LC
+        GR --> FC
+    end
+    
+    LC -.->|Cross-cluster| FC
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Input
+        CMD[Gradle Command]
+        PROP[-PdualCluster=true]
+    end
+    
+    subgraph Processing
+        BUILD[Build Plugin]
+        CONFIG[Configure Clusters]
+        START[Start Clusters]
+    end
+    
+    subgraph Output
+        LEADER[Leader: 9200/9300]
+        FOLLOW[Follower: 9201/9301]
+        PROPS[System Properties]
+    end
+    
+    CMD --> BUILD
+    PROP --> CONFIG
+    BUILD --> CONFIG
+    CONFIG --> START
+    START --> LEADER
+    START --> FOLLOW
+    START --> PROPS
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `leaderCluster` | Primary test cluster with `cluster_role=leader` attribute |
+| `followCluster` | Secondary test cluster with `cluster_role=follower` attribute |
+| `configureClusterPlugins()` | Shared function for plugin installation and security configuration |
+| `integTest` | Default single cluster for standard testing |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `-PdualCluster` | Enable dual cluster mode | `false` |
+| `discovery.type` | Cluster discovery mode | `single-node` |
+| `path.repo` | Snapshot repository path | `${buildDir}/{clusterName}/repo` |
+| `node.attr.cluster_role` | Custom attribute for cluster identification | `leader` or `follower` |
+
+### Network Configuration
+
+| Cluster | HTTP Port | Transport Port |
+|---------|-----------|----------------|
+| Leader | 9200 | 9300 |
+| Follower | 9201 | 9301 |
+
+### Usage Example
+
+```bash
+# Standard single cluster mode
+./gradlew :run
+
+# Dual cluster mode for cross-cluster testing
+./gradlew :run -PdualCluster=true
+```
+
+When running in dual cluster mode, the console output displays:
+
+```
+Leader cluster running at HTTP: localhost:9200, Transport: localhost:9300
+Follower cluster running at HTTP: localhost:9201, Transport: localhost:9301
+```
+
+### System Properties for Tests
+
+When dual cluster mode is enabled, the following system properties are set for integration tests:
+
+```groovy
+systemProperty "tests.leader.cluster.name", "leader"
+systemProperty "tests.follow.cluster.name", "follower"
+systemProperty "tests.cluster.leader.http_hosts", "localhost:9200"
+systemProperty "tests.cluster.follow.http_hosts", "localhost:9201"
+systemProperty "tests.cluster.leader.transport_hosts", "localhost:9300"
+systemProperty "tests.cluster.follow.transport_hosts", "localhost:9301"
+```
+
+### Security Configuration
+
+When security is enabled (`-Dsecurity=true`), both clusters are configured with:
+- SSL/TLS certificates (kirk.pem, esnode.pem, root-ca.pem)
+- Demo certificates for development
+- Security plugin settings for HTTPS and transport layer encryption
+
+## Limitations
+
+- Both clusters run on localhost only (not suitable for distributed testing)
+- Clusters share the same security configuration when enabled
+- Single node per cluster (no multi-node cluster simulation)
+- Requires sufficient system resources to run two JVM instances
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#1441](https://github.com/opensearch-project/anomaly-detection/pull/1441) | Initial implementation of dual cluster gradle run |
+
+## References
+
+- [DEVELOPER_GUIDE.md](https://github.com/opensearch-project/anomaly-detection/blob/main/DEVELOPER_GUIDE.md): Official developer documentation
+- [build.gradle](https://github.com/opensearch-project/anomaly-detection/blob/main/build.gradle): Gradle build configuration
+
+## Change History
+
+- **v3.0.0** (2025-03-19): Initial implementation - Added `-PdualCluster` property to launch leader and follower clusters for cross-cluster testing

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -77,3 +77,7 @@
 ## ml-commons
 
 - [ML Commons Connector Blueprints](ml-commons/ml-commons-blueprints.md)
+
+## anomaly-detection
+
+- [Dual Cluster Development Environment](anomaly-detection/dual-cluster-development.md)

--- a/docs/releases/v3.0.0/features/anomaly-detection/dual-cluster-gradle-run.md
+++ b/docs/releases/v3.0.0/features/anomaly-detection/dual-cluster-gradle-run.md
@@ -1,0 +1,100 @@
+# Dual Cluster Gradle Run
+
+## Summary
+
+This release adds the ability to run the Anomaly Detection plugin locally with two separate OpenSearch clusters using a single Gradle command. This enhancement enables developers to easily test cross-cluster features such as cross-cluster replication and remote cluster configurations without manual cluster setup.
+
+## Details
+
+### What's New in v3.0.0
+
+PR #1441 introduces a new Gradle property `-PdualCluster=true` that launches two independent single-node clusters:
+- **Leader cluster**: HTTP port 9200, Transport port 9300
+- **Follower cluster**: HTTP port 9201, Transport port 9301
+
+Both clusters are automatically configured with the Anomaly Detection and Job Scheduler plugins installed.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Single Cluster Mode (default)"
+        G1[./gradlew :run] --> IC[integTest Cluster]
+        IC --> P1[Port 9200/9300]
+    end
+    
+    subgraph "Dual Cluster Mode (-PdualCluster=true)"
+        G2[./gradlew :run -PdualCluster=true] --> LC[Leader Cluster]
+        G2 --> FC[Follower Cluster]
+        LC --> P2[Port 9200/9300]
+        FC --> P3[Port 9201/9301]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `leaderCluster` | Test cluster configured with `node.attr.cluster_role=leader` |
+| `followCluster` | Test cluster configured with `node.attr.cluster_role=follower` |
+| `configureClusterPlugins()` | Refactored helper function for plugin configuration |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `-PdualCluster` | Gradle property to enable dual cluster mode | `false` |
+| `node.attr.cluster_role` | Custom node attribute identifying cluster role | N/A |
+| `path.repo` | Repository path for each cluster | `${buildDir}/{clusterName}/repo` |
+
+#### System Properties (Dual Cluster Mode)
+
+| Property | Description |
+|----------|-------------|
+| `tests.leader.cluster.name` | Name of the leader cluster |
+| `tests.follow.cluster.name` | Name of the follower cluster |
+| `tests.cluster.leader.http_hosts` | HTTP endpoints for leader cluster |
+| `tests.cluster.follow.http_hosts` | HTTP endpoints for follower cluster |
+| `tests.cluster.leader.transport_hosts` | Transport endpoints for leader cluster |
+| `tests.cluster.follow.transport_hosts` | Transport endpoints for follower cluster |
+
+### Usage Example
+
+```bash
+# Launch dual clusters for cross-cluster testing
+./gradlew :run -PdualCluster=true
+
+# Output shows both clusters:
+# Leader cluster running at HTTP: localhost:9200, Transport: localhost:9300
+# Follower cluster running at HTTP: localhost:9201, Transport: localhost:9301
+```
+
+### Additional Changes
+
+- Added `dependabot/**` branch to changelog verifier ignore list
+- Removed deprecated `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` environment variable from labeler workflow
+- Code refactoring to extract common plugin configuration into `configureClusterPlugins()` function
+
+## Limitations
+
+- Both clusters run on localhost only
+- Security plugin configuration is shared between clusters when enabled
+- Backport to 2.x branch failed due to merge conflicts (requires manual backport)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1441](https://github.com/opensearch-project/anomaly-detection/pull/1441) | Adding dual cluster arg to gradle run |
+| [#1442](https://github.com/opensearch-project/anomaly-detection/pull/1442) | Backport to 2.x (includes #1441) |
+
+## References
+
+- [PR #1441](https://github.com/opensearch-project/anomaly-detection/pull/1441): Main implementation
+- [DEVELOPER_GUIDE.md](https://github.com/opensearch-project/anomaly-detection/blob/main/DEVELOPER_GUIDE.md): Updated developer documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/anomaly-detection/dual-cluster-development.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -79,3 +79,7 @@
 ## ml-commons
 
 - [ML Commons Blueprints & Tutorials](features/ml-commons/ml-commons-blueprints-tutorials.md)
+
+## anomaly-detection
+
+- [Dual Cluster Gradle Run](features/anomaly-detection/dual-cluster-gradle-run.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Anomaly Detection dual cluster gradle run feature introduced in v3.0.0.

## Changes

- Added release report: `docs/releases/v3.0.0/features/anomaly-detection/dual-cluster-gradle-run.md`
- Added feature report: `docs/features/anomaly-detection/dual-cluster-development.md`
- Updated release index and features index

## Investigation Notes

- The original Issue #188 referenced PR #998, but the actual PR is **#1441** "Adding dual cluster arg to gradle run"
- PR #1441 was merged on 2025-03-19 by @amitgalitz
- The feature adds `-PdualCluster=true` gradle property to launch two clusters (leader on 9200/9300, follower on 9201/9301)

Closes #188