### PR TITLE
docs: add Bulk API Changes report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -9,6 +9,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
+- [Bulk API](opensearch/bulk-api.md)
 - [Deprecated Code Cleanup](opensearch/deprecated-code-cleanup.md)
 - [Cluster Permissions](opensearch/cluster-permissions.md)
 - [gRPC Transport & Services](opensearch/grpc-transport--services.md)

--- a/docs/features/opensearch/bulk-api.md
+++ b/docs/features/opensearch/bulk-api.md
@@ -1,0 +1,144 @@
+# Bulk API
+
+## Summary
+
+The Bulk API allows adding, updating, or deleting multiple documents in a single request. Compared to individual indexing requests, the bulk operation provides significant performance benefits by reducing network overhead and allowing OpenSearch to optimize internal operations. The API supports index, create, update, and delete operations, each with specific behaviors and requirements.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Client"
+        A[Bulk Request]
+    end
+    
+    subgraph "OpenSearch Node"
+        B[REST Layer]
+        C[TransportBulkAction]
+        D[Ingest Pipeline]
+        E[Shard Operations]
+    end
+    
+    subgraph "Storage"
+        F[Primary Shard]
+        G[Replica Shards]
+    end
+    
+    A --> B
+    B --> C
+    C --> D
+    D --> E
+    E --> F
+    F --> G
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Parse Bulk Request] --> B{Has Pipeline?}
+    B -->|Yes| C[Execute Ingest Pipeline]
+    B -->|No| D[Route to Shards]
+    C --> D
+    D --> E[Execute on Primary]
+    E --> F[Replicate to Replicas]
+    F --> G[Return Response]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `RestBulkAction` | REST handler for `_bulk` endpoint |
+| `BulkRequest` | Container for bulk operations |
+| `TransportBulkAction` | Coordinates bulk execution across shards |
+| `IngestService` | Processes documents through ingest pipelines |
+| `BulkShardRequest` | Per-shard bulk operations |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `timeout` | Request timeout | `1m` |
+| `refresh` | Refresh policy (`true`, `false`, `wait_for`) | `false` |
+| `routing` | Custom routing value | - |
+| `pipeline` | Ingest pipeline to use | - |
+| `require_alias` | Require target to be an alias | `false` |
+| `wait_for_active_shards` | Number of active shards required | `1` |
+
+### Supported Operations
+
+#### Index
+Creates or replaces a document:
+```json
+{ "index": { "_index": "test", "_id": "1" } }
+{ "field": "value" }
+```
+
+#### Create
+Creates a document only if it doesn't exist:
+```json
+{ "create": { "_index": "test", "_id": "1" } }
+{ "field": "value" }
+```
+
+#### Update
+Updates an existing document:
+```json
+{ "update": { "_index": "test", "_id": "1" } }
+{ "doc": { "field": "new_value" } }
+```
+
+#### Delete
+Deletes a document:
+```json
+{ "delete": { "_index": "test", "_id": "1" } }
+```
+
+### Usage Example
+
+```bash
+POST _bulk
+{ "index": { "_index": "movies", "_id": "1" } }
+{ "title": "The Matrix", "year": 1999 }
+{ "create": { "_index": "movies", "_id": "2" } }
+{ "title": "Inception", "year": 2010 }
+{ "update": { "_index": "movies", "_id": "1" } }
+{ "doc": { "rating": 8.7 } }
+{ "delete": { "_index": "movies", "_id": "3" } }
+```
+
+### Document ID Constraints
+
+- Document `_id` must be 512 bytes or less in size (enforced since v2.9.0)
+- This limit applies to all bulk operations (index, create, update)
+
+## Limitations
+
+- Each line in the request body must be on a single line (no pretty-printing)
+- Request body must end with a newline character
+- Large bulk requests may cause memory pressure; consider splitting into smaller batches
+- The `batch_size` parameter was removed in v3.0.0
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17801](https://github.com/opensearch-project/OpenSearch/pull/17801) | Remove deprecated `batch_size` parameter |
+| v2.9.0 | [#8039](https://github.com/opensearch-project/OpenSearch/pull/8039) | Enforce 512 byte document ID limit |
+| v2.14.0 | [#12457](https://github.com/opensearch-project/OpenSearch/pull/12457) | Add batch processing for ingest processors |
+
+## References
+
+- [Issue #14283](https://github.com/opensearch-project/OpenSearch/issues/14283): Make batch ingestion automatic
+- [Issue #6595](https://github.com/opensearch-project/OpenSearch/issues/6595): Bug report for _id size limit bypass
+- [Bulk API Documentation](https://docs.opensearch.org/3.0/api-reference/document-apis/bulk/): Official documentation
+
+## Change History
+
+- **v3.0.0** (2025-05-13): Removed deprecated `batch_size` parameter; batch processing is now automatic
+- **v2.14.0** (2024-04-30): Added `batch_size` parameter for ingest pipeline batch processing (deprecated)
+- **v2.9.0** (2023-07-18): Enforced 512 byte document ID limit in bulk updates
+- **v1.0.0** (2021-07-12): Initial implementation

--- a/docs/releases/v3.0.0/features/opensearch/bulk-api-changes.md
+++ b/docs/releases/v3.0.0/features/opensearch/bulk-api-changes.md
@@ -1,0 +1,109 @@
+# Bulk API Changes
+
+## Summary
+
+OpenSearch 3.0.0 introduces breaking changes to the Bulk API. The deprecated `batch_size` parameter has been removed, and batch ingestion is now automatic. This change simplifies the API and improves performance by allowing ingest processors to determine optimal batch sizes internally.
+
+## Details
+
+### What's New in v3.0.0
+
+#### Removal of `batch_size` Parameter
+
+The `batch_size` parameter on the `_bulk` API has been completely removed. This parameter was deprecated in v2.14.0 and is no longer supported in v3.0.0.
+
+**Before (v2.x):**
+```bash
+POST _bulk?batch_size=100
+{ "index": { "_index": "test", "_id": "1" } }
+{ "field": "value" }
+```
+
+**After (v3.0.0):**
+```bash
+POST _bulk
+{ "index": { "_index": "test", "_id": "1" } }
+{ "field": "value" }
+```
+
+#### Automatic Batch Processing
+
+Batch processing for ingest pipelines is now automatic. The entire content of a bulk request is passed to each ingest processor, allowing processors to determine optimal batch sizes internally. This provides:
+
+- **Simplified API**: No need to determine and specify `batch_size` parameter
+- **Better Performance**: Ingest processors can optimize batch processing based on their specific requirements
+- **Backward Compatibility**: The default implementation of `batchExecute` operates on one document at a time, so existing processors work without modification
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "v2.x Behavior"
+        A1[Bulk Request] --> B1[batch_size parameter]
+        B1 --> C1[Fixed batch processing]
+        C1 --> D1[Ingest Pipeline]
+    end
+    
+    subgraph "v3.0.0 Behavior"
+        A2[Bulk Request] --> B2[Automatic batching]
+        B2 --> C2[Processor-optimized batching]
+        C2 --> D2[Ingest Pipeline]
+    end
+```
+
+#### Code Changes
+
+| File | Change |
+|------|--------|
+| `BulkRequest.java` | Removed `batchSize` field and methods |
+| `RestBulkAction.java` | Removed `batch_size` parameter handling |
+| `IngestService.java` | Simplified batch processing logic |
+| `TransportBulkAction.java` | Removed batch size parameter passing |
+
+#### Serialization Compatibility
+
+For backward compatibility during rolling upgrades:
+- Nodes running v2.14.0+ can communicate with v3.0.0 nodes
+- The `batch_size` field is read but ignored when receiving from v2.x nodes
+- A placeholder value (`Integer.MAX_VALUE`) is written when sending to v2.x nodes
+
+### Migration Notes
+
+1. **Remove `batch_size` parameter**: If your application specifies `batch_size` in bulk requests, remove it
+2. **No code changes needed for processors**: Existing ingest processors continue to work without modification
+3. **Performance may improve**: Batch processing is now optimized per-processor rather than using a fixed size
+
+### Usage Example
+
+```bash
+# Standard bulk request (same as before, but without batch_size)
+POST _bulk
+{ "index": { "_index": "movies", "_id": "1" } }
+{ "title": "The Matrix", "year": 1999 }
+{ "index": { "_index": "movies", "_id": "2" } }
+{ "title": "Inception", "year": 2010 }
+{ "delete": { "_index": "movies", "_id": "3" } }
+```
+
+## Limitations
+
+- Applications that relied on `batch_size` for controlling memory usage must find alternative approaches
+- Custom ingest processors should implement `batchExecute` method for optimal performance
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17801](https://github.com/opensearch-project/OpenSearch/pull/17801) | Remove deprecated `batch_size` parameter from `_bulk` |
+
+## References
+
+- [Issue #14283](https://github.com/opensearch-project/OpenSearch/issues/14283): Feature request to make batch ingestion automatic
+- [Bulk API Documentation](https://docs.opensearch.org/3.0/api-reference/document-apis/bulk/): Official documentation
+- [OpenSearch 3.0 Breaking Changes](https://opensearch.org/blog/opensearch-3-0-what-to-expect/): Blog post about v3.0.0 changes
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/bulk-api.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -13,6 +13,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)
+- [Bulk API Changes](features/opensearch/bulk-api-changes.md)
 - [Deprecated Code Cleanup](features/opensearch/deprecated-code-cleanup.md)
 - [Cluster Permissions](features/opensearch/cluster-permissions.md)
 - [gRPC Transport & Services](features/opensearch/grpc-transport--services.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Bulk API breaking changes in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/bulk-api-changes.md`
- Feature report: `docs/features/opensearch/bulk-api.md` (created)

### Key Changes in v3.0.0
- Removed deprecated `batch_size` parameter from `_bulk` API
- Batch processing for ingest pipelines is now automatic
- Ingest processors can now determine optimal batch sizes internally

### Related Issue
Closes #139

### References
- [PR #17801](https://github.com/opensearch-project/OpenSearch/pull/17801): Remove deprecated batch_size parameter
- [Issue #14283](https://github.com/opensearch-project/OpenSearch/issues/14283): Feature request for automatic batch ingestion