### PR TITLE
docs: add SQL/PPL Engine report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -59,6 +59,7 @@
 
 ## sql
 
+- [SQL/PPL Engine](sql/sql-ppl-engine.md)
 - [SQL/PPL Breaking Changes](sql/sql-ppl-breaking-changes.md)
 
 ## asynchronous-search

--- a/docs/features/sql/sql-ppl-engine.md
+++ b/docs/features/sql/sql-ppl-engine.md
@@ -1,0 +1,201 @@
+# SQL/PPL Engine
+
+## Summary
+
+The OpenSearch SQL/PPL Engine provides SQL and Piped Processing Language (PPL) query interfaces for OpenSearch. Starting with v3.0.0, the plugin integrates Apache Calcite as a new query engine (V3) that enables advanced features like joins, lookups, and subsearches for complex log analysis and data correlation workflows.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "SQL/PPL Plugin"
+        Client[Client Request]
+        REST[REST Handler]
+        
+        subgraph "Query Parsing"
+            ANTLR[ANTLR4 Grammar]
+            AST[Abstract Syntax Tree]
+        end
+        
+        subgraph "Query Engines"
+            V1[V1 Legacy Engine]
+            V2[V2 Engine]
+            V3[V3 Calcite Engine]
+        end
+        
+        subgraph "Calcite Processing"
+            RelBuilder[RelBuilder]
+            RelNode[RelNode Tree]
+            Optimizer[Query Optimizer]
+            OSRel[OpenSearchEnumerableRel]
+        end
+        
+        subgraph "Execution"
+            Linq4j[Linq4j Code Gen]
+            QueryBuilder[OpenSearch QueryBuilder]
+            Pushdown[Filter Pushdown]
+        end
+        
+        OS[OpenSearch]
+    end
+    
+    Client --> REST
+    REST --> ANTLR
+    ANTLR --> AST
+    AST --> V1
+    AST --> V2
+    AST --> V3
+    V3 --> RelBuilder
+    RelBuilder --> RelNode
+    RelNode --> Optimizer
+    Optimizer --> OSRel
+    OSRel --> Linq4j
+    OSRel --> Pushdown
+    Pushdown --> QueryBuilder
+    Linq4j --> OS
+    QueryBuilder --> OS
+    V2 --> OS
+    V1 --> OS
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    Query[SQL/PPL Query] --> Parse[ANTLR4 Parse]
+    Parse --> AST[Build AST]
+    AST --> Convert[Convert to RelNode]
+    Convert --> Optimize[Calcite Optimize]
+    Optimize --> Plan[Execution Plan]
+    Plan --> Execute[Execute]
+    Execute --> Format[Format Response]
+    Format --> Response[Return Results]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| REST Handler | Handles `/_plugins/_sql` and `/_plugins/_ppl` endpoints |
+| ANTLR4 Parser | Parses SQL/PPL syntax into parse tree, then AST |
+| V1 Engine | Original SQL processing engine (legacy) |
+| V2 Engine | Modern query engine with improved features |
+| V3 Calcite Engine | Apache Calcite-based engine with advanced optimization |
+| PPLFuncImpTable | Logical-level function implementation registry |
+| PPLBuiltinOperators | Physical-level UDF implementations |
+| RelBuilder | Converts AST to Calcite RelNode tree |
+| Query Optimizer | Applies transformation rules for optimization |
+| OpenSearchEnumerableRel | OpenSearch-specific Calcite operators |
+| Linq4j | Code generation for row-by-row processing |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.sql.enabled` | Enable/disable SQL support | `true` |
+| `plugins.ppl.enabled` | Enable/disable PPL support | `true` |
+| `plugins.calcite.enabled` | Enable V3 Calcite engine | `false` |
+| `plugins.sql.slowlog` | Slow query log threshold (seconds) | `2` |
+| `plugins.sql.cursor.keep_alive` | Cursor keep alive duration | `1m` |
+| `plugins.query.memory_limit` | Query memory limit | `85%` |
+| `plugins.query.size_limit` | Maximum query result size | `200` |
+| `plugins.query.field_type_tolerance` | Handle array datasets | `true` |
+
+### PPL Commands (V3)
+
+| Command | Description | Example |
+|---------|-------------|---------|
+| `lookup` | Enrich data with reference table | `source=logs \| lookup users user_id` |
+| `join` | Correlate data from multiple indexes | `source=a \| join ON a.id = b.id b` |
+| `subsearch` | Dynamic filtering with subqueries | `source=a \| where exists [source=b \| where ...]` |
+| `patterns` | Extract log patterns (Brain algorithm) | `source=logs \| patterns message` |
+
+### Usage Example
+
+```bash
+# Enable Calcite engine
+PUT _cluster/settings
+{
+  "transient": {
+    "plugins.calcite.enabled": true
+  }
+}
+
+# SQL Query
+POST /_plugins/_sql
+{
+  "query": "SELECT * FROM my_index WHERE status = 'active' LIMIT 10"
+}
+
+# PPL Query with lookup
+POST /_plugins/_ppl
+{
+  "query": "source=auth_logs | lookup user_info user_id | where status='failed'"
+}
+
+# PPL Query with join
+POST /_plugins/_ppl
+{
+  "query": "source=auth_logs | join left=l right=r ON l.user_id = r.user_id app_logs | fields timestamp, user_id, action"
+}
+
+# PPL Query with subsearch
+POST /_plugins/_ppl
+{
+  "query": "source=auth_logs | where status='failed' AND exists [source=app_logs | where user_id=auth_logs.user_id]"
+}
+
+# PPL with comments
+POST /_plugins/_ppl
+{
+  "query": "source=logs /* main logs */ | where level = 'ERROR' // filter errors"
+}
+
+# JSON functions
+POST /_plugins/_ppl
+{
+  "query": "source=data | eval parsed = json(json_string) | fields parsed"
+}
+```
+
+## Limitations
+
+- V3 Calcite engine is experimental (v3.0.0)
+- JOIN queries auto-terminate after 60 seconds by default
+- Some features not supported in V3: `trendline`, `top`, `rare`, `fillnull`, `dedup` with `consecutive=true`
+- Pagination/cursor only supported in V1 engine
+- JSON formatted output only in V1 engine
+- Aggregation over expressions not supported
+- Subquery in FROM clause has limited support
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#3448](https://github.com/opensearch-project/sql/pull/3448) | Merge Calcite engine to main |
+| v3.0.0 | [#3243](https://github.com/opensearch-project/sql/pull/3243) | Add `json` function and `cast(x as json)` |
+| v3.0.0 | [#3263](https://github.com/opensearch-project/sql/pull/3263) | Improved patterns command with Brain algorithm |
+| v3.0.0 | [#2806](https://github.com/opensearch-project/sql/pull/2806) | Support line and block comments in PPL |
+| v3.0.0 | [#3522](https://github.com/opensearch-project/sql/pull/3522) | Function framework refactoring |
+| v3.0.0 | [#3304](https://github.com/opensearch-project/sql/pull/3304) | Add functions to SQL query validator |
+| v3.0.0 | [#3306](https://github.com/opensearch-project/sql/pull/3306) | Remove SparkSQL support |
+| v3.0.0 | [#3326](https://github.com/opensearch-project/sql/pull/3326) | Remove opendistro settings and endpoints |
+| v3.0.0 | [#3337](https://github.com/opensearch-project/sql/pull/3337) | Deprecate SQL Delete statement |
+| v3.0.0 | [#3345](https://github.com/opensearch-project/sql/pull/3345) | Unified OpenSearch PPL Data Type |
+| v3.0.0 | [#3346](https://github.com/opensearch-project/sql/pull/3346) | Deprecate scroll API usage |
+| v3.0.0 | [#3367](https://github.com/opensearch-project/sql/pull/3367) | Deprecate OpenSearch DSL format |
+
+## References
+
+- [SQL and PPL Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/index/): Official documentation
+- [SQL Settings](https://docs.opensearch.org/3.0/search-plugins/sql/settings/): Configuration reference
+- [SQL Limitations](https://docs.opensearch.org/3.0/search-plugins/sql/limitation/): Engine limitations
+- [PPL Commands](https://docs.opensearch.org/3.0/search-plugins/sql/ppl/functions/): PPL command reference
+- [Enhanced Log Analysis Blog](https://opensearch.org/blog/enhanced-log-analysis-with-opensearch-ppl-introducing-lookup-join-and-subsearch/): New PPL commands
+- [SQL Plugin Repository](https://github.com/opensearch-project/sql): Source code
+
+## Change History
+
+- **v3.0.0** (2025): Major update - Apache Calcite integration (V3 engine), new PPL commands (lookup, join, subsearch), json functions, improved patterns command with Brain algorithm, comment support, function framework refactoring; breaking changes include removal of SparkSQL, DELETE statement, DSL format, scroll API, and opendistro settings

--- a/docs/releases/v3.0.0/features/sql/sqlppl-engine.md
+++ b/docs/releases/v3.0.0/features/sql/sqlppl-engine.md
@@ -1,0 +1,168 @@
+# SQL/PPL Engine
+
+## Summary
+
+OpenSearch 3.0.0 introduces a major evolution of the SQL/PPL plugin with the integration of Apache Calcite as the new query engine (V3). This release adds powerful new PPL commands (`lookup`, `join`, `subsearch`) for advanced log analysis, new functions (`json`, `cast to json`), improved `patterns` command with the Brain algorithm, and significant internal refactoring for better query optimization and execution.
+
+## Details
+
+### What's New in v3.0.0
+
+The SQL/PPL plugin in v3.0.0 introduces:
+
+1. **Apache Calcite Integration (V3 Engine)**: A new experimental query engine leveraging Apache Calcite for query optimization and execution
+2. **New PPL Commands**: `lookup`, `join`, and `subsearch` for advanced log correlation and analysis
+3. **New Functions**: `json()` function and `cast(x as json)` for JSON handling
+4. **Improved Patterns Command**: New Brain algorithm for intelligent log pattern detection
+5. **Function Framework Refactoring**: Cleaner architecture with `PPLFuncImpTable` and `PPLBuiltinOperators`
+6. **Comment Support**: Line (`//`) and block (`/* */`) comments in PPL queries
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "SQL/PPL Plugin v3.0.0"
+        Client[Client Request]
+        REST[REST Handler]
+        Parser[ANTLR4 Parser]
+        AST[Abstract Syntax Tree]
+        
+        subgraph "Query Engines"
+            V2[V2 Engine]
+            V3[V3 Calcite Engine]
+        end
+        
+        subgraph "Calcite Processing"
+            RelBuilder[RelBuilder]
+            RelNode[RelNode Tree]
+            Optimizer[Calcite Optimizer]
+            OSRel[OpenSearchEnumerableRel]
+        end
+        
+        Linq4j[Linq4j Code Gen]
+        QueryBuilder[OpenSearch QueryBuilder]
+        OS[OpenSearch]
+    end
+    
+    Client --> REST
+    REST --> Parser
+    Parser --> AST
+    AST --> V2
+    AST --> V3
+    V3 --> RelBuilder
+    RelBuilder --> RelNode
+    RelNode --> Optimizer
+    Optimizer --> OSRel
+    OSRel --> Linq4j
+    OSRel --> QueryBuilder
+    Linq4j --> OS
+    QueryBuilder --> OS
+    V2 --> OS
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `PPLFuncImpTable` | Logical-level function implementation registry for resolving BuiltinFunctionName |
+| `PPLBuiltinOperators` | Physical-level UDF implementations for Calcite operators |
+| `CalciteFuncSignature` | Function signature resolution for different parameter types |
+| Brain Algorithm | New log pattern detection algorithm for the `patterns` command |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.calcite.enabled` | Enable V3 Calcite engine for advanced SQL/PPL features | `false` |
+
+### Usage Example
+
+#### Enable Calcite Engine
+```bash
+PUT _cluster/settings
+{
+  "transient": {
+    "plugins.calcite.enabled": true
+  }
+}
+```
+
+#### New PPL Commands
+
+**Lookup - Enrich logs with reference data:**
+```sql
+source=auth_logs | lookup user_info user_id | where status='failed'
+```
+
+**Join - Correlate logs from different indexes:**
+```sql
+source=auth_logs 
+| join left=l right=r ON l.user_id = r.user_id AND TIME_TO_SEC(TIMEDIFF(r.timestamp, l.timestamp)) <= 60 app_logs 
+| fields timestamp, user_id, action
+```
+
+**Subsearch - Dynamic filtering based on subquery results:**
+```sql
+source=auth_logs 
+| where status='failed' AND exists [source=app_logs | where user_id=auth_logs.user_id AND action='login']
+```
+
+#### JSON Functions
+```sql
+source=json_test 
+| where json_valid(json_string) 
+| eval json=json(json_string) 
+| fields test_name, json_string, json
+```
+
+#### PPL Comments
+```sql
+source=otel_logs /* OpenTelemetry logs */
+| where kind = 'SPAN_KIND_CLIENT' // filter client spans
+| eval r = 0.99 /* precision */
+| stats sum(droppedEventsCount * r) as lostEvents
+```
+
+### Migration Notes
+
+- V3 engine is experimental and disabled by default; enable with `plugins.calcite.enabled: true`
+- Queries automatically fall back from V3 to V2 if V3 execution fails
+- Some return types differ between V2 and V3 (see Limitations)
+- New commands (`lookup`, `join`, `subsearch`) require Calcite to be enabled
+
+## Limitations
+
+- V3 engine is experimental in v3.0.0
+- Some features not yet supported in V3: `trendline`, `top`, `rare`, `fillnull`, `patterns`, `dedup` with `consecutive=true`
+- Return type differences between V2 and V3:
+  - `timestampdiff`: V2 returns `timestamp`, V3 returns `int`
+  - `regexp`: V2 returns `int`, V3 returns `boolean`
+  - `count`/`dc`/`distinct_count`: V2 returns `int`, V3 returns `bigint`
+- JOIN queries auto-terminate after 60 seconds by default (configurable via hint)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3448](https://github.com/opensearch-project/sql/pull/3448) | Merge feature/calcite-engine to main |
+| [#3243](https://github.com/opensearch-project/sql/pull/3243) | PPL: Add `json` function and `cast(x as json)` function |
+| [#3263](https://github.com/opensearch-project/sql/pull/3263) | Improved patterns command with new Brain algorithm |
+| [#2806](https://github.com/opensearch-project/sql/pull/2806) | Support line comment and block comment in PPL |
+| [#3522](https://github.com/opensearch-project/sql/pull/3522) | Function framework refactoring |
+| [#3304](https://github.com/opensearch-project/sql/pull/3304) | Add other functions to SQL query validator |
+| [#3269](https://github.com/opensearch-project/sql/pull/3269) | Add SQLQuery Utils support for Vacuum queries |
+| [#3278](https://github.com/opensearch-project/reporting/pull/3278) | Clean up syntax error reporting |
+
+## References
+
+- [Issue #154](https://github.com/tkykenmt/opensearch-feature-explorer/issues/154): SQL/PPL Engine tracking issue
+- [SQL and PPL Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/index/): Official documentation
+- [SQL Settings](https://docs.opensearch.org/3.0/search-plugins/sql/settings/): Configuration reference
+- [SQL Limitations](https://docs.opensearch.org/3.0/search-plugins/sql/limitation/): V3 engine limitations
+- [Enhanced Log Analysis Blog](https://opensearch.org/blog/enhanced-log-analysis-with-opensearch-ppl-introducing-lookup-join-and-subsearch/): New PPL commands introduction
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/sql/sql-ppl-engine.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -60,6 +60,7 @@
 
 ## sql
 
+- [SQL/PPL Engine](features/sql/sqlppl-engine.md)
 - [SQL/PPL v3.0.0 Breaking Changes](features/sql/sql-ppl-v3-breaking-changes.md)
 - [SQL/PPL Documentation](features/sql/sql-ppl-documentation.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the SQL/PPL Engine feature group for OpenSearch v3.0.0.

### Key Changes in v3.0.0

- **Apache Calcite Integration (V3 Engine)**: New experimental query engine leveraging Apache Calcite for query optimization and execution
- **New PPL Commands**: `lookup`, `join`, and `subsearch` for advanced log correlation and analysis
- **New Functions**: `json()` function and `cast(x as json)` for JSON handling
- **Improved Patterns Command**: New Brain algorithm for intelligent log pattern detection
- **Function Framework Refactoring**: Cleaner architecture with `PPLFuncImpTable` and `PPLBuiltinOperators`
- **Comment Support**: Line (`//`) and block (`/* */`) comments in PPL queries

### Reports Created

- Release report: `docs/releases/v3.0.0/features/sql/sqlppl-engine.md`
- Feature report: `docs/features/sql/sql-ppl-engine.md`

### Resources Used

- PRs: #3448, #3243, #3263, #2806, #3522, #3304, #3269, #3278
- Docs: https://docs.opensearch.org/3.0/search-plugins/sql/settings/
- Blog: https://opensearch.org/blog/enhanced-log-analysis-with-opensearch-ppl-introducing-lookup-join-and-subsearch/

Closes #154