### PR TITLE
docs: add JDK 21 & Java Agent Migration report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -71,6 +71,7 @@
 
 - [CI/CD & Testing Infrastructure](multi-plugin/ci-cd-testing-infrastructure.md)
 - [CVE Fixes & Dependency Updates](multi-plugin/cve-fixes-dependency-updates.md)
+- [JDK 21 & Java Agent Migration](multi-plugin/jdk-21-java-agent-migration.md)
 
 ## opensearch-remote-metadata-sdk
 

--- a/docs/features/multi-plugin/jdk-21-java-agent-migration.md
+++ b/docs/features/multi-plugin/jdk-21-java-agent-migration.md
@@ -1,0 +1,157 @@
+# JDK 21 & Java Agent Migration
+
+## Summary
+
+OpenSearch's JDK 21 & Java Agent Migration represents a fundamental shift in how OpenSearch handles security sandboxing. With Java Security Manager (JSM) deprecated in JDK 17 and scheduled for permanent removal in JDK 24, OpenSearch has adopted a Java Agent-based approach for runtime security instrumentation. This migration requires JDK 21 as the minimum runtime and affects all OpenSearch plugins through a new Gradle plugin that simplifies the transition.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Core"
+        GP["opensearch.java-agent<br/>Gradle Plugin"]
+        JA["Java Agent<br/>(Runtime)"]
+        GP --> |"Configures"| JA
+    end
+    
+    subgraph "Plugin Ecosystem"
+        P1[flow-framework]
+        P2[k-NN]
+        P3[security]
+        P4[asynchronous-search]
+        P5[geospatial]
+        P6[job-scheduler]
+    end
+    
+    GP --> |"apply plugin"| P1
+    GP --> |"apply plugin"| P2
+    GP --> |"apply plugin"| P3
+    GP --> |"apply plugin"| P4
+    GP --> |"apply plugin"| P5
+    GP --> |"apply plugin"| P6
+    
+    subgraph "JDK Evolution"
+        JDK17["JDK 17<br/>(JSM Deprecated)"]
+        JDK21["JDK 21<br/>(OpenSearch 3.0 Baseline)"]
+        JDK24["JDK 24<br/>(JSM Removed)"]
+        JDK17 --> JDK21 --> JDK24
+    end
+    
+    JDK21 --> JA
+```
+
+### Security Model Evolution
+
+```mermaid
+flowchart LR
+    subgraph "Legacy (JDK ≤ 17)"
+        SM[Security Manager]
+        PP[Policy Files]
+        PC[Permission Checks]
+        SM --> PP --> PC
+    end
+    
+    subgraph "Modern (JDK 21+)"
+        JA[Java Agent]
+        BI[Bytecode Instrumentation]
+        RC[Runtime Checks]
+        JA --> BI --> RC
+    end
+    
+    SM -.->|"Migration"| JA
+```
+
+### Components
+
+| Component | Description | Location |
+|-----------|-------------|----------|
+| opensearch.java-agent | Gradle plugin for Java Agent configuration | OpenSearch build-tools |
+| Java Agent JAR | Runtime instrumentation agent | Bundled with OpenSearch |
+| JdkJarHellCheck | JDK compatibility validator | org.opensearch.common.bootstrap |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `sourceCompatibility` | Java source version | `JavaVersion.VERSION_21` |
+| `targetCompatibility` | Java target version | `JavaVersion.VERSION_21` |
+| `JAVA_HOME` | JDK installation path | System default |
+| `OPENSEARCH_JAVA_HOME` | OpenSearch-specific JDK | Not set |
+
+### JDK Version Requirements
+
+| OpenSearch Version | Minimum JDK | Bundled JDK | Notes |
+|-------------------|-------------|-------------|-------|
+| 1.x | 8/11 | 11/15 | SecurityManager active |
+| 2.x | 11 | 17 | SecurityManager deprecated |
+| 3.0+ | 21 | 21 | Java Agent replaces SecurityManager |
+
+### Usage Example
+
+```groovy
+// Plugin build.gradle configuration
+plugins {
+    id 'opensearch.opensearchplugin'
+    id 'opensearch.java-agent'  // Enable Java Agent support
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+// For plugins using shadow JAR
+plugins {
+    id 'com.gradleup.shadow'  // Updated shadow plugin
+}
+```
+
+```yaml
+# CI workflow update (.github/workflows/ci.yml)
+jobs:
+  build:
+    strategy:
+      matrix:
+        java: [21, 23]  # Removed 11, 17
+    steps:
+      - uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+```
+
+## Limitations
+
+- **JDK 21 Required**: No backward compatibility with JDK 11/17
+- **Plugin Recompilation**: All plugins must be recompiled for OpenSearch 3.0
+- **SecurityManager Code**: Legacy permission-based code must be refactored
+- **Third-party Dependencies**: Some libraries may require updates for JDK 21
+
+## Related PRs
+
+| Version | PR | Repository | Description |
+|---------|-----|------------|-------------|
+| v3.0.0 | [#17900](https://github.com/opensearch-project/OpenSearch/pull/17900) | OpenSearch | Custom Gradle plugin for Java Agent |
+| v3.0.0 | [#730](https://github.com/opensearch-project/flow-framework/pull/730) | flow-framework | JDK 21 target compatibility |
+| v3.0.0 | [#1108](https://github.com/opensearch-project/flow-framework/pull/1108) | flow-framework | Java Agent Gradle plugin |
+| v3.0.0 | [#1087](https://github.com/opensearch-project/flow-framework/pull/1087) | flow-framework | BC to BCFIPS migration |
+| v3.0.0 | [#2422](https://github.com/opensearch-project/k-NN/pull/2422) | k-NN | JDK 21 minimum |
+| v3.0.0 | [#1921](https://github.com/opensearch-project/k-NN/pull/1921) | k-NN | Remove JDK 11/17 CI |
+| v3.0.0 | [#719](https://github.com/opensearch-project/asynchronous-search/pull/719) | asynchronous-search | Java Agent migration |
+| v3.0.0 | [#695](https://github.com/opensearch-project/geospatial/pull/695) | geospatial | JDK 21 baseline |
+| v3.0.0 | [#723](https://github.com/opensearch-project/geospatial/pull/723) | geospatial | Gradle 8.10.2, JDK 23 |
+| v3.0.0 | [#722](https://github.com/opensearch-project/job-scheduler/pull/722) | job-scheduler | Shadow plugin update |
+
+## References
+
+- [Issue #10745](https://github.com/opensearch-project/OpenSearch/issues/10745): Set OpenSearch 3.0.0 baseline JDK to JDK-21
+- [Issue #16634](https://github.com/opensearch-project/OpenSearch/issues/16634): META - Replace Java Security Manager
+- [Issue #16753](https://github.com/opensearch-project/OpenSearch/issues/16753): Java Agent implementation tracking
+- [JEP 411](https://openjdk.org/jeps/411): Deprecate the Security Manager for Removal
+- [JDK 24 Project](https://openjdk.org/projects/jdk/24/): SecurityManager permanently disabled
+
+## Change History
+
+- **v3.0.0** (2025): JDK 21 minimum requirement, Java Agent Gradle plugin, SecurityManager phase-out across all plugins

--- a/docs/releases/v3.0.0/features/multi-plugin/jdk-21-java-agent-migration.md
+++ b/docs/releases/v3.0.0/features/multi-plugin/jdk-21-java-agent-migration.md
@@ -1,0 +1,129 @@
+# JDK 21 & Java Agent Migration
+
+## Summary
+
+OpenSearch 3.0.0 requires JDK 21 as the minimum runtime version and introduces a Java Agent-based approach to replace the deprecated Java Security Manager. This migration affects all OpenSearch plugins, requiring updates to build configurations, CI/CD pipelines, and security-related code. The changes ensure compatibility with JDK 24+ where SecurityManager will be permanently disabled.
+
+## Details
+
+### What's New in v3.0.0
+
+1. **JDK 21 Baseline**: All plugins now require JDK 21 as the minimum version
+2. **Java Agent Gradle Plugin**: New `opensearch.java-agent` plugin for phasing off SecurityManager
+3. **CI/CD Updates**: Removed JDK 11/17 from CI runs, added JDK 21/23 support
+4. **Dependency Updates**: Gradle 8.10.2, shadow plugin migration to `com.gradleup.shadow`
+5. **Cryptography Migration**: BC (BouncyCastle) to BCFIPS libraries
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.0.0"
+        SM[Java Security Manager]
+        SM --> |"Permission Checks"| Plugin1[Plugin Code]
+        SM --> |"Permission Checks"| Plugin2[Plugin Code]
+    end
+    
+    subgraph "v3.0.0+"
+        JA[Java Agent]
+        GP[opensearch.java-agent<br/>Gradle Plugin]
+        GP --> |"Configures"| JA
+        JA --> |"Runtime Instrumentation"| Plugin3[Plugin Code]
+        JA --> |"Runtime Instrumentation"| Plugin4[Plugin Code]
+    end
+    
+    SM -.->|"Deprecated in JDK 17<br/>Removed in JDK 24"| JA
+```
+
+#### Plugin Migration Flow
+
+```mermaid
+flowchart LR
+    A[Plugin build.gradle] --> B{Apply Plugin}
+    B --> C["apply plugin: 'opensearch.java-agent'"]
+    C --> D[Gradle configures<br/>Java Agent]
+    D --> E[Tests run with<br/>Java Agent]
+    E --> F[Build succeeds<br/>without SecurityManager]
+```
+
+#### Affected Repositories
+
+| Repository | Changes | Key PRs |
+|------------|---------|---------|
+| flow-framework | JDK 21 target, Java Agent plugin, BC→BCFIPS | #730, #1108, #1087 |
+| k-NN | JDK 21 minimum, removed JDK 11/17 CI | #1921, #2422 |
+| security | Java Agent plugin migration | #1917, #1086, #1406 |
+| asynchronous-search | Java Agent plugin | #719 |
+| geospatial | JDK 21 baseline, Gradle 8.10.2, JDK 23 | #695, #723 |
+| job-scheduler | Shadow plugin update | #722 |
+| dashboards-observability | JDK 21 for OpenSearch 3.0 | #563 |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `sourceCompatibility` | Java source version | `JavaVersion.VERSION_21` |
+| `targetCompatibility` | Java target version | `JavaVersion.VERSION_21` |
+| `opensearch.java-agent` | Gradle plugin for Java Agent | Applied in build.gradle |
+
+### Usage Example
+
+```groovy
+// build.gradle - Plugin migration example
+plugins {
+    id 'opensearch.opensearchplugin'
+    id 'opensearch.java-agent'  // New: replaces SecurityManager
+}
+
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+
+// Shadow plugin migration (if applicable)
+plugins {
+    id 'com.gradleup.shadow'  // Replaces 'com.github.johnrengelman.shadow'
+}
+```
+
+### Migration Notes
+
+1. **Update JDK**: Ensure JDK 21+ is installed and configured
+2. **Apply Java Agent Plugin**: Add `apply plugin: 'opensearch.java-agent'` to build.gradle
+3. **Update CI Workflows**: Remove JDK 11/17 matrix entries, add JDK 21/23
+4. **Shadow Plugin**: Migrate from `com.github.johnrengelman.shadow` to `com.gradleup.shadow`
+5. **Cryptography**: Update BouncyCastle imports from BC to BCFIPS if applicable
+
+## Limitations
+
+- **Breaking Change**: Plugins compiled for JDK 11/17 are incompatible with OpenSearch 3.0
+- **SecurityManager Removal**: Code relying on SecurityManager permissions must be refactored
+- **CI Matrix**: Older JDK versions no longer tested in CI pipelines
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#17900](https://github.com/opensearch-project/OpenSearch/pull/17900) | OpenSearch | Custom Gradle plugin for Java Agent |
+| [#730](https://github.com/opensearch-project/flow-framework/pull/730) | flow-framework | Set Java target compatibility to JDK 21 |
+| [#1108](https://github.com/opensearch-project/flow-framework/pull/1108) | flow-framework | Java Agent Gradle plugin |
+| [#1087](https://github.com/opensearch-project/flow-framework/pull/1087) | flow-framework | BC to BCFIPS migration |
+| [#2422](https://github.com/opensearch-project/k-NN/pull/2422) | k-NN | Upgrade min JDK to 21 |
+| [#1921](https://github.com/opensearch-project/k-NN/pull/1921) | k-NN | Remove JDK 11/17 from CI |
+| [#719](https://github.com/opensearch-project/asynchronous-search/pull/719) | asynchronous-search | Java Agent migration |
+| [#695](https://github.com/opensearch-project/geospatial/pull/695) | geospatial | JDK 21 baseline |
+| [#723](https://github.com/opensearch-project/geospatial/pull/723) | geospatial | Gradle 8.10.2, JDK 23 support |
+| [#722](https://github.com/opensearch-project/job-scheduler/pull/722) | job-scheduler | Shadow plugin update |
+
+## References
+
+- [Issue #10745](https://github.com/opensearch-project/OpenSearch/issues/10745): Set OpenSearch 3.0.0 baseline JDK to JDK-21
+- [Issue #16634](https://github.com/opensearch-project/OpenSearch/issues/16634): META - Replace Java Security Manager
+- [JEP 411](https://openjdk.org/jeps/411): Deprecate the Security Manager for Removal
+- [JDK 24 Project](https://openjdk.org/projects/jdk/24/): SecurityManager permanently disabled
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/multi-plugin/jdk-21-java-agent-migration.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -73,6 +73,7 @@
 
 - [CI/CD & Testing Infrastructure](features/multi-plugin/ci-cd-testing-infrastructure.md)
 - [CVE Fixes & Dependency Updates](features/multi-plugin/cve-fixes-dependency-updates.md)
+- [JDK 21 & Java Agent Migration](features/multi-plugin/jdk-21-java-agent-migration.md)
 
 ## opensearch-remote-metadata-sdk
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the JDK 21 & Java Agent Migration release item for OpenSearch v3.0.0.

## Changes

### Release Report
- `docs/releases/v3.0.0/features/multi-plugin/jdk-21-java-agent-migration.md`

### Feature Report
- `docs/features/multi-plugin/jdk-21-java-agent-migration.md`

## Key Findings

OpenSearch 3.0.0 introduces significant changes to Java runtime requirements:

1. **JDK 21 Baseline**: All plugins now require JDK 21 as the minimum version
2. **Java Agent Migration**: New `opensearch.java-agent` Gradle plugin replaces deprecated SecurityManager
3. **CI/CD Updates**: Removed JDK 11/17 from CI runs across multiple repositories
4. **Build Tool Updates**: Gradle 8.10.2, shadow plugin migration to `com.gradleup.shadow`
5. **Cryptography**: BC to BCFIPS library migration

## Affected Repositories

- flow-framework (PRs #730, #1108, #1087)
- k-NN (PRs #1921, #2422)
- security (PRs #1917, #1086, #1406)
- asynchronous-search (PR #719)
- geospatial (PRs #695, #723)
- job-scheduler (PR #722)
- dashboards-observability (PR #563)

## Related Issue

Closes #184