### PR TITLE
docs: add Skills / Tools bugfixes report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -159,3 +159,7 @@
 ## query-insights
 
 - [Query Insights](query-insights/query-insights.md)
+
+## skills
+
+- [Skills / Tools](skills/skills-tools.md)

--- a/docs/features/skills/skills-tools.md
+++ b/docs/features/skills/skills-tools.md
@@ -1,0 +1,148 @@
+# Skills / Tools
+
+## Summary
+
+The Skills plugin provides a collection of tools for the OpenSearch ML Commons agent framework. These tools enable agents to perform various tasks such as searching indexes, querying data using PPL, performing web searches, and interacting with anomaly detection and alerting features. The plugin is designed to be extensible, allowing developers to create custom tools for specific use cases.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph ML Commons
+        Agent[Agent Framework]
+        MLCommons[ML Commons Plugin]
+    end
+    
+    subgraph Skills Plugin
+        ToolPlugin[ToolPlugin]
+        subgraph Tools
+            PPL[PPLTool]
+            VDB[VectorDBTool]
+            WST[WebSearchTool]
+            SI[SearchIndexTool]
+            AD[AnomalyDetectorTools]
+            Alert[AlertingTools]
+            Log[LogPatternTool]
+        end
+    end
+    
+    subgraph External
+        Search[Search Engines]
+        Index[OpenSearch Indexes]
+    end
+    
+    Agent --> ToolPlugin
+    ToolPlugin --> Tools
+    WST --> Search
+    PPL --> Index
+    VDB --> Index
+    SI --> Index
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ToolPlugin` | Main plugin class that registers all tools with ML Commons |
+| `PPLTool` | Translates natural language to PPL queries |
+| `VectorDBTool` | Performs dense vector retrieval |
+| `WebSearchTool` | Performs web searches using various search engines |
+| `SearchIndexTool` | Searches indexes using query DSL |
+| `SearchAnomalyDetectorsTool` | Searches for anomaly detectors |
+| `SearchAnomalyResultsTool` | Searches anomaly detection results |
+| `SearchMonitorsTool` | Searches for alerting monitors |
+| `SearchAlertsTool` | Searches for alerts |
+| `CreateAlertTool` | Creates alerting monitors |
+| `CreateAnomalyDetectorTool` | Creates anomaly detectors |
+| `LogPatternTool` | Analyzes log patterns |
+
+### Tool Registration
+
+Tools are registered with the ML Commons framework through the `ToolPlugin` class:
+
+```java
+@Override
+public List<Tool.Factory<? extends Tool>> getToolFactories() {
+    return List.of(
+        PPLTool.Factory.getInstance(),
+        VectorDBTool.Factory.getInstance(),
+        WebSearchTool.Factory.getInstance(),
+        SearchIndexTool.Factory.getInstance(),
+        // ... other tools
+    );
+}
+```
+
+### WebSearchTool
+
+The WebSearchTool enables agents to search the web and retrieve information. It supports multiple search engines:
+
+| Engine | Endpoint | Authentication |
+|--------|----------|----------------|
+| Google | `https://customsearch.googleapis.com/customsearch/v1` | API key + Engine ID |
+| Bing | `https://api.bing.microsoft.com/v7.0/search` | API key |
+| DuckDuckGo | `https://duckduckgo.com/html` | None |
+| Custom | User-defined | User-defined |
+
+**Usage Example:**
+```json
+{
+  "type": "WebSearchTool",
+  "parameters": {
+    "engine": "duckduckgo",
+    "query": "OpenSearch vector search"
+  }
+}
+```
+
+### PPLTool
+
+The PPLTool translates natural language questions into Piped Processing Language (PPL) queries:
+
+**Usage Example:**
+```json
+{
+  "type": "PPLTool",
+  "parameters": {
+    "model_id": "<llm_model_id>",
+    "index": "my-index",
+    "question": "Show me the top 10 errors"
+  }
+}
+```
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.skills.enabled` | Enable/disable the skills plugin | `true` |
+| Thread pool: `websearch-crawler-threadpool` | Thread pool for web crawling | CPU cores - 1 |
+
+## Limitations
+
+- WebSearchTool may be blocked by CAPTCHA or login-protected pages
+- PPLTool requires an LLM model for natural language translation
+- Some tools require specific plugins to be installed (e.g., anomaly detection, alerting)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#547](https://github.com/opensearch-project/skills/pull/547) | Add WebSearchTool |
+| v3.0.0 | [#541](https://github.com/opensearch-project/skills/pull/541) | Fix PPLTool empty list bug |
+| v3.0.0 | [#529](https://github.com/opensearch-project/skills/pull/529) | Update ML Commons dependencies |
+| v3.0.0 | [#521](https://github.com/opensearch-project/skills/pull/521) | Developer guide enhancement |
+
+## References
+
+- [Issue #538](https://github.com/opensearch-project/skills/issues/538): WebSearchTool feature request
+- [Tools Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/tools/index/): Official tools documentation
+- [WebSearchTool Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/tools/web-search-tool/): WebSearchTool reference
+- [PPL Tool Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/tools/ppl-tool/): PPL tool reference
+- [Skills Repository](https://github.com/opensearch-project/skills): Source code
+
+## Change History
+
+- **v3.0.0** (2025-02-25): Added WebSearchTool, fixed PPLTool empty list bug, updated dependencies, enhanced developer guide

--- a/docs/releases/v3.0.0/features/skills/skills-tools-bugfixes.md
+++ b/docs/releases/v3.0.0/features/skills/skills-tools-bugfixes.md
@@ -1,0 +1,158 @@
+# Skills / Tools Bugfixes and Enhancements
+
+## Summary
+
+OpenSearch 3.0.0 includes several improvements to the Skills plugin, which provides tools for the ML Commons agent framework. This release adds a new WebSearchTool for web search capabilities, fixes a bug in PPLTool when handling empty lists, updates build dependencies, and enhances developer documentation.
+
+## Details
+
+### What's New in v3.0.0
+
+#### WebSearchTool (New Feature)
+
+A new `WebSearchTool` has been added to enable web search capabilities within the agent framework. This tool supports multiple search engines and allows agents to retrieve information from the web to answer user questions.
+
+**Supported Search Engines:**
+- Google (requires API key and engine ID)
+- Bing (requires API key)
+- DuckDuckGo (no credentials required)
+- Custom API endpoints
+
+**Key Features:**
+- Multi-engine support with configurable endpoints
+- Pagination support via `next_page` parameter
+- Web page crawling with content extraction using Jsoup
+- CAPTCHA detection to skip protected pages
+- Dedicated thread pool for web crawling operations
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph Agent Framework
+        Agent[Flow Agent]
+        WST[WebSearchTool]
+    end
+    
+    subgraph Search Engines
+        Google[Google Custom Search]
+        Bing[Bing Search API]
+        DDG[DuckDuckGo HTML]
+        Custom[Custom API]
+    end
+    
+    subgraph Processing
+        Crawler[Web Crawler]
+        Parser[Content Parser]
+    end
+    
+    Agent --> WST
+    WST --> Google
+    WST --> Bing
+    WST --> DDG
+    WST --> Custom
+    WST --> Crawler
+    Crawler --> Parser
+    Parser --> Agent
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `WebSearchTool` | Main tool class implementing web search functionality |
+| `WebSearchTool.Factory` | Factory class for tool instantiation |
+| `websearch-crawler-threadpool` | Dedicated thread pool for web crawling operations |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `engine` | Search engine to use | Required |
+| `endpoint` | API endpoint URL | Engine-specific default |
+| `api_key` | API key for authentication | None |
+| `engine_id` | Google Custom Search Engine ID | None |
+| `query` | Search query | Required |
+| `next_page` | Pagination link | None |
+| `token` | Authorization token for crawling | None |
+
+### PPLTool Empty List Bug Fix
+
+Fixed a bug in `PPLTool` where passing an empty list would cause an `IndexOutOfBoundsException`. The fix adds proper null and empty list checks before accessing list elements.
+
+**Before (buggy):**
+```java
+while (v instanceof List<?>) {
+    v = ((List<?>) v).get(0);  // Throws if list is empty
+}
+```
+
+**After (fixed):**
+```java
+while (!Objects.isNull(v) && v instanceof List<?>) {
+    List<?> listValue = (List<?>) v;
+    if (!listValue.isEmpty()) {
+        v = ((List<?>) v).get(0);
+    } else {
+        break;
+    }
+}
+```
+
+### Dependency Updates
+
+Replaced `ml-common-client` build dependency with `ml-common-common` and `ml-common-spi`. This change reduces unnecessary dependencies since the skills plugin doesn't use any classes from the client library.
+
+### Developer Guide Enhancement
+
+Added a new section to the Developer Guide explaining how to build and test custom tools, including:
+- Creating a new tool Java file
+- Modifying ToolPlugin to register the tool
+- Testing with remote connectors and agents
+
+### Usage Example
+
+```json
+POST /_plugins/_ml/agents/_register
+{
+  "name": "WebSearch Agent",
+  "type": "flow",
+  "description": "Agent with web search capability",
+  "tools": [
+    {
+      "type": "WebSearchTool",
+      "name": "DuckduckgoWebSearchTool",
+      "parameters": {
+        "engine": "duckduckgo",
+        "input": "${parameters.question}"
+      }
+    }
+  ]
+}
+```
+
+## Limitations
+
+- WebSearchTool may be blocked by CAPTCHA or login pages
+- DuckDuckGo uses HTML scraping which may break if page structure changes
+- Web crawling is subject to rate limiting and robots.txt restrictions
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#547](https://github.com/opensearch-project/skills/pull/547) | Add WebSearchTool |
+| [#541](https://github.com/opensearch-project/skills/pull/541) | Fix list bug in PPLTool when passing empty list |
+| [#529](https://github.com/opensearch-project/skills/pull/529) | Replace ml-common-client with ml-common-common and ml-common-spi |
+| [#521](https://github.com/opensearch-project/skills/pull/521) | Add tutorial to build and test custom tool |
+
+## References
+
+- [Issue #538](https://github.com/opensearch-project/skills/issues/538): Feature request for WebSearchTool
+- [WebSearchTool Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/tools/web-search-tool/): Official documentation
+- [Tools Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/tools/index/): Tools overview
+- [PPL Tool Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/tools/ppl-tool/): PPL tool reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/skills/skills-tools.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -174,3 +174,7 @@
 ## query-insights
 
 - [Query Insights](features/query-insights/query-insights.md)
+
+## skills
+
+- [Skills / Tools Bugfixes and Enhancements](features/skills/skills-tools-bugfixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Skills / Tools bugfixes and enhancements in OpenSearch v3.0.0.

## Changes

### Release Report
- `docs/releases/v3.0.0/features/skills/skills-tools-bugfixes.md`

### Feature Report
- `docs/features/skills/skills-tools.md`

## Key Changes in v3.0.0

- **WebSearchTool**: New tool enabling web search capabilities with support for Google, Bing, DuckDuckGo, and custom APIs
- **PPLTool Bug Fix**: Fixed IndexOutOfBoundsException when passing empty lists
- **Dependency Update**: Replaced ml-common-client with ml-common-common and ml-common-spi
- **Developer Guide**: Added tutorial for building and testing custom tools

## Related PRs
- opensearch-project/skills#547 - Add WebSearchTool
- opensearch-project/skills#541 - Fix PPLTool empty list bug
- opensearch-project/skills#529 - Update ML Commons dependencies
- opensearch-project/skills#521 - Developer guide enhancement

## Related Issue
Closes #165