### PR TITLE
docs: add ML Commons Test Fixes report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -114,6 +114,7 @@
 
 - [ML Commons Connector Blueprints](ml-commons/ml-commons-blueprints.md)
 - [ML Commons MCP (Model Context Protocol)](ml-commons/ml-commons-mcp.md)
+- [ML Commons Test Fixes](ml-commons/ml-commons-test-fixes.md)
 
 ## anomaly-detection
 

--- a/docs/features/ml-commons/ml-commons-test-fixes.md
+++ b/docs/features/ml-commons/ml-commons-test-fixes.md
@@ -1,0 +1,95 @@
+# ML Commons Test Fixes
+
+## Summary
+
+This feature tracks test infrastructure improvements and documentation additions for the ML Commons plugin, including fixes for multi-node cluster integration tests and tutorials for integrating external services like Amazon Bedrock Guardrails.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "ML Commons Testing"
+        IT[Integration Tests]
+        SIT[Search Index Tool IT]
+        MN[Multi-Node Support]
+    end
+    
+    subgraph "Guardrails Integration"
+        GR[Guardrails Model]
+        BR[Bedrock Runtime]
+        CM[Claude Model]
+    end
+    
+    IT --> SIT
+    SIT --> MN
+    GR --> BR
+    CM --> GR
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Search Index Tool IT | Integration tests for the Search Index Tool functionality |
+| Multi-Node Test Support | Enables running integration tests across distributed clusters |
+| Bedrock Guardrails Tutorial | Documentation for integrating Amazon Bedrock Guardrails |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `numNodes` | Number of nodes for integration test cluster | 1 |
+| `guardrails.input_guardrail.model_id` | Model ID for input validation | - |
+| `guardrails.input_guardrail.response_filter` | JSONPath to extract guardrail action | - |
+| `guardrails.input_guardrail.response_validation_regex` | Regex to validate allowed responses | - |
+
+### Usage Example
+
+**Running Multi-Node Integration Tests:**
+```bash
+./gradlew opensearch-ml-plugin:integTest \
+  --tests "org.opensearch.ml.rest.RestSearchIndexToolIT" \
+  -PnumNodes=3
+```
+
+**Configuring Bedrock Guardrails:**
+```json
+POST /_plugins/_ml/models/_register?deploy=true
+{
+  "name": "Model with Guardrails",
+  "function_name": "remote",
+  "connector_id": "<connector_id>",
+  "guardrails": {
+    "input_guardrail": {
+      "model_id": "<guardrail_model_id>",
+      "response_filter": "$.action",
+      "response_validation_regex": "^\"NONE\"$"
+    },
+    "type": "model"
+  }
+}
+```
+
+## Limitations
+
+- Bedrock Guardrails require AWS credentials and pre-configured guardrails in AWS console
+- Multi-node test execution requires additional system resources
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#2407](https://github.com/opensearch-project/ml-commons/pull/2407) | Test: recover search index tool IT in multi node cluster |
+| v2.17.0 | [#2695](https://github.com/opensearch-project/ml-commons/pull/2695) | Add tutorial for Bedrock Guardrails |
+
+## References
+
+- [Issue #2362](https://github.com/opensearch-project/ml-commons/issues/2362): Original bug report for multi-node test failure
+- [OpenSearch Guardrails Documentation](https://opensearch.org/docs/latest/ml-commons-plugin/remote-models/guardrails/)
+- [AWS Bedrock Guardrails](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-create.html)
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Added multi-node cluster test support and Bedrock Guardrails tutorial

--- a/docs/releases/v2.17.0/features/ml-commons/ml-commons-test-fixes.md
+++ b/docs/releases/v2.17.0/features/ml-commons/ml-commons-test-fixes.md
@@ -1,0 +1,113 @@
+# ML Commons Test Fixes
+
+## Summary
+
+This release includes two improvements to the ML Commons plugin: a fix for the Search Index Tool integration tests to support multi-node clusters, and a new tutorial for integrating Amazon Bedrock Guardrails with OpenSearch ML models.
+
+## Details
+
+### What's New in v2.17.0
+
+#### 1. Multi-Node Cluster Test Fix
+
+The Search Index Tool integration tests were previously excluded from multi-node cluster test runs due to issues with exception message handling. This fix removes the exclusion, enabling the tests to run successfully in both single-node and multi-node cluster configurations.
+
+**Problem**: The `RestSearchIndexToolIT` tests failed when running with multiple nodes (`-PnumNodes=3`) because concrete exception messages could not be reliably retrieved in a distributed environment.
+
+**Solution**: The test exclusion logic was removed from `plugin/build.gradle`, allowing the tests to run in multi-node clusters.
+
+#### 2. Bedrock Guardrails Tutorial
+
+A comprehensive tutorial was added demonstrating two methods to integrate Amazon Bedrock Guardrails with OpenSearch ML models:
+
+**Method 1: Bedrock Guardrails Independent API**
+- Create a dedicated connector for the Bedrock Guardrails endpoint
+- Register a guardrail model that validates input before processing
+- Configure the main model to use the guardrail model for input validation
+
+**Method 2: Embedded Guardrails via Model Inference API**
+- Configure guardrail headers directly in the Bedrock model connector
+- Use `post_process_function` to handle guardrail intervention responses
+- Simpler setup with guardrails embedded in the model invocation
+
+### Technical Changes
+
+#### Build Configuration Change
+
+```groovy
+// Removed from plugin/build.gradle
+if (_numNodes > 1) {
+    filter {
+        excludeTestsMatching "org.opensearch.ml.rest.RestSearchIndexToolIT.*"
+    }
+}
+```
+
+#### New Tutorial File
+
+Added `docs/tutorials/guardrails/use_bedrock_guardrails.md` with:
+- Step-by-step connector configuration
+- Model registration with guardrails
+- Example requests and responses
+- Both independent API and embedded approaches
+
+### Usage Example
+
+**Bedrock Guardrails Connector:**
+```json
+POST _plugins/_ml/connectors/_create
+{
+  "name": "BedRock Guardrail Connector",
+  "protocol": "aws_sigv4",
+  "parameters": {
+    "region": "us-east-1",
+    "service_name": "bedrock",
+    "source": "INPUT"
+  },
+  "actions": [{
+    "action_type": "predict",
+    "method": "POST",
+    "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/guardrail/<guardrailId>/version/1/apply"
+  }]
+}
+```
+
+**Model with Input Guardrail:**
+```json
+POST /_plugins/_ml/models/_register?deploy=true
+{
+  "name": "Bedrock Claude V2 model",
+  "function_name": "remote",
+  "connector_id": "<connector_id>",
+  "guardrails": {
+    "input_guardrail": {
+      "model_id": "<guardrail_model_id>",
+      "response_filter": "$.action",
+      "response_validation_regex": "^\"NONE\"$"
+    },
+    "type": "model"
+  }
+}
+```
+
+## Limitations
+
+- The Bedrock Guardrails tutorial requires AWS credentials with appropriate permissions
+- Guardrail configuration requires creating and managing guardrails in Amazon Bedrock console first
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2407](https://github.com/opensearch-project/ml-commons/pull/2407) | Test: recover search index tool IT in multi node cluster |
+| [#2695](https://github.com/opensearch-project/ml-commons/pull/2695) | Add tutorial for Bedrock Guardrails |
+
+## References
+
+- [Issue #2362](https://github.com/opensearch-project/ml-commons/issues/2362): Bug report for multi-node cluster test failure
+- [OpenSearch Guardrails Documentation](https://opensearch.org/docs/latest/ml-commons-plugin/remote-models/guardrails/): Official guardrails documentation
+- [AWS Bedrock Guardrails](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-create.html): Creating guardrails in Amazon Bedrock
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/ml-commons-test-fixes.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -16,6 +16,9 @@
 ### security
 - [Dependency Bumps](features/security/dependency-bumps.md)
 
+### ml-commons
+- [ML Commons Test Fixes](features/ml-commons/ml-commons-test-fixes.md)
+
 ### multi-plugin
 - [CI/Infrastructure Fixes](features/multi-plugin/ci-infrastructure-fixes.md)
 - [Maintainer Updates](features/multi-plugin/maintainer-updates.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the ML Commons Test Fixes release item in v2.17.0.

### Changes
- **Release report**: `docs/releases/v2.17.0/features/ml-commons/ml-commons-test-fixes.md`
- **Feature report**: `docs/features/ml-commons/ml-commons-test-fixes.md`
- Updated release and feature indexes

### PRs Investigated
- [#2407](https://github.com/opensearch-project/ml-commons/pull/2407): Test: recover search index tool IT in multi node cluster
- [#2695](https://github.com/opensearch-project/ml-commons/pull/2695): Add tutorial for Bedrock Guardrails

### Key Findings
1. **Multi-Node Test Fix**: Removed test exclusion for `RestSearchIndexToolIT` in multi-node clusters
2. **Bedrock Guardrails Tutorial**: Added comprehensive documentation for integrating Amazon Bedrock Guardrails with OpenSearch ML models

Closes #439