### PR TITLE
docs: add release-notes-and-version-updates report for v2.17.0

### DIFF
--- a/docs/features/multi-plugin/version-bumps-release-notes.md
+++ b/docs/features/multi-plugin/version-bumps-release-notes.md
@@ -66,6 +66,13 @@ release-notes/
 | v3.0.0 | [#1843](https://github.com/opensearch-project/alerting/pull/1843) | alerting | Added 3.0 release notes |
 | v3.0.0 | [#775](https://github.com/opensearch-project/common-utils/pull/775) | common-utils | Update shadow plugin and bump to 3.0.0.0-alpha1 |
 | v3.0.0 | [#1384](https://github.com/opensearch-project/index-management/pull/1384) | index-management | Bump Version to 3.0.0-alpha1 |
+| v2.17.0 | [#1650](https://github.com/opensearch-project/alerting/pull/1650) | alerting | Added 2.17 release notes |
+| v2.17.0 | [#1635](https://github.com/opensearch-project/alerting/pull/1635) | alerting | Increment version to 2.17.0-SNAPSHOT |
+| v2.17.0 | [#727](https://github.com/opensearch-project/common-utils/pull/727) | common-utils | Added 2.17.0.0 release notes |
+| v2.17.0 | [#1221](https://github.com/opensearch-project/index-management/pull/1221) | index-management | Increment version to 2.17.0-SNAPSHOT |
+| v2.17.0 | [#947](https://github.com/opensearch-project/notifications/pull/947) | notifications | Add 2.17.0 release notes |
+| v2.17.0 | [#4615](https://github.com/opensearch-project/security/pull/4615) | security | Increment version to 2.17.0-SNAPSHOT |
+| v2.17.0 | [#2892](https://github.com/opensearch-project/sql/pull/2892) | sql | Increment version to 2.17.0-SNAPSHOT |
 
 ## References
 
@@ -75,3 +82,4 @@ release-notes/
 ## Change History
 
 - **v3.0.0** (2025-05-06): Version bumps and release notes across 9 repositories (alerting, common-utils, index-management, notifications, security, sql, and dashboard plugins)
+- **v2.17.0** (2024-09-17): Version bumps and release notes across 12 repositories (alerting, anomaly-detection, asynchronous-search, common-utils, dashboards-notifications, index-management, job-scheduler, ml-commons, notifications, query-insights, security, sql)

--- a/docs/releases/v2.17.0/features/multi-plugin/release-notes-and-version-updates.md
+++ b/docs/releases/v2.17.0/features/multi-plugin/release-notes-and-version-updates.md
@@ -1,0 +1,80 @@
+# Release Notes and Version Updates
+
+## Summary
+
+Standard maintenance PRs for v2.17.0 release cycle across 12 OpenSearch plugin repositories. These changes include version bumps to 2.17.0 and addition of release notes documentation.
+
+## Details
+
+### What's New in v2.17.0
+
+Version increment and release notes additions for the 2.17.0 release across multiple plugins.
+
+### Repositories Updated
+
+| Repository | Version Bump PRs | Release Notes PRs |
+|------------|------------------|-------------------|
+| alerting | #1635, #1054 | #1650, #1065 |
+| anomaly-detection | #844 | - |
+| asynchronous-search | #602 | - |
+| common-utils | - | #727 |
+| dashboards (notifications) | #425, #386 | #392 |
+| index-management | #1221, #1127 | - |
+| job-scheduler | #660 | - |
+| ml-commons | #353 | - |
+| notifications | #939, #237 | #248, #947 |
+| query-insights | #376 | #91, #388 |
+| security | #4615 | #1290, #1141 |
+| sql | #2892 | - |
+
+### Version Changes
+
+- alerting: → 2.17.0-SNAPSHOT / 2.17.0.0
+- anomaly-detection: → 2.17.0
+- asynchronous-search: → 2.17.0
+- dashboards (notifications): → 2.17.0.0
+- index-management: → 2.17.0-SNAPSHOT / 2.17.0.0
+- job-scheduler: → 2.17.0
+- ml-commons: → 2.17.0.0
+- notifications: → 2.17.0-SNAPSHOT / 2.17.0.0
+- query-insights: → 2.17.0.0
+- security: → 2.17.0-SNAPSHOT
+- sql: → 2.17.0-SNAPSHOT
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#1650](https://github.com/opensearch-project/alerting/pull/1650) | alerting | Added 2.17 release notes |
+| [#1065](https://github.com/opensearch-project/alerting/pull/1065) | alerting | Added 2.17 release notes |
+| [#727](https://github.com/opensearch-project/common-utils/pull/727) | common-utils | Added 2.17.0.0 release notes |
+| [#248](https://github.com/opensearch-project/notifications/pull/248) | notifications | 2.17 release notes |
+| [#947](https://github.com/opensearch-project/notifications/pull/947) | notifications | Add 2.17.0 release notes |
+| [#91](https://github.com/opensearch-project/query-insights/pull/91) | query-insights | Added 2.17 release notes |
+| [#388](https://github.com/opensearch-project/query-insights/pull/388) | query-insights | Add release notes for 2.17.0 |
+| [#1290](https://github.com/opensearch-project/security/pull/1290) | security | Added 2.17.0 release notes |
+| [#1141](https://github.com/opensearch-project/security/pull/1141) | security | Added v2.17 release notes |
+| [#1635](https://github.com/opensearch-project/alerting/pull/1635) | alerting | Increment version to 2.17.0-SNAPSHOT |
+| [#1054](https://github.com/opensearch-project/alerting/pull/1054) | alerting | Increment version to 2.17.0.0 |
+| [#844](https://github.com/opensearch-project/anomaly-detection/pull/844) | anomaly-detection | Update 2.x to 2.17.0 |
+| [#602](https://github.com/opensearch-project/asynchronous-search/pull/602) | asynchronous-search | Increment version to 2.17.0 |
+| [#237](https://github.com/opensearch-project/notifications/pull/237) | notifications | Increment version to 2.17.0.0 |
+| [#425](https://github.com/opensearch-project/dashboards-notifications/pull/425) | dashboards-notifications | Increment version to 2.17.0.0 |
+| [#2892](https://github.com/opensearch-project/sql/pull/2892) | sql | Increment version to 2.17.0-SNAPSHOT |
+| [#386](https://github.com/opensearch-project/dashboards-notifications/pull/386) | dashboards-notifications | Increment version to 2.17.0.0 |
+| [#392](https://github.com/opensearch-project/dashboards-notifications/pull/392) | dashboards-notifications | Adding release notes for 2.17.0 |
+| [#1221](https://github.com/opensearch-project/index-management/pull/1221) | index-management | Increment version to 2.17.0-SNAPSHOT |
+| [#1127](https://github.com/opensearch-project/index-management/pull/1127) | index-management | Increment version to 2.17.0.0 |
+| [#660](https://github.com/opensearch-project/job-scheduler/pull/660) | job-scheduler | Increment version to 2.17.0 |
+| [#353](https://github.com/opensearch-project/ml-commons/pull/353) | ml-commons | Increment version to 2.17.0.0 |
+| [#939](https://github.com/opensearch-project/notifications/pull/939) | notifications | Increment version to 2.17.0-SNAPSHOT |
+| [#376](https://github.com/opensearch-project/query-insights/pull/376) | query-insights | Increment version to 2.17.0.0 |
+| [#4615](https://github.com/opensearch-project/security/pull/4615) | security | Increment version to 2.17.0-SNAPSHOT |
+
+## References
+
+- [OpenSearch 2.17.0 Release Notes](https://github.com/opensearch-project/opensearch-build/blob/main/release-notes/opensearch-release-notes-2.17.0.md)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/multi-plugin/version-bumps-release-notes.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -19,6 +19,7 @@
 ### multi-plugin
 - [CI/Infrastructure Fixes](features/multi-plugin/ci-infrastructure-fixes.md)
 - [Maintainer Updates](features/multi-plugin/maintainer-updates.md)
+- [Release Notes and Version Updates](features/multi-plugin/release-notes-and-version-updates.md)
 
 ## Key Features in This Release
 


### PR DESCRIPTION
## Summary

Documents the v2.17.0 version bumps and release notes additions across 12 OpenSearch plugin repositories.

## Changes
- Created release report: `docs/releases/v2.17.0/features/multi-plugin/release-notes-and-version-updates.md`
- Updated feature report: `docs/features/multi-plugin/version-bumps-release-notes.md`
- Updated release index

## Related Issue
Closes #440