### PR TITLE
docs: add deprecated-code-cleanup report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -8,6 +8,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
+- [Deprecated Code Cleanup](opensearch/deprecated-code-cleanup.md)
 - [Cluster Permissions](opensearch/cluster-permissions.md)
 - [gRPC Transport & Services](opensearch/grpc-transport--services.md)
 - [Mapping Transformer](opensearch/mapping-transformer.md)

--- a/docs/features/opensearch/deprecated-code-cleanup.md
+++ b/docs/features/opensearch/deprecated-code-cleanup.md
@@ -1,0 +1,119 @@
+# Deprecated Code Cleanup
+
+## Summary
+
+OpenSearch maintains code quality by periodically removing deprecated features, settings, and APIs. This cleanup process ensures the codebase remains maintainable while providing clear migration paths for users. Major version releases (like 3.0) are the primary opportunity for removing deprecated functionality that has been marked for removal.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Deprecation Lifecycle"
+        A[Feature Introduced] --> B[Feature Deprecated]
+        B --> C[Deprecation Warning Period]
+        C --> D[Feature Removed in Major Version]
+    end
+    
+    subgraph "Categories"
+        E[Settings]
+        F[APIs]
+        G[Plugins]
+        H[Internal Classes]
+        I[Terminology]
+    end
+    
+    D --> E
+    D --> F
+    D --> G
+    D --> H
+    D --> I
+```
+
+### Deprecation Categories
+
+| Category | Description | Impact |
+|----------|-------------|--------|
+| Settings | Configuration options in opensearch.yml | Cluster startup may fail |
+| APIs | REST endpoints and parameters | Client applications may break |
+| Plugins | Bundled or optional plugins | Functionality unavailable |
+| Internal Classes | Java classes and methods | Plugin compatibility |
+| Terminology | Naming conventions | Documentation/code updates |
+
+### Removed in v3.0.0
+
+#### Thread Pool Settings
+```yaml
+# Removed settings
+thread_pool.test.max_queue_size
+thread_pool.test.min_queue_size
+```
+
+#### Index Store Settings
+```yaml
+# Removed setting
+index.store.hybrid.mmap.extensions
+```
+The hybridfs store type now automatically determines optimal file handling without explicit extension configuration.
+
+#### Locale Provider
+The COMPAT locale provider was removed due to JDK 21 deprecation (JEP 411). OpenSearch now uses CLDR locale data exclusively.
+
+#### Tokenizer Naming
+CamelCase tokenizer names are deprecated:
+- `PathHierarchy` → `path_hierarchy`
+
+#### Feature Flags
+Experimental feature flags removed when features became GA:
+- `PLUGGABLE_CACHE` - Tiered caching now always available
+- `APPROXIMATE_POINT_RANGE_QUERY_SETTING` - Range query approximation now standard
+
+#### Legacy Version Constants
+All `LegacyESVersion` constants removed:
+- V_7_0_* through V_7_10_*
+- V_1_* constants
+
+#### Non-inclusive Terminology
+- "blacklist" → "allow list"
+- "whitelist" → "deny list"
+- "master" → "cluster manager"
+
+### Migration Guide
+
+1. **Review Configuration**: Check `opensearch.yml` for deprecated settings
+2. **Update Scripts**: Replace deprecated datetime methods in Painless scripts
+3. **Update Analyzers**: Use snake_case tokenizer names
+4. **Test Plugins**: Verify custom plugins don't depend on removed classes
+5. **Update Clients**: Ensure client applications use current API parameters
+
+## Limitations
+
+- Deprecated code removal is permanent in major versions
+- No runtime compatibility layer for removed features
+- Custom plugins may require updates
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#3346](https://github.com/opensearch-project/OpenSearch/pull/3346) | Remove JodaCompatibleZonedDateTime deprecated methods |
+| v3.0.0 | [#9392](https://github.com/opensearch-project/OpenSearch/pull/9392) | Remove mmap.extensions setting |
+| v3.0.0 | [#13988](https://github.com/opensearch-project/OpenSearch/pull/13988) | Remove COMPAT locale provider |
+| v3.0.0 | [#17344](https://github.com/opensearch-project/OpenSearch/pull/17344) | Remove PLUGGABLE_CACHE feature flag |
+| v3.0.0 | [#17769](https://github.com/opensearch-project/OpenSearch/pull/17769) | Remove ApproximatePointRangeQuery feature flag |
+| v3.0.0 | [#4042](https://github.com/opensearch-project/OpenSearch/pull/4042) | Rename Plugin classes to Module |
+| v3.0.0 | [#10894](https://github.com/opensearch-project/OpenSearch/pull/10894) | Deprecate CamelCase PathHierarchy tokenizer |
+| v2.0.0 | [#2595](https://github.com/opensearch-project/OpenSearch/pull/2595) | Cleanup deprecated thread pool settings |
+| v2.0.0 | [#1683](https://github.com/opensearch-project/OpenSearch/pull/1683) | Replace blacklist/whitelist terminology |
+
+## References
+
+- [Breaking Changes Documentation](https://docs.opensearch.org/3.0/breaking-changes/)
+- [Issue #2773](https://github.com/opensearch-project/OpenSearch/issues/2773): List of deprecated code removal in 3.0
+- [JEP 411](https://openjdk.org/jeps/411): Deprecate the Security Manager for Removal
+
+## Change History
+
+- **v3.0.0** (2025): Major deprecated code cleanup including thread pool settings, locale provider, feature flags, and legacy version constants
+- **v2.0.0** (2022): Initial deprecation of non-inclusive terminology, thread pool settings marked for removal

--- a/docs/releases/v3.0.0/features/opensearch/deprecated-code-cleanup.md
+++ b/docs/releases/v3.0.0/features/opensearch/deprecated-code-cleanup.md
@@ -1,0 +1,119 @@
+# Deprecated Code Cleanup
+
+## Summary
+
+OpenSearch 3.0.0 includes a comprehensive cleanup of deprecated code, removing legacy settings, APIs, and terminology that were deprecated in earlier versions. This is a breaking change that affects users upgrading from 2.x versions who may still be using deprecated features.
+
+## Details
+
+### What's New in v3.0.0
+
+This release removes deprecated code across multiple categories:
+
+1. **Thread Pool Settings**: Deprecated `thread_pool.test.max_queue_size` and `thread_pool.test.min_queue_size` settings removed
+2. **Index Store Settings**: `index.store.hybrid.mmap.extensions` setting removed in favor of improved hybridfs file handling
+3. **Transport Plugin**: `transport-nio` plugin removed; Netty remains the standard network framework
+4. **Locale Provider**: COMPAT locale provider replaced with CLDR for JDK 21+ compatibility
+5. **Tokenizer Naming**: CamelCase `PathHierarchy` tokenizer name deprecated in favor of snake_case `path_hierarchy`
+6. **Module Renaming**: Classes ending with `Plugin` under `modules` directory renamed to `Module`
+7. **JodaCompatibleZonedDateTime**: Deprecated methods removed from scripts
+8. **Feature Flags**: Experimental feature flags removed for GA features (PLUGGABLE_CACHE, APPROXIMATE_POINT_RANGE_QUERY)
+9. **Legacy Version Constants**: LegacyESVersion constants (V_7_0 through V_7_10, V_1_) removed
+10. **Non-inclusive Terminology**: "blacklist/whitelist" replaced with "allow list/deny list"
+
+### Technical Changes
+
+#### Removed Settings
+
+| Setting | Replacement | PR |
+|---------|-------------|-----|
+| `thread_pool.test.max_queue_size` | None (removed) | [#2595](https://github.com/opensearch-project/OpenSearch/pull/2595) |
+| `thread_pool.test.min_queue_size` | None (removed) | [#2595](https://github.com/opensearch-project/OpenSearch/pull/2595) |
+| `index.store.hybrid.mmap.extensions` | Auto-detection | [#9392](https://github.com/opensearch-project/OpenSearch/pull/9392) |
+
+#### Removed Components
+
+| Component | Reason | PR |
+|-----------|--------|-----|
+| `transport-nio` plugin | Netty is standard | [#16887](https://github.com/opensearch-project/OpenSearch/issues/16887) |
+| COMPAT locale provider | JDK 21 deprecation | [#13988](https://github.com/opensearch-project/OpenSearch/pull/13988) |
+| LegacyESVersion constants | Version cleanup | Multiple PRs |
+
+#### Removed Feature Flags
+
+| Feature Flag | Status | PR |
+|--------------|--------|-----|
+| `PLUGGABLE_CACHE` | GA in 3.0 | [#17344](https://github.com/opensearch-project/OpenSearch/pull/17344) |
+| `APPROXIMATE_POINT_RANGE_QUERY_SETTING` | GA in 3.0 | [#17769](https://github.com/opensearch-project/OpenSearch/pull/17769) |
+
+### Migration Notes
+
+#### Thread Pool Settings
+Remove any references to deprecated thread pool settings from your configuration:
+```yaml
+# Remove these settings from opensearch.yml
+# thread_pool.test.max_queue_size: ...
+# thread_pool.test.min_queue_size: ...
+```
+
+#### Index Store Settings
+The `index.store.hybrid.mmap.extensions` setting is no longer needed. OpenSearch now automatically determines which file extensions use mmap vs nio:
+```yaml
+# Remove this setting - no longer supported
+# index.store.hybrid.mmap.extensions: ...
+```
+
+#### Tokenizer Naming
+Update analyzer configurations to use snake_case tokenizer names:
+```json
+// Before (deprecated)
+{
+  "tokenizer": {
+    "type": "PathHierarchy"
+  }
+}
+
+// After (recommended)
+{
+  "tokenizer": {
+    "type": "path_hierarchy"
+  }
+}
+```
+
+#### Locale Changes
+If your application relies on locale-specific date/time formatting, be aware that CLDR locale data may have minor differences from COMPAT. For example, German short day/month names may include a trailing period.
+
+#### Script Updates
+Update any Painless scripts that use deprecated `JodaCompatibleZonedDateTime` methods. These methods were causing performance overhead due to deprecation warnings.
+
+## Limitations
+
+- No backward compatibility for removed settings
+- Scripts using deprecated datetime methods will fail
+- Plugins depending on `transport-nio` must migrate to Netty
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3346](https://github.com/opensearch-project/OpenSearch/pull/3346) | Remove deprecated JodaCompatibleZonedDateTime methods |
+| [#9392](https://github.com/opensearch-project/OpenSearch/pull/9392) | Remove mmap.extensions setting |
+| [#13988](https://github.com/opensearch-project/OpenSearch/pull/13988) | Remove COMPAT locale provider |
+| [#17344](https://github.com/opensearch-project/OpenSearch/pull/17344) | Remove PLUGGABLE_CACHE feature flag |
+| [#17769](https://github.com/opensearch-project/OpenSearch/pull/17769) | Remove ApproximatePointRangeQuery feature flag |
+| [#4042](https://github.com/opensearch-project/OpenSearch/pull/4042) | Rename Plugin classes to Module |
+| [#10894](https://github.com/opensearch-project/OpenSearch/pull/10894) | Deprecate CamelCase PathHierarchy tokenizer |
+
+## References
+
+- [Breaking Changes Documentation](https://docs.opensearch.org/3.0/breaking-changes/)
+- [Issue #2773](https://github.com/opensearch-project/OpenSearch/issues/2773): List of deprecated code removal in 3.0
+- [Issue #3156](https://github.com/opensearch-project/OpenSearch/issues/3156): JodaCompatibleZonedDateTime deprecation
+- [Issue #8297](https://github.com/opensearch-project/OpenSearch/issues/8297): mmap.extensions removal
+- [Issue #11550](https://github.com/opensearch-project/OpenSearch/issues/11550): COMPAT locale provider removal
+- [Issue #17343](https://github.com/opensearch-project/OpenSearch/issues/17343): Tiered caching GA
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/deprecated-code-cleanup.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -8,6 +8,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)
+- [Deprecated Code Cleanup](features/opensearch/deprecated-code-cleanup.md)
 - [Cluster Permissions](features/opensearch/cluster-permissions.md)
 - [gRPC Transport & Services](features/opensearch/grpc-transport--services.md)
 - [Mapping Transformer](features/opensearch/mapping-transformer.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Deprecated Code Cleanup breaking change in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/deprecated-code-cleanup.md`
- Feature report: `docs/features/opensearch/deprecated-code-cleanup.md`

### Key Changes Documented

OpenSearch 3.0.0 removes deprecated code across multiple categories:

1. **Thread Pool Settings**: Removed `thread_pool.test.max_queue_size` and `min_queue_size`
2. **Index Store Settings**: Removed `index.store.hybrid.mmap.extensions`
3. **Transport Plugin**: Removed `transport-nio` plugin
4. **Locale Provider**: Replaced COMPAT with CLDR for JDK 21+ compatibility
5. **Tokenizer Naming**: Deprecated CamelCase `PathHierarchy` in favor of `path_hierarchy`
6. **Module Renaming**: Classes ending with `Plugin` renamed to `Module`
7. **JodaCompatibleZonedDateTime**: Removed deprecated methods from scripts
8. **Feature Flags**: Removed experimental flags for GA features (PLUGGABLE_CACHE, APPROXIMATE_POINT_RANGE_QUERY)
9. **Legacy Version Constants**: Removed LegacyESVersion constants
10. **Non-inclusive Terminology**: Replaced blacklist/whitelist with allow list/deny list

### Related Issue
Closes #143