### PR TITLE
docs: add cross-cluster-replication-bugfixes report for v2.17.0

### DIFF
--- a/docs/features/cross-cluster-replication/cross-cluster-replication.md
+++ b/docs/features/cross-cluster-replication/cross-cluster-replication.md
@@ -149,6 +149,7 @@ POST _plugins/_replication/follower-index/_stop
 | v3.0.0 | [#667](https://github.com/opensearch-project/common-utils/pull/667) | common-utils | Adding replication plugin interface |
 | v3.0.0 | [#1198](https://github.com/opensearch-project/index-management/pull/1198) | index-management | Adding unfollow action in ISM |
 | v3.0.0 | [#1496](https://github.com/opensearch-project/cross-cluster-replication/pull/1496) | cross-cluster-replication | Gradle 8.10.2 and JDK23 support |
+| v2.17.0 | [#1412](https://github.com/opensearch-project/cross-cluster-replication/pull/1412) | cross-cluster-replication | Update remote-migration IT with correct setting names |
 | v1.1.0 | - | cross-cluster-replication | Initial CCR implementation |
 
 ## References
@@ -164,4 +165,5 @@ POST _plugins/_replication/follower-index/_stop
 ## Change History
 
 - **v3.0.0** (2025-05-06): ISM-CCR integration with `stop_replication` action, Gradle 8.10.2 and JDK23 support
+- **v2.17.0** (2024-09-17): Fixed integration tests to use correct cluster setting names after Remote Store Migration GA
 - **v1.1.0** (2021-10-05): Initial cross-cluster replication implementation

--- a/docs/releases/v2.17.0/features/cross-cluster-replication/cross-cluster-replication-bugfixes.md
+++ b/docs/releases/v2.17.0/features/cross-cluster-replication/cross-cluster-replication-bugfixes.md
@@ -1,0 +1,63 @@
+# Cross-Cluster Replication Bugfixes
+
+## Summary
+
+This release fixes the cross-cluster replication integration tests to use the correct cluster setting names after the Remote Store Migration feature was moved from experimental to GA in OpenSearch core. The setting names were updated from `remote_store.compatibility_mode` and `migration.direction` to `cluster.remote_store.compatibility_mode` and `cluster.migration.direction` respectively.
+
+## Details
+
+### What's New in v2.17.0
+
+The integration test `test operations are fetched from lucene when leader is in mixed mode` was updated to use the correct cluster setting names following changes in OpenSearch core PR #14100.
+
+### Technical Changes
+
+#### Setting Name Updates
+
+| Old Setting | New Setting |
+|-------------|-------------|
+| `remote_store.compatibility_mode` | `cluster.remote_store.compatibility_mode` |
+| `migration.direction` | `cluster.migration.direction` |
+
+#### Build Configuration Changes
+
+1. Removed the experimental feature flag `opensearch.experimental.feature.remote_store.migration.enabled` from test configuration as it's no longer needed (feature is now GA)
+2. Re-enabled the previously excluded integration test `test operations are fetched from lucene when leader is in mixed mode`
+
+### Code Changes
+
+The test file `StartReplicationIT.kt` was updated to use the new cluster-prefixed setting names:
+
+```kotlin
+val entityAsString = """
+    {
+      "persistent": {
+        "cluster.remote_store.compatibility_mode": "mixed",
+        "cluster.migration.direction" : "remote_store"
+      }
+    }""".trimMargin()
+```
+
+### Migration Notes
+
+No user action required. This is an internal test fix that aligns with the Remote Store Migration GA changes in OpenSearch core.
+
+## Limitations
+
+- This change only affects integration tests, not production functionality
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1412](https://github.com/opensearch-project/cross-cluster-replication/pull/1412) | Updating remote-migration IT with correct setting name |
+| [#14100](https://github.com/opensearch-project/OpenSearch/pull/14100) | Move Remote Store Migration from DocRep to GA (OpenSearch core) |
+
+## References
+
+- [Cross-cluster replication documentation](https://docs.opensearch.org/2.17/tuning-your-cluster/replication-plugin/index/)
+- [Remote-backed storage migration](https://docs.opensearch.org/2.17/tuning-your-cluster/availability-and-recovery/remote-store/migrating-to-remote/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/cross-cluster-replication/cross-cluster-replication.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -73,6 +73,9 @@
 ### k-nn
 - [k-NN Bugfixes](features/k-nn/k-nn-bugfixes.md)
 
+### cross-cluster-replication
+- [Cross-Cluster Replication Bugfixes](features/cross-cluster-replication/cross-cluster-replication-bugfixes.md)
+
 ## Key Features in This Release
 
 ### Generally Available


### PR DESCRIPTION
## Summary

This PR adds the release report for Cross-Cluster Replication Bugfixes in v2.17.0.

### Changes
- Created release report: `docs/releases/v2.17.0/features/cross-cluster-replication/cross-cluster-replication-bugfixes.md`
- Updated feature report: `docs/features/cross-cluster-replication/cross-cluster-replication.md`
- Updated release index: `docs/releases/v2.17.0/index.md`

### Key Changes in v2.17.0
- Fixed integration tests to use correct cluster setting names after Remote Store Migration moved to GA
- Updated settings from `remote_store.compatibility_mode` to `cluster.remote_store.compatibility_mode`
- Updated settings from `migration.direction` to `cluster.migration.direction`
- Removed experimental feature flag that is no longer needed

### Related Issue
Closes #416