### PR TITLE
docs: add Threat Intelligence custom format report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -163,3 +163,7 @@
 ## skills
 
 - [Skills / Tools](skills/skills-tools.md)
+
+## security-analytics
+
+- [Threat Intelligence](security-analytics/threat-intelligence.md)

--- a/docs/features/security-analytics/threat-intelligence.md
+++ b/docs/features/security-analytics/threat-intelligence.md
@@ -1,0 +1,196 @@
+# Threat Intelligence
+
+## Summary
+
+Threat Intelligence in OpenSearch Security Analytics enables users to detect security threats by scanning their data against known Indicators of Compromise (IOCs). Users can configure threat intelligence sources from various feeds (S3, local file upload, URL download) and set up monitors to automatically scan incoming data for malicious indicators such as IP addresses, domain names, and file hashes.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Threat Intel Sources"
+        A[S3 Feed] --> D[Source Config]
+        B[Local Upload] --> D
+        C[URL Download] --> D
+    end
+    
+    subgraph "IOC Processing"
+        D --> E[STIX2IOCFetchService]
+        E --> F{Format?}
+        F -->|STIX2| G[Standard Parser]
+        F -->|Custom JSON| H[JsonPath Parser]
+        G --> I[STIX2IOC Objects]
+        H --> I
+    end
+    
+    subgraph "Storage & Monitoring"
+        I --> J[IOC Index Store]
+        J --> K[Threat Intel Monitor]
+        K --> L[IOC Scan Service]
+        L --> M{Match Found?}
+        M -->|Yes| N[Create Finding]
+        M -->|Yes| O[Create Alert]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User Data Index] --> B[Threat Intel Monitor]
+    B --> C[Extract IOC Fields]
+    C --> D[Query IOC Store]
+    D --> E{Malicious IOC?}
+    E -->|Yes| F[Generate Finding]
+    F --> G[Trigger Alert]
+    G --> H[Send Notification]
+    E -->|No| I[Continue Monitoring]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SATIFSourceConfig` | Threat intelligence source configuration model |
+| `SATIFSourceConfigDto` | Data transfer object for source configuration |
+| `STIX2IOC` | Indicator of Compromise model in STIX2 format |
+| `STIX2IOCFetchService` | Service for downloading and indexing IOCs |
+| `IoCScanService` | Service for scanning data against IOC store |
+| `ThreatIntelMonitor` | Monitor for automated threat detection |
+| `JsonPathIocSchema` | Custom JSON schema definition using JSONPath |
+| `JsonPathIocSchemaThreatIntelHandler` | Parser for custom format IOCs |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `type` | Source type: `S3_CUSTOM`, `IOC_UPLOAD`, `URL_DOWNLOAD` | Required |
+| `name` | Human-readable name for the source | Required |
+| `format` | Data format (e.g., `STIX2`) | Required |
+| `enabled` | Enable/disable scheduled refresh | `true` |
+| `schedule` | Refresh schedule for S3/URL sources | Optional |
+| `ioc_types` | List of IOC types to process | Computed |
+| `ioc_schema` | Custom JSONPath schema for parsing | Optional |
+| `enabled_for_scan` | Enable source for threat scanning | `true` |
+
+### Supported IOC Types
+
+| IOC Type | Description |
+|----------|-------------|
+| `ipv4-addr` | IPv4 addresses |
+| `ipv6-addr` | IPv6 addresses |
+| `domain-name` | Domain names |
+| `hashes` | File hashes (MD5, SHA-1, SHA-256) |
+| Custom types | User-defined IOC types (v3.0.0+) |
+
+### Usage Example
+
+#### Standard STIX2 Format Upload
+
+```json
+POST _plugins/_security_analytics/threat_intel/sources/
+{
+  "type": "IOC_UPLOAD",
+  "name": "my_threat_feed",
+  "format": "STIX2",
+  "description": "Internal threat intelligence feed",
+  "enabled": false,
+  "ioc_types": ["ipv4-addr", "domain-name"],
+  "source": {
+    "ioc_upload": {
+      "file_name": "threat_iocs.json",
+      "iocs": [
+        {
+          "id": "1",
+          "name": "malicious-ip",
+          "type": "ipv4-addr",
+          "value": "192.168.1.100",
+          "severity": "high",
+          "created": "2024-01-01T00:00:00Z",
+          "modified": "2024-01-01T00:00:00Z",
+          "description": "Known malicious IP"
+        }
+      ]
+    }
+  }
+}
+```
+
+#### Custom JSON Format Upload (v3.0.0+)
+
+```json
+POST _plugins/_security_analytics/threat_intel/sources/
+{
+  "type": "IOC_UPLOAD",
+  "name": "custom_format_feed",
+  "format": "STIX2",
+  "source": {
+    "custom_schema_ioc_upload": {
+      "iocs": "{\"threats\":[{\"type\":\"ip\",\"indicator\":\"10.0.0.1\"}]}"
+    }
+  },
+  "ioc_schema": {
+    "json_path_schema": {
+      "type": {"json_path": "$.threats[*].type"},
+      "value": {"json_path": "$.threats[*].indicator"}
+    }
+  }
+}
+```
+
+#### S3 Source Configuration
+
+```json
+POST _plugins/_security_analytics/threat_intel/sources/
+{
+  "type": "S3_CUSTOM",
+  "name": "s3-threat-feed",
+  "format": "STIX2",
+  "enabled": true,
+  "schedule": {
+    "interval": {
+      "start_time": 1717097122,
+      "period": "1",
+      "unit": "DAYS"
+    }
+  },
+  "source": {
+    "s3": {
+      "bucket_name": "threat-intel-bucket",
+      "object_key": "iocs.json",
+      "region": "us-west-2",
+      "role_arn": "arn:aws:iam::123456789012:role/threat_intel_role"
+    }
+  },
+  "ioc_types": ["ipv4-addr", "domain-name"]
+}
+```
+
+## Limitations
+
+- IOC_UPLOAD sources cannot be refreshed on a schedule; manual re-upload is required
+- Custom schema parsing requires both `type` and `value` JSONPath expressions
+- Maximum IOC batch size is configurable but defaults to reasonable limits
+- Threat intel monitors require at least one enabled source for scanning
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#1493](https://github.com/opensearch-project/security-analytics/pull/1493) | Custom format IOC upload support |
+| v3.0.0 | [#1455](https://github.com/opensearch-project/security-analytics/pull/1455) | Custom format implementation (2.x backport) |
+
+## References
+
+- [Issue #1421](https://github.com/opensearch-project/security-analytics/issues/1421): Custom JSON schema feature request
+- [Threat Intelligence Documentation](https://docs.opensearch.org/3.0/security-analytics/threat-intelligence/index/): Official documentation
+- [Source API](https://docs.opensearch.org/3.0/security-analytics/threat-intelligence/api/source/): API reference
+- [Monitor API](https://docs.opensearch.org/3.0/security-analytics/threat-intelligence/api/monitor/): Monitor API reference
+- [Getting Started Guide](https://docs.opensearch.org/3.0/security-analytics/threat-intelligence/getting-started/): Setup guide
+
+## Change History
+
+- **v3.0.0** (2025-05-13): Added custom JSON format support with JSONPath schema, relaxed IOC type validation to support custom types
+- **v2.15.0**: Initial threat intelligence feature with S3, IOC_UPLOAD, and URL_DOWNLOAD source types

--- a/docs/releases/v3.0.0/features/security-analytics/threat-intelligence-custom-format.md
+++ b/docs/releases/v3.0.0/features/security-analytics/threat-intelligence-custom-format.md
@@ -1,0 +1,169 @@
+# Threat Intelligence Custom Format Support
+
+## Summary
+
+OpenSearch v3.0.0 adds support for uploading threat intelligence Indicators of Compromise (IOCs) in custom JSON formats. Previously, users could only upload IOCs in a predefined STIX2 format. This enhancement allows users to define their own JSON schema using JSONPath notation, enabling integration with third-party security vendors and internally curated threat intelligence feeds without format conversion.
+
+## Details
+
+### What's New in v3.0.0
+
+This release introduces the ability to upload threat intelligence IOCs using custom JSON schemas. Users can now:
+
+- Upload IOCs in any JSON format by specifying JSONPath expressions to extract IOC fields
+- Use the `custom_schema_ioc_upload` source type for local file uploads with custom schemas
+- Define custom IOC types beyond the predefined STIX2 types
+- Automatically compute IOC types from parsed data
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Threat Intel Source Creation"
+        A[Create Source API] --> B{Source Type?}
+        B -->|IOC_UPLOAD| C[IocUploadSource]
+        B -->|IOC_UPLOAD + ioc_schema| D[CustomSchemaIocUploadSource]
+        B -->|S3_CUSTOM| E[S3Source]
+        B -->|S3_CUSTOM + ioc_schema| F[S3Source + JsonPathCodec]
+    end
+    
+    subgraph "Custom Schema Processing"
+        D --> G[JsonPathIocSchemaThreatIntelHandler]
+        F --> H[JsonPathAwareInputCodec]
+        G --> I[Parse IOCs via JSONPath]
+        H --> I
+        I --> J[STIX2IOC Objects]
+    end
+    
+    subgraph "Storage"
+        J --> K[Index IOCs]
+        K --> L[IOC Store]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `JsonPathIocSchema` | Stores JSONPath expressions for extracting IOC fields from custom JSON |
+| `JsonPathSchemaField` | Encapsulates a single JSONPath expression for a field |
+| `CustomSchemaIocUploadSource` | New source type for uploading IOCs with custom schema |
+| `JsonPathIocSchemaThreatIntelHandler` | Parses IOCs from JSON using JSONPath notation |
+| `JsonPathAwareInputCodec` | Input codec for parsing S3 downloads with custom schema |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `ioc_schema` | Object containing JSONPath schema definition | `null` |
+| `ioc_schema.json_path_schema.type.json_path` | JSONPath to extract IOC type | Required |
+| `ioc_schema.json_path_schema.value.json_path` | JSONPath to extract IOC value | Required |
+| `ioc_schema.json_path_schema.id.json_path` | JSONPath to extract IOC ID | Optional |
+| `ioc_schema.json_path_schema.name.json_path` | JSONPath to extract IOC name | Optional |
+| `ioc_schema.json_path_schema.severity.json_path` | JSONPath to extract severity | Optional |
+| `ioc_schema.json_path_schema.created.json_path` | JSONPath to extract creation time | Optional |
+| `ioc_schema.json_path_schema.modified.json_path` | JSONPath to extract modification time | Optional |
+| `ioc_schema.json_path_schema.description.json_path` | JSONPath to extract description | Optional |
+
+#### API Changes
+
+The Create Threat Intel Source API now accepts an optional `ioc_schema` field and a new `custom_schema_ioc_upload` source type.
+
+### Usage Example
+
+```json
+POST _plugins/_security_analytics/threat_intel/sources/
+{
+  "name": "custom_threat_feed",
+  "format": "STIX2",
+  "type": "IOC_UPLOAD",
+  "description": "Custom format threat intel feed",
+  "enabled": false,
+  "source": {
+    "custom_schema_ioc_upload": {
+      "file_name": "custom_iocs.json",
+      "iocs": "{\"indicators\":[{\"indicator_type\":\"ipv4-addr\",\"indicator_value\":\"192.168.1.1\"},{\"indicator_type\":\"domain-name\",\"indicator_value\":\"malware.example.com\"}]}"
+    }
+  },
+  "ioc_schema": {
+    "json_path_schema": {
+      "type": {
+        "json_path": "$.indicators[*].indicator_type"
+      },
+      "value": {
+        "json_path": "$.indicators[*].indicator_value"
+      }
+    }
+  }
+}
+```
+
+### S3 Custom Schema Example
+
+```json
+POST _plugins/_security_analytics/threat_intel/sources/
+{
+  "type": "S3_CUSTOM",
+  "name": "s3-custom-format-feed",
+  "format": "STIX2",
+  "enabled": true,
+  "schedule": {
+    "interval": {
+      "start_time": 1717097122,
+      "period": "1",
+      "unit": "DAYS"
+    }
+  },
+  "source": {
+    "s3": {
+      "bucket_name": "my-threat-intel-bucket",
+      "object_key": "custom-iocs.json",
+      "region": "us-west-2",
+      "role_arn": "arn:aws:iam::123456789012:role/threat_intel_role"
+    }
+  },
+  "ioc_schema": {
+    "json_path_schema": {
+      "type": {
+        "json_path": "$.*[*].ioc_type"
+      },
+      "value": {
+        "json_path": "$.*[*].ioc_value"
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- Existing threat intel sources using `IOC_UPLOAD` or `S3_CUSTOM` types continue to work without changes
+- The `ioc_types` field is now computed automatically from parsed IOCs when using custom schema
+- IOC type validation has been relaxed to support custom IOC types beyond predefined STIX2 types
+
+## Limitations
+
+- JSONPath expressions must return equal numbers of type and value elements
+- Custom schema parsing requires both `type` and `value` JSONPath expressions
+- The `ioc_schema` field is only supported for `IOC_UPLOAD` and `S3_CUSTOM` source types
+- Labels field parsing from custom schema is not yet supported
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1493](https://github.com/opensearch-project/security-analytics/pull/1493) | Adds support for uploading threat intelligence in Custom Format (main branch) |
+| [#1455](https://github.com/opensearch-project/security-analytics/pull/1455) | Original implementation for 2.x branch |
+
+## References
+
+- [Issue #1421](https://github.com/opensearch-project/security-analytics/issues/1421): Feature request for custom JSON schema support
+- [Threat Intelligence Documentation](https://docs.opensearch.org/3.0/security-analytics/threat-intelligence/index/): Official docs
+- [Source API Documentation](https://docs.opensearch.org/3.0/security-analytics/threat-intelligence/api/source/): API reference
+- [JSONPath Wikipedia](https://en.wikipedia.org/wiki/JSONPath): JSONPath specification reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/security-analytics/threat-intelligence.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -178,3 +178,7 @@
 ## skills
 
 - [Skills / Tools Bugfixes and Enhancements](features/skills/skills-tools-bugfixes.md)
+
+## security-analytics
+
+- [Threat Intelligence Custom Format Support](features/security-analytics/threat-intelligence-custom-format.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Threat Intelligence custom format support feature in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/security-analytics/threat-intelligence-custom-format.md`
- Feature report: `docs/features/security-analytics/threat-intelligence.md`

### Key Changes in v3.0.0
- Added support for uploading threat intelligence IOCs in custom JSON formats using JSONPath notation
- New `custom_schema_ioc_upload` source type for local file uploads with custom schemas
- Support for custom IOC types beyond predefined STIX2 types
- Automatic IOC type computation from parsed data

### Resources Used
- PR: opensearch-project/security-analytics#1493
- PR: opensearch-project/security-analytics#1455
- Issue: opensearch-project/security-analytics#1421
- Docs: https://docs.opensearch.org/3.0/security-analytics/threat-intelligence/api/source/

Closes #164