### PR TITLE
docs: add Learning to Rank bug fixes report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -127,3 +127,7 @@
 - [k-NN Explain API](k-nn/explain-api.md)
 - [Lucene On Faiss (Memory Optimized Search)](k-nn/lucene-on-faiss.md)
 - [Remote Vector Index Build](k-nn/remote-vector-index-build.md)
+
+## learning
+
+- [Learning to Rank](learning/learning-to-rank.md)

--- a/docs/features/learning/learning-to-rank.md
+++ b/docs/features/learning/learning-to-rank.md
@@ -1,0 +1,165 @@
+# Learning to Rank
+
+## Summary
+
+Learning to Rank (LTR) is an OpenSearch plugin that enables machine learning-based search relevance ranking. It uses models from XGBoost and RankLib libraries to rescore search results based on query-dependent features like click-through data or field matches.
+
+The plugin allows you to:
+- Define features as OpenSearch queries
+- Log feature scores for training data collection
+- Upload trained models (RankLib, XGBoost, linear)
+- Apply ML models to rescore search results
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Training Phase"
+        A[Judgment Data] --> B[Feature Logging]
+        B --> C[Training Data]
+        C --> D[ML Training]
+        D --> E[Trained Model]
+    end
+    
+    subgraph "OpenSearch LTR Plugin"
+        F[Feature Set] --> G[Model Store]
+        E --> G
+        H[Search Query] --> I[Feature Extraction]
+        F --> I
+        I --> J[Model Scoring]
+        G --> J
+        J --> K[Rescored Results]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Model Upload"
+        A[Model File] --> B{Parser}
+        B -->|RankLib| C[RanklibModelParser]
+        B -->|XGBoost JSON| D[XGBoostJsonParser]
+        B -->|XGBoost Raw| E[XGBoostRawJsonParser]
+        B -->|Linear| F[LinearRankerParser]
+        C --> G[NaiveAdditiveDecisionTree]
+        D --> G
+        E --> G
+        F --> H[LinearRanker]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Feature Set | Collection of features defined as OpenSearch queries |
+| Feature Store | Storage for feature sets and models (`.ltrstore` index) |
+| Model Parsers | Parsers for different model formats (RankLib, XGBoost, Linear) |
+| SLTR Query | Special query type for applying LTR models at search time |
+| Feature Logging | Mechanism to log feature scores for training data |
+
+### Supported Model Types
+
+| Type | Format | Description |
+|------|--------|-------------|
+| `model/ranklib` | RankLib XML | LambdaMART, RankNet, and other RankLib models |
+| `model/xgboost+json` | XGBoost `get_dump` | XGBoost models in dump format (visualization) |
+| `model/xgboost+json+raw` | XGBoost `save_model` | XGBoost models in proper serialization format |
+| `model/linear` | JSON weights | Simple linear models (SVM, linear regression) |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `ltr.plugin.enabled` | Enable/disable the LTR plugin | `true` |
+
+### Usage Example
+
+#### Define a Feature Set
+
+```json
+PUT _ltr/_featureset/my_features
+{
+    "featureset": {
+        "name": "my_features",
+        "features": [
+            {
+                "name": "title_match",
+                "params": ["keywords"],
+                "template": {
+                    "match": { "title": "{{keywords}}" }
+                }
+            },
+            {
+                "name": "description_match",
+                "params": ["keywords"],
+                "template": {
+                    "match": { "description": "{{keywords}}" }
+                }
+            }
+        ]
+    }
+}
+```
+
+#### Upload a Model
+
+```json
+POST _ltr/_featureset/my_features/_createmodel
+{
+    "model": {
+        "name": "my_model",
+        "model": {
+            "type": "model/xgboost+json+raw",
+            "definition": "{...xgboost model json...}"
+        }
+    }
+}
+```
+
+#### Search with LTR
+
+```json
+POST my_index/_search
+{
+    "query": {
+        "sltr": {
+            "params": {
+                "keywords": "search terms"
+            },
+            "model": "my_model"
+        }
+    }
+}
+```
+
+## Limitations
+
+- Only `float` feature types are supported for XGBoost raw models
+- Feature names in models must match feature set definitions
+- Models are copied at creation time; changes to feature sets don't affect existing models
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#151](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/151) | Add XGBoost model parser for correct serialization format |
+| v3.0.0 | [#158](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/158) | Fix test for ApproximateScoreQuery |
+
+## References
+
+- [Learning to Rank Documentation](https://docs.opensearch.org/3.0/search-plugins/ltr/index/)
+- [ML Ranking Core Concepts](https://docs.opensearch.org/3.0/search-plugins/ltr/core-concepts/)
+- [Working with Features](https://docs.opensearch.org/3.0/search-plugins/ltr/working-with-features/)
+- [Uploading Trained Models](https://docs.opensearch.org/3.0/search-plugins/ltr/training-models/)
+- [Searching with LTR](https://docs.opensearch.org/3.0/search-plugins/ltr/searching-with-your-model/)
+- [GitHub Repository](https://github.com/opensearch-project/opensearch-learning-to-rank-base)
+- [XGBoost Documentation](https://xgboost.readthedocs.io/)
+- [RankLib Documentation](https://sourceforge.net/p/lemur/wiki/RankLib/)
+
+## Change History
+
+- **v3.0.0** (2025-05-13): Added XGBoost raw JSON parser for proper `save_model` format support; fixed ApproximateScoreQuery test

--- a/docs/releases/v3.0.0/features/learning/learning-to-rank.md
+++ b/docs/releases/v3.0.0/features/learning/learning-to-rank.md
@@ -1,0 +1,102 @@
+# Learning to Rank Bug Fixes
+
+## Summary
+
+OpenSearch v3.0.0 includes two bug fixes for the Learning to Rank (LTR) plugin: a new XGBoost model parser for the correct serialization format (`save_model` output), and a test fix for `ApproximateScoreQuery`.
+
+## Details
+
+### What's New in v3.0.0
+
+#### XGBoost Raw JSON Parser (PR #151)
+
+The LTR plugin previously used the wrong method for loading XGBoost models. It expected the output format of the `get_dump` method, which is only meant for visualization purposes and cannot be loaded back into XGBoost. This PR adds a new parser (`XGBoostRawJsonParser`) that correctly handles the output format of XGBoost's `save_model` method.
+
+**Problem**: The existing `model/xgboost+json` type expected the `get_dump` format, which is human-readable but not the correct serialization format.
+
+**Solution**: A new model type `model/xgboost+json+raw` was added that parses the proper `save_model` JSON output.
+
+#### ApproximateScoreQuery Test Fix (PR #158)
+
+A test assertion was updated to match the correct query type. The test expected `MatchAllDocsQuery` but the actual query type is `ApproximateScoreQuery`.
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `XGBoostRawJsonParser` | New parser for XGBoost `save_model` JSON format |
+| Model type `model/xgboost+json+raw` | New model type identifier for raw XGBoost models |
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Model Upload"
+        A[XGBoost Model] --> B{Model Type}
+        B -->|model/xgboost+json| C[XGBoostJsonParser]
+        B -->|model/xgboost+json+raw| D[XGBoostRawJsonParser]
+        C --> E[NaiveAdditiveDecisionTree]
+        D --> E
+    end
+```
+
+#### Key Implementation Details
+
+The new `XGBoostRawJsonParser` handles:
+- Feature name mapping from model to feature set
+- Feature reordering to match the feature set order
+- Objective function normalization (sigmoid for logistic, noop for linear/ranking)
+- Tree structure parsing from the raw JSON format
+
+**Supported Objectives**:
+- `binary:logistic`, `reg:logistic` → Sigmoid normalization
+- `binary:logitraw`, `rank:ndcg`, `rank:map`, `rank:pairwise`, `reg:linear` → No normalization
+
+### Usage Example
+
+Upload an XGBoost model using the new raw format:
+
+```json
+POST _ltr/_featureset/my_features/_createmodel
+{
+    "model": {
+        "name": "my_xgboost_model",
+        "model": {
+            "type": "model/xgboost+json+raw",
+            "definition": "{\"learner\":{\"feature_names\":[\"feat1\"],\"feature_types\":[\"float\"],\"gradient_booster\":{\"model\":{\"trees\":[...]}},\"objective\":{\"name\":\"reg:linear\"}}}"
+        }
+    }
+}
+```
+
+### Migration Notes
+
+- Existing models using `model/xgboost+json` continue to work unchanged
+- For new XGBoost models, use `model/xgboost+json+raw` with the output from `booster.save_model()`
+- The raw format includes feature names, allowing automatic feature mapping
+
+## Limitations
+
+- Only `float` feature types are supported (OpenSearch scores are always float32)
+- Feature names in the model must match feature names in the feature set
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#151](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/151) | Add XGBoost model parser for correct serialization format |
+| [#158](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/158) | Fix test for ApproximateScoreQuery |
+
+## References
+
+- [Original Issue (o19s)](https://github.com/o19s/elasticsearch-learning-to-rank/issues/497): XGBoost model loading issue
+- [Port from o19s](https://github.com/o19s/elasticsearch-learning-to-rank/pull/500): Original fix in Elasticsearch LTR
+- [XGBoost save_model documentation](https://xgboost.readthedocs.io/en/stable/python/python_api.html#xgboost.Booster.save_model)
+- [Learning to Rank Documentation](https://docs.opensearch.org/3.0/search-plugins/ltr/index/)
+- [Uploading trained models](https://docs.opensearch.org/3.0/search-plugins/ltr/training-models/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/learning/learning-to-rank.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -135,3 +135,7 @@
 - [Explain API Support](features/k-nn/explain-api-support.md)
 - [Lucene On Faiss (Memory Optimized Search)](features/k-nn/lucene-on-faiss.md)
 - [Remote Vector Index Build](features/k-nn/remote-vector-index-build.md)
+
+## learning
+
+- [Learning to Rank Bug Fixes](features/learning/learning-to-rank.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Learning to Rank bug fixes in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/learning/learning-to-rank.md`
- Feature report: `docs/features/learning/learning-to-rank.md`

### Key Changes in v3.0.0
- **PR #151**: Added new XGBoost model parser (`XGBoostRawJsonParser`) for the correct `save_model` serialization format
- **PR #158**: Fixed test assertion for `ApproximateScoreQuery`

### Resources Used
- PR: [#151](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/151), [#158](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/158)
- Docs: https://docs.opensearch.org/3.0/search-plugins/ltr/index/

Closes #180