### PR TITLE
docs: add cluster-permissions report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -8,6 +8,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
+- [Cluster Permissions](opensearch/cluster-permissions.md)
 - [gRPC Transport & Services](opensearch/grpc-transport--services.md)
 - [Mapping Transformer](opensearch/mapping-transformer.md)
 - [Cluster Manager Task Throttling](opensearch/cluster-manager-throttling.md)

--- a/docs/features/opensearch/cluster-permissions.md
+++ b/docs/features/opensearch/cluster-permissions.md
@@ -1,0 +1,134 @@
+# Cluster Permissions
+
+## Summary
+
+OpenSearch uses a permission-based access control system to manage what actions users can perform on the cluster. Cluster permissions control access to cluster-wide operations like monitoring, administration, and management tasks. This feature documentation covers the `CatShardsAction` permission and its evolution across OpenSearch versions.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "User Request"
+        User[User] --> API[REST API]
+    end
+    
+    subgraph "Security Plugin"
+        API --> Auth[Authentication]
+        Auth --> Authz[Authorization]
+        Authz --> PermCheck{Permission Check}
+    end
+    
+    subgraph "Permission Types"
+        PermCheck --> Cluster[Cluster Permissions]
+        PermCheck --> Index[Index Permissions]
+        PermCheck --> Internal[Internal Permissions]
+    end
+    
+    subgraph "Actions"
+        Cluster --> ClusterAction[Cluster Actions]
+        Index --> IndexAction[Index Actions]
+        Internal --> InternalAction[Internal Actions]
+    end
+```
+
+### Permission Types
+
+| Type | Prefix | Description |
+|------|--------|-------------|
+| Cluster | `cluster:` | Cluster-wide operations (admin, monitor) |
+| Index | `indices:` | Index-specific operations (read, write, admin) |
+| Internal | `internal:` | Internal operations (not exposed to users) |
+
+### CatShardsAction Permission
+
+The `CatShardsAction` is responsible for handling the `_cat/shards` API, which displays shard allocation information across the cluster.
+
+#### Permission Evolution
+
+| Version | Permission | Behavior |
+|---------|------------|----------|
+| < 2.17 | N/A (direct handler) | Index-level permissions only |
+| 2.17 - 2.x | `cluster:monitor/shards` | Required explicit cluster permission |
+| 3.0.0+ | `internal:monitor/shards` | No explicit permission required |
+
+### Configuration
+
+#### Role Definition Example
+
+```yaml
+# Role with read access to specific indexes
+read_only_role:
+  reserved: false
+  cluster_permissions: []
+  index_permissions:
+    - index_patterns:
+        - 'logs-*'
+        - 'metrics-*'
+      allowed_actions:
+        - 'indices:data/read/*'
+        - 'indices:monitor/stats'
+  tenant_permissions: []
+```
+
+#### Testing Permissions
+
+To verify a user's permissions for the `_cat/shards` API:
+
+```bash
+# Test as a specific user
+curl -u user:password -X GET "https://localhost:9200/_cat/shards?v"
+```
+
+If permissions are insufficient, you'll receive an error like:
+
+```json
+{
+  "error": {
+    "root_cause": [{
+      "type": "security_exception",
+      "reason": "no permissions for [cluster:monitor/shards] and User [name=user, ...]"
+    }]
+  },
+  "status": 403
+}
+```
+
+### Usage Example
+
+```bash
+# List all shards
+GET _cat/shards?v
+
+# List shards for specific index
+GET _cat/shards/my-index?v
+
+# List shards with additional columns
+GET _cat/shards?v&h=index,shard,prirep,state,docs,store,node
+```
+
+## Limitations
+
+- The `_cat/shards` API shows shard information only for indexes the user has access to
+- Cluster-level permissions cannot be scoped to specific indexes
+- Internal permissions are not configurable by users
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17203](https://github.com/opensearch-project/OpenSearch/pull/17203) | Changed CatShardsAction to internal to allow non-admin users |
+| v3.0.0 | [#18185](https://github.com/opensearch-project/OpenSearch/pull/18185) | Adding new permission for _cat/shard action to 3.0 release notes |
+
+## References
+
+- [Issue #17199](https://github.com/opensearch-project/OpenSearch/issues/17199): Bug report - Make CatShardsAction internal
+- [CAT shards API](https://docs.opensearch.org/3.0/api-reference/cat/cat-shards/): Official documentation
+- [Permissions](https://docs.opensearch.org/3.0/security/access-control/permissions/): Security permissions reference
+- [Default action groups](https://docs.opensearch.org/3.0/security/access-control/default-action-groups/): Predefined permission groups
+
+## Change History
+
+- **v3.0.0** (2025): Changed `CatShardsAction` permission from `cluster:monitor/shards` to `internal:monitor/shards`, restoring pre-2.17 behavior for non-admin users
+- **v2.17.0** (2024): Introduced `CatShardsAction` with `cluster:monitor/shards` permission for pagination and cancellation support

--- a/docs/releases/v3.0.0/features/opensearch/cluster-permissions.md
+++ b/docs/releases/v3.0.0/features/opensearch/cluster-permissions.md
@@ -1,0 +1,91 @@
+# Cluster Permissions
+
+## Summary
+
+OpenSearch 3.0.0 includes a breaking change to the `_cat/shards` API permission model. The `CatShardsAction` permission has been changed from `cluster:monitor/shards` to `internal:monitor/shards`, restoring the pre-2.17 behavior where non-admin users can call the `_cat/shards` API without requiring explicit cluster-level permissions.
+
+## Details
+
+### What's New in v3.0.0
+
+The `CatShardsAction` class has been modified to use an internal permission instead of a cluster-level permission:
+
+```java
+// Before (v2.17 - v2.x)
+public static final String NAME = "cluster:monitor/shards";
+
+// After (v3.0.0)
+public static final String NAME = "internal:monitor/shards";
+```
+
+### Background
+
+In OpenSearch 2.17, the `CatShardsAction` was introduced to support pagination and cancellation for the `_cat/shards` API. This action was registered with the permission `cluster:monitor/shards`, which inadvertently required non-admin users to have explicit cluster-level permissions to call the API.
+
+Prior to 2.17, the `_cat/shards` API only required index-level permissions (`indices:monitor/stats`), allowing users with read access to specific indexes to view shard information for those indexes.
+
+### Technical Changes
+
+#### Permission Change
+
+| Version | Permission | Type |
+|---------|------------|------|
+| < 2.17 | `indices:monitor/stats` | Index-level |
+| 2.17 - 2.x | `cluster:monitor/shards` | Cluster-level |
+| 3.0.0+ | `internal:monitor/shards` | Internal |
+
+#### Impact
+
+- **Non-admin users**: Can now call `_cat/shards` without explicit `cluster:monitor/shards` permission
+- **Security configurations**: The `cluster:monitor/shards` permission is no longer required and can be removed from role definitions
+
+### Migration Notes
+
+If you added `cluster:monitor/shards` to your role definitions after upgrading to 2.17, you can safely remove this permission when upgrading to 3.0.0. The permission will be ignored but removing it keeps your security configuration clean.
+
+**Before (2.17+):**
+```yaml
+my_role:
+  cluster_permissions:
+    - 'cluster:monitor/shards'  # Can be removed
+  index_permissions:
+    - index_patterns:
+        - 'my-index-*'
+      allowed_actions:
+        - 'indices:data/read/*'
+        - 'indices:monitor/stats'
+```
+
+**After (3.0.0):**
+```yaml
+my_role:
+  index_permissions:
+    - index_patterns:
+        - 'my-index-*'
+      allowed_actions:
+        - 'indices:data/read/*'
+        - 'indices:monitor/stats'
+```
+
+## Limitations
+
+- This change only affects the `_cat/shards` API
+- Other CAT APIs may still require their respective permissions
+- The change is backward compatible for users who already have the `cluster:monitor/shards` permission configured
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17203](https://github.com/opensearch-project/OpenSearch/pull/17203) | Changed CatShardsAction to internal to allow non-admin users |
+| [#18185](https://github.com/opensearch-project/OpenSearch/pull/18185) | Adding new permission for _cat/shard action to 3.0 release notes |
+
+## References
+
+- [Issue #17199](https://github.com/opensearch-project/OpenSearch/issues/17199): Bug report - Make CatShardsAction internal
+- [CAT shards API](https://docs.opensearch.org/3.0/api-reference/cat/cat-shards/): Official documentation
+- [Permissions](https://docs.opensearch.org/3.0/security/access-control/permissions/): Security permissions reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/cluster-permissions.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -8,6 +8,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)
+- [Cluster Permissions](features/opensearch/cluster-permissions.md)
 - [gRPC Transport & Services](features/opensearch/grpc-transport--services.md)
 - [Mapping Transformer](features/opensearch/mapping-transformer.md)
 - [Cluster Manager Throttling](features/opensearch/cluster-manager-throttling.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Cluster Permissions breaking change in OpenSearch v3.0.0.

### Key Changes in v3.0.0

The `CatShardsAction` permission has been changed from `cluster:monitor/shards` to `internal:monitor/shards`, which:

- Restores pre-2.17 behavior where non-admin users can call `_cat/shards` without explicit cluster permissions
- Fixes a regression introduced in v2.17 that required users to add `cluster:monitor/shards` permission

### Reports Created

- Release report: `docs/releases/v3.0.0/features/opensearch/cluster-permissions.md`
- Feature report: `docs/features/opensearch/cluster-permissions.md`

### Related

- Closes #144
- OpenSearch PR: [#17203](https://github.com/opensearch-project/OpenSearch/pull/17203)
- OpenSearch Issue: [#17199](https://github.com/opensearch-project/OpenSearch/issues/17199)