### PR TITLE
docs: add node-roles-configuration report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -28,6 +28,7 @@
 - [Lucene Similarity](opensearch/lucene-similarity.md)
 - [Merge & Segment Settings](opensearch/merge-segment-settings.md)
 - [Nodes Info API](opensearch/nodes-info-api.md)
+- [Node Roles Configuration](opensearch/node-roles-configuration.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)
 - [Search Backpressure](opensearch/search-backpressure.md)
 - [Segment Warmer](opensearch/segment-warmer.md)

--- a/docs/features/opensearch/node-roles-configuration.md
+++ b/docs/features/opensearch/node-roles-configuration.md
@@ -1,0 +1,166 @@
+# Node Roles Configuration
+
+## Summary
+
+OpenSearch nodes can be configured with specific roles to optimize cluster performance and resource utilization. The `node.roles` setting defines what functions a node performs in the cluster. Starting from v3.0.0, list settings like `node.roles` can be properly configured via environment variables using JSON array syntax, enabling easier containerized deployments.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Cluster"
+        CM[Cluster Manager Node<br/>node.roles: cluster_manager]
+        
+        subgraph "Data Tier"
+            D1[Data Node 1<br/>node.roles: data, ingest]
+            D2[Data Node 2<br/>node.roles: data, ingest]
+        end
+        
+        subgraph "Search Tier"
+            S1[Search Node<br/>node.roles: search]
+        end
+        
+        CO[Coordinating Node<br/>node.roles: empty]
+        
+        Client[Client] --> CO
+        CO --> CM
+        CO --> D1
+        CO --> D2
+        CO --> S1
+        CM --> D1
+        CM --> D2
+    end
+```
+
+### Node Role Types
+
+| Role | Abbreviation | Description | Use Case |
+|------|--------------|-------------|----------|
+| `cluster_manager` | `m` | Manages cluster state, index creation/deletion, node tracking | Dedicated management in large clusters |
+| `data` | `d` | Stores data, executes search and aggregation operations | Primary data storage and processing |
+| `ingest` | `i` | Runs ingest pipelines to transform data before indexing | Data preprocessing |
+| `search` | `s` | Hosts search replicas for read-heavy workloads | Separating search from indexing |
+| `remote_cluster_client` | `r` | Connects to remote clusters | Cross-cluster search/replication |
+| `ml` | `l` | Executes machine learning tasks | ML workloads isolation |
+| `coordinating_only` | `-` | Routes requests, aggregates results (set `node.roles: []`) | Load balancing, query coordination |
+
+### Configuration
+
+#### In opensearch.yml
+
+```yaml
+# Dedicated cluster manager node
+node.name: cluster-manager-1
+node.roles: [ cluster_manager ]
+
+# Data and ingest node
+node.name: data-node-1
+node.roles: [ data, ingest ]
+
+# Coordinating-only node (empty array)
+node.name: coordinating-1
+node.roles: []
+
+# Search node for read-heavy workloads
+node.name: search-node-1
+node.roles: [ search ]
+```
+
+#### Via Environment Variables (v3.0.0+)
+
+```bash
+# Coordinating-only node
+docker run -e 'node.roles=[]' opensearchproject/opensearch:3.0.0
+
+# Data node only
+docker run -e 'node.roles=["data"]' opensearchproject/opensearch:3.0.0
+
+# Multiple roles
+docker run -e 'node.roles=["data", "ingest", "remote_cluster_client"]' opensearchproject/opensearch:3.0.0
+```
+
+### Default Behavior
+
+When `node.roles` is not specified, a node assumes all default roles:
+- `cluster_manager`
+- `data`
+- `ingest`
+- `remote_cluster_client`
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Client
+        C[Application]
+    end
+    
+    subgraph Coordinating
+        CO[Coordinating Node]
+    end
+    
+    subgraph Data
+        D1[Data Node 1]
+        D2[Data Node 2]
+    end
+    
+    C -->|Request| CO
+    CO -->|Scatter| D1
+    CO -->|Scatter| D2
+    D1 -->|Partial Result| CO
+    D2 -->|Partial Result| CO
+    CO -->|Gather & Return| C
+```
+
+### Best Practices
+
+| Cluster Size | Recommendation |
+|--------------|----------------|
+| Small (< 10 nodes) | Use default roles on all nodes |
+| Medium (10-50 nodes) | 3 dedicated cluster managers, separate data nodes |
+| Large (50+ nodes) | Dedicated cluster managers, data nodes, coordinating nodes, and optionally search nodes |
+
+### Viewing Node Roles
+
+```bash
+# View all nodes with their roles
+GET _cat/nodes?v&h=name,node.role,node.roles
+
+# Example output
+name              node.role node.roles
+cluster-manager-1 m         cluster_manager
+data-node-1       dir       data,ingest,remote_cluster_client
+coordinating-1    -         -
+```
+
+## Limitations
+
+- Node roles are static and require a node restart to change
+- A cluster must have at least one cluster-manager-eligible node
+- Coordinating-only nodes still consume resources for query coordination
+- The `master` role is deprecated; use `cluster_manager` instead
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#10625](https://github.com/opensearch-project/OpenSearch/pull/10625) | Fix empty array parsing from environment variables |
+| v2.4.0 | [#4689](https://github.com/opensearch-project/OpenSearch/pull/4689) | Add 'search' node role |
+| v2.3.0 | [#3436](https://github.com/opensearch-project/OpenSearch/pull/3436) | Support dynamic node roles |
+| v2.7.0 | [#6331](https://github.com/opensearch-project/OpenSearch/pull/6331) | Fix deprecated master role attachment |
+
+## References
+
+- [Issue #3412](https://github.com/opensearch-project/OpenSearch/issues/3412): Bug report for empty node.roles environment variable
+- [Configuration and System Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/configuration-system/): Official documentation
+- [Creating a Cluster](https://docs.opensearch.org/3.0/tuning-your-cluster/): Cluster architecture guide
+- [CAT Nodes API](https://docs.opensearch.org/3.0/api-reference/cat/cat-nodes/): View node information
+
+## Change History
+
+- **v3.0.0** (2025-02-25): Fixed empty array parsing from environment variables for `node.roles` setting
+- **v2.4.0** (2022-11-15): Added `search` node role for dedicated search workloads
+- **v2.3.0** (2022-09-06): Added support for dynamic/custom node roles defined by plugins
+- **v2.0.0** (2022-05-26): Renamed `master` role to `cluster_manager`

--- a/docs/releases/v3.0.0/features/opensearch/node-roles-configuration.md
+++ b/docs/releases/v3.0.0/features/opensearch/node-roles-configuration.md
@@ -1,0 +1,154 @@
+# Node Roles & Configuration
+
+## Summary
+
+OpenSearch v3.0.0 introduces a breaking change that fixes how list settings (like `node.roles`) are parsed from environment variables. Previously, passing an empty array `[]` via environment variables would fail with an "unknown role" error. This fix enables proper configuration of coordinating-only nodes through environment variables, which is essential for containerized deployments.
+
+## Details
+
+### What's New in v3.0.0
+
+The settings parser now correctly interprets JSON array syntax (`[]`, `["a", "b"]`) when passed through environment variables. This is particularly important for the `node.roles` setting, which requires an empty array to create a dedicated coordinating node.
+
+### Technical Changes
+
+#### Problem Solved
+
+Before this fix, setting `node.roles` via environment variables was problematic:
+
+```bash
+# These would fail before v3.0.0
+docker run -e 'node.roles=[]' opensearchproject/opensearch:2.x
+# Error: unknown role [[]]
+
+docker run -e 'node.roles=' opensearchproject/opensearch:2.x
+# Would assign all default roles instead of empty
+```
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Settings Parsing Flow"
+        A[Environment Variable] --> B[Property Placeholder Resolver]
+        B --> C{Is JSON Array?}
+        C -->|Yes| D[Parse as List]
+        C -->|No| E[Use as String]
+        D --> F[Settings Object]
+        E --> F
+    end
+    
+    subgraph "Node Role Assignment"
+        F --> G{node.roles value}
+        G -->|Empty List| H[Coordinating Only]
+        G -->|Has Roles| I[Assigned Roles]
+        G -->|Not Set| J[Default Roles]
+    end
+```
+
+#### Code Changes
+
+The fix modifies `Settings.java` to parse placeholder values as JSON arrays:
+
+```java
+// New method in Settings.Builder
+private static Optional<List<String>> tryParseableStringToList(String parsableString) {
+    try (XContentParser xContentParser = MediaTypeRegistry.JSON.xContent()
+            .createParser(NamedXContentRegistry.EMPTY, 
+                         DeprecationHandler.THROW_UNSUPPORTED_OPERATION, 
+                         parsableString)) {
+        XContentParser.Token token = xContentParser.nextToken();
+        if (token != XContentParser.Token.START_ARRAY) {
+            return Optional.empty();
+        }
+        ArrayList<String> list = new ArrayList<>();
+        while ((token = xContentParser.nextToken()) != XContentParser.Token.END_ARRAY) {
+            if (token != XContentParser.Token.VALUE_STRING) {
+                return Optional.empty();
+            }
+            list.add(xContentParser.text());
+        }
+        return Optional.of(list);
+    } catch (IOException e) {
+        return Optional.empty();
+    }
+}
+```
+
+#### New Configuration Options
+
+| Setting | Environment Variable | Example | Result |
+|---------|---------------------|---------|--------|
+| `node.roles: []` | `node.roles=[]` | Coordinating only | No data, ingest, or cluster_manager roles |
+| `node.roles: ["data"]` | `node.roles=["data"]` | Data node only | Only data role assigned |
+| `node.roles: ["data", "ingest"]` | `node.roles=["data", "ingest"]` | Data + Ingest | Both roles assigned |
+
+### Available Node Roles
+
+| Role | Description |
+|------|-------------|
+| `cluster_manager` | Manages cluster state, creates/deletes indexes, tracks nodes |
+| `data` | Stores and searches data, performs indexing and aggregations |
+| `ingest` | Pre-processes data before storing using ingest pipelines |
+| `search` | Dedicated to search operations (introduced in v2.4.0) |
+| `remote_cluster_client` | Connects to remote clusters for cross-cluster operations |
+| `ml` | Runs machine learning tasks |
+| `coordinating_only` | Set `node.roles: []` - routes requests, aggregates results |
+
+### Usage Example
+
+```yaml
+# opensearch.yml - Coordinating node
+node.name: coordinating-node-1
+node.roles: []
+
+# Or via environment variable
+# docker run -e 'node.roles=[]' opensearchproject/opensearch:3.0.0
+```
+
+```yaml
+# opensearch.yml - Dedicated data node
+node.name: data-node-1
+node.roles: [ data ]
+
+# Or via environment variable
+# docker run -e 'node.roles=["data"]' opensearchproject/opensearch:3.0.0
+```
+
+### Migration Notes
+
+**For Docker/Kubernetes Deployments:**
+
+You can now properly configure coordinating-only nodes using environment variables:
+
+```bash
+# Before v3.0.0 - Required opensearch.yml modification
+# v3.0.0+ - Works with environment variables
+docker run -e 'node.roles=[]' opensearchproject/opensearch:3.0.0
+```
+
+**Breaking Change Notice:**
+
+This is marked as a breaking change because the behavior of parsing `[]` from environment variables has changed. Previously it would fail; now it correctly creates an empty list.
+
+## Limitations
+
+- The JSON array syntax must be valid JSON (e.g., `["a", "b"]` not `[a, b]`)
+- Whitespace within the array is handled, but the outer brackets are required
+- This fix applies to all list settings, not just `node.roles`
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10625](https://github.com/opensearch-project/OpenSearch/pull/10625) | Treat Setting value with empty array string as empty array |
+
+## References
+
+- [Issue #3412](https://github.com/opensearch-project/OpenSearch/issues/3412): Bug report for empty node.roles environment variable
+- [Configuration and System Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/configuration-system/): Official documentation
+- [Creating a Cluster](https://docs.opensearch.org/3.0/tuning-your-cluster/): Node roles and cluster configuration guide
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/node-roles-configuration.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -33,6 +33,7 @@
 - [Lucene Similarity](features/opensearch/lucene-similarity.md)
 - [Merge & Segment Settings](features/opensearch/merge-segment-settings.md)
 - [Node Roles & Configuration](features/opensearch/node-roles-and-configuration.md)
+- [Node Roles Configuration (Environment Variables)](features/opensearch/node-roles-configuration.md)
 - [Nodes Info API Changes](features/opensearch/nodes-info-api-changes.md)
 - [Refresh Task Scheduling](features/opensearch/refresh-task-scheduling.md)
 - [Search Backpressure](features/opensearch/search-backpressure.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Node Roles & Configuration feature in OpenSearch v3.0.0.

### Key Changes in v3.0.0

- **Fixed empty array parsing from environment variables**: The `node.roles` setting can now be properly configured via environment variables using JSON array syntax (`[]`, `["data"]`, etc.)
- This enables proper configuration of coordinating-only nodes in containerized deployments

### Reports Created

- Release report: `docs/releases/v3.0.0/features/opensearch/node-roles-configuration.md`
- Feature report: `docs/features/opensearch/node-roles-configuration.md`

### Resources Used

- PR: [#10625](https://github.com/opensearch-project/OpenSearch/pull/10625) - Treat Setting value with empty array string as empty array
- Issue: [#3412](https://github.com/opensearch-project/OpenSearch/issues/3412) - Bug report for empty node.roles environment variable
- Docs: [Configuration and System Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/configuration-system/)
- Docs: [Creating a Cluster](https://docs.opensearch.org/3.0/tuning-your-cluster/)

Closes #128