### PR TITLE
docs: add AI Search Flows report for v3.0.0

### DIFF
--- a/docs/features/dashboards-flow-framework/ai-search-flows.md
+++ b/docs/features/dashboards-flow-framework/ai-search-flows.md
@@ -1,0 +1,193 @@
+# AI Search Flows
+
+## Summary
+
+AI Search Flows (formerly "OpenSearch Flow") is a visual UI designer in OpenSearch Dashboards for building AI-powered search workflows. It enables users to iteratively build and test ingest and search pipelines with ML inference processors, supporting use cases like semantic search, hybrid search, RAG (Retrieval-Augmented Generation), and multimodal search. The plugin simplifies the creation of AI/ML workflows by providing preset templates, visual flow editors, and exportable workflow templates.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        subgraph "AI Search Flows Plugin"
+            WE[Workflow Editor]
+            PT[Preset Templates]
+            PF[Preview Flows]
+            IP[Inspector Panel]
+        end
+    end
+    
+    subgraph "Configuration"
+        IF[Ingest Flow]
+        SF[Search Flow]
+        QC[Quick Configure]
+    end
+    
+    subgraph "OpenSearch Backend"
+        FF[Flow Framework API]
+        MLC[ML Commons]
+        ING[Ingest Pipeline]
+        SP[Search Pipeline]
+        IDX[Index]
+    end
+    
+    WE --> PT
+    WE --> PF
+    WE --> IP
+    PT --> QC
+    QC --> IF
+    QC --> SF
+    IF --> FF
+    SF --> FF
+    FF --> ING
+    FF --> SP
+    FF --> IDX
+    ING --> MLC
+    SP --> MLC
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Ingest Flow"
+        D[Documents] --> IP[Ingest Pipeline]
+        IP --> MLP1[ML Inference Processor]
+        MLP1 --> EMB[Generate Embeddings]
+        EMB --> IDX[Index]
+    end
+    
+    subgraph "Search Flow"
+        Q[Query] --> SRP[Search Request Processor]
+        SRP --> MLP2[ML Inference Processor]
+        MLP2 --> QR[Query Rewrite]
+        QR --> SEARCH[Execute Search]
+        SEARCH --> RESP[Search Response Processor]
+        RESP --> MLP3[ML Inference Processor]
+        MLP3 --> RAG[RAG/Summarization]
+        RAG --> RES[Results]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Workflow Editor | Multi-step form for configuring ingest and search flows |
+| Preset Templates | Pre-configured templates for common AI search use cases |
+| Preview Flows | Read-only visualization of data flow through pipelines |
+| Inspector Panel | Test flows, view responses, errors, and created resources |
+| Quick Configure | Modal for rapid setup with model selection and field mapping |
+| ML Inference Processor | Processor for integrating ML models in pipelines |
+
+### Preset Templates
+
+| Preset | Description | Use Case |
+|--------|-------------|----------|
+| Semantic Search | Vector search with text embeddings | Finding semantically similar documents |
+| Hybrid Search | Combined keyword + vector search | Balanced relevance with BM25 and semantic |
+| RAG + Vector Search | Vector retrieval with LLM summarization | Question answering with context |
+| RAG + Hybrid Search | Hybrid retrieval with LLM summarization | Enhanced RAG with keyword matching |
+| Multimodal Search | Text and image embedding search | Cross-modal retrieval |
+| Custom | Blank configuration for advanced use cases | Specialized workflows |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Workflow Name | Unique identifier for the workflow | Required |
+| Embedding Model | Model for generating vector embeddings | User-selected |
+| LLM Model | Large language model for RAG | User-selected (RAG presets) |
+| Text Field | Source field for text content | `text` |
+| Vector Field | Field for storing embeddings | `embedding` |
+| Index Settings | k-NN enabled index configuration | `index.knn: true` |
+
+### Usage Example
+
+#### Creating a Semantic Search Workflow
+
+1. Access AI Search Flows from OpenSearch Dashboards
+2. Select "Semantic Search" preset
+3. Configure embedding model in Quick Configure modal
+4. Import sample data (JSON array format)
+5. Configure ML Inference Processor input/output mappings
+6. Build and run ingestion
+7. Configure search pipeline with query rewrite
+8. Test and export workflow template
+
+```yaml
+# Exported Workflow Template
+name: semantic-search-workflow
+description: Semantic search with text embeddings
+workflows:
+  provision:
+    nodes:
+      - id: create_ingest_pipeline
+        type: create_ingest_pipeline
+        user_inputs:
+          pipeline_id: semantic-ingest
+          configurations:
+            processors:
+              - ml_inference:
+                  model_id: ${embedding_model_id}
+                  input_map:
+                    - text: $.text_field
+                  output_map:
+                    - embedding: $.embedding
+      - id: create_index
+        type: create_index
+        user_inputs:
+          index_name: semantic-index
+          settings:
+            index.knn: true
+          mappings:
+            properties:
+              text_field:
+                type: text
+              embedding:
+                type: knn_vector
+                dimension: 768
+```
+
+### Advanced Data Transformations
+
+| Transform Type | Direction | Description |
+|----------------|-----------|-------------|
+| Data Field | Input | Maps document field to model input |
+| JSONPath Expression | Input/Output | Extracts data using JSONPath syntax |
+| Prompt Template | Input | Constant value with dynamic variables |
+| Custom String | Input | Static string value |
+| No Transformation | Output | Preserves model output as-is |
+
+## Limitations
+
+- Models must have defined interfaces for simplified ML processor forms
+- Datasource version required for simulate API calls
+- Plugin URL unchanged from original "flow-framework" for compatibility
+- Complex nested data may require JSONPath expressions
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#662](https://github.com/opensearch-project/dashboards-flow-framework/pull/662) | Rename to "AI Search Flows" |
+| v3.0.0 | [#665](https://github.com/opensearch-project/dashboards-flow-framework/pull/665) | Add RAG + hybrid search preset |
+| v3.0.0 | [#676](https://github.com/opensearch-project/dashboards-flow-framework/pull/676) | Simplify ML processor forms |
+| v3.0.0 | [#610](https://github.com/opensearch-project/dashboards-flow-framework/pull/610) | Simplify RAG presets |
+| v3.0.0 | [#602](https://github.com/opensearch-project/dashboards-flow-framework/pull/602) | Legacy preset integration |
+| v3.0.0 | [#701](https://github.com/opensearch-project/dashboards-flow-framework/pull/701) | Optional model inputs support |
+
+## References
+
+- [AI Search Flows Documentation](https://docs.opensearch.org/3.0/vector-search/ai-search/workflow-builder/)
+- [Creating AI Search Workflows Tutorial](https://docs.opensearch.org/3.0/tutorials/gen-ai/ai-search-flows/building-flows/)
+- [Flow Framework Plugin](https://docs.opensearch.org/3.0/automating-configurations/workflow-templates/)
+- [ML Commons Integration](https://docs.opensearch.org/3.0/ml-commons-plugin/integrating-ml-models/)
+- [dashboards-flow-framework Repository](https://github.com/opensearch-project/dashboards-flow-framework)
+- [Model Configuration Examples](https://github.com/opensearch-project/dashboards-flow-framework/blob/main/documentation/models.md)
+
+## Change History
+
+- **v3.0.0** (2025-05-13): Renamed to "AI Search Flows", added RAG + hybrid search preset, simplified ML processor forms, improved state persistence, added processor reordering

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -61,6 +61,7 @@
 
 ## dashboards-flow-framework
 
+- [AI Search Flows](dashboards-flow-framework/ai-search-flows.md)
 - [Backward Compatibility](dashboards-flow-framework/backward-compatibility.md)
 - [Data Ingestion](dashboards-flow-framework/data-ingestion.md)
 

--- a/docs/releases/v3.0.0/features/dashboards-flow-framework/ai-search-flows.md
+++ b/docs/releases/v3.0.0/features/dashboards-flow-framework/ai-search-flows.md
@@ -1,0 +1,171 @@
+# AI Search Flows
+
+## Summary
+
+OpenSearch v3.0.0 introduces significant enhancements to the AI Search Flows plugin (formerly "OpenSearch Flow"), providing a visual UI designer for building AI-powered search workflows in OpenSearch Dashboards. This release focuses on improving the RAG (Retrieval-Augmented Generation) preset experience, simplifying ML processor configuration, and rebranding the plugin to "AI Search Flows" for better clarity.
+
+## Details
+
+### What's New in v3.0.0
+
+The AI Search Flows plugin received 20 enhancements in this release, focusing on:
+
+1. **Plugin Rebranding**: Renamed from "OpenSearch Flow" to "AI Search Flows"
+2. **RAG Preset Improvements**: Simplified RAG presets leveraging `ext.ml_inference` result storing
+3. **ML Processor Form Simplification**: Streamlined forms when model interfaces are defined
+4. **New Presets**: Added RAG + hybrid search preset combining vector and keyword search
+5. **UX Improvements**: Better state persistence, processor reordering, and model configuration
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "AI Search Flows UI"
+        WF[Workflow Editor]
+        QC[Quick Configure Modal]
+        IP[Inspector Panel]
+    end
+    
+    subgraph "Preset Templates"
+        VS[Vector Search]
+        RAG[RAG + Vector]
+        HYB[RAG + Hybrid Search]
+    end
+    
+    subgraph "ML Processors"
+        ING[Ingest ML Processor]
+        REQ[Search Request ML Processor]
+        RES[Search Response ML Processor]
+    end
+    
+    subgraph "OpenSearch Backend"
+        FF[Flow Framework]
+        ML[ML Commons]
+        IDX[Index/Pipeline]
+    end
+    
+    WF --> QC
+    WF --> IP
+    QC --> VS
+    QC --> RAG
+    QC --> HYB
+    VS --> ING
+    RAG --> ING
+    RAG --> REQ
+    RAG --> RES
+    HYB --> ING
+    HYB --> REQ
+    HYB --> RES
+    ING --> FF
+    REQ --> FF
+    RES --> FF
+    FF --> ML
+    FF --> IDX
+```
+
+#### Key Enhancements
+
+| Enhancement | Description | PR |
+|-------------|-------------|-----|
+| Plugin Rename | Updated visible name to "AI Search Flows" | [#662](https://github.com/opensearch-project/dashboards-flow-framework/pull/662), [#664](https://github.com/opensearch-project/dashboards-flow-framework/pull/664) |
+| RAG Preset Simplification | Leverages `ext.ml_inference` for result storing, removes workaround collapse processor | [#610](https://github.com/opensearch-project/dashboards-flow-framework/pull/610) |
+| RAG + Hybrid Search | New preset combining RAG with hybrid (match + knn) queries | [#665](https://github.com/opensearch-project/dashboards-flow-framework/pull/665) |
+| ML Processor Form Simplification | Read-only inputs/outputs when model interface is defined | [#676](https://github.com/opensearch-project/dashboards-flow-framework/pull/676) |
+| Legacy Preset Integration | Legacy presets work with quick-configure fields | [#602](https://github.com/opensearch-project/dashboards-flow-framework/pull/602) |
+| Processor Reordering | Added icons to reorder processors up and down | [#690](https://github.com/opensearch-project/dashboards-flow-framework/pull/690) |
+| State Persistence | Query state persists across Inspector tab switches | [#671](https://github.com/opensearch-project/dashboards-flow-framework/pull/671) |
+| Optional Model Inputs | Support for optional model input parameters | [#701](https://github.com/opensearch-project/dashboards-flow-framework/pull/701) |
+
+#### New Features
+
+| Feature | Description |
+|---------|-------------|
+| Bulk API Details | Added popover with bulk API example and documentation links | [#610](https://github.com/opensearch-project/dashboards-flow-framework/pull/610) |
+| ML Outputs Tab | Dedicated tab for displaying ML inference results | [#610](https://github.com/opensearch-project/dashboards-flow-framework/pull/610) |
+| Model Suggestions Popover | Links to suggested models displayed in popover | [#625](https://github.com/opensearch-project/dashboards-flow-framework/pull/625) |
+| Presets Dropdown | Query preset dropdown in Inspector panel | [#671](https://github.com/opensearch-project/dashboards-flow-framework/pull/671) |
+| Form Caching | ML transform form state cached across type switches | [#678](https://github.com/opensearch-project/dashboards-flow-framework/pull/678) |
+
+### Usage Example
+
+The new RAG + Hybrid Search preset can be configured with minimal clicks:
+
+1. Select "RAG with Hybrid Search" preset
+2. Configure embedding model and LLM in quick-configure modal
+3. Import sample data
+4. Build and run ingestion
+5. Test search with automatic query rewriting to hybrid (match + knn)
+
+```json
+{
+  "query": {
+    "hybrid": {
+      "queries": [
+        {
+          "match": {
+            "text_field": {
+              "query": "search term"
+            }
+          }
+        },
+        {
+          "knn": {
+            "embedding_field": {
+              "vector": "${embedding}",
+              "k": 10
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- The plugin URL remains unchanged to prevent build/registration issues
+- Only user-facing text has been updated from "OpenSearch Flow" to "AI Search Flows"
+- Existing workflows continue to work without modification
+
+## Limitations
+
+- ML processor forms require models with defined interfaces for simplified configuration
+- Datasource version must be available for simulate API calls ([#657](https://github.com/opensearch-project/dashboards-flow-framework/pull/657))
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#602](https://github.com/opensearch-project/dashboards-flow-framework/pull/602) | Integrate legacy presets with quick-configure fields |
+| [#610](https://github.com/opensearch-project/dashboards-flow-framework/pull/610) | Simplify RAG presets, add bulk API details |
+| [#617](https://github.com/opensearch-project/dashboards-flow-framework/pull/617) | Improve RAG preset experience |
+| [#622](https://github.com/opensearch-project/dashboards-flow-framework/pull/622) | Update model options and callout |
+| [#625](https://github.com/opensearch-project/dashboards-flow-framework/pull/625) | Added popover to display links to suggested models |
+| [#632](https://github.com/opensearch-project/dashboards-flow-framework/pull/632) | Implicitly update input maps on non-expanded queries |
+| [#633](https://github.com/opensearch-project/dashboards-flow-framework/pull/633) | Show interim JSON provision flow even if provisioned |
+| [#649](https://github.com/opensearch-project/dashboards-flow-framework/pull/649) | Add functional buttons in form headers, fix query parse bug |
+| [#657](https://github.com/opensearch-project/dashboards-flow-framework/pull/657) | Block simulate API calls if datasource version is missing |
+| [#660](https://github.com/opensearch-project/dashboards-flow-framework/pull/660) | Update default queries, quick config fields, misc updates |
+| [#662](https://github.com/opensearch-project/dashboards-flow-framework/pull/662) | Update visible plugin name to 'AI Search Flows' |
+| [#664](https://github.com/opensearch-project/dashboards-flow-framework/pull/664) | Update plugin name and rearrange Try AI Search Flows card |
+| [#665](https://github.com/opensearch-project/dashboards-flow-framework/pull/665) | Add new RAG + hybrid search preset |
+| [#670](https://github.com/opensearch-project/dashboards-flow-framework/pull/670) | Update new index mappings if selecting from existing index |
+| [#671](https://github.com/opensearch-project/dashboards-flow-framework/pull/671) | Persist state across Inspector tab switches; add presets dropdown |
+| [#676](https://github.com/opensearch-project/dashboards-flow-framework/pull/676) | Simplify ML processor form when interface is defined |
+| [#678](https://github.com/opensearch-project/dashboards-flow-framework/pull/678) | Cache form across ML transform types |
+| [#690](https://github.com/opensearch-project/dashboards-flow-framework/pull/690) | Adding icons to reorder processors up and down |
+| [#701](https://github.com/opensearch-project/dashboards-flow-framework/pull/701) | Support optional model inputs |
+| [#702](https://github.com/opensearch-project/dashboards-flow-framework/pull/702) | Support whitespace for string constant; support ext toggling on ML resp processors |
+
+## References
+
+- [AI Search Flows Documentation](https://docs.opensearch.org/3.0/vector-search/ai-search/workflow-builder/)
+- [Creating AI Search Workflows Tutorial](https://docs.opensearch.org/3.0/tutorials/gen-ai/ai-search-flows/building-flows/)
+- [dashboards-flow-framework Repository](https://github.com/opensearch-project/dashboards-flow-framework)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-flow-framework/ai-search-flows.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -68,6 +68,7 @@
 
 ## dashboards-flow-framework
 
+- [AI Search Flows](features/dashboards-flow-framework/ai-search-flows.md)
 - [Dashboards BWC](features/dashboards-flow-framework/dashboards-bwc.md)
 - [Data Ingestion Dashboards](features/dashboards-flow-framework/data-ingestion-dashboards.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the AI Search Flows enhancements in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/dashboards-flow-framework/ai-search-flows.md`
- Feature report: `docs/features/dashboards-flow-framework/ai-search-flows.md`

### Key Changes in v3.0.0
- Plugin renamed from "OpenSearch Flow" to "AI Search Flows"
- New RAG + hybrid search preset combining vector and keyword search
- Simplified ML processor forms when model interfaces are defined
- Improved RAG presets leveraging `ext.ml_inference` result storing
- Better state persistence across Inspector tab switches
- Processor reordering with up/down icons
- Support for optional model inputs

### Resources Used
- 20 PRs from dashboards-flow-framework repository
- Official OpenSearch documentation for AI Search Flows
- Tutorial documentation for creating AI search workflows

Closes #167