### PR TITLE
docs: add analyzer-based neural sparse query report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -3,6 +3,7 @@
 ## neural-search
 
 - [Neural Search Compatibility](neural-search/neural-search-compatibility.md)
+- [Neural Sparse Search](neural-search/neural-sparse-search.md)
 - [Semantic Field](neural-search/semantic-field.md)
 
 ## opensearch

--- a/docs/features/neural-search/neural-sparse-search.md
+++ b/docs/features/neural-search/neural-sparse-search.md
@@ -1,0 +1,192 @@
+# Neural Sparse Search
+
+## Summary
+
+Neural sparse search is a semantic search technique that uses sparse vector representations to find relevant documents. Unlike dense vector search which uses fixed-dimension embeddings, sparse vectors have variable dimensions where each dimension corresponds to a vocabulary token with an associated weight. This approach combines the interpretability of keyword search with the semantic understanding of neural models.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Indexing"
+        A[Document] --> B[Sparse Encoding Model]
+        B --> C[Sparse Vector]
+        C --> D[rank_features Field]
+    end
+    
+    subgraph "Query Processing"
+        E[Query Text] --> F{Encoding Method}
+        F -->|model_id| G[ML Commons Model]
+        F -->|analyzer| H[Lucene Analyzer]
+        F -->|query_tokens| I[Direct Tokens]
+        G --> J[Query Tokens]
+        H --> J
+        I --> J
+    end
+    
+    subgraph "Search"
+        J --> K[BooleanQuery]
+        K --> L[FeatureField Queries]
+        L --> M[Ranked Results]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Query Text] --> B{Encoding Method}
+    B -->|ML Model| C[ML Commons Inference]
+    B -->|Analyzer| D[Lucene TokenStream]
+    B -->|Raw Tokens| E[Direct Token Map]
+    C --> F[Token-Weight Map]
+    D --> F
+    E --> F
+    F --> G[Build BooleanQuery]
+    G --> H[FeatureField.newLinearQuery per token]
+    H --> I[Execute Search]
+    I --> J[Return Results]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `NeuralSparseQueryBuilder` | Query builder that constructs neural sparse queries from text, model, analyzer, or raw tokens |
+| `NeuralSparseQueryTwoPhaseInfo` | Encapsulates two-phase execution state for query optimization |
+| `sparse_encoding` processor | Ingest processor that generates sparse vectors from text during indexing |
+| `neural_sparse_two_phase` processor | Search pipeline processor for two-phase query optimization |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `query_text` | The text to encode into sparse vectors | Required (unless `query_tokens` provided) |
+| `model_id` | ID of the sparse encoding model in ML Commons | Optional |
+| `analyzer` | Name of the Lucene analyzer for tokenization | `bert-uncased` |
+| `query_tokens` | Pre-computed token-weight map | Optional |
+| `max_token_score` | (Deprecated) Maximum token score threshold | N/A |
+
+### Query Modes
+
+Neural sparse query supports three encoding methods:
+
+1. **Model-based**: Uses ML Commons sparse encoding model
+   ```json
+   {
+     "neural_sparse": {
+       "field": {
+         "query_text": "search query",
+         "model_id": "<model-id>"
+       }
+     }
+   }
+   ```
+
+2. **Analyzer-based** (v3.0.0+): Uses Lucene analyzer for tokenization
+   ```json
+   {
+     "neural_sparse": {
+       "field": {
+         "query_text": "search query",
+         "analyzer": "bert-uncased"
+       }
+     }
+   }
+   ```
+
+3. **Raw tokens**: Directly provides token-weight map
+   ```json
+   {
+     "neural_sparse": {
+       "field": {
+         "query_tokens": {
+           "token1": 1.5,
+           "token2": 2.3
+         }
+       }
+     }
+   }
+   ```
+
+### Two-Phase Query Optimization
+
+The neural sparse query supports two-phase execution for improved performance:
+
+```mermaid
+flowchart LR
+    A[Query Tokens] --> B[Split by Threshold]
+    B --> C[High-Weight Tokens]
+    B --> D[Low-Weight Tokens]
+    C --> E[Phase 1: Initial Search]
+    E --> F[Top-K Results]
+    F --> G[Phase 2: Rescore]
+    D --> G
+    G --> H[Final Results]
+```
+
+Two-phase status values:
+- `NOT_ENABLED`: Standard single-phase execution
+- `PHASE_ONE`: First phase with high-weight tokens only
+- `PHASE_TWO`: Rescoring phase with low-weight tokens
+
+### Usage Example
+
+```json
+PUT /my-sparse-index
+{
+  "settings": {
+    "default_pipeline": "sparse-ingest-pipeline"
+  },
+  "mappings": {
+    "properties": {
+      "text_sparse": {
+        "type": "rank_features"
+      },
+      "text": {
+        "type": "text"
+      }
+    }
+  }
+}
+
+GET /my-sparse-index/_search
+{
+  "query": {
+    "neural_sparse": {
+      "text_sparse": {
+        "query_text": "semantic search query",
+        "analyzer": "bert-uncased"
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Sparse encoding models must be deployed in ML Commons before use (for model-based queries)
+- Analyzer must be configured in index settings (for analyzer-based queries)
+- Token weights in analyzer mode must be encoded as 4-byte floats in payload attribute
+- Two-phase optimization requires search pipeline configuration
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#1088](https://github.com/opensearch-project/neural-search/pull/1088) | Implement analyzer-based neural sparse query |
+| v2.11.0 | - | Initial neural sparse query implementation |
+
+## References
+
+- [Issue #1052](https://github.com/opensearch-project/neural-search/issues/1052): RFC for analyzer-based neural sparse query
+- [Neural Sparse Query Documentation](https://docs.opensearch.org/3.0/query-dsl/specialized/neural-sparse/)
+- [Neural Sparse Search Guide](https://docs.opensearch.org/3.0/vector-search/ai-search/neural-sparse-search/)
+- [Neural Search API](https://docs.opensearch.org/3.0/vector-search/api/neural/)
+
+## Change History
+
+- **v3.0.0** (2025-03-11): Added analyzer-based neural sparse query support, enabling tokenization without ML Commons models
+- **v2.11.0**: Initial implementation of neural sparse query with model-based and raw token support

--- a/docs/releases/v3.0.0/features/neural-search/analyzer-based-neural-sparse-query.md
+++ b/docs/releases/v3.0.0/features/neural-search/analyzer-based-neural-sparse-query.md
@@ -1,0 +1,110 @@
+# Analyzer-Based Neural Sparse Query
+
+## Summary
+
+OpenSearch 3.0.0 introduces analyzer-based neural sparse query support, enabling users to perform neural sparse search using Lucene analyzers instead of ML models. This simplifies the doc-only mode workflow by eliminating the need to register and manage tokenizer models through ML Commons, reducing operational overhead and network traffic.
+
+## Details
+
+### What's New in v3.0.0
+
+The `neural_sparse` query now supports an `analyzer` parameter that allows query text tokenization using Lucene analyzers bound to index fields. This is particularly beneficial for doc-only mode neural sparse search where only a tokenizer (not a full sparse encoding model) is needed at query time.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.0.0"
+        A1[Query Text] --> B1[ML Commons]
+        B1 --> C1[Tokenizer Model]
+        C1 --> D1[Token Weights]
+        D1 --> E1[Neural Sparse Query]
+    end
+    
+    subgraph "v3.0.0 with Analyzer"
+        A2[Query Text] --> B2[Lucene Analyzer]
+        B2 --> C2[Token + Payload]
+        C2 --> D2[Neural Sparse Query]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `NeuralSparseQueryTwoPhaseInfo` | New class encapsulating two-phase execution state, prune ratio, and prune type |
+| `analyzer` field | New query parameter to specify the Lucene analyzer for tokenization |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `analyzer` | Name of the Lucene analyzer to use for query tokenization | `bert-uncased` |
+
+#### API Changes
+
+The `neural_sparse` query now accepts an optional `analyzer` parameter:
+
+```json
+{
+  "query": {
+    "neural_sparse": {
+      "<field_name>": {
+        "query_text": "<query_text>",
+        "analyzer": "<analyzer_name>"
+      }
+    }
+  }
+}
+```
+
+When `analyzer` is specified, the query bypasses ML Commons model inference and uses the specified Lucene analyzer directly.
+
+### Usage Example
+
+```json
+GET my-nlp-index/_search
+{
+  "query": {
+    "neural_sparse": {
+      "passage_embedding": {
+        "query_text": "Hello world",
+        "analyzer": "bert-uncased"
+      }
+    }
+  }
+}
+```
+
+The analyzer extracts tokens and their weights from the payload attribute. If no payload is present, tokens receive a default weight of 1.0.
+
+### Migration Notes
+
+- Existing queries using `model_id` continue to work unchanged
+- To use analyzer-based queries, ensure the analyzer is configured in your index settings
+- The `analyzer` parameter defaults to `bert-uncased` if not specified and `model_id` is not provided
+- Token weights are extracted from the Lucene `PayloadAttribute` as 4-byte floats
+
+## Limitations
+
+- Analyzer must be configured in the index settings before use
+- Token weights must be encoded as 4-byte floats in the payload attribute
+- Two-phase processing with analyzer requires token splitting at query time (not during rewrite)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1088](https://github.com/opensearch-project/neural-search/pull/1088) | Implement analyzer-based neural sparse query |
+
+## References
+
+- [Issue #1052](https://github.com/opensearch-project/neural-search/issues/1052): RFC for analyzer-based neural sparse query
+- [Neural Sparse Query Documentation](https://docs.opensearch.org/3.0/query-dsl/specialized/neural-sparse/)
+- [Neural Search API Documentation](https://docs.opensearch.org/3.0/vector-search/api/neural/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/neural-search/neural-sparse-search.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -6,6 +6,7 @@
 
 ### neural-search
 
+- [Analyzer-Based Neural Sparse Query](features/neural-search/analyzer-based-neural-sparse-query.md)
 - [Neural Search Compatibility](features/neural-search/neural-search-compatibility.md)
 - [Semantic Field](features/neural-search/semantic-field.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the analyzer-based neural sparse query feature introduced in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/neural-search/analyzer-based-neural-sparse-query.md`
- Feature report: `docs/features/neural-search/neural-sparse-search.md` (created)

### Key Changes in v3.0.0
- New `analyzer` parameter in `neural_sparse` query allows tokenization using Lucene analyzers
- Eliminates need for ML Commons model registration for doc-only mode neural sparse search
- Default analyzer is `bert-uncased`
- Token weights extracted from Lucene PayloadAttribute

### Resources Used
- PR: [#1088](https://github.com/opensearch-project/neural-search/pull/1088)
- Issue: [#1052](https://github.com/opensearch-project/neural-search/issues/1052)
- Docs: https://docs.opensearch.org/3.0/query-dsl/specialized/neural-sparse/