### PR TITLE
docs: add performance-analyzer-bugfixes report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -125,6 +125,10 @@
 
 - [Observability Integrations](observability/observability-integrations.md)
 
+## performance-analyzer
+
+- [Performance Analyzer](performance-analyzer/performance-analyzer.md)
+
 ## dashboards-observability
 
 - [Observability Notebooks](dashboards-observability/observability-notebooks.md)

--- a/docs/features/performance-analyzer/performance-analyzer.md
+++ b/docs/features/performance-analyzer/performance-analyzer.md
@@ -1,0 +1,129 @@
+# Performance Analyzer
+
+## Summary
+
+Performance Analyzer is an OpenSearch plugin that provides detailed performance metrics from your cluster independently of the Java Virtual Machine (JVM). It includes an agent and REST API for querying cluster performance metrics, aggregations, and root cause analysis (RCA) capabilities.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Cluster"
+        OS[OpenSearch Node]
+        PA[Performance Analyzer Plugin]
+        RCA[RCA Agent]
+    end
+    
+    subgraph "PA Commons Library"
+        MC[Metrics Collectors]
+        SC[Stats Collector]
+        RTF[RTF Metrics]
+    end
+    
+    subgraph "Storage"
+        SHM[/dev/shm]
+        MDB[Metrics DB]
+    end
+    
+    OS --> PA
+    PA --> MC
+    MC --> SC
+    SC --> RTF
+    PA --> SHM
+    SHM --> MDB
+    RCA --> MDB
+    
+    API[REST API :9600] --> PA
+    API --> RCA
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[OpenSearch Operations] --> B[Metrics Collectors]
+    B --> C[Stats Collector]
+    C --> D[/dev/shm Storage]
+    D --> E[Metrics DB]
+    E --> F[REST API]
+    F --> G[PerfTop / Custom Dashboards]
+    E --> H[RCA Framework]
+    H --> I[Root Cause Analysis]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Performance Analyzer Plugin | Core plugin that collects metrics from OpenSearch |
+| PA Commons Library | Shared library with metrics definitions and collectors |
+| Stats Collector | Collects and aggregates statistics across collector modes |
+| RTF Metrics | Real-time framework metrics constants |
+| RCA Agent | Root cause analysis agent for identifying performance issues |
+| Metrics DB | Temporary storage for metrics data |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `webservice-bind-host` | Host to bind the web service | `0.0.0.0` |
+| `webservice-listener-port` | Port for the web service | `9600` |
+| `metrics-location` | Location for metrics data | `/dev/shm/performanceanalyzer/` |
+| `metrics-deletion-interval` | Interval (minutes) for metrics cleanup | `1` |
+| `cleanup-metrics-db-files` | Whether to clean up old metrics files | `true` |
+| `https-enabled` | Enable HTTPS for the web service | `false` |
+
+### Usage Example
+
+Query available metrics:
+
+```bash
+GET localhost:9600/_plugins/_performanceanalyzer/metrics/units
+```
+
+Enable Performance Analyzer:
+
+```bash
+curl -XPOST localhost:9200/_plugins/_performanceanalyzer/cluster/config \
+  -H 'Content-Type: application/json' \
+  -d '{"enabled": true}'
+```
+
+Enable RCA framework:
+
+```bash
+curl -XPOST localhost:9200/_plugins/_performanceanalyzer/rca/cluster/config \
+  -H 'Content-Type: application/json' \
+  -d '{"enabled": true}'
+```
+
+Query RCA results:
+
+```bash
+GET localhost:9600/_plugins/_performanceanalyzer/rca?name=HighHeapUsageClusterRCA
+```
+
+## Limitations
+
+- Requires `/dev/shm` with at least 1GB of space for heavy workloads
+- Does not support client or server authentication for requests (only encryption in transit)
+- RCA framework requires separate enablement
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#712](https://github.com/opensearch-project/performance-analyzer/pull/712) | Bump PA to use 1.6.0 PA commons lib |
+
+## References
+
+- [Performance Analyzer Documentation](https://docs.opensearch.org/latest/monitoring-your-cluster/pa/index/): Official documentation
+- [Performance Analyzer Repository](https://github.com/opensearch-project/performance-analyzer): Source code
+- [PA Commons Repository](https://github.com/opensearch-project/performance-analyzer-commons): Commons library
+- [RCA Documentation](https://docs.opensearch.org/latest/monitoring-your-cluster/pa/rca/index/): Root cause analysis
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Updated PA Commons dependency to 1.6.0, including bugfix for statsCollector scheduling

--- a/docs/releases/v2.17.0/features/performance-analyzer/performance-analyzer-bugfixes.md
+++ b/docs/releases/v2.17.0/features/performance-analyzer/performance-analyzer-bugfixes.md
@@ -1,0 +1,69 @@
+# Performance Analyzer Bugfixes
+
+## Summary
+
+This release item updates the Performance Analyzer plugin to use version 1.6.0 of the PA Commons library. This dependency bump brings in several bug fixes and improvements from the commons library, including fixes for statsCollector scheduling and new metrics constants.
+
+## Details
+
+### What's New in v2.17.0
+
+The Performance Analyzer plugin dependency on `performance-analyzer-commons` was updated from version 1.5.0 to 1.6.0.
+
+### Technical Changes
+
+#### Dependency Update
+
+| Dependency | Previous Version | New Version |
+|------------|------------------|-------------|
+| performance-analyzer-commons | 1.5.0 | 1.6.0 |
+
+#### Changes in PA Commons 1.6.0
+
+The PA Commons 1.6.0 release includes the following improvements merged between versions 1.5.0 and 1.6.0:
+
+| PR | Description |
+|----|-------------|
+| [#87](https://github.com/opensearch-project/performance-analyzer-commons/pull/87) | Adds CacheConfig related info for telemetry collector |
+| [#86](https://github.com/opensearch-project/performance-analyzer-commons/pull/86) | Adds heap metrics constants |
+| [#85](https://github.com/opensearch-project/performance-analyzer-commons/pull/85) | Updates cpu_utilization metric name and adds constant |
+| [#84](https://github.com/opensearch-project/performance-analyzer-commons/pull/84) | Adds OSMetrics constants to RTFMetrics |
+| [#83](https://github.com/opensearch-project/performance-analyzer-commons/pull/83) | Adds index_uuid as a common dimension |
+| [#82](https://github.com/opensearch-project/performance-analyzer-commons/pull/82) | Bugfix: Scheduling statsCollector for all collectorModes |
+
+#### Key Bug Fix
+
+The most significant fix in this update is PR #82, which ensures that the `statsCollector` is properly scheduled for all collector modes. Previously, the statsCollector was not being scheduled in certain collector modes, which could lead to incomplete metrics collection.
+
+### Configuration
+
+No configuration changes are required. The dependency update is transparent to users.
+
+### Usage Example
+
+Performance Analyzer continues to work as before. Query metrics using:
+
+```bash
+GET localhost:9600/_plugins/_performanceanalyzer/metrics/units
+```
+
+## Limitations
+
+- This is a dependency update only; no new user-facing features are introduced
+- Requires restart of the Performance Analyzer agent to pick up the new library
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#712](https://github.com/opensearch-project/performance-analyzer/pull/712) | Bump PA to use 1.6.0 PA commons lib |
+
+## References
+
+- [PA Commons PR #90](https://github.com/opensearch-project/performance-analyzer-commons/pull/90): Bump PA commons to 1.6.0
+- [PA Commons PR #82](https://github.com/opensearch-project/performance-analyzer-commons/pull/82): Bugfix for statsCollector scheduling
+- [Performance Analyzer Documentation](https://docs.opensearch.org/2.17/monitoring-your-cluster/pa/index/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/performance-analyzer/performance-analyzer.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -27,6 +27,9 @@
 - [Maintainer Updates](features/multi-plugin/maintainer-updates.md)
 - [Release Notes and Version Updates](features/multi-plugin/release-notes-and-version-updates.md)
 
+### performance-analyzer
+- [Performance Analyzer Bugfixes](features/performance-analyzer/performance-analyzer-bugfixes.md)
+
 ### query-insights
 - [Query Insights Infrastructure](features/query-insights/query-insights-infrastructure.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Performance Analyzer Bugfixes release item in OpenSearch v2.17.0.

### Changes

- **Release Report**: `docs/releases/v2.17.0/features/performance-analyzer/performance-analyzer-bugfixes.md`
  - Documents the PA Commons library update from 1.5.0 to 1.6.0
  - Lists key changes included in PA Commons 1.6.0
  - Highlights the statsCollector scheduling bugfix

- **Feature Report**: `docs/features/performance-analyzer/performance-analyzer.md`
  - Comprehensive documentation of the Performance Analyzer plugin
  - Architecture diagram and data flow
  - Configuration options and usage examples

### Related Issue

Closes #436