### PR TITLE
docs: add Observability Notebooks report for v3.0.0

### DIFF
--- a/docs/features/dashboards-observability/observability-notebooks.md
+++ b/docs/features/dashboards-observability/observability-notebooks.md
@@ -1,0 +1,172 @@
+# OpenSearch Dashboards Notebooks
+
+## Summary
+
+OpenSearch Dashboards Notebooks is a feature that enables users to combine live visualizations, narrative text, and SQL/PPL queries in an interactive document format. Notebooks facilitate data exploration, collaboration, and reporting by allowing users to create rich, shareable reports backed by live data. Use cases include postmortem reports, operations runbooks, infrastructure reports, and documentation.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        UI[Notebooks UI]
+        API[Notebooks API]
+        SO[Saved Objects Service]
+    end
+    
+    subgraph "Storage"
+        KB[.kibana Index]
+    end
+    
+    subgraph "Query Engines"
+        SQL[SQL Engine]
+        PPL[PPL Engine]
+    end
+    
+    subgraph "Visualization"
+        VIS[Visualizations]
+        DASH[Dashboards]
+    end
+    
+    UI --> API
+    API --> SO
+    SO --> KB
+    UI --> SQL
+    UI --> PPL
+    UI --> VIS
+    UI --> DASH
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    User[User] --> Create[Create Notebook]
+    Create --> AddPara[Add Paragraphs]
+    AddPara --> MD[Markdown]
+    AddPara --> Query[SQL/PPL Query]
+    AddPara --> Viz[Visualization]
+    MD --> Run[Run Paragraph]
+    Query --> Run
+    Viz --> Run
+    Run --> Output[Rendered Output]
+    Output --> Export[Export PDF/PNG]
+    Output --> Share[Share URL]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Notebooks UI | React-based interface for creating and editing notebooks |
+| Notebooks API | Server-side REST API for notebook CRUD operations |
+| Saved Objects Backend | Storage layer using OpenSearch Dashboards saved objects |
+| Paragraph Renderer | nteract library-based renderer for markdown and code blocks |
+| Query Integration | Integration with SQL and PPL query engines |
+| Visualization Integration | Embedding of OpenSearch Dashboards visualizations |
+| Reporting Integration | Export capabilities for PDF, PNG, and shareable URLs |
+
+### Paragraph Types
+
+| Type | Syntax | Description |
+|------|--------|-------------|
+| Markdown | `%md` | Rich text formatting with markdown syntax |
+| SQL | `%sql` | SQL queries against OpenSearch indices |
+| PPL | `%ppl` | Piped Processing Language queries |
+| Visualization | UI selection | Embedded visualizations with time range support |
+
+### Storage
+
+Notebooks are stored as saved objects in the `.kibana` index. Each notebook contains:
+
+- **Metadata**: Name, creation date, modification date
+- **Paragraphs**: Array of paragraph objects with input and output
+
+```json
+{
+  "type": "notebook",
+  "attributes": {
+    "name": "My Notebook",
+    "dateCreated": "2024-01-01T00:00:00Z",
+    "dateModified": "2024-01-01T00:00:00Z",
+    "paragraphs": [
+      {
+        "id": "paragraph_uuid",
+        "input": {
+          "inputType": "MARKDOWN",
+          "inputText": "%md\n# Title"
+        },
+        "output": [
+          {
+            "outputType": "MARKDOWN",
+            "result": "# Title"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Usage Example
+
+```markdown
+# Creating a Notebook
+
+1. Navigate to Observability > Notebooks in OpenSearch Dashboards
+2. Click "Create notebook" and enter a name
+3. Add paragraphs:
+
+## Markdown Paragraph
+%md
+# Flight Data Analysis
+This notebook analyzes sample flight data.
+
+## SQL Query Paragraph
+%sql
+SELECT * FROM opensearch_dashboards_sample_data_flights LIMIT 20;
+
+## PPL Query Paragraph
+%ppl
+source=opensearch_dashboards_sample_data_logs | head 20
+```
+
+### Security
+
+Notebooks support OpenSearch security features:
+
+- **Multi-tenancy**: Notebooks can be scoped to tenants
+- **Access control**: Permissions via `cluster:admin/opensearch/observability/*` actions
+- **Role-based access**: Integration with OpenSearch security roles
+
+## Limitations
+
+- Notebooks require the dashboards-observability plugin
+- Query execution depends on SQL/PPL plugin availability
+- Visualization embedding requires saved visualizations
+- Export functionality requires the reporting plugin
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#2406](https://github.com/opensearch-project/dashboards-observability/pull/2406) | Remove support for legacy notebooks |
+| v2.17.0 | - | Introduced saved objects storage for notebooks |
+| v1.0.0 | - | Initial production release of Notebooks |
+
+## References
+
+- [Issue #2350](https://github.com/opensearch-project/dashboards-observability/issues/2350): Deprecation notice for legacy notebooks
+- [Issue #2311](https://github.com/opensearch-project/dashboards-observability/issues/2311): Notebooks migration tracking
+- [Notebooks Documentation](https://docs.opensearch.org/3.0/observing-your-data/notebooks/): Official documentation
+- [Blog: Feature Deep Dive - OpenSearch Dashboards Notebooks](https://opensearch.org/blog/feature-highlight-opensearch-dashboards-notebooks/): Feature overview and use cases
+- [Observability Security](https://docs.opensearch.org/3.0/observing-your-data/observability-security/): Security configuration for observability features
+
+## Change History
+
+- **v3.0.0** (2025): Removed legacy notebooks support; only `.kibana` storage supported
+- **v2.19.0** (2024): Deprecated legacy notebooks with migration notice
+- **v2.17.0** (2024): Introduced saved objects storage in `.kibana` index
+- **v1.0.0** (2021): Initial production release with SQL, PPL, and visualization support

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -95,6 +95,10 @@
 
 - [Observability Integrations](observability/observability-integrations.md)
 
+## dashboards-observability
+
+- [Observability Notebooks](dashboards-observability/observability-notebooks.md)
+
 ## dashboards-maps
 
 - [Maps & Geospatial](dashboards-maps/maps-geospatial.md)

--- a/docs/releases/v3.0.0/features/dashboards-observability/observability-notebooks.md
+++ b/docs/releases/v3.0.0/features/dashboards-observability/observability-notebooks.md
@@ -1,0 +1,126 @@
+# Observability Notebooks - Legacy Support Removal
+
+## Summary
+
+OpenSearch Dashboards 3.0.0 removes support for legacy notebooks stored in the `.opensearch-observability` index. This is a breaking change that requires users to migrate their notebooks to the new storage system (`.kibana` index) before upgrading. The change simplifies the notebooks architecture by consolidating storage to a single location and removes approximately 1,000 lines of legacy backend code.
+
+## Details
+
+### What's New in v3.0.0
+
+The legacy notebooks feature has been completely removed from the dashboards-observability plugin. Key changes include:
+
+- **Storage consolidation**: Only notebooks stored in the `.kibana` index (introduced in v2.17) are now supported
+- **Legacy backend removal**: The `DefaultBackend` class and related adaptor code have been removed
+- **API simplification**: Legacy notebook API endpoints have been removed
+- **Migration endpoint removal**: The `/note/migrate` endpoint is no longer available
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.0.0"
+        UI1[Notebooks UI]
+        API1[Notebooks API]
+        LB[Legacy Backend<br/>.opensearch-observability]
+        SB[Saved Objects Backend<br/>.kibana]
+        API1 --> LB
+        API1 --> SB
+        UI1 --> API1
+    end
+    
+    subgraph "v3.0.0+"
+        UI2[Notebooks UI]
+        API2[Notebooks API]
+        SO[Saved Objects<br/>.kibana]
+        UI2 --> API2
+        API2 --> SO
+    end
+```
+
+#### Removed Components
+
+| Component | Description |
+|-----------|-------------|
+| `server/adaptors/notebooks/default_backend.ts` | Legacy backend implementation for `.opensearch-observability` index |
+| `server/adaptors/notebooks/notebook_adaptor.ts` | Interface definition for notebook backends |
+| `server/adaptors/notebooks/index.ts` | Backend export module |
+| Legacy API routes | Routes for `/note`, `/paragraph`, etc. that used legacy backend |
+
+#### Removed API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `${NOTEBOOKS_API_PREFIX}/` | GET | Fetch all legacy notebooks |
+| `${NOTEBOOKS_API_PREFIX}/note/{noteId}` | GET | Get legacy notebook paragraphs |
+| `${NOTEBOOKS_API_PREFIX}/note` | POST | Add legacy notebook |
+| `${NOTEBOOKS_API_PREFIX}/note/rename` | PUT | Rename legacy notebook |
+| `${NOTEBOOKS_API_PREFIX}/note/clone` | POST | Clone legacy notebook |
+| `${NOTEBOOKS_API_PREFIX}/note/{noteList}` | DELETE | Delete legacy notebooks |
+| `${NOTEBOOKS_API_PREFIX}/note/addSampleNotebooks` | POST | Add sample notebooks to legacy storage |
+| `${NOTEBOOKS_API_PREFIX}/note/migrate` | POST | Migrate notebook from legacy to saved objects |
+| `${NOTEBOOKS_API_PREFIX}/paragraph/*` | Various | Legacy paragraph operations |
+
+### Migration Notes
+
+Users must migrate their notebooks before upgrading to v3.0.0:
+
+1. **Upgrade to v2.17 or later** (but before v3.0.0)
+2. **Identify legacy notebooks**: Legacy notebooks are stored in `.opensearch-observability` index
+3. **Migrate notebooks**: Use the migration functionality available in v2.17-v2.19 to move notebooks to `.kibana` index
+4. **Verify migration**: Ensure all notebooks are accessible after migration
+5. **Upgrade to v3.0.0**: Once migration is complete, proceed with the upgrade
+
+### Code Changes
+
+The main code change in `main.tsx` simplifies the `fetchNotebooks` function:
+
+```typescript
+// Before: Fetched from both legacy and saved objects storage
+fetchNotebooks = () => {
+  return Promise.all([
+    this.props.http.get(`${NOTEBOOKS_API_PREFIX}/savedNotebook`),
+    this.props.http.get(`${NOTEBOOKS_API_PREFIX}/`),
+  ]).then(([savedNotebooksResponse, secondResponse]) => {
+    const combinedData = {
+      data: [...savedNotebooksResponse.data, ...secondResponse.data],
+    };
+    this.setState(combinedData);
+  });
+};
+
+// After: Only fetches from saved objects storage
+fetchNotebooks = () => {
+  return this.props.http
+    .get(`${NOTEBOOKS_API_PREFIX}/savedNotebook`)
+    .then((savedNotebooksResponse) => {
+      this.setState({ data: savedNotebooksResponse.data });
+    });
+};
+```
+
+## Limitations
+
+- **No backward compatibility**: Legacy notebooks cannot be accessed after upgrading to v3.0.0
+- **No automatic migration**: Users must manually migrate notebooks before upgrading
+- **Data loss risk**: Notebooks not migrated before upgrade will be inaccessible
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2406](https://github.com/opensearch-project/dashboards-observability/pull/2406) | Remove support for legacy notebooks |
+
+## References
+
+- [Issue #2350](https://github.com/opensearch-project/dashboards-observability/issues/2350): Deprecation notice for legacy notebooks
+- [Issue #2311](https://github.com/opensearch-project/dashboards-observability/issues/2311): Parent issue for notebooks migration
+- [Breaking Changes Documentation](https://docs.opensearch.org/3.0/breaking-changes/): Official v3.0.0 breaking changes
+- [Notebooks Documentation](https://docs.opensearch.org/3.0/observing-your-data/notebooks/): Current notebooks feature documentation
+- [Blog: Feature Deep Dive - OpenSearch Dashboards Notebooks](https://opensearch.org/blog/feature-highlight-opensearch-dashboards-notebooks/): Feature overview
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-observability/observability-notebooks.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -98,6 +98,10 @@
 
 - [Observability Integrations](features/observability/observability-integrations.md)
 
+## dashboards-observability
+
+- [Observability Notebooks](features/dashboards-observability/observability-notebooks.md)
+
 ## dashboards-maps
 
 - [Maps & Geospatial](features/dashboards-maps/maps-geospatial.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Observability Notebooks breaking change in OpenSearch v3.0.0.

### Changes

- **Release Report**: `docs/releases/v3.0.0/features/dashboards-observability/observability-notebooks.md`
  - Documents the removal of legacy notebooks support
  - Details removed API endpoints and components
  - Provides migration guidance

- **Feature Report**: `docs/features/dashboards-observability/observability-notebooks.md`
  - Comprehensive documentation of the Notebooks feature
  - Architecture diagrams and component descriptions
  - Change history tracking

### Key Points

- Legacy notebooks stored in `.opensearch-observability` index are no longer supported in v3.0.0
- Only notebooks stored in `.kibana` index (introduced in v2.17) are supported
- Users must migrate notebooks before upgrading to v3.0.0

### Related Issue

Closes #148