### PR TITLE
docs: add neural-search hybrid query bugfixes report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -3,6 +3,7 @@
 ## neural-search
 
 - [Batch Ingestion](neural-search/batch-ingestion.md)
+- [Hybrid Query](neural-search/hybrid-query.md)
 - [Neural Search Compatibility](neural-search/neural-search-compatibility.md)
 - [Neural Sparse Search](neural-search/neural-sparse-search.md)
 - [Semantic Field](neural-search/semantic-field.md)

--- a/docs/features/neural-search/hybrid-query.md
+++ b/docs/features/neural-search/hybrid-query.md
@@ -1,0 +1,138 @@
+# Hybrid Query
+
+## Summary
+
+Hybrid query is a compound query type in OpenSearch that combines lexical (keyword) search with neural (vector) search to improve search relevance. It was introduced in OpenSearch 2.11 as part of the neural-search plugin and enables users to leverage both traditional BM25 scoring and semantic similarity in a single query.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Hybrid Query Execution"
+        HQ[Hybrid Query] --> LQ[Lexical Sub-query]
+        HQ --> NQ[Neural Sub-query]
+        
+        LQ --> LC[Lucene Collector]
+        NQ --> VC[Vector Collector]
+        
+        LC --> HTC[HybridTopScoreDocCollector]
+        VC --> HTC
+        
+        HTC --> TDM[TopDocsMerger]
+        TDM --> NP[Normalization Processor]
+        NP --> Results[Combined Results]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    Query[Search Request] --> Parse[Parse Hybrid Query]
+    Parse --> Execute[Execute Sub-queries]
+    Execute --> Collect[Collect Results per Shard]
+    Collect --> Merge[Merge Shard Results]
+    Merge --> Normalize[Score Normalization]
+    Normalize --> Combine[Score Combination]
+    Combine --> Response[Search Response]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `HybridQuery` | Compound query containing multiple sub-queries |
+| `HybridQueryPhaseSearcher` | Custom query phase searcher for hybrid execution |
+| `HybridTopScoreDocCollector` | Collector that maintains results from all sub-queries |
+| `TopDocsMerger` | Merges results from multiple shards/segments |
+| `NormalizationProcessor` | Search pipeline processor for score normalization |
+| `ScoreCombinationTechnique` | Combines normalized scores (arithmetic_mean, geometric_mean, harmonic_mean) |
+
+### Configuration
+
+Hybrid search requires a search pipeline with normalization and combination processors:
+
+```json
+PUT /_search/pipeline/hybrid-pipeline
+{
+  "description": "Pipeline for hybrid search",
+  "phase_results_processors": [
+    {
+      "normalization-processor": {
+        "normalization": {
+          "technique": "min_max"
+        },
+        "combination": {
+          "technique": "arithmetic_mean",
+          "parameters": {
+            "weights": [0.3, 0.7]
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `normalization.technique` | Score normalization method (`min_max`, `l2`) | `min_max` |
+| `combination.technique` | Score combination method (`arithmetic_mean`, `geometric_mean`, `harmonic_mean`) | `arithmetic_mean` |
+| `combination.parameters.weights` | Weights for each sub-query | Equal weights |
+
+### Usage Example
+
+```json
+GET /my-index/_search?search_pipeline=hybrid-pipeline
+{
+  "query": {
+    "hybrid": {
+      "queries": [
+        {
+          "match": {
+            "text_field": "search terms"
+          }
+        },
+        {
+          "neural": {
+            "embedding_field": {
+              "query_text": "semantic search query",
+              "model_id": "model-id",
+              "k": 10
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Limitations
+
+- **Pagination**: The `from` parameter is not supported with hybrid queries. Use `search_after` for pagination instead.
+- **Explain API**: The `explain` parameter is not fully supported for hybrid queries.
+- **Nested queries**: Hybrid queries cannot be nested inside other compound queries.
+- **Concurrent segment search**: Results may vary due to non-deterministic merge order when concurrent segment search is enabled.
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#867](https://github.com/opensearch-project/neural-search/pull/867) | Removed misleading pagination code, added clear error |
+| v2.17.0 | [#877](https://github.com/opensearch-project/neural-search/pull/877) | Fixed merge logic for empty shard results |
+
+## References
+
+- [Hybrid Search Documentation](https://docs.opensearch.org/latest/search-plugins/hybrid-search/)
+- [Hybrid Query DSL](https://docs.opensearch.org/latest/query-dsl/compound/hybrid/)
+- [Neural Search Tutorial](https://docs.opensearch.org/latest/search-plugins/neural-search-tutorial/)
+- [Issue #875](https://github.com/opensearch-project/neural-search/issues/875): Unable to merge results from shards
+- [Issue #280](https://github.com/opensearch-project/neural-search/issues/280): Pagination support tracking
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Fixed pagination error handling and multi-shard merge logic
+- **v2.11.0** (2023-10-16): Initial implementation of hybrid search

--- a/docs/releases/v2.17.0/features/neural-search/neural-search-hybrid-query.md
+++ b/docs/releases/v2.17.0/features/neural-search/neural-search-hybrid-query.md
@@ -1,0 +1,104 @@
+# Neural Search Hybrid Query Bugfixes
+
+## Summary
+
+OpenSearch v2.17.0 includes two critical bugfixes for hybrid query in the neural-search plugin. These fixes address pagination behavior and shard result merging issues that affected hybrid search reliability, particularly when concurrent segment search is enabled.
+
+## Details
+
+### What's New in v2.17.0
+
+Two bugs were fixed in this release:
+
+1. **Pagination Error Handling (PR #867)**: Removed misleading code that gave users the impression pagination worked with hybrid queries when it did not. Now throws a clear error message when pagination is attempted.
+
+2. **Multi-Shard Merge Logic Fix (PR #877)**: Fixed a bug where hybrid query results could fail to merge correctly when concurrent segment search is enabled and one shard returns empty results first.
+
+### Technical Changes
+
+#### Bug 1: Pagination Behavior Clarification
+
+The `HybridTopScoreDocCollector` previously contained code that cut search results in the priority queue, which gave users a false impression that pagination worked. This code was removed, and an explicit error is now thrown when `from` parameter is non-zero:
+
+```java
+// HybridQueryPhaseSearcher.java
+if (searchContext.from() != 0) {
+    throw new IllegalArgumentException(
+        "In the current OpenSearch version pagination is not supported with hybrid query"
+    );
+}
+```
+
+**Impact**: Users attempting to use pagination with hybrid queries now receive a clear error message instead of silently incorrect results.
+
+#### Bug 2: Empty Shard Result Merge Fix
+
+The `TopDocsMerger` class was updated to handle scenarios where:
+- Concurrent segment search is enabled
+- One shard returns no results
+- That empty shard appears first in the merge sequence
+
+```mermaid
+flowchart TB
+    subgraph Before["Before Fix"]
+        A1[Shard 1: Empty] --> M1[Merge]
+        A2[Shard 2: Results] --> M1
+        M1 --> E1[Error: Cannot merge]
+    end
+    
+    subgraph After["After Fix"]
+        B1[Shard 1: Empty] --> M2[Merge]
+        B2[Shard 2: Results] --> M2
+        M2 --> R2[Return Shard 2 Results]
+    end
+```
+
+The fix adds symmetric handling for empty source objects:
+
+```java
+// TopDocsMerger.java
+if (isEmpty(newTopDocs)) {
+    return source;
+}
+if (isEmpty(source)) {
+    return newTopDocs;
+}
+```
+
+### Affected Components
+
+| Component | File | Change |
+|-----------|------|--------|
+| Collector | `HybridTopScoreDocCollector.java` | Removed result cutting code |
+| Query Phase | `HybridQueryPhaseSearcher.java` | Added pagination validation |
+| Merger | `TopDocsMerger.java` | Added empty source handling |
+
+### Error Messages
+
+When attempting pagination with hybrid query:
+```
+illegal_argument_exception: In the current OpenSearch version pagination is not supported with hybrid query
+```
+
+## Limitations
+
+- **Pagination not supported**: Hybrid queries do not support the `from` parameter. Use `search_after` for pagination instead.
+- **Concurrent segment search edge cases**: While the merge logic fix addresses the known issue, the order of shard results is non-deterministic with concurrent segment search.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#867](https://github.com/opensearch-project/neural-search/pull/867) | Removing code to cut search results of hybrid search in the priority queue |
+| [#877](https://github.com/opensearch-project/neural-search/pull/877) | Fixed merge logic in hybrid query for multiple shards case |
+
+## References
+
+- [Issue #875](https://github.com/opensearch-project/neural-search/issues/875): Unable to merge results from shards
+- [Issue #280](https://github.com/opensearch-project/neural-search/issues/280): Pagination support tracking issue
+- [Hybrid Search Documentation](https://docs.opensearch.org/2.17/search-plugins/hybrid-search/)
+- [Hybrid Query DSL](https://docs.opensearch.org/2.17/query-dsl/compound/hybrid/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/neural-search/hybrid-query.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -41,6 +41,7 @@
 
 ### neural-search
 - [Neural Search Bugfixes](features/neural-search/neural-search-bugfixes.md)
+- [Neural Search Hybrid Query Bugfixes](features/neural-search/neural-search-hybrid-query.md)
 
 ### multi-plugin
 - [CI/Infrastructure Fixes](features/multi-plugin/ci-infrastructure-fixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Neural Search Hybrid Query bugfixes in OpenSearch v2.17.0.

## Reports Created

- **Release report**: `docs/releases/v2.17.0/features/neural-search/neural-search-hybrid-query.md`
- **Feature report**: `docs/features/neural-search/hybrid-query.md` (new)

## Key Changes in v2.17.0

1. **Pagination Error Handling (PR #867)**: Removed misleading code that gave users the impression pagination worked with hybrid queries. Now throws a clear error message when pagination is attempted.

2. **Multi-Shard Merge Logic Fix (PR #877)**: Fixed a bug where hybrid query results could fail to merge correctly when concurrent segment search is enabled and one shard returns empty results first.

## Related Issue

Closes #423