### PR TITLE
docs: add notifications-bugfixes report for v2.17.0

### DIFF
--- a/docs/features/dashboards-notifications/dashboards-notifications.md
+++ b/docs/features/dashboards-notifications/dashboards-notifications.md
@@ -1,0 +1,107 @@
+# OpenSearch Dashboards Notifications
+
+## Summary
+
+OpenSearch Dashboards Notifications is a plugin that provides a user interface for managing notification channels and sending test messages. It integrates with the OpenSearch Notifications backend plugin to enable users to configure various notification destinations including Email, Slack, Amazon SNS, Amazon Chime, Microsoft Teams, and custom webhooks.
+
+The plugin supports Multi-Data-Source (MDS) functionality, allowing users to manage notifications across multiple OpenSearch clusters from a single Dashboards instance.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        UI[Notifications UI]
+        MDS[Multi-Data-Source Support]
+        Router[React Router]
+    end
+    
+    subgraph "Pages"
+        Channels[Channels Page]
+        EmailSenders[Email Senders Page]
+        EmailGroups[Email Groups Page]
+    end
+    
+    subgraph "Backend"
+        NotifPlugin[Notifications Plugin]
+        NotifIndex[.opensearch-notifications-config]
+    end
+    
+    UI --> Router
+    Router --> Channels
+    Router --> EmailSenders
+    Router --> EmailGroups
+    MDS --> Channels
+    MDS --> EmailSenders
+    MDS --> EmailGroups
+    Channels --> NotifPlugin
+    EmailSenders --> NotifPlugin
+    EmailGroups --> NotifPlugin
+    NotifPlugin --> NotifIndex
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Channels | Manage notification channels (Slack, Email, SNS, etc.) |
+| Email Senders | Configure SMTP and SES email senders |
+| Email Recipient Groups | Manage groups of email recipients |
+| MDSEnabledComponent | Base component for multi-data-source support |
+| DataSourceMenuContext | React context for data source selection |
+
+### Supported Channel Types
+
+| Channel Type | Description |
+|--------------|-------------|
+| Slack | Send notifications to Slack channels |
+| Email | Send email notifications via SMTP or SES |
+| Amazon SNS | Publish to SNS topics |
+| Amazon Chime | Send to Chime webhooks |
+| Microsoft Teams | Send to Teams webhooks |
+| Custom Webhook | Send to custom HTTP endpoints |
+
+### Multi-Data-Source Support
+
+The plugin supports OpenSearch Dashboards' Multi-Data-Source (MDS) feature, allowing users to:
+
+- Select a data source from the data source picker
+- Persist the selected data source across page navigation
+- View and manage notifications for different OpenSearch clusters
+
+### Configuration
+
+The plugin uses the following URL parameters for state management:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `dataSourceId` | ID of the selected data source | Local cluster ("") |
+
+## Limitations
+
+- Requires the Notifications backend plugin to be installed on the OpenSearch cluster
+- Email functionality requires proper SMTP or SES configuration
+- Some channel types may require additional AWS permissions
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#242](https://github.com/opensearch-project/dashboards-notifications/pull/242) | Fix link checker |
+| v2.17.0 | [#244](https://github.com/opensearch-project/dashboards-notifications/pull/244) | Persist dataSourceId across applications |
+| v2.14.0 | [#186](https://github.com/opensearch-project/dashboards-notifications/pull/186) | Added MDS Support |
+| v2.15.0 | [#205](https://github.com/opensearch-project/dashboards-notifications/pull/205) | Bug fixes for MDS in getServerFeatures API |
+
+## References
+
+- [OpenSearch Notifications Documentation](https://docs.opensearch.org/latest/observing-your-data/notifications/index/)
+- [dashboards-notifications Repository](https://github.com/opensearch-project/dashboards-notifications)
+- [notifications Repository](https://github.com/opensearch-project/notifications)
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Fixed link checker CI, added dataSourceId persistence for new navigation
+- **v2.15.0**: Bug fixes for MDS support in getServerFeatures API
+- **v2.14.0**: Added Multi-Data-Source (MDS) support

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -148,6 +148,10 @@
 
 - [Maps & Geospatial](dashboards-maps/maps-geospatial.md)
 
+## dashboards-notifications
+
+- [OpenSearch Dashboards Notifications](dashboards-notifications/dashboards-notifications.md)
+
 ## custom-codecs
 
 - [Custom Codecs](custom-codecs/custom-codecs.md)

--- a/docs/releases/v2.17.0/features/dashboards-notifications/notifications-bugfixes.md
+++ b/docs/releases/v2.17.0/features/dashboards-notifications/notifications-bugfixes.md
@@ -1,0 +1,90 @@
+# Notifications Bugfixes
+
+## Summary
+
+This release includes two bugfixes for the OpenSearch Dashboards Notifications plugin: fixing the link checker CI workflow and persisting the dataSourceId across applications when using the new navigation.
+
+## Details
+
+### What's New in v2.17.0
+
+Two bugfixes were introduced to improve the stability and usability of the Notifications plugin:
+
+1. **Link Checker Fix**: Added missing files (CONTRIBUTING.md, NOTICE) to fix the link checker CI check that was failing due to broken internal links.
+
+2. **DataSourceId Persistence**: Fixed an issue where the selected data source was not persisted when navigating between different Notifications pages (Channels, Email Senders, Email Recipient Groups) under the new navigation system.
+
+### Technical Changes
+
+#### DataSourceId Persistence Implementation
+
+The fix introduces a new hook `useUpdateUrlWithDataSourceProperties` that automatically updates the URL with the current `dataSourceId` when multi-data-source (MDS) is enabled:
+
+```typescript
+export function useUpdateUrlWithDataSourceProperties() {
+  const dataSourceMenuProps = useContext(DataSourceMenuContext);
+  const { dataSourceId, multiDataSourceEnabled } = dataSourceMenuProps;
+  const history = useHistory();
+  
+  useEffect(() => {
+    if (multiDataSourceEnabled) {
+      history.replace({
+        search: queryString.stringify({
+          ...currentQuery,
+          dataSourceId,
+        }),
+      });
+    }
+  }, [dataSourceId, multiDataSourceEnabled]);
+}
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `useUpdateUrlWithDataSourceProperties` | React hook to persist dataSourceId in URL |
+| `dataSourceObservable` | BehaviorSubject to share data source state across the plugin |
+
+#### Modified Files
+
+| File | Changes |
+|------|---------|
+| `MDSEnabledComponent.tsx` | Added `useUpdateUrlWithDataSourceProperties` hook |
+| `PageHeader.tsx` | Integrated URL update hook |
+| `EmailSenders.tsx` | Added hook for data source persistence |
+| `Main.tsx` | Enhanced data source initialization and state management |
+| `plugin.ts` | Added app state updater for default routes with dataSourceId |
+| `constants.ts` | Added `dataSourceObservable` for cross-component state |
+
+### Usage Example
+
+When MDS is enabled, navigating to the Channels page will now include the dataSourceId in the URL:
+
+```
+/app/notifications-dashboards#/channels?dataSourceId=abc123
+```
+
+This ensures that when users navigate between Channels, Email Senders, and Email Recipient Groups, the selected data source is preserved.
+
+## Limitations
+
+- The dataSourceId persistence only applies when multi-data-source is enabled
+- URL-based state management may cause issues with very long dataSourceId values
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#242](https://github.com/opensearch-project/dashboards-notifications/pull/242) | Fix link checker - Added missing CONTRIBUTING.md and NOTICE files |
+| [#244](https://github.com/opensearch-project/dashboards-notifications/pull/244) | Persist dataSourceId across applications under new Nav change |
+
+## References
+
+- [OpenSearch Notifications Documentation](https://docs.opensearch.org/2.17/observing-your-data/notifications/index/)
+- [Backport PR #249 (2.x)](https://github.com/opensearch-project/dashboards-notifications/pull/249)
+- [Backport PR #255 (2.17)](https://github.com/opensearch-project/dashboards-notifications/pull/255)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-notifications/dashboards-notifications.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -7,6 +7,9 @@
 ### dashboards-maps
 - [Maps Plugin Bugfixes](features/dashboards-maps/maps-plugin-bugfixes.md)
 
+### dashboards-notifications
+- [Notifications Bugfixes](features/dashboards-notifications/notifications-bugfixes.md)
+
 ### dashboards-observability
 - [Observability Notebooks Bugfixes](features/dashboards-observability/observability-notebooks.md)
 - [Trace Analytics Bugfixes](features/observability/trace-analytics-bugfixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Notifications Bugfixes in OpenSearch v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/dashboards-notifications/notifications-bugfixes.md`
- Feature report: `docs/features/dashboards-notifications/dashboards-notifications.md` (new)

### Key Changes in v2.17.0
- Fixed link checker CI by adding missing CONTRIBUTING.md and NOTICE files
- Added dataSourceId persistence across Notifications pages when using new navigation

### PRs Investigated
- [#242](https://github.com/opensearch-project/dashboards-notifications/pull/242): Fix link checker
- [#244](https://github.com/opensearch-project/dashboards-notifications/pull/244): Persist dataSourceId across applications under new Nav change

Closes #417