### PR TITLE
docs: add maintainer-updates report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -99,6 +99,7 @@
 - [CVE Fixes & Dependency Updates](multi-plugin/cve-fixes-dependency-updates.md)
 - [Dependency Bumps](multi-plugin/dependency-bumps.md)
 - [JDK 21 & Java Agent Migration](multi-plugin/jdk-21-java-agent-migration.md)
+- [Maintainer Updates](multi-plugin/maintainer-updates.md)
 - [Version Bumps & Release Notes](multi-plugin/version-bumps-release-notes.md)
 
 ## opensearch-remote-metadata-sdk

--- a/docs/features/multi-plugin/maintainer-updates.md
+++ b/docs/features/multi-plugin/maintainer-updates.md
@@ -1,0 +1,67 @@
+# Maintainer Updates
+
+## Summary
+
+OpenSearch project governance includes maintaining accurate MAINTAINERS.md files across all repositories. These files document active maintainers responsible for code review, release management, and project direction. Periodic updates add new maintainers and transition inactive contributors to emeritus status.
+
+## Details
+
+### Governance Structure
+
+```mermaid
+graph TB
+    subgraph "Maintainer Lifecycle"
+        Contributor[Contributor]
+        Maintainer[Active Maintainer]
+        Emeritus[Emeritus Maintainer]
+    end
+    
+    subgraph "Responsibilities"
+        Review[Code Review]
+        Release[Release Management]
+        Direction[Project Direction]
+    end
+    
+    Contributor -->|Nomination| Maintainer
+    Maintainer -->|Inactivity| Emeritus
+    Emeritus -->|Re-engagement| Maintainer
+    
+    Maintainer --> Review
+    Maintainer --> Release
+    Maintainer --> Direction
+```
+
+### Maintainer Status Types
+
+| Status | Description |
+|--------|-------------|
+| Active | Current maintainers with commit access and review responsibilities |
+| Emeritus | Former maintainers who are no longer actively contributing |
+
+### MAINTAINERS.md Structure
+
+Each OpenSearch repository contains a MAINTAINERS.md file with:
+- List of active maintainers with GitHub handles and affiliations
+- Emeritus section for former maintainers
+- Alphabetical ordering for consistency
+
+## Limitations
+
+- Maintainer updates are administrative and do not affect software functionality
+- Changes require consensus from existing maintainers
+
+## Related PRs
+
+| Version | PR | Repository | Description |
+|---------|-----|------------|-------------|
+| v2.17.0 | [#4673](https://github.com/opensearch-project/security/pull/4673) | security | Add Nils Bandener as maintainer |
+| v2.17.0 | [#1233](https://github.com/opensearch-project/index-management/pull/1233) | index-management | Move inactive maintainers to emeritus |
+
+## References
+
+- [OpenSearch Project Governance](https://github.com/opensearch-project/.github/blob/main/GOVERNANCE.md)
+- [Issue #1230](https://github.com/opensearch-project/index-management/issues/1230): Index Management maintainer update request
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Added maintainers (nibix to security, sumukhswamy to dashboards, riysaxen to notifications); moved inactive index-management maintainers to emeritus

--- a/docs/releases/v2.17.0/features/multi-plugin/maintainer-updates.md
+++ b/docs/releases/v2.17.0/features/multi-plugin/maintainer-updates.md
@@ -1,0 +1,55 @@
+# Maintainer Updates
+
+## Summary
+
+Administrative updates to MAINTAINERS.md files across multiple OpenSearch repositories in v2.17.0. These changes include adding new maintainers and transitioning inactive maintainers to emeritus status.
+
+## Details
+
+### What's New in v2.17.0
+
+This release includes governance updates across four repositories:
+
+| Repository | Change Type | Description |
+|------------|-------------|-------------|
+| security | Addition | Added Nils Bandener (nibix) as maintainer |
+| index-management | Transition | Moved inactive maintainers to emeritus status |
+| dashboards | Addition | Added sumukhswamy as maintainer |
+| notifications | Addition | Added riysaxen as maintainer |
+
+### Maintainer Changes by Repository
+
+#### Security Plugin
+- **New Maintainer**: Nils Bandener (GitHub: [nibix](https://github.com/nibix))
+- Backported to 2.x branch
+
+#### Index Management Plugin
+- **Emeritus Transition**: Non-active maintainers moved to emeritus status
+- Maintainer list sorted alphabetically
+- Related Issue: [#1230](https://github.com/opensearch-project/index-management/issues/1230)
+
+#### OpenSearch Dashboards
+- **New Maintainer**: sumukhswamy
+
+#### Notifications Plugin
+- **New Maintainer**: riysaxen
+
+## Limitations
+
+- These are administrative changes only; no functional impact on the software
+- Some PR references in the original tracking may have incorrect numbers
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#4673](https://github.com/opensearch-project/security/pull/4673) | security | Add Nils Bandener as maintainer (backport 2.x) |
+| [#1233](https://github.com/opensearch-project/index-management/pull/1233) | index-management | Move non-active maintainers to emeritus |
+
+## References
+
+- [Issue #1230](https://github.com/opensearch-project/index-management/issues/1230): Index Management maintainer update request
+
+## Related Feature Report
+
+- [Maintainer Updates](../../../features/multi-plugin/maintainer-updates.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -12,6 +12,7 @@
 
 ### multi-plugin
 - [CI/Infrastructure Fixes](features/multi-plugin/ci-infrastructure-fixes.md)
+- [Maintainer Updates](features/multi-plugin/maintainer-updates.md)
 
 ## Key Features in This Release
 


### PR DESCRIPTION
## Summary\n\nAdds documentation for maintainer updates in OpenSearch v2.17.0.\n\n### Reports Created\n- Release report: `docs/releases/v2.17.0/features/multi-plugin/maintainer-updates.md`\n- Feature report: `docs/features/multi-plugin/maintainer-updates.md`\n\n### Key Changes Documented\n- Added Nils Bandener (nibix) as maintainer to security plugin\n- Moved inactive maintainers to emeritus in index-management\n- Added sumukhswamy as maintainer to dashboards\n- Added riysaxen as maintainer to notifications\n\nCloses #442