### PR TITLE
docs: add CVE fixes report for v2.17.0

### DIFF
--- a/docs/features/multi-plugin/cve-fixes-dependency-updates.md
+++ b/docs/features/multi-plugin/cve-fixes-dependency-updates.md
@@ -90,6 +90,11 @@ No user configuration required. Dependency updates are applied automatically dur
 | Version | PR | Repository | Description |
 |---------|-----|------------|-------------|
 | v3.0.0 | [#1802](https://github.com/opensearch-project/alerting/pull/1802) | alerting | Bump logback to 1.5.16 |
+| v2.17.0 | [#864](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/864) | anomaly-detection-dashboards | Address CVE-2024-4067 (micromatch) |
+| v2.17.0 | [#1024](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1024) | alerting-dashboards | Pin braces for CVE-2024-4068 |
+| v2.17.0 | [#1074](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1074) | alerting-dashboards | Fix CVE-2024-4067 (micromatch) |
+| v2.17.0 | [#2138](https://github.com/opensearch-project/dashboards-observability/pull/2138) | dashboards-observability | Bump lint-staged for CVE-2024-4067 |
+| v2.17.0 | [#2144](https://github.com/opensearch-project/security-dashboards-plugin/pull/2144) | security-dashboards | Bump micromatch for CVE-2024-4067 |
 | v3.0.0 | [#993](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/993) | anomaly-detection | Update @babel/runtime (CVE-2025-27789) |
 | v3.0.0 | [#529](https://github.com/opensearch-project/dashboards-reporting/pull/529) | reporting | Bump jspdf to 3.0 (CVE-2025-26791) |
 | v3.0.0 | [#555](https://github.com/opensearch-project/dashboards-reporting/pull/555) | reporting | Bump jspdf to 3.0.1 (CVE-2025-29907) |
@@ -100,6 +105,8 @@ No user configuration required. Dependency updates are applied automatically dur
 
 ## References
 
+- [CVE-2024-4067 (GHSA-952p-6rrq-rcjv)](https://github.com/advisories/GHSA-952p-6rrq-rcjv): micromatch ReDoS vulnerability
+- [CVE-2024-4068](https://nvd.nist.gov/vuln/detail/CVE-2024-4068): braces DoS vulnerability
 - [CVE-2025-27789](https://nvd.nist.gov/vuln/detail/CVE-2025-27789): @babel/runtime vulnerability
 - [CVE-2025-26791](https://nvd.nist.gov/vuln/detail/CVE-2025-26791): jspdf vulnerability
 - [CVE-2025-29907](https://nvd.nist.gov/vuln/detail/CVE-2025-29907): jspdf vulnerability
@@ -108,3 +115,4 @@ No user configuration required. Dependency updates are applied automatically dur
 ## Change History
 
 - **v3.0.0** (2025-05-06): Multiple CVE fixes across alerting, security, anomaly-detection, reporting, index-management, and notifications plugins
+- **v2.17.0** (2024-09-17): CVE-2024-4067 and CVE-2024-4068 fixes across anomaly-detection-dashboards, alerting-dashboards, security-dashboards, and dashboards-observability

--- a/docs/releases/v2.17.0/features/dashboards-plugins/cve-fixes.md
+++ b/docs/releases/v2.17.0/features/dashboards-plugins/cve-fixes.md
@@ -1,0 +1,94 @@
+# CVE Fixes
+
+## Summary
+
+OpenSearch v2.17.0 addresses CVE-2024-4067 and CVE-2024-4068 across multiple dashboard plugins. These vulnerabilities affect the `micromatch` and `braces` npm packages, which are transitive dependencies used in build tooling. The fixes involve bumping package versions to patched releases.
+
+## Details
+
+### What's New in v2.17.0
+
+This release addresses two related CVEs in the JavaScript ecosystem:
+
+- **CVE-2024-4067**: Regular Expression Denial of Service (ReDoS) vulnerability in `micromatch` package (versions < 4.0.8)
+- **CVE-2024-4068**: Denial of Service vulnerability in `braces` package (versions < 3.0.3)
+
+### Technical Changes
+
+#### Vulnerability Details
+
+| CVE | Package | Severity | CVSS Score | Fixed Version |
+|-----|---------|----------|------------|---------------|
+| CVE-2024-4067 | micromatch | Moderate | 5.3 | 4.0.8 |
+| CVE-2024-4068 | braces | Moderate | N/A | 3.0.3 |
+
+#### Fix Approach
+
+```mermaid
+graph TB
+    subgraph "Affected Plugins"
+        AD[anomaly-detection-dashboards]
+        AL[alerting-dashboards]
+        SEC[security-dashboards]
+        OBS[dashboards-observability]
+    end
+    
+    subgraph "Fix Methods"
+        M1[Bump micromatch to 4.0.8]
+        M2[Pin braces to ^3.0.3]
+        M3[Bump lint-staged to 15.2.10]
+    end
+    
+    AD --> M1
+    AL --> M1
+    AL --> M2
+    SEC --> M1
+    OBS --> M3
+```
+
+#### Affected Repositories
+
+| Repository | Fix Method | PR |
+|------------|------------|-----|
+| anomaly-detection-dashboards-plugin | Bump micromatch to 4.0.8 | [#864](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/864) |
+| alerting-dashboards-plugin | Pin braces to ^3.0.3 | [#1024](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1024) |
+| alerting-dashboards-plugin | Bump micromatch to 4.0.8 | [#1074](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1074) |
+| security-dashboards-plugin | Bump micromatch to 4.0.8 | [#2144](https://github.com/opensearch-project/security-dashboards-plugin/pull/2144) |
+| dashboards-observability | Bump lint-staged to 15.2.10 | [#2138](https://github.com/opensearch-project/dashboards-observability/pull/2138) |
+
+### Usage Example
+
+No user action required. The fixes are applied automatically when upgrading to OpenSearch Dashboards 2.17.0.
+
+### Migration Notes
+
+Users should upgrade to OpenSearch Dashboards 2.17.0 to receive these security fixes. No configuration changes are needed.
+
+## Limitations
+
+- These CVEs affect development/build dependencies and have limited runtime impact
+- The vulnerabilities require crafted malicious input to exploit
+- The micromatch maintainers consider these issues low-priority
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#864](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/864) | anomaly-detection-dashboards | Address CVE-2024-4067 |
+| [#866](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/866) | anomaly-detection-dashboards | Backport to 2.17 |
+| [#1024](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1024) | alerting-dashboards | Pin braces for CVE-2024-4068 |
+| [#1074](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1074) | alerting-dashboards | Fix CVE-2024-4067 |
+| [#1076](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1076) | alerting-dashboards | Backport to 2.17 |
+| [#2138](https://github.com/opensearch-project/dashboards-observability/pull/2138) | dashboards-observability | Bump lint-staged for CVE-2024-4067 |
+| [#2143](https://github.com/opensearch-project/dashboards-observability/pull/2143) | dashboards-observability | Backport to 2.17 |
+| [#2144](https://github.com/opensearch-project/security-dashboards-plugin/pull/2144) | security-dashboards | Backport micromatch fix to 2.x |
+
+## References
+
+- [CVE-2024-4067 (GHSA-952p-6rrq-rcjv)](https://github.com/advisories/GHSA-952p-6rrq-rcjv): micromatch ReDoS vulnerability
+- [CVE-2024-4068](https://nvd.nist.gov/vuln/detail/CVE-2024-4068): braces DoS vulnerability
+- [micromatch v4.0.8 Release](https://github.com/micromatch/micromatch/releases/tag/4.0.8): Ultimate fix for both CVEs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/multi-plugin/cve-fixes-dependency-updates.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -19,6 +19,9 @@
 ### security
 - [Dependency Bumps](features/security/dependency-bumps.md)
 
+### dashboards-plugins
+- [CVE Fixes](features/dashboards-plugins/cve-fixes.md)
+
 ### ml-commons
 - [ML Commons Test Fixes](features/ml-commons/ml-commons-test-fixes.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for CVE fixes in OpenSearch v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/dashboards-plugins/cve-fixes.md`
- Feature report updated: `docs/features/multi-plugin/cve-fixes-dependency-updates.md`

### CVEs Addressed
- **CVE-2024-4067**: Regular Expression Denial of Service (ReDoS) in micromatch (< 4.0.8)
- **CVE-2024-4068**: Denial of Service in braces (< 3.0.3)

### Affected Repositories
- anomaly-detection-dashboards-plugin
- alerting-dashboards-plugin
- security-dashboards-plugin
- dashboards-observability

### Related Issue
Closes #434