### PR TITLE
docs: add job-scheduler-bugfixes report for v2.17.0

### DIFF
--- a/docs/features/job-scheduler/job-scheduler.md
+++ b/docs/features/job-scheduler/job-scheduler.md
@@ -167,6 +167,7 @@ Job Scheduler supports two schedule formats:
 | v3.0.0 | [#702](https://github.com/opensearch-project/job-scheduler/pull/702) | Enable custom start commands and options to resolve GHA issues |
 | v3.0.0 | [#730](https://github.com/opensearch-project/job-scheduler/pull/730) | Fix JS compile issues caused by OpenSearch JPMS Refactoring |
 | v3.0.0 | [#737](https://github.com/opensearch-project/job-scheduler/pull/737) | Only download demo certs when integTest run with -Dsecurity.enabled=true |
+| v2.17.0 | [#658](https://github.com/opensearch-project/job-scheduler/pull/658) | Fix system index compatibility with v1 templates |
 
 ## References
 
@@ -175,7 +176,9 @@ Job Scheduler supports two schedule formats:
 - [Sample Extension Plugin](https://github.com/opensearch-project/job-scheduler/tree/main/sample-extension-plugin)
 - [Issue #698](https://github.com/opensearch-project/job-scheduler/issues/698): GitHub Action Deprecation
 - [Issue #715](https://github.com/opensearch-project/job-scheduler/issues/715): Release 3.0 Breaking Changes
+- [Issue #14984](https://github.com/opensearch-project/OpenSearch/issues/14984): CreateIndexRequest.mapping() bug with v1 templates
 
 ## Change History
 
 - **v3.0.0** (2025): CI/CD improvements, JPMS compatibility fixes, conditional demo certificate downloads
+- **v2.17.0** (2024-09-17): Fixed system index compatibility with v1 templates in LockService and JobDetailsService

--- a/docs/releases/v2.17.0/features/job-scheduler/job-scheduler-bugfixes.md
+++ b/docs/releases/v2.17.0/features/job-scheduler/job-scheduler-bugfixes.md
@@ -1,0 +1,71 @@
+# Job Scheduler Bugfixes
+
+## Summary
+
+This release fixes a compatibility issue with v1 index templates in the Job Scheduler plugin. The bug caused system indexes (`LockService` and `JobDetailsService`) to use dynamic mappings instead of the specified mappings when a deprecated v1 index template was present in the cluster.
+
+## Details
+
+### What's New in v2.17.0
+
+Fixed the `CreateIndexRequest.mapping()` calls in `LockService` and `JobDetailsService` to include the required `MediaType` parameter, ensuring proper mapping application even when v1 index templates exist.
+
+### Technical Changes
+
+#### Root Cause
+
+The `CreateIndexRequest.mapping(String)` method requires the mapping JSON to be wrapped in a `_doc` field when v1 index templates are present. However, the Job Scheduler code was using the single-argument version without specifying the content type, which caused the mapping to be silently ignored.
+
+#### The Fix
+
+The fix adds the `MediaType` parameter to `CreateIndexRequest.mapping()` calls:
+
+```java
+// Before (broken with v1 templates)
+CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(mapping);
+
+// After (works with v1 templates)
+CreateIndexRequest request = new CreateIndexRequest(indexName).mapping(
+    mapping,
+    (MediaType) XContentType.JSON
+);
+```
+
+#### Affected Components
+
+| Component | File | Description |
+|-----------|------|-------------|
+| `LockService` | `spi/src/main/java/org/opensearch/jobscheduler/spi/utils/LockService.java` | Distributed lock index creation |
+| `JobDetailsService` | `src/main/java/org/opensearch/jobscheduler/utils/JobDetailsService.java` | Job metadata index creation |
+
+### Impact
+
+Without this fix, clusters with v1 index templates (deprecated but still supported) would experience:
+- System indexes created with dynamic mappings instead of specified mappings
+- Potential `IllegalArgumentException` errors like `mapper [master_key] cannot be changed from type [text] to [keyword]`
+- Job scheduling failures due to incorrect field types
+
+### Migration Notes
+
+No migration required. The fix is automatically applied when upgrading to v2.17.0. Existing indexes with incorrect mappings may need to be recreated if experiencing mapping conflicts.
+
+## Limitations
+
+- This fix addresses the Job Scheduler plugin only; similar issues exist in other plugins (see Related Issues)
+- V1 index templates remain deprecated and should be migrated to v2 composable templates
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#658](https://github.com/opensearch-project/job-scheduler/pull/658) | Fix system index compatibility with v1 templates |
+
+## References
+
+- [Issue #14984](https://github.com/opensearch-project/OpenSearch/issues/14984): Original bug report affecting multiple plugins
+- [CreateIndexRequest Javadoc](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/admin/indices/create/CreateIndexRequest.java#L246-L257): Documentation for mapping method
+- [Job Scheduler Documentation](https://docs.opensearch.org/2.17/monitoring-your-cluster/job-scheduler/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/job-scheduler/job-scheduler.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -19,6 +19,7 @@
 
 ### job-scheduler
 - [Dependency Bumps](features/job-scheduler/dependency-bumps.md)
+- [Job Scheduler Bugfixes](features/job-scheduler/job-scheduler-bugfixes.md)
 
 ### security
 - [Dependency Bumps](features/security/dependency-bumps.md)


### PR DESCRIPTION
## Summary

Adds documentation for Job Scheduler bugfixes in v2.17.0.

### Changes
- **Release report**: `docs/releases/v2.17.0/features/job-scheduler/job-scheduler-bugfixes.md`
- **Feature report update**: Added v2.17.0 entry to `docs/features/job-scheduler/job-scheduler.md`
- **Release index update**: Added link to new report

### Key Fix
Fixed `CreateIndexRequest.mapping()` calls in `LockService` and `JobDetailsService` to include the required `MediaType` parameter, ensuring proper mapping application even when deprecated v1 index templates exist in the cluster.

### Related
- Closes #421
- PR: [opensearch-project/job-scheduler#658](https://github.com/opensearch-project/job-scheduler/pull/658)
- Issue: [opensearch-project/OpenSearch#14984](https://github.com/opensearch-project/OpenSearch/issues/14984)