### PR TITLE
docs: add observability-notebooks report for v2.17.0

### DIFF
--- a/docs/features/dashboards-observability/observability-notebooks.md
+++ b/docs/features/dashboards-observability/observability-notebooks.md
@@ -153,7 +153,8 @@ Notebooks support OpenSearch security features:
 | Version | PR | Description |
 |---------|-----|-------------|
 | v3.0.0 | [#2406](https://github.com/opensearch-project/dashboards-observability/pull/2406) | Remove support for legacy notebooks |
-| v2.17.0 | - | Introduced saved objects storage for notebooks |
+| v2.17.0 | [#2110](https://github.com/opensearch-project/dashboards-observability/pull/2110) | UI update: badge counter in breadcrumbs, simplified delete workflow |
+| v2.17.0 | [#2108](https://github.com/opensearch-project/dashboards-observability/pull/2108) | Fix sample notebooks for MDS environments |
 | v1.0.0 | - | Initial production release of Notebooks |
 
 ## References
@@ -168,5 +169,5 @@ Notebooks support OpenSearch security features:
 
 - **v3.0.0** (2025-05-06): Removed legacy notebooks support; only `.kibana` storage supported
 - **v2.19.0** (2025-02-11): Deprecated legacy notebooks with migration notice
-- **v2.17.0** (2024-09-17): Introduced saved objects storage in `.kibana` index
+- **v2.17.0** (2024-09-17): UI improvements (badge counter in breadcrumbs, simplified delete workflow); fixed sample notebooks for MDS environments
 - **v1.0.0** (2021-07-12): Initial production release with SQL, PPL, and visualization support

--- a/docs/releases/v2.17.0/features/dashboards-observability/observability-notebooks.md
+++ b/docs/releases/v2.17.0/features/dashboards-observability/observability-notebooks.md
@@ -1,0 +1,109 @@
+# Observability Notebooks Bugfixes
+
+## Summary
+
+This release includes UI improvements and bug fixes for the Notebooks feature in OpenSearch Dashboards Observability. The changes improve the navigation experience with badge counters in breadcrumbs, simplify the notebook deletion workflow, and fix sample notebook functionality for Multi-Data Source (MDS) environments.
+
+## Details
+
+### What's New in v2.17.0
+
+Two bug fixes improve the Notebooks user experience:
+
+1. **UI Improvements (PR #2110)**: Updated badge counter display and simplified notebook deletion
+2. **Sample Notebooks Fix (PR #2108)**: Fixed sample notebook addition in MDS-enabled environments
+
+### Technical Changes
+
+#### UI Changes
+
+```mermaid
+flowchart TB
+    subgraph Before["Before v2.17.0"]
+        B1[Badge in Header] --> B2[Actions Popover]
+        B2 --> B3[Delete Option]
+    end
+    
+    subgraph After["After v2.17.0"]
+        A1[Counter in Breadcrumb] --> A2[Direct Delete Button]
+    end
+```
+
+| Change | Before | After |
+|--------|--------|-------|
+| Notebook count display | Badge in header component | Counter appended to breadcrumb text |
+| Delete action | Actions popover → Delete menu item | Direct "Delete N notebook(s)" button |
+| Delete button visibility | Always visible in popover | Only visible when notebooks selected |
+
+#### Breadcrumb Counter Implementation
+
+The `setNavBreadCrumbs` function now accepts an optional `counter` parameter:
+
+```typescript
+export const setNavBreadCrumbs = (
+  parentBreadCrumb: EuiBreadcrumb[],
+  pageBreadCrumb: EuiBreadcrumb[],
+  counter?: number  // New parameter
+) => {
+  const isNavGroupEnabled = coreRefs?.chrome?.navGroup.getNavGroupEnabled();
+  const updatedPageBreadCrumb = pageBreadCrumb.map((crumb) => ({
+    ...crumb,
+    text: isNavGroupEnabled && counter !== undefined 
+      ? `${crumb.text} (${counter})` 
+      : crumb.text,
+  }));
+  // ...
+};
+```
+
+#### MDS Support for Sample Notebooks
+
+The sample notebooks feature now properly supports Multi-Data Source environments:
+
+| Component | Change |
+|-----------|--------|
+| `getSampleNotebooksModal` | Added DataSourceSelector when MDS enabled |
+| `addSampleNotebooks` | Accepts `dataSourceMDSId` and `dataSourceMDSLabel` parameters |
+| Sample data API calls | Include `data_source_id` query parameter |
+| Visualization search | Appends data source label to visualization titles |
+
+```typescript
+// Sample data now includes data source ID
+await this.props.http.post('../api/sample_data/flights', {
+  query: { data_source_id: dataSourceMDSId },
+});
+```
+
+### Usage Example
+
+The delete workflow is now more direct:
+
+1. Select one or more notebooks using checkboxes
+2. Click the "Delete N notebook(s)" button that appears
+3. Confirm deletion in the modal
+
+For MDS environments, adding sample notebooks now prompts for data source selection:
+
+1. Click "Add sample notebooks"
+2. Select a data source from the dropdown (if MDS enabled)
+3. Confirm to add sample data and notebooks
+
+## Limitations
+
+- Sample notebooks require the selected data source to be accessible
+- Badge counter only displays when new navigation is enabled
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2110](https://github.com/opensearch-project/dashboards-observability/pull/2110) | UI update: badge counter in breadcrumbs, simplified delete workflow |
+| [#2108](https://github.com/opensearch-project/dashboards-observability/pull/2108) | Fix sample notebooks for MDS environments |
+
+## References
+
+- [Notebooks Documentation](https://docs.opensearch.org/2.17/observing-your-data/notebooks/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-observability/observability-notebooks.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -7,6 +7,9 @@
 ### dashboards-maps
 - [Maps Plugin Bugfixes](features/dashboards-maps/maps-plugin-bugfixes.md)
 
+### dashboards-observability
+- [Observability Notebooks Bugfixes](features/dashboards-observability/observability-notebooks.md)
+
 ### dashboards-search-relevance
 - [Documentation Link Updates](features/dashboards-search-relevance/documentation-link-updates.md)
 


### PR DESCRIPTION
## Summary

Adds release report for Observability Notebooks bugfixes in v2.17.0.

### Changes in v2.17.0

**UI Improvements (PR #2110)**:
- Badge counter moved to breadcrumb text
- Simplified notebook deletion workflow (direct button instead of Actions popover)

**Sample Notebooks Fix (PR #2108)**:
- Fixed sample notebook addition for Multi-Data Source (MDS) environments
- Added DataSourceSelector to sample notebooks modal
- Sample data API calls now include data source ID

### Files Changed
- Created: `docs/releases/v2.17.0/features/dashboards-observability/observability-notebooks.md`
- Updated: `docs/features/dashboards-observability/observability-notebooks.md`
- Updated: `docs/releases/v2.17.0/index.md`

Closes #425