### PR TITLE
docs: add Query Insights Bugfixes report for v2.17.0

### DIFF
--- a/docs/features/query-insights/query-insights.md
+++ b/docs/features/query-insights/query-insights.md
@@ -185,6 +185,13 @@ GET /_insights/live_queries?sort=latency&size=5
 | v3.0.0 | [#300](https://github.com/opensearch-project/query-insights/pull/300) | Top queries API verbose param |
 | v3.0.0 | [#298](https://github.com/opensearch-project/query-insights/pull/298) | Skip profile queries |
 | v3.0.0 | [#266](https://github.com/opensearch-project/query-insights/pull/266) | Strict hash check on top queries indices |
+| v2.17.0 | [#74](https://github.com/opensearch-project/query-insights/pull/74) | Fix listener startup when query metrics enabled |
+| v2.17.0 | [#64](https://github.com/opensearch-project/query-insights/pull/64) | Add query shape hash method |
+| v2.17.0 | [#71](https://github.com/opensearch-project/query-insights/pull/71) | Add more integration tests |
+| v2.17.0 | [#85](https://github.com/opensearch-project/query-insights/pull/85) | Query grouping integration tests |
+| v2.17.0 | [#89](https://github.com/opensearch-project/query-insights/pull/89) | Additional grouping ITs and refactor |
+| v2.17.0 | [#58](https://github.com/opensearch-project/query-insights/pull/58) | Fix CVE-2023-2976 for checkstyle |
+| v2.17.0 | [#59](https://github.com/opensearch-project/query-insights/pull/59) | Fix security based integration tests |
 | v2.17.0 | [#8139](https://github.com/opensearch-project/documentation-website/pull/8139) | Update GET top N api documentation |
 | v2.17.0 | [#51](https://github.com/opensearch-project/query-insights/pull/51) | Add code hygiene checks (Spotless, Checkstyle) |
 | v2.17.0 | [#90](https://github.com/opensearch-project/query-insights/pull/90) | Fix snapshot publishing configuration |
@@ -202,5 +209,5 @@ GET /_insights/live_queries?sort=latency&size=5
 ## Change History
 
 - **v3.0.0**: Added Live Queries API, default index template, verbose parameter, profile query filtering, strict hash check
-- **v2.17.0**: Improved Top N API documentation; added code hygiene checks (Spotless, Checkstyle); fixed snapshot publishing configuration
+- **v2.17.0**: Fixed listener startup when query metrics enabled; added query shape hash method; fixed CVE-2023-2976; improved integration test coverage for query grouping; added code hygiene checks (Spotless, Checkstyle); fixed snapshot publishing configuration
 - **v2.12.0**: Initial release with Top N queries feature

--- a/docs/releases/v2.17.0/features/query-insights/query-insights-bugfixes.md
+++ b/docs/releases/v2.17.0/features/query-insights/query-insights-bugfixes.md
@@ -1,0 +1,119 @@
+# Query Insights Bugfixes
+
+## Summary
+
+This release item includes critical bugfixes and test improvements for the Query Insights plugin. The key fix ensures the query listener starts correctly when query metrics are enabled, even if Top N queries is disabled. Additional improvements include a hash method for query shape grouping, CVE fix for checkstyle, and comprehensive integration test coverage for query grouping functionality.
+
+## Details
+
+### What's New in v2.17.0
+
+#### Listener Startup Fix (PR #74)
+
+Fixed a bug where the Query Insights listener would not start when only query metrics was enabled. Previously, the listener only started when Top N queries was enabled, causing query metrics collection to fail silently.
+
+**Before:**
+```java
+// Listener only started when Top N enabled
+if (topNEnabled) {
+    startListener();
+}
+```
+
+**After:**
+```java
+// Listener starts when either Top N or query metrics enabled
+if (topNEnabled || queryMetricsEnabled) {
+    startListener();
+}
+```
+
+#### Query Shape Hash Method (PR #64)
+
+Added a hash code method to the `QueryShapeGenerator` class for consistent query shape identification. This enables efficient query grouping by similarity.
+
+**New Components:**
+| Component | Description |
+|-----------|-------------|
+| `QueryShapeGenerator.hashCode()` | Generates consistent hash for query shapes |
+| `SearchSourceBuilderUtils` | Utility class providing common search source objects for testing |
+
+#### CVE-2023-2976 Fix (PR #58)
+
+Fixed security vulnerability CVE-2023-2976 in the checkstyle dependency by updating to a patched version.
+
+#### Security Integration Tests Fix (PR #59)
+
+Fixed security-based integration tests to run correctly with the `integTestWithSecurity` task only. This ensures proper test isolation when security plugin is enabled.
+
+**Test Configuration:**
+```groovy
+// Security tests now run with dedicated task
+task integTestWithSecurity(type: Test) {
+    // Security plugin enabled
+}
+```
+
+### Technical Changes
+
+#### Integration Test Improvements
+
+Added comprehensive integration tests for query grouping functionality:
+
+| PR | Test Coverage |
+|----|---------------|
+| #71 | Basic query insights integration tests |
+| #85 | Query grouping integration tests for similarity-based grouping |
+| #89 | Additional grouping ITs with test refactoring |
+
+**Test Scenarios Covered:**
+- Top N queries collection with various metric types
+- Query grouping by similarity
+- Query shape hash consistency
+- Multi-node cluster behavior
+
+### Usage Example
+
+**Enable query metrics (now works correctly):**
+```bash
+PUT _cluster/settings
+{
+  "persistent": {
+    "search.insights.top_queries.latency.enabled": false,
+    "search.insights.query_metrics.enabled": true
+  }
+}
+```
+
+### Migration Notes
+
+No migration required. These are bugfixes and test improvements that don't change the API or configuration.
+
+## Limitations
+
+- Query metrics collection requires the listener to be active
+- Security-based integration tests require separate test execution
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#74](https://github.com/opensearch-project/query-insights/pull/74) | Make sure listener is started when query metrics enabled |
+| [#64](https://github.com/opensearch-project/query-insights/pull/64) | Add query shape hash method |
+| [#71](https://github.com/opensearch-project/query-insights/pull/71) | Add more integration tests for query insights |
+| [#85](https://github.com/opensearch-project/query-insights/pull/85) | Query grouping integration tests |
+| [#89](https://github.com/opensearch-project/query-insights/pull/89) | Add additional grouping ITs and refactor |
+| [#58](https://github.com/opensearch-project/query-insights/pull/58) | Fix CVE-2023-2976 for checkstyle |
+| [#59](https://github.com/opensearch-project/query-insights/pull/59) | Fix security based integration tests |
+
+## References
+
+- [Issue #57](https://github.com/opensearch-project/query-insights/issues/57): CVE-2023-2976 vulnerability report
+- [Issue #39](https://github.com/opensearch-project/query-insights/issues/39): Security integration tests issue
+- [Issue #8](https://github.com/opensearch-project/query-insights/issues/8): Integration tests tracking
+- [Issue #13357](https://github.com/opensearch-project/OpenSearch/issues/13357): Query grouping feature request
+- [Query Insights Documentation](https://docs.opensearch.org/2.17/observing-your-data/query-insights/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/query-insights/query-insights.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -47,6 +47,7 @@
 - [Performance Analyzer Bugfixes](features/performance-analyzer/performance-analyzer-bugfixes.md)
 
 ### query-insights
+- [Query Insights Bugfixes](features/query-insights/query-insights-bugfixes.md)
 - [Query Insights Infrastructure](features/query-insights/query-insights-infrastructure.md)
 
 ### reporting


### PR DESCRIPTION
## Summary

This PR adds the release report for Query Insights Bugfixes in v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/query-insights/query-insights-bugfixes.md`
- Feature report: `docs/features/query-insights/query-insights.md` (updated)

### Key Changes in v2.17.0
- Fixed listener startup when query metrics enabled (PR #74)
- Added query shape hash method for grouping (PR #64)
- Fixed CVE-2023-2976 for checkstyle (PR #58)
- Fixed security-based integration tests (PR #59)
- Added comprehensive integration tests for query grouping (PRs #71, #85, #89)

### PRs Investigated
| PR | Description |
|----|-------------|
| [#74](https://github.com/opensearch-project/query-insights/pull/74) | Make sure listener is started when query metrics enabled |
| [#64](https://github.com/opensearch-project/query-insights/pull/64) | Add query shape hash method |
| [#71](https://github.com/opensearch-project/query-insights/pull/71) | Add more integration tests |
| [#85](https://github.com/opensearch-project/query-insights/pull/85) | Query grouping integration tests |
| [#89](https://github.com/opensearch-project/query-insights/pull/89) | Additional grouping ITs and refactor |
| [#58](https://github.com/opensearch-project/query-insights/pull/58) | Fix CVE-2023-2976 for checkstyle |
| [#59](https://github.com/opensearch-project/query-insights/pull/59) | Fix security based integration tests |

Closes #426