### PR TITLE
docs: add alerting bugfixes report for v3.0.0

### DIFF
--- a/docs/features/alerting/alerting.md
+++ b/docs/features/alerting/alerting.md
@@ -1,0 +1,168 @@
+# Alerting
+
+## Summary
+
+OpenSearch Alerting is a plugin that enables proactive monitoring of data by creating monitors that check for specific conditions and trigger alerts with notifications. It supports multiple monitor types including per-query, per-bucket, per-document, per-cluster-metrics, and composite monitors, allowing users to be notified when data meets certain criteria.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Alerting Plugin"
+        Monitor[Monitor]
+        Trigger[Trigger]
+        Action[Action]
+    end
+    
+    subgraph "Monitor Types"
+        PerQuery[Per Query Monitor]
+        PerBucket[Per Bucket Monitor]
+        PerDoc[Per Document Monitor]
+        ClusterMetrics[Cluster Metrics Monitor]
+        Composite[Composite Monitor]
+    end
+    
+    subgraph "Notifications"
+        NotifPlugin[Notifications Plugin]
+        Channels[Notification Channels]
+    end
+    
+    subgraph "Data Sources"
+        Indices[OpenSearch Indices]
+        ClusterAPI[Cluster APIs]
+    end
+    
+    Monitor --> Trigger
+    Trigger --> Action
+    Action --> NotifPlugin
+    NotifPlugin --> Channels
+    
+    PerQuery --> Monitor
+    PerBucket --> Monitor
+    PerDoc --> Monitor
+    ClusterMetrics --> Monitor
+    Composite --> Monitor
+    
+    PerQuery --> Indices
+    PerBucket --> Indices
+    PerDoc --> Indices
+    ClusterMetrics --> ClusterAPI
+```
+
+### Monitor Types
+
+| Monitor Type | Description | Use Case |
+|--------------|-------------|----------|
+| Per Query | Runs a query and generates alerts based on matching criteria | Simple threshold-based alerting |
+| Per Bucket | Evaluates trigger criteria based on aggregated values | Alerting on grouped/bucketed data |
+| Per Document | Returns individual documents matching trigger conditions | Document-level alerting |
+| Per Cluster Metrics | Runs API requests to monitor cluster health | Infrastructure monitoring |
+| Composite | Combines multiple monitors into a single workflow | Complex multi-condition alerting |
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Monitor | Defines what data to check and how often |
+| Trigger | Specifies conditions that generate alerts |
+| Action | Defines what happens when a trigger fires |
+| Destination | Where notifications are sent (via Notifications plugin) |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.alerting.monitor.max_monitors` | Maximum number of monitors | 1000 |
+| `plugins.alerting.request_timeout` | Timeout for alerting requests | 10s |
+| `plugins.alerting.alert_history_enabled` | Enable alert history | true |
+| `plugins.alerting.alert_history_max_age` | Max age of alert history | 30d |
+
+### Usage Example
+
+Creating a per-query monitor:
+
+```json
+POST _plugins/_alerting/monitors
+{
+  "type": "monitor",
+  "name": "high-error-rate-monitor",
+  "monitor_type": "query_level_monitor",
+  "enabled": true,
+  "schedule": {
+    "period": {
+      "interval": 1,
+      "unit": "MINUTES"
+    }
+  },
+  "inputs": [{
+    "search": {
+      "indices": ["logs-*"],
+      "query": {
+        "size": 0,
+        "query": {
+          "bool": {
+            "filter": [{
+              "range": {
+                "@timestamp": {
+                  "gte": "now-5m"
+                }
+              }
+            }, {
+              "term": {
+                "level": "ERROR"
+              }
+            }]
+          }
+        }
+      }
+    }
+  }],
+  "triggers": [{
+    "name": "high-error-count",
+    "severity": "1",
+    "condition": {
+      "script": {
+        "source": "ctx.results[0].hits.total.value > 100",
+        "lang": "painless"
+      }
+    },
+    "actions": [{
+      "name": "notify-ops",
+      "destination_id": "notification-channel-id",
+      "message_template": {
+        "source": "High error rate detected: {{ctx.results[0].hits.total.value}} errors in the last 5 minutes"
+      }
+    }]
+  }]
+}
+```
+
+## Limitations
+
+- Maximum of 1000 monitors by default (configurable)
+- Composite monitors require delegate monitors to be created first
+- Per-document monitors may have performance impact on large datasets
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#1780](https://github.com/opensearch-project/alerting/pull/1780) | Fix bucket selector aggregation writeable name |
+| v3.0.0 | [#1823](https://github.com/opensearch-project/alerting/pull/1823) | Fix build due to phasing off SecurityManager |
+| v3.0.0 | [#1824](https://github.com/opensearch-project/alerting/pull/1824) | Use java-agent Gradle plugin |
+| v3.0.0 | [#1831](https://github.com/opensearch-project/alerting/pull/1831) | Correct release notes filename |
+| v3.0.0 | [#1234](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1234) | Fix .keyword subfield selection in bucket monitor |
+
+## References
+
+- [Alerting Documentation](https://docs.opensearch.org/3.0/observing-your-data/alerting/index/): Official alerting documentation
+- [Monitors Documentation](https://docs.opensearch.org/3.0/observing-your-data/alerting/monitors/): Monitor types and configuration
+- [Composite Monitors](https://docs.opensearch.org/3.0/observing-your-data/alerting/composite-monitors/): Composite monitor documentation
+- [Alerting Security](https://docs.opensearch.org/3.0/observing-your-data/alerting/security/): Security configuration for alerting
+- [Notifications Plugin](https://docs.opensearch.org/3.0/observing-your-data/notifications/index/): Notifications integration
+
+## Change History
+
+- **v3.0.0** (2025): Bug fixes for bucket selector aggregation, Java Agent migration, and dashboard subfield selection

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -148,3 +148,7 @@
 ## common-utils
 
 - [Common Utils](common-utils/common-utils.md)
+
+## alerting
+
+- [Alerting](alerting/alerting.md)

--- a/docs/releases/v3.0.0/features/alerting/alerting-bugfixes.md
+++ b/docs/releases/v3.0.0/features/alerting/alerting-bugfixes.md
@@ -1,0 +1,79 @@
+# Alerting Bugfixes
+
+## Summary
+
+OpenSearch 3.0.0 includes several bug fixes for the Alerting plugin, addressing issues with bucket selector aggregation, namespace conflicts, build compatibility with Java Agent migration, and release notes corrections. These fixes improve the stability and reliability of the alerting functionality.
+
+## Details
+
+### What's New in v3.0.0
+
+This release focuses on maintenance and compatibility fixes rather than new features:
+
+1. **Bucket Selector Aggregation Fix**: Corrected the pipeline aggregation registration for bucket selector, fixing issues with bucket-level monitors
+2. **Namespace Conflict Resolution**: Updated namespace for the alerting plugin to avoid conflicts
+3. **Java Agent Migration**: Fixed build issues related to phasing off SecurityManager usage in favor of Java Agent
+4. **Dashboard Field Selection Fix**: Ensured `.keyword` subfields are selectable in bucket monitor group-by dropdown
+5. **Release Notes Correction**: Fixed the filename for 3.0-beta release notes
+
+### Technical Changes
+
+#### Bucket Selector Aggregation Fix
+
+The bucket selector aggregation writeable name was incorrectly registered, causing issues with bucket-level monitors. PR #1780 fixed the pipeline aggregation registration and moved the unit test suite to common-utils.
+
+This fix depends on changes in [common-utils PR #773](https://github.com/opensearch-project/common-utils/pull/773).
+
+#### Java Agent Migration
+
+Two PRs addressed the transition from SecurityManager to Java Agent:
+
+- **PR #1823**: Initial fix for build compatibility with Java Agent
+- **PR #1824**: Adopted the java-agent Gradle plugin for proper support
+
+This change aligns with the broader OpenSearch ecosystem migration away from the deprecated SecurityManager API.
+
+#### Dashboard Subfield Selection
+
+PR #1234 (alerting-dashboards-plugin) fixed an issue where `.keyword` subfields were not selectable in the group-by dropdown when creating bucket monitors. OpenSearch auto-creates `.keyword` subfields for text fields, and these are now properly available for selection.
+
+Example mapping that now works correctly:
+```json
+{
+  "audit_category": {
+    "type": "text",
+    "fields": {
+      "keyword": {
+        "type": "keyword",
+        "ignore_above": 256
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- The bucket selector aggregation fix requires corresponding changes in common-utils (PR #773)
+- Backporting the bucket selector fix to versions prior to v2.4 requires separate PRs due to code location changes
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#1780](https://github.com/opensearch-project/alerting/pull/1780) | alerting | Fix bucket selector aggregation writeable name |
+| [#1823](https://github.com/opensearch-project/alerting/pull/1823) | alerting | Fix build due to phasing off SecurityManager |
+| [#1824](https://github.com/opensearch-project/alerting/pull/1824) | alerting | Use java-agent Gradle plugin |
+| [#1831](https://github.com/opensearch-project/alerting/pull/1831) | alerting | Correct release notes filename |
+| [#1234](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1234) | alerting-dashboards-plugin | Fix .keyword subfield selection in bucket monitor |
+
+## References
+
+- [Alerting Documentation](https://docs.opensearch.org/3.0/observing-your-data/alerting/index/): Official alerting documentation
+- [Monitors Documentation](https://docs.opensearch.org/3.0/observing-your-data/alerting/monitors/): Monitor types and configuration
+- [common-utils PR #773](https://github.com/opensearch-project/common-utils/pull/773): Related bucket selector fix in common-utils
+- [job-scheduler PR #762](https://github.com/opensearch-project/job-scheduler/pull/762): Related Java Agent migration
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/alerting/alerting.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -163,3 +163,7 @@
 ## common-utils
 
 - [Common Utils Bugfixes and Enhancements](features/common-utils/common-utils-bugfixes.md)
+
+## alerting
+
+- [Alerting Bugfixes](features/alerting/alerting-bugfixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Alerting plugin bugfixes in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/alerting/alerting-bugfixes.md`
- Feature report: `docs/features/alerting/alerting.md` (new)

### Key Changes in v3.0.0
- Fixed bucket selector aggregation writeable name (PR #1780)
- Fixed build compatibility with Java Agent migration (PRs #1823, #1824)
- Fixed .keyword subfield selection in bucket monitor (alerting-dashboards-plugin PR #1234)
- Corrected release notes filename (PR #1831)

### PRs Investigated
| PR | Repository | Description |
|----|------------|-------------|
| #1780 | alerting | Fix bucket selector aggregation |
| #1823 | alerting | Fix build for Java Agent |
| #1824 | alerting | Use java-agent Gradle plugin |
| #1831 | alerting | Correct release notes filename |
| #1234 | alerting-dashboards-plugin | Fix subfield selection |

Closes #170