### PR TITLE
docs: update java-runtime-jpms report for v3.0.0

### DIFF
--- a/docs/features/opensearch/java-runtime-and-jpms.md
+++ b/docs/features/opensearch/java-runtime-and-jpms.md
@@ -133,6 +133,9 @@ JDK 21 provides stable `MemorySegment` API for memory-mapped files:
 | v3.0.0 | [#17117](https://github.com/opensearch-project/OpenSearch/pull/17117) | Refactor bootstrap package |
 | v3.0.0 | [#17241](https://github.com/opensearch-project/OpenSearch/pull/17241) | Refactor Lucene packages |
 | v3.0.0 | [#17272](https://github.com/opensearch-project/OpenSearch/pull/17272) | Refactor client package |
+| v3.0.0 | [#16366](https://github.com/opensearch-project/OpenSearch/pull/16366) | Update to Apache Lucene 10 (requires JDK 21) |
+| v3.0.0 | [#16429](https://github.com/opensearch-project/OpenSearch/pull/16429) | Update JDK to 23.0.1 |
+| v3.0.0 | [#17900](https://github.com/opensearch-project/OpenSearch/pull/17900) | Custom Gradle plugin for Java agent (SecurityManager replacement) |
 | v2.4.0 | [#5151](https://github.com/opensearch-project/OpenSearch/pull/5151) | Enable JDK 19 preview APIs for mmap |
 
 ## References

--- a/docs/releases/v3.0.0/features/opensearch/java-runtime-and-jpms.md
+++ b/docs/releases/v3.0.0/features/opensearch/java-runtime-and-jpms.md
@@ -117,6 +117,9 @@ OpenSearch 3.0.0 can leverage JDK 21's `MemorySegment` API for memory-mapped fil
 | [#17117](https://github.com/opensearch-project/OpenSearch/pull/17117) | Refactor `:libs` module `bootstrap` package |
 | [#17241](https://github.com/opensearch-project/OpenSearch/pull/17241) | Refactor `org.apache.lucene` codebase |
 | [#17272](https://github.com/opensearch-project/OpenSearch/pull/17272) | Refactor `org.opensearch.client` from `:server` module |
+| [#16366](https://github.com/opensearch-project/OpenSearch/pull/16366) | Update to Apache Lucene 10 for 3.0.0 (requires JDK 21) |
+| [#16429](https://github.com/opensearch-project/OpenSearch/pull/16429) | Update JDK to 23.0.1 |
+| [#17900](https://github.com/opensearch-project/OpenSearch/pull/17900) | Custom Gradle plugin to leverage Java agent (SecurityManager replacement) |
 | [#5151](https://github.com/opensearch-project/OpenSearch/pull/5151) | Allow mmap to use JDK-19 preview APIs in Lucene 9.4+ |
 
 ## References


### PR DESCRIPTION
## Summary

Updated the Java Runtime & JPMS report for v3.0.0 with additional PRs discovered during investigation.

### Changes
- Added PR #16366 (Lucene 10 update requiring JDK 21)
- Added PR #16429 (JDK 23.0.1 update)
- Added PR #17900 (Java agent Gradle plugin for SecurityManager replacement)

### Reports Updated
- `docs/releases/v3.0.0/features/opensearch/java-runtime-and-jpms.md`
- `docs/features/opensearch/java-runtime-and-jpms.md`

Closes #124