### PR TITLE
docs: add Reporting Enhancements report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -66,6 +66,7 @@
 
 - [AUTO Version Management](reporting/auto-version-management.md)
 - [CI/CD Workflow](reporting/ci-workflow.md)
+- [Integration Test Stability](reporting/integration-test-stability.md)
 - [Java Agent Migration](reporting/java-agent-migration.md)
 
 ## dashboards-reporting

--- a/docs/features/reporting/integration-test-stability.md
+++ b/docs/features/reporting/integration-test-stability.md
@@ -1,0 +1,74 @@
+# Integration Test Stability
+
+## Summary
+
+The OpenSearch Reporting plugin includes integration tests that validate report generation functionality. These tests verify timing accuracy of generated reports, and require appropriate tolerance settings to account for infrastructure variability across different CI environments.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Integration Test Flow"
+        A[Test Request] --> B[OnDemandReportGenerationIT]
+        B --> C[Create Report Definition]
+        C --> D[Generate On-Demand Report]
+        D --> E[Validate Report Instance]
+        E --> F[validateTimeNearRefTime]
+        F --> G{Time Within Tolerance?}
+        G -->|Yes| H[Test Pass]
+        G -->|No| I[Test Fail]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `OnDemandReportGenerationIT` | Integration test class for on-demand report generation |
+| `validateTimeNearRefTime` | Helper function that validates timestamps are within expected tolerance |
+| `IntegTestHelpers.kt` | Utility file containing test helper functions |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Accuracy (seconds) | Time tolerance for timestamp validation | 3 |
+
+### Test Validation Logic
+
+The `validateTimeNearRefTime` function compares:
+
+1. The report's `beginTimeMs` timestamp
+2. The expected time based on report definition duration
+3. A tolerance window (in seconds)
+
+```kotlin
+validateTimeNearRefTime(
+    Instant.ofEpochMilli(reportInstance.get("beginTimeMs").asLong),
+    Instant.now().minus(Duration.parse(reportDefinition.get("format").asJsonObject.get("duration").asString)),
+    3  // seconds tolerance
+)
+```
+
+## Limitations
+
+- Higher tolerance values may mask genuine timing issues
+- Test stability depends on CI infrastructure performance
+- Windows ARM64 environments show higher timing variability
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#1022](https://github.com/opensearch-project/reporting/pull/1022) | Increase accuracy seconds for on-demand report test |
+
+## References
+
+- [Issue #1019](https://github.com/opensearch-project/reporting/issues/1019): Original test failure report
+- [Reporting Documentation](https://docs.opensearch.org/2.17/reporting/): Official OpenSearch Reporting docs
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Increased time tolerance from 1 to 3 seconds for `OnDemandReportGenerationIT`

--- a/docs/releases/v2.17.0/features/reporting/reporting-enhancements.md
+++ b/docs/releases/v2.17.0/features/reporting/reporting-enhancements.md
@@ -1,0 +1,71 @@
+# Reporting Enhancements
+
+## Summary
+
+This release fixes a flaky integration test in the OpenSearch Reporting plugin by increasing the time accuracy tolerance from 1 second to 3 seconds when validating on-demand report generation timestamps.
+
+## Details
+
+### What's New in v2.17.0
+
+The `OnDemandReportGenerationIT` integration test was failing intermittently due to timing issues in CI environments. The test validates that report timestamps are within an expected time range, but infrastructure delays caused occasional failures.
+
+### Technical Changes
+
+#### Test Fix
+
+The fix increases the accuracy tolerance in the `validateTimeNearRefTime` function call:
+
+```kotlin
+// Before (v2.16.0)
+validateTimeNearRefTime(
+    Instant.ofEpochMilli(reportInstance.get("beginTimeMs").asLong),
+    Instant.now().minus(Duration.parse(reportDefinition.get("format").asJsonObject.get("duration").asString)),
+    1  // 1 second tolerance
+)
+
+// After (v2.17.0)
+validateTimeNearRefTime(
+    Instant.ofEpochMilli(reportInstance.get("beginTimeMs").asLong),
+    Instant.now().minus(Duration.parse(reportDefinition.get("format").asJsonObject.get("duration").asString)),
+    3  // 3 seconds tolerance
+)
+```
+
+#### Root Cause
+
+The test failures occurred because:
+
+1. CI infrastructure (especially Windows ARM64) has variable execution times
+2. The 1-second tolerance was too strict for environments with higher latency
+3. Time differences observed in failures ranged from 1.04 to 2.76 seconds
+
+#### Changed Files
+
+| File | Change |
+|------|--------|
+| `src/test/kotlin/org/opensearch/integTest/rest/OnDemandReportGenerationIT.kt` | Increased accuracy parameter from 1 to 3 |
+
+### Migration Notes
+
+No migration required. This is a test-only change with no impact on production functionality.
+
+## Limitations
+
+- This fix addresses test flakiness but does not change the actual report generation behavior
+- The increased tolerance may mask genuine timing regressions in edge cases
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1022](https://github.com/opensearch-project/reporting/pull/1022) | Increase accuracy seconds while testing create on-demand report from definition |
+
+## References
+
+- [Issue #1019](https://github.com/opensearch-project/reporting/issues/1019): Integration test failure for opensearch-reports 2.16.0
+- [Reporting Documentation](https://docs.opensearch.org/2.17/reporting/): Official OpenSearch Reporting docs
+
+## Related Feature Report
+
+- [Integration Test Stability](../../../features/reporting/integration-test-stability.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -49,6 +49,9 @@
 ### query-insights
 - [Query Insights Infrastructure](features/query-insights/query-insights-infrastructure.md)
 
+### reporting
+- [Reporting Enhancements](features/reporting/reporting-enhancements.md)
+
 ### sql
 - [SQL/PPL Bugfixes](features/sql/sql-ppl-bugfixes.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Reporting Enhancements bugfix in OpenSearch v2.17.0.

### Changes

- **Release Report**: `docs/releases/v2.17.0/features/reporting/reporting-enhancements.md`
  - Documents the integration test fix that increased time tolerance from 1 to 3 seconds
  
- **Feature Report**: `docs/features/reporting/integration-test-stability.md`
  - New feature report documenting the integration test stability improvements

### Related Issue

Closes #427

### PR Investigated

- [opensearch-project/reporting#1022](https://github.com/opensearch-project/reporting/pull/1022): Increase accuracy seconds while testing create on-demand report from definition