### PR TITLE
docs: add Anomaly Detection Bugfixes report for v2.17.0

### DIFF
--- a/docs/features/anomaly-detection/anomaly-detection.md
+++ b/docs/features/anomaly-detection/anomaly-detection.md
@@ -236,6 +236,10 @@ POST _plugins/_anomaly_detection/detectors/<detector_id>/_start
 | v3.0.0 | [#1424](https://github.com/opensearch-project/anomaly-detection/pull/1424) | Fix breaking changes for 3.0.0 release |
 | v3.0.0 | [#1450](https://github.com/opensearch-project/anomaly-detection/pull/1450) | Java Agent migration (SecurityManager removal) |
 | v3.0.0 | [#1441](https://github.com/opensearch-project/anomaly-detection/pull/1441) | Dual cluster gradle run for development |
+| v2.17.0 | [#1287](https://github.com/opensearch-project/anomaly-detection/pull/1287) | Prevent resetting latest flag of real-time when starting historical |
+| v2.17.0 | [#1292](https://github.com/opensearch-project/anomaly-detection/pull/1292) | Correct handling of null max aggregation values |
+| v2.17.0 | [#828](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/828) | Fix dataSourceId not showing in URL |
+| v2.17.0 | [#837](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/837) | Remove dataSourceFilter that breaks DataSourceView |
 
 ## References
 
@@ -249,4 +253,5 @@ POST _plugins/_anomaly_detection/detectors/<detector_id>/_start
 ## Change History
 
 - **v3.0.0** (2025-05-06): AWS SAM template for WAF logs, cross-cluster improvements, OpenSearch 3.0.0 compatibility updates, Java Agent migration
+- **v2.17.0** (2024-09-17): Bugfixes for real-time/historical task flag management, null aggregation handling, Dashboards data source integration
 - **v2.x**: High-cardinality detection, historical analysis, custom result indices

--- a/docs/releases/v2.17.0/features/anomaly-detection/anomaly-detection-bugfixes.md
+++ b/docs/releases/v2.17.0/features/anomaly-detection/anomaly-detection-bugfixes.md
@@ -1,0 +1,128 @@
+# Anomaly Detection Bugfixes
+
+## Summary
+
+OpenSearch v2.17.0 includes four important bugfixes for the Anomaly Detection plugin, addressing issues with real-time/historical task management, null aggregation value handling, and Dashboards data source integration. These fixes improve stability when running mixed real-time and historical analyses and resolve UI issues in multi-data-source environments.
+
+## Details
+
+### What's New in v2.17.0
+
+This release focuses on stability improvements and bug fixes across both the backend anomaly-detection plugin and the anomaly-detection-dashboards-plugin.
+
+### Technical Changes
+
+#### Real-time and Historical Task Flag Management
+
+**Problem**: When starting a historical analysis after a real-time analysis on the same detector, the real-time task's `is_latest` flag was incorrectly reset to `false` by the historical run.
+
+**Solution**: The fix ensures that only the latest flags of the same analysis type are reset:
+- Real-time analysis only resets the latest flag of previous real-time analyses
+- Historical analysis only resets the latest flag of previous historical analyses
+
+**Changed Files**:
+- `ADTaskManager.java`: Simplified `getTaskTypes()` method to return task types based on date range without the `resetLatestTaskStateFlag` parameter
+- `TaskManager.java`: Updated query filter to reset only same-type task flags
+- `ForecastTaskManager.java`: Updated method signature for consistency
+
+**Additional Changes in PR #1287**:
+- Set minimum `recencyEmphasis` value to 2 to align with RCF (Random Cut Forest) requirements
+- Updated imputation logic to execute only when the entity maps to the local node ID in the hash ring, reducing errors when models exist on multiple nodes
+
+#### Null Max Aggregation Value Handling
+
+**Problem**: When the max aggregation in SearchResponse returned a null value, it was converted to a negative number (`-9223372036854775808`), leading to erroneous timestamps and parse errors.
+
+**Solution**: Added validation to ensure only valid positive aggregation values are considered for timestamps.
+
+```java
+// Before: Could return invalid negative values
+.map(agg -> (long) agg.getValue());
+
+// After: Filters out null/invalid values
+.filter(agg -> agg != null && agg.getValue() > 0)
+.map(agg -> (long) agg.getValue());
+```
+
+**Error Before Fix**:
+```
+OpenSearchParseException[failed to parse date field [-9223372036854775808] 
+with format [strict_date_optional_time||epoch_millis]]
+```
+
+**Response After Fix**:
+```json
+{
+  "model": {
+    "time_field": {
+      "message": "There isn't enough historical data found with current timefield selected."
+    }
+  }
+}
+```
+
+#### DataSourceView Integration Fix
+
+**Problem**: DataSourceView was broken on future playground and TrineoApp environments under OpenSearch 2.16, though no console/network errors were shown. The issue was caused by `dataSourceFilter` filtering out the version, causing DataSourceView to error with "cannot find data source".
+
+**Solution**: Removed the `dataSourceFilter` check from all DataSourceView usage in the Anomaly Detection Dashboards plugin, as the scenarios where AD uses DataSourceView don't require data source filtering.
+
+**Changed Files**:
+- `ConfigureModel.tsx`
+- `DefineDetector.tsx`
+- `DetectorDetail.tsx`
+- `DetectorJobs.tsx`
+- `ReviewAndCreate.tsx`
+
+#### DataSourceId URL Parameter Fix
+
+**Problem**: The `dataSourceId` was not showing in the URL on the Overview landing page when using multi-data-source environments.
+
+**Solution**: Fixed the condition check in `AnomalyDetectionOverview.tsx` to properly update URL parameters with the selected data source ID.
+
+```typescript
+// Before: Only updated when landingDataSourceId was defined
+if (dataSourceEnabled && props.landingDataSourceId !== undefined) {
+
+// After: Updates whenever dataSourceEnabled is true
+if (dataSourceEnabled) {
+```
+
+### Usage Example
+
+After these fixes, you can safely run historical analysis after real-time analysis without affecting the real-time task state:
+
+```json
+// Start real-time detection
+POST _plugins/_anomaly_detection/detectors/<detector_id>/_start
+
+// Later, start historical analysis - won't affect real-time task's is_latest flag
+POST _plugins/_anomaly_detection/detectors/<detector_id>/_start
+{
+  "start_time": 1633048868000,
+  "end_time": 1633394468000
+}
+```
+
+## Limitations
+
+- The `recencyEmphasis` parameter now requires a minimum value of 2 (previously allowed 1)
+- DataSourceView no longer filters data sources by version compatibility in AD plugin
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#1287](https://github.com/opensearch-project/anomaly-detection/pull/1287) | anomaly-detection | Prevent resetting latest flag of real-time when starting historical analysis |
+| [#1292](https://github.com/opensearch-project/anomaly-detection/pull/1292) | anomaly-detection | Correct handling of null max aggregation values in SearchResponse |
+| [#828](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/828) | anomaly-detection-dashboards-plugin | Fix dataSourceId not showing in URL on Overview landing page |
+| [#837](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/837) | anomaly-detection-dashboards-plugin | Remove dataSourceFilter that breaks DataSourceView |
+
+## References
+
+- [Anomaly Detection Documentation](https://docs.opensearch.org/2.17/observing-your-data/ad/index/): Official documentation
+- [Anomaly Detection API](https://docs.opensearch.org/2.17/observing-your-data/ad/api/): API reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/anomaly-detection/anomaly-detection.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -7,6 +7,9 @@
 ### alerting
 - [Alerting Bugfixes](features/alerting/alerting-bugfixes.md)
 
+### anomaly-detection
+- [Anomaly Detection Bugfixes](features/anomaly-detection/anomaly-detection-bugfixes.md)
+
 ### dashboards-maps
 - [Maps Plugin Bugfixes](features/dashboards-maps/maps-plugin-bugfixes.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Anomaly Detection bugfixes included in OpenSearch v2.17.0.

## Changes

### Release Report Created
- `docs/releases/v2.17.0/features/anomaly-detection/anomaly-detection-bugfixes.md`

### Feature Report Updated
- `docs/features/anomaly-detection/anomaly-detection.md` - Added v2.17.0 PRs and change history

### Release Index Updated
- `docs/releases/v2.17.0/index.md` - Added anomaly-detection section

## Bugfixes Documented

| PR | Repository | Description |
|----|------------|-------------|
| #1287 | anomaly-detection | Prevent resetting latest flag of real-time when starting historical analysis |
| #1292 | anomaly-detection | Correct handling of null max aggregation values in SearchResponse |
| #828 | anomaly-detection-dashboards-plugin | Fix dataSourceId not showing in URL on Overview landing page |
| #837 | anomaly-detection-dashboards-plugin | Remove dataSourceFilter that breaks DataSourceView |

## Key Findings

1. **Real-time/Historical Task Management**: Fixed issue where starting historical analysis incorrectly reset real-time task's `is_latest` flag
2. **Null Aggregation Handling**: Added validation to prevent null max aggregation values from being converted to invalid negative timestamps
3. **DataSourceView Fix**: Removed `dataSourceFilter` that was breaking DataSourceView in multi-data-source environments
4. **URL Parameter Fix**: Fixed `dataSourceId` not appearing in URL on Overview landing page

Closes #413