### PR TITLE
docs: add CI/Infrastructure Fixes report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -95,6 +95,7 @@
 ## multi-plugin
 
 - [CI/CD & Testing Infrastructure](multi-plugin/ci-cd-testing-infrastructure.md)
+- [CI/Infrastructure Fixes](multi-plugin/ci-infrastructure-fixes.md)
 - [CVE Fixes & Dependency Updates](multi-plugin/cve-fixes-dependency-updates.md)
 - [Dependency Bumps](multi-plugin/dependency-bumps.md)
 - [JDK 21 & Java Agent Migration](multi-plugin/jdk-21-java-agent-migration.md)

--- a/docs/features/multi-plugin/ci-infrastructure-fixes.md
+++ b/docs/features/multi-plugin/ci-infrastructure-fixes.md
@@ -1,0 +1,92 @@
+# CI/Infrastructure Fixes
+
+## Summary
+
+CI/Infrastructure fixes are maintenance changes to GitHub Actions workflows and CI configurations across OpenSearch plugin repositories. These fixes ensure continuous integration pipelines remain functional as GitHub deprecates older action versions and as plugin dependencies evolve.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "GitHub Actions CI"
+        PR[Pull Request] --> Workflow[CI Workflow]
+        Workflow --> Build[Build Job]
+        Workflow --> Test[Test Job]
+        Build --> Artifact[Upload Artifact]
+        Test --> Report[Test Report]
+    end
+    
+    subgraph "Dependencies"
+        JobScheduler[Job Scheduler Plugin]
+        SQL[SQL Plugin]
+        Observability[Observability Plugin]
+        SQL --> JobScheduler
+        Observability --> SQL
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| GitHub Actions Workflows | CI/CD pipeline definitions in `.github/workflows/` |
+| actions/upload-artifact | GitHub Action for uploading build artifacts |
+| Job Scheduler Plugin | Dependency for SQL and Observability plugins |
+| Link Checker | Validates documentation links |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` | Allows older Node.js versions for GLIBC compatibility | `false` |
+| `actions/upload-artifact` version | GitHub Action version for artifact uploads | v4 (current) |
+
+### Common Issues Addressed
+
+1. **Deprecated GitHub Actions**: GitHub periodically deprecates older versions of actions
+2. **GLIBC Compatibility**: Docker containers may have older GLIBC versions incompatible with newer Node.js
+3. **Plugin Dependencies**: Changes in plugin dependency chains require CI workflow updates
+4. **Link Validation**: Documentation link checkers need exclusion patterns for localhost URLs
+
+### Usage Example
+
+```yaml
+# Example: Setting environment variable for GLIBC compatibility
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-artifact
+          path: ./build/
+```
+
+## Limitations
+
+- Infrastructure changes require coordination across multiple repositories
+- Temporary workarounds (like `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION`) may need future updates
+- Plugin dependency changes can cascade to multiple downstream repositories
+
+## Related PRs
+
+| Version | PR | Repository | Description |
+|---------|-----|------------|-------------|
+| v2.17.0 | [#703](https://github.com/opensearch-project/common-utils/pull/703) | common-utils | GLIBC compatibility fix |
+| v2.17.0 | [#2046](https://github.com/opensearch-project/dashboards-observability/pull/2046) | dashboards-observability | Job Scheduler dependency, link checker fix |
+| v2.17.0 | [#2133](https://github.com/opensearch-project/dashboards-observability/pull/2133) | dashboards-observability | upload-artifact v1 to v4 |
+
+## References
+
+- [GitHub Actions upload-artifact deprecation notice](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)
+- [Issue #1886](https://github.com/opensearch-project/dashboards-observability/issues/1886): Observability CI failures
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Fixed CI workflows across common-utils and dashboards-observability repositories

--- a/docs/releases/v2.17.0/features/multi-plugin/ci-infrastructure-fixes.md
+++ b/docs/releases/v2.17.0/features/multi-plugin/ci-infrastructure-fixes.md
@@ -1,0 +1,83 @@
+# CI/Infrastructure Fixes
+
+## Summary
+
+This release item addresses multiple CI/CD infrastructure issues across OpenSearch plugin repositories. The fixes ensure CI workflows continue to function correctly by addressing deprecated GitHub Actions, GLIBC compatibility issues, and missing plugin dependencies.
+
+## Details
+
+### What's New in v2.17.0
+
+Multiple CI workflow fixes were implemented across different plugin repositories to maintain build stability and test reliability.
+
+### Technical Changes
+
+#### GitHub Actions Updates
+
+| Repository | Change | Reason |
+|------------|--------|--------|
+| dashboards-observability | `actions/upload-artifact` v1 → v4 | v1/v2 deprecated by GitHub |
+| common-utils | Added `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` | GLIBC compatibility in Linux containers |
+
+#### CI Workflow Improvements
+
+| Repository | Change | Impact |
+|------------|--------|--------|
+| dashboards-observability | Added Job Scheduler plugin dependency | SQL plugin dependency chain |
+| dashboards-observability | Removed datasources tests | Test suite cleanup |
+| dashboards-observability | Updated link checker exclusions | Exclude localhost links |
+
+### Changes by Repository
+
+#### common-utils
+
+Fixed CI build failures in Linux environments caused by Node.js version incompatibility with older GLIBC versions in Docker containers.
+
+```yaml
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+```
+
+**Issue**: Build failures with error:
+```
+/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found
+/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found
+```
+
+#### dashboards-observability
+
+1. **Upload Artifact Update**: Updated `actions/upload-artifact` from v1 to v4 across multiple workflow files:
+   - `dashboards-observability-test-and-build-workflow.yml`
+   - `ftr-e2e-dashboards-observability-test.yml`
+   - `integration-tests-workflow.yml`
+
+2. **Job Scheduler Dependency**: Added Job Scheduler plugin installation to CI workflows due to SQL plugin adding it as a dependency.
+
+3. **Link Checker Fix**: Updated link checker to exclude localhost URLs:
+   ```yaml
+   args: --accept=200,403,429 "./**/*.html" "./**/*.md" "./**/*.txt" --exclude "http://localhost" --exclude "https://localhost"
+   ```
+
+4. **Test Suite Cleanup**: Removed `datasources_test` from integration test matrix.
+
+## Limitations
+
+- These are infrastructure-only changes with no user-facing impact
+- The `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` flag is a temporary workaround
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#703](https://github.com/opensearch-project/common-utils/pull/703) | common-utils | Fixed CI build failures due to GLIBC version issues |
+| [#2046](https://github.com/opensearch-project/dashboards-observability/pull/2046) | dashboards-observability | Fixed CI workflow checks, added Job Scheduler dependency |
+| [#2133](https://github.com/opensearch-project/dashboards-observability/pull/2133) | dashboards-observability | Updated actions/upload-artifact from v1 to v4 |
+
+## References
+
+- [GitHub Actions upload-artifact deprecation notice](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/)
+- [Issue #1886](https://github.com/opensearch-project/dashboards-observability/issues/1886): Observability CI failures
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/multi-plugin/ci-infrastructure-fixes.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -10,6 +10,9 @@
 ### security
 - [Dependency Bumps](features/security/dependency-bumps.md)
 
+### multi-plugin
+- [CI/Infrastructure Fixes](features/multi-plugin/ci-infrastructure-fixes.md)
+
 ## Key Features in This Release
 
 ### Generally Available


### PR DESCRIPTION
## Summary

This PR adds documentation for CI/Infrastructure Fixes in OpenSearch v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/multi-plugin/ci-infrastructure-fixes.md`
- Feature report: `docs/features/multi-plugin/ci-infrastructure-fixes.md`

### Key Changes in v2.17.0
- **common-utils #703**: Fixed CI build failures due to GLIBC version issues by setting `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true`
- **dashboards-observability #2046**: Fixed CI workflow by adding Job Scheduler dependency, removing datasources tests, updating link checker
- **dashboards-observability #2133**: Updated `actions/upload-artifact` from v1 to v4 due to deprecation

### Resources Used
- PR: [common-utils#703](https://github.com/opensearch-project/common-utils/pull/703)
- PR: [dashboards-observability#2046](https://github.com/opensearch-project/dashboards-observability/pull/2046)
- PR: [dashboards-observability#2133](https://github.com/opensearch-project/dashboards-observability/pull/2133)

Closes #443