### PR TITLE
docs: add Thread Context Permissions report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -32,6 +32,7 @@
 - [Search Backpressure](opensearch/search-backpressure.md)
 - [Segment Warmer](opensearch/segment-warmer.md)
 - [Stream Input/Output](opensearch/stream-inputoutput.md)
+- [Thread Context Permissions](opensearch/thread-context-permissions.md)
 - [Tiered Caching](opensearch/tiered-caching.md)
 - [Transport Nodes Action Optimization](opensearch/transport-nodes-action-optimization.md)
 - [Wildcard Field](opensearch/wildcard-field.md)

--- a/docs/features/opensearch/thread-context-permissions.md
+++ b/docs/features/opensearch/thread-context-permissions.md
@@ -1,0 +1,127 @@
+# Thread Context Permissions
+
+## Summary
+
+Thread Context Permissions is a security enhancement that protects sensitive methods in OpenSearch's `ThreadContext` class using Java Security Manager permissions. This feature ensures that plugins must explicitly declare their need to perform privileged operations like marking a thread as a system context or manipulating thread context origins.
+
+The `ThreadContext` class manages request-scoped state (headers, transient values) that flows through OpenSearch operations. Certain methods in this class can bypass security checks or affect authorization decisions, making them sensitive from a security perspective.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Plugin Execution"
+        PC[Plugin Code]
+        PSP[plugin-security.policy]
+    end
+    
+    subgraph "Security Layer"
+        SM[Java Security Manager]
+        TCP[ThreadContextPermission]
+    end
+    
+    subgraph "ThreadContext"
+        MAS[markAsSystemContext]
+        SWO[stashWithOrigin]
+        SAM[stashAndMergeHeaders]
+    end
+    
+    PC -->|1. Call method| SM
+    PSP -.->|Grants permissions| SM
+    SM -->|2. Check permission| TCP
+    TCP -->|3. Allow/Deny| MAS
+    TCP -->|3. Allow/Deny| SWO
+    TCP -->|3. Allow/Deny| SAM
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Plugin calls ThreadContext method] --> B{Security Manager enabled?}
+    B -->|No| C[Method executes directly]
+    B -->|Yes| D{Permission granted?}
+    D -->|Yes| E[Method executes via doPrivileged]
+    D -->|No| F[SecurityException thrown]
+```
+
+### Components
+
+| Component | Package | Description |
+|-----------|---------|-------------|
+| `ThreadContextPermission` | `org.opensearch.secure_sm` | A `BasicPermission` subclass that defines permissions for ThreadContext operations |
+| `ThreadContextAccess` | `org.opensearch.common.util.concurrent` | Internal utility class providing privileged access wrappers for core code |
+| `ThreadContext` | `org.opensearch.common.util.concurrent` | Core class managing thread-local request context with permission checks |
+
+### Protected Methods
+
+| Method | Purpose | Risk if Unprotected |
+|--------|---------|---------------------|
+| `markAsSystemContext()` | Marks current thread as system context, bypassing user authentication | Plugins could impersonate system operations |
+| `stashWithOrigin(String)` | Stashes context and sets action origin | Plugins could spoof action origins affecting authorization |
+| `stashAndMergeHeaders(Map)` | Stashes context and merges headers | Plugins could inject arbitrary headers |
+
+### Configuration
+
+Plugins requiring these permissions must add entries to their `plugin-security.policy` file:
+
+| Permission | Declaration |
+|------------|-------------|
+| markAsSystemContext | `permission org.opensearch.secure_sm.ThreadContextPermission "markAsSystemContext";` |
+| stashWithOrigin | `permission org.opensearch.secure_sm.ThreadContextPermission "stashWithOrigin";` |
+| stashAndMergeHeaders | `permission org.opensearch.secure_sm.ThreadContextPermission "stashAndMergeHeaders";` |
+
+### Usage Example
+
+```java
+// plugin-security.policy
+grant {
+    permission org.opensearch.secure_sm.ThreadContextPermission "markAsSystemContext";
+};
+
+// Plugin code
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+public class MyPlugin extends Plugin {
+    
+    public void executeAsSystem(ThreadContext threadContext) {
+        try (ThreadContext.StoredContext ignore = threadContext.stashContext()) {
+            // Must use doPrivileged when calling protected methods
+            AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+                threadContext.markAsSystemContext();
+                return null;
+            });
+            
+            // Now executing in system context
+            performSystemOperation();
+        }
+    }
+}
+```
+
+## Limitations
+
+- Requires Java Security Manager to be enabled (default in OpenSearch)
+- Plugins must be recompiled and updated to include security policy declarations
+- Does not provide fine-grained control over which origins or headers can be set
+- Permission is binary (granted or not)—no partial access
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#15016](https://github.com/opensearch-project/OpenSearch/pull/15016) | Add ThreadContextPermission for markAsSystemContext |
+| v3.0.0 | [#15039](https://github.com/opensearch-project/OpenSearch/pull/15039) | Add ThreadContextPermission for stashAndMergeHeaders and stashWithOrigin |
+
+## References
+
+- [Issue #14931](https://github.com/opensearch-project/OpenSearch/issues/14931): Original feature request for higher-level plugin context switching APIs
+- [OpenSearch Security Permissions](https://docs.opensearch.org/3.0/security/access-control/permissions/): Security plugin permissions documentation
+- [Installing Plugins](https://docs.opensearch.org/3.0/install-and-configure/plugins/): Plugin security policy documentation
+
+## Change History
+
+- **v3.0.0** (2024-07-31): Initial implementation - Added ThreadContextPermission for markAsSystemContext, stashWithOrigin, and stashAndMergeHeaders methods

--- a/docs/releases/v3.0.0/features/opensearch/thread-context-permissions.md
+++ b/docs/releases/v3.0.0/features/opensearch/thread-context-permissions.md
@@ -1,0 +1,120 @@
+# Thread Context Permissions
+
+## Summary
+
+OpenSearch v3.0.0 introduces `ThreadContextPermission`, a new Java Security Manager permission class that protects sensitive methods in the `ThreadContext` class. This is a **breaking change** for plugins that directly call `markAsSystemContext()`, `stashWithOrigin()`, or `stashAndMergeHeaders()` methods—they must now declare explicit permissions in their `plugin-security.policy` file.
+
+## Details
+
+### What's New in v3.0.0
+
+This release adds permission-based access control to three critical `ThreadContext` methods:
+
+| Method | Permission Required |
+|--------|---------------------|
+| `markAsSystemContext()` | `ThreadContextPermission "markAsSystemContext"` |
+| `stashWithOrigin(String)` | `ThreadContextPermission "stashWithOrigin"` |
+| `stashAndMergeHeaders(Map)` | `ThreadContextPermission "stashAndMergeHeaders"` |
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.0.0"
+        Plugin1[Plugin Code] --> TC1[ThreadContext.markAsSystemContext]
+        Plugin1 --> TC2[ThreadContext.stashWithOrigin]
+    end
+    
+    subgraph "v3.0.0+"
+        Plugin2[Plugin Code] --> SM[Security Manager]
+        SM -->|Check Permission| TCA[ThreadContextAccess]
+        TCA -->|doPrivileged| TC3[ThreadContext Methods]
+        Policy[plugin-security.policy] -.->|Grant| SM
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ThreadContextPermission` | New `BasicPermission` subclass in `org.opensearch.secure_sm` package for guarding ThreadContext methods |
+| `ThreadContextAccess` | Internal helper class providing `doPrivileged()` and `doPrivilegedVoid()` wrappers for core code |
+
+#### Security Policy Changes
+
+The core OpenSearch server now includes these permissions in `security.policy`:
+
+```
+grant codeBase "${codebase.opensearch}" {
+  permission org.opensearch.secure_sm.ThreadContextPermission "markAsSystemContext";
+  permission org.opensearch.secure_sm.ThreadContextPermission "stashWithOrigin";
+};
+```
+
+### Usage Example
+
+Plugins that need to use these methods must:
+
+1. Add permission declarations to `plugin-security.policy`:
+
+```
+grant {
+  permission org.opensearch.secure_sm.ThreadContextPermission "markAsSystemContext";
+  permission org.opensearch.secure_sm.ThreadContextPermission "stashWithOrigin";
+  permission org.opensearch.secure_sm.ThreadContextPermission "stashAndMergeHeaders";
+};
+```
+
+2. Wrap calls using `AccessController.doPrivileged()`:
+
+```java
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+// Before (no longer works without permission)
+threadContext.markAsSystemContext();
+
+// After (with permission granted)
+AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+    threadContext.markAsSystemContext();
+    return null;
+});
+```
+
+### Migration Notes
+
+**For Plugin Developers:**
+
+1. Identify all usages of `markAsSystemContext()`, `stashWithOrigin()`, and `stashAndMergeHeaders()` in your plugin code
+2. Add the required permissions to your `plugin-security.policy` file
+3. Consider whether your plugin truly needs these capabilities—they allow bypassing security context checks
+
+**Why This Change?**
+
+- `markAsSystemContext()` marks the current thread as a system context, bypassing user authentication checks
+- `stashWithOrigin()` sets an action origin that can affect authorization decisions
+- These methods were previously public and accessible to any plugin without explicit permission
+- The new permission model ensures plugins explicitly declare their need for these sensitive operations
+
+## Limitations
+
+- Plugins compiled against older OpenSearch versions will fail at runtime if they call these methods without the required permissions
+- The Security Manager must be enabled for these permissions to be enforced (default in OpenSearch)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#15016](https://github.com/opensearch-project/OpenSearch/pull/15016) | Add ThreadContextPermission for markAsSystemContext |
+| [#15039](https://github.com/opensearch-project/OpenSearch/pull/15039) | Add ThreadContextPermission for stashAndMergeHeaders and stashWithOrigin |
+
+## References
+
+- [Issue #14931](https://github.com/opensearch-project/OpenSearch/issues/14931): Feature request for higher-level APIs for plugins to switch contexts
+- [OpenSearch Security Plugin Documentation](https://docs.opensearch.org/3.0/security/access-control/permissions/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/thread-context-permissions.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -38,6 +38,7 @@
 - [Search Backpressure](features/opensearch/search-backpressure.md)
 - [Segment Warmer](features/opensearch/segment-warmer.md)
 - [Stream Input/Output](features/opensearch/stream-inputoutput.md)
+- [Thread Context Permissions](features/opensearch/thread-context-permissions.md)
 - [Tiered Caching](features/opensearch/tiered-caching.md)
 - [Wildcard Field](features/opensearch/wildcard-field.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Thread Context Permissions feature introduced in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/thread-context-permissions.md`
- Feature report: `docs/features/opensearch/thread-context-permissions.md`

### Key Changes in v3.0.0
- Added `ThreadContextPermission` class to protect sensitive ThreadContext methods
- `markAsSystemContext()`, `stashWithOrigin()`, and `stashAndMergeHeaders()` now require explicit permissions
- Plugins must declare permissions in `plugin-security.policy` to use these methods
- This is a **breaking change** for plugins that directly call these methods

### Related PRs
- opensearch-project/OpenSearch#15016: Add ThreadContextPermission for markAsSystemContext
- opensearch-project/OpenSearch#15039: Add ThreadContextPermission for stashAndMergeHeaders and stashWithOrigin

### Related Issue
- Closes #137