### PR TITLE
docs: add maps-geospatial report for v3.0.0

### DIFF
--- a/docs/features/dashboards-maps/maps-geospatial.md
+++ b/docs/features/dashboards-maps/maps-geospatial.md
@@ -1,0 +1,175 @@
+# Maps & Geospatial
+
+## Summary
+
+OpenSearch Dashboards Maps is a visualization plugin that enables users to create interactive map visualizations with multiple layers. It supports various layer types including base maps, document layers, custom maps, and cluster layers. The plugin integrates with OpenSearch's geospatial capabilities to visualize geo_point and geo_shape data on maps powered by MapLibre GL.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        Maps[Maps Plugin]
+        UI[Layer Control Panel]
+        Config[Layer Configuration]
+    end
+    
+    subgraph "Layer Types"
+        Base[Base Layers]
+        Doc[Document Layer]
+        Custom[Custom Map Layer]
+        Cluster[Cluster Layer]
+    end
+    
+    subgraph "Data Sources"
+        Index[Index Patterns]
+        WMS[WMS/TMS Services]
+        OSM[OpenSearch Map Service]
+    end
+    
+    subgraph "Rendering"
+        MapLibre[MapLibre GL]
+        Legend[Legend Component]
+        Tooltip[Tooltip Component]
+    end
+    
+    Maps --> UI
+    UI --> Config
+    Config --> Base
+    Config --> Doc
+    Config --> Custom
+    Config --> Cluster
+    
+    Base --> OSM
+    Base --> WMS
+    Doc --> Index
+    Cluster --> Index
+    
+    Doc --> MapLibre
+    Cluster --> MapLibre
+    Cluster --> Legend
+    Doc --> Tooltip
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[User Interaction] --> B[Layer Config]
+    B --> C[Query Builder]
+    C --> D[OpenSearch Search API]
+    D --> E[Response Processing]
+    E --> F[GeoJSON Conversion]
+    F --> G[MapLibre Rendering]
+    G --> H[Map Display]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `MapContainer` | Main container component managing map state and layers |
+| `LayerControlPanel` | UI panel for managing map layers |
+| `AddLayerPanel` | Dialog for adding new layers |
+| `LayerConfigPanel` | Configuration panel for layer settings |
+| `DocumentLayerFunctions` | Rendering logic for document layers |
+| `ClusterLayerFunctions` | Rendering logic for cluster layers |
+| `OSMLayerFunctions` | Rendering logic for OpenSearch Map base layers |
+| `CustomLayerFunctions` | Rendering logic for custom WMS/TMS layers |
+| `MapsLegend` | Legend component for cluster layer gradients |
+
+### Layer Types
+
+#### Base Layers
+- **OpenSearch Map**: Default vector tile basemap
+- **Custom Map**: WMS or TMS custom map sources
+
+#### Data Layers
+- **Documents**: Visualize individual geo_point/geo_shape documents
+- **Cluster**: Aggregate documents using geospatial bucket aggregations
+
+### Cluster Layer Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `source.indexPatternId` | Index pattern for data source | Required |
+| `source.cluster.agg` | Aggregation type (geohash_grid, geotile_grid, geohex_grid) | `geohash_grid` |
+| `source.cluster.field` | Geospatial field name | Required |
+| `source.cluster.precision` | Aggregation precision | `2` |
+| `source.cluster.changePrecision` | Auto-adjust precision on zoom | `false` |
+| `source.cluster.useCentroid` | Use geocentroid for placement | `false` |
+| `source.metric.agg` | Metric aggregation (count, avg, sum, max, min) | `count` |
+| `source.metric.field` | Field for metric aggregation | - |
+| `source.filters` | Layer-level filters | `[]` |
+| `source.useGeoBoundingBoxFilter` | Filter by map extent | `false` |
+| `source.applyGlobalFilters` | Apply dashboard global filters | `true` |
+| `style.fillType` | Fill type (solid, gradient) | `gradient` |
+| `style.fillColor` | Solid fill color | `#ff0000` |
+| `style.palette` | Gradient color palette | `blue` |
+| `style.borderColor` | Border color | `#000000` |
+| `style.borderThickness` | Border thickness (0-100px) | `1` |
+
+### Supported Aggregations
+
+#### Cluster Aggregations
+| Type | Field Types | Precision Range |
+|------|-------------|-----------------|
+| Geohash Grid | geo_point, geo_shape | 1-12 |
+| Geotile Grid | geo_point, geo_shape | 0-29 |
+| Geohex Grid | geo_point only | 0-15 |
+
+#### Metric Aggregations
+| Type | Field Types |
+|------|-------------|
+| Count | Any |
+| Average | number |
+| Sum | number |
+| Max | number, date |
+| Min | number, date |
+
+### Usage Example
+
+```yaml
+# Adding a cluster layer to visualize flight destinations
+1. Navigate to Maps visualization
+2. Click "Add layer" > "Data layer" > "Cluster"
+3. Configure Data tab:
+   - Index pattern: opensearch_dashboards_sample_data_flights
+   - Geoaggregation type: Geohash
+   - Geospatial field: DestLocation
+   - Metric: Count
+4. Configure Style tab:
+   - Fill color: Gradient
+   - Palette: Blue
+5. Click "Update"
+```
+
+## Limitations
+
+- Geohex grid aggregation only supports `geo_point` fields
+- Geocentroid option unavailable for `geo_shape` fields
+- Maximum 10,000 documents per document layer
+- Border thickness limited to 0-100px
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#703](https://github.com/opensearch-project/dashboards-maps/pull/703) | Introduce cluster layer |
+| v3.0.0 | [#704](https://github.com/opensearch-project/dashboards-maps/pull/704) | Fix layer config panel background |
+| v3.0.0 | [#718](https://github.com/opensearch-project/dashboards-maps/pull/718) | Fix data label overlap |
+
+## References
+
+- [Issue #250](https://github.com/opensearch-project/dashboards-maps/issues/250): Cluster layer feature request
+- [Using Maps](https://docs.opensearch.org/3.0/dashboards/visualize/maps/): Official documentation
+- [Geohash Grid](https://docs.opensearch.org/3.0/aggregations/bucket/geohash-grid/): Geohash aggregation docs
+- [Geotile Grid](https://docs.opensearch.org/3.0/aggregations/bucket/geotile-grid/): Geotile aggregation docs
+- [Geohex Grid](https://docs.opensearch.org/3.0/aggregations/bucket/geohex-grid/): Geohex aggregation docs
+- [Getting started with multilayer maps](https://opensearch.org/blog/multilayer-maps/): Blog post
+
+## Change History
+
+- **v3.0.0** (2025-05): Added Cluster Layer with geohash/geotile/geohex aggregations, legend support, and multi-data source support. Fixed layer config panel styling and data label overlap issues.

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -91,3 +91,7 @@
 ## observability
 
 - [Observability Integrations](observability/observability-integrations.md)
+
+## dashboards-maps
+
+- [Maps & Geospatial](dashboards-maps/maps-geospatial.md)

--- a/docs/releases/v3.0.0/features/dashboards-maps/maps-geospatial.md
+++ b/docs/releases/v3.0.0/features/dashboards-maps/maps-geospatial.md
@@ -1,0 +1,161 @@
+# Maps & Geospatial
+
+## Summary
+
+OpenSearch Dashboards Maps v3.0.0 introduces the **Cluster Layer**, a new data layer type that groups geospatial documents into clusters using bucket aggregations. This feature enables users to visualize large datasets more effectively by showing data density rather than individual points. The release also includes bug fixes for layer configuration panel styling and data label overlap issues.
+
+## Details
+
+### What's New in v3.0.0
+
+#### Cluster Layer Feature
+
+The Cluster Layer is a new layer type in OpenSearch Dashboards Maps that aggregates geospatial data points into clusters based on proximity. This addresses the challenge of visualizing large datasets where individual points would overlap and become indistinguishable.
+
+Key capabilities:
+- **Geospatial Aggregation Types**: Supports three aggregation methods:
+  - Geohash grid (precision 1-12)
+  - Geotile grid (precision 0-29)
+  - Geohex grid (precision 0-15, using H3 library)
+- **Metric Aggregations**: Count, Average, Sum, Max, Min
+- **Dynamic Precision**: Option to change precision based on map zoom level
+- **Geocentroid Support**: Place markers at the centroid of clustered points
+- **Multi-data Source Support**: Works with multiple data sources
+- **Legend Integration**: Dynamic legend showing value ranges with gradient colors
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Maps Plugin"
+        UI[Layer Control Panel]
+        Config[Cluster Layer Config]
+        Render[Cluster Layer Functions]
+    end
+    
+    subgraph "Data Flow"
+        Index[Index Pattern]
+        Agg[Aggregation Builder]
+        Search[Search API]
+    end
+    
+    subgraph "Visualization"
+        MapLibre[MapLibre GL]
+        Legend[Legend Component]
+        Circle[Circle Layer]
+        Symbol[Symbol Layer]
+    end
+    
+    UI --> Config
+    Config --> Agg
+    Agg --> Search
+    Search --> Index
+    Search --> Render
+    Render --> Circle
+    Render --> Symbol
+    Render --> Legend
+    Circle --> MapLibre
+    Symbol --> MapLibre
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ClusterLayerFunctions` | Core rendering logic for cluster layers |
+| `ClusterLayerConfigPanel` | Configuration UI with Data, Style, and Settings tabs |
+| `ClusterLayerSource` | Data source configuration including index pattern, cluster, metric, and filter sections |
+| `ClusterLayerStyle` | Style configuration for fill color, border, and gradient palettes |
+| `MapsLegend` | Legend component showing color ranges for gradient fills |
+| `buildAgg` | Aggregation query builder for cluster layers |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.agg` | Geoaggregation type (geohash_grid, geotile_grid, geohex_grid) | `geohash_grid` |
+| `cluster.precision` | Aggregation precision level | `2` |
+| `cluster.changePrecision` | Auto-adjust precision on zoom | `false` |
+| `cluster.useCentroid` | Use geocentroid for marker placement | `false` |
+| `metric.agg` | Metric aggregation type | `count` |
+| `style.fillType` | Fill type (solid, gradient) | `gradient` |
+| `style.palette` | Color palette for gradient | `blue` |
+
+### Usage Example
+
+To add a Cluster Layer:
+
+1. Open Maps visualization
+2. Click "Add layer" → "Data layer" → "Cluster"
+3. Configure the Data tab:
+   - Select an index pattern
+   - Choose geoaggregation type and geospatial field
+   - Configure metric aggregation
+4. Configure the Style tab:
+   - Choose fill type (solid or gradient)
+   - Select color palette
+   - Set border color and thickness
+5. Click "Update" to apply
+
+```json
+// Example cluster layer configuration
+{
+  "type": "cluster",
+  "source": {
+    "indexPatternId": "flights-*",
+    "cluster": {
+      "agg": "geohash_grid",
+      "field": "DestLocation",
+      "precision": 5,
+      "changePrecision": true,
+      "useCentroid": true
+    },
+    "metric": {
+      "agg": "count"
+    }
+  },
+  "style": {
+    "fillType": "gradient",
+    "palette": "blue",
+    "borderColor": "#000000",
+    "borderThickness": 1
+  }
+}
+```
+
+### Bug Fixes
+
+#### Layer Config Panel Background Color (#704)
+Fixed inconsistent grey background in document layer configuration panels caused by EuiCollapsibleNavGroup's default styling. Added CSS override to make backgrounds transparent.
+
+#### Data Label Overlap (#718)
+Fixed overlapping data labels on map layers introduced in #703. Reverted the `text-allow-overlap` setting to prevent label collision when displaying many documents.
+
+## Limitations
+
+- Geohex grid aggregation only supports `geo_point` fields (not `geo_shape`)
+- Geocentroid option is disabled for `geo_shape` field types
+- Maximum border thickness is 100px
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#703](https://github.com/opensearch-project/dashboards-maps/pull/703) | Introduce cluster layer in maps-dashboards |
+| [#704](https://github.com/opensearch-project/dashboards-maps/pull/704) | Fix layer config panel background color inconsistency |
+| [#718](https://github.com/opensearch-project/dashboards-maps/pull/718) | Fix overlapping data labels on map layer |
+| [#423](https://github.com/opensearch-project/dashboards-maps/pull/423) | Original cluster layer contribution (superseded by #703) |
+
+## References
+
+- [Issue #250](https://github.com/opensearch-project/dashboards-maps/issues/250): Feature request for cluster layer
+- [Using Maps Documentation](https://docs.opensearch.org/3.0/dashboards/visualize/maps/): Official maps documentation
+- [Geohash Grid Aggregation](https://docs.opensearch.org/3.0/aggregations/bucket/geohash-grid/): Geohash aggregation reference
+- [Geotile Grid Aggregation](https://docs.opensearch.org/3.0/aggregations/bucket/geotile-grid/): Geotile aggregation reference
+- [Geohex Grid Aggregation](https://docs.opensearch.org/3.0/aggregations/bucket/geohex-grid/): Geohex aggregation reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/dashboards-maps/maps-geospatial.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -94,3 +94,7 @@
 ## observability
 
 - [Observability Integrations](features/observability/observability-integrations.md)
+
+## dashboards-maps
+
+- [Maps & Geospatial](features/dashboards-maps/maps-geospatial.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Maps & Geospatial feature in OpenSearch Dashboards v3.0.0.

### Key Changes in v3.0.0

- **Cluster Layer**: New data layer type that groups geospatial documents into clusters using bucket aggregations (geohash_grid, geotile_grid, geohex_grid)
- **Legend Support**: Dynamic legend showing value ranges with gradient colors
- **Multi-data Source Support**: Works with multiple data sources
- **Bug Fixes**: Fixed layer config panel background color and data label overlap issues

### Reports Created

- Release report: `docs/releases/v3.0.0/features/dashboards-maps/maps-geospatial.md`
- Feature report: `docs/features/dashboards-maps/maps-geospatial.md`

### Related PRs

- [#703](https://github.com/opensearch-project/dashboards-maps/pull/703): Introduce cluster layer
- [#704](https://github.com/opensearch-project/dashboards-maps/pull/704): Fix layer config panel background
- [#718](https://github.com/opensearch-project/dashboards-maps/pull/718): Fix data label overlap

Closes #159