### PR TITLE
docs: add alerting bugfixes report for v2.17.0

### DIFF
--- a/docs/features/alerting/alerting.md
+++ b/docs/features/alerting/alerting.md
@@ -154,6 +154,14 @@ POST _plugins/_alerting/monitors
 | v3.0.0 | [#1824](https://github.com/opensearch-project/alerting/pull/1824) | Use java-agent Gradle plugin |
 | v3.0.0 | [#1831](https://github.com/opensearch-project/alerting/pull/1831) | Correct release notes filename |
 | v3.0.0 | [#1234](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1234) | Fix .keyword subfield selection in bucket monitor |
+| v2.17.0 | [#1623](https://github.com/opensearch-project/alerting/pull/1623) | Fix monitor renew lock issue |
+| v2.17.0 | [#1637](https://github.com/opensearch-project/alerting/pull/1637) | Fix distribution builds |
+| v2.17.0 | [#1640](https://github.com/opensearch-project/alerting/pull/1640) | Fix distribution builds |
+| v2.17.0 | [#1027](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1027) | Fixed cypress tests |
+| v2.17.0 | [#1028](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1028) | Fix workspace navigation visibility |
+| v2.17.0 | [#1040](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1040) | Fix failed UT of AddAlertingMonitor.test.js |
+| v2.17.0 | [#794](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/794) | Fix trigger name validation |
+| v2.17.0 | [#1073](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1073) | Fix alerts card in all-use case overview page |
 
 ## References
 
@@ -162,7 +170,10 @@ POST _plugins/_alerting/monitors
 - [Composite Monitors](https://docs.opensearch.org/3.0/observing-your-data/alerting/composite-monitors/): Composite monitor documentation
 - [Alerting Security](https://docs.opensearch.org/3.0/observing-your-data/alerting/security/): Security configuration for alerting
 - [Notifications Plugin](https://docs.opensearch.org/3.0/observing-your-data/notifications/index/): Notifications integration
+- [Issue #1617](https://github.com/opensearch-project/alerting/issues/1617): Distribution build issue
+- [Issue #671](https://github.com/opensearch-project/alerting-dashboards-plugin/issues/671): Trigger name validation issue
 
 ## Change History
 
 - **v3.0.0** (2025): Bug fixes for bucket selector aggregation, Java Agent migration, and dashboard subfield selection
+- **v2.17.0** (2024-09-17): Monitor lock renewal fix, distribution build fixes, workspace navigation fix, trigger name validation fix, alerts card rendering fix, cypress and unit test fixes

--- a/docs/releases/v2.17.0/features/alerting/alerting-bugfixes.md
+++ b/docs/releases/v2.17.0/features/alerting/alerting-bugfixes.md
@@ -1,0 +1,91 @@
+# Alerting Bugfixes
+
+## Summary
+
+OpenSearch v2.17.0 includes several bug fixes for the Alerting plugin and Alerting Dashboards plugin, addressing issues with monitor lock renewal, distribution builds, cypress tests, workspace navigation, unit tests, trigger name validation, alerts card rendering, and build configuration.
+
+## Details
+
+### What's New in v2.17.0
+
+This release focuses on stability and reliability improvements across both the backend Alerting plugin and the frontend Alerting Dashboards plugin.
+
+### Technical Changes
+
+#### Backend Fixes (alerting)
+
+| Fix | Description | Impact |
+|-----|-------------|--------|
+| Monitor Lock Renewal | Fixed issue where failed lock release prevented future lock renewal | Monitors no longer get stuck when lock release fails |
+| Distribution Builds | Fixed build configuration issues affecting distribution packaging | Improved build reliability |
+
+#### Frontend Fixes (alerting-dashboards-plugin)
+
+| Fix | Description | Impact |
+|-----|-------------|--------|
+| Cypress Tests | Fixed cypress tests following alerting PR #1612 changes | Improved test reliability |
+| Workspace Navigation | Removed `workspaceAvailability` field to make alerts visible within workspace | Alerts now properly visible in workspace navigation |
+| Unit Test Fix | Fixed failed UT of `AddAlertingMonitor.test.js` | Improved test stability |
+| Trigger Name Validation | Fixed trigger name validation for all monitor types | Prevents duplicate trigger names across monitors |
+| Alerts Card Rendering | Fixed alerts card in all-use case overview page when MDS is disabled | Card renders correctly without multi-data-source |
+| Build Configuration | Updated build.gradle to use alerting-spi snapshot version | Resolved dependency issues |
+
+### Monitor Lock Renewal Fix
+
+When a monitor run fails to release its lock, the lock could never be renewed, causing every subsequent monitor run to be skipped. The fix allows the lock to be renewed and acquired after a fixed timeout of 5 minutes.
+
+```mermaid
+flowchart TB
+    subgraph "Before Fix"
+        A1[Monitor Run] --> B1[Lock Acquired]
+        B1 --> C1[Execution Fails]
+        C1 --> D1[Lock Not Released]
+        D1 --> E1[Future Runs Skipped]
+    end
+    
+    subgraph "After Fix"
+        A2[Monitor Run] --> B2[Lock Acquired]
+        B2 --> C2[Execution Fails]
+        C2 --> D2[Lock Not Released]
+        D2 --> E2[5 min Timeout]
+        E2 --> F2[Lock Renewed]
+        F2 --> G2[Monitor Resumes]
+    end
+```
+
+### Trigger Name Validation Fix
+
+Updated the trigger name validation helper to work with the current trigger and monitor setup, applying validation to all monitor types and updating callback usage.
+
+### Workspace Navigation Fix
+
+Removed the `workspaceAvailability` field from the plugin configuration, which was preventing alerts from being visible within workspace navigation.
+
+## Limitations
+
+- Lock renewal timeout is fixed at 5 minutes and not configurable
+- Trigger name validation applies only to new monitors; existing monitors with duplicate trigger names are not affected
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#1623](https://github.com/opensearch-project/alerting/pull/1623) | alerting | Fix monitor renew lock issue |
+| [#1637](https://github.com/opensearch-project/alerting/pull/1637) | alerting | Fix distribution builds |
+| [#1640](https://github.com/opensearch-project/alerting/pull/1640) | alerting | Fix distribution builds |
+| [#1027](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1027) | alerting-dashboards-plugin | Fixed cypress tests |
+| [#1028](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1028) | alerting-dashboards-plugin | Fix workspace navigation visibility |
+| [#1040](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1040) | alerting-dashboards-plugin | Fix failed UT of AddAlertingMonitor.test.js |
+| [#794](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/794) | alerting-dashboards-plugin | Issue #671 fix trigger name validation |
+| [#1071](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1071) | alerting-dashboards-plugin | Backport trigger name validation to 2.17 |
+| [#1073](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1073) | alerting-dashboards-plugin | Fix alerts card in all-use case overview page |
+
+## References
+
+- [Issue #1617](https://github.com/opensearch-project/alerting/issues/1617): Distribution build issue
+- [Issue #671](https://github.com/opensearch-project/alerting-dashboards-plugin/issues/671): Trigger name validation issue
+- [Issue #1039](https://github.com/opensearch-project/alerting-dashboards-plugin/issues/1039): AddAlertingMonitor test failure
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/alerting/alerting.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -4,6 +4,9 @@
 
 ## Feature Reports
 
+### alerting
+- [Alerting Bugfixes](features/alerting/alerting-bugfixes.md)
+
 ### dashboards-maps
 - [Maps Plugin Bugfixes](features/dashboards-maps/maps-plugin-bugfixes.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for Alerting plugin bugfixes in OpenSearch v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/alerting/alerting-bugfixes.md`
- Feature report: `docs/features/alerting/alerting.md` (updated)

### Key Changes in v2.17.0

**Backend (alerting)**
- Fix monitor renew lock issue - locks can now be renewed after 5 min timeout
- Fix distribution builds

**Frontend (alerting-dashboards-plugin)**
- Fixed cypress tests
- Fix workspace navigation visibility
- Fix failed UT of AddAlertingMonitor.test.js
- Fix trigger name validation for all monitor types
- Fix alerts card in all-use case overview page when MDS is disabled

### Related PRs
- alerting: #1623, #1637, #1640
- alerting-dashboards-plugin: #1027, #1028, #1040, #794, #1071, #1073

Closes #414