### PR TITLE
docs: add Query Insights report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -152,3 +152,7 @@
 ## alerting
 
 - [Alerting](alerting/alerting.md)
+
+## query-insights
+
+- [Query Insights](query-insights/query-insights.md)

--- a/docs/features/query-insights/query-insights.md
+++ b/docs/features/query-insights/query-insights.md
@@ -1,0 +1,202 @@
+# Query Insights
+
+## Summary
+
+Query Insights is an OpenSearch plugin that provides comprehensive monitoring and analysis capabilities for search queries. It enables cluster administrators to identify slow or resource-intensive queries, understand query performance patterns, and optimize search operations. The plugin collects performance metrics during query execution with minimal overhead and provides APIs for accessing historical and real-time query data.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Cluster"
+        subgraph "Query Insights Plugin"
+            A[Search Request] --> B[Query Listener]
+            B --> C{Profile Query?}
+            C -->|Yes| D[Skip]
+            C -->|No| E[Collectors]
+            
+            E --> F[Latency Collector]
+            E --> G[CPU Collector]
+            E --> H[Memory Collector]
+            
+            F --> I[Processors]
+            G --> I
+            H --> I
+            
+            I --> J[Top N Processor]
+            J --> K[Exporters]
+            
+            K --> L[Local Index Exporter]
+            L --> M[(top_queries-* Index)]
+            
+            N[Task Manager] --> O[Live Queries]
+        end
+        
+        subgraph "APIs"
+            P[/_insights/top_queries]
+            Q[/_insights/live_queries]
+            R[/_insights/health]
+        end
+        
+        J --> P
+        O --> Q
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Search Request] --> B[SearchRequestOperationsListener]
+    B --> C[onRequestStart]
+    C --> D[Collect Start Time]
+    
+    D --> E[Query Execution]
+    E --> F[onRequestEnd]
+    
+    F --> G[Calculate Metrics]
+    G --> H{Meets Threshold?}
+    
+    H -->|Yes| I[Create SearchQueryRecord]
+    H -->|No| J[Discard]
+    
+    I --> K[Add to Top N Queue]
+    K --> L{Export Interval?}
+    
+    L -->|Yes| M[Export to Local Index]
+    L -->|No| N[Keep in Memory]
+    
+    M --> O[(top_queries-* Index)]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `QueryInsightsPlugin` | Main plugin entry point, registers listeners and services |
+| `QueryInsightsService` | Core service managing collectors, processors, and exporters |
+| `SearchQueryRecord` | Data model representing a captured query with metrics |
+| `TopQueriesService` | Manages Top N queries collection and retrieval |
+| `QueryInsightsExporter` | Exports query records to local index |
+| `QueryInsightsIndexTemplate` | Manages default index template for local indexes |
+| `LiveQueriesAction` | Transport action for fetching in-flight queries |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `search.insights.top_queries.latency.enabled` | Enable latency-based Top N queries | `false` |
+| `search.insights.top_queries.latency.top_n_size` | Number of top queries to track | `10` |
+| `search.insights.top_queries.latency.window_size` | Time window for collection | `1m` |
+| `search.insights.top_queries.cpu.enabled` | Enable CPU-based Top N queries | `false` |
+| `search.insights.top_queries.cpu.top_n_size` | Number of top queries to track | `10` |
+| `search.insights.top_queries.cpu.window_size` | Time window for collection | `1m` |
+| `search.insights.top_queries.memory.enabled` | Enable memory-based Top N queries | `false` |
+| `search.insights.top_queries.memory.top_n_size` | Number of top queries to track | `10` |
+| `search.insights.top_queries.memory.window_size` | Time window for collection | `1m` |
+| `search.insights.top_queries.group_by` | Group queries by: `NONE`, `SIMILARITY` | `NONE` |
+| `search.insights.top_queries.exporter.type` | Exporter type: `none`, `local_index` | `none` |
+| `search.insights.top_queries.exporter.template_priority` | Index template priority | `1847` |
+
+### APIs
+
+#### Top N Queries API
+
+Retrieve the most resource-intensive queries:
+
+```bash
+GET /_insights/top_queries
+GET /_insights/top_queries?type=latency
+GET /_insights/top_queries?type=cpu
+GET /_insights/top_queries?type=memory
+GET /_insights/top_queries?verbose=false
+GET /_insights/top_queries?from=2025-01-01T00:00:00.000Z&to=2025-01-02T00:00:00.000Z
+```
+
+#### Live Queries API
+
+Monitor currently executing queries:
+
+```bash
+GET /_insights/live_queries
+GET /_insights/live_queries?nodeId=node1,node2
+GET /_insights/live_queries?sort=cpu
+GET /_insights/live_queries?size=10
+GET /_insights/live_queries?verbose=false
+```
+
+#### Health API
+
+Check plugin health status:
+
+```bash
+GET /_insights/health
+```
+
+### Usage Examples
+
+**Enable Top N queries by latency:**
+```bash
+PUT _cluster/settings
+{
+  "persistent": {
+    "search.insights.top_queries.latency.enabled": true,
+    "search.insights.top_queries.latency.top_n_size": 10,
+    "search.insights.top_queries.latency.window_size": "1m"
+  }
+}
+```
+
+**Enable local index export:**
+```bash
+PUT _cluster/settings
+{
+  "persistent": {
+    "search.insights.top_queries.exporter.type": "local_index"
+  }
+}
+```
+
+**Query historical data:**
+```bash
+GET /_insights/top_queries?from=2025-01-01T00:00:00.000Z&to=2025-01-02T00:00:00.000Z
+```
+
+**Monitor live queries:**
+```bash
+GET /_insights/live_queries?sort=latency&size=5
+```
+
+## Limitations
+
+- Query Insights adds minimal overhead but should be monitored in high-throughput environments
+- Live Queries API returns coordinator node resource usage only
+- Profile queries are automatically excluded from Top N collection
+- Local index export requires additional storage capacity
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#295](https://github.com/opensearch-project/query-insights/pull/295) | Inflight Queries API |
+| v3.0.0 | [#254](https://github.com/opensearch-project/query-insights/pull/254) | Default index template for local index |
+| v3.0.0 | [#300](https://github.com/opensearch-project/query-insights/pull/300) | Top queries API verbose param |
+| v3.0.0 | [#298](https://github.com/opensearch-project/query-insights/pull/298) | Skip profile queries |
+| v3.0.0 | [#266](https://github.com/opensearch-project/query-insights/pull/266) | Strict hash check on top queries indices |
+| v2.12.0 | - | Initial release with Top N queries |
+
+## References
+
+- [Query Insights Documentation](https://docs.opensearch.org/3.0/observing-your-data/query-insights/index/)
+- [Top N Queries Documentation](https://docs.opensearch.org/3.0/observing-your-data/query-insights/top-n-queries/)
+- [Live Queries Documentation](https://docs.opensearch.org/3.0/observing-your-data/query-insights/live-queries/)
+- [Query Metrics Documentation](https://docs.opensearch.org/3.0/observing-your-data/query-insights/query-metrics/)
+- [Query Insights Dashboards](https://docs.opensearch.org/3.0/observing-your-data/query-insights/query-insights-dashboard/)
+- [GitHub Repository](https://github.com/opensearch-project/query-insights)
+
+## Change History
+
+- **v3.0.0**: Added Live Queries API, default index template, verbose parameter, profile query filtering, strict hash check
+- **v2.12.0**: Initial release with Top N queries feature

--- a/docs/releases/v3.0.0/features/query-insights/query-insights.md
+++ b/docs/releases/v3.0.0/features/query-insights/query-insights.md
@@ -1,0 +1,204 @@
+# Query Insights
+
+## Summary
+
+OpenSearch v3.0.0 introduces significant enhancements to the Query Insights plugin, including a new Live Queries API for real-time monitoring of in-flight search queries, default index templates for improved data management, a verbose parameter for lightweight API responses, and profile query filtering. These improvements provide better observability, performance optimization, and operational flexibility for monitoring search query performance.
+
+## Details
+
+### What's New in v3.0.0
+
+#### Live Queries API (New Feature)
+
+A new API endpoint `GET /_insights/live_queries` enables real-time monitoring of currently executing search queries across the cluster. This is useful for identifying and debugging queries that are running for an unexpectedly long time or consuming significant resources.
+
+**API Endpoint:**
+```
+GET /_insights/live_queries
+```
+
+**Query Parameters:**
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `verbose` | Boolean | Include detailed query information | `true` |
+| `nodeId` | String | Filter results by node IDs (comma-separated) | All nodes |
+| `sort` | String | Sort by metric: `latency`, `cpu`, or `memory` | `latency` |
+| `size` | Integer | Number of query records to return | `100` |
+
+**Example Request:**
+```bash
+GET /_insights/live_queries?verbose=false&sort=cpu&size=10
+```
+
+**Example Response:**
+```json
+{
+  "live_queries": [
+    {
+      "timestamp": 1745359226777,
+      "id": "troGHNGUShqDj3wK_K5ZIw:512",
+      "description": "indices[my-index-*], search_type[QUERY_THEN_FETCH], source[...]",
+      "node_id": "troGHNGUShqDj3wK_K5ZIw",
+      "measurements": {
+        "latency": { "number": 13959364458, "count": 1, "aggregationType": "NONE" },
+        "memory": { "number": 3104, "count": 1, "aggregationType": "NONE" },
+        "cpu": { "number": 405000, "count": 1, "aggregationType": "NONE" }
+      }
+    }
+  ]
+}
+```
+
+#### Default Index Template for Local Index
+
+A default index template is now automatically created for Query Insights local indexes (`top_queries-*`), providing:
+
+- Auto-expanding replicas (0-2) for high availability
+- Single shard configuration for optimal performance
+- Configurable template priority via cluster settings
+
+**New Configuration:**
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `search.insights.top_queries.exporter.template_priority` | Priority of the index template | `1847` |
+
+**Index Template Settings:**
+```json
+{
+  "index_patterns": ["top_queries-*"],
+  "template": {
+    "settings": {
+      "index": {
+        "number_of_shards": "1",
+        "auto_expand_replicas": "0-2"
+      }
+    }
+  }
+}
+```
+
+#### Top Queries API Verbose Parameter
+
+The `top_queries` API now supports a `verbose` parameter for lightweight responses:
+
+```bash
+GET /_insights/top_queries?verbose=false
+```
+
+When `verbose=false`, the following fields are omitted:
+- `task_resource_usages`
+- `source`
+- `phase_latency_map`
+
+This reduces response payload size for monitoring and overview use cases.
+
+#### Skip Profile Queries
+
+Profile search requests are now automatically filtered out from Top N queries collection. This prevents diagnostic queries from polluting the query insights data.
+
+#### Strict Hash Check on Top Queries Indices
+
+Added strict hash validation for top queries indices to ensure data integrity and prevent potential data corruption issues.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Query Insights Plugin v3.0.0"
+        A[Search Request] --> B[Query Listener]
+        B --> C{Profile Query?}
+        C -->|Yes| D[Skip]
+        C -->|No| E[Collectors]
+        E --> F[Processors]
+        F --> G[Exporters]
+        G --> H[(Local Index)]
+        H --> I[Index Template]
+        
+        J[Live Queries API] --> K[Task Manager]
+        K --> L[Running Tasks]
+        L --> M[SearchQueryRecord]
+    end
+    
+    subgraph "APIs"
+        N[/_insights/top_queries]
+        O[/_insights/live_queries]
+    end
+    
+    F --> N
+    M --> O
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `LiveQueriesAction` | Transport action for fetching in-flight queries |
+| `LiveQueriesRequest` | Request model with filtering and sorting options |
+| `LiveQueriesResponse` | Response containing live query records |
+| `QueryInsightsIndexTemplate` | Manages default index template creation |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `search.insights.top_queries.exporter.template_priority` | Index template priority | `1847` |
+
+### Usage Examples
+
+**Monitor live queries sorted by CPU usage:**
+```bash
+curl -X GET "localhost:9200/_insights/live_queries?sort=cpu&size=5&pretty"
+```
+
+**Get lightweight top queries response:**
+```bash
+curl -X GET "localhost:9200/_insights/top_queries?verbose=false&pretty"
+```
+
+**Override index template priority:**
+```bash
+curl -X PUT 'localhost:9200/_cluster/settings' -H 'Content-Type: application/json' -d'
+{
+    "persistent": {
+        "search.insights.top_queries.exporter.template_priority": "3000"
+    }
+}'
+```
+
+### Migration Notes
+
+- The default index template is automatically created when the plugin starts
+- Existing top queries indices are not affected; new indices will use the template
+- Profile queries are now automatically excluded from Top N queries
+
+## Limitations
+
+- Live Queries API returns only coordinator node resource usage (not data node usage)
+- The `verbose` parameter only affects response serialization, not data collection
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#295](https://github.com/opensearch-project/query-insights/pull/295) | Inflight Queries API |
+| [#254](https://github.com/opensearch-project/query-insights/pull/254) | Add default index template for query insights local index |
+| [#300](https://github.com/opensearch-project/query-insights/pull/300) | Add top_queries API verbose param |
+| [#298](https://github.com/opensearch-project/query-insights/pull/298) | Skip profile queries |
+| [#266](https://github.com/opensearch-project/query-insights/pull/266) | Add strict hash check on top queries indices |
+
+## References
+
+- [Issue #285](https://github.com/opensearch-project/query-insights/issues/285): Inflight Queries API feature request
+- [Issue #248](https://github.com/opensearch-project/query-insights/issues/248): Index template feature request
+- [Issue #291](https://github.com/opensearch-project/query-insights/issues/291): Verbose parameter feature request
+- [Issue #180](https://github.com/opensearch-project/query-insights/issues/180): Skip profile queries feature request
+- [Documentation](https://docs.opensearch.org/3.0/observing-your-data/query-insights/index/): Query Insights overview
+- [Live Queries Documentation](https://docs.opensearch.org/3.0/observing-your-data/query-insights/live-queries/): Live Queries API
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/query-insights/query-insights.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -167,3 +167,7 @@
 ## alerting
 
 - [Alerting Bugfixes](features/alerting/alerting-bugfixes.md)
+
+## query-insights
+
+- [Query Insights](features/query-insights/query-insights.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for Query Insights enhancements in OpenSearch v3.0.0.

## Changes

### Release Report
- `docs/releases/v3.0.0/features/query-insights/query-insights.md`

### Feature Report
- `docs/features/query-insights/query-insights.md`

## Key Enhancements Documented

1. **Live Queries API** (PR #295) - New `/_insights/live_queries` endpoint for real-time monitoring of in-flight search queries
2. **Default Index Template** (PR #254) - Auto-expanding replicas (0-2) and configurable template priority for local indexes
3. **Verbose Parameter** (PR #300) - Lightweight response option for top_queries API
4. **Skip Profile Queries** (PR #298) - Filters out profile queries from Top N queries
5. **Strict Hash Check** (PR #266) - Data integrity improvement for top queries indices

## Related Issue

Closes #169