### PR TITLE
docs: add cross-cluster-search report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -32,6 +32,7 @@
 ## opensearch-dashboards
 
 - [CI/CD & Build Fixes](opensearch-dashboards/ci-cd-build-fixes.md)
+- [Cross-Cluster Search](opensearch-dashboards/cross-cluster-search.md)
 - [Dashboards CI/CD & Documentation](opensearch-dashboards/dashboards-ci-cd-documentation.md)
 - [Dashboards Cypress Testing](opensearch-dashboards/dashboards-cypress-testing.md)
 - [Dashboards UI/UX Fixes](opensearch-dashboards/dashboards-ui-ux-fixes.md)

--- a/docs/features/opensearch-dashboards/cross-cluster-search.md
+++ b/docs/features/opensearch-dashboards/cross-cluster-search.md
@@ -1,0 +1,151 @@
+# Cross-Cluster Search in OpenSearch Dashboards
+
+## Summary
+
+Cross-Cluster Search (CCS) in OpenSearch Dashboards provides native UI support for discovering, visualizing, and querying data across multiple OpenSearch clusters. This feature enables users to work with remote cluster connections directly from the Dashboards interface, eliminating the need to use APIs for cross-cluster operations.
+
+Key benefits:
+- **Unified Data Access**: Query and visualize data from multiple clusters in a single interface
+- **Simplified Discovery**: Easily identify which data sources have remote cluster connections
+- **Seamless Integration**: Remote indices appear alongside local indices in familiar workflows
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        subgraph "UI Layer"
+            DSM[Data Source Management]
+            IPM[Index Pattern Management]
+            DIS[Discover]
+            WS[Workspaces]
+        end
+        
+        subgraph "Server Layer"
+            QE[Query Enhancements Plugin]
+            DSP[Data Source Plugin]
+        end
+    end
+    
+    subgraph "OpenSearch Backend"
+        LC[Local Cluster]
+        RC1[Remote Cluster 1]
+        RC2[Remote Cluster 2]
+    end
+    
+    DSM --> QE
+    IPM --> QE
+    DIS --> QE
+    WS --> QE
+    
+    QE --> DSP
+    DSP --> LC
+    LC -->|"/_remote/info"| RC1
+    LC -->|"/_resolve/index/{alias}:*"| RC2
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[User selects Data Source] --> B{Has Remote Connections?}
+    B -->|Yes| C[Fetch /_remote/info]
+    B -->|No| D[Show Local Indices Only]
+    C --> E[Display Remote Clusters]
+    E --> F[User selects Remote Index]
+    F --> G[Fetch /_resolve/index]
+    G --> H[Display Remote Indices]
+    H --> I[Query Remote Data]
+```
+
+### Components
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| `DataSourceEngineType.OpenSearchCrossCluster` | `data_source/common` | Engine type identifier for cross-cluster connections |
+| Remote Cluster Routes | `query_enhancements/server/routes` | Server-side API endpoints |
+| `getRemoteClusterConnections` | `data_source_management/public` | Fetches remote cluster list |
+| `getRemoteClusterIndices` | `data/public` | Fetches indices from remote clusters |
+| Cross-Cluster UI Components | Multiple plugins | UI elements for displaying remote connections |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Remote cluster configuration | Configured at OpenSearch level via `/_cluster/settings` | N/A |
+| `data_source.enabled` | Must be enabled for MDS support | `false` |
+| `workspace.enabled` | Required for workspace CCS features | `false` |
+
+### API Endpoints
+
+| Endpoint | Method | Parameters | Description |
+|----------|--------|------------|-------------|
+| `/api/enhancements/remote_cluster/list` | GET | `dataSourceId` | Lists remote cluster connections |
+| `/api/enhancements/remote_cluster/indexes` | GET | `dataSourceId`, `connectionAlias` | Lists indices in a remote cluster |
+
+### Usage Example
+
+**Setting up Cross-Cluster Search:**
+
+1. Configure remote cluster connections in OpenSearch:
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.remote": {
+      "remote-cluster-alias": {
+        "seeds": ["remote-host:9300"]
+      }
+    }
+  }
+}
+```
+
+2. In OpenSearch Dashboards, navigate to Data Sources
+3. Data sources with remote connections display an expand arrow
+4. Click to view connected remote clusters
+
+**Creating an Index Pattern with Remote Indices:**
+
+1. Navigate to Index Patterns → Create index pattern
+2. Select a data source with remote connections
+3. Remote indices appear as `cluster_alias:index_name`
+4. Enter pattern like `remote-cluster:logs-*` to match remote indices
+
+**Querying Remote Data:**
+
+```sql
+-- Note: SQL has limited support for CCS
+SELECT * FROM "remote-cluster:logs-2024.01.*" LIMIT 10
+```
+
+```
+-- PPL query (limited support)
+source = remote-cluster:logs-2024.01.01 | head 10
+```
+
+## Limitations
+
+- **SQL Support**: SQL queries are not supported for cross-cluster indexes/index patterns
+- **PPL Support**: PPL queries only work for remote indexes that have their mapping stored in the local cluster
+- **Authentication**: Remote cluster authentication must be configured at the OpenSearch cluster level
+- **Network Requirements**: Local cluster must have network access to remote clusters on transport port (default 9300)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#9566](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9566) | Show cross cluster connections in Data Sources and Workspaces page |
+| v3.0.0 | [#9660](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9660) | Show cross cluster connections in Index Pattern and Discover Page |
+
+## References
+
+- [Issue #9578](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9578): Original enhancement request
+- [Cross-cluster search documentation](https://docs.opensearch.org/3.0/search-plugins/cross-cluster-search/): Official OpenSearch CCS documentation
+- [Cross-cluster replication intro blog](https://opensearch.org/blog/cross-cluster-replication-intro/): Related blog post on cross-cluster features
+
+## Change History
+
+- **v3.0.0** (2025-04): Initial implementation of Cross-Cluster Search UI support in OpenSearch Dashboards

--- a/docs/releases/v3.0.0/features/opensearch-dashboards/cross-cluster-search.md
+++ b/docs/releases/v3.0.0/features/opensearch-dashboards/cross-cluster-search.md
@@ -1,0 +1,114 @@
+# Cross-Cluster Search Support in OpenSearch Dashboards
+
+## Summary
+
+OpenSearch Dashboards v3.0.0 introduces native UI support for Cross-Cluster Search (CCS), enabling users to discover, view, and query data across multiple OpenSearch clusters directly from the Dashboards interface. Previously, while CCS was available via APIs since OpenSearch 1.0, there was no way to visualize or interact with remote cluster connections through the UI.
+
+## Details
+
+### What's New in v3.0.0
+
+This release adds comprehensive Cross-Cluster Search support across multiple Dashboards pages:
+
+1. **Data Sources Page**: Displays remote cluster connections as expandable rows under parent data sources
+2. **Workspaces Page**: Shows cross-cluster connections when associating data sources with workspaces
+3. **Index Pattern Creation**: Lists remote indices alongside local indices with visual indicators
+4. **Discover Page**: Enables querying of remote cluster indices through the dataset selector
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        UI[UI Components]
+        API[Server Routes]
+        DS[Data Source Plugin]
+    end
+    
+    subgraph "OpenSearch Cluster"
+        Local[Local Cluster]
+        Remote1[Remote Cluster 1]
+        Remote2[Remote Cluster 2]
+    end
+    
+    UI --> API
+    API --> DS
+    DS --> Local
+    Local -->|"/_remote/info"| Remote1
+    Local -->|"/_resolve/index"| Remote2
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `DataSourceEngineType.OpenSearchCrossCluster` | New engine type for cross-cluster connections |
+| Remote Cluster Routes | Server-side API endpoints for listing remote clusters and indices |
+| Cross-Cluster Connection UI | Expandable table rows showing remote connections |
+| Dataset Explorer Enhancements | Support for remote indices in dataset selection |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| N/A | Feature is enabled by default when remote clusters are configured | - |
+
+#### API Changes
+
+New server-side routes added to `query_enhancements` plugin:
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/enhancements/remote_cluster/list` | GET | Lists remote cluster connections for a data source |
+| `/api/enhancements/remote_cluster/indexes` | GET | Lists indices available in a remote cluster |
+
+### Usage Example
+
+**Viewing Cross-Cluster Connections in Data Sources:**
+
+1. Navigate to Data Sources management page
+2. Data sources with remote connections show an expand arrow
+3. Click to expand and view connected remote clusters
+
+**Creating Index Patterns with Remote Indices:**
+
+1. Go to Index Patterns → Create index pattern
+2. Select a data source with remote connections
+3. Remote indices appear with `cluster_alias:index_name` format
+4. Select remote indices to include in the pattern
+
+**Querying Remote Data in Discover:**
+
+1. Open Discover page
+2. In dataset selector, data sources with remote connections show an info icon
+3. Remote indices are listed under the parent data source
+4. Select a remote index to query data from the remote cluster
+
+### Migration Notes
+
+- No migration required - feature is automatically available when remote clusters are configured
+- Existing cross-cluster search configurations via `/_remote/info` API are automatically detected
+
+## Limitations
+
+- **SQL queries**: Not supported for cross-cluster indexes/index patterns
+- **PPL queries**: Limited support - only works for remote indexes that have their mapping stored in the local cluster
+- **Authentication**: Remote cluster authentication must be configured at the OpenSearch level
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9566](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9566) | Show cross cluster connections in Data Sources and Workspaces page |
+| [#9660](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9660) | Show cross cluster connections in Index Pattern and Discover Page |
+
+## References
+
+- [Issue #9578](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9578): Enhancement request for Cross-Cluster Search support
+- [Cross-cluster search documentation](https://docs.opensearch.org/3.0/search-plugins/cross-cluster-search/): Official OpenSearch CCS documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/cross-cluster-search.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -32,6 +32,7 @@
 ## opensearch-dashboards
 
 - [CI/CD & Build Fixes](features/opensearch-dashboards/ci-cd-build-fixes.md)
+- [Cross-Cluster Search](features/opensearch-dashboards/cross-cluster-search.md)
 - [Dashboards CI/CD & Documentation](features/opensearch-dashboards/dashboards-ci-cd-documentation.md)
 - [Dashboards Cypress Testing](features/opensearch-dashboards/dashboards-cypress-testing.md)
 - [Dashboards Dependencies](features/opensearch-dashboards/dashboards-dependencies.md)


### PR DESCRIPTION
## Summary

Add documentation for Cross-Cluster Search support in OpenSearch Dashboards v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch-dashboards/cross-cluster-search.md`
- Feature report: `docs/features/opensearch-dashboards/cross-cluster-search.md`

### Key Changes in v3.0.0
- Native UI support for Cross-Cluster Search in OpenSearch Dashboards
- Data Sources page shows remote cluster connections as expandable rows
- Workspaces page displays cross-cluster connections when associating data sources
- Index Pattern creation lists remote indices alongside local indices
- Discover page enables querying of remote cluster indices

### Related PRs
- opensearch-project/OpenSearch-Dashboards#9566: Show cross cluster connections in Data Sources and Workspaces page
- opensearch-project/OpenSearch-Dashboards#9660: Show cross cluster connections in Index Pattern and Discover Page

Closes #160