### PR TITLE
docs: add common-utils-bugfixes report for v2.17.0

### DIFF
--- a/docs/features/common-utils/alerting-context-variables.md
+++ b/docs/features/common-utils/alerting-context-variables.md
@@ -1,0 +1,161 @@
+# Alerting Context Variables
+
+## Summary
+
+The Alerting plugin provides context (`ctx`) variables that can be used in monitor action message templates. These variables allow users to include dynamic information about monitors, triggers, alerts, and actions in their notification messages. This feature enables rich, informative alert notifications that include relevant context about what triggered the alert.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Monitor Execution"
+        M[Monitor] --> T[Trigger Evaluation]
+        T --> A[Action Execution]
+    end
+    
+    subgraph "Template Context"
+        M --> |asTemplateArg| MC[Monitor Context]
+        T --> |asTemplateArg| TC[Trigger Context]
+        A --> |asTemplateArg| AC[Action Context]
+    end
+    
+    subgraph "Message Rendering"
+        MC --> MR[Mustache Renderer]
+        TC --> MR
+        AC --> MR
+        MR --> MSG[Notification Message]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Model Classes"
+        Monitor.kt
+        Trigger.kt
+        Action.kt
+        Schedule.kt
+        Input.kt
+    end
+    
+    subgraph "Template Args"
+        Monitor.kt --> |asTemplateArg| ctx.monitor
+        Trigger.kt --> |asTemplateArg| ctx.trigger
+        Action.kt --> |asTemplateArg| ctx.action
+        Schedule.kt --> |asTemplateArg| ctx.monitor.schedule
+        Input.kt --> |asTemplateArg| ctx.monitor.inputs
+    end
+    
+    subgraph "Template Engine"
+        ctx.monitor --> Mustache
+        ctx.trigger --> Mustache
+        ctx.action --> Mustache
+        Mustache --> Message
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `Monitor` | Contains monitor metadata including name, type, schedule, and inputs |
+| `Trigger` | Contains trigger configuration including name, severity, condition, and actions |
+| `Action` | Contains action configuration including name, destination, and throttle settings |
+| `Schedule` | Contains schedule configuration (cron or interval) |
+| `Input` | Contains monitor input configuration (search query or document-level queries) |
+
+### Available Context Variables
+
+#### Monitor Context (`ctx.monitor`)
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `_id` | String | Monitor ID |
+| `_version` | Long | Monitor version |
+| `name` | String | Monitor name |
+| `enabled` | Boolean | Whether monitor is enabled |
+| `monitor_type` | String | Type of monitor (query_level_monitor, bucket_level_monitor, doc_level_monitor) |
+| `enabled_time` | Long | Epoch milliseconds when monitor was enabled |
+| `last_update_time` | Long | Epoch milliseconds of last update |
+| `schedule` | Object | Schedule configuration |
+| `inputs` | Array | Monitor inputs |
+
+#### Trigger Context (`ctx.trigger`)
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `id` | String | Trigger ID |
+| `name` | String | Trigger name |
+| `severity` | String | Trigger severity level |
+| `actions` | Array | List of actions |
+| `condition` | Object | Trigger condition with script source and language |
+
+#### Action Context (`ctx.action`)
+
+| Variable | Type | Description |
+|----------|------|-------------|
+| `id` | String | Action ID |
+| `name` | String | Action name |
+| `destination_id` | String | Destination ID for notifications |
+| `throttle_enabled` | Boolean | Whether throttling is enabled |
+
+#### Schedule Context (`ctx.monitor.schedule`)
+
+For cron schedules:
+| Variable | Type | Description |
+|----------|------|-------------|
+| `cron.expression` | String | Cron expression |
+| `cron.timezone` | String | Timezone |
+
+For interval schedules:
+| Variable | Type | Description |
+|----------|------|-------------|
+| `period.interval` | Integer | Interval value |
+| `period.unit` | String | Time unit (MINUTES, HOURS, DAYS) |
+
+### Usage Example
+
+```mustache
+Alert: {{ctx.monitor.name}}
+
+Monitor Details:
+- Type: {{ctx.monitor.monitor_type}}
+- Last Updated: {{ctx.monitor.last_update_time}}
+{{#ctx.monitor.schedule.period}}
+- Schedule: Every {{interval}} {{unit}}
+{{/ctx.monitor.schedule.period}}
+{{#ctx.monitor.schedule.cron}}
+- Schedule: {{expression}} ({{timezone}})
+{{/ctx.monitor.schedule.cron}}
+
+Trigger: {{ctx.trigger.name}} (Severity: {{ctx.trigger.severity}})
+Condition: {{ctx.trigger.condition.script.source}}
+
+Action: {{ctx.action.name}}
+Destination: {{ctx.action.destination_id}}
+Throttle Enabled: {{ctx.action.throttle_enabled}}
+```
+
+## Limitations
+
+- Context variables are only available within action message templates
+- Some variables may be null depending on monitor configuration
+- The `results` and `alert` context variables are populated at runtime and not covered by this feature
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#710](https://github.com/opensearch-project/common-utils/pull/710) | Add missing ctx variables |
+
+## References
+
+- [Issue #200](https://github.com/opensearch-project/alerting/issues/200): Original feature request for missing ctx variables
+- [OpenSearch Alerting Documentation](https://opensearch.org/docs/latest/monitoring-plugins/alerting/monitors/#available-variables): Official documentation for available variables
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Added missing context variables for monitor, trigger, action, schedule, and input models

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -185,6 +185,7 @@
 
 ## common-utils
 
+- [Alerting Context Variables](common-utils/alerting-context-variables.md)
 - [Common Utils](common-utils/common-utils.md)
 
 ## alerting

--- a/docs/releases/v2.17.0/features/common-utils/common-utils-bugfixes.md
+++ b/docs/releases/v2.17.0/features/common-utils/common-utils-bugfixes.md
@@ -1,0 +1,79 @@
+# Common Utils Bugfixes
+
+## Summary
+
+This release fixes a long-standing bug where several `ctx` (context) variables documented for Alerting monitor actions were not actually available at runtime. The fix adds missing template argument fields to various alerting model classes, ensuring that users can access all documented context variables in their monitor action templates.
+
+## Details
+
+### What's New in v2.17.0
+
+The PR adds missing `ctx` variables that were documented but not implemented in the Alerting plugin. This allows users to access additional context information when configuring monitor actions.
+
+### Technical Changes
+
+#### New Context Variables Added
+
+The following context variables are now available in monitor action templates:
+
+| Model | New Fields |
+|-------|------------|
+| `Monitor` | `monitor_type`, `enabled_time`, `last_update_time`, `schedule`, `inputs` |
+| `Action` | `id`, `destination_id`, `throttle_enabled` |
+| `QueryLevelTrigger` | `condition.script.source`, `condition.script.lang` |
+| `DocumentLevelTrigger` | `condition.script.source`, `condition.script.lang` |
+| `BucketLevelTrigger` | `condition.script.source`, `condition.script.lang` |
+| `Schedule` (Cron) | `cron.expression`, `cron.timezone` |
+| `Schedule` (Interval) | `period.interval`, `period.unit` |
+| `SearchInput` | `search.indices`, `search.query` |
+
+#### Modified Components
+
+| Component | Description |
+|-----------|-------------|
+| `Monitor.kt` | Extended `asTemplateArg()` to include monitor type, enabled time, last update time, schedule, and inputs |
+| `Action.kt` | Extended `asTemplateArg()` to include id, destination_id, and throttle_enabled |
+| `QueryLevelTrigger.kt` | Added condition field with script source and language |
+| `DocumentLevelTrigger.kt` | Added condition field with script source and language |
+| `BucketLevelTrigger.kt` | Added condition field with script source and language |
+| `Schedule.kt` | Added `asTemplateArg()` method to both `CronSchedule` and `IntervalSchedule` |
+| `SearchInput.kt` | Added `asTemplateArg()` method with indices and query |
+| `Input.kt` | Added abstract `asTemplateArg()` method to interface |
+
+### Usage Example
+
+With this fix, users can now access additional context variables in their monitor action message templates:
+
+```mustache
+Monitor "{{ctx.monitor.name}}" (type: {{ctx.monitor.monitor_type}}) triggered!
+
+Trigger: {{ctx.trigger.name}}
+Condition: {{ctx.trigger.condition.script.source}}
+
+Action: {{ctx.action.name}} (ID: {{ctx.action.id}})
+Destination: {{ctx.action.destination_id}}
+
+Schedule: {{#ctx.monitor.schedule.period}}Every {{interval}} {{unit}}{{/ctx.monitor.schedule.period}}
+Last updated: {{ctx.monitor.last_update_time}}
+```
+
+## Limitations
+
+- This fix is in the common-utils library; the Alerting plugin must use the updated version to benefit from these changes
+- The original issue (alerting#200) remains open as there may be additional context variables to add
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#710](https://github.com/opensearch-project/common-utils/pull/710) | Add missing ctx variables |
+| [#318](https://github.com/opensearch-project/common-utils/pull/318) | Original PR (superseded by #710) |
+
+## References
+
+- [Issue #200](https://github.com/opensearch-project/alerting/issues/200): Missing ctx variables for Actions
+- [OpenSearch Alerting Documentation](https://opensearch.org/docs/latest/monitoring-plugins/alerting/monitors/#available-variables): Available variables documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/common-utils/alerting-context-variables.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -76,6 +76,9 @@
 ### cross-cluster-replication
 - [Cross-Cluster Replication Bugfixes](features/cross-cluster-replication/cross-cluster-replication-bugfixes.md)
 
+### common-utils
+- [Common Utils Bugfixes](features/common-utils/common-utils-bugfixes.md)
+
 ## Key Features in This Release
 
 ### Generally Available


### PR DESCRIPTION
## Summary

This PR adds documentation for the Common Utils bugfixes in v2.17.0, specifically the fix for missing `ctx` (context) variables in Alerting monitor actions.

## Changes

### Release Report
- `docs/releases/v2.17.0/features/common-utils/common-utils-bugfixes.md`

### Feature Report
- `docs/features/common-utils/alerting-context-variables.md`

## Key Changes in v2.17.0

PR [#710](https://github.com/opensearch-project/common-utils/pull/710) fixes a long-standing bug where several `ctx` variables documented for Alerting monitor actions were not actually available at runtime.

New context variables added:
- Monitor: `monitor_type`, `enabled_time`, `last_update_time`, `schedule`, `inputs`
- Action: `id`, `destination_id`, `throttle_enabled`
- Triggers: `condition.script.source`, `condition.script.lang`
- Schedule: cron/interval configuration details
- SearchInput: `indices`, `query`

## Related Issue
Closes #415