### PR TITLE
docs: add Jackson & Query Limits report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -16,6 +16,7 @@
 - [Dependency Management](opensearch/dependency-management.md)
 - [Locale Provider](opensearch/locale-provider.md)
 - [HTTP API](opensearch/http-api.md)
+- [Jackson & Query Limits](opensearch/jackson--query-limits.md)
 - [Source Field Matching](opensearch/source-field-matching.md)
 - [Cryptography & Security Libraries](opensearch/cryptography-security-libraries.md)
 - [Gradle Build System](opensearch/gradle-build-system.md)

--- a/docs/features/opensearch/jackson--query-limits.md
+++ b/docs/features/opensearch/jackson--query-limits.md
@@ -1,0 +1,145 @@
+# Jackson & Query Limits
+
+## Summary
+
+OpenSearch enforces configurable limits on JSON content parsing and nested query depth to ensure stability and prevent resource exhaustion. These limits protect against malicious or malformed input that could cause memory issues or stack overflows.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Request Processing"
+        Request[HTTP Request] --> Parser[XContent Parser]
+        Parser --> Validate{Validate Constraints}
+        Validate -->|Pass| Process[Process Content]
+        Validate -->|Fail| Reject[Reject Request]
+    end
+    
+    subgraph "XContent Constraints"
+        StringLen[String Length Max]
+        NameLen[Name Length Max]
+        DepthMax[Nesting Depth Max]
+    end
+    
+    subgraph "Query Execution"
+        Query[Search Query] --> NestedScope[NestedScope]
+        NestedScope --> DepthCheck{Check Depth}
+        DepthCheck -->|OK| Execute[Execute]
+        DepthCheck -->|Exceeded| Error[Error]
+    end
+    
+    Validate --> StringLen
+    Validate --> NameLen
+    Validate --> DepthMax
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `XContentConstraints` | Interface defining limits for JSON/CBOR/SMILE/YAML parsing |
+| `JsonXContent` | JSON parser with constraint enforcement |
+| `CborXContent` | CBOR parser with constraint enforcement |
+| `SmileXContent` | SMILE parser with constraint enforcement |
+| `YamlXContent` | YAML parser with constraint enforcement |
+| `NestedScope` | Tracks and enforces nested query depth during query execution |
+
+### Configuration
+
+#### XContent Parsing Limits (System Properties)
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `opensearch.xcontent.string.length.max` | Maximum string value length | 50,000,000 (~50 MB) |
+| `opensearch.xcontent.name.length.max` | Maximum field name length | 50,000 |
+| `opensearch.xcontent.depth.max` | Maximum JSON nesting depth | 1,000 |
+
+#### Query Depth Limits (Index Settings)
+
+| Setting | Description | Default | Dynamic |
+|---------|-------------|---------|---------|
+| `index.query.max_nested_depth` | Maximum nested query depth | 20 | Yes |
+
+### Usage Example
+
+#### Setting XContent Limits
+
+Configure via JVM system properties at startup:
+
+```bash
+./bin/opensearch \
+  -Dopensearch.xcontent.string.length.max=100000000 \
+  -Dopensearch.xcontent.name.length.max=100000 \
+  -Dopensearch.xcontent.depth.max=2000
+```
+
+#### Configuring Nested Query Depth
+
+Create index with custom limit:
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index.query.max_nested_depth": 50
+  }
+}
+```
+
+Update existing index:
+
+```json
+PUT /my-index/_settings
+{
+  "index.query.max_nested_depth": 30
+}
+```
+
+#### Example Nested Query
+
+```json
+GET /my-index/_search
+{
+  "query": {
+    "nested": {
+      "path": "level1",
+      "query": {
+        "nested": {
+          "path": "level1.level2",
+          "query": {
+            "match": { "level1.level2.field": "value" }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+If nesting exceeds `index.query.max_nested_depth`, an `IllegalArgumentException` is thrown.
+
+## Limitations
+
+- XContent limits are JVM-wide and cannot be configured per-index or per-request
+- Changing XContent limits requires cluster restart
+- Nested query depth limit only applies to nested queries, not general JSON document depth
+- No API to query current effective limits at runtime
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#11811](https://github.com/opensearch-project/OpenSearch/pull/11811) | Jackson default maximums for XContent parsing |
+| v3.0.0 | [#11670](https://github.com/opensearch-project/OpenSearch/pull/11670) | Nested query depth limit setting |
+
+## References
+
+- [Issue #11278](https://github.com/opensearch-project/OpenSearch/issues/11278): Jackson default maximums feature request
+- [Issue #3268](https://github.com/opensearch-project/OpenSearch/issues/3268): Nested query depth limit feature request
+- [Breaking Changes](https://docs.opensearch.org/3.0/breaking-changes/): OpenSearch 3.0 breaking changes documentation
+
+## Change History
+
+- **v3.0.0** (2024): Initial implementation - Jackson 2.16.x XContent constraints and nested query depth limit

--- a/docs/releases/v3.0.0/features/opensearch/jackson--query-limits.md
+++ b/docs/releases/v3.0.0/features/opensearch/jackson--query-limits.md
@@ -1,0 +1,114 @@
+# Jackson & Query Limits
+
+## Summary
+
+OpenSearch 3.0.0 introduces breaking changes related to JSON processing limits and nested query depth restrictions. These changes address security and stability concerns by enforcing configurable maximums for JSON content parsing (via Jackson 2.16.x) and nested query depth at the index level.
+
+## Details
+
+### What's New in v3.0.0
+
+Two significant changes affect how OpenSearch handles content parsing and query depth:
+
+1. **Jackson Default Maximums**: New limits on JSON/CBOR/SMILE/YAML content parsing
+2. **Nested Query Depth Limit**: New index setting to restrict nested query depth
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Content Parsing Layer"
+        Input[Incoming Request] --> XContent[XContent Parser]
+        XContent --> Constraints{XContentConstraints}
+        Constraints -->|String Length| SL[Max 50MB]
+        Constraints -->|Name Length| NL[Max 50,000 chars]
+        Constraints -->|Nesting Depth| ND[Max 1,000 levels]
+    end
+    
+    subgraph "Query Layer"
+        Query[Nested Query] --> NestedScope[NestedScope]
+        NestedScope --> DepthCheck{Depth Check}
+        DepthCheck -->|Within Limit| Execute[Execute Query]
+        DepthCheck -->|Exceeds Limit| Error[IllegalArgumentException]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `XContentConstraints` | Interface defining configurable limits for content parsing |
+| `NestedScope` depth tracking | Enhanced to enforce `index.query.max_nested_depth` |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `opensearch.xcontent.string.length.max` | Maximum string length in JSON content | 50,000,000 (~50 MB) |
+| `opensearch.xcontent.name.length.max` | Maximum field name length | 50,000 |
+| `opensearch.xcontent.depth.max` | Maximum nesting depth for JSON objects/arrays | 1,000 |
+| `index.query.max_nested_depth` | Maximum depth for nested queries (index-level, dynamic) | 20 |
+
+### Usage Example
+
+#### Customizing XContent Limits via System Properties
+
+```bash
+# Start OpenSearch with custom limits
+./bin/opensearch \
+  -Dopensearch.xcontent.string.length.max=100000000 \
+  -Dopensearch.xcontent.name.length.max=100000 \
+  -Dopensearch.xcontent.depth.max=2000
+```
+
+#### Configuring Nested Query Depth
+
+```json
+PUT /my-index/_settings
+{
+  "index.query.max_nested_depth": 30
+}
+```
+
+#### Creating Index with Custom Nested Depth
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index.query.max_nested_depth": 50
+  }
+}
+```
+
+### Migration Notes
+
+1. **Review existing deeply nested JSON documents**: Documents with nesting depth exceeding 1,000 levels will fail to parse
+2. **Check nested query complexity**: Queries with nested depth exceeding 20 (default) will throw `IllegalArgumentException`
+3. **Adjust settings if needed**: Use system properties for XContent limits or index settings for query depth
+4. **Test with production data**: Validate that existing documents and queries work within new limits
+
+## Limitations
+
+- XContent limits are JVM-wide (system properties), not configurable per-index
+- Nested query depth limit is per-index but requires index settings update for existing indices
+- No runtime API to query current XContent limits
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#11811](https://github.com/opensearch-project/OpenSearch/pull/11811) | Ensure Jackson default maximums introduced in 2.16.0 do not conflict with OpenSearch settings |
+| [#11670](https://github.com/opensearch-project/OpenSearch/pull/11670) | Introduce index.query.max_nested_depth |
+
+## References
+
+- [Issue #11278](https://github.com/opensearch-project/OpenSearch/issues/11278): Jackson default maximums feature request
+- [Issue #3268](https://github.com/opensearch-project/OpenSearch/issues/3268): Nested query depth limit feature request
+- [Breaking Changes Documentation](https://docs.opensearch.org/3.0/breaking-changes/): Official v3.0 breaking changes
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/jackson--query-limits.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -17,6 +17,7 @@
 - [Locale Provider Changes](features/opensearch/locale-provider-changes.md)
 - [HTTP API Improvements](features/opensearch/http-api-improvements.md)
 - [Indexing Buffer Fix](features/opensearch/indexing-buffer-fix.md)
+- [Jackson & Query Limits](features/opensearch/jackson--query-limits.md)
 - [Source Field Matching](features/opensearch/source-field-matching.md)
 - [Cryptography & Security Libraries](features/opensearch/cryptography-security-libraries.md)
 - [Gradle Build System](features/opensearch/gradle-build-system.md)


### PR DESCRIPTION
## Summary

Documents the breaking changes related to Jackson & Query Limits in OpenSearch v3.0.0.

### Key Changes

1. **Jackson Default Maximums (PR #11811)**
   - Upgraded Jackson from 2.16.0 to 2.16.1
   - Added `XContentConstraints` interface with configurable limits:
     - `DEFAULT_MAX_STRING_LEN`: 50,000,000 (~50 MB)
     - `DEFAULT_MAX_NAME_LEN`: 50,000
     - `DEFAULT_MAX_DEPTH`: 1,000
   - System properties for customization

2. **Nested Query Depth Limit (PR #11670)**
   - New index setting `index.query.max_nested_depth` (default: 20)
   - Dynamic, index-scoped setting
   - Throws `IllegalArgumentException` when depth exceeded

### Reports Created

- Release report: `docs/releases/v3.0.0/features/opensearch/jackson--query-limits.md`
- Feature report: `docs/features/opensearch/jackson--query-limits.md`

Closes #141