### PR TITLE
docs: add dependency bumps report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -96,6 +96,7 @@
 
 - [CI/CD & Testing Infrastructure](multi-plugin/ci-cd-testing-infrastructure.md)
 - [CVE Fixes & Dependency Updates](multi-plugin/cve-fixes-dependency-updates.md)
+- [Dependency Bumps](multi-plugin/dependency-bumps.md)
 - [JDK 21 & Java Agent Migration](multi-plugin/jdk-21-java-agent-migration.md)
 - [Version Bumps & Release Notes](multi-plugin/version-bumps-release-notes.md)
 

--- a/docs/features/multi-plugin/dependency-bumps.md
+++ b/docs/features/multi-plugin/dependency-bumps.md
@@ -1,0 +1,99 @@
+# Dependency Bumps
+
+## Summary
+
+Dependency bumps are routine maintenance updates performed across OpenSearch repositories to keep third-party libraries current, address security vulnerabilities, and maintain compatibility with the latest tooling. These updates are typically automated via Dependabot and reviewed by maintainers.
+
+## Details
+
+### Dependency Update Workflow
+
+```mermaid
+flowchart TB
+    A[Dependabot Scan] --> B{Security Issue?}
+    B -->|Yes| C[Priority Update]
+    B -->|No| D[Scheduled Update]
+    C --> E[PR Created]
+    D --> E
+    E --> F[CI Tests]
+    F --> G{Tests Pass?}
+    G -->|Yes| H[Review & Merge]
+    G -->|No| I[Fix Compatibility]
+    I --> F
+```
+
+### Common Dependency Categories
+
+| Category | Examples | Purpose |
+|----------|----------|---------|
+| Build Tools | Gradle, Maven plugins | Build automation |
+| Testing | JUnit, Mockito | Test frameworks |
+| Logging | SLF4J, Log4j | Logging infrastructure |
+| Security | Cryptacular, Passay | Security utilities |
+| Utilities | Commons CLI, Guava | General utilities |
+| Frameworks | Spring | Application framework |
+
+### Dependabot Configuration
+
+Most OpenSearch repositories use Dependabot with configuration in `.github/dependabot.yml`:
+
+```yaml
+version: 2
+updates:
+  - package-ecosystem: "gradle"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+```
+
+### Security-Related Updates
+
+Security-related dependency updates are prioritized and may include:
+- CVE fixes in transitive dependencies
+- Cryptographic library updates
+- Authentication/authorization library patches
+
+## Limitations
+
+- Dependency updates may introduce breaking changes requiring code modifications
+- Some updates may be blocked by compatibility requirements with OpenSearch core
+- Transitive dependency conflicts may require manual resolution
+
+## Related PRs
+
+### v2.17.0
+
+#### Job Scheduler
+| PR | Description |
+|----|-------------|
+| [#653](https://github.com/opensearch-project/job-scheduler/pull/653) | Bump org.gradle.test-retry from 1.5.9 to 1.5.10 |
+| [#663](https://github.com/opensearch-project/job-scheduler/pull/663) | Bump google-java-format |
+| [#666](https://github.com/opensearch-project/job-scheduler/pull/666) | Bump slf4j-api from 2.0.13 to 2.0.16 |
+| [#668](https://github.com/opensearch-project/job-scheduler/pull/668) | Bump nebula.ospackage from 11.9.1 to 11.10.0 |
+
+#### Security
+| PR | Description |
+|----|-------------|
+| [#4696](https://github.com/opensearch-project/security/pull/4696) | Bump error_prone_annotations from 2.30.0 to 2.31.0 |
+| [#4682](https://github.com/opensearch-project/security/pull/4682) | Bump passay from 1.6.4 to 1.6.5 |
+| [#4661](https://github.com/opensearch-project/security/pull/4661) | Bump spring_version from 5.3.37 to 5.3.39 |
+| [#4659](https://github.com/opensearch-project/security/pull/4659) | Bump commons-cli from 1.8.0 to 1.9.0 |
+| [#4657](https://github.com/opensearch-project/security/pull/4657) | Bump junit-jupiter from 5.10.3 to 5.11.0 |
+| [#4656](https://github.com/opensearch-project/security/pull/4656) | Bump cryptacular from 1.2.6 to 1.2.7 |
+| [#4646](https://github.com/opensearch-project/security/pull/4646) | Update Gradle to 8.10 |
+| [#4639](https://github.com/opensearch-project/security/pull/4639) | Bump snappy-java from 1.1.10.5 to 1.1.10.6 |
+| [#4622](https://github.com/opensearch-project/security/pull/4622) | Bump google-java-format from 1.22.0 to 1.23.0 |
+| [#4660](https://github.com/opensearch-project/security/pull/4660) | Bump metrics-core from 4.2.26 to 4.2.27 |
+| [#4681](https://github.com/opensearch-project/security/pull/4681) | Bump nebula.ospackage from 11.9.1 to 11.10.0 |
+| [#4623](https://github.com/opensearch-project/security/pull/4623) | Bump checker-qual from 3.45.0 to 3.46.0 |
+
+## References
+
+- [Dependabot Documentation](https://docs.github.com/en/code-security/dependabot)
+- [Job Scheduler Repository](https://github.com/opensearch-project/job-scheduler)
+- [Security Plugin Repository](https://github.com/opensearch-project/security)
+
+## Change History
+
+- **v2.17.0** (2024-09-17): 16 dependency updates across Job Scheduler (4 PRs) and Security (12 PRs) plugins

--- a/docs/releases/v2.17.0/features/job-scheduler/dependency-bumps.md
+++ b/docs/releases/v2.17.0/features/job-scheduler/dependency-bumps.md
@@ -1,0 +1,58 @@
+# Dependency Bumps (Job Scheduler)
+
+## Summary
+
+Routine dependency updates for the Job Scheduler plugin in v2.17.0, including updates to Gradle plugins, logging libraries, and build tools to maintain security and compatibility.
+
+## Details
+
+### What's New in v2.17.0
+
+The Job Scheduler plugin received 4 dependency updates via Dependabot:
+
+| Dependency | From | To | Type |
+|------------|------|-----|------|
+| org.gradle.test-retry | 1.5.9 | 1.5.10 | Gradle Plugin |
+| com.google.googlejavaformat:google-java-format | - | Latest | Code Formatting |
+| org.slf4j:slf4j-api | 2.0.13 | 2.0.16 | Logging |
+| com.netflix.nebula.ospackage | 11.9.1 | 11.10.0 | Packaging |
+
+### Technical Changes
+
+#### Gradle Test Retry Plugin (1.5.9 → 1.5.10)
+- Minor bug fixes and improvements for test retry functionality
+- Enhances CI reliability by retrying flaky tests
+
+#### SLF4J API (2.0.13 → 2.0.16)
+- Logging framework update with bug fixes
+- Maintains compatibility with existing logging configuration
+
+#### Nebula OS Package (11.9.1 → 11.10.0)
+- Gradle plugin for building OS packages (RPM, DEB)
+- Improvements to package generation
+
+#### Google Java Format
+- Code formatting tool update
+- Ensures consistent code style across the codebase
+
+## Limitations
+
+- These are maintenance updates with no functional changes
+- No migration required
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#653](https://github.com/opensearch-project/job-scheduler/pull/653) | Bump org.gradle.test-retry from 1.5.9 to 1.5.10 |
+| [#663](https://github.com/opensearch-project/job-scheduler/pull/663) | Bump com.google.googlejavaformat:google-java-format |
+| [#666](https://github.com/opensearch-project/job-scheduler/pull/666) | Bump org.slf4j:slf4j-api from 2.0.13 to 2.0.16 |
+| [#668](https://github.com/opensearch-project/job-scheduler/pull/668) | Bump com.netflix.nebula.ospackage from 11.9.1 to 11.10.0 |
+
+## References
+
+- [Job Scheduler Repository](https://github.com/opensearch-project/job-scheduler)
+
+## Related Feature Report
+
+- [Dependency Management](../../../../features/multi-plugin/dependency-bumps.md)

--- a/docs/releases/v2.17.0/features/security/dependency-bumps.md
+++ b/docs/releases/v2.17.0/features/security/dependency-bumps.md
@@ -1,0 +1,77 @@
+# Dependency Bumps (Security)
+
+## Summary
+
+Routine dependency updates for the Security plugin in v2.17.0, including updates to testing frameworks, security libraries, build tools, and Gradle to maintain security and compatibility.
+
+## Details
+
+### What's New in v2.17.0
+
+The Security plugin received 12 dependency updates:
+
+| Dependency | From | To | Category |
+|------------|------|-----|----------|
+| com.google.errorprone:error_prone_annotations | 2.30.0 | 2.31.0 | Static Analysis |
+| org.passay:passay | 1.6.4 | 1.6.5 | Password Validation |
+| spring_version | 5.3.37 | 5.3.39 | Framework |
+| commons-cli:commons-cli | 1.8.0 | 1.9.0 | CLI Parsing |
+| org.junit.jupiter:junit-jupiter | 5.10.3 | 5.11.0 | Testing |
+| org.cryptacular:cryptacular | 1.2.6 | 1.2.7 | Cryptography |
+| Gradle | - | 8.10 | Build Tool |
+| org.xerial.snappy:snappy-java | 1.1.10.5 | 1.1.10.6 | Compression |
+| com.google.googlejavaformat:google-java-format | 1.22.0 | 1.23.0 | Code Formatting |
+| io.dropwizard.metrics:metrics-core | 4.2.26 | 4.2.27 | Metrics |
+| com.netflix.nebula.ospackage | 11.9.1 | 11.10.0 | Packaging |
+| org.checkerframework:checker-qual | 3.45.0 | 3.46.0 | Static Analysis |
+
+### Technical Changes
+
+#### Security-Related Updates
+
+- **Passay (1.6.4 → 1.6.5)**: Password validation library with bug fixes
+- **Cryptacular (1.2.6 → 1.2.7)**: Cryptographic utilities library update
+- **Spring Framework (5.3.37 → 5.3.39)**: Security and bug fixes for the Spring framework
+
+#### Build & Testing Updates
+
+- **Gradle 8.10**: Major build tool update with performance improvements
+- **JUnit Jupiter (5.10.3 → 5.11.0)**: Testing framework update with new features
+- **Error Prone Annotations (2.30.0 → 2.31.0)**: Static analysis improvements
+- **Checker Framework (3.45.0 → 3.46.0)**: Type checking annotations update
+
+#### Utility Updates
+
+- **Commons CLI (1.8.0 → 1.9.0)**: Command-line parsing library
+- **Snappy Java (1.1.10.5 → 1.1.10.6)**: Compression library bug fixes
+- **Metrics Core (4.2.26 → 4.2.27)**: Metrics collection library
+
+## Limitations
+
+- These are maintenance updates with no functional changes
+- No migration required
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4696](https://github.com/opensearch-project/security/pull/4696) | Bump error_prone_annotations from 2.30.0 to 2.31.0 |
+| [#4682](https://github.com/opensearch-project/security/pull/4682) | Bump passay from 1.6.4 to 1.6.5 |
+| [#4661](https://github.com/opensearch-project/security/pull/4661) | Bump spring_version from 5.3.37 to 5.3.39 |
+| [#4659](https://github.com/opensearch-project/security/pull/4659) | Bump commons-cli from 1.8.0 to 1.9.0 |
+| [#4657](https://github.com/opensearch-project/security/pull/4657) | Bump junit-jupiter from 5.10.3 to 5.11.0 |
+| [#4656](https://github.com/opensearch-project/security/pull/4656) | Bump cryptacular from 1.2.6 to 1.2.7 |
+| [#4646](https://github.com/opensearch-project/security/pull/4646) | Update Gradle to 8.10 |
+| [#4639](https://github.com/opensearch-project/security/pull/4639) | Bump snappy-java from 1.1.10.5 to 1.1.10.6 |
+| [#4622](https://github.com/opensearch-project/security/pull/4622) | Bump google-java-format from 1.22.0 to 1.23.0 |
+| [#4660](https://github.com/opensearch-project/security/pull/4660) | Bump metrics-core from 4.2.26 to 4.2.27 |
+| [#4681](https://github.com/opensearch-project/security/pull/4681) | Bump nebula.ospackage from 11.9.1 to 11.10.0 |
+| [#4623](https://github.com/opensearch-project/security/pull/4623) | Bump checker-qual from 3.45.0 to 3.46.0 |
+
+## References
+
+- [Security Plugin Repository](https://github.com/opensearch-project/security)
+
+## Related Feature Report
+
+- [Dependency Management](../../../../features/multi-plugin/dependency-bumps.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -4,7 +4,11 @@
 
 ## Feature Reports
 
-*No individual feature reports have been created yet. Run the investigate agent to generate detailed reports for specific features.*
+### job-scheduler
+- [Dependency Bumps](features/job-scheduler/dependency-bumps.md)
+
+### security
+- [Dependency Bumps](features/security/dependency-bumps.md)
 
 ## Key Features in This Release
 


### PR DESCRIPTION
## Summary

Add release and feature reports for dependency bumps in OpenSearch v2.17.0.

## Reports Created

### Release Reports
- `docs/releases/v2.17.0/features/job-scheduler/dependency-bumps.md` - 4 dependency updates
- `docs/releases/v2.17.0/features/security/dependency-bumps.md` - 12 dependency updates

### Feature Report
- `docs/features/multi-plugin/dependency-bumps.md` - Comprehensive dependency management documentation

## Key Changes in v2.17.0

### Job Scheduler (4 PRs)
- Gradle test-retry plugin update
- Google Java Format update
- SLF4J API update
- Nebula OS Package update

### Security (12 PRs)
- Gradle 8.10 update
- Spring Framework 5.3.39
- JUnit Jupiter 5.11.0
- Various security and utility library updates

## Related Issue

Closes #444