### PR TITLE
docs: add indexing-buffer-fix report for v3.0.0

### DIFF
--- a/docs/features/opensearch/nodes-info-api.md
+++ b/docs/features/opensearch/nodes-info-api.md
@@ -117,6 +117,17 @@ NodesInfoRequest customRequest = new NodesInfoRequest()
     .addMetric(NodesInfoRequest.Metric.SEARCH_PIPELINES.metricName());
 ```
 
+### Response Field Formats
+
+The API returns indexing buffer information with the following fields:
+
+| Field | Format | Example |
+|-------|--------|---------|
+| `total_indexing_buffer_in_bytes` | Raw bytes (number) | `53687091` |
+| `total_indexing_buffer` | Human-readable (string) | `"51.1mb"` |
+
+**Note**: Prior to v3.0.0, these field formats were incorrectly swapped. See [PR #17070](https://github.com/opensearch-project/OpenSearch/pull/17070) for details.
+
 ## Limitations
 
 - The `search_pipelines` metric is not included in default responses (v3.0.0+)
@@ -127,14 +138,18 @@ NodesInfoRequest customRequest = new NodesInfoRequest()
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.0.0 | [#17070](https://github.com/opensearch-project/OpenSearch/pull/17070) | Breaking change: Fix swapped indexing buffer field formats |
 | v3.0.0 | [#12497](https://github.com/opensearch-project/OpenSearch/pull/12497) | Breaking change: Do not request search_pipelines by default |
 
 ## References
 
 - [Nodes Info API Documentation](https://docs.opensearch.org/3.0/api-reference/nodes-apis/nodes-info/): Official API reference
-- [PR #12497](https://github.com/opensearch-project/OpenSearch/pull/12497): Implementation PR
-- [PR #10296](https://github.com/opensearch-project/OpenSearch/pull/10296): Related - Add optional section of node analyzers
+- [Breaking Changes Documentation](https://docs.opensearch.org/3.0/breaking-changes/): v3.0.0 breaking changes
+- [Issue #16910](https://github.com/opensearch-project/OpenSearch/issues/16910): Bug report for swapped field formats
+- [PR #12497](https://github.com/opensearch-project/OpenSearch/pull/12497): Default metrics change
+- [PR #17070](https://github.com/opensearch-project/OpenSearch/pull/17070): Indexing buffer format fix
 
 ## Change History
 
+- **v3.0.0** (2025-01-21): Breaking change - Fixed swapped `total_indexing_buffer` and `total_indexing_buffer_in_bytes` field formats
 - **v3.0.0** (2024-03-12): Breaking change - `search_pipelines` metric excluded from default metrics set

--- a/docs/releases/v3.0.0/features/opensearch/indexing-buffer-fix.md
+++ b/docs/releases/v3.0.0/features/opensearch/indexing-buffer-fix.md
@@ -1,0 +1,97 @@
+# Indexing Buffer Fix
+
+## Summary
+
+This breaking change fixes a long-standing bug where the `total_indexing_buffer_in_bytes` and `total_indexing_buffer` fields in the Nodes Info API response were swapped. The fix corrects the field formats so that `total_indexing_buffer_in_bytes` displays raw bytes and `total_indexing_buffer` displays human-readable format.
+
+## Details
+
+### What's New in v3.0.0
+
+The Nodes Info API response now correctly formats the indexing buffer fields:
+
+- `total_indexing_buffer_in_bytes`: Raw byte count (e.g., `53687091`)
+- `total_indexing_buffer`: Human-readable format (e.g., `51.1mb`)
+
+Previously, these values were reversed, which was inconsistent with other human-readable byte fields in OpenSearch APIs.
+
+### Technical Changes
+
+#### Bug Origin
+
+The bug was introduced over 8 years ago when two explicit fields were merged to use the `humanReadableField` XContentBuilder method. The parameters to `byteSizeField` were accidentally swapped:
+
+```java
+// Before (incorrect)
+builder.humanReadableField("total_indexing_buffer", "total_indexing_buffer_in_bytes", nodeInfo.getTotalIndexingBuffer());
+
+// After (correct)
+builder.humanReadableField("total_indexing_buffer_in_bytes", "total_indexing_buffer", nodeInfo.getTotalIndexingBuffer());
+```
+
+#### Changed Files
+
+| File | Change |
+|------|--------|
+| `NodesInfoResponse.java` | Fixed parameter order in `humanReadableField()` call |
+| `50_nodes_total_indexing_buffer_format.yml` | Added REST API test to verify correct formats |
+
+### Usage Example
+
+Before v3.0.0 (incorrect):
+```json
+GET /_nodes?human&filter_path=nodes.*.total_indexing_buffer*
+
+{
+  "nodes": {
+    "741KuezCTUaGy0RDV7oxEA": {
+      "total_indexing_buffer_in_bytes": "51.1mb",
+      "total_indexing_buffer": 53687091
+    }
+  }
+}
+```
+
+After v3.0.0 (correct):
+```json
+GET /_nodes?human&filter_path=nodes.*.total_indexing_buffer*
+
+{
+  "nodes": {
+    "741KuezCTUaGy0RDV7oxEA": {
+      "total_indexing_buffer_in_bytes": 53687091,
+      "total_indexing_buffer": "51.1mb"
+    }
+  }
+}
+```
+
+### Migration Notes
+
+If your application parses the Nodes Info API response and relies on these fields:
+
+1. **Update field type expectations**: `total_indexing_buffer_in_bytes` is now a number, `total_indexing_buffer` is now a string
+2. **Review client code**: Any code that parsed `total_indexing_buffer_in_bytes` as a string or `total_indexing_buffer` as a number needs updating
+3. **Test with v3.0.0**: Verify your monitoring and management tools handle the corrected format
+
+## Limitations
+
+- This is a breaking change that affects API response format
+- No backward compatibility option is provided
+- The change only takes effect in v3.0.0 and later
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17070](https://github.com/opensearch-project/OpenSearch/pull/17070) | Fix interchanged formats of total_indexing_buffer_in_bytes and total_indexing_buffer |
+
+## References
+
+- [Issue #16910](https://github.com/opensearch-project/OpenSearch/issues/16910): Bug report - NodesInfoResponse serializes fields swapped
+- [Breaking Changes Documentation](https://docs.opensearch.org/3.0/breaking-changes/): Official v3.0.0 breaking changes
+- [Nodes Info API Documentation](https://docs.opensearch.org/3.0/api-reference/nodes-apis/nodes-info/): API reference
+
+## Related Feature Report
+
+- [Nodes Info API](../../../features/opensearch/nodes-info-api.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -16,6 +16,7 @@
 - [Dependency Bumps](features/opensearch/dependency-bumps.md)
 - [Locale Provider Changes](features/opensearch/locale-provider-changes.md)
 - [HTTP API Improvements](features/opensearch/http-api-improvements.md)
+- [Indexing Buffer Fix](features/opensearch/indexing-buffer-fix.md)
 - [Source Field Matching](features/opensearch/source-field-matching.md)
 - [Cryptography & Security Libraries](features/opensearch/cryptography-security-libraries.md)
 - [Gradle Build System](features/opensearch/gradle-build-system.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Indexing Buffer Fix breaking change in OpenSearch v3.0.0.

### Changes

- Created release report: `docs/releases/v3.0.0/features/opensearch/indexing-buffer-fix.md`
- Updated feature report: `docs/features/opensearch/nodes-info-api.md` with the indexing buffer fix information
- Updated release index: `docs/releases/v3.0.0/index.md`

### Key Points

- Fixes a long-standing bug where `total_indexing_buffer_in_bytes` and `total_indexing_buffer` fields were swapped
- `total_indexing_buffer_in_bytes` now correctly displays raw bytes (e.g., `53687091`)
- `total_indexing_buffer` now correctly displays human-readable format (e.g., `51.1mb`)

### Related

- Closes #142
- PR: [opensearch-project/OpenSearch#17070](https://github.com/opensearch-project/OpenSearch/pull/17070)
- Issue: [opensearch-project/OpenSearch#16910](https://github.com/opensearch-project/OpenSearch/issues/16910)