### PR TITLE
docs: add Reporting Plugin Java Agent build fix report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -46,6 +46,7 @@
 
 - [AUTO Version Management](reporting/auto-version-management.md)
 - [CI/CD Workflow](reporting/ci-workflow.md)
+- [Java Agent Migration](reporting/java-agent-migration.md)
 
 ## dashboards-flow-framework
 

--- a/docs/features/reporting/java-agent-migration.md
+++ b/docs/features/reporting/java-agent-migration.md
@@ -1,0 +1,126 @@
+# Reporting Plugin Java Agent Migration
+
+## Summary
+
+The Reporting plugin has been updated to support OpenSearch 3.0's Java Agent-based security model. This migration replaces the deprecated Java SecurityManager with a modern bytecode instrumentation approach, ensuring the plugin remains compatible with JDK 21+ and future Java versions where SecurityManager is permanently removed.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Build Time"
+        BG[build.gradle]
+        AC[Agent Configuration]
+        PA[prepareAgent Task]
+        BG --> AC --> PA
+    end
+    
+    subgraph "Agent Dependencies"
+        AB[opensearch-agent-bootstrap]
+        OA[opensearch-agent]
+        BB[byte-buddy]
+    end
+    
+    PA --> |"Downloads"| AB
+    PA --> |"Downloads"| OA
+    PA --> |"Downloads"| BB
+    
+    subgraph "Test Execution"
+        TT[Test Tasks]
+        JA[Java Agent]
+        RI[Runtime Instrumentation]
+        TT --> |"-javaagent"| JA --> RI
+    end
+    
+    PA --> |"Provides JARs"| TT
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Gradle Build"
+        A[Configure Agent] --> B[Download Dependencies]
+        B --> C[Copy to Build Dir]
+    end
+    
+    subgraph "Test Phase"
+        D[Run Tests] --> E[Load Java Agent]
+        E --> F[Instrument Classes]
+        F --> G[Execute Tests]
+    end
+    
+    C --> D
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Agent Configuration | Gradle configuration for agent dependencies |
+| prepareAgent Task | Copies agent JARs to build directory |
+| Test JVM Args | Configures Java Agent for test execution |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `agent` configuration | Dependency configuration for agent JARs | N/A |
+| `javaagent` JVM arg | Path to opensearch-agent JAR | `$buildDir/agent/opensearch-agent-${version}.jar` |
+
+### Usage Example
+
+```groovy
+// build.gradle configuration for Java Agent support
+allprojects {
+    plugins.withId('java') {
+        sourceCompatibility = targetCompatibility = "21"
+    }
+
+    configurations {
+        agent
+    }
+
+    task prepareAgent(type: Copy) {
+        from(configurations.agent)
+        into "$buildDir/agent"
+    }
+
+    dependencies {
+        agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
+        agent "org.opensearch:opensearch-agent:${opensearch_version}"
+        agent "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
+    }
+
+    tasks.withType(Test) {
+        dependsOn prepareAgent
+        jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
+    }
+}
+```
+
+## Limitations
+
+- Requires JDK 21 as minimum runtime
+- All tests must run with the Java Agent enabled
+- Not backward compatible with OpenSearch 2.x builds
+- Plugin must be rebuilt for OpenSearch 3.0
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#1085](https://github.com/opensearch-project/reporting/pull/1085) | Fix build due to phasing off SecurityManager usage in favor of Java Agent |
+
+## References
+
+- [Issue #16634](https://github.com/opensearch-project/OpenSearch/issues/16634): META - Replace Java Security Manager
+- [PR #17861](https://github.com/opensearch-project/OpenSearch/pull/17861): Phase off SecurityManager usage in favor of Java Agent
+- [PR #17900](https://github.com/opensearch-project/OpenSearch/pull/17900): Custom Gradle plugin for Java Agent
+- [Documentation](https://docs.opensearch.org/3.0/reporting/): Reporting plugin documentation
+
+## Change History
+
+- **v3.0.0** (2025-04-11): Added Java Agent build configuration for SecurityManager replacement

--- a/docs/releases/v3.0.0/features/reporting/java-agent-build-fix.md
+++ b/docs/releases/v3.0.0/features/reporting/java-agent-build-fix.md
@@ -1,0 +1,81 @@
+# Java Agent Build Fix
+
+## Summary
+
+This bugfix updates the Reporting plugin's build configuration to support the Java Agent-based security model introduced in OpenSearch 3.0. The change ensures that tests run correctly with the new Java Agent instead of the deprecated SecurityManager.
+
+## Details
+
+### What's New in v3.0.0
+
+The Reporting plugin's Gradle build configuration has been updated to integrate with OpenSearch's Java Agent infrastructure. This is a required change as OpenSearch 3.0 phases out SecurityManager usage in favor of Java Agent-based runtime instrumentation.
+
+### Technical Changes
+
+#### Build Configuration Updates
+
+The `build.gradle` file now includes:
+
+1. **Agent Configuration**: New `agent` configuration for Java Agent dependencies
+2. **PrepareAgent Task**: Copies agent JARs to the build directory
+3. **Test JVM Arguments**: Configures tests to run with the Java Agent
+
+```groovy
+configurations {
+    agent
+}
+
+task prepareAgent(type: Copy) {
+    from(configurations.agent)
+    into "$buildDir/agent"
+}
+
+dependencies {
+    agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
+    agent "org.opensearch:opensearch-agent:${opensearch_version}"
+    agent "net.bytebuddy:byte-buddy:${versions.bytebuddy}"
+}
+
+tasks.withType(Test) {
+    dependsOn prepareAgent
+    jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
+}
+```
+
+#### New Dependencies
+
+| Dependency | Description |
+|------------|-------------|
+| opensearch-agent-bootstrap | Bootstrap agent for OpenSearch runtime |
+| opensearch-agent | Main Java Agent for security instrumentation |
+| byte-buddy | Bytecode manipulation library used by the agent |
+
+### Migration Notes
+
+Plugin developers maintaining forks or custom builds of the Reporting plugin should:
+
+1. Update their `build.gradle` to include the agent configuration
+2. Ensure JDK 21 is used for building and testing
+3. Remove any SecurityManager-related code or configurations
+
+## Limitations
+
+- Requires JDK 21 or later
+- Tests must run with the Java Agent enabled
+- Not backward compatible with OpenSearch 2.x
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1085](https://github.com/opensearch-project/reporting/pull/1085) | Fix build due to phasing off SecurityManager usage in favor of Java Agent |
+
+## References
+
+- [Issue #16634](https://github.com/opensearch-project/OpenSearch/issues/16634): META - Replace Java Security Manager
+- [PR #17861](https://github.com/opensearch-project/OpenSearch/pull/17861): Phase off SecurityManager usage in favor of Java Agent
+- [Documentation](https://docs.opensearch.org/3.0/reporting/): Reporting plugin documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/reporting/java-agent-migration.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -43,6 +43,7 @@
 
 - [AUTO Version Increment](features/reporting/auto-version-increment.md)
 - [CI/Workflow Fixes](features/reporting/ci-workflow-fixes.md)
+- [Java Agent Build Fix](features/reporting/java-agent-build-fix.md)
 
 ## security
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Reporting plugin's Java Agent build fix in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/reporting/java-agent-build-fix.md`
- Feature report: `docs/features/reporting/java-agent-migration.md`

### Key Changes in v3.0.0
- Added Java Agent configuration to build.gradle
- Configured test tasks to run with Java Agent
- Added dependencies for opensearch-agent-bootstrap, opensearch-agent, and byte-buddy

### Related Issue
Closes #182

### Source PR
- [opensearch-project/reporting#1085](https://github.com/opensearch-project/reporting/pull/1085): Fix build due to phasing off SecurityManager usage in favor of Java Agent