### PR TITLE
docs: add dashboards-bugfixes report for v2.17.0

### DIFF
--- a/docs/features/dashboards-search-relevance/build-maintenance.md
+++ b/docs/features/dashboards-search-relevance/build-maintenance.md
@@ -1,0 +1,68 @@
+# Dashboards Search Relevance Build Maintenance
+
+## Summary
+
+The dashboards-search-relevance plugin requires ongoing maintenance to ensure compatibility with evolving build tools and dependencies. This includes updating deprecated syntax, fixing build warnings, and maintaining documentation.
+
+## Details
+
+### Build System Compatibility
+
+The plugin uses Sass for styling, which requires updates as the Sass compiler evolves. Key maintenance areas include:
+
+```mermaid
+graph TB
+    subgraph "Build Process"
+        SCSS[SCSS Files] --> Compiler[Sass Compiler]
+        Compiler --> CSS[CSS Output]
+    end
+    subgraph "Maintenance Areas"
+        Syntax[Syntax Updates]
+        Deps[Dependency Updates]
+        Docs[Documentation]
+    end
+    Syntax --> SCSS
+    Deps --> Compiler
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `result_grid.scss` | Styling for query comparison result grid |
+| `CONTRIBUTING.md` | Contributor guidelines |
+| `DEVELOPER_GUIDE.md` | Development setup instructions |
+
+### Sass Syntax Modernization
+
+Modern Sass compilers (Dart Sass) have deprecated certain syntax patterns:
+
+| Deprecated Syntax | Modern Syntax | Status |
+|-------------------|---------------|--------|
+| `$var / 2` (division) | `calc($var / 2)` or `math.div($var, 2)` | Fixed in v2.17.0 |
+
+### Configuration
+
+No additional configuration is required. The fixes are applied at the source code level.
+
+## Limitations
+
+- Build warnings may appear with older Sass compiler versions
+- Future Sass versions may introduce additional deprecations requiring updates
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#426](https://github.com/opensearch-project/dashboards-search-relevance/pull/426) | Fix sass division warning |
+| v2.17.0 | [#420](https://github.com/opensearch-project/dashboards-search-relevance/pull/420) | Update Links in Documentation |
+
+## References
+
+- [dashboards-search-relevance Repository](https://github.com/opensearch-project/dashboards-search-relevance)
+- [Sass Breaking Change: Slash as Division](https://sass-lang.com/documentation/breaking-changes/slash-div/)
+- [OpenSearch Dashboards PR #5338](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5338): Replace `node-sass` with `sass-embedded`
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Fixed Sass division warning by updating to `calc()` syntax; Fixed broken LICENSE file link and removed unused Docker documentation links

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -76,6 +76,7 @@
 
 ## dashboards-search-relevance
 
+- [Build Maintenance](dashboards-search-relevance/build-maintenance.md)
 - [Documentation Maintenance](dashboards-search-relevance/documentation-maintenance.md)
 
 ## dashboards-flow-framework

--- a/docs/releases/v2.17.0/features/dashboards-search-relevance/dashboards-bugfixes.md
+++ b/docs/releases/v2.17.0/features/dashboards-search-relevance/dashboards-bugfixes.md
@@ -1,0 +1,81 @@
+# Dashboards Bugfixes
+
+## Summary
+
+This release item fixes a Sass division warning in the dashboards-search-relevance plugin by updating deprecated Sass division syntax to use the modern `calc()` function. This change ensures compatibility with newer versions of Sass compilers that have deprecated the `/` operator for division.
+
+## Details
+
+### What's New in v2.17.0
+
+The fix addresses a deprecation warning that appeared during the build process when using Sass division with the `/` operator. Modern Sass compilers (Dart Sass) have deprecated this syntax in favor of the `calc()` function or `math.div()`.
+
+### Technical Changes
+
+#### Code Change
+
+The change is minimal but important for build compatibility:
+
+**Before:**
+```scss
+padding: ($euiSizeXS / 2) $euiSizeXS;
+```
+
+**After:**
+```scss
+padding: calc($euiSizeXS / 2) $euiSizeXS;
+```
+
+#### Affected File
+
+| File | Description |
+|------|-------------|
+| `public/components/query_compare/search_result/result_components/result_grid.scss` | Updated Sass division syntax |
+
+### Background
+
+Sass deprecated the `/` operator for division starting with Dart Sass 1.33.0 (released in 2021). The deprecation warning indicates that this syntax will be removed in Dart Sass 2.0.0. The recommended migration path is to use:
+
+1. `calc()` function (CSS native) - used in this fix
+2. `math.div()` function (Sass native)
+
+Using `calc()` is preferred when the result needs to be a CSS value, as it's natively supported by browsers and doesn't require importing the Sass math module.
+
+### Usage Example
+
+The affected code is part of the result grid styling in the Search Relevance plugin's query comparison feature:
+
+```scss
+doc-table {
+  dt {
+    background-color: tintOrShade($euiColorPrimary, 90%, 70%);
+    color: $euiTextColor;
+    padding: calc($euiSizeXS / 2) $euiSizeXS;  // Fixed division syntax
+    margin-right: $euiSizeXS;
+    word-break: normal;
+    border-radius: $euiBorderRadius;
+  }
+}
+```
+
+## Limitations
+
+- This is a build-time fix only; no runtime behavior changes
+- The visual appearance of the UI remains unchanged
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#426](https://github.com/opensearch-project/dashboards-search-relevance/pull/426) | Fix sass division warning |
+| [#435](https://github.com/opensearch-project/dashboards-search-relevance/pull/435) | Backport to 2.x |
+| [#436](https://github.com/opensearch-project/dashboards-search-relevance/pull/436) | Backport to 2.17 |
+
+## References
+
+- [Sass Breaking Change: Slash as Division](https://sass-lang.com/documentation/breaking-changes/slash-div/)
+- [OpenSearch Dashboards PR #5338](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5338): Replace `node-sass` with `sass-embedded` (related modernization)
+
+## Related Feature Report
+
+- [Dashboards Search Relevance Documentation Maintenance](../../../features/dashboards-search-relevance/documentation-maintenance.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -12,6 +12,7 @@
 - [Trace Analytics Bugfixes](features/observability/trace-analytics-bugfixes.md)
 
 ### dashboards-search-relevance
+- [Dashboards Bugfixes](features/dashboards-search-relevance/dashboards-bugfixes.md)
 - [Documentation Link Updates](features/dashboards-search-relevance/documentation-link-updates.md)
 
 ### documentation-website


### PR DESCRIPTION
## Summary

Adds documentation for the Dashboards Bugfixes release item in v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/dashboards-search-relevance/dashboards-bugfixes.md`
- Feature report: `docs/features/dashboards-search-relevance/build-maintenance.md`

### Key Changes
- Documents PR #426 which fixes Sass division deprecation warning in dashboards-search-relevance plugin
- Changed deprecated `/` operator to `calc()` function for Dart Sass 2.0.0 compatibility

Closes #419