### PR TITLE
docs: add Dashboards Frontend Cleanup report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -35,6 +35,7 @@
 - [Cross-Cluster Search](opensearch-dashboards/cross-cluster-search.md)
 - [Dashboards CI/CD & Documentation](opensearch-dashboards/dashboards-ci-cd-documentation.md)
 - [Dashboards Cypress Testing](opensearch-dashboards/dashboards-cypress-testing.md)
+- [Dashboards Frontend Cleanup](opensearch-dashboards/dashboards-frontend-cleanup.md)
 - [Dashboards UI/UX Fixes](opensearch-dashboards/dashboards-ui-ux-fixes.md)
 - [DOMPurify Sanitization](opensearch-dashboards/dompurify-sanitization.md)
 - [Monaco Editor](opensearch-dashboards/monaco-editor.md)

--- a/docs/features/opensearch-dashboards/dashboards-frontend-cleanup.md
+++ b/docs/features/opensearch-dashboards/dashboards-frontend-cleanup.md
@@ -1,0 +1,141 @@
+# Dashboards Frontend Cleanup
+
+## Summary
+
+OpenSearch Dashboards periodically removes deprecated frontend APIs and dependencies to maintain code quality and reduce technical debt. This feature tracks the cleanup of deprecated exports, HTTP options, third-party dependencies, and UI components that have been superseded by newer implementations.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Removed in v3.0.0"
+        CSS[CssDistFilename exports]
+        LN[withLongNumerals option]
+        FS[@elastic/filesaver]
+        DG[DataGrid / newExperience]
+    end
+    
+    subgraph "Replacements"
+        BASE[baseCssDistFilename + theme config]
+        LNS[withLongNumeralsSupport]
+        FSN[file-saver package]
+        DDT[DefaultDiscoverTable]
+    end
+    
+    CSS --> BASE
+    LN --> LNS
+    FS --> FSN
+    DG --> DDT
+```
+
+### Components
+
+| Component | Status | Replacement | Deprecated In | Removed In |
+|-----------|--------|-------------|---------------|------------|
+| `darkCssDistFilename` | Removed | `baseCssDistFilename` | v2.x | v3.0.0 |
+| `darkV8CssDistFilename` | Removed | `baseCssDistFilename` | v2.x | v3.0.0 |
+| `lightCssDistFilename` | Removed | `baseCssDistFilename` | v2.x | v3.0.0 |
+| `lightV8CssDistFilename` | Removed | `baseCssDistFilename` | v2.x | v3.0.0 |
+| `withLongNumerals` | Removed | `withLongNumeralsSupport` | v2.x | v3.0.0 |
+| `@elastic/filesaver` | Removed | `file-saver` | v2.x | v3.0.0 |
+| `DataGrid` component | Removed | `DefaultDiscoverTable` | v2.x | v3.0.0 |
+| `newExperience` setting | Removed | N/A (default behavior) | v2.x | v3.0.0 |
+
+### Migration Guide
+
+#### CssDistFilename Migration
+
+The theme-specific CSS filename exports were deprecated in favor of a unified approach using `baseCssDistFilename` combined with theme configuration.
+
+```typescript
+// Before (deprecated)
+import { 
+  darkCssDistFilename, 
+  lightCssDistFilename,
+  darkV8CssDistFilename,
+  lightV8CssDistFilename 
+} from '@osd/ui-shared-deps';
+
+// After
+import { baseCssDistFilename } from '@osd/ui-shared-deps';
+// Theme selection is handled through theme configuration
+```
+
+#### HTTP Fetch Options Migration
+
+The `withLongNumerals` option was renamed to `withLongNumeralsSupport` for clarity.
+
+```typescript
+// Before (deprecated)
+const response = await http.fetch('/api/data', {
+  withLongNumerals: true
+});
+
+// After
+const response = await http.fetch('/api/data', {
+  withLongNumeralsSupport: true
+});
+```
+
+#### File Saver Migration
+
+The `@elastic/filesaver` package (last published 7 years ago) was replaced with the actively maintained `file-saver` package.
+
+```typescript
+// Before
+// @ts-expect-error - no types available
+import { saveAs } from '@elastic/filesaver';
+
+// After
+import { saveAs } from 'file-saver';
+// TypeScript types available via @types/file-saver
+```
+
+Affected files:
+- `src/plugins/console/public/application/containers/main/main.tsx`
+- `src/plugins/inspector/public/views/data/lib/export_csv.ts`
+- `src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx`
+- `src/plugins/vis_type_table/public/utils/convert_to_csv_data.ts`
+
+#### Discover Table Migration
+
+The `newExperience` DataGrid table option was removed. The `DefaultDiscoverTable` is now the only supported table implementation.
+
+```typescript
+// Before - DataGrid was available via newExperience setting
+// The DiscoverOptions component allowed toggling between tables
+
+// After - DefaultDiscoverTable is used exclusively
+// No configuration needed
+```
+
+## Limitations
+
+- Breaking change: Plugins using deprecated APIs will fail to compile against v3.0.0
+- No automatic migration path for custom plugins
+- Plugins must be updated before upgrading to v3.0.0
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#9446](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9446) | Remove deprecated CssDistFilename |
+| v3.0.0 | [#9448](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9448) | Remove withLongNumerals in HttpFetchOptions |
+| v3.0.0 | [#9484](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9484) | Remove @elastic/filesaver |
+| v3.0.0 | [#9531](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9531) | Remove newExperience table option |
+| v2.x | [#5592](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5592) | Deprecate withLongNumerals |
+| v2.x | [#7625](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7625) | Deprecate CssDistFilename |
+| v2.x | [#9511](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9511) | Deprecate newExperience table option |
+
+## References
+
+- [Issue #9253](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9253): Planned Breaking Changes for 3.0
+- [Issue #9341](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9341): Remove @elastic/filesaver dependency
+- [Breaking Changes Documentation](https://docs.opensearch.org/3.0/breaking-changes/): Official v3.0.0 breaking changes
+- [file-saver npm package](https://www.npmjs.com/package/file-saver): Replacement for @elastic/filesaver
+
+## Change History
+
+- **v3.0.0** (2025): Removed deprecated CssDistFilename exports, withLongNumerals option, @elastic/filesaver dependency, and newExperience Discover table option

--- a/docs/releases/v3.0.0/features/opensearch-dashboards/dashboards-frontend-cleanup.md
+++ b/docs/releases/v3.0.0/features/opensearch-dashboards/dashboards-frontend-cleanup.md
@@ -1,0 +1,121 @@
+# Dashboards Frontend Cleanup
+
+## Summary
+
+OpenSearch Dashboards v3.0.0 removes several deprecated frontend APIs and dependencies as part of a major cleanup effort. This breaking change removes `CssDistFilename` exports, the `withLongNumerals` HTTP option, the `@elastic/filesaver` dependency, and the deprecated "newExperience" Discover table option. Plugin developers and users relying on these deprecated features must update their code before upgrading to v3.0.0.
+
+## Details
+
+### What's New in v3.0.0
+
+This release removes deprecated code that was marked for removal in the 3.0 major version:
+
+1. **CssDistFilename removal**: Deprecated CSS filename exports from `osd-ui-shared-deps` package
+2. **withLongNumerals removal**: Deprecated HTTP fetch option replaced by `withLongNumeralsSupport`
+3. **@elastic/filesaver removal**: Replaced with the modern `file-saver` package
+4. **newExperience Discover table removal**: Legacy DataGrid table implementation removed in favor of DefaultDiscoverTable
+
+### Technical Changes
+
+#### Removed Components
+
+| Component | Package/Location | Replacement |
+|-----------|------------------|-------------|
+| `darkCssDistFilename` | `@osd/ui-shared-deps` | Use `baseCssDistFilename` with theme config |
+| `darkV8CssDistFilename` | `@osd/ui-shared-deps` | Use `baseCssDistFilename` with theme config |
+| `lightCssDistFilename` | `@osd/ui-shared-deps` | Use `baseCssDistFilename` with theme config |
+| `lightV8CssDistFilename` | `@osd/ui-shared-deps` | Use `baseCssDistFilename` with theme config |
+| `withLongNumerals` | `HttpFetchOptions` | Use `withLongNumeralsSupport` |
+| `@elastic/filesaver` | `package.json` | Use `file-saver` |
+| `DataGrid` component | `discover` plugin | Use `DefaultDiscoverTable` |
+| `newExperience` setting | `discover` plugin | Removed (DefaultDiscoverTable is now default) |
+
+#### Dependency Changes
+
+| Old Dependency | New Dependency | Notes |
+|----------------|----------------|-------|
+| `@elastic/filesaver@1.1.2` | `file-saver@^2.0.5` | Modern, actively maintained package |
+| - | `@types/file-saver@^2.0.7` | TypeScript types added |
+
+#### Files Removed
+
+The following files were removed from the Discover plugin:
+
+- `data_grid.tsx` - Deprecated DataGrid component
+- `data_grid_table_cell_actions.tsx` - Cell actions for deprecated grid
+- `data_grid_table_cell_value.test.tsx` - Tests for deprecated component
+- `data_grid_table_columns.tsx` - Column definitions for deprecated grid
+- `data_grid_table_columns.test.tsx` - Tests for deprecated component
+- `data_grid_table_context.tsx` - Context provider for deprecated grid
+- `data_grid_table_docview_inspect_button.tsx` - Inspect button for deprecated grid
+- `data_grid_table_flyout.tsx` - Flyout for deprecated grid
+- `data_grid_toolbar.tsx` - Toolbar for deprecated grid
+- `discover_options.tsx` - Options component for legacy toggle
+- Multiple context view test files
+
+### Migration Notes
+
+#### For Plugin Developers
+
+1. **CSS Filename Migration**:
+   ```typescript
+   // Before (deprecated)
+   import { darkCssDistFilename, lightCssDistFilename } from '@osd/ui-shared-deps';
+   
+   // After
+   import { baseCssDistFilename } from '@osd/ui-shared-deps';
+   // Use theme configuration to determine styling
+   ```
+
+2. **HTTP Fetch Options Migration**:
+   ```typescript
+   // Before (deprecated)
+   http.fetch('/api/endpoint', { withLongNumerals: true });
+   
+   // After
+   http.fetch('/api/endpoint', { withLongNumeralsSupport: true });
+   ```
+
+3. **File Saver Migration**:
+   ```typescript
+   // Before
+   // @ts-expect-error
+   import { saveAs } from '@elastic/filesaver';
+   
+   // After
+   import { saveAs } from 'file-saver';
+   ```
+
+#### For Users
+
+- The Discover table now uses `DefaultDiscoverTable` exclusively
+- The "Enable legacy Discover" option has been removed from Discover settings
+- No user action required unless custom plugins depend on removed APIs
+
+## Limitations
+
+- Plugins using the deprecated `CssDistFilename` exports will fail to compile
+- Plugins using `withLongNumerals` will need code changes
+- Plugins importing `@elastic/filesaver` must update imports
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9446](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9446) | Remove deprecated CssDistFilename for 3.0 |
+| [#9448](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9448) | Remove withLongNumerals in HttpFetchOptions |
+| [#9484](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9484) | Remove @elastic/filesaver in favor of file-saver |
+| [#9531](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9531) | Remove the deprecated "newExperience" table option in Discover |
+
+## References
+
+- [Issue #9253](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9253): Planned Breaking Changes for 3.0 in OpenSearch-Dashboards
+- [Issue #9341](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9341): Remove @elastic/filesaver dependency
+- [PR #5592](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5592): Original deprecation of withLongNumerals
+- [PR #7625](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7625): Original deprecation of CssDistFilename
+- [PR #9511](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9511): Deprecation of newExperience table option
+- [Breaking Changes Documentation](https://docs.opensearch.org/3.0/breaking-changes/): Official breaking changes for v3.0.0
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/dashboards-frontend-cleanup.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -36,6 +36,7 @@
 - [Dashboards CI/CD & Documentation](features/opensearch-dashboards/dashboards-ci-cd-documentation.md)
 - [Dashboards Cypress Testing](features/opensearch-dashboards/dashboards-cypress-testing.md)
 - [Dashboards Dependencies](features/opensearch-dashboards/dashboards-dependencies.md)
+- [Dashboards Frontend Cleanup](features/opensearch-dashboards/dashboards-frontend-cleanup.md)
 - [Dashboards UI/UX Fixes](features/opensearch-dashboards/dashboards-ui-ux-fixes.md)
 - [Monaco Editor Upgrade](features/opensearch-dashboards/monaco-editor-upgrade.md)
 - [UI/UX Improvements](features/opensearch-dashboards/ui-ux-improvements.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dashboards Frontend Cleanup breaking changes in OpenSearch Dashboards v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch-dashboards/dashboards-frontend-cleanup.md`
- Feature report: `docs/features/opensearch-dashboards/dashboards-frontend-cleanup.md`

### Key Changes in v3.0.0
- Removed deprecated `CssDistFilename` exports from `@osd/ui-shared-deps`
- Removed deprecated `withLongNumerals` option from `HttpFetchOptions`
- Replaced `@elastic/filesaver` with `file-saver` package
- Removed deprecated "newExperience" DataGrid table option in Discover

### Resources Used
- PR: #9446, #9448, #9484, #9531
- Issue: #9253 (Planned Breaking Changes for 3.0)
- Docs: https://docs.opensearch.org/3.0/breaking-changes/

Closes #145