### PR TITLE
docs: add node-roles-and-configuration report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -31,6 +31,7 @@
 - [Segment Warmer](opensearch/segment-warmer.md)
 - [Stream Input/Output](opensearch/stream-inputoutput.md)
 - [Tiered Caching](opensearch/tiered-caching.md)
+- [Transport Nodes Action Optimization](opensearch/transport-nodes-action-optimization.md)
 - [Wildcard Field](opensearch/wildcard-field.md)
 
 ## opensearch-dashboards

--- a/docs/features/opensearch/transport-nodes-action-optimization.md
+++ b/docs/features/opensearch/transport-nodes-action-optimization.md
@@ -1,0 +1,115 @@
+# Transport Nodes Action Optimization
+
+## Summary
+
+The Transport Nodes Action Optimization feature improves the performance of inter-node communication in OpenSearch clusters by eliminating redundant discovery node information from transport requests. This optimization significantly reduces network traffic, serialization overhead, and memory usage, particularly beneficial for large clusters with hundreds or thousands of nodes.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Transport Layer"
+        A[REST API Request] --> B[Coordinating Node]
+        B --> C[TransportNodesAction]
+        C --> D[AsyncAction]
+        D --> E{Create Node Requests}
+        E --> F[Node 1]
+        E --> G[Node 2]
+        E --> H[Node N]
+    end
+    
+    subgraph "Request Processing"
+        I[BaseNodesRequest] --> J[Resolve Node IDs]
+        J --> K[Set Concrete Nodes]
+        K --> L[AsyncAction Constructor]
+        L --> M[Clear Concrete Nodes]
+        M --> N[Send to Individual Nodes]
+    end
+    
+    C --> I
+    D --> L
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Client] -->|REST Request| B[Coordinating Node]
+    B -->|Parse Request| C[BaseNodesRequest]
+    C -->|Resolve| D[Concrete DiscoveryNodes]
+    D -->|Transfer to| E[AsyncAction]
+    E -->|Clear from Request| F[Lightweight Request]
+    F -->|Transport| G[Target Nodes]
+    G -->|Response| H[Aggregate Results]
+    H -->|Return| A
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `BaseNodesRequest` | Base class for all node-targeted requests; no longer carries discovery nodes during transport |
+| `TransportNodesAction` | Abstract transport action that handles node-level operations |
+| `AsyncAction` | Inner class that manages asynchronous execution and owns the concrete nodes reference |
+| `NodesStatsRequest` | Request for node statistics (optimized) |
+| `NodesInfoRequest` | Request for node information (optimized) |
+| `ClusterStatsRequest` | Request for cluster statistics (optimized) |
+
+### Configuration
+
+This optimization is built into the core transport layer and requires no configuration. It is automatically applied to all actions extending `TransportNodesAction`.
+
+### Usage Example
+
+No changes required for end users. The optimization is transparent:
+
+```bash
+# These APIs automatically benefit from the optimization
+GET /_nodes/stats
+GET /_nodes
+GET /_cat/nodes
+GET /_cluster/stats
+```
+
+For plugin developers extending `BaseNodesRequest`:
+
+```java
+// Simple constructor - discovery nodes handled automatically
+public class MyNodesRequest extends BaseNodesRequest<MyNodesRequest> {
+    public MyNodesRequest(String... nodesIds) {
+        super(nodesIds);
+    }
+    
+    public MyNodesRequest(DiscoveryNode... concreteNodes) {
+        super(concreteNodes);
+    }
+}
+```
+
+## Limitations
+
+- Actions requiring discovery node information during transport must implement custom handling
+- Breaking change for plugins using the removed `includeDiscoveryNodes` parameter
+- The `concreteNodes` field is null when accessed within transport action handlers
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17682](https://github.com/opensearch-project/OpenSearch/pull/17682) | Unset discovery nodes for every transport node actions request (breaking change) |
+| v2.16.0 | [#15131](https://github.com/opensearch-project/OpenSearch/pull/15131) | Reset discovery nodes in all transport node actions request |
+| v2.16.0 | [#14749](https://github.com/opensearch-project/OpenSearch/pull/14749) | Initial optimization for NodeStats, ClusterStats, NodeInfo |
+
+## References
+
+- [Issue #17008](https://github.com/opensearch-project/OpenSearch/issues/17008): Feature request for v3.0.0 breaking change
+- [Issue #14713](https://github.com/opensearch-project/OpenSearch/issues/14713): Original performance issue report
+- [Nodes APIs Documentation](https://docs.opensearch.org/3.0/api-reference/nodes-apis/index/): Official API documentation
+- [Configuration and System Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/configuration-system/): Node roles configuration
+
+## Change History
+
+- **v3.0.0** (2025-05-13): Breaking change - removed `includeDiscoveryNodes` field, made optimization mandatory for all TransportNodesAction requests
+- **v2.16.0** (2024-07-22): Initial optimization with opt-in flag for NodeStats, ClusterStats, NodeInfo actions

--- a/docs/releases/v3.0.0/features/opensearch/node-roles-and-configuration.md
+++ b/docs/releases/v3.0.0/features/opensearch/node-roles-and-configuration.md
@@ -1,0 +1,115 @@
+# Node Roles & Configuration
+
+## Summary
+
+OpenSearch v3.0.0 introduces a breaking change to the transport layer that optimizes inter-node communication by removing the `includeDiscoveryNodes` field from `BaseNodesRequest`. This change eliminates redundant discovery node information from transport requests, significantly improving performance in large clusters by reducing network traffic and serialization overhead.
+
+## Details
+
+### What's New in v3.0.0
+
+This release completes the optimization work started in v2.16.0 (PR #14749 and #15131) by making the discovery nodes exclusion the default behavior for all transport node actions. Previously, this was opt-in per action; now it's mandatory for all `TransportNodesAction` requests.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.0.0"
+        A1[Client Request] --> B1[Coordinating Node]
+        B1 --> C1[BaseNodesRequest with DiscoveryNodes]
+        C1 --> D1[Node 1]
+        C1 --> E1[Node 2]
+        C1 --> F1[Node N]
+        style C1 fill:#f9d0c4
+    end
+    
+    subgraph "v3.0.0+"
+        A2[Client Request] --> B2[Coordinating Node]
+        B2 --> C2[BaseNodesRequest without DiscoveryNodes]
+        C2 --> D2[Node 1]
+        C2 --> E2[Node 2]
+        C2 --> F2[Node N]
+        style C2 fill:#90EE90
+    end
+```
+
+#### API Changes
+
+The `BaseNodesRequest` class has been simplified:
+
+| Change | Before | After |
+|--------|--------|-------|
+| Constructor | `super(includeDiscoveryNodes, nodesIds)` | `super(nodesIds)` |
+| `includeDiscoveryNodes` field | Present (boolean) | Removed |
+| `getIncludeDiscoveryNodes()` method | Available | Removed |
+| `concreteNodes` access in transport | Conditional based on flag | Always null after AsyncAction |
+
+#### Affected Components
+
+| Component | File | Change |
+|-----------|------|--------|
+| BaseNodesRequest | `server/.../BaseNodesRequest.java` | Removed `includeDiscoveryNodes` field and related constructors |
+| TransportNodesAction | `server/.../TransportNodesAction.java` | Always unsets concrete nodes before transport |
+| NodesStatsRequest | `server/.../NodesStatsRequest.java` | Updated constructor calls |
+| NodesInfoRequest | `server/.../NodesInfoRequest.java` | Updated constructor calls |
+| ClusterStatsRequest | `server/.../ClusterStatsRequest.java` | Updated constructor calls |
+| NodesHotThreadsRequest | `server/.../NodesHotThreadsRequest.java` | Updated constructor calls |
+| WlmStatsRequest | `server/.../WlmStatsRequest.java` | Updated constructor calls |
+| Various Gateway Requests | Multiple files | Updated constructor calls |
+
+### Migration Notes
+
+**For Plugin Developers:**
+
+If your plugin extends `BaseNodesRequest`, update your constructors:
+
+```java
+// Before v3.0.0
+public MyNodesRequest(String... nodesIds) {
+    super(false, nodesIds);  // or super(true, nodesIds)
+}
+
+// v3.0.0+
+public MyNodesRequest(String... nodesIds) {
+    super(nodesIds);
+}
+```
+
+**Important:** The `concreteNodes` field will be `null` when accessed by transport actions. If your action requires discovery node information, handle it within your action's own request class rather than relying on `BaseNodesRequest`.
+
+### Performance Impact
+
+Based on testing in large clusters (1000+ nodes), this change provides significant performance improvements:
+
+| API | Metric | Improvement |
+|-----|--------|-------------|
+| `_nodes/stats` | Average latency | ~86% reduction |
+| `_cat/nodes` | Average latency | ~96% reduction |
+| `_cluster/stats` | Average latency | ~80% reduction |
+| `_nodes` | Average latency | ~58% reduction |
+
+## Limitations
+
+- Actions that genuinely require discovery node information must now handle this within their own request classes
+- This is a breaking change for plugins that relied on the `includeDiscoveryNodes` parameter
+- The `TransportNodesReloadSecureSettingsAction` previously required discovery nodes but has been updated to work without them
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17682](https://github.com/opensearch-project/OpenSearch/pull/17682) | Unset discovery nodes for every transport node actions request |
+| [#15131](https://github.com/opensearch-project/OpenSearch/pull/15131) | Reset discovery nodes in all transport node actions request (predecessor) |
+| [#14749](https://github.com/opensearch-project/OpenSearch/pull/14749) | Optimise TransportNodesAction to not send DiscoveryNodes (initial optimization) |
+
+## References
+
+- [Issue #17008](https://github.com/opensearch-project/OpenSearch/issues/17008): Feature request for unsetting discoveryNodes from BaseNodeRequest
+- [Issue #14713](https://github.com/opensearch-project/OpenSearch/issues/14713): Original performance issue
+- [Nodes APIs Documentation](https://docs.opensearch.org/3.0/api-reference/nodes-apis/index/): Official API documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/transport-nodes-action-optimization.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -30,6 +30,7 @@
 - [Lucene 10 Upgrade](features/opensearch/lucene-10-upgrade.md)
 - [Lucene Similarity](features/opensearch/lucene-similarity.md)
 - [Merge & Segment Settings](features/opensearch/merge-segment-settings.md)
+- [Node Roles & Configuration](features/opensearch/node-roles-and-configuration.md)
 - [Nodes Info API Changes](features/opensearch/nodes-info-api-changes.md)
 - [Refresh Task Scheduling](features/opensearch/refresh-task-scheduling.md)
 - [Search Backpressure](features/opensearch/search-backpressure.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Node Roles & Configuration breaking change in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/node-roles-and-configuration.md`
- Feature report: `docs/features/opensearch/transport-nodes-action-optimization.md`

### Key Changes in v3.0.0
- Removed `includeDiscoveryNodes` field from `BaseNodesRequest`
- Made discovery nodes exclusion mandatory for all `TransportNodesAction` requests
- Significant performance improvements (up to 96% latency reduction for some APIs)

### Resources Used
- PR: #17682 (main implementation)
- PR: #15131, #14749 (predecessor work)
- Issue: #17008 (feature request)
- Issue: #14713 (original performance issue)

Closes #140