### PR TITLE
docs: add Common Utils report for v3.0.0

### DIFF
--- a/docs/features/common-utils/common-utils.md
+++ b/docs/features/common-utils/common-utils.md
@@ -1,0 +1,143 @@
+# Common Utils
+
+## Summary
+
+Common Utils is a shared library that provides utilities for building Java-based OpenSearch plugins. It offers common interfaces, request/response classes, and helper utilities that enable communication between different OpenSearch plugins without tight coupling. The library facilitates plugin interoperability by providing shared transport action interfaces for plugins like Alerting, Notifications, and Cross-Cluster Replication.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Plugins"
+        ISM[Index State Management]
+        Alerting[Alerting Plugin]
+        Notifications[Notifications Plugin]
+        CCR[Cross-Cluster Replication]
+        Security[Security Plugin]
+    end
+    subgraph "Common Utils Library"
+        API[Plugin Interfaces]
+        Auth[Auth Utilities]
+        Utils[Helper Utilities]
+    end
+    subgraph "OpenSearch Core"
+        Transport[Transport Layer]
+        ThreadCtx[ThreadContext]
+    end
+    ISM --> API
+    Alerting --> API
+    Notifications --> API
+    CCR --> API
+    API --> Transport
+    Auth --> ThreadCtx
+    Security --> Auth
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `AlertingPluginInterface` | Transport action interface for Alerting plugin operations |
+| `NotificationsPluginInterface` | Transport action interface for Notifications plugin operations |
+| `ReplicationPluginInterface` | Transport action interface for CCR plugin operations |
+| `InjectSecurity` | Utility for injecting security context into ThreadContext |
+| `User` | Model class representing authenticated user information |
+| `Utils` | Helper utilities for string manipulation (escape/unescape) |
+| `SecureClientWrapper` | Wrapper for Client with security context handling |
+
+### Plugin Interfaces
+
+The library provides standardized interfaces for inter-plugin communication:
+
+```mermaid
+flowchart LR
+    subgraph "Plugin A"
+        PA[Plugin Code]
+    end
+    subgraph "Common Utils"
+        IF[Plugin Interface]
+        REQ[Request Classes]
+        RES[Response Classes]
+    end
+    subgraph "Plugin B"
+        PB[Transport Action]
+    end
+    PA -->|Create Request| REQ
+    PA -->|Call Interface| IF
+    IF -->|Transport Action| PB
+    PB -->|Response| RES
+    RES -->|Return| PA
+```
+
+### Security Context Handling
+
+User information is stored in ThreadContext using a pipe-delimited format:
+```
+username|backendRole1,backendRole2|role1,role2|tenant
+```
+
+**Escape Handling:**
+- Pipe characters in values are escaped as `\|`
+- Parsing uses negative lookbehind regex to split on unescaped pipes
+
+### Configuration
+
+Common Utils is a library dependency and does not have runtime configuration. Plugins include it as a Gradle dependency:
+
+```groovy
+dependencies {
+    implementation "org.opensearch:common-utils:${version}"
+}
+```
+
+### Usage Examples
+
+**Injecting User Security Context:**
+```java
+try (InjectSecurity helper = new InjectSecurity("plugin-name", settings, threadContext)) {
+    User user = new User("username", backendRoles, roles, attributes, "tenant");
+    helper.injectUserInfo(user);
+    // Execute operations with injected security context
+}
+// Security context automatically cleaned up
+```
+
+**Parsing User from ThreadContext:**
+```java
+String userString = threadContext.getTransient(OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
+User user = User.parse(userString);
+String username = user.getName();
+List<String> roles = user.getRoles();
+```
+
+**Calling Replication Plugin:**
+```kotlin
+val request = StopIndexReplicationRequest("follower-index")
+ReplicationPluginInterface.stopReplication(client, request, listener)
+```
+
+## Limitations
+
+- Plugin interfaces require the target plugin to be installed
+- User info format uses pipe delimiter, requiring escape handling for pipe characters in values
+- Library changes require coordinated updates across dependent plugins
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#667](https://github.com/opensearch-project/common-utils/pull/667) | Adding replication (CCR) plugin interface |
+| v3.0.0 | [#790](https://github.com/opensearch-project/common-utils/pull/790) | Fix imports for split transport package |
+| v3.0.0 | [#801](https://github.com/opensearch-project/common-utils/pull/801) | Escape/Unescape pipe in UserInfo |
+
+## References
+
+- [Common Utils Repository](https://github.com/opensearch-project/common-utils)
+- [Issue #2756](https://github.com/opensearch-project/security/issues/2756): Username pipe character issue
+- [Issue #726](https://github.com/opensearch-project/index-management/issues/726): Manage CCR follower indices
+
+## Change History
+
+- **v3.0.0** (2025-03-19): Added replication plugin interface, fixed transport package imports, added pipe character escaping in user info

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -144,3 +144,7 @@
 ## index-management
 
 - [Index Management](index-management/index-management.md)
+
+## common-utils
+
+- [Common Utils](common-utils/common-utils.md)

--- a/docs/releases/v3.0.0/features/common-utils/common-utils-bugfixes.md
+++ b/docs/releases/v3.0.0/features/common-utils/common-utils-bugfixes.md
@@ -1,0 +1,140 @@
+# Common Utils Bugfixes and Enhancements
+
+## Summary
+
+OpenSearch v3.0.0 includes several important updates to the common-utils library: fixes for split package imports related to `org.opensearch.transport`, proper escaping/unescaping of pipe characters in user information stored in ThreadContext, and new replication (CCR) plugin interfaces to enable integration between Index State Management (ISM) and Cross-Cluster Replication plugins.
+
+## Details
+
+### What's New in v3.0.0
+
+#### 1. Split Package Import Fixes (PR #790)
+
+Updated import statements across multiple files to accommodate the split of the `org.opensearch.transport` package in OpenSearch core. The `NodeClient` and `Client` classes were moved from `org.opensearch.client` to `org.opensearch.transport.client`.
+
+**Changed Files:**
+- `AlertingPluginInterface.kt`
+- `NotificationsPluginInterface.kt`
+- `SecureClientWrapper.kt`
+- Related test files
+
+**Import Changes:**
+```kotlin
+// Before
+import org.opensearch.client.node.NodeClient
+import org.opensearch.client.Client
+
+// After
+import org.opensearch.transport.client.node.NodeClient
+import org.opensearch.transport.client.Client
+```
+
+#### 2. Pipe Character Escaping in UserInfo (PR #801)
+
+Fixed an issue where usernames, backend roles, roles, or tenant names containing pipe (`|`) characters would cause parsing failures. The pipe character is used as a delimiter in the ThreadContext user info string format.
+
+**Problem:**
+When OIDC providers send usernames with pipe characters (e.g., `idp-provider|email@test.com|tenant-account-id|user-id`), OpenSearch would throw:
+```
+java.lang.IllegalStateException: Username cannot have '|' in the security plugin.
+```
+
+**Solution:**
+- Added `Utils.java` class with `escapePipe()` and `unescapePipe()` methods
+- Modified `InjectSecurity.java` to escape pipe characters when setting user info
+- Modified `User.java` to unescape pipe characters when parsing user info
+- Uses backslash escaping: `|` becomes `\|`
+
+**New Components:**
+
+| Component | Description |
+|-----------|-------------|
+| `Utils.escapePipe()` | Escapes pipe characters by replacing `\|` with `\\|` |
+| `Utils.unescapePipe()` | Unescapes pipe characters by replacing `\\|` with `\|` |
+
+#### 3. Replication Plugin Interface (PR #667)
+
+Added new interfaces and classes to enable the Index State Management (ISM) plugin to invoke stop-replication actions from the Cross-Cluster Replication (CCR) plugin.
+
+**Background:**
+- ISM plugin needs to manage CCR follower indices (e.g., delete them after a retention period)
+- CCR makes follower indices read-only, preventing direct deletion
+- ISM needs to invoke stop-replication before deleting follower indices
+
+**New Components:**
+
+| Component | Description |
+|-----------|-------------|
+| `ReplicationPluginInterface` | Transport action interface for CCR plugin |
+| `ReplicationActions` | Action names and types for stop replication |
+| `StopIndexReplicationRequest` | Request class for stopping index replication |
+
+```mermaid
+graph TB
+    subgraph "Index State Management Plugin"
+        ISM[ISM Policy Engine]
+    end
+    subgraph "Common Utils"
+        RPI[ReplicationPluginInterface]
+        SIR[StopIndexReplicationRequest]
+    end
+    subgraph "CCR Plugin"
+        CCR[TransportStopIndexReplicationAction]
+    end
+    ISM -->|stopReplication| RPI
+    RPI -->|StopIndexReplicationRequest| CCR
+    CCR -->|AcknowledgedResponse| RPI
+    RPI -->|Response| ISM
+```
+
+### Usage Example
+
+**Escaping pipe characters in user info:**
+```java
+// When setting user info with pipe characters
+User user = new User("Bob|test-pipe", backendRoles, roles, attrs, "tenant1");
+injectSecurity.injectUserInfo(user);
+// ThreadContext contains: "Bob\|test-pipe|backendRole1,backendRole2|role1,role2|tenant1"
+
+// When parsing user info
+String userString = threadContext.getTransient(OPENSEARCH_SECURITY_USER_INFO_THREAD_CONTEXT);
+User parsedUser = User.parse(userString);
+// parsedUser.getName() returns: "Bob|test-pipe"
+```
+
+**Using replication interface from ISM:**
+```kotlin
+// Stop replication on a follower index
+val request = StopIndexReplicationRequest("follower-index-001")
+ReplicationPluginInterface.stopReplication(client, request, object : ActionListener<AcknowledgedResponse> {
+    override fun onResponse(response: AcknowledgedResponse) {
+        // Replication stopped, can now delete the index
+    }
+    override fun onFailure(e: Exception) {
+        // Handle failure
+    }
+})
+```
+
+## Limitations
+
+- The pipe escaping solution uses backslash as the escape character, which may conflict if backslashes are present in usernames
+- The replication interface requires both ISM and CCR plugins to be installed
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#667](https://github.com/opensearch-project/common-utils/pull/667) | Adding replication (CCR) plugin interface and classes |
+| [#790](https://github.com/opensearch-project/common-utils/pull/790) | Fix imports related to split package of org.opensearch.transport |
+| [#801](https://github.com/opensearch-project/common-utils/pull/801) | Escape/Unescape pipe UserInfo in ThreadContext |
+
+## References
+
+- [Issue #2756](https://github.com/opensearch-project/security/issues/2756): Username cannot have '|' in the security plugin
+- [Issue #726](https://github.com/opensearch-project/index-management/issues/726): Manage CCR follower indices with ISM
+- [PR #17272](https://github.com/opensearch-project/OpenSearch/pull/17272): Related OpenSearch core transport package split
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/common-utils/common-utils.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -159,3 +159,7 @@
 ## index-management
 
 - [Index Management Bugfixes](features/index-management/index-management-bugfixes.md)
+
+## common-utils
+
+- [Common Utils Bugfixes and Enhancements](features/common-utils/common-utils-bugfixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for Common Utils bugfixes and enhancements in OpenSearch v3.0.0.

### Changes in v3.0.0

1. **Split Package Import Fixes (PR #790)**: Updated import statements for `NodeClient` and `Client` classes moved from `org.opensearch.client` to `org.opensearch.transport.client`

2. **Pipe Character Escaping (PR #801)**: Fixed issue where usernames containing pipe (`|`) characters would cause parsing failures. Added `Utils.escapePipe()` and `Utils.unescapePipe()` methods.

3. **Replication Plugin Interface (PR #667)**: Added new interfaces to enable ISM plugin to invoke stop-replication actions from CCR plugin.

### Reports Created

- Release report: `docs/releases/v3.0.0/features/common-utils/common-utils-bugfixes.md`
- Feature report: `docs/features/common-utils/common-utils.md`

### Related Issue

Closes #171