### PR TITLE
docs: add Notifications Java Agent build fix report for v3.0.0

### DIFF
--- a/docs/features/multi-plugin/jdk-21-java-agent-migration.md
+++ b/docs/features/multi-plugin/jdk-21-java-agent-migration.md
@@ -143,6 +143,7 @@ jobs:
 | v3.0.0 | [#695](https://github.com/opensearch-project/geospatial/pull/695) | geospatial | JDK 21 baseline |
 | v3.0.0 | [#723](https://github.com/opensearch-project/geospatial/pull/723) | geospatial | Gradle 8.10.2, JDK 23 |
 | v3.0.0 | [#722](https://github.com/opensearch-project/job-scheduler/pull/722) | job-scheduler | Shadow plugin update |
+| v3.0.0 | [#1013](https://github.com/opensearch-project/notifications/pull/1013) | notifications | Java Agent build fix |
 
 ## References
 

--- a/docs/releases/v3.0.0/features/notifications/java-agent-build-fix.md
+++ b/docs/releases/v3.0.0/features/notifications/java-agent-build-fix.md
@@ -1,0 +1,81 @@
+# Java Agent Build Fix
+
+## Summary
+
+This bugfix updates the Notifications plugin build configuration to support the Java Agent-based security model introduced in OpenSearch 3.0.0. The change adds the necessary Gradle configuration to run tests with the Java Agent, replacing the deprecated SecurityManager approach.
+
+## Details
+
+### What's New in v3.0.0
+
+The Notifications plugin build was updated to work with OpenSearch's transition from Java SecurityManager to Java Agent for runtime security instrumentation. This change was required because SecurityManager is deprecated in JDK 17 and will be permanently disabled in JDK 24.
+
+### Technical Changes
+
+#### Build Configuration Updates
+
+The `notifications/build.gradle` file was modified to:
+
+1. Add an `agent` configuration for Java Agent dependencies
+2. Create a `prepareAgent` task to copy agent JARs to the build directory
+3. Configure all test tasks to run with the Java Agent
+
+```groovy
+configurations {
+    agent
+}
+
+task prepareAgent(type: Copy) {
+    from(configurations.agent)
+    into "$buildDir/agent"
+}
+
+dependencies {
+    agent "org.opensearch:opensearch-agent-bootstrap:${opensearch_version}"
+    agent "org.opensearch:opensearch-agent:${opensearch_version}"
+    agent "net.bytebuddy:byte-buddy:1.17.5"
+}
+
+tasks.withType(Test) {
+    dependsOn prepareAgent
+    jvmArgs += ["-javaagent:" + project.layout.buildDirectory.file("agent/opensearch-agent-${opensearch_version}.jar").get()]
+}
+```
+
+#### Dependencies Added
+
+| Dependency | Version | Purpose |
+|------------|---------|---------|
+| opensearch-agent-bootstrap | ${opensearch_version} | Agent bootstrap classes |
+| opensearch-agent | ${opensearch_version} | Main Java Agent implementation |
+| byte-buddy | 1.17.5 | Bytecode manipulation library |
+
+### Migration Notes
+
+Plugin developers maintaining forks or custom builds of the Notifications plugin should:
+
+1. Update their `build.gradle` to include the agent configuration
+2. Ensure JDK 21+ is used for building and testing
+3. Run tests to verify compatibility with the Java Agent
+
+## Limitations
+
+- Requires JDK 21 or later
+- Tests must run with the Java Agent enabled
+- Legacy SecurityManager-based security checks are no longer supported
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1013](https://github.com/opensearch-project/notifications/pull/1013) | Fix build due to phasing off SecurityManager usage in favor of Java Agent |
+
+## References
+
+- [PR #17861](https://github.com/opensearch-project/OpenSearch/pull/17861): Core OpenSearch SecurityManager replacement
+- [Issue #16634](https://github.com/opensearch-project/OpenSearch/issues/16634): META - Replace Java Security Manager
+- [Issue #17662](https://github.com/opensearch-project/OpenSearch/issues/17662): Phase off SecurityManager usage in favor of Java Agent
+
+## Related Feature Report
+
+- [JDK 21 & Java Agent Migration](../../../../features/multi-plugin/jdk-21-java-agent-migration.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -139,3 +139,7 @@
 ## learning
 
 - [Learning to Rank Bug Fixes](features/learning/learning-to-rank.md)
+
+## notifications
+
+- [Java Agent Build Fix](features/notifications/java-agent-build-fix.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Notifications plugin Java Agent build fix in OpenSearch v3.0.0.

## Changes

### Release Report Created
- `docs/releases/v3.0.0/features/notifications/java-agent-build-fix.md`

### Feature Report Updated
- `docs/features/multi-plugin/jdk-21-java-agent-migration.md` - Added Notifications PR #1013 to the related PRs table

### Release Index Updated
- `docs/releases/v3.0.0/index.md` - Added Notifications section

## Key Findings

The Notifications plugin build was updated to support OpenSearch's transition from Java SecurityManager to Java Agent for runtime security instrumentation. The change adds:

1. An `agent` configuration for Java Agent dependencies
2. A `prepareAgent` task to copy agent JARs to the build directory
3. Configuration for all test tasks to run with the Java Agent

## Related Issue
Closes #179