### PR TITLE
docs: add Trace Analytics bugfixes report for v2.17.0

### DIFF
--- a/docs/features/dashboards-observability/trace-analytics.md
+++ b/docs/features/dashboards-observability/trace-analytics.md
@@ -1,0 +1,165 @@
+# Trace Analytics
+
+## Summary
+
+Trace Analytics is a feature in OpenSearch Dashboards Observability plugin that enables visualization and analysis of distributed traces from applications instrumented with OpenTelemetry or Jaeger. It helps identify performance bottlenecks, troubleshoot errors, and understand request flows across microservices by providing trace visualization, service maps, and correlation with logs.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Data Collection"
+        APP[Applications]
+        OTEL[OpenTelemetry Collector]
+        JAEGER[Jaeger Agent]
+    end
+    
+    subgraph "OpenSearch"
+        TRACES[Trace Indices]
+        SERVICES[Service Map Index]
+        LOGS[Log Indices]
+    end
+    
+    subgraph "Dashboards Observability"
+        TA[Trace Analytics]
+        SVC[Services View]
+        TG[Trace Groups]
+        CORR[Log Correlation]
+        MDS[Multi-Data Source Support]
+    end
+    
+    APP --> OTEL
+    APP --> JAEGER
+    OTEL --> TRACES
+    OTEL --> SERVICES
+    JAEGER --> TRACES
+    
+    TRACES --> TA
+    SERVICES --> SVC
+    TRACES --> TG
+    LOGS --> CORR
+    TA --> CORR
+    MDS --> TA
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph Input
+        SPAN[Span Data]
+        ATTR[Attributes]
+    end
+    
+    subgraph Processing
+        INDEX[Indexing]
+        MAP[Service Map Generation]
+    end
+    
+    subgraph Visualization
+        TRACE[Trace View]
+        GRID[Data Grid]
+        FLYOUT[Detail Flyout]
+    end
+    
+    SPAN --> INDEX
+    ATTR --> INDEX
+    INDEX --> MAP
+    INDEX --> TRACE
+    TRACE --> GRID
+    GRID --> FLYOUT
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Trace Analytics | Main interface for viewing and filtering traces |
+| Services View | Service dependency visualization with metrics |
+| Trace Groups | Grouping of traces by operation patterns |
+| Service Map | Visual representation of service dependencies |
+| Custom Logs Correlation | Configurable log source for trace-log correlation |
+| Data Grid Table | Paginated traces table with column customization |
+| Multi-Data Source Support | Connect to multiple OpenSearch clusters |
+| Application Analytics | Integrated traces/spans view within app analytics |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Custom Log Source | User-defined log index for correlation | None |
+| Database Selector | Database name for integration setup | `default` |
+| Spans Limit | Maximum spans displayed in trace view | 3000 |
+| Trace Data Source | OTEL or Jaeger format | OTEL |
+| MDS ID | Multi-Data Source identifier | Local cluster |
+
+### Usage Example
+
+#### Viewing Traces
+```
+1. Navigate to Observability → Trace Analytics
+2. Use filters to narrow down traces by:
+   - Service name
+   - Operation name
+   - Time range
+   - Latency threshold
+3. Click on a trace to view the span waterfall
+```
+
+#### Direct URL Navigation
+```
+# Navigate directly to traces view
+http://host:port/app/observability-traces#/traces
+
+# Navigate to services view
+http://host:port/app/observability-traces#/services
+```
+
+#### Multi-Data Source Usage
+```
+1. Configure data sources in Dashboards Management
+2. Select data source from dropdown in Trace Analytics
+3. View traces from the selected cluster
+```
+
+## Limitations
+
+- Custom logs correlation requires manual configuration
+- Discover may show errors when loading data from specific indexes using PPL
+- Sorting is disabled on attribute fields in the data grid
+- Maximum 10,000 spans can be retrieved for pagination
+- Service map generation requires proper span relationships
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#2375](https://github.com/opensearch-project/dashboards-observability/pull/2375) | Support custom logs correlation |
+| v3.0.0 | [#2380](https://github.com/opensearch-project/dashboards-observability/pull/2380) | Database selector in integration setup |
+| v3.0.0 | [#2383](https://github.com/opensearch-project/dashboards-observability/pull/2383) | Service Content/View Optimizations |
+| v3.0.0 | [#2390](https://github.com/opensearch-project/dashboards-observability/pull/2390) | Custom source switch to data grid |
+| v3.0.0 | [#2398](https://github.com/opensearch-project/dashboards-observability/pull/2398) | Trace to logs correlation |
+| v3.0.0 | [#2410](https://github.com/opensearch-project/dashboards-observability/pull/2410) | Amazon Network Firewall Integration |
+| v3.0.0 | [#2432](https://github.com/opensearch-project/dashboards-observability/pull/2432) | OTEL attributes field support |
+| v2.17.0 | [#2006](https://github.com/opensearch-project/dashboards-observability/pull/2006) | MDS fix for local cluster rendering |
+| v2.17.0 | [#2023](https://github.com/opensearch-project/dashboards-observability/pull/2023) | Traces/Spans tab fix for App Analytics |
+| v2.17.0 | [#2024](https://github.com/opensearch-project/dashboards-observability/pull/2024) | Fix direct URL load |
+| v2.17.0 | [#2037](https://github.com/opensearch-project/dashboards-observability/pull/2037) | Breadcrumbs and ID pathing fix |
+| v2.17.0 | [#2100](https://github.com/opensearch-project/dashboards-observability/pull/2100) | Fix missing MDS ID in flyout |
+
+## References
+
+- [Trace Analytics Documentation](https://docs.opensearch.org/latest/observing-your-data/trace/index/): Official documentation
+- [Trace Analytics Plugin](https://docs.opensearch.org/latest/observing-your-data/trace/ta-dashboards/): Dashboards plugin guide
+- [Jaeger Trace Data](https://docs.opensearch.org/latest/observing-your-data/trace/trace-analytics-jaeger/): Jaeger integration
+- [Simple Schema for Observability](https://docs.opensearch.org/latest/observing-your-data/ss4o/): SS4O schema
+- [Application Analytics](https://docs.opensearch.org/latest/observing-your-data/app-analytics/): App analytics documentation
+- [Issue #1878](https://github.com/opensearch-project/dashboards-observability/issues/1878): MDS rendering issue
+- [Issue #1931](https://github.com/opensearch-project/dashboards-observability/issues/1931): App Analytics crash
+
+## Change History
+
+- **v3.0.0** (2025-02-25): Custom logs correlation, data grid migration, OTEL attributes support, service view optimizations, Amazon Network Firewall integration, trace-to-logs correlation improvements
+- **v2.17.0** (2024-09-17): Multi-Data Source bug fixes, URL routing fixes, breadcrumb navigation improvements, Getting Started link fixes, org.json security update

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -139,6 +139,7 @@
 
 - [Observability Notebooks](dashboards-observability/observability-notebooks.md)
 - [Observability Traces](dashboards-observability/observability-traces.md)
+- [Trace Analytics](dashboards-observability/trace-analytics.md)
 
 ## dashboards-maps
 

--- a/docs/releases/v2.17.0/features/observability/trace-analytics-bugfixes.md
+++ b/docs/releases/v2.17.0/features/observability/trace-analytics-bugfixes.md
@@ -1,0 +1,85 @@
+# Trace Analytics Bugfixes
+
+## Summary
+
+OpenSearch v2.17.0 includes multiple bug fixes for Trace Analytics in the dashboards-observability plugin. These fixes address issues with Multi-Data Source (MDS) support, URL routing, breadcrumb navigation, and broken links in the Getting Started workflows. The fixes improve stability when using Trace Analytics with multiple data sources and ensure proper navigation within the Application Analytics feature.
+
+## Details
+
+### What's New in v2.17.0
+
+This release focuses on stability improvements for Trace Analytics, particularly around Multi-Data Source (MDS) integration:
+
+1. **MDS ID Handling Fixes**: Multiple PRs address missing or incorrect MDS ID propagation, which caused page crashes when using Trace Analytics with multiple data sources
+2. **URL Routing Fixes**: Direct URL navigation to `/traces` path now works correctly instead of defaulting to services page
+3. **Navigation Improvements**: Breadcrumbs and ID pathing now work correctly in both old and new navigation modes
+4. **Link Fixes**: Broken links in Getting Started workflows and CSV documentation have been corrected
+5. **Dependency Updates**: Security vulnerability fix for org.json library (CVE-2023-5072)
+
+### Technical Changes
+
+#### Bug Categories
+
+| Category | Issue | Fix |
+|----------|-------|-----|
+| MDS Support | Local cluster not rendering correctly | Added proper MDS ID handling for local cluster |
+| MDS Support | Missing MDS ID in flyout | Added MDS ID parameter to trace flyout component |
+| MDS Support | App Analytics crash | Fixed MDS ID propagation to Traces/Spans tabs |
+| URL Routing | Direct URL load fails | Fixed default route path when URL hash is present |
+| Navigation | Breadcrumbs incorrect | Fixed breadcrumb generation and ID pathing |
+| Documentation | Broken links | Updated Getting Started and CSV workflow links |
+| Dependencies | CVE-2023-5072 | Bumped org.json from 20210307 to 20231013 |
+
+#### Components Affected
+
+| Component | Description |
+|-----------|-------------|
+| TraceAnalytics | Main trace analytics page with MDS support |
+| TraceFlyout | Detail flyout for individual traces |
+| ApplicationAnalytics | Traces and Spans tabs in app analytics |
+| GettingStarted | Getting started workflow links |
+
+### Usage Example
+
+After these fixes, Trace Analytics works correctly with Multi-Data Source:
+
+```
+# Direct URL navigation now works
+http://host:port/app/observability-traces#/traces
+
+# Previously would redirect to /services, now correctly loads /traces
+```
+
+### Migration Notes
+
+No migration required. These are bug fixes that improve existing functionality.
+
+## Limitations
+
+- These fixes are specific to the dashboards-observability plugin
+- MDS support requires proper configuration of data sources in OpenSearch Dashboards
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2006](https://github.com/opensearch-project/dashboards-observability/pull/2006) | Trace Analytics bug fix for local cluster rendering |
+| [#2017](https://github.com/opensearch-project/dashboards-observability/pull/2017) | Fix docker links & index patterns names |
+| [#2023](https://github.com/opensearch-project/dashboards-observability/pull/2023) | Traces and Spans tab fix for Application Analytics |
+| [#2031](https://github.com/opensearch-project/dashboards-observability/pull/2031) | Getting Started broken link fix for CSV |
+| [#2024](https://github.com/opensearch-project/dashboards-observability/pull/2024) | Fix direct URL load for Trace Analytics |
+| [#2037](https://github.com/opensearch-project/dashboards-observability/pull/2037) | Trace Analytics bugfix for breadcrumbs and ID pathing |
+| [#2100](https://github.com/opensearch-project/dashboards-observability/pull/2100) | Fixed traces bug for missing MDS ID |
+| [#2012](https://github.com/opensearch-project/dashboards-observability/pull/2012) | Update Getting Started links to match catalog PR merges |
+| [#1966](https://github.com/opensearch-project/dashboards-observability/pull/1966) | Bump org.json:json for CVE-2023-5072 |
+
+## References
+
+- [Issue #1878](https://github.com/opensearch-project/dashboards-observability/issues/1878): Trace Analytics MDS rendering issue
+- [Issue #1931](https://github.com/opensearch-project/dashboards-observability/issues/1931): App Analytics page crash for missing MDS ID
+- [Trace Analytics Documentation](https://docs.opensearch.org/2.17/observing-your-data/trace/index/): Official documentation
+- [CVE-2023-5072](https://nvd.nist.gov/vuln/detail/CVE-2023-5072): org.json vulnerability
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-observability/trace-analytics.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -9,6 +9,7 @@
 
 ### dashboards-observability
 - [Observability Notebooks Bugfixes](features/dashboards-observability/observability-notebooks.md)
+- [Trace Analytics Bugfixes](features/observability/trace-analytics-bugfixes.md)
 
 ### dashboards-search-relevance
 - [Documentation Link Updates](features/dashboards-search-relevance/documentation-link-updates.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for Trace Analytics bugfixes in OpenSearch v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/observability/trace-analytics-bugfixes.md`
- Feature report: `docs/features/dashboards-observability/trace-analytics.md`

### Key Changes in v2.17.0
- Multi-Data Source (MDS) ID handling fixes for local cluster rendering
- URL routing fix for direct navigation to `/traces` path
- Breadcrumb and ID pathing fixes for navigation
- Application Analytics Traces/Spans tab crash fix
- Getting Started and CSV workflow link fixes
- Security update for org.json (CVE-2023-5072)

### PRs Investigated
- #2006: Trace Analytics bug fix for local cluster rendering
- #2017: Fix docker links & index patterns names
- #2023: Traces and Spans tab fix for Application Analytics
- #2024: Fix direct URL load for Trace Analytics
- #2031: Getting Started broken link fix for CSV
- #2037: Trace Analytics bugfix for breadcrumbs and ID pathing
- #2100: Fixed traces bug for missing MDS ID
- #2012: Update Getting Started links
- #1966: Bump org.json:json for CVE-2023-5072

Closes #424