### PR TITLE
docs: add reporting bugfixes report for v3.0.0

### DIFF
--- a/docs/features/dashboards-reporting/dashboards-reporting.md
+++ b/docs/features/dashboards-reporting/dashboards-reporting.md
@@ -1,0 +1,133 @@
+# OpenSearch Dashboards Reporting
+
+## Summary
+
+OpenSearch Dashboards Reporting is a plugin that enables users to export and automate PNG, PDF, and CSV reports directly from OpenSearch Dashboards. It provides both an interactive UI for on-demand report generation and a CLI tool for programmatic report creation in automated workflows.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        UI[Reporting UI]
+        Plugin[Reporting Plugin]
+    end
+    
+    subgraph "Report Generation"
+        PDF[PDF Generator]
+        PNG[PNG Generator]
+        CSV[CSV Generator]
+    end
+    
+    subgraph "Data Sources"
+        Dashboard[Dashboards]
+        Viz[Visualizations]
+        Notebook[Notebooks]
+        Discover[Discover]
+    end
+    
+    UI --> Plugin
+    Plugin --> PDF
+    Plugin --> PNG
+    Plugin --> CSV
+    
+    Dashboard --> Plugin
+    Viz --> Plugin
+    Notebook --> Plugin
+    Discover --> Plugin
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Reporting Plugin | Core plugin that handles report generation requests |
+| Report Definition | Configuration for scheduled or on-demand reports |
+| Time Range Handler | Manages absolute and relative time ranges for reports |
+| Popover UI | User interface for initiating report downloads |
+| CLI Tool | Command-line interface for programmatic report generation |
+
+### Report Types
+
+| Type | Description | Use Case |
+|------|-------------|----------|
+| PDF | Portable Document Format export | Sharing dashboards as documents |
+| PNG | Image export | Embedding visualizations in presentations |
+| CSV | Comma-separated values | Data export for analysis |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `timeFrom` | Start time for report data (optional) | Dashboard default |
+| `timeTo` | End time for report data (optional) | Dashboard default |
+| Report Format | PDF, PNG, or CSV | PDF |
+| Schedule | Cron expression for scheduled reports | None (on-demand) |
+
+### Usage Example
+
+#### Generating a Report from the UI
+
+1. Navigate to a dashboard, visualization, or notebook
+2. Click the "Reporting" button in the top navigation
+3. Select "Download PDF" or "Download PNG"
+4. The report will be generated with the current time range
+
+#### Using the CLI
+
+```bash
+# Generate a PDF report
+opensearch-reporting-cli \
+  --url https://localhost:5601/app/dashboards#/view/7adfa750-4c81-11e8-b3d7-01146121b73d \
+  --format pdf \
+  --auth basic \
+  --credentials admin:admin
+```
+
+#### Creating a Report Definition with Absolute Date Range
+
+```json
+{
+  "reportDefinition": {
+    "name": "Monthly Sales Report",
+    "source": {
+      "type": "Dashboard",
+      "id": "dashboard-id"
+    },
+    "timeRange": {
+      "timeFrom": "2024-08-01T00:00:00.000Z",
+      "timeTo": "2024-08-31T23:59:59.999Z"
+    },
+    "format": "pdf"
+  }
+}
+```
+
+## Limitations
+
+- Report generation requires sufficient memory for rendering large dashboards
+- PDF/PNG generation uses headless browser rendering which may have performance implications
+- Time range parameters are optional; reports without them use the dashboard's default time range
+- The popover UI requires JavaScript to be enabled
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#524](https://github.com/opensearch-project/dashboards-reporting/pull/524) | Support for date range in report generation |
+| v3.0.0 | [#554](https://github.com/opensearch-project/dashboards-reporting/pull/554) | Updated optional parameters for timeFrom and timeTo |
+| v3.0.0 | [#570](https://github.com/opensearch-project/dashboards-reporting/pull/570) | Reporting Popover UI fix |
+
+## References
+
+- [Issue #414](https://github.com/opensearch-project/dashboards-reporting/issues/414): Absolute date interval interpreted as relative to "now"
+- [Issue #401](https://github.com/opensearch-project/dashboards-reporting/issues/401): Reporting UI issue
+- [Documentation](https://docs.opensearch.org/3.0/reporting/): Reporting overview
+- [Dashboard Reporting](https://docs.opensearch.org/3.0/reporting/report-dashboard-index/): Reporting using OpenSearch Dashboards
+- [CLI Documentation](https://docs.opensearch.org/3.0/reporting/rep-cli-index/): Reporting using the CLI
+
+## Change History
+
+- **v3.0.0** (2025-05-20): Fixed date range handling in report generation, made time parameters optional, fixed popover UI positioning

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -55,6 +55,10 @@
 - [CI/CD Workflow](reporting/ci-workflow.md)
 - [Java Agent Migration](reporting/java-agent-migration.md)
 
+## dashboards-reporting
+
+- [OpenSearch Dashboards Reporting](dashboards-reporting/dashboards-reporting.md)
+
 ## dashboards-flow-framework
 
 - [Backward Compatibility](dashboards-flow-framework/backward-compatibility.md)

--- a/docs/releases/v3.0.0/features/dashboards-reporting/reporting-bugfixes.md
+++ b/docs/releases/v3.0.0/features/dashboards-reporting/reporting-bugfixes.md
@@ -1,0 +1,79 @@
+# Reporting Bugfixes
+
+## Summary
+
+OpenSearch Dashboards Reporting v3.0.0 includes three bug fixes that improve the report generation experience. These fixes address issues with date range handling in report definitions and the positioning of the reporting popover UI.
+
+## Details
+
+### What's New in v3.0.0
+
+This release fixes critical bugs in the Dashboards Reporting plugin that affected report generation and UI usability:
+
+1. **Date Range Support**: Fixed an issue where absolute date ranges were incorrectly interpreted as relative to "now"
+2. **Optional Time Parameters**: Made `timeFrom` and `timeTo` parameters optional to prevent errors when loading reports without time ranges
+3. **Popover UI Positioning**: Fixed the reporting popover to use relative positioning instead of fixed positioning
+
+### Technical Changes
+
+#### Bug Fix 1: Date Range in Report Generation (PR #524)
+
+**Problem**: When creating a report definition with an absolute time range (e.g., a specific date from a month ago), the generated PDF report would use a time interval relative to "now" instead of the specified absolute dates.
+
+**Solution**: Updated the time picker component to correctly preserve and use absolute date ranges when generating reports.
+
+**Affected Component**: Report definition creation and editing functionality
+
+#### Bug Fix 2: Optional Time Parameters (PR #554)
+
+**Problem**: Loading reports that did not have `timeFrom` and `timeTo` values would throw an error: "Error generating report".
+
+**Solution**: Made the `timeFrom` and `timeTo` parameters optional in the report generation logic, allowing reports without explicit time ranges to load successfully.
+
+**Affected Component**: Report loading and generation logic
+
+#### Bug Fix 3: Reporting Popover UI (PR #570)
+
+**Problem**: The reporting popover was set to a fixed position. When users scrolled down a dashboard and clicked the reporting button, the popover would appear at the top of the page (hidden from view) instead of near the button.
+
+**Solution**: Changed the popover positioning from fixed to relative, ensuring it always opens correctly near the reporting button regardless of scroll position.
+
+**Affected Component**: Reporting UI popover component
+
+Additionally, this PR fixed a failing Cypress test that was looking for a non-existent nested span element.
+
+### Usage Example
+
+After these fixes, users can:
+
+1. Create report definitions with absolute date ranges that are preserved correctly:
+```
+Time Range: Aug 1, 2024 00:00:00 to Aug 15, 2024 23:59:59
+```
+
+2. Load reports without time parameters without encountering errors
+
+3. Access the reporting popover from any scroll position on a dashboard
+
+## Limitations
+
+- These fixes are specific to the OpenSearch Dashboards Reporting plugin
+- The date range fix applies to new report definitions; existing definitions may need to be recreated
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#524](https://github.com/opensearch-project/dashboards-reporting/pull/524) | Support for date range in report generation |
+| [#554](https://github.com/opensearch-project/dashboards-reporting/pull/554) | Updated optional parameters for timeFrom and timeTo |
+| [#570](https://github.com/opensearch-project/dashboards-reporting/pull/570) | Reporting Popover UI fix |
+
+## References
+
+- [Issue #414](https://github.com/opensearch-project/dashboards-reporting/issues/414): Absolute date interval interpreted as relative to "now"
+- [Issue #401](https://github.com/opensearch-project/dashboards-reporting/issues/401): Reporting UI issue (popover positioning)
+- [Documentation](https://docs.opensearch.org/3.0/reporting/report-dashboard-index/): Reporting using OpenSearch Dashboards
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/dashboards-reporting/dashboards-reporting.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -56,6 +56,10 @@
 - [CI/Workflow Fixes](features/reporting/ci-workflow-fixes.md)
 - [Java Agent Build Fix](features/reporting/java-agent-build-fix.md)
 
+## dashboards-reporting
+
+- [Reporting Bugfixes](features/dashboards-reporting/reporting-bugfixes.md)
+
 ## security
 
 - [Security Plugin Bugfixes](features/security/security-plugin-bugfixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the OpenSearch Dashboards Reporting bugfixes included in v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/dashboards-reporting/reporting-bugfixes.md`
- Feature report: `docs/features/dashboards-reporting/dashboards-reporting.md`

### Key Changes in v3.0.0
- **Date Range Support (PR #524)**: Fixed an issue where absolute date ranges were incorrectly interpreted as relative to "now"
- **Optional Time Parameters (PR #554)**: Made `timeFrom` and `timeTo` parameters optional to prevent errors when loading reports without time ranges
- **Popover UI Positioning (PR #570)**: Fixed the reporting popover to use relative positioning instead of fixed positioning

### Related Issue
Closes #173