### PR TITLE
docs: add AI Assistant / Chatbot report for v3.0.0

### DIFF
--- a/docs/features/dashboards-assistant/ai-assistant-chatbot.md
+++ b/docs/features/dashboards-assistant/ai-assistant-chatbot.md
@@ -1,0 +1,142 @@
+# AI Assistant / Chatbot
+
+## Summary
+
+The OpenSearch AI Assistant (Chatbot) is an AI-powered conversational interface integrated into OpenSearch Dashboards. It enables users to interact with their data through natural language, generate visualizations from text descriptions, receive alert insights, and get data summaries without requiring specialized query skills. The assistant leverages ML Commons agents and tools to provide intelligent responses.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        Entry[Entry Point Button]
+        ChatUI[Chat Interface]
+        T2V[Text-to-Visualization]
+        AlertInsight[Alert Insights]
+        DataSummary[Data Summary]
+    end
+    
+    subgraph "Backend"
+        Router[Request Router]
+        Stream[Streaming Handler]
+        Memory[Conversation Memory]
+    end
+    
+    subgraph "ML Commons"
+        RootAgent[Root Chat Agent]
+        Tools[Agent Tools]
+        Models[ML Models]
+    end
+    
+    Entry --> ChatUI
+    ChatUI --> Router
+    Router --> Stream
+    Stream --> RootAgent
+    RootAgent --> Tools
+    Tools --> Models
+    ChatUI --> Memory
+    T2V --> RootAgent
+    AlertInsight --> RootAgent
+    DataSummary --> RootAgent
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    User[User Input] --> UI[Chat UI]
+    UI --> API[Backend API]
+    API --> Agent[ML Agent]
+    Agent --> LLM[LLM Model]
+    LLM --> Stream[Streaming Response]
+    Stream --> UI
+    UI --> Display[Display Response]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Chat Interface | Main conversational UI with message history and input |
+| Entry Point Button | Single button in header for accessing the chatbot |
+| Streaming Handler | Processes real-time response chunks for smooth UX |
+| Conversation Memory | Stores and retrieves conversation history |
+| Text-to-Visualization | Generates visualizations from natural language |
+| Alert Insights | Provides AI-generated insights for alerts |
+| Data Summary | Generates summaries of data patterns |
+| Auto Aggregation | Suggests appropriate aggregations for visualizations |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `assistant.chat.enabled` | Enable/disable the chatbot feature | `false` |
+| `assistant.next.enabled` | Enable experimental features (text-to-viz) | `false` |
+
+### Usage Example
+
+1. Enable the assistant in `opensearch_dashboards.yml`:
+
+```yaml
+assistant.chat.enabled: true
+assistant.next.enabled: true
+```
+
+2. Configure the root agent via API:
+
+```json
+PUT .plugins-ml-config/_doc/os_chat
+{
+    "type": "os_chat_root_agent",
+    "configuration": {
+        "agent_id": "your_root_agent_id"
+    }
+}
+```
+
+3. Access the chatbot via the button in the OpenSearch Dashboards header.
+
+### Key Features
+
+- **Natural Language Interaction**: Ask questions in plain English
+- **Streaming Responses**: Real-time response display for better UX
+- **Conversation History**: Resume previous conversations
+- **Text-to-Visualization**: Generate charts from text descriptions
+- **Alert Insights**: AI-powered alert analysis
+- **Data Summaries**: Automatic data pattern summaries
+- **Notebook Integration**: Save conversations to Notebooks
+
+## Limitations
+
+- Requires ML Commons plugin with configured agents and models
+- Streaming output requires compatible backend support
+- Text-to-visualization requires PPL queries with aggregations
+- Response quality depends on the underlying LLM model
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#398](https://github.com/opensearch-project/dashboards-assistant/pull/398) | Expose chatEnabled flag to capabilities |
+| v3.0.0 | [#435](https://github.com/opensearch-project/dashboards-assistant/pull/435) | Update chatbot UI to align with new look |
+| v3.0.0 | [#493](https://github.com/opensearch-project/dashboards-assistant/pull/493) | Support streaming output |
+| v3.0.0 | [#505](https://github.com/opensearch-project/dashboards-assistant/pull/505) | Generate visualization on t2v page mount |
+| v3.0.0 | [#514](https://github.com/opensearch-project/dashboards-assistant/pull/514) | Add auto aggregation suggest for t2v |
+| v3.0.0 | [#540](https://github.com/opensearch-project/dashboards-assistant/pull/540) | Change chatbot entry point to single button |
+
+## References
+
+- [OpenSearch Assistant Documentation](https://docs.opensearch.org/3.0/dashboards/dashboards-assistant/index/)
+- [Build Your Own Chatbot Tutorial](https://docs.opensearch.org/3.0/tutorials/gen-ai/chatbots/build-chatbot/)
+- [OpenSearch Assistant Toolkit](https://docs.opensearch.org/3.0/ml-commons-plugin/opensearch-assistant/)
+- [Alert Insights](https://docs.opensearch.org/3.0/dashboards/dashboards-assistant/alert-insight/)
+- [Data Summary](https://docs.opensearch.org/3.0/dashboards/dashboards-assistant/data-summary/)
+- [Text to Visualization](https://docs.opensearch.org/3.0/dashboards/dashboards-assistant/text-to-visualization/)
+- [dashboards-assistant Repository](https://github.com/opensearch-project/dashboards-assistant)
+
+## Change History
+
+- **v3.0.0** (2025): Major UI redesign, streaming output support, single button entry point, text-to-visualization enhancements with auto-aggregation, conversation auto-loading
+- **v2.13** (2024): Initial introduction of OpenSearch Assistant for OpenSearch Dashboards

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -104,3 +104,7 @@
 ## cross-cluster-replication
 
 - [Cross-Cluster Replication](cross-cluster-replication/cross-cluster-replication.md)
+
+## dashboards-assistant
+
+- [AI Assistant / Chatbot](dashboards-assistant/ai-assistant-chatbot.md)

--- a/docs/releases/v3.0.0/features/dashboards-assistant/ai-assistant-chatbot.md
+++ b/docs/releases/v3.0.0/features/dashboards-assistant/ai-assistant-chatbot.md
@@ -1,0 +1,121 @@
+# AI Assistant / Chatbot
+
+## Summary
+
+OpenSearch Dashboards v3.0.0 introduces significant enhancements to the AI Assistant (Chatbot) feature, including a redesigned UI, streaming output support, improved text-to-visualization capabilities, and a simplified single-button entry point. These changes improve the user experience for interacting with AI-powered assistants directly within OpenSearch Dashboards.
+
+## Details
+
+### What's New in v3.0.0
+
+The AI Assistant received major updates across UI/UX, functionality, and developer experience:
+
+1. **Redesigned Chatbot UI** - Updated visual design with edge-to-edge responses, new loading states, and primary color backgrounds
+2. **Streaming Output Support** - Real-time response streaming for improved perceived performance
+3. **Single Button Entry Point** - Simplified chatbot access with a unified button interface
+4. **Text-to-Visualization Enhancements** - Auto-generation on page mount, auto-suggested aggregations, and improved error handling
+5. **Conversation Management** - Auto-load last conversation, scroll-based conversation loading
+6. **Alert Summary Improvements** - Redesigned popover styling and positioning
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        UI[Chatbot UI]
+        Entry[Single Button Entry]
+        T2V[Text-to-Visualization]
+        Alert[Alert Summary]
+    end
+    
+    subgraph "Backend Services"
+        Stream[Streaming Handler]
+        Agent[ML Agent]
+        Conv[Conversation Store]
+    end
+    
+    Entry --> UI
+    UI --> Stream
+    Stream --> Agent
+    UI --> Conv
+    T2V --> Agent
+    Alert --> Agent
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| Streaming Output Handler | Processes real-time response chunks from ML agents |
+| Single Button Entry | Unified chatbot access point in the header |
+| Auto Aggregation Suggester | Automatically suggests aggregations for text-to-visualization |
+| Conversation Scroll Loader | Lazy-loads conversation history on scroll |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `assistant.chat.enabled` | Enable/disable the chatbot feature | `false` |
+| `assistant.next.enabled` | Enable experimental features like text-to-visualization | `false` |
+
+### Usage Example
+
+Enable the AI Assistant in `opensearch_dashboards.yml`:
+
+```yaml
+assistant.chat.enabled: true
+assistant.next.enabled: true
+```
+
+Configure the root agent:
+
+```json
+PUT .plugins-ml-config/_doc/os_chat
+{
+    "type": "os_chat_root_agent",
+    "configuration": {
+        "agent_id": "your_root_agent_id"
+    }
+}
+```
+
+### Migration Notes
+
+- The chatbot entry point has changed from multiple buttons to a single unified button
+- The `os_insight` agent has been removed; use `data2summary` agent instead
+- UI styling has been updated; custom CSS overrides may need adjustment
+
+## Limitations
+
+- Streaming output requires OpenSearch Dashboards PR #9647 for pure HTTP fetch response support
+- Text-to-visualization requires PPL queries with aggregations
+- The experimental badge has been removed from natural language visualization
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#398](https://github.com/opensearch-project/dashboards-assistant/pull/398) | Expose chatEnabled flag to capabilities |
+| [#435](https://github.com/opensearch-project/dashboards-assistant/pull/435) | Update chatbot UI to align with new look |
+| [#436](https://github.com/opensearch-project/dashboards-assistant/pull/436) | Add data to summary response post processing |
+| [#438](https://github.com/opensearch-project/dashboards-assistant/pull/438) | Add flag to control conversation list display |
+| [#439](https://github.com/opensearch-project/dashboards-assistant/pull/439) | Auto-load last conversation on chatbot open |
+| [#452](https://github.com/opensearch-project/dashboards-assistant/pull/452) | Remove os_insight agent |
+| [#485](https://github.com/opensearch-project/dashboards-assistant/pull/485) | Add error handling for chatbot loading |
+| [#493](https://github.com/opensearch-project/dashboards-assistant/pull/493) | Support streaming output |
+| [#505](https://github.com/opensearch-project/dashboards-assistant/pull/505) | Generate visualization on t2v page mount |
+| [#514](https://github.com/opensearch-project/dashboards-assistant/pull/514) | Add auto aggregation suggest for t2v |
+| [#540](https://github.com/opensearch-project/dashboards-assistant/pull/540) | Change chatbot entry point to single button |
+
+## References
+
+- [OpenSearch Assistant Documentation](https://docs.opensearch.org/3.0/dashboards/dashboards-assistant/index/)
+- [Build Your Own Chatbot Tutorial](https://docs.opensearch.org/3.0/tutorials/gen-ai/chatbots/build-chatbot/)
+- [OpenSearch Assistant Toolkit](https://docs.opensearch.org/3.0/ml-commons-plugin/opensearch-assistant/)
+- [Issue #387](https://github.com/opensearch-project/dashboards-assistant/issues/387): Streaming output feature request
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/dashboards-assistant/ai-assistant-chatbot.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -107,3 +107,7 @@
 ## cross-cluster-replication
 
 - [Cross-Cluster Replication (CCR)](features/cross-cluster-replication/cross-cluster-replication-ccr.md)
+
+## dashboards-assistant
+
+- [AI Assistant / Chatbot](features/dashboards-assistant/ai-assistant-chatbot.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the AI Assistant / Chatbot feature in OpenSearch Dashboards v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/dashboards-assistant/ai-assistant-chatbot.md`
- Feature report: `docs/features/dashboards-assistant/ai-assistant-chatbot.md`

### Key Changes in v3.0.0
- Redesigned chatbot UI with edge-to-edge responses and new loading states
- Streaming output support for real-time response display
- Single button entry point for simplified access
- Text-to-visualization enhancements with auto-aggregation suggestions
- Conversation auto-loading and scroll-based history loading
- Alert summary popover improvements

### Resources Used
- PRs: #398, #435, #436, #438, #439, #452, #485, #493, #505, #514, #540
- Docs: https://docs.opensearch.org/3.0/dashboards/dashboards-assistant/index/

Closes #155