### PR TITLE
docs: add Flint Index Operations report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -93,6 +93,7 @@
 ## sql
 
 - [Calcite Query Engine](sql/calcite-query-engine.md)
+- [Flint Index Operations](sql/flint-index-operations.md)
 - [SQL/PPL Engine](sql/sql-ppl-engine.md)
 - [SQL/PPL Breaking Changes](sql/sql-ppl-breaking-changes.md)
 

--- a/docs/features/sql/flint-index-operations.md
+++ b/docs/features/sql/flint-index-operations.md
@@ -1,0 +1,149 @@
+# Flint Index Operations
+
+## Summary
+
+Flint Index Operations provide SQL-based management commands for Flint indexes in OpenSearch. Flint indexes enable query acceleration by creating materialized views, skipping indexes, and covering indexes on external data sources (like S3) through Apache Spark integration. The operations include CREATE, DROP, ALTER, REFRESH, DESCRIBE, SHOW, and VACUUM commands for managing these indexes.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch SQL Plugin"
+        A[SQL/PPL Query] --> B[Query Parser]
+        B --> C[SparkQueryDispatcher]
+        C --> D{Query Type}
+        D -->|DML| E[IndexDMLHandler]
+        D -->|DDL/Other| F[Spark Job]
+    end
+    
+    subgraph "Apache Spark"
+        F --> G[Flint Spark]
+        G --> H[Index Operations]
+    end
+    
+    subgraph "Storage"
+        H --> I[OpenSearch Index]
+        H --> J[S3 Checkpoint]
+    end
+    
+    E --> I
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User Query] --> B[Async Query API]
+    B --> C[SQL Plugin]
+    C --> D[Query Dispatcher]
+    D --> E{Operation Type}
+    E -->|DROP| F[IndexDMLHandler]
+    E -->|ALTER| F
+    E -->|VACUUM| G[Spark Job]
+    E -->|CREATE/REFRESH| G
+    F --> H[State Management]
+    G --> I[Flint Spark]
+    I --> J[Execute Operation]
+    J --> K[Update Index State]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SparkQueryDispatcher` | Routes queries to appropriate handlers based on query type |
+| `IndexDMLHandler` | Handles DROP and ALTER operations directly in the SQL plugin |
+| `FlintIndexOpFactory` | Factory for creating index operation handlers |
+| `FlintIndexStateModelService` | Manages index state transitions |
+| `AsyncQueryScheduler` | Handles scheduled refresh operations |
+
+### Supported Operations
+
+| Operation | Description | Handler |
+|-----------|-------------|---------|
+| CREATE INDEX | Creates a new Flint index | Spark Job |
+| DROP INDEX | Marks index as deleted | IndexDMLHandler |
+| ALTER INDEX | Modifies index options | IndexDMLHandler |
+| REFRESH INDEX | Triggers manual refresh | Spark Job |
+| VACUUM INDEX | Cleans up deleted index and checkpoint | Spark Job |
+| DESCRIBE INDEX | Shows index metadata | Spark Job |
+| SHOW INDEX | Lists indexes | Spark Job |
+
+### Index Types
+
+| Type | Description | Example |
+|------|-------------|---------|
+| Skipping Index | Partition pruning optimization | `CREATE SKIPPING INDEX ON table (col VALUE_SET)` |
+| Covering Index | Materialized column subset | `CREATE INDEX idx ON table (col1, col2)` |
+| Materialized View | Pre-computed query results | `CREATE MATERIALIZED VIEW mv AS SELECT ...` |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `auto_refresh` | Enable automatic refresh | `false` |
+| `checkpoint_location` | S3 path for streaming checkpoints | None |
+| `scheduler_mode` | Refresh scheduler mode (`internal`/`external`) | `internal` |
+| `refresh_interval` | Interval for auto-refresh | `15 minutes` |
+
+### Usage Examples
+
+#### Create Materialized View with Auto-Refresh
+
+```sql
+CREATE MATERIALIZED VIEW mys3.default.http_logs_metrics AS
+SELECT 
+    date_trunc('hour', timestamp) as hour,
+    status,
+    COUNT(*) as count
+FROM mys3.default.http_logs
+GROUP BY 1, 2
+WITH (
+    auto_refresh = true,
+    checkpoint_location = 's3://my-bucket/checkpoints/http_logs_metrics'
+)
+```
+
+#### Alter Index to Disable Auto-Refresh
+
+```sql
+ALTER INDEX my_index ON mys3.default.http_logs 
+WITH (auto_refresh = false)
+```
+
+#### Vacuum Deleted Index
+
+```sql
+-- First drop the index
+DROP MATERIALIZED VIEW mys3.default.http_logs_metrics
+
+-- Then vacuum to clean up index and checkpoint data
+VACUUM MATERIALIZED VIEW mys3.default.http_logs_metrics
+```
+
+## Limitations
+
+- Vacuum operations require Spark job submission, adding latency compared to direct operations
+- Checkpoint cleanup depends on proper S3 permissions
+- Index state transitions must follow valid state machine paths
+- External scheduler mode requires additional configuration
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#2995](https://github.com/opensearch-project/sql/pull/2995) | Delegate vacuum operation to Spark |
+| v2.14.0 | [#2557](https://github.com/opensearch-project/sql/pull/2557) | Initial vacuum implementation in SQL plugin |
+
+## References
+
+- [Issue #580](https://github.com/opensearch-project/opensearch-spark/issues/580): VACUUM should delete checkpoint data
+- [Issue #104](https://github.com/opensearch-project/opensearch-spark/issues/104): Original VACUUM feature request
+- [Scheduled Query Acceleration](https://docs.opensearch.org/2.17/dashboards/management/scheduled-query-acceleration/): Official documentation
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Delegated vacuum operation to Spark for checkpoint cleanup support
+- **v2.14.0**: Initial vacuum operation implementation in SQL plugin

--- a/docs/releases/v2.17.0/features/sql/flint-index-operations.md
+++ b/docs/releases/v2.17.0/features/sql/flint-index-operations.md
@@ -1,0 +1,100 @@
+# Flint Index Operations
+
+## Summary
+
+This release delegates the Flint index vacuum operation from the SQL plugin to Apache Spark (Flint Spark). Previously, the SQL plugin handled vacuum operations directly to minimize latency and cost. However, with the need for checkpoint cleanup functionality, this approach became impractical. The change removes redundant vacuum logic from the SQL plugin and fully delegates the operation to Flint Spark, enabling proper checkpoint data cleanup.
+
+## Details
+
+### What's New in v2.17.0
+
+The vacuum operation for Flint indexes is now delegated to Spark instead of being handled directly by the SQL plugin. This architectural change enables:
+
+1. **Checkpoint cleanup**: The vacuum operation can now delete checkpoint data stored in S3, which was not possible when handled by the SQL plugin
+2. **Simplified codebase**: Removes duplicate vacuum logic that existed in both the SQL plugin and Flint Spark
+3. **Consistent behavior**: All vacuum operations now go through Spark, ensuring consistent handling across all index types
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v2.17.0"
+        A1[VACUUM Command] --> B1[SQL Plugin]
+        B1 --> C1[IndexDMLHandler]
+        C1 --> D1[FlintIndexOpVacuum]
+        D1 --> E1[Delete OpenSearch Index]
+    end
+    
+    subgraph "After v2.17.0"
+        A2[VACUUM Command] --> B2[SQL Plugin]
+        B2 --> C2[SparkQueryDispatcher]
+        C2 --> D2[Spark Job]
+        D2 --> E2[Flint Spark]
+        E2 --> F2[Delete Index + Checkpoint]
+    end
+```
+
+#### Removed Components
+
+| Component | Description |
+|-----------|-------------|
+| `FlintIndexOpVacuum` | Class that handled vacuum operations in the SQL plugin |
+| `FlintIndexOpFactory.getVacuum()` | Factory method for creating vacuum operations |
+| Vacuum statement visitors | SQL parser visitors for VACUUM statements |
+
+#### Changed Components
+
+| Component | Change |
+|-----------|--------|
+| `IndexDMLHandler` | Removed VACUUM case from index operation handling |
+| `SparkQueryDispatcher` | VACUUM no longer eligible for IndexDML handling |
+| `SQLQueryUtils` | Removed vacuum statement visitor methods |
+
+### Usage Example
+
+The VACUUM command syntax remains unchanged. The difference is in how it's processed internally:
+
+```sql
+-- Create a materialized view with checkpoint
+CREATE MATERIALIZED VIEW mys3.default.my_view AS 
+SELECT clientip FROM mys3.default.http_logs 
+WITH (auto_refresh = true, checkpoint_location = 's3://checkpoint/my-view')
+
+-- Drop the materialized view (index remains in DELETED state)
+DROP MATERIALIZED VIEW mys3.default.my_view
+
+-- Vacuum to clean up both index and checkpoint data
+VACUUM MATERIALIZED VIEW mys3.default.my_view
+```
+
+After vacuum, both the OpenSearch index and the S3 checkpoint data are deleted.
+
+### Migration Notes
+
+- No user-facing changes required
+- VACUUM commands continue to work with the same syntax
+- Vacuum operations may take slightly longer as they now run as Spark jobs
+- Checkpoint data is now properly cleaned up during vacuum operations
+
+## Limitations
+
+- Vacuum operations now require a Spark job to be submitted, which may increase latency compared to the previous direct handling
+- The operation depends on Flint Spark availability
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2985](https://github.com/opensearch-project/sql/pull/2985) | Delegate Flint index vacuum operation to Spark (main) |
+| [#2995](https://github.com/opensearch-project/sql/pull/2995) | Manual backport to 2.17 branch |
+
+## References
+
+- [Issue #580](https://github.com/opensearch-project/opensearch-spark/issues/580): VACUUM index statement should delete checkpoint data
+- [PR #2557](https://github.com/opensearch-project/sql/pull/2557): Original vacuum implementation in SQL plugin
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/sql/flint-index-operations.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -74,6 +74,7 @@
 - [Reporting Enhancements](features/reporting/reporting-enhancements.md)
 
 ### sql
+- [Flint Index Operations](features/sql/flint-index-operations.md)
 - [SQL/PPL Bugfixes](features/sql/sql-ppl-bugfixes.md)
 
 ### k-nn


### PR DESCRIPTION
## Summary

This PR adds documentation for the Flint Index Operations enhancement in OpenSearch v2.17.0.

### Key Changes in v2.17.0

- Delegated Flint index vacuum operation from SQL plugin to Apache Spark (Flint Spark)
- Enables proper checkpoint data cleanup during vacuum operations
- Removes redundant vacuum logic from the SQL plugin

### Reports Created

- Release report: `docs/releases/v2.17.0/features/sql/flint-index-operations.md`
- Feature report: `docs/features/sql/flint-index-operations.md`

### Related PRs

- [opensearch-project/sql#2985](https://github.com/opensearch-project/sql/pull/2985): Original implementation
- [opensearch-project/sql#2995](https://github.com/opensearch-project/sql/pull/2995): Backport to 2.17

### Related Issue

Closes #412