### PR TITLE
docs: add Vector Search (k-NN) report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -109,3 +109,7 @@
 ## dashboards-assistant
 
 - [AI Assistant / Chatbot](dashboards-assistant/ai-assistant-chatbot.md)
+
+## k-nn
+
+- [Vector Search (k-NN)](k-nn/vector-search-k-nn.md)

--- a/docs/features/k-nn/vector-search-k-nn.md
+++ b/docs/features/k-nn/vector-search-k-nn.md
@@ -1,0 +1,237 @@
+# Vector Search (k-NN)
+
+## Summary
+
+The k-NN (k-Nearest Neighbors) plugin enables vector similarity search in OpenSearch, allowing users to find documents with vectors most similar to a query vector. It supports multiple search algorithms (HNSW, IVF), engines (Faiss, NMSLIB, Lucene), and distance metrics (L2, cosine, inner product). The plugin is essential for AI/ML applications including semantic search, recommendation systems, and image similarity search.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "k-NN Plugin Architecture"
+        Query[k-NN Query] --> QP[Query Parser]
+        QP --> Engine{Engine Selection}
+        
+        Engine --> Faiss[Faiss Engine]
+        Engine --> NMSLIB[NMSLIB Engine]
+        Engine --> Lucene[Lucene Engine]
+        
+        Faiss --> NM[Native Memory Cache]
+        NMSLIB --> NM
+        Lucene --> LI[Lucene Index]
+        
+        NM --> CB[Circuit Breaker]
+        CB --> Results[Search Results]
+        LI --> Results
+    end
+    
+    subgraph "Index Build"
+        Doc[Document] --> VP[Vector Processing]
+        VP --> IBS{Build Strategy}
+        IBS --> Local[Local Build]
+        IBS --> Remote[Remote Build]
+        Local --> Graph[Graph Index]
+        Remote --> RS[Remote Service]
+        RS --> Graph
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Indexing
+        V[Vector Data] --> E[Encoder]
+        E --> G[Graph Builder]
+        G --> S[Segment Storage]
+    end
+    
+    subgraph Search
+        Q[Query Vector] --> L[Graph Loader]
+        L --> C[Cache Manager]
+        C --> ANN[ANN Search]
+        ANN --> R[Results]
+    end
+    
+    S --> L
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `KNNQueryBuilder` | Builds k-NN queries with support for filters and scoring |
+| `NativeMemoryCacheManager` | Manages native memory allocation for graph indexes |
+| `NativeMemoryLoadStrategy` | Handles loading graph files into native memory |
+| `KNNCircuitBreaker` | Prevents OOM by limiting memory usage |
+| `RemoteNativeIndexBuildStrategy` | Offloads index building to remote infrastructure |
+| `RemoteIndexClient` | HTTP client for remote build service communication |
+
+### Supported Engines
+
+| Engine | Algorithms | Best For |
+|--------|------------|----------|
+| Faiss | HNSW, IVF, PQ | Large-scale, GPU acceleration |
+| NMSLIB | HNSW | High recall requirements |
+| Lucene | HNSW | Simplicity, no native dependencies |
+
+### Configuration
+
+#### Index Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.knn` | Enable k-NN for the index | `false` |
+| `index.knn.algo_param.ef_search` | Size of dynamic candidate list during search | `100` |
+
+#### Cluster Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `knn.memory.circuit_breaker.enabled` | Enable circuit breaker | `true` |
+| `knn.memory.circuit_breaker.limit` | Memory limit as percentage of JVM heap | `50%` |
+| `knn.memory.circuit_breaker.limit.<tier>` | Node-specific limit by tier (v3.0.0+) | Cluster default |
+| `knn.cache.item.expiry.enabled` | Enable cache expiry | `false` |
+| `knn.cache.item.expiry.minutes` | Cache expiry time | `180` |
+
+#### Remote Index Build Settings (v3.0.0+)
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `knn.remote_index_build.enabled` | Enable remote index building | `false` |
+| `knn.remote_index_build.size_threshold` | Size threshold for remote build | - |
+| `knn.remote_index_build.repository` | Repository name for vector storage | - |
+
+### Usage Example
+
+#### Creating a k-NN Index
+
+```json
+PUT /my-knn-index
+{
+  "settings": {
+    "index.knn": true,
+    "number_of_shards": 1,
+    "number_of_replicas": 0
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 128,
+        "method": {
+          "name": "hnsw",
+          "space_type": "l2",
+          "engine": "faiss",
+          "parameters": {
+            "ef_construction": 256,
+            "m": 16
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### Indexing Vectors
+
+```json
+POST /my-knn-index/_doc
+{
+  "my_vector": [0.1, 0.2, 0.3, ...]
+}
+```
+
+#### k-NN Search
+
+```json
+GET /my-knn-index/_search
+{
+  "size": 10,
+  "query": {
+    "knn": {
+      "my_vector": {
+        "vector": [0.1, 0.2, 0.3, ...],
+        "k": 10
+      }
+    }
+  }
+}
+```
+
+#### Filtered k-NN Search
+
+```json
+GET /my-knn-index/_search
+{
+  "size": 10,
+  "query": {
+    "knn": {
+      "my_vector": {
+        "vector": [0.1, 0.2, 0.3, ...],
+        "k": 10,
+        "filter": {
+          "term": {
+            "category": "electronics"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### Node-Level Circuit Breaker (v3.0.0+)
+
+```yaml
+# opensearch.yml
+node.attr.knn_cb_tier: "large"
+```
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "knn.memory.circuit_breaker.limit.large": "75%",
+    "knn.memory.circuit_breaker.limit.small": "40%"
+  }
+}
+```
+
+## Limitations
+
+- Native engines (Faiss, NMSLIB) require native library dependencies
+- Graph indexes consume significant memory
+- Remote Index Build is experimental (v3.0.0)
+- Maximum vector dimension depends on engine and available memory
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#2564](https://github.com/opensearch-project/k-NN/pull/2564) | Breaking changes - remove deprecated settings |
+| v3.0.0 | [#2509](https://github.com/opensearch-project/k-NN/pull/2509) | Node-level circuit breakers |
+| v3.0.0 | [#2599](https://github.com/opensearch-project/k-NN/pull/2599) | Filter function in KNNQueryBuilder |
+| v3.0.0 | [#2345](https://github.com/opensearch-project/k-NN/pull/2345) | Concurrency optimizations for graph loading |
+| v3.0.0 | [#2525](https://github.com/opensearch-project/k-NN/pull/2525) | Remote Native Index Build skeleton |
+| v3.0.0 | [#2550](https://github.com/opensearch-project/k-NN/pull/2550) | Vector data upload implementation |
+| v3.0.0 | [#2554](https://github.com/opensearch-project/k-NN/pull/2554) | Data download and IndexOutput write |
+| v3.0.0 | [#2560](https://github.com/opensearch-project/k-NN/pull/2560) | RemoteIndexClient skeleton |
+
+## References
+
+- [Vector Search Documentation](https://docs.opensearch.org/3.0/vector-search/): Official documentation
+- [k-NN API Reference](https://docs.opensearch.org/3.0/vector-search/api/knn/): API documentation
+- [Approximate k-NN Search](https://docs.opensearch.org/3.0/vector-search/vector-search-techniques/approximate-knn/): ANN search guide
+- [Efficient k-NN Filtering](https://docs.opensearch.org/3.0/vector-search/filter-search-knn/efficient-knn-filtering/): Filtering guide
+- [Issue #2263](https://github.com/opensearch-project/k-NN/issues/2263): Node-level circuit breaker request
+- [Issue #2265](https://github.com/opensearch-project/k-NN/issues/2265): Concurrency optimizations request
+- [Issue #2465](https://github.com/opensearch-project/k-NN/issues/2465): Remote Native Index Build design
+- [OpenSearch 3.0 Blog](https://opensearch.org/blog/opensearch-3-0-what-to-expect/): Release overview
+
+## Change History
+
+- **v3.0.0** (2026-01-09): Breaking changes removing deprecated index settings; node-level circuit breakers; filter function in KNNQueryBuilder; concurrency optimizations for graph loading; Remote Native Index Build foundation

--- a/docs/releases/v3.0.0/features/k-nn/vector-search-k-nn.md
+++ b/docs/releases/v3.0.0/features/k-nn/vector-search-k-nn.md
@@ -1,0 +1,187 @@
+# Vector Search (k-NN)
+
+## Summary
+
+OpenSearch 3.0.0 introduces significant breaking changes and new features to the k-NN plugin. The breaking changes remove deprecated index-level settings (`index.knn.algo_param.ef_construction`, `index.knn.algo_param.m`, `index.knn.space_type`, and `knn.plugin.enabled`) that were previously deprecated in favor of method-level parameters. New features include node-level circuit breakers for heterogeneous clusters, filter functions in KNNQueryBuilder, concurrency optimizations for graph loading, and the foundation for Remote Native Index Build capability.
+
+## Details
+
+### What's New in v3.0.0
+
+#### Breaking Changes
+
+The following deprecated settings have been removed:
+
+| Removed Setting | Migration Path |
+|-----------------|----------------|
+| `index.knn.algo_param.ef_construction` | Use `method.parameters.ef_construction` in field mapping |
+| `index.knn.algo_param.m` | Use `method.parameters.m` in field mapping |
+| `index.knn.space_type` | Use `method.space_type` in field mapping |
+| `knn.plugin.enabled` | Setting removed; plugin is always enabled when installed |
+
+**Migration Example:**
+
+Before (deprecated):
+```json
+PUT /my-index
+{
+  "settings": {
+    "index.knn": true,
+    "index.knn.algo_param.ef_construction": 256,
+    "index.knn.algo_param.m": 16,
+    "index.knn.space_type": "l2"
+  }
+}
+```
+
+After (v3.0.0):
+```json
+PUT /my-index
+{
+  "settings": {
+    "index.knn": true
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 128,
+        "method": {
+          "name": "hnsw",
+          "space_type": "l2",
+          "engine": "faiss",
+          "parameters": {
+            "ef_construction": 256,
+            "m": 16
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### New Features
+
+##### Node-Level Circuit Breakers
+
+Introduces node-specific circuit breaker limits using node attributes, enabling heterogeneous memory limits across nodes with different capacities.
+
+**Configuration:**
+
+1. Set node attribute in `opensearch.yml`:
+```yaml
+node.attr.knn_cb_tier: "large"
+```
+
+2. Configure limit for that tier:
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "knn.memory.circuit_breaker.limit.large": "75%"
+  }
+}
+```
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `knn.memory.circuit_breaker.limit.<tier>` | Memory limit for nodes with `knn_cb_tier` attribute | Falls back to cluster default |
+
+##### Filter Function in KNNQueryBuilder
+
+Adds filter function support to KNNQueryBuilder, enabling filtered k-NN searches with custom scoring functions.
+
+##### Concurrency Optimizations for Graph Loading
+
+Refactors graph loading into a 2-step approach that moves file operations outside synchronized blocks, enabling parallel graph file downloads while maintaining thread safety for cache operations.
+
+```mermaid
+flowchart LR
+    subgraph "Before v3.0.0"
+        A1[Request] --> B1[Synchronized Block]
+        B1 --> C1[Download Graph]
+        C1 --> D1[Load to Memory]
+        D1 --> E1[Update Cache]
+    end
+    
+    subgraph "v3.0.0"
+        A2[Request] --> B2[Parallel Download]
+        B2 --> C2[Synchronized Block]
+        C2 --> D2[Load to Memory]
+        D2 --> E2[Update Cache]
+    end
+```
+
+##### Remote Native Index Build (Foundation)
+
+Introduces the foundation for building k-NN indexes on remote infrastructure:
+
+| Component | Description |
+|-----------|-------------|
+| `RemoteNativeIndexBuildStrategy` | Strategy skeleton for remote index building |
+| `RemoteIndexClient` | HTTP client for communicating with remote build service |
+| Vector data upload | Parallel blob upload to remote repository (S3) |
+| Graph download | Sequential download with 64KB buffer for memory efficiency |
+
+**New Settings:**
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `knn.remote_index_build.enabled` | Feature flag for remote index build | `false` |
+| `knn.remote_index_build.size_threshold` | Size threshold above which remote build is used | - |
+| `knn.remote_index_build.repository` | Repository name for vector storage | - |
+
+### Bug Fixes
+
+| PR | Description |
+|----|-------------|
+| [#2556](https://github.com/opensearch-project/k-NN/pull/2556) | Fix NullPointerException during PUT mappings |
+| [#2629](https://github.com/opensearch-project/k-NN/pull/2629) | Add index operation listener to update translog source |
+| [#2647](https://github.com/opensearch-project/k-NN/pull/2647) | Add parent join support for faiss hnsw cagra |
+| [#2646](https://github.com/opensearch-project/k-NN/pull/2646) | Disable doc value storage for vector field storage |
+| [#2666](https://github.com/opensearch-project/k-NN/pull/2666) | Fix KNN Quantization state cache invalid weight threshold |
+| [#2671](https://github.com/opensearch-project/k-NN/pull/2671) | Fix enable rescoring when dimensions > 1000 |
+| [#2533](https://github.com/opensearch-project/k-NN/pull/2533) | Fix derived source for binary and byte vectors |
+| [#2542](https://github.com/opensearch-project/k-NN/pull/2542) | Fix put mapping issue for already created index with flat mapper |
+| [#2445](https://github.com/opensearch-project/k-NN/pull/2445) | Prevent index.knn setting from being modified on restore snapshot |
+| [#2429](https://github.com/opensearch-project/k-NN/pull/2429) | Fix Lucene912Codec BWC issue for Lucene 10.0.1 upgrade |
+
+### Enhancements
+
+| PR | Description |
+|----|-------------|
+| [#688](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/688) | Add callout if knn query does not have knn index |
+| [#2378](https://github.com/opensearch-project/k-NN/pull/2378) | Add detailed error messages for KNN model training |
+
+## Limitations
+
+- Remote Native Index Build is behind a feature flag and not production-ready
+- Node-level circuit breakers require manual node attribute configuration
+- Parallel graph download not yet implemented for Remote Index Build
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2564](https://github.com/opensearch-project/k-NN/pull/2564) | 3.0.0 Breaking Changes for KNN |
+| [#2509](https://github.com/opensearch-project/k-NN/pull/2509) | Introduce node level circuit breaker settings |
+| [#2599](https://github.com/opensearch-project/k-NN/pull/2599) | Add filter function to KNNQueryBuilder |
+| [#2345](https://github.com/opensearch-project/k-NN/pull/2345) | Concurrency optimization for native graph loading |
+| [#2525](https://github.com/opensearch-project/k-NN/pull/2525) | Remote Native Index Build skeleton |
+| [#2550](https://github.com/opensearch-project/k-NN/pull/2550) | Vector data upload implementation |
+| [#2554](https://github.com/opensearch-project/k-NN/pull/2554) | Data download and IndexOutput write |
+| [#2560](https://github.com/opensearch-project/k-NN/pull/2560) | RemoteIndexClient skeleton and Build Request |
+
+## References
+
+- [Issue #2263](https://github.com/opensearch-project/k-NN/issues/2263): Node level circuit breaker feature request
+- [Issue #2265](https://github.com/opensearch-project/k-NN/issues/2265): Concurrency optimizations feature request
+- [Issue #2465](https://github.com/opensearch-project/k-NN/issues/2465): Remote Native Index Build design
+- [Vector Search Documentation](https://docs.opensearch.org/3.0/vector-search/): Official docs
+- [k-NN API Documentation](https://docs.opensearch.org/3.0/vector-search/api/knn/): API reference
+- [OpenSearch 3.0 Blog](https://opensearch.org/blog/opensearch-3-0-what-to-expect/): Release overview
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/k-nn/vector-search-k-nn.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -112,3 +112,7 @@
 ## dashboards-assistant
 
 - [AI Assistant / Chatbot](features/dashboards-assistant/ai-assistant-chatbot.md)
+
+## k-nn
+
+- [Vector Search (k-NN)](features/k-nn/vector-search-k-nn.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Vector Search (k-NN) changes in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/k-nn/vector-search-k-nn.md`
- Feature report: `docs/features/k-nn/vector-search-k-nn.md`

### Key Changes in v3.0.0

**Breaking Changes:**
- Removed deprecated index settings: `index.knn.algo_param.ef_construction`, `index.knn.algo_param.m`, `index.knn.space_type`, `knn.plugin.enabled`
- Users must migrate to method-level parameters in field mappings

**New Features:**
- Node-level circuit breakers for heterogeneous clusters
- Filter function support in KNNQueryBuilder
- Concurrency optimizations for native graph loading
- Remote Native Index Build foundation (experimental)

**Bug Fixes:**
- Multiple fixes for PUT mappings, translog, parent join support, quantization cache, rescoring, and more

### PRs Investigated
- #2564: 3.0.0 Breaking Changes for KNN
- #2509: Node level circuit breaker settings
- #2599: Filter function in KNNQueryBuilder
- #2345: Concurrency optimization for graph loading
- #2525, #2550, #2554, #2560: Remote Native Index Build

Closes #153