### PR TITLE
docs: add Data Ingestion Dashboards report for v3.0.0

### DIFF
--- a/docs/features/dashboards-flow-framework/data-ingestion.md
+++ b/docs/features/dashboards-flow-framework/data-ingestion.md
@@ -1,0 +1,143 @@
+# Data Ingestion in OpenSearch Flow
+
+## Summary
+
+OpenSearch Flow (dashboards-flow-framework plugin) provides a visual interface for building AI search workflows, including data ingestion pipelines. The data ingestion feature allows users to import data into OpenSearch indexes through ingest pipelines with ML inference processors, enabling vector search and RAG use cases.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Flow UI"
+        UI[Workflow Editor]
+        Form[Configuration Form]
+        Inspector[Inspector Panel]
+    end
+    
+    subgraph "Data Ingestion"
+        Import[Data Import]
+        JsonLines[JSON Lines Parser]
+        Validate[Validation]
+    end
+    
+    subgraph "Pipeline Processing"
+        IngestPipeline[Ingest Pipeline]
+        MLProcessor[ML Inference Processor]
+        Transform[Data Transformation]
+    end
+    
+    subgraph "OpenSearch"
+        Index[Target Index]
+        Mappings[Index Mappings]
+    end
+    
+    UI --> Form
+    Form --> Import
+    Import --> JsonLines
+    JsonLines --> Validate
+    Validate --> IngestPipeline
+    IngestPipeline --> MLProcessor
+    MLProcessor --> Transform
+    Transform --> Index
+    Inspector --> IngestPipeline
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User Input] --> B{Input Type}
+    B -->|Manual Entry| C[JSON Lines Editor]
+    B -->|File Upload| D[.jsonl File]
+    B -->|Existing Index| E[Sample Documents]
+    C --> F[Parse & Validate]
+    D --> F
+    E --> F
+    F --> G[Simulate Pipeline]
+    G -->|Errors| H[Display in Inspector]
+    G -->|Success| I[Bulk Ingest]
+    I --> J[Index Documents]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| JsonLinesField | Input component for JSON Lines format with validation and error handling |
+| Data Import Modal | Interface for importing data via manual entry, file upload, or existing index |
+| Inspector Panel | Displays ingest responses, errors, and resource information |
+| Error Tab | Shows processor-level errors with details about failures |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Input Format | Data format for ingestion | JSON Lines |
+| File Extension | Accepted file type for upload | `.jsonl` |
+| Verbose Mode | Enable detailed error reporting | `true` |
+
+### Usage Example
+
+#### JSON Lines Input Format
+
+```jsonl
+{"title": "Document 1", "content": "First document content", "category": "tech"}
+{"title": "Document 2", "content": "Second document content", "category": "science"}
+{"title": "Document 3", "content": "Third document content", "category": "tech"}
+```
+
+#### Workflow Configuration
+
+1. Access OpenSearch Flow via **OpenSearch Plugins** > **OpenSearch Flow**
+2. Select a preset template (e.g., "Semantic Search" or "RAG with Vector Retrieval")
+3. Configure the embedding model for vector generation
+4. Import sample data using JSON Lines format
+5. Configure the ML Inference Processor with input/output mappings
+6. Update the workflow to create the ingest pipeline and index
+7. Test the ingestion in the Inspector panel
+
+### Error Handling
+
+The data ingestion feature provides fine-grained error handling:
+
+1. **Pre-ingestion validation**: Uses the simulate pipeline API with `verbose=true` to detect errors before actual ingestion
+2. **Processor-level errors**: Displays which specific processor failed and why
+3. **Error display locations**:
+   - Errors tab in Inspector with detailed information
+   - Error icons next to failed processors in the form
+
+## Limitations
+
+- JSON Lines format requires one JSON object per line (no multi-line JSON objects)
+- File uploads limited to `.jsonl` extension
+- Error handling quality depends on model interface definitions
+- Local cluster version detection required for proper preset rendering
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#598](https://github.com/opensearch-project/dashboards-flow-framework/pull/598) | Add fine-grained error handling |
+| v3.0.0 | [#639](https://github.com/opensearch-project/dashboards-flow-framework/pull/639) | Change ingestion input to JSON Lines format |
+| v3.0.0 | [#606](https://github.com/opensearch-project/dashboards-flow-framework/pull/606) | Fix local cluster version detection |
+| v3.0.0 | [#613](https://github.com/opensearch-project/dashboards-flow-framework/pull/613) | UX improvements XI |
+| v3.0.0 | [#618](https://github.com/opensearch-project/dashboards-flow-framework/pull/618) | UX improvements XII |
+| v3.0.0 | [#630](https://github.com/opensearch-project/dashboards-flow-framework/pull/630) | Bug fixes XIII |
+| v3.0.0 | [#644](https://github.com/opensearch-project/dashboards-flow-framework/pull/644) | Various bug fixes & improvements |
+| v3.0.0 | [#654](https://github.com/opensearch-project/dashboards-flow-framework/pull/654) | Search Index Local Cluster fix |
+| v3.0.0 | [#672](https://github.com/opensearch-project/dashboards-flow-framework/pull/672) | JSON Lines autofilling fixes |
+
+## References
+
+- [Issue #571](https://github.com/opensearch-project/dashboards-flow-framework/issues/571): Fine-grained error handling feature request
+- [Issue #627](https://github.com/opensearch-project/dashboards-flow-framework/issues/627): Various bug fixes request
+- [Issue #653](https://github.com/opensearch-project/dashboards-flow-framework/issues/653): Search Index Local Cluster bug
+- [Documentation: Building AI search workflows](https://docs.opensearch.org/3.0/vector-search/ai-search/workflow-builder/): Official OpenSearch Flow documentation
+- [JSON Lines specification](https://jsonlines.org/): JSON Lines format specification
+- [Ingest Pipelines](https://docs.opensearch.org/3.0/ingest-pipelines/): OpenSearch ingest pipeline documentation
+
+## Change History
+
+- **v3.0.0** (2025): Added fine-grained error handling, JSON Lines format support, local cluster version detection fixes, and various UX improvements

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -58,6 +58,7 @@
 ## dashboards-flow-framework
 
 - [Backward Compatibility](dashboards-flow-framework/backward-compatibility.md)
+- [Data Ingestion](dashboards-flow-framework/data-ingestion.md)
 
 ## flow-framework
 

--- a/docs/releases/v3.0.0/features/dashboards-flow-framework/data-ingestion-dashboards.md
+++ b/docs/releases/v3.0.0/features/dashboards-flow-framework/data-ingestion-dashboards.md
@@ -1,0 +1,96 @@
+# Data Ingestion Dashboards
+
+## Summary
+
+This release item includes bug fixes and enhancements to the data ingestion experience in OpenSearch Flow (dashboards-flow-framework plugin). Key improvements include fine-grained error handling for ingest and search pipelines, JSON Lines format support for data ingestion, local cluster version detection fixes, and various UX improvements.
+
+## Details
+
+### What's New in v3.0.0
+
+The Data Ingestion Dashboards improvements in v3.0.0 focus on enhancing the user experience when building AI search workflows through OpenSearch Flow. These changes make it easier to ingest data, debug pipeline errors, and work with local clusters.
+
+### Technical Changes
+
+#### Fine-Grained Error Handling (#598)
+
+Surfaces processor-level errors for both ingest and search flows:
+
+- **Ingest errors**: Uses the `verbose` parameter from the simulate pipeline API to check for errors before data ingestion
+- **Search errors**: Passes `verbose_pipeline=true` to the search API to fetch processor-level results
+- Errors are displayed in two places:
+  1. The `Errors` tab in the Inspector with details about failed processors
+  2. Error icons next to processors in the form with hover tooltips
+
+#### JSON Lines Format Support (#639)
+
+Changed the ingestion input format from JSON array to JSON Lines format (https://jsonlines.org/):
+
+- New `JsonLinesField` component with specific error handling and formatting
+- File upload now accepts `*.jsonl` extension
+- New JSON Lines config field type with corresponding schema/value presets
+- Updated all ingest docs parsing to handle JSON Lines strings
+
+#### Local Cluster Version Detection (#606)
+
+Fixed an issue where selecting a local data source showed a loading state without rendering presets:
+
+- Now correctly retrieves version from the datasource
+- Renders presets based on the data source version
+
+#### UX Improvements
+
+| PR | Description |
+|----|-------------|
+| #613 | Added prompt message when no compatible datasource; index configurations retained in configure ingest page |
+| #618 | Fixed `Get started` accordion visibility; BWC 2.17 datasource support; processor error reformatting; model refresh buttons |
+| #630 | Loading state improvements when switching datasources; fixed "Transform query" section visibility |
+| #644 | Description fields changed to textarea; unsaved changes confirmation modal; normalization processor UI updates |
+| #654 | Fixed Search Index bug in Local Cluster scenario |
+| #672 | Fixed UI autofilling edge cases after JSON Lines format change |
+
+### Usage Example
+
+Data ingestion now uses JSON Lines format:
+
+```jsonl
+{"title": "Document 1", "content": "First document content"}
+{"title": "Document 2", "content": "Second document content"}
+{"title": "Document 3", "content": "Third document content"}
+```
+
+### Migration Notes
+
+- If you have existing workflows using JSON array format for ingestion, you'll need to convert your data to JSON Lines format
+- File uploads now require `.jsonl` extension instead of `.json`
+
+## Limitations
+
+- JSON Lines format requires one JSON object per line with no trailing commas
+- Error handling requires models with properly defined interfaces for best results
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#598](https://github.com/opensearch-project/dashboards-flow-framework/pull/598) | Add fine-grained error handling; misc bug fixes |
+| [#639](https://github.com/opensearch-project/dashboards-flow-framework/pull/639) | Change ingestion input to JSON lines format |
+| [#606](https://github.com/opensearch-project/dashboards-flow-framework/pull/606) | Fix error that local cluster cannot get version |
+| [#613](https://github.com/opensearch-project/dashboards-flow-framework/pull/613) | UX fit-n-finish updates XI |
+| [#618](https://github.com/opensearch-project/dashboards-flow-framework/pull/618) | UX fit-n-finish updates XII |
+| [#630](https://github.com/opensearch-project/dashboards-flow-framework/pull/630) | Bug fixes XIII |
+| [#644](https://github.com/opensearch-project/dashboards-flow-framework/pull/644) | Various bug fixes & improvements |
+| [#654](https://github.com/opensearch-project/dashboards-flow-framework/pull/654) | Fixed bug related to Search Index in Local Cluster scenario |
+| [#672](https://github.com/opensearch-project/dashboards-flow-framework/pull/672) | Fix missed UI autofilling after JSON Lines change |
+
+## References
+
+- [Issue #571](https://github.com/opensearch-project/dashboards-flow-framework/issues/571): Fine-grained error handling feature request
+- [Issue #627](https://github.com/opensearch-project/dashboards-flow-framework/issues/627): Various bug fixes request
+- [Issue #653](https://github.com/opensearch-project/dashboards-flow-framework/issues/653): Search Index Local Cluster bug
+- [Documentation: Building AI search workflows](https://docs.opensearch.org/3.0/vector-search/ai-search/workflow-builder/): Official OpenSearch Flow documentation
+- [JSON Lines specification](https://jsonlines.org/): JSON Lines format specification
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/dashboards-flow-framework/data-ingestion.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -65,6 +65,7 @@
 ## dashboards-flow-framework
 
 - [Dashboards BWC](features/dashboards-flow-framework/dashboards-bwc.md)
+- [Data Ingestion Dashboards](features/dashboards-flow-framework/data-ingestion-dashboards.md)
 
 ## flow-framework
 


### PR DESCRIPTION
## Summary

Adds documentation for Data Ingestion Dashboards improvements in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/dashboards-flow-framework/data-ingestion-dashboards.md`
- Feature report: `docs/features/dashboards-flow-framework/data-ingestion.md`

### Key Changes in v3.0.0
- Fine-grained error handling using verbose parameter in simulate pipeline API
- JSON Lines format (.jsonl) for data ingestion replacing JSON array format
- Local cluster version detection fix for proper preset rendering
- Multiple UX improvements including unsaved changes confirmation modal

Closes #174