### PR TITLE
docs: add Custom Codecs & Libraries report for v3.0.0

### DIFF
--- a/docs/features/custom-codecs/custom-codecs.md
+++ b/docs/features/custom-codecs/custom-codecs.md
@@ -1,0 +1,188 @@
+# Custom Codecs
+
+## Summary
+
+The Custom Codecs plugin provides custom Lucene codecs for OpenSearch, enabling users to customize the on-disk representation of indexes. It supports advanced compression algorithms including ZSTD (Zstandard) and hardware-accelerated compression via Intel QAT (Quick Assist Technology). These codecs offer better compression ratios and improved performance compared to the default LZ4 codec.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Index"
+        Index[Index Creation]
+        Settings[Index Settings]
+    end
+    
+    subgraph "Custom Codecs Plugin"
+        CodecService[Codec Service]
+        ZstdCodec[ZSTD Codec]
+        ZstdNoDictCodec[ZSTD No Dict Codec]
+        QatLz4[QAT LZ4 Codec]
+        QatDeflate[QAT DEFLATE Codec]
+    end
+    
+    subgraph "Compression Libraries"
+        ZstdJni[zstd-jni]
+        QatJava[qat-java]
+    end
+    
+    subgraph "Hardware"
+        IntelQAT[Intel QAT Accelerator]
+    end
+    
+    Index --> Settings
+    Settings --> CodecService
+    CodecService --> ZstdCodec
+    CodecService --> ZstdNoDictCodec
+    CodecService --> QatLz4
+    CodecService --> QatDeflate
+    
+    ZstdCodec --> ZstdJni
+    ZstdNoDictCodec --> ZstdJni
+    QatLz4 --> QatJava
+    QatDeflate --> QatJava
+    QatJava --> IntelQAT
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Write Path"
+        Doc[Document] --> Indexer[Indexer]
+        Indexer --> Codec[Selected Codec]
+        Codec --> Compress[Compression]
+        Compress --> Segment[Lucene Segment]
+    end
+    
+    subgraph "Read Path"
+        Query[Query] --> Search[Search]
+        Search --> Decompress[Decompression]
+        Decompress --> StoredFields[Stored Fields]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ZstdCodec` | ZSTD compression with dictionary support |
+| `ZstdNoDictCodec` | ZSTD compression without dictionary (faster) |
+| `Lucene99QatCodec` | Base codec for QAT hardware acceleration |
+| `QatLz4Codec` | Hardware-accelerated LZ4 compression |
+| `QatDeflateCodec` | Hardware-accelerated DEFLATE compression |
+
+### Supported Codecs
+
+| Codec | Algorithm | Dictionary | Hardware Accel | Introduced |
+|-------|-----------|------------|----------------|------------|
+| `zstd` | Zstandard | Yes | No | 2.9.0 |
+| `zstd_no_dict` | Zstandard | No | No | 2.9.0 |
+| `qat_lz4` | LZ4 | N/A | Yes (Intel QAT) | 2.15.0 |
+| `qat_deflate` | DEFLATE | N/A | Yes (Intel QAT) | 2.15.0 |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.codec` | Compression codec to use | `default` (LZ4) |
+| `index.codec.compression_level` | Compression level (1-6) | 3 |
+| `index.codec.qatmode` | QAT mode: `auto` or `hardware` | `auto` |
+
+### Usage Example
+
+#### ZSTD Codec
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "codec": "zstd",
+      "codec.compression_level": 3
+    }
+  }
+}
+```
+
+#### ZSTD No Dictionary Codec
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "codec": "zstd_no_dict",
+      "codec.compression_level": 4
+    }
+  }
+}
+```
+
+#### QAT Hardware-Accelerated Codec
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "codec": "qat_lz4",
+      "codec.compression_level": 1,
+      "codec.qatmode": "auto"
+    }
+  }
+}
+```
+
+### Performance Comparison
+
+Benchmark results comparing codecs against the default LZ4 codec (using `nyc_taxi` dataset):
+
+| Metric | `best_compression` | `zstd` | `zstd_no_dict` |
+|--------|-------------------|--------|----------------|
+| Write Median Latency | 0% | 0% | -1% |
+| Write p90 Latency | +3% | +2% | -5% |
+| Write Throughput | -2% | +7% | +14% |
+| Read Median Latency | 0% | +1% | 0% |
+| Read p90 Latency | +1% | +1% | -2% |
+| Compression Ratio | -34% | -35% | -30% |
+
+*Negative percentages indicate improvement (smaller size or lower latency)*
+
+### Dependencies
+
+| Library | Version | Purpose |
+|---------|---------|---------|
+| `com.github.luben:zstd-jni` | 1.5.6-1 | ZSTD compression via JNI |
+| `com.intel.qat:qat-java` | 1.1.1 | Intel QAT hardware acceleration |
+
+## Limitations
+
+- ZSTD codecs (`zstd` and `zstd_no_dict`) cannot be used for k-NN or Security Analytics indexes
+- Compression levels are limited to range [1, 6] for ZSTD codecs
+- QAT hardware acceleration requires Intel 4th/5th Gen Xeon processors with Linux kernel 3.10+
+- Changing codec on an existing index requires closing the index or reindexing
+- QAT `hardware` mode requires hardware availability; use `auto` for fallback to software
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#232](https://github.com/opensearch-project/custom-codecs/pull/232) | Bump ZTD lib version to 1.5.6-1 |
+
+## References
+
+- [Custom Codecs Repository](https://github.com/opensearch-project/custom-codecs): Source code
+- [Index Codecs Documentation](https://docs.opensearch.org/3.0/im-plugin/index-codecs/): Official documentation
+- [ZSTD GitHub](https://github.com/facebook/zstd): Zstandard compression algorithm
+- [zstd-jni](https://github.com/luben/zstd-jni): JNI bindings for ZSTD
+- [Intel QAT Overview](https://www.intel.com/content/www/us/en/developer/topic-technology/open/quick-assist-technology/overview.html): Hardware acceleration
+- [OpenSearch 2.9.0 Blog](https://opensearch.org/blog/introducing-opensearch-2-9-0/): ZSTD codec introduction
+
+## Change History
+
+- **v3.0.0** (2025-05): Bumped zstd-jni to 1.5.6-1, adding support for custom sequence producers
+- **v2.15.0** (2024): Added QAT hardware-accelerated codecs (`qat_lz4`, `qat_deflate`)
+- **v2.9.0** (2023): Initial implementation of ZSTD codecs (`zstd`, `zstd_no_dict`)

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -95,3 +95,7 @@
 ## dashboards-maps
 
 - [Maps & Geospatial](dashboards-maps/maps-geospatial.md)
+
+## custom-codecs
+
+- [Custom Codecs](custom-codecs/custom-codecs.md)

--- a/docs/releases/v3.0.0/features/custom-codecs/zstd-library-bump.md
+++ b/docs/releases/v3.0.0/features/custom-codecs/zstd-library-bump.md
@@ -1,0 +1,103 @@
+# ZSTD Library Version Bump
+
+## Summary
+
+This release item updates the ZSTD (Zstandard) compression library in the custom-codecs plugin from version 1.5.5-5 to 1.5.6-1. This upgrade adds support for custom sequence producers, enabling future QAT-accelerated ZSTD compression alongside existing `qat_deflate` and `qat_lz4` codecs.
+
+## Details
+
+### What's New in v3.0.0
+
+The custom-codecs plugin now uses zstd-jni version 1.5.6-1, which includes:
+
+- Support for custom sequence producers
+- Foundation for QAT-accelerated ZSTD compression
+- Compatibility with OpenSearch 3.0.0-beta1
+
+### Technical Changes
+
+#### Dependency Update
+
+| Dependency | Previous Version | New Version |
+|------------|------------------|-------------|
+| `com.github.luben:zstd-jni` | 1.5.5-5 | 1.5.6-1 |
+
+#### Build Configuration Changes
+
+The `build.gradle` file was updated:
+
+```groovy
+dependencies {
+  api "com.github.luben:zstd-jni:1.5.6-1"
+  api "com.intel.qat:qat-java:1.1.1"
+}
+```
+
+#### Version Alignment
+
+The plugin version was also aligned with OpenSearch 3.0.0-beta1:
+
+| Setting | Previous | New |
+|---------|----------|-----|
+| `opensearch_version` | 3.0.0-alpha1-SNAPSHOT | 3.0.0-beta1-SNAPSHOT |
+| `buildVersionQualifier` | alpha1 | beta1 |
+
+### Custom Sequence Producers
+
+The ZSTD 1.5.6 release introduces support for custom sequence producers, which is a key feature for hardware acceleration. This enables:
+
+1. **QAT-accelerated ZSTD**: Future support for Intel QAT hardware acceleration for ZSTD compression
+2. **Flexible compression pipelines**: Custom sequence producers allow external hardware or software to generate compression sequences
+3. **Performance optimization**: Hardware offloading of compression workloads
+
+### Usage Example
+
+The ZSTD codecs can be used when creating an index:
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "codec": "zstd",
+      "codec.compression_level": 3
+    }
+  }
+}
+```
+
+Or with the no-dictionary variant:
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "codec": "zstd_no_dict"
+    }
+  }
+}
+```
+
+## Limitations
+
+- ZSTD codecs (`zstd` and `zstd_no_dict`) cannot be used for k-NN or Security Analytics indexes
+- QAT-accelerated ZSTD is not yet available in this release (foundation only)
+- Compression levels are limited to range [1, 6]
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#232](https://github.com/opensearch-project/custom-codecs/pull/232) | Bump ZTD lib version to 1.5.6-1 |
+
+## References
+
+- [ZSTD GitHub Repository](https://github.com/facebook/zstd): Zstandard compression algorithm
+- [zstd-jni](https://github.com/luben/zstd-jni): JNI bindings for ZSTD
+- [Index Codecs Documentation](https://docs.opensearch.org/3.0/im-plugin/index-codecs/): Official OpenSearch documentation
+- [Intel QAT Overview](https://www.intel.com/content/www/us/en/developer/topic-technology/open/quick-assist-technology/overview.html): Hardware acceleration information
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/custom-codecs/custom-codecs.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -98,3 +98,7 @@
 ## dashboards-maps
 
 - [Maps & Geospatial](features/dashboards-maps/maps-geospatial.md)
+
+## custom-codecs
+
+- [ZSTD Library Bump](features/custom-codecs/zstd-library-bump.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Custom Codecs & Libraries feature in OpenSearch v3.0.0.

### Changes

- **Release Report**: `docs/releases/v3.0.0/features/custom-codecs/zstd-library-bump.md`
  - Documents the ZSTD library version bump from 1.5.5-5 to 1.5.6-1
  - Explains the new custom sequence producer support for future QAT-accelerated ZSTD

- **Feature Report**: `docs/features/custom-codecs/custom-codecs.md`
  - Comprehensive documentation of the custom-codecs plugin
  - Architecture diagrams showing codec components and data flow
  - Configuration options and usage examples
  - Performance comparison benchmarks
  - Change history tracking

### Key Changes in v3.0.0

- Bumped zstd-jni from 1.5.5-5 to 1.5.6-1
- Added support for custom sequence producers (foundation for QAT-accelerated ZSTD)
- Version alignment with OpenSearch 3.0.0-beta1

### Related Issue

Closes #158