### PR TITLE
docs: add documentation-updates report for v2.17.0

### DIFF
--- a/docs/features/dashboards-search-relevance/documentation-maintenance.md
+++ b/docs/features/dashboards-search-relevance/documentation-maintenance.md
@@ -1,0 +1,48 @@
+# Documentation Maintenance
+
+## Summary
+
+The dashboards-search-relevance plugin maintains documentation files including CONTRIBUTING.md and DEVELOPER_GUIDE.md. These files provide guidance for contributors and developers working with the plugin.
+
+## Details
+
+### Documentation Files
+
+| File | Purpose |
+|------|---------|
+| `CONTRIBUTING.md` | Guidelines for contributing to the project |
+| `DEVELOPER_GUIDE.md` | Setup and development instructions |
+| `LICENSE` | Apache 2.0 license file |
+
+### CONTRIBUTING.md
+
+Contains information about:
+- How to find issues to work on
+- Developer Certificate of Origin (DCO) requirements
+- Apache 2.0 license information
+- Signing off commits
+
+### DEVELOPER_GUIDE.md
+
+Contains information about:
+- Building the plugin
+- Running the plugin with OpenSearch Dashboards
+- Submitting changes
+
+## Limitations
+
+Documentation must be kept up-to-date as the project evolves.
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#420](https://github.com/opensearch-project/dashboards-search-relevance/pull/420) | Update Links in Documentation |
+
+## References
+
+- [dashboards-search-relevance Repository](https://github.com/opensearch-project/dashboards-search-relevance)
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Fixed broken LICENSE file link and removed unused Docker documentation links

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -67,6 +67,10 @@
 
 - [OpenSearch Dashboards Reporting](dashboards-reporting/dashboards-reporting.md)
 
+## dashboards-search-relevance
+
+- [Documentation Maintenance](dashboards-search-relevance/documentation-maintenance.md)
+
 ## dashboards-flow-framework
 
 - [AI Search Flows](dashboards-flow-framework/ai-search-flows.md)

--- a/docs/features/query-insights/query-insights.md
+++ b/docs/features/query-insights/query-insights.md
@@ -185,6 +185,7 @@ GET /_insights/live_queries?sort=latency&size=5
 | v3.0.0 | [#300](https://github.com/opensearch-project/query-insights/pull/300) | Top queries API verbose param |
 | v3.0.0 | [#298](https://github.com/opensearch-project/query-insights/pull/298) | Skip profile queries |
 | v3.0.0 | [#266](https://github.com/opensearch-project/query-insights/pull/266) | Strict hash check on top queries indices |
+| v2.17.0 | [#8139](https://github.com/opensearch-project/documentation-website/pull/8139) | Update GET top N api documentation |
 | v2.12.0 | - | Initial release with Top N queries |
 
 ## References
@@ -199,4 +200,5 @@ GET /_insights/live_queries?sort=latency&size=5
 ## Change History
 
 - **v3.0.0**: Added Live Queries API, default index template, verbose parameter, profile query filtering, strict hash check
+- **v2.17.0**: Improved Top N API documentation with clearer explanations of type parameter and troubleshooting guidance
 - **v2.12.0**: Initial release with Top N queries feature

--- a/docs/releases/v2.17.0/features/dashboards-search-relevance/documentation-link-updates.md
+++ b/docs/releases/v2.17.0/features/dashboards-search-relevance/documentation-link-updates.md
@@ -1,0 +1,58 @@
+# Documentation Link Updates
+
+## Summary
+
+This release item fixes broken documentation links in the dashboards-search-relevance plugin. The changes update the LICENSE file reference and remove unused Docker-related links to ensure the link checker passes.
+
+## Details
+
+### What's New in v2.17.0
+
+Minor documentation maintenance to fix broken links in the repository's contributing documentation.
+
+### Technical Changes
+
+#### Files Modified
+
+| File | Change |
+|------|--------|
+| `CONTRIBUTING.md` | Updated LICENSE file link from `LICENSE.txt` to `LICENSE` |
+| `DEVELOPER_GUIDE.md` | Removed unused Docker section with broken links |
+
+#### CONTRIBUTING.md Change
+
+The LICENSE file reference was corrected:
+- Before: `[LICENSE.txt file](./LICENSE.txt)`
+- After: `[LICENSE file](./LICENSE)`
+
+#### DEVELOPER_GUIDE.md Change
+
+Removed the "Run Docker" section that contained broken links to non-existent files:
+- Removed reference to `Dockerfile`
+- Removed reference to `Using-Docker.md` tutorial
+
+### Usage Example
+
+No usage changes - this is a documentation-only fix.
+
+### Migration Notes
+
+No migration required. This is a documentation fix only.
+
+## Limitations
+
+None - this is a documentation maintenance change.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#420](https://github.com/opensearch-project/dashboards-search-relevance/pull/420) | Update Links in Documentation |
+
+## References
+
+- [PR #420](https://github.com/opensearch-project/dashboards-search-relevance/pull/420): Main implementation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-search-relevance/documentation-maintenance.md)

--- a/docs/releases/v2.17.0/features/documentation-website/top-n-api-documentation.md
+++ b/docs/releases/v2.17.0/features/documentation-website/top-n-api-documentation.md
@@ -1,0 +1,72 @@
+# Query Insights Top N API Documentation Update
+
+## Summary
+
+This release item improves the documentation for the Query Insights Top N API. The changes clarify the API behavior, explain the `type` parameter usage, and add troubleshooting guidance for users who receive empty results.
+
+## Details
+
+### What's New in v2.17.0
+
+Enhanced documentation for the GET top N queries API with clearer explanations and troubleshooting tips.
+
+### Technical Changes
+
+#### Documentation Improvements
+
+| Section | Change |
+|---------|--------|
+| Introduction | Clarified that the feature provides visibility into queries with highest latency or resource consumption |
+| API Default Behavior | Documented that the API returns `latency` results by default |
+| Type Parameter | Explained that results are sorted in descending order based on the specified metric type |
+| Troubleshooting | Added important note about ensuring monitoring is enabled and requests are within the time window |
+
+#### Updated API Description
+
+The documentation now clearly states:
+- The Insights API returns top N `latency` results by default
+- The `type` parameter can be used to retrieve results for other metric types (`cpu`, `memory`)
+- Results are sorted in descending order based on the specified metric type
+
+#### New Troubleshooting Guidance
+
+Added an important note to help users troubleshoot empty results:
+> If your query returns no results, ensure that top N query monitoring is enabled for the target metric type and that search requests were made within the current time window.
+
+### Usage Example
+
+```json
+# Get top N queries (defaults to latency)
+GET /_insights/top_queries
+
+# Get top N queries by CPU usage
+GET /_insights/top_queries?type=cpu
+
+# Get top N queries by memory usage
+GET /_insights/top_queries?type=memory
+```
+
+### Migration Notes
+
+No migration required. This is a documentation improvement only.
+
+## Limitations
+
+None - this is a documentation update.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8139](https://github.com/opensearch-project/documentation-website/pull/8139) | Update GET top N api documentation |
+
+## References
+
+- [PR #8139](https://github.com/opensearch-project/documentation-website/pull/8139): Main implementation
+- [Issue #80](https://github.com/opensearch-project/query-insights/issues/80): Related issue
+- [Issue #83](https://github.com/opensearch-project/query-insights/issues/83): Related issue
+- [Top N Queries Documentation](https://opensearch.org/docs/latest/observing-your-data/query-insights/top-n-queries/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/query-insights/query-insights.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -4,6 +4,12 @@
 
 ## Feature Reports
 
+### dashboards-search-relevance
+- [Documentation Link Updates](features/dashboards-search-relevance/documentation-link-updates.md)
+
+### documentation-website
+- [Top N API Documentation Update](features/documentation-website/top-n-api-documentation.md)
+
 ### job-scheduler
 - [Dependency Bumps](features/job-scheduler/dependency-bumps.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation reports for the v2.17.0 documentation updates bugfix item.

### Reports Created

**Release Reports:**
- `docs/releases/v2.17.0/features/dashboards-search-relevance/documentation-link-updates.md`
- `docs/releases/v2.17.0/features/documentation-website/top-n-api-documentation.md`

**Feature Reports:**
- `docs/features/dashboards-search-relevance/documentation-maintenance.md` (new)
- `docs/features/query-insights/query-insights.md` (updated)

### Key Changes in v2.17.0

1. **dashboards-search-relevance PR #420**: Fixed broken LICENSE file link and removed unused Docker documentation links
2. **documentation-website PR #8139**: Improved Top N API documentation with clearer explanations of type parameter and troubleshooting guidance

### Resources Used
- PR: [#420](https://github.com/opensearch-project/dashboards-search-relevance/pull/420)
- PR: [#8139](https://github.com/opensearch-project/documentation-website/pull/8139)

Closes #441