### PR TITLE
docs: add Security Plugin Bugfixes report for v2.17.0

### DIFF
--- a/docs/features/security/security-plugin.md
+++ b/docs/features/security/security-plugin.md
@@ -198,6 +198,14 @@ config:
 | v3.0.0 | [#1467](https://github.com/opensearch-project/security/pull/1467) | Refactored flaky test |
 | v3.0.0 | [#1498](https://github.com/opensearch-project/security/pull/1498) | Remove overrides of preserveIndicesUponCompletion |
 | v3.0.0 | [#1503](https://github.com/opensearch-project/security/pull/1503) | Remove usage of deprecated batchSize() method |
+| v2.17.0 | [#4603](https://github.com/opensearch-project/security/pull/4603) | Fix demo certificate hash validation |
+| v2.17.0 | [#4631](https://github.com/opensearch-project/security/pull/4631) | Fix authtoken endpoint |
+| v2.17.0 | [#4664](https://github.com/opensearch-project/security/pull/4664) | Handle null audit config |
+| v2.17.0 | [#4640](https://github.com/opensearch-project/security/pull/4640) | Sort DNS names in SANs for certificate comparison |
+| v2.17.0 | [#4607](https://github.com/opensearch-project/security/pull/4607) | Fix TermsAggregationEvaluator READ_ACTIONS |
+| v2.17.0 | [#4611](https://github.com/opensearch-project/security/pull/4611) | Refactor security provider instantiation |
+| v2.17.0 | [#4653](https://github.com/opensearch-project/security/pull/4653) | Remove Log4j Strings utility usage |
+| v2.17.0 | [#4694](https://github.com/opensearch-project/security/pull/4694) | PluginSubject build fix |
 
 ## References
 
@@ -206,6 +214,10 @@ config:
 - [Issue #4927](https://github.com/opensearch-project/security/issues/4927): CIDR range support
 - [Issue #5238](https://github.com/opensearch-project/security/issues/5238): DlsFlsFilterLeafReader termVectors issue
 - [Issue #1483](https://github.com/opensearch-project/OpenSearch/issues/1483): Deprecate non-inclusive terms
+- [Issue #4599](https://github.com/opensearch-project/security/issues/4599): Demo certificate setting bug (v2.17.0)
+- [Issue #4627](https://github.com/opensearch-project/security/issues/4627): Auth token endpoint issue (v2.17.0)
+- [Issue #4480](https://github.com/opensearch-project/security/issues/4480): Certificate SAN ordering issue (v2.17.0)
+- [Issue #4583](https://github.com/opensearch-project/security/issues/4583): Security provider refactoring (v2.17.0)
 - [Documentation: Security](https://docs.opensearch.org/3.0/security/)
 - [Documentation: Breaking Changes](https://docs.opensearch.org/3.0/breaking-changes/)
 - [Documentation: Security Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/security-settings/)
@@ -216,3 +228,4 @@ config:
 
 - **v3.0.0** (2025-05-06): Breaking changes - Blake2b hash fix, OpenSSL removal, whitelist→allowlist; Enhancements - optimized privilege evaluation, CIDR support in ignore_hosts, password validation improvements
 - **v2.18.0** (2024-11-05): Auto-convert security config models from v6 to v7
+- **v2.17.0** (2024-09-17): Bugfixes - demo certificate validation, auth token endpoint, audit config null handling, certificate SAN ordering, TermsAggregationEvaluator permissions; Refactoring - security provider instantiation for FIPS support, Log4j utility removal

--- a/docs/releases/v2.17.0/features/security/security-plugin-bugfixes.md
+++ b/docs/releases/v2.17.0/features/security/security-plugin-bugfixes.md
@@ -1,0 +1,86 @@
+# Security Plugin Bugfixes
+
+## Summary
+
+OpenSearch v2.17.0 includes 11 bugfixes and improvements for the Security plugin, addressing issues with demo certificates, authentication tokens, audit configuration, certificate hot-reload, terms aggregation permissions, and code quality improvements.
+
+## Details
+
+### What's New in v2.17.0
+
+This release focuses on stability and reliability improvements across multiple Security plugin components.
+
+### Technical Changes
+
+#### Bug Fixes
+
+| Issue | Fix | Impact |
+|-------|-----|--------|
+| Demo certificate validation | Fixed mismatching demo certificate hashes that prevented `plugins.security.allow_unsafe_democertificates` from working | Clusters can now boot with demo certificates when setting is enabled |
+| Auth token endpoint | Fixed `generateAuthToken()` method in UserService to properly vend auth tokens for `internalusers` API | Auth token generation now works correctly |
+| Audit config null handling | Added null check for audit configuration | Prevents NullPointerException when audit config is not set |
+| Certificate SAN ordering | DNS names in SANs are now sorted before comparison during hot reload | Certificate hot reload works correctly with equivalent certificates having different SAN ordering |
+| TermsAggregationEvaluator permissions | Fixed READ_ACTIONS to use actual action names instead of patterns | `indices:data/read/field_caps` privilege now works correctly |
+| Certificates API timeout | Fixed `timeout` parameter not working as expected | Timeout parameter now functions correctly |
+
+#### Refactoring and Code Quality
+
+| Change | Description |
+|--------|-------------|
+| Security provider instantiation | Refactored BouncyCastleProvider initialization to support potential FIPS-compatible providers |
+| Log4j utility removal | Removed usages of `org.apache.logging.log4j.util.Strings` for better compatibility |
+| PluginSubject build fix | Interim fix for PluginSubject related changes to maintain build compatibility |
+
+#### Infrastructure Fixes
+
+| Change | Description |
+|--------|-------------|
+| Coverage report workflow | Fixed coverage-report workflow |
+| Backport handling | Backported PRs with `backport-failed` labels that weren't acted upon |
+| PR template update | Updated backport section of PR template |
+
+### Configuration Changes
+
+| Setting | Description | Status |
+|---------|-------------|--------|
+| `plugins.security.allow_unsafe_democertificates` | Allows cluster to start with demo certificates | Fixed in v2.17.0 |
+
+### Usage Example
+
+```yaml
+# opensearch.yml - Demo certificate setting now works correctly
+plugins.security.allow_unsafe_democertificates: true
+```
+
+## Limitations
+
+- Demo certificates should only be used for development/testing environments
+- The `allow_unsafe_democertificates` setting is not recommended for production use
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4603](https://github.com/opensearch-project/security/pull/4603) | Fix demo certificate hash validation |
+| [#4631](https://github.com/opensearch-project/security/pull/4631) | Fix authtoken endpoint |
+| [#4664](https://github.com/opensearch-project/security/pull/4664) | Handle null audit config |
+| [#4640](https://github.com/opensearch-project/security/pull/4640) | Sort DNS names in SANs |
+| [#4607](https://github.com/opensearch-project/security/pull/4607) | Fix TermsAggregationEvaluator READ_ACTIONS |
+| [#4611](https://github.com/opensearch-project/security/pull/4611) | Refactor security provider instantiation |
+| [#4653](https://github.com/opensearch-project/security/pull/4653) | Remove Log4j Strings utility usage |
+| [#4694](https://github.com/opensearch-project/security/pull/4694) | PluginSubject build fix |
+| [#4684](https://github.com/opensearch-project/security/pull/4684) | Fix coverage-report workflow |
+| [#4610](https://github.com/opensearch-project/security/pull/4610) | Backport failed PRs |
+| [#4625](https://github.com/opensearch-project/security/pull/4625) | Update PR template backport section |
+
+## References
+
+- [Issue #4599](https://github.com/opensearch-project/security/issues/4599): Demo certificate setting bug
+- [Issue #4627](https://github.com/opensearch-project/security/issues/4627): Auth token endpoint issue
+- [Issue #4480](https://github.com/opensearch-project/security/issues/4480): Certificate SAN ordering issue
+- [Issue #4583](https://github.com/opensearch-project/security/issues/4583): Security provider refactoring
+- [Issue #3870](https://github.com/opensearch-project/security/issues/3870): Terms aggregation permissions
+
+## Related Feature Report
+
+- [Security Plugin](../../../features/security/security-plugin.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -18,6 +18,7 @@
 
 ### security
 - [Dependency Bumps](features/security/dependency-bumps.md)
+- [Security Plugin Bugfixes](features/security/security-plugin-bugfixes.md)
 
 ### security-analytics
 - [Threat Intel Bugfixes](features/security-analytics/threat-intel-bugfixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for Security Plugin bugfixes in OpenSearch v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/security/security-plugin-bugfixes.md`
- Feature report updated: `docs/features/security/security-plugin.md`

### Key Changes in v2.17.0

**Bug Fixes:**
- Demo certificate validation (`plugins.security.allow_unsafe_democertificates` setting)
- Auth token endpoint for `internalusers` API
- Audit config null handling
- Certificate SAN ordering during hot reload
- TermsAggregationEvaluator READ_ACTIONS permissions
- Certificates API timeout parameter

**Refactoring:**
- Security provider instantiation for FIPS support
- Log4j utility removal
- PluginSubject build fix

### PRs Investigated
- #4603, #4631, #4664, #4640, #4607, #4611, #4653, #4694, #4684, #4610, #4625

Closes #428