### PR TITLE
docs: add query-insights-infrastructure report for v2.17.0

### DIFF
--- a/docs/features/query-insights/query-insights.md
+++ b/docs/features/query-insights/query-insights.md
@@ -186,6 +186,8 @@ GET /_insights/live_queries?sort=latency&size=5
 | v3.0.0 | [#298](https://github.com/opensearch-project/query-insights/pull/298) | Skip profile queries |
 | v3.0.0 | [#266](https://github.com/opensearch-project/query-insights/pull/266) | Strict hash check on top queries indices |
 | v2.17.0 | [#8139](https://github.com/opensearch-project/documentation-website/pull/8139) | Update GET top N api documentation |
+| v2.17.0 | [#51](https://github.com/opensearch-project/query-insights/pull/51) | Add code hygiene checks (Spotless, Checkstyle) |
+| v2.17.0 | [#90](https://github.com/opensearch-project/query-insights/pull/90) | Fix snapshot publishing configuration |
 | v2.12.0 | - | Initial release with Top N queries |
 
 ## References
@@ -200,5 +202,5 @@ GET /_insights/live_queries?sort=latency&size=5
 ## Change History
 
 - **v3.0.0**: Added Live Queries API, default index template, verbose parameter, profile query filtering, strict hash check
-- **v2.17.0**: Improved Top N API documentation with clearer explanations of type parameter and troubleshooting guidance
+- **v2.17.0**: Improved Top N API documentation; added code hygiene checks (Spotless, Checkstyle); fixed snapshot publishing configuration
 - **v2.12.0**: Initial release with Top N queries feature

--- a/docs/releases/v2.17.0/features/query-insights/query-insights-infrastructure.md
+++ b/docs/releases/v2.17.0/features/query-insights/query-insights-infrastructure.md
@@ -1,0 +1,120 @@
+# Query Insights Infrastructure
+
+## Summary
+
+This release item adds code hygiene checks and fixes snapshot publishing configuration for the Query Insights plugin. These infrastructure improvements ensure code quality through automated Spotless and Checkstyle checks, and enable proper snapshot artifact publishing to the Sonatype repository.
+
+## Details
+
+### What's New in v2.17.0
+
+Two infrastructure improvements were made to the Query Insights plugin:
+
+1. **Code Hygiene Checks (PR #51)**: Added automated code quality enforcement through Spotless and Checkstyle integration
+2. **Snapshot Publishing Configuration (PR #90)**: Fixed the Maven snapshot publishing workflow to properly publish plugin artifacts
+
+### Technical Changes
+
+#### Code Hygiene Checks
+
+Added GitHub Actions workflow for automated code quality checks:
+
+| Check | Tool | Purpose |
+|-------|------|---------|
+| Spotless | `com.diffplug.spotless` | Code formatting enforcement |
+| Checkstyle | `checkstyle` | Code style validation |
+
+**New Files Added:**
+- `.github/workflows/code-hygiene.yml` - GitHub Actions workflow
+- `config/checkstyle/checkstyle.xml` - Checkstyle configuration (Sun coding conventions)
+- `config/formatterConfig.xml` - Eclipse formatter configuration for Spotless
+
+**Spotless Configuration:**
+```groovy
+spotless {
+  java {
+    target fileTree('.') {
+      include '**/*.java'
+      exclude '**/build/**', '**/build-*/**'
+    }
+    removeUnusedImports()
+    importOrder()
+    eclipse().configFile rootProject.file('config/formatterConfig.xml')
+    trimTrailingWhitespace()
+    endWithNewline()
+  }
+}
+```
+
+**Checkstyle Rules Include:**
+- Import ordering and unused import detection (error severity)
+- Star import prevention
+- Illegal import detection (e.g., `sun.*` packages)
+- System.out.println detection
+- Inclusive language enforcement (e.g., "master" → "cluster manager")
+
+#### Snapshot Publishing Fix
+
+Fixed the Maven publish workflow by:
+
+1. Adding Snapshots repository configuration to `build.gradle`:
+```groovy
+repositories {
+  maven {
+    name = "Snapshots"
+    url = "https://aws.oss.sonatype.org/content/repositories/snapshots"
+    credentials {
+      username "$System.env.SONATYPE_USERNAME"
+      password "$System.env.SONATYPE_PASSWORD"
+    }
+  }
+}
+```
+
+2. Simplifying `.github/workflows/maven-publish.yml` to only publish the plugin zip:
+```yaml
+# For JS plugin zip
+./gradlew publishPluginZipPublicationToSnapshotsRepository
+```
+
+The previous workflow attempted to publish `ShadowPublication` and `NebulaPublication` which don't exist in this plugin.
+
+### Usage Example
+
+**Run code hygiene checks locally:**
+```bash
+# Run Spotless check
+./gradlew spotlessCheck
+
+# Apply Spotless formatting
+./gradlew spotlessApply
+
+# Run Checkstyle
+./gradlew checkstyleMain checkstyleTest
+```
+
+### Migration Notes
+
+No migration required. These are infrastructure-only changes that don't affect plugin functionality.
+
+## Limitations
+
+- Checkstyle severity is set to `ignore` by default for most rules, with specific rules (imports, System.out.println) set to `error`
+- The code hygiene workflow runs on every push and pull request
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#51](https://github.com/opensearch-project/query-insights/pull/51) | Add code hygiene checks for query insights |
+| [#90](https://github.com/opensearch-project/query-insights/pull/90) | Add configuration for publishing snapshot |
+
+## References
+
+- [Issue #7](https://github.com/opensearch-project/query-insights/issues/7): Set up GitHub Actions
+- [Issue #72](https://github.com/opensearch-project/query-insights/issues/72): Snapshots not being published bug report
+- [Query Insights Repository](https://github.com/opensearch-project/query-insights)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/query-insights/query-insights.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -27,6 +27,9 @@
 - [Maintainer Updates](features/multi-plugin/maintainer-updates.md)
 - [Release Notes and Version Updates](features/multi-plugin/release-notes-and-version-updates.md)
 
+### query-insights
+- [Query Insights Infrastructure](features/query-insights/query-insights-infrastructure.md)
+
 ## Key Features in This Release
 
 ### Generally Available


### PR DESCRIPTION
## Summary

This PR adds documentation for the Query Insights Infrastructure bugfixes in v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/query-insights/query-insights-infrastructure.md`
- Feature report: `docs/features/query-insights/query-insights.md` (updated)

### Key Changes in v2.17.0
- Added code hygiene checks (Spotless, Checkstyle) via PR #51
- Fixed snapshot publishing configuration via PR #90

### Resources Used
- PR: [#51](https://github.com/opensearch-project/query-insights/pull/51) - Code hygiene checks
- PR: [#90](https://github.com/opensearch-project/query-insights/pull/90) - Snapshot publishing fix
- Issue: [#7](https://github.com/opensearch-project/query-insights/issues/7) - Set up GitHub Actions
- Issue: [#72](https://github.com/opensearch-project/query-insights/issues/72) - Snapshots not being published

Closes #437