### PR TITLE
docs: add HTTP Client Migration report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -22,6 +22,7 @@
 - [Source Field Matching](opensearch/source-field-matching.md)
 - [Cryptography & Security Libraries](opensearch/cryptography-security-libraries.md)
 - [Gradle Build System](opensearch/gradle-build-system.md)
+- [HTTP Client](opensearch/http-client.md)
 - [Java Runtime & JPMS](opensearch/java-runtime-and-jpms.md)
 - [Lucene 10 Upgrade](opensearch/lucene-10-upgrade.md)
 - [Lucene Similarity](opensearch/lucene-similarity.md)

--- a/docs/features/opensearch/http-client.md
+++ b/docs/features/opensearch/http-client.md
@@ -1,0 +1,124 @@
+# HTTP Client
+
+## Summary
+
+OpenSearch uses Apache HttpClient as the underlying HTTP transport for its REST clients. This library handles all HTTP communication between OpenSearch clients and the cluster, including connection management, authentication, SSL/TLS, and request/response handling. Starting with OpenSearch 3.0.0, the client transports use Apache HttpClient 5.x, which provides modern HTTP features and improved performance.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Client"
+        App[Application Code]
+        RHLC[Rest High Level Client]
+        RC[Rest Client]
+        Transport[Apache HttpClient 5 Transport]
+    end
+    
+    subgraph "Apache HttpClient 5.x"
+        CM[Connection Manager]
+        Auth[Authentication]
+        TLS[TLS/SSL Handler]
+        Pool[Connection Pool]
+    end
+    
+    subgraph "OpenSearch Cluster"
+        Node1[Node 1]
+        Node2[Node 2]
+        Node3[Node 3]
+    end
+    
+    App --> RHLC
+    RHLC --> RC
+    RC --> Transport
+    Transport --> CM
+    CM --> Auth
+    CM --> TLS
+    CM --> Pool
+    Pool --> Node1
+    Pool --> Node2
+    Pool --> Node3
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ApacheHttpClient5TransportBuilder` | Default transport builder for Java client using HttpClient 5.x |
+| `RestClient` | Low-level REST client for direct HTTP communication |
+| `RestHighLevelClient` | High-level client with typed request/response handling |
+| `ByteArrayEntity` | HTTP entity for binary content |
+| `StringEntity` | HTTP entity for string content |
+| `BasicCredentialsProvider` | Authentication credentials management |
+| `PoolingAsyncClientConnectionManager` | Connection pooling for async operations |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Connection timeout | Time to establish connection | 1000ms |
+| Socket timeout | Time to wait for data | 30000ms |
+| Max connections per route | Maximum connections to single host | 10 |
+| Max total connections | Maximum total connections | 30 |
+
+### Usage Example
+
+```java
+// Using Apache HttpClient 5 Transport (recommended for OpenSearch 3.x)
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.impl.auth.BasicCredentialsProvider;
+import org.apache.hc.core5.http.HttpHost;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
+
+final HttpHost host = new HttpHost("https", "localhost", 9200);
+final BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+credentialsProvider.setCredentials(
+    new AuthScope(host), 
+    new UsernamePasswordCredentials("admin", "admin".toCharArray())
+);
+
+final ApacheHttpClient5TransportBuilder builder = ApacheHttpClient5TransportBuilder.builder(host);
+builder.setHttpClientConfigCallback(httpClientBuilder -> {
+    return httpClientBuilder.setDefaultCredentialsProvider(credentialsProvider);
+});
+
+OpenSearchClient client = new OpenSearchClient(builder.build());
+```
+
+### Package Structure
+
+| Package | Purpose |
+|---------|---------|
+| `org.apache.hc.core5.http` | Core HTTP interfaces and classes |
+| `org.apache.hc.core5.http.io.entity` | HTTP entity implementations |
+| `org.apache.hc.core5.http.message` | HTTP message implementations |
+| `org.apache.hc.client5.http` | HTTP client interfaces |
+| `org.apache.hc.client5.http.classic.methods` | HTTP method implementations |
+| `org.apache.hc.client5.http.impl.auth` | Authentication implementations |
+| `org.apache.hc.client5.http.impl.nio` | Async client implementations |
+
+## Limitations
+
+- HTTP/2 support requires additional configuration
+- Custom SSL contexts need to be configured for self-signed certificates
+- Connection pool settings may need tuning for high-throughput scenarios
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#4459](https://github.com/opensearch-project/OpenSearch/pull/4459) | Migrate client transports to Apache HttpClient / Core 5.x |
+
+## References
+
+- [Issue #4256](https://github.com/opensearch-project/OpenSearch/issues/4256): Original feature request
+- [Java Client Documentation](https://docs.opensearch.org/3.0/clients/java/): Official documentation
+- [Apache HttpClient 5.x](https://hc.apache.org/httpcomponents-client-5.1.x/): Apache HttpClient project
+
+## Change History
+
+- **v3.0.0** (2025-03-11): Migrated from Apache HttpComponents 4.x to Apache HttpClient 5.x

--- a/docs/releases/v3.0.0/features/opensearch/http-client-migration.md
+++ b/docs/releases/v3.0.0/features/opensearch/http-client-migration.md
@@ -1,0 +1,98 @@
+# HTTP Client Migration
+
+## Summary
+
+OpenSearch 3.0.0 migrates client transports from Apache HttpComponents/Core 4.x to Apache HttpClient/Core 5.x. This is a breaking change that affects all OpenSearch clients (rest-client, RHLC, opensearch-java) and provides access to modern HTTP features including HTTP/2 support while moving away from end-of-life libraries.
+
+## Details
+
+### What's New in v3.0.0
+
+The migration updates the underlying HTTP client library used by OpenSearch's REST clients from the legacy Apache HttpComponents 4.x to the modern Apache HttpClient 5.x. This change was necessary because Apache HttpComponents 4.x has reached end-of-life status.
+
+### Technical Changes
+
+#### Package Migration
+
+The migration involves updating import statements from the old `org.apache.http` packages to the new `org.apache.hc` packages:
+
+| Old Package | New Package |
+|-------------|-------------|
+| `org.apache.http.HttpHost` | `org.apache.hc.core5.http.HttpHost` |
+| `org.apache.http.HttpEntity` | `org.apache.hc.core5.http.HttpEntity` |
+| `org.apache.http.client.methods.HttpGet` | `org.apache.hc.client5.http.classic.methods.HttpGet` |
+| `org.apache.http.client.methods.HttpPost` | `org.apache.hc.client5.http.classic.methods.HttpPost` |
+| `org.apache.http.client.methods.HttpPut` | `org.apache.hc.client5.http.classic.methods.HttpPut` |
+| `org.apache.http.client.methods.HttpDelete` | `org.apache.hc.client5.http.classic.methods.HttpDelete` |
+| `org.apache.http.entity.ContentType` | `org.apache.hc.core5.http.ContentType` |
+| `org.apache.http.nio.entity.NByteArrayEntity` | `org.apache.hc.core5.http.io.entity.ByteArrayEntity` |
+| `org.apache.http.nio.entity.NStringEntity` | `org.apache.hc.core5.http.io.entity.StringEntity` |
+| `org.apache.http.message.BasicStatusLine` | `org.apache.hc.core5.http.message.StatusLine` |
+| `org.apache.http.message.BasicRequestLine` | `org.apache.hc.core5.http.message.RequestLine` |
+
+#### API Changes
+
+| Change | Description |
+|--------|-------------|
+| `ContentType.getValue()` | Now returns `String` directly instead of `Header` |
+| `NByteArrayEntity` | Replaced with `ByteArrayEntity` |
+| `NStringEntity` | Replaced with `StringEntity` |
+| `BasicHttpResponse` | Replaced with `BasicClassicHttpResponse` |
+| `HttpResponse` | Replaced with `ClassicHttpResponse` |
+
+#### New Dependencies
+
+| Dependency | Version |
+|------------|---------|
+| `httpclient5` | 5.1.3 |
+| `httpcore5` | 5.1.4 |
+
+### Usage Example
+
+```java
+// Before (Apache HttpClient 4.x)
+import org.apache.http.HttpHost;
+import org.apache.http.entity.ContentType;
+import org.apache.http.nio.entity.NByteArrayEntity;
+
+HttpHost host = new HttpHost("localhost", 9200, "https");
+NByteArrayEntity entity = new NByteArrayEntity(bytes, ContentType.APPLICATION_JSON);
+
+// After (Apache HttpClient 5.x)
+import org.apache.hc.core5.http.HttpHost;
+import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
+
+HttpHost host = new HttpHost("https", "localhost", 9200);
+ByteArrayEntity entity = new ByteArrayEntity(bytes, ContentType.APPLICATION_JSON);
+```
+
+### Migration Notes
+
+1. **Update imports**: Replace all `org.apache.http` imports with corresponding `org.apache.hc` packages
+2. **HttpHost constructor**: The constructor parameter order has changed - protocol comes first in 5.x
+3. **Entity classes**: Replace `NByteArrayEntity` and `NStringEntity` with `ByteArrayEntity` and `StringEntity`
+4. **ContentType access**: `entity.getContentType()` now returns `String` directly instead of a `Header` object
+5. **Response classes**: Use `ClassicHttpResponse` and `BasicClassicHttpResponse` instead of `HttpResponse` and `BasicHttpResponse`
+
+## Limitations
+
+- Custom HTTP client configurations may need to be updated to use the new API
+- Third-party plugins using the REST client directly will need to update their dependencies
+- The migration is a breaking change and requires code modifications for custom client implementations
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4459](https://github.com/opensearch-project/OpenSearch/pull/4459) | Migrate client transports to Apache HttpClient / Core 5.x |
+
+## References
+
+- [Issue #4256](https://github.com/opensearch-project/OpenSearch/issues/4256): Feature request for migration
+- [Java Client Documentation](https://docs.opensearch.org/3.0/clients/java/): Official Java client documentation with Apache HttpClient 5 examples
+- [Apache HttpClient 5.x Migration Guide](https://hc.apache.org/httpcomponents-client-5.1.x/migration-guide/index.html): Official Apache migration guide
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/http-client.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -27,6 +27,7 @@
 - [Source Field Matching](features/opensearch/source-field-matching.md)
 - [Cryptography & Security Libraries](features/opensearch/cryptography-security-libraries.md)
 - [Gradle Build System](features/opensearch/gradle-build-system.md)
+- [HTTP Client Migration](features/opensearch/http-client-migration.md)
 - [Java Runtime & JPMS](features/opensearch/java-runtime-and-jpms.md)
 - [Lucene 10 Upgrade](features/opensearch/lucene-10-upgrade.md)
 - [Lucene Similarity](features/opensearch/lucene-similarity.md)


### PR DESCRIPTION
## Summary

Add documentation for the HTTP Client Migration breaking change in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/http-client-migration.md`
- Feature report: `docs/features/opensearch/http-client.md`

### Key Changes
- Migration from Apache HttpComponents/Core 4.x to Apache HttpClient/Core 5.x
- Package changes from `org.apache.http.*` to `org.apache.hc.*`
- Entity class changes (NByteArrayEntity → ByteArrayEntity, NStringEntity → StringEntity)
- New dependencies: httpclient5 5.1.3, httpcore5 5.1.4

### Related
- Closes #138
- PR: https://github.com/opensearch-project/OpenSearch/pull/4459
- Issue: https://github.com/opensearch-project/OpenSearch/issues/4256