### PR TITLE
docs: add neural-search-compatibility report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -2,6 +2,7 @@
 
 ## neural-search
 
+- [Neural Search Compatibility](neural-search/neural-search-compatibility.md)
 - [Semantic Field](neural-search/semantic-field.md)
 
 ## opensearch

--- a/docs/features/neural-search/neural-search-compatibility.md
+++ b/docs/features/neural-search/neural-search-compatibility.md
@@ -1,0 +1,131 @@
+# Neural Search Compatibility
+
+## Summary
+
+Neural Search Compatibility refers to the ongoing maintenance work required to keep the neural-search plugin compatible with OpenSearch core releases. This includes adapting to Lucene API changes, OpenSearch core API updates, and maintaining backward compatibility with previous versions.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Neural Search Plugin"
+        NS[Neural Search]
+        HQ[HybridQuery]
+        HQS[HybridQueryScorer]
+        NKQ[NeuralKNNQuery]
+        NSQ[NeuralSparseQuery]
+    end
+    
+    subgraph "OpenSearch Core"
+        OS[OpenSearch Core]
+        LC[Lucene]
+        Client[Transport Client]
+    end
+    
+    subgraph "ML Commons"
+        ML[ML Commons Plugin]
+        Models[ML Models]
+    end
+    
+    NS --> OS
+    NS --> LC
+    NS --> ML
+    HQ --> LC
+    HQS --> LC
+    NKQ --> LC
+    NSQ --> Client
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| HybridQuery | Combines multiple sub-queries for hybrid search |
+| HybridQueryScorer | Scores documents across multiple sub-queries |
+| NeuralKNNQuery | Wrapper for k-NN queries with neural capabilities |
+| NeuralSparseQueryBuilder | Builds sparse vector queries using ML models |
+| ScoreCombiner | Combines scores from multiple sub-queries |
+| NormalizationProcessor | Normalizes scores across different query types |
+
+### Compatibility Matrix
+
+| Neural Search Version | OpenSearch Version | Lucene Version | JDK Version |
+|----------------------|-------------------|----------------|-------------|
+| 3.0.0 | 3.0.0 | 10.x | 21+ |
+| 2.19.x | 2.19.x | 9.x | 11+ |
+| 2.18.x | 2.18.x | 9.x | 11+ |
+
+### Key API Changes in v3.0.0
+
+#### Lucene 10 Changes
+
+```java
+// Before (Lucene 9)
+long totalHits = topDocs.totalHits.value;
+TotalHits.Relation relation = topDocs.totalHits.relation;
+Query query = booleanClause.getQuery();
+
+// After (Lucene 10)
+long totalHits = topDocs.totalHits.value();
+TotalHits.Relation relation = topDocs.totalHits.relation();
+Query query = booleanClause.query();
+```
+
+#### OpenSearch Core Changes
+
+```java
+// Before
+import org.opensearch.client.Client;
+
+// After
+import org.opensearch.transport.client.Client;
+```
+
+### BWC Testing Strategy
+
+```mermaid
+flowchart LR
+    subgraph "Restart Upgrade"
+        R1[Old Cluster] --> R2[Stop All]
+        R2 --> R3[New Cluster]
+    end
+    
+    subgraph "Rolling Upgrade"
+        RO1[Mixed Cluster] --> RO2[Upgrade Node]
+        RO2 --> RO3[Verify]
+        RO3 --> RO1
+    end
+```
+
+Supported BWC versions: 2.9.0 through 2.20.0-SNAPSHOT
+
+## Limitations
+
+- BWC tests limited to Linux platforms for CI efficiency
+- Rolling upgrade requires minimum version 2.20.0-SNAPSHOT for 3.0.0 compatibility
+- Some CI jobs removed for Windows to reduce build times
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#1141](https://github.com/opensearch-project/neural-search/pull/1141) | OpenSearch 3.0 compatibility |
+| v3.0.0 | [#1245](https://github.com/opensearch-project/neural-search/pull/1245) | OpenSearch 3.0 beta compatibility |
+| v3.0.0 | [#502](https://github.com/opensearch-project/neural-search/pull/502) | Code guidelines |
+
+## References
+
+- [Issue #225](https://github.com/opensearch-project/neural-search/issues/225): Release version 3.0.0
+- [OpenSearch 3.0 Blog](https://opensearch.org/blog/opensearch-3-0-what-to-expect/): Breaking changes overview
+- [Neural Search Documentation](https://docs.opensearch.org/3.0/vector-search/ai-search/neural-sparse-search/): Official docs
+- [Lucene 10 Changelog](https://lucene.apache.org/core/10_0_0/changes/Changes.html): API changes
+
+## Change History
+
+- **v3.0.0** (2025-07-16): Major compatibility update for Lucene 10 and OpenSearch 3.0
+  - Updated all Lucene API calls to use accessor methods
+  - Migrated Client import to transport package
+  - Updated BWC test infrastructure
+  - Removed redundant Windows CI jobs

--- a/docs/releases/v3.0.0/features/neural-search/neural-search-compatibility.md
+++ b/docs/releases/v3.0.0/features/neural-search/neural-search-compatibility.md
@@ -1,0 +1,102 @@
+# Neural Search Compatibility
+
+## Summary
+
+This release item updates the neural-search plugin for OpenSearch 3.0 compatibility. The changes include adapting to Lucene 10 API changes, updating to the latest OpenSearch core APIs, and improving CI/CD infrastructure for backward compatibility testing.
+
+## Details
+
+### What's New in v3.0.0
+
+The neural-search plugin required significant updates to maintain compatibility with OpenSearch 3.0, which introduced breaking changes from Lucene 10 and JVM 21 requirements.
+
+### Technical Changes
+
+#### API Compatibility Updates
+
+The following API changes were made to align with Lucene 10 and OpenSearch 3.0:
+
+| Change | Description |
+|--------|-------------|
+| `TotalHits.value` → `TotalHits.value()` | Lucene 10 changed TotalHits from public fields to accessor methods |
+| `TotalHits.relation` → `TotalHits.relation()` | Same accessor method pattern for relation field |
+| `BooleanClause.getQuery()` → `BooleanClause.query()` | Simplified accessor method naming |
+| `Scorer(Weight)` → `Scorer()` | Scorer constructor no longer requires Weight parameter |
+| `DisiWrapper(Scorer)` → `DisiWrapper(Scorer, boolean)` | Additional parameter for DisiWrapper constructor |
+| `Query.rewrite(IndexReader)` → `Query.rewrite(IndexSearcher)` | Rewrite method now takes IndexSearcher |
+| `org.opensearch.client.Client` → `org.opensearch.transport.client.Client` | Client class relocated to transport package |
+| `ChildScorable.child` → `ChildScorable.child()` | Accessor method pattern for child scorable |
+| `LeafMetaData.getSort()` → `LeafMetaData.sort()` | Simplified accessor for index sort |
+
+#### HybridQuery Changes
+
+The `HybridQuery` class was updated to handle boolean clauses differently:
+
+```java
+// New constructor accepting BooleanClause list directly
+public HybridQuery(
+    final Collection<Query> subQueries,
+    final HybridQueryContext hybridQueryContext,
+    final List<BooleanClause> booleanClauses
+)
+```
+
+This change improves handling of wrapped queries for index aliases where core OpenSearch rewrites queries into boolean queries with modified clause structures.
+
+#### Infrastructure Updates
+
+| Component | Change |
+|-----------|--------|
+| BWC Version | Updated from 2.19.0-SNAPSHOT to 2.20.0-SNAPSHOT |
+| OpenSearch Version | Updated to 3.0.0-beta1-SNAPSHOT |
+| Build Qualifier | Changed from alpha1 to beta1 |
+| CI Windows Precommit | Removed redundant Windows precommit job |
+| BWC Tests | Removed Windows from BWC test matrix |
+| Aggregation Tests | Reduced JDK matrix for Windows aggregation tests |
+
+#### Model State Handling
+
+Improved model loading state detection for BWC tests:
+
+```java
+private static final Set<MLModelState> READY_FOR_INFERENCE_STATES = 
+    Set.of(MLModelState.LOADED, MLModelState.DEPLOYED);
+
+protected boolean isModelReadyForInference(final MLModelState mlModelState) {
+    return READY_FOR_INFERENCE_STATES.contains(mlModelState);
+}
+```
+
+### Migration Notes
+
+For plugin developers extending neural-search:
+
+1. Update all `TotalHits` field accesses to use accessor methods
+2. Update `BooleanClause` query access to use `query()` method
+3. Update `Scorer` subclasses to use parameterless constructor
+4. Update `Query.rewrite()` implementations to accept `IndexSearcher`
+5. Update Client imports to use `org.opensearch.transport.client.Client`
+
+## Limitations
+
+- BWC tests are now limited to Linux platforms only
+- Rolling upgrade BWC tests require 2.20.0-SNAPSHOT as the minimum version
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1141](https://github.com/opensearch-project/neural-search/pull/1141) | Update neural-search for OpenSearch 3.0 compatibility |
+| [#1245](https://github.com/opensearch-project/neural-search/pull/1245) | Update neural-search for OpenSearch 3.0 beta compatibility |
+| [#502](https://github.com/opensearch-project/neural-search/pull/502) | Adding code guidelines |
+
+## References
+
+- [Issue #225](https://github.com/opensearch-project/neural-search/issues/225): Release version 3.0.0
+- [Issue #3747](https://github.com/opensearch-project/opensearch-build/issues/3747): OpenSearch 3.0.0 release tracking
+- [OpenSearch 3.0 Blog](https://opensearch.org/blog/opensearch-3-0-what-to-expect/): New features and breaking changes
+- [Lucene 10 Changelog](https://lucene.apache.org/core/10_0_0/changes/Changes.html): Apache Lucene 10 changes
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/neural-search/neural-search-compatibility.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -2,6 +2,7 @@
 
 ## neural-search
 
+- [Neural Search Compatibility](features/neural-search/neural-search-compatibility.md)
 - [Semantic Field](features/neural-search/semantic-field.md)
 
 ## opensearch


### PR DESCRIPTION
## Summary

This PR adds documentation for the Neural Search Compatibility release item in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/neural-search/neural-search-compatibility.md`
- Feature report: `docs/features/neural-search/neural-search-compatibility.md`

### Key Changes in v3.0.0
- Updated Lucene 10 API calls (TotalHits, BooleanClause accessor methods)
- Migrated Client import to transport package
- Updated BWC test infrastructure (2.20.0-SNAPSHOT)
- Removed redundant Windows CI jobs

### Related PRs
- opensearch-project/neural-search#1141: OpenSearch 3.0 compatibility
- opensearch-project/neural-search#1245: OpenSearch 3.0 beta compatibility
- opensearch-project/neural-search#502: Code guidelines

Closes #185