### PR TITLE
docs: add Monaco Editor Upgrade report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -37,6 +37,7 @@
 - [Dashboards Cypress Testing](opensearch-dashboards/dashboards-cypress-testing.md)
 - [Dashboards UI/UX Fixes](opensearch-dashboards/dashboards-ui-ux-fixes.md)
 - [DOMPurify Sanitization](opensearch-dashboards/dompurify-sanitization.md)
+- [Monaco Editor](opensearch-dashboards/monaco-editor.md)
 - [Workspace](opensearch-dashboards/workspace.md)
 
 ## security

--- a/docs/features/opensearch-dashboards/monaco-editor.md
+++ b/docs/features/opensearch-dashboards/monaco-editor.md
@@ -1,0 +1,164 @@
+# Monaco Editor
+
+## Summary
+
+Monaco Editor is the code editor component that powers OpenSearch Dashboards' query editors, Dev Tools console, and various configuration interfaces. It provides syntax highlighting, autocomplete, error detection, and a rich editing experience for users writing queries in DQL, SQL, PPL, and JSON formats.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        QE[Query Editor]
+        DT[Dev Tools Console]
+        CE[Config Editors]
+    end
+    
+    subgraph "Monaco Integration Layer"
+        OSD[osd-monaco package]
+        RME[react-monaco-editor]
+        ENV[MonacoEnvironment]
+    end
+    
+    subgraph "Monaco Editor Core"
+        ME[monaco-editor]
+        WK[Web Workers]
+        LS[Language Services]
+    end
+    
+    QE --> OSD
+    DT --> OSD
+    CE --> OSD
+    OSD --> RME
+    OSD --> ENV
+    RME --> ME
+    ENV --> WK
+    ME --> LS
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[User Input] --> B[Monaco Editor]
+    B --> C[Language Service]
+    C --> D{Completion Provider}
+    D --> E[Suggestions]
+    E --> B
+    B --> F[Query String]
+    F --> G[OpenSearch Query]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `@osd/monaco` | OpenSearch Dashboards Monaco wrapper package |
+| `react-monaco-editor` | React component wrapper for Monaco |
+| `MonacoEnvironment` | Worker configuration and initialization |
+| `CodeEditor` | Reusable code editor component |
+| `SingleLineInput` | Single-line query input component |
+| `DefaultInput` | Multi-line query editor component |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `minimap.enabled` | Show code minimap | `false` |
+| `scrollBeyondLastLine` | Allow scrolling past last line | `false` |
+| `suggest.showWords` | Enable word-based suggestions | `false` |
+| `suggest.showStatusBar` | Show suggestion status bar | `true` |
+| `acceptSuggestionOnEnter` | Accept suggestion on Enter key | `'off'` |
+| `wordWrap` | Enable word wrapping | `'on'` |
+| `lineNumbers` | Show line numbers | `'on'` |
+
+### Supported Languages
+
+| Language ID | Description | Use Case |
+|-------------|-------------|----------|
+| `dql` | Dashboards Query Language | Discover search bar |
+| `sql` | OpenSearch SQL | Query Workbench |
+| `ppl` | Piped Processing Language | Query Workbench |
+| `json` | JSON | Dev Tools, configurations |
+| `xjson` | Extended JSON | Console requests |
+
+### Usage Example
+
+```tsx
+import { CodeEditor } from '@osd/monaco';
+
+const MyEditor = () => {
+  const [value, setValue] = useState('');
+  
+  return (
+    <CodeEditor
+      languageId="sql"
+      value={value}
+      onChange={setValue}
+      options={{
+        minimap: { enabled: false },
+        suggest: {
+          showWords: false,
+          showStatusBar: true,
+        },
+      }}
+      suggestionProvider={{
+        triggerCharacters: [' ', '.'],
+        provideCompletionItems: async (model, position, context, token) => {
+          // Return completion suggestions
+          return { suggestions: [] };
+        },
+      }}
+    />
+  );
+};
+```
+
+### Worker Configuration
+
+```typescript
+// MonacoEnvironment setup
+window.MonacoEnvironment = {
+  getWorker: (workerId: string, label: string) => {
+    const workerSrc = getWorker(label);
+    if (workerSrc) {
+      const blob = new Blob([workerSrc], { type: 'application/javascript' });
+      return new Worker(URL.createObjectURL(blob));
+    }
+    // Fallback worker
+    return new Worker(URL.createObjectURL(new Blob([''], { type: 'application/javascript' })));
+  },
+};
+```
+
+## Limitations
+
+- Monaco Editor adds significant bundle size to the application
+- Web Workers require proper CORS configuration in some deployment scenarios
+- Custom language support requires implementing full language service
+- Some advanced Monaco features may not be exposed through the OSD wrapper
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#9618](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9618) | Bump monaco-editor from 0.30.1 to 0.52.0 |
+| v3.0.0 | [#9497](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9497) | Bump monaco-editor from 0.17.0 to 0.30.1 |
+
+## References
+
+- [Issue #9573](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9573): Monaco upgrade implementation notes
+- [Monaco Editor Documentation](https://microsoft.github.io/monaco-editor/): Official Monaco documentation
+- [Monaco Editor GitHub](https://github.com/microsoft/monaco-editor): Source repository
+
+## Change History
+
+- **v3.0.0** (2025-04-01): Major upgrade from 0.17.0 to 0.52.0
+  - Switched from image sprite icons to Codicon font system
+  - Updated API from `getModeId()` to `getLanguageId()`
+  - Redesigned worker architecture
+  - Added built-in suggestion status bar
+  - Updated completion provider signatures with context and token parameters
+  - Added babel plugins for modern JavaScript syntax support

--- a/docs/releases/v3.0.0/features/opensearch-dashboards/monaco-editor-upgrade.md
+++ b/docs/releases/v3.0.0/features/opensearch-dashboards/monaco-editor-upgrade.md
@@ -1,0 +1,155 @@
+# Monaco Editor Upgrade
+
+## Summary
+
+OpenSearch Dashboards v3.0.0 includes a major upgrade of the Monaco Editor from version 0.17.0 to 0.52.0. This is a **breaking change** that modernizes the code editor component used throughout the Dashboards UI, including the Query Editor, Dev Tools Console, and various configuration editors. The upgrade brings improved performance, better accessibility, and modern JavaScript features support.
+
+## Details
+
+### What's New in v3.0.0
+
+The Monaco Editor upgrade was implemented in two phases:
+1. **Phase 1 (PR #9497)**: Upgrade from 0.17.0 to 0.30.1
+2. **Phase 2 (PR #9618)**: Upgrade from 0.30.1 to 0.52.0
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Monaco 0.17.0 (Old)"
+        A1[Image Sprite Icons]
+        B1[getModeId API]
+        C1[wordBasedSuggestions option]
+        D1[Simple Worker Pattern]
+    end
+    
+    subgraph "Monaco 0.52.0 (New)"
+        A2[Codicon Font Icons]
+        B2[getLanguageId API]
+        C2[suggest.showWords option]
+        D2[Redesigned Worker Architecture]
+    end
+    
+    A1 --> A2
+    B1 --> B2
+    C1 --> C2
+    D1 --> D2
+```
+
+#### Key API Changes
+
+| Old API (0.17.0) | New API (0.52.0) | Description |
+|------------------|------------------|-------------|
+| `model.getModeId()` | `model.getLanguageId()` | Language identification |
+| `wordBasedSuggestions: false` | `suggest: { showWords: false }` | Disable word suggestions |
+| `getWorker(module, languageId)` | `getWorker(workerId, label)` | Worker initialization |
+| CSS pseudo-element status bar | Built-in `showStatusBar: true` | Suggestion widget status |
+
+#### New Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `monaco-editor` | ^0.52.0 | Core editor |
+| `react-monaco-editor` | ^0.58.0 | React wrapper |
+| `file-loader` | ^6.2.0 | Font file loading |
+| `style-loader` | ^1.1.3 | CSS injection |
+| `@babel/plugin-transform-numeric-separator` | ^7.25.9 | Modern JS syntax |
+
+#### Webpack Configuration Changes
+
+New babel plugins required to handle modern JavaScript syntax in Monaco 0.52.0:
+- `@babel/plugin-transform-class-static-block`
+- `@babel/plugin-transform-nullish-coalescing-operator`
+- `@babel/plugin-transform-optional-chaining`
+- `@babel/plugin-transform-numeric-separator`
+
+#### Worker Implementation Changes
+
+The worker architecture was significantly redesigned. Workers now use simplified implementations:
+
+```typescript
+// New simplified worker pattern
+self.onmessage = () => {
+  // Basic initialization
+  // Worker is initialized and ready
+};
+```
+
+#### Import Path Changes
+
+Many import paths now include `/browser/` in their structure:
+
+```typescript
+// Old
+import 'monaco-editor/esm/vs/editor/contrib/suggest/suggestController.js';
+
+// New
+import 'monaco-editor/esm/vs/editor/contrib/suggest/browser/suggestController';
+```
+
+### Migration Notes
+
+#### For Plugin Developers
+
+1. **Update completion providers**: Add `context` and `token` parameters to `provideCompletionItems`
+2. **Update signature help providers**: Return a Promise with `{ value: {...}, dispose: () => {} }` structure
+3. **Replace deprecated options**: Change `wordBasedSuggestions: false` to `suggest: { showWords: false }`
+4. **Update language detection**: Replace `getModeId()` with `getLanguageId()`
+
+#### For Test Authors
+
+1. Add Monaco mock to Jest configuration
+2. Add `window.matchMedia` mock for Monaco editor tests
+3. Update `transformIgnorePatterns` to include `react-monaco-editor`
+
+### Usage Example
+
+```typescript
+// Updated editor options for Monaco 0.52.0
+const editorOptions = {
+  minimap: { enabled: false },
+  scrollBeyondLastLine: false,
+  suggest: {
+    snippetsPreventQuickSuggestions: false,
+    filterGraceful: false,
+    showStatusBar: true,  // Built-in status bar
+    showWords: false,     // Replaces wordBasedSuggestions
+  },
+  acceptSuggestionOnEnter: 'off',
+};
+
+// Updated completion provider signature
+const suggestionProvider = {
+  triggerCharacters: [' '],
+  provideCompletionItems: async (model, position, context, token) => {
+    if (token.isCancellationRequested) {
+      return { suggestions: [], incomplete: false };
+    }
+    // ... provide suggestions
+  },
+};
+```
+
+## Limitations
+
+- Custom CSS-based status bar styling no longer works; must use Monaco's built-in status bar
+- Some older plugins may need updates to work with the new Monaco API
+- Worker files are simplified and may have reduced functionality compared to Monaco's full workers
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9497](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9497) | Bump monaco-editor from 0.17.0 to 0.30.1 |
+| [#9618](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9618) | Bump monaco-editor from 0.30.1 to 0.52.0 |
+
+## References
+
+- [Issue #9573](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9573): Bump monaco-editor from 0.30.1 to 0.52.0 (implementation notes)
+- [Monaco Editor Changelog](https://github.com/microsoft/monaco-editor/blob/main/CHANGELOG.md): Official changelog
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/monaco-editor.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -37,6 +37,7 @@
 - [Dashboards Cypress Testing](features/opensearch-dashboards/dashboards-cypress-testing.md)
 - [Dashboards Dependencies](features/opensearch-dashboards/dashboards-dependencies.md)
 - [Dashboards UI/UX Fixes](features/opensearch-dashboards/dashboards-ui-ux-fixes.md)
+- [Monaco Editor Upgrade](features/opensearch-dashboards/monaco-editor-upgrade.md)
 - [UI/UX Improvements](features/opensearch-dashboards/ui-ux-improvements.md)
 - [Workspace Improvements](features/opensearch-dashboards/workspace-improvements.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Monaco Editor Upgrade breaking change in OpenSearch Dashboards v3.0.0.

## Changes

### Release Report
- `docs/releases/v3.0.0/features/opensearch-dashboards/monaco-editor-upgrade.md`

### Feature Report
- `docs/features/opensearch-dashboards/monaco-editor.md`

## Key Findings

The Monaco Editor was upgraded from version 0.17.0 to 0.52.0 in two phases:
1. PR #9497: 0.17.0 → 0.30.1
2. PR #9618: 0.30.1 → 0.52.0

### Breaking Changes
- Icon system changed from image sprites to Codicon fonts
- API changes: `getModeId()` → `getLanguageId()`
- Options restructured: `wordBasedSuggestions` → `suggest.showWords`
- Worker architecture redesigned
- Completion provider signatures updated with context and token parameters

### Migration Required
- Plugin developers need to update completion providers
- Test authors need to add Monaco mocks
- Custom CSS status bar styling no longer works

## Related Issue
Closes #146