### PR TITLE
docs: add Version Bumps & Release Notes report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -72,6 +72,7 @@
 - [CI/CD & Testing Infrastructure](multi-plugin/ci-cd-testing-infrastructure.md)
 - [CVE Fixes & Dependency Updates](multi-plugin/cve-fixes-dependency-updates.md)
 - [JDK 21 & Java Agent Migration](multi-plugin/jdk-21-java-agent-migration.md)
+- [Version Bumps & Release Notes](multi-plugin/version-bumps-release-notes.md)
 
 ## opensearch-remote-metadata-sdk
 

--- a/docs/features/multi-plugin/version-bumps-release-notes.md
+++ b/docs/features/multi-plugin/version-bumps-release-notes.md
@@ -1,0 +1,77 @@
+# Version Bumps & Release Notes
+
+## Summary
+
+Version bumps and release notes are standard maintenance tasks performed across all OpenSearch repositories during each release cycle. These changes ensure consistent versioning across the project and provide documentation of changes for each release.
+
+## Details
+
+### Release Cycle Workflow
+
+```mermaid
+flowchart LR
+    A[Development] --> B[Alpha]
+    B --> C[Beta]
+    C --> D[GA Release]
+    D --> E[SNAPSHOT]
+    
+    subgraph "Version Examples"
+        B1[3.0.0.0-alpha1]
+        C1[3.0.0.0-beta1]
+        D1[3.0.0.0]
+        E1[3.0.0-SNAPSHOT]
+    end
+```
+
+### Version String Format
+
+OpenSearch plugins follow a consistent versioning scheme:
+
+| Component | Format | Example |
+|-----------|--------|---------|
+| Major.Minor.Patch.Build | X.Y.Z.W | 3.0.0.0 |
+| With Qualifier | X.Y.Z.W-qualifier | 3.0.0.0-alpha1 |
+| SNAPSHOT | X.Y.Z-SNAPSHOT | 3.0.0-SNAPSHOT |
+
+### Files Typically Modified
+
+| File | Purpose |
+|------|---------|
+| `build.gradle` | Plugin version declaration |
+| `gradle.properties` | Version properties |
+| `release-notes/*.md` | Release documentation |
+| `plugin-descriptor.properties` | Plugin metadata |
+
+### Release Notes Structure
+
+Each plugin maintains release notes in a standard format:
+
+```
+release-notes/
+├── opensearch-{plugin}.release-notes-3.0.0.0.md
+├── opensearch-{plugin}.release-notes-2.19.0.0.md
+└── ...
+```
+
+## Limitations
+
+- Version bumps are mechanical changes with no functional impact
+- Release notes accuracy depends on PR descriptions and changelog entries
+- Timing of version bumps must coordinate with release branch creation
+
+## Related PRs
+
+| Version | PR | Repository | Description |
+|---------|-----|------------|-------------|
+| v3.0.0 | [#1843](https://github.com/opensearch-project/alerting/pull/1843) | alerting | Added 3.0 release notes |
+| v3.0.0 | [#775](https://github.com/opensearch-project/common-utils/pull/775) | common-utils | Update shadow plugin and bump to 3.0.0.0-alpha1 |
+| v3.0.0 | [#1384](https://github.com/opensearch-project/index-management/pull/1384) | index-management | Bump Version to 3.0.0-alpha1 |
+
+## References
+
+- [opensearch-build#5267](https://github.com/opensearch-project/opensearch-build/issues/5267): Release coordination
+- [OpenSearch Release Process](https://github.com/opensearch-project/opensearch-build/blob/main/RELEASING.md): Official release documentation
+
+## Change History
+
+- **v3.0.0** (2025-05): Version bumps and release notes across 9 repositories (alerting, common-utils, index-management, notifications, security, sql, and dashboard plugins)

--- a/docs/releases/v3.0.0/features/multi-plugin/version-bumps-release-notes.md
+++ b/docs/releases/v3.0.0/features/multi-plugin/version-bumps-release-notes.md
@@ -1,0 +1,89 @@
+# Version Bumps & Release Notes
+
+## Summary
+
+This release item covers the standard version bump and release notes updates across multiple OpenSearch plugins for the v3.0.0 release cycle. These changes ensure all plugins are properly versioned and documented for the major release.
+
+## Details
+
+### What's New in v3.0.0
+
+Version bumps and release notes were added across 9 repositories to prepare for the OpenSearch 3.0.0 release:
+
+- **alerting**: Version bumps from alpha1 → beta1 → GA, plus release notes
+- **alerting-dashboards-plugin**: Version increments through alpha1, beta1, and GA
+- **common-utils**: Shadow plugin repo update and version bumps
+- **index-management**: Version bumps and SNAPSHOT updates
+- **notifications**: Version increments and release notes
+- **notifications-dashboards-plugin**: Version bumps through release cycle
+- **query-insights-dashboards**: Release notes for alpha1 and beta1
+- **security**: Release notes additions
+- **security-dashboards-plugin**: Release notes for 3.0.0
+
+### Technical Changes
+
+#### Version Progression
+
+| Phase | Version String | Qualifier |
+|-------|---------------|-----------|
+| Alpha | 3.0.0.0-alpha1 | alpha1 |
+| Beta | 3.0.0.0-beta1 | beta1 |
+| GA | 3.0.0.0 | (none) |
+| Post-GA | 3.0.0-SNAPSHOT | SNAPSHOT |
+
+#### Affected Files
+
+Typical files modified in version bump PRs:
+
+- `build.gradle` - Version number updates
+- `gradle.properties` - Version properties
+- `release-notes/*.md` - Release documentation
+- Plugin descriptor files
+
+### Repositories Affected
+
+| Repository | PRs | Changes |
+|------------|-----|---------|
+| alerting | 6 | Version bumps, release notes |
+| alerting-dashboards-plugin | 6 | Version increments |
+| common-utils | 2 | Shadow plugin, version bumps |
+| index-management | 3 | Version bumps |
+| notifications | 2 | Version increments, release notes |
+| notifications-dashboards-plugin | 3 | Version bumps |
+| query-insights-dashboards | 2 | Release notes |
+| security | 2 | Release notes |
+| security-dashboards-plugin | 2 | Release notes |
+
+## Limitations
+
+- Version bump PRs are routine maintenance and do not introduce functional changes
+- Release notes content depends on features merged before the cutoff date
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#1843](https://github.com/opensearch-project/alerting/pull/1843) | alerting | Added 3.0 release notes |
+| [#1837](https://github.com/opensearch-project/alerting/pull/1837) | alerting | Increment version to 3.0.0-SNAPSHOT |
+| [#1816](https://github.com/opensearch-project/alerting/pull/1816) | alerting | Update version qualifier to beta1 |
+| [#1786](https://github.com/opensearch-project/alerting/pull/1786) | alerting | Increment version to 3.0.0.0-alpha1 |
+| [#1246](https://github.com/opensearch-project/alerting/pull/1246) | alerting | Added 3.0.0 release notes / Increment version |
+| [#775](https://github.com/opensearch-project/common-utils/pull/775) | common-utils | Update shadow plugin repo and bump to 3.0.0.0-alpha1 |
+| [#808](https://github.com/opensearch-project/common-utils/pull/808) | common-utils | Change 3.0.0 qualifier from alpha1 to beta1 |
+| [#1384](https://github.com/opensearch-project/index-management/pull/1384) | index-management | Bump Version to 3.0.0-alpha1 |
+| [#1398](https://github.com/opensearch-project/index-management/pull/1398) | index-management | Update 3.0.0 qualifier from alpha1 to beta1 |
+| [#1412](https://github.com/opensearch-project/index-management/pull/1412) | index-management | Increment version to 3.0.0-SNAPSHOT |
+| [#347](https://github.com/opensearch-project/notifications/pull/347) | notifications | Added 3.0.0 release notes / Increment version |
+| [#1033](https://github.com/opensearch-project/notifications/pull/1033) | notifications | Add 3.0.0 release notes |
+| [#1523](https://github.com/opensearch-project/security/pull/1523) | security | Added 3.0.0 release notes |
+| [#1283](https://github.com/opensearch-project/security/pull/1283) | security | Added 3.0.0 release notes |
+| [#3589](https://github.com/opensearch-project/sql/pull/3589) | sql | Remove beta1 qualifier |
+
+## References
+
+- [opensearch-build#5267](https://github.com/opensearch-project/opensearch-build/issues/5267): Release coordination issue
+- [opensearch-build#3747](https://github.com/opensearch-project/opensearch-build/issues/3747): Build configuration issue
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/multi-plugin/version-bumps-release-notes.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -74,6 +74,7 @@
 - [CI/CD & Testing Infrastructure](features/multi-plugin/ci-cd-testing-infrastructure.md)
 - [CVE Fixes & Dependency Updates](features/multi-plugin/cve-fixes-dependency-updates.md)
 - [JDK 21 & Java Agent Migration](features/multi-plugin/jdk-21-java-agent-migration.md)
+- [Version Bumps & Release Notes](features/multi-plugin/version-bumps-release-notes.md)
 
 ## opensearch-remote-metadata-sdk
 


### PR DESCRIPTION
## Summary

Adds documentation for the Version Bumps & Release Notes release item in OpenSearch v3.0.0.

This covers the standard version bump and release notes updates across 9 repositories:
- alerting
- alerting-dashboards-plugin
- common-utils
- index-management
- notifications
- notifications-dashboards-plugin
- query-insights-dashboards
- security
- security-dashboards-plugin

## Reports Created
- Release report: `docs/releases/v3.0.0/features/multi-plugin/version-bumps-release-notes.md`
- Feature report: `docs/features/multi-plugin/version-bumps-release-notes.md`

Closes #183