### PR TITLE
docs: add Remote Vector Index Build report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -115,3 +115,4 @@
 - [Vector Search (k-NN)](k-nn/vector-search-k-nn.md)
 - [k-NN Explain API](k-nn/explain-api.md)
 - [Lucene On Faiss (Memory Optimized Search)](k-nn/lucene-on-faiss.md)
+- [Remote Vector Index Build](k-nn/remote-vector-index-build.md)

--- a/docs/features/k-nn/remote-vector-index-build.md
+++ b/docs/features/k-nn/remote-vector-index-build.md
@@ -1,0 +1,200 @@
+# Remote Vector Index Build
+
+## Summary
+
+Remote Vector Index Build is an experimental feature that enables OpenSearch to offload vector index construction to external GPU-accelerated services. By leveraging GPUs for the computationally intensive HNSW graph building process, this feature dramatically reduces index build times and operational costs for large-scale vector search workloads.
+
+The feature introduces a client-server architecture where OpenSearch uploads vectors to an intermediate object store (Amazon S3), a remote GPU-powered service builds the index, and OpenSearch downloads the completed index for use in search operations.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph OpenSearch Cluster
+        KNN[k-NN Plugin]
+        RBS[RemoteIndexBuildStrategy]
+        RC[RemoteIndexClient]
+        RW[RemoteIndexWaiter]
+        RS[Repository Service]
+    end
+    
+    subgraph Object Store
+        S3[(Amazon S3)]
+    end
+    
+    subgraph Remote Build Service
+        API[Build API]
+        GPU[GPU Workers]
+        FAISS[Faiss Library]
+    end
+    
+    KNN --> RBS
+    RBS -->|Decide Local/Remote| RC
+    RBS --> RS
+    RS -->|Upload Vectors + DocIDs| S3
+    RC -->|POST /build| API
+    API --> GPU
+    GPU --> FAISS
+    FAISS -->|Read Vectors| S3
+    FAISS -->|Write Index| S3
+    RW -->|Poll Status| API
+    RS -->|Download Index| S3
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Indexing
+        A[Documents] --> B[Extract Vectors]
+        B --> C{Size > Threshold?}
+        C -->|Yes| D[Remote Build]
+        C -->|No| E[Local Build]
+    end
+    
+    subgraph Remote Build
+        D --> F[Upload to S3]
+        F --> G[Submit Build Request]
+        G --> H[Poll for Completion]
+        H --> I[Download Index]
+    end
+    
+    subgraph Local Build
+        E --> J[Build HNSW Graph]
+    end
+    
+    I --> K[Merge with Segment]
+    J --> K
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `RemoteIndexBuildStrategy` | Decides whether to use local or remote build based on segment size threshold |
+| `RemoteIndexClient` | Interface for communicating with remote build services |
+| `RemoteIndexHTTPClient` | HTTP client implementation with connection pooling and retry logic |
+| `RemoteIndexWaiter` | Interface for awaiting build completion |
+| `RemoteIndexPoller` | Polling-based implementation that checks build status periodically |
+| `RemoteBuildRequest` | Request object containing vectors, parameters, and S3 paths |
+| `RemoteBuildResponse` | Response object with build status and result file location |
+| `remote-index-build-client` | Separate Gradle module for client code (supports future extraction) |
+
+### Configuration
+
+| Setting | Description | Default | Dynamic |
+|---------|-------------|---------|---------|
+| `knn.feature.remote_index_build.enabled` | Enable remote build feature for the cluster | `false` | Yes |
+| `index.knn.remote_index_build.enabled` | Enable remote build for specific index | `false` | Yes |
+| `knn.remote_index_build.client.endpoint` | URL of the remote build service | - | Yes |
+| `knn.remote_index_build.vector_repo` | Name of registered S3 repository | - | Yes |
+| `index.knn.remote_index_build.size_threshold` | Minimum segment size (bytes) to trigger remote build | - | Yes |
+
+### Metrics
+
+Remote build statistics are exposed via the k-NN stats API (`GET /_plugins/_knn/stats`):
+
+**Repository Stats**
+- `read_success_count` / `read_failure_count`: S3 read operations
+- `write_success_count` / `write_failure_count`: S3 write operations
+- `successful_read_time_in_millis` / `successful_write_time_in_millis`: Latency metrics
+
+**Client Stats**
+- `build_request_success_count` / `build_request_failure_count`: Build submission
+- `status_request_success_count` / `status_request_failure_count`: Status polling
+- `index_build_success_count` / `index_build_failure_count`: Overall build outcomes
+- `waiting_time_in_ms`: Total time spent waiting for builds
+
+**Build Stats**
+- `remote_index_build_flush_time_in_millis`: Time for flush-triggered builds
+- `remote_index_build_merge_time_in_millis`: Time for merge-triggered builds
+- `remote_index_build_current_flush_operations`: In-progress flush builds
+- `remote_index_build_current_merge_operations`: In-progress merge builds
+
+### Usage Example
+
+```yaml
+# Step 1: Register S3 repository
+PUT _snapshot/vector-repo
+{
+  "type": "s3",
+  "settings": {
+    "bucket": "my-vector-bucket",
+    "base_path": "vectors"
+  }
+}
+
+# Step 2: Enable remote build cluster-wide
+PUT _cluster/settings
+{
+  "persistent": {
+    "knn.feature.remote_index_build.enabled": true,
+    "knn.remote_index_build.client.endpoint": "http://gpu-builder.example.com:8080",
+    "knn.remote_index_build.vector_repo": "vector-repo"
+  }
+}
+
+# Step 3: Create index with remote build
+PUT my-vectors
+{
+  "settings": {
+    "index.knn": true,
+    "index.knn.remote_index_build.enabled": true
+  },
+  "mappings": {
+    "properties": {
+      "embedding": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "parameters": {
+            "m": 16,
+            "ef_construction": 100
+          }
+        }
+      }
+    }
+  }
+}
+
+# Step 4: Index documents (remote build happens automatically)
+POST my-vectors/_bulk
+{"index": {}}
+{"embedding": [0.1, 0.2, ...]}
+```
+
+## Limitations
+
+- **Experimental Status**: Feature is experimental and not recommended for production
+- **Engine Support**: Only Faiss engine with HNSW method
+- **Vector Type**: Only 32-bit floating-point (FP32) vectors
+- **Encoder**: Only flat encoding (HNSWFlat), no product quantization
+- **Repository**: Only Amazon S3 repositories
+- **Space Types**: L2, inner product, and cosine similarity
+- **Network**: Requires connectivity between OpenSearch, S3, and build service
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#2576](https://github.com/opensearch-project/k-NN/pull/2576) | Client polling, encoder validation, parameter retrieval |
+| v3.0.0 | [#2603](https://github.com/opensearch-project/k-NN/pull/2603) | Separate client module for reduced dependencies |
+| v3.0.0 | [#2615](https://github.com/opensearch-project/k-NN/pull/2615) | Metric collection for monitoring |
+| v3.0.0 | [#2627](https://github.com/opensearch-project/k-NN/pull/2627) | COSINESIMIL space type fix |
+
+## References
+
+- [Issue #2391](https://github.com/opensearch-project/k-NN/issues/2391): Meta issue tracking all remote build work
+- [Issue #2518](https://github.com/opensearch-project/k-NN/issues/2518): Low-level design document
+- [Documentation](https://docs.opensearch.org/3.0/vector-search/remote-index-build/): Official OpenSearch docs
+- [Remote Vector Index Builder](https://github.com/opensearch-project/remote-vector-index-builder): GPU build service
+- [User Guide](https://github.com/opensearch-project/remote-vector-index-builder/blob/main/USER_GUIDE.md): Service setup instructions
+- [GPU Acceleration Blog](https://opensearch.org/blog/GPU-Accelerated-Vector-Search-OpenSearch-New-Frontier/): Performance benchmarks
+
+## Change History
+
+- **v3.0.0** (2025-05): Initial experimental implementation with HTTP client, S3 repository integration, metrics, and COSINESIMIL support

--- a/docs/releases/v3.0.0/features/k-nn/remote-vector-index-build.md
+++ b/docs/releases/v3.0.0/features/k-nn/remote-vector-index-build.md
@@ -1,0 +1,173 @@
+# Remote Vector Index Build
+
+## Summary
+
+OpenSearch 3.0 introduces experimental support for building vector indexes remotely using GPU-accelerated services. This feature offloads the computationally intensive HNSW index construction to external GPU-powered infrastructure, dramatically reducing index build times and costs for large-scale vector workloads.
+
+## Details
+
+### What's New in v3.0.0
+
+This release introduces the foundational components for remote vector index building:
+
+- **Remote Index Client**: HTTP client with polling mechanism to communicate with external build services
+- **Repository Integration**: Support for Amazon S3 as intermediate storage between OpenSearch and the build service
+- **Metric Collection**: Comprehensive statistics for monitoring remote build operations
+- **COSINESIMIL Support**: Bug fix to properly handle cosine similarity space type conversion for Faiss
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph OpenSearch Cluster
+        KNN[k-NN Plugin]
+        RC[Remote Client]
+        RS[Repository Service]
+    end
+    
+    subgraph Object Store
+        S3[Amazon S3]
+    end
+    
+    subgraph Remote Build Service
+        GPU[GPU Builder]
+    end
+    
+    KNN --> RC
+    KNN --> RS
+    RS -->|Upload Vectors| S3
+    RC -->|Submit Build Request| GPU
+    GPU -->|Read Vectors| S3
+    GPU -->|Write Index| S3
+    RC -->|Poll Status| GPU
+    RS -->|Download Index| S3
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `RemoteIndexClient` | Interface for communicating with remote build services |
+| `RemoteIndexHTTPClient` | HTTP implementation with connection pooling |
+| `RemoteIndexWaiter` | Interface for awaiting build completion |
+| `RemoteIndexPoller` | Polling-based implementation for status checks |
+| `RemoteIndexBuildStrategy` | Strategy pattern for local vs remote build decisions |
+| `remote-index-build-client` | Separate module for client code |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `knn.feature.remote_index_build.enabled` | Enable remote build for cluster | `false` |
+| `index.knn.remote_index_build.enabled` | Enable remote build for index | `false` |
+| `knn.remote_index_build.client.endpoint` | Remote builder service endpoint | - |
+| `knn.remote_index_build.vector_repo` | S3 repository name for vectors | - |
+| `index.knn.remote_index_build.size_threshold` | Minimum segment size for remote build | - |
+
+#### New Metrics
+
+The `/stats` API returns remote build statistics when the feature is enabled:
+
+```json
+{
+  "remote_vector_index_build_stats": {
+    "repository_stats": {
+      "read_success_count": 0,
+      "read_failure_count": 0,
+      "successful_read_time_in_millis": 0,
+      "write_success_count": 0,
+      "write_failure_count": 0,
+      "successful_write_time_in_millis": 0
+    },
+    "client_stats": {
+      "status_request_failure_count": 0,
+      "status_request_success_count": 0,
+      "index_build_success_count": 0,
+      "index_build_failure_count": 0,
+      "build_request_failure_count": 0,
+      "build_request_success_count": 0,
+      "waiting_time_in_ms": 0
+    },
+    "build_stats": {
+      "remote_index_build_flush_time_in_millis": 0,
+      "remote_index_build_current_merge_operations": 0,
+      "remote_index_build_current_flush_operations": 0,
+      "remote_index_build_current_merge_size": 0,
+      "remote_index_build_current_flush_size": 0,
+      "remote_index_build_merge_time_in_millis": 0
+    }
+  }
+}
+```
+
+### Usage Example
+
+```yaml
+# 1. Enable the feature flag
+PUT _cluster/settings
+{
+  "persistent": {
+    "knn.feature.remote_index_build.enabled": true,
+    "knn.remote_index_build.client.endpoint": "http://gpu-builder:8080",
+    "knn.remote_index_build.vector_repo": "vector-repo"
+  }
+}
+
+# 2. Create index with remote build enabled
+PUT my-vector-index
+{
+  "settings": {
+    "index.knn": true,
+    "index.knn.remote_index_build.enabled": true
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss"
+        }
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+This is an experimental feature requiring:
+1. A running [remote-vector-index-builder](https://github.com/opensearch-project/remote-vector-index-builder) service
+2. An S3 repository registered with OpenSearch
+3. Network connectivity between OpenSearch, S3, and the build service
+
+## Limitations
+
+- **Experimental**: Not recommended for production use
+- **Engine Support**: Only Faiss HNSW indexes with FP32 vectors
+- **Encoder Support**: Only `HNSWFlat` (no product quantization)
+- **Repository**: Only Amazon S3 repositories supported
+- **Space Types**: L2, inner product, and cosine similarity
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2576](https://github.com/opensearch-project/k-NN/pull/2576) | Client polling mechanism, encoder check, method parameter retrieval |
+| [#2603](https://github.com/opensearch-project/k-NN/pull/2603) | Move client to separate module |
+| [#2615](https://github.com/opensearch-project/k-NN/pull/2615) | Add metric collection for remote build process |
+| [#2627](https://github.com/opensearch-project/k-NN/pull/2627) | Fix COSINESIMIL space type support |
+
+## References
+
+- [Issue #2391](https://github.com/opensearch-project/k-NN/issues/2391): Meta issue for remote vector index build
+- [Documentation](https://docs.opensearch.org/3.0/vector-search/remote-index-build/): Official docs
+- [Remote Vector Index Builder](https://github.com/opensearch-project/remote-vector-index-builder): Build service repository
+- [GPU Acceleration Blog](https://opensearch.org/blog/GPU-Accelerated-Vector-Search-OpenSearch-New-Frontier/): Benchmarking results
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/k-nn/remote-vector-index-build.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -118,3 +118,4 @@
 - [Vector Search (k-NN)](features/k-nn/vector-search-k-nn.md)
 - [Explain API Support](features/k-nn/explain-api-support.md)
 - [Lucene On Faiss (Memory Optimized Search)](features/k-nn/lucene-on-faiss.md)
+- [Remote Vector Index Build](features/k-nn/remote-vector-index-build.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Remote Vector Index Build feature introduced in OpenSearch v3.0.0.

## Changes

### Release Report
- `docs/releases/v3.0.0/features/k-nn/remote-vector-index-build.md`

### Feature Report
- `docs/features/k-nn/remote-vector-index-build.md`

### Index Updates
- Updated `docs/releases/v3.0.0/index.md`
- Updated `docs/features/index.md`

## Feature Overview

Remote Vector Index Build is an experimental feature that enables OpenSearch to offload vector index construction to external GPU-accelerated services. Key components:

- HTTP client with polling mechanism for remote build service communication
- Amazon S3 repository integration for intermediate vector storage
- Comprehensive metrics for monitoring build operations
- Support for Faiss HNSW indexes with FP32 vectors

## Related PRs (k-NN)
- #2576: Client polling mechanism
- #2603: Separate client module
- #2615: Metric collection
- #2627: COSINESIMIL space type fix

## Related Issue
Closes #150