### PR TITLE
docs: add SQL/PPL Bugfixes report for v2.17.0

### DIFF
--- a/docs/features/sql/sql-ppl-engine.md
+++ b/docs/features/sql/sql-ppl-engine.md
@@ -175,6 +175,13 @@ POST /_plugins/_ppl
 | Version | PR | Description |
 |---------|-----|-------------|
 | v3.0.0 | [#3448](https://github.com/opensearch-project/sql/pull/3448) | Merge Calcite engine to main |
+| v2.17.0 | [#2842](https://github.com/opensearch-project/sql/pull/2842) | Boolean function in PPL case insensitivity fix |
+| v2.17.0 | [#2884](https://github.com/opensearch-project/sql/pull/2884) | Restrict UDF functions in async query API |
+| v2.17.0 | [#2890](https://github.com/opensearch-project/sql/pull/2890) | Update SqlBaseParser for build fix |
+| v2.17.0 | [#2972](https://github.com/opensearch-project/sql/pull/2972) | Fix SparkExecutionEngineConfigClusterSetting deserialize issue |
+| v2.17.0 | [#2982](https://github.com/opensearch-project/sql/pull/2982) | Fix jobType for Batch and IndexDML query |
+| v2.17.0 | [#2983](https://github.com/opensearch-project/sql/pull/2983) | Fix handler for existing query |
+| v2.17.0 | [#2996](https://github.com/opensearch-project/sql/pull/2996) | Fix BWC integration test |
 | v3.0.0 | [#3243](https://github.com/opensearch-project/sql/pull/3243) | Add `json` function and `cast(x as json)` |
 | v3.0.0 | [#3263](https://github.com/opensearch-project/sql/pull/3263) | Improved patterns command with Brain algorithm |
 | v3.0.0 | [#2806](https://github.com/opensearch-project/sql/pull/2806) | Support line and block comments in PPL |
@@ -199,3 +206,4 @@ POST /_plugins/_ppl
 ## Change History
 
 - **v3.0.0** (2025-05-06): Major update - Apache Calcite integration (V3 engine), new PPL commands (lookup, join, subsearch), json functions, improved patterns command with Brain algorithm, comment support, function framework refactoring; breaking changes include removal of SparkSQL, DELETE statement, DSL format, scroll API, and opendistro settings
+- **v2.17.0** (2024-09-17): Bugfixes - PPL boolean function case insensitivity, UDF function restrictions, SqlBaseParser build fix, Spark execution engine config deserialization fix, job type handling fixes

--- a/docs/releases/v2.17.0/features/sql/sql-ppl-bugfixes.md
+++ b/docs/releases/v2.17.0/features/sql/sql-ppl-bugfixes.md
@@ -1,0 +1,75 @@
+# SQL/PPL Bugfixes
+
+## Summary
+
+OpenSearch v2.17.0 includes several bugfixes for the SQL/PPL plugin addressing issues with PPL boolean function case sensitivity, UDF function restrictions, Spark execution engine configuration, query job type handling, and build infrastructure fixes.
+
+## Details
+
+### What's New in v2.17.0
+
+This release focuses on stability and correctness improvements across the SQL/PPL plugin:
+
+1. **PPL Boolean Function Case Insensitivity**: Fixed an issue where boolean functions like `isnotnull()` worked but `ISNOTNULL()` did not
+2. **UDF Function Restrictions**: Blocked UDF creation queries in the async query API for security
+3. **SqlBaseParser Update**: Fixed parser file validity for network-disconnected build environments
+4. **Spark Execution Engine Config Fix**: Resolved deserialization issues with `SparkExecutionEngineConfigClusterSetting`
+5. **Job Type Fixes**: Corrected job type handling for Batch and IndexDML queries
+6. **Query Handler Fix**: Fixed handler for existing query scenarios
+7. **BWC Test Fix**: Resolved integration test issues with `sqlBwcCluster#fullRestartClusterTask`
+
+### Technical Changes
+
+#### PPL Boolean Function Case Sensitivity
+
+The PPL parser was updated to handle boolean functions in a case-insensitive manner, aligning with standard SQL behavior.
+
+**Before (broken)**:
+```ppl
+source=logs | where ISNOTNULL(field)  // Error
+```
+
+**After (fixed)**:
+```ppl
+source=logs | where ISNOTNULL(field)  // Works
+source=logs | where isnotnull(field)  // Also works
+```
+
+#### UDF Function Restrictions
+
+UDF (User Defined Function) creation queries are now blocked in the async query API to prevent potential security issues.
+
+#### Spark Execution Engine Configuration
+
+Fixed a deserialization issue in `SparkExecutionEngineConfigClusterSetting` that could cause configuration loading failures.
+
+#### Job Type Handling
+
+Corrected the job type assignment for Batch and IndexDML queries, ensuring proper query execution routing.
+
+## Limitations
+
+- These are bugfixes only; no new features are introduced
+- UDF creation is now restricted in async query API
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2842](https://github.com/opensearch-project/sql/pull/2842) | Boolean function in PPL should be case insensitive (backport of #2758) |
+| [#2884](https://github.com/opensearch-project/sql/pull/2884) | Restrict UDF functions (backport of #2790) |
+| [#2890](https://github.com/opensearch-project/sql/pull/2890) | Update SqlBaseParser for build fix |
+| [#2972](https://github.com/opensearch-project/sql/pull/2972) | Fix SparkExecutionEngineConfigClusterSetting deserialize issue (backport of #2966) |
+| [#2982](https://github.com/opensearch-project/sql/pull/2982) | Fix jobType for Batch and IndexDML query (backport of #2955) |
+| [#2983](https://github.com/opensearch-project/sql/pull/2983) | Fix handler for existing query (backport of #2968) |
+| [#2996](https://github.com/opensearch-project/sql/pull/2996) | Fix :integ-test:sqlBwcCluster#fullRestartClusterTask (backport of #2900) |
+
+## References
+
+- [Issue #2431](https://github.com/opensearch-project/sql/issues/2431): Boolean function case sensitivity issue
+- [Issue #2761](https://github.com/opensearch-project/sql/issues/2761): UDF restriction requirement
+- [SQL and PPL Documentation](https://docs.opensearch.org/2.17/search-plugins/sql/index/): Official documentation
+
+## Related Feature Report
+
+- [SQL/PPL Engine](../../../features/sql/sql-ppl-engine.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -39,6 +39,9 @@
 ### query-insights
 - [Query Insights Infrastructure](features/query-insights/query-insights-infrastructure.md)
 
+### sql
+- [SQL/PPL Bugfixes](features/sql/sql-ppl-bugfixes.md)
+
 ## Key Features in This Release
 
 ### Generally Available


### PR DESCRIPTION
## Summary

This PR adds the release report for SQL/PPL Bugfixes in OpenSearch v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/sql/sql-ppl-bugfixes.md`
- Feature report updated: `docs/features/sql/sql-ppl-engine.md`

### Key Changes in v2.17.0
- PPL boolean function case insensitivity fix
- UDF function restrictions in async query API
- SqlBaseParser build fix for network-disconnected environments
- Spark execution engine config deserialization fix
- Job type handling fixes for Batch and IndexDML queries
- BWC integration test fix

### PRs Investigated
- #2842, #2884, #2890, #2972, #2982, #2983, #2996

Closes #433