### PR TITLE
docs: add security-plugin-changes report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -42,6 +42,7 @@
 ## security
 
 - [Security Configuration](security/security-configuration.md)
+- [Security Plugin](security/security-plugin.md)
 
 ## reporting
 

--- a/docs/features/security/security-plugin.md
+++ b/docs/features/security/security-plugin.md
@@ -1,0 +1,200 @@
+# Security Plugin
+
+## Summary
+
+The OpenSearch Security plugin provides comprehensive security features for OpenSearch clusters, including TLS encryption, authentication backends, data masking, audit logging, and role-based access control (RBAC) on indices, documents, and fields. It supports multiple authentication methods and provides fine-grained access control for enterprise deployments.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Security Plugin Architecture"
+        subgraph "Authentication Layer"
+            HTTP[HTTP Authenticator]
+            Transport[Transport Authenticator]
+            Backends[Auth Backends]
+        end
+        
+        subgraph "Authorization Layer"
+            Privilege[Privilege Evaluator]
+            DLS[Document-Level Security]
+            FLS[Field-Level Security]
+            FM[Field Masking]
+        end
+        
+        subgraph "Configuration"
+            YAML[Security YAML Files]
+            Index[.opendistro_security Index]
+            Admin[Security Admin Tool]
+        end
+        
+        subgraph "Audit & Compliance"
+            Audit[Audit Logging]
+            Compliance[Compliance Features]
+        end
+    end
+    
+    HTTP --> Backends
+    Transport --> Backends
+    Backends --> Privilege
+    Privilege --> DLS
+    Privilege --> FLS
+    Privilege --> FM
+    YAML --> Admin
+    Admin --> Index
+    Privilege --> Audit
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    Request[Client Request] --> Auth[Authentication]
+    Auth --> |Valid| Authz[Authorization]
+    Auth --> |Invalid| Reject1[401 Unauthorized]
+    Authz --> |Allowed| Execute[Execute Request]
+    Authz --> |Denied| Reject2[403 Forbidden]
+    Execute --> DLS[Apply DLS]
+    DLS --> FLS[Apply FLS]
+    FLS --> FM[Apply Field Masking]
+    FM --> Response[Response]
+    Execute --> Audit[Audit Log]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| HTTP Authenticator | Handles REST API authentication |
+| Transport Authenticator | Handles node-to-node authentication |
+| Privilege Evaluator | Evaluates user permissions against requested actions |
+| DLS Filter | Applies document-level security filters |
+| FLS Filter | Applies field-level security filters |
+| Field Masking | Masks sensitive field values |
+| Audit Logger | Records security events |
+| Security Admin | CLI tool for configuration management |
+
+### Authentication Backends
+
+| Backend | Description |
+|---------|-------------|
+| Internal | Built-in user database |
+| LDAP/AD | LDAP and Active Directory integration |
+| OIDC | OpenID Connect providers |
+| SAML | SAML 2.0 identity providers |
+| JWT | JSON Web Token authentication |
+| Kerberos | Kerberos/SPNEGO authentication |
+| Proxy | Proxy-based authentication |
+| Client Certificate | X.509 client certificate authentication |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.ssl.transport.enabled` | Enable TLS for transport layer | `true` |
+| `plugins.security.ssl.http.enabled` | Enable TLS for HTTP layer | `true` |
+| `plugins.security.allow_default_init_securityindex` | Allow default security index initialization | `false` |
+| `plugins.security.audit.type` | Audit log storage type | `internal_opensearch` |
+| `plugins.security.restapi.password_score_based_validation_strength` | Password strength requirement | `fair` |
+| `plugins.security.restapi.roles_enabled` | Roles allowed to use REST API | `[]` |
+
+### Configuration Files
+
+| File | Description |
+|------|-------------|
+| `config.yml` | Main security configuration |
+| `roles.yml` | Role definitions |
+| `roles_mapping.yml` | User-to-role mappings |
+| `internal_users.yml` | Internal user database |
+| `action_groups.yml` | Action group definitions |
+| `tenants.yml` | Multi-tenancy configuration |
+| `allowlist.yml` | API allowlist configuration |
+| `audit.yml` | Audit logging configuration |
+| `nodes_dn.yml` | Node distinguished names |
+
+### Usage Example
+
+```yaml
+# roles.yml - Define a custom role
+custom_read_role:
+  cluster_permissions:
+    - cluster_composite_ops_ro
+  index_permissions:
+    - index_patterns:
+        - "logs-*"
+      allowed_actions:
+        - read
+      dls: '{"term": {"department": "${user.department}"}}'
+      fls:
+        - "~password"
+        - "~ssn"
+      masked_fields:
+        - "email"
+
+# roles_mapping.yml - Map users to roles
+custom_read_role:
+  users:
+    - analyst_user
+  backend_roles:
+    - analysts
+```
+
+### Rate Limiting Configuration
+
+```yaml
+# config.yml - Rate limiting with CIDR support (v3.0.0+)
+config:
+  dynamic:
+    auth_failure_listeners:
+      ip_rate_limiting:
+        type: ip
+        allowed_tries: 5
+        time_window_seconds: 60
+        block_expiry_seconds: 600
+        max_blocked_clients: 100000
+        max_tracked_clients: 100000
+        ignore_hosts:
+          - 127.0.0.0/8
+          - 10.0.0.0/8
+```
+
+## Limitations
+
+- Configuration changes require `securityadmin.sh` or cluster restart
+- Some settings are not hot-reloadable
+- Blake2b hash change in v3.0.0 requires password re-hashing
+- OpenSSL TLS provider removed in v3.0.0 (JDK TLS only)
+- Whitelist settings removed in v3.0.0 (use allowlist)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#5089](https://github.com/opensearch-project/security/pull/5089) | Fix Blake2b hash implementation (breaking) |
+| v3.0.0 | [#5220](https://github.com/opensearch-project/security/pull/5220) | Remove OpenSSL provider (breaking) |
+| v3.0.0 | [#5224](https://github.com/opensearch-project/security/pull/5224) | Remove whitelist settings (breaking) |
+| v3.0.0 | [#4380](https://github.com/opensearch-project/security/pull/4380) | Optimized Privilege Evaluation |
+| v3.0.0 | [#5099](https://github.com/opensearch-project/security/pull/5099) | CIDR ranges in ignore_hosts |
+| v3.0.0 | [#5119](https://github.com/opensearch-project/security/pull/5119) | Add 'good' password validation strength |
+| v3.0.0 | [#5160](https://github.com/opensearch-project/security/pull/5160) | Add stop-replication permission |
+| v3.0.0 | [#5153](https://github.com/opensearch-project/security/pull/5153) | Secure password generator action |
+| v3.0.0 | [#5193](https://github.com/opensearch-project/security/pull/5193) | Default to v7 config models |
+| v3.0.0 | [#5175](https://github.com/opensearch-project/security/pull/5175) | Escape pipe character in usernames |
+
+## References
+
+- [Issue #4274](https://github.com/opensearch-project/security/issues/4274): Blake2b hash issue
+- [Issue #3870](https://github.com/opensearch-project/security/issues/3870): Optimized privilege evaluation
+- [Issue #4927](https://github.com/opensearch-project/security/issues/4927): CIDR range support
+- [Issue #1483](https://github.com/opensearch-project/OpenSearch/issues/1483): Deprecate non-inclusive terms
+- [Documentation: Security](https://docs.opensearch.org/3.0/security/)
+- [Documentation: Breaking Changes](https://docs.opensearch.org/3.0/breaking-changes/)
+- [Documentation: Security Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/security-settings/)
+- [Documentation: Access Control API](https://docs.opensearch.org/3.0/security/access-control/api/)
+
+## Change History
+
+- **v3.0.0** (2025): Breaking changes - Blake2b hash fix, OpenSSL removal, whitelist→allowlist; Enhancements - optimized privilege evaluation, CIDR support in ignore_hosts, password validation improvements
+- **v2.18.0** (2024): Auto-convert security config models from v6 to v7

--- a/docs/releases/v3.0.0/features/security/security-plugin-changes.md
+++ b/docs/releases/v3.0.0/features/security/security-plugin-changes.md
@@ -1,0 +1,155 @@
+# Security Plugin Changes
+
+## Summary
+
+OpenSearch 3.0.0 introduces significant breaking changes to the Security plugin, including a corrected Blake2b hash implementation, removal of OpenSSL provider support, removal of deprecated whitelist settings in favor of allowlist, and optimized privilege evaluation. These changes improve security, performance, and align with inclusive terminology standards.
+
+## Details
+
+### What's New in v3.0.0
+
+This release includes three breaking changes and several enhancements to the Security plugin.
+
+### Technical Changes
+
+#### Breaking Changes
+
+```mermaid
+graph TB
+    subgraph "Breaking Changes in v3.0.0"
+        B1[Blake2b Hash Fix]
+        B2[OpenSSL Provider Removal]
+        B3[Whitelist → Allowlist]
+    end
+    
+    B1 --> |"Different hash values"| Migration1[Re-hash passwords]
+    B2 --> |"JDK 21 requirement"| Migration2[Use JDK TLS]
+    B3 --> |"Config rename"| Migration3[Update settings]
+```
+
+##### 1. Blake2b Hash Implementation Fix (PR #5089)
+
+The Blake2b hash implementation was passing parameters incorrectly, resulting in wrong hash values. This fix produces correct but different hashes compared to previous versions.
+
+**Impact:**
+- Existing hashed passwords will no longer match
+- Users must re-hash passwords after upgrade
+- Affects internal user database authentication
+
+**Resolution:** Resolves [Issue #4274](https://github.com/opensearch-project/security/issues/4274)
+
+##### 2. OpenSSL Provider Removal (PR #5220)
+
+Support for configuring OpenSSL as a TLS provider has been removed. OpenSSL was not supported with JDK > 11, and since OpenSearch 3.0.0 requires JDK 21 minimum, this configuration option is no longer applicable.
+
+**Impact:**
+- `plugins.security.ssl.transport.enable_openssl_if_available` setting removed
+- `plugins.security.ssl.http.enable_openssl_if_available` setting removed
+- All TLS operations now use JDK's built-in TLS implementation
+
+**Migration:** Remove any OpenSSL-related settings from `opensearch.yml`.
+
+##### 3. Whitelist Settings Removal (PR #5224)
+
+Non-inclusive "whitelist" terminology has been removed in favor of "allowlist", completing the deprecation started in OpenSearch 2.0.
+
+**Impact:**
+- `whitelist.yml` configuration file renamed to `allowlist.yml`
+- API endpoints using "whitelist" removed
+- Settings with "whitelist" prefix removed
+
+**Migration:** 
+- Rename `whitelist.yml` to `allowlist.yml`
+- Update any automation scripts using whitelist endpoints
+
+#### Enhancements
+
+| PR | Title | Description |
+|----|-------|-------------|
+| [#4380](https://github.com/opensearch-project/security/pull/4380) | Optimized Privilege Evaluation | De-normalized data structures for faster privilege checks |
+| [#5099](https://github.com/opensearch-project/security/pull/5099) | CIDR Ranges in ignore_hosts | Support for CIDR notation in rate limiting configuration |
+| [#5119](https://github.com/opensearch-project/security/pull/5119) | Password Validation Strength | Added 'good' as valid value for password strength validation |
+| [#5160](https://github.com/opensearch-project/security/pull/5160) | Stop-Replication Permission | Added permission to index_management_full_access role |
+| [#5153](https://github.com/opensearch-project/security/pull/5153) | Secure Password Generator | Replaced password generator step with secure action |
+| [#2223](https://github.com/opensearch-project/security-dashboards-plugin/pull/2223) | Cat Shard API Permission | Added permission for cat shards API |
+
+#### Optimized Privilege Evaluation (PR #4380)
+
+A major performance enhancement that introduces de-normalized data structures optimized for privilege evaluation checks. Key improvements:
+
+- Faster action privilege evaluation
+- Optimized DLS/FLS/FM privilege evaluation
+- DLS queries prepared ahead of time
+- Reduced overhead during indexing operations
+
+**Behavioral Changes:**
+- `config.dynamic.multi_rolespan_enabled` is no longer evaluated (behaves as always `true`)
+- More detailed error messages for missing privileges
+- DLS/FLS defaults to "deny by default" implementation
+
+#### CIDR Range Support in ignore_hosts (PR #5099)
+
+The `ignore_hosts` setting in authentication failure listeners now supports CIDR notation:
+
+```yaml
+auth_failure_listeners:
+  ip_rate_limiting:
+    type: ip
+    allowed_tries: 3
+    time_window_seconds: 60
+    block_expiry_seconds: 600
+    ignore_hosts:
+      - 127.0.0.0/8
+      - 10.0.0.0/8
+      - 192.168.0.0/16
+```
+
+### Migration Notes
+
+1. **Blake2b Hash Migration:**
+   - After upgrade, users with hashed passwords must reset their passwords
+   - Use `securityadmin.sh` to update internal users
+
+2. **OpenSSL Removal:**
+   - Remove OpenSSL settings from configuration
+   - Verify TLS works with JDK implementation before upgrade
+
+3. **Whitelist to Allowlist:**
+   - Rename configuration files
+   - Update API calls in scripts
+
+4. **Privilege Evaluation:**
+   - No action required for most users
+   - Review error messages if experiencing privilege issues
+
+## Limitations
+
+- Blake2b hash change requires password re-hashing for all internal users
+- OpenSSL removal may affect performance in some high-throughput TLS scenarios
+- Whitelist settings migration must be done before upgrade
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5089](https://github.com/opensearch-project/security/pull/5089) | Fix Blake2b hash implementation |
+| [#5220](https://github.com/opensearch-project/security/pull/5220) | Remove OpenSSL provider |
+| [#5224](https://github.com/opensearch-project/security/pull/5224) | Remove whitelist settings in favor of allowlist |
+| [#4380](https://github.com/opensearch-project/security/pull/4380) | Optimized Privilege Evaluation |
+| [#5099](https://github.com/opensearch-project/security/pull/5099) | Add support for CIDR ranges in ignore_hosts |
+| [#5119](https://github.com/opensearch-project/security/pull/5119) | Add 'good' as valid password validation strength |
+| [#5160](https://github.com/opensearch-project/security/pull/5160) | Add stop-replication permission |
+| [#5153](https://github.com/opensearch-project/security/pull/5153) | Replace password generator with secure action |
+
+## References
+
+- [Issue #4274](https://github.com/opensearch-project/security/issues/4274): Blake2b hash issue
+- [Issue #3870](https://github.com/opensearch-project/security/issues/3870): Optimized privilege evaluation proposal
+- [Issue #4927](https://github.com/opensearch-project/security/issues/4927): CIDR range support request
+- [Issue #1483](https://github.com/opensearch-project/OpenSearch/issues/1483): Deprecate non-inclusive terms
+- [Documentation: Breaking Changes](https://docs.opensearch.org/3.0/breaking-changes/)
+- [Documentation: Security Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/security-settings/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/security-plugin.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -49,6 +49,7 @@
 ## security
 
 - [Security Plugin Bugfixes for Release 3.0](features/security/release-3-0-bugfixes.md)
+- [Security Plugin Changes](features/security/security-plugin-changes.md)
 
 ## dashboards-flow-framework
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security Plugin breaking changes and enhancements in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/security/security-plugin-changes.md`
- Feature report: `docs/features/security/security-plugin.md`

### Key Changes in v3.0.0

**Breaking Changes:**
- Blake2b hash implementation fix (produces different but correct hashes)
- OpenSSL provider removal (JDK 21 requirement)
- Whitelist settings removed in favor of allowlist

**Enhancements:**
- Optimized Privilege Evaluation for better performance
- CIDR range support in ignore_hosts setting
- Password validation strength improvements
- Stop-replication permission added
- Secure password generator action

### Resources Used
- PRs: #5089, #5220, #5224, #4380, #5099, #5119, #5160, #5153
- Docs: https://docs.opensearch.org/3.0/breaking-changes/
- Docs: https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/security-settings/

Closes #149