### PR TITLE
docs: add Security Lake Data Source report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -94,6 +94,7 @@
 
 - [Calcite Query Engine](sql/calcite-query-engine.md)
 - [Flint Index Operations](sql/flint-index-operations.md)
+- [Security Lake Data Source](sql/security-lake-data-source.md)
 - [SQL/PPL Engine](sql/sql-ppl-engine.md)
 - [SQL/PPL Breaking Changes](sql/sql-ppl-breaking-changes.md)
 

--- a/docs/features/sql/security-lake-data-source.md
+++ b/docs/features/sql/security-lake-data-source.md
@@ -1,0 +1,157 @@
+# Security Lake Data Source
+
+## Summary
+
+The Security Lake Data Source feature enables OpenSearch to query Amazon Security Lake tables directly using SQL and PPL. Amazon Security Lake centralizes security data from AWS environments, SaaS providers, and on-premises sources into a purpose-built data lake stored in S3. This integration allows security analysts to query normalized security data in OCSF (Open Cybersecurity Schema Framework) format directly from OpenSearch.
+
+Key benefits:
+- Direct querying of Security Lake tables without data movement
+- Automatic Iceberg and Lake Formation integration for secure access
+- Query validation to prevent privilege escalation
+- Support for Flint index acceleration on Security Lake data
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Cluster"
+        API[Data Source API]
+        SLF[SecurityLakeDataSourceFactory]
+        SPD[SparkQueryDispatcher]
+        QV[Query Validator]
+        FI[Flint Index Store]
+    end
+    
+    subgraph "EMR Serverless"
+        Spark[Apache Spark]
+        Iceberg[Iceberg Runtime]
+    end
+    
+    subgraph "AWS Services"
+        SL[Amazon Security Lake]
+        LF[Lake Formation]
+        Glue[AWS Glue Catalog]
+        S3[Amazon S3]
+    end
+    
+    API --> SLF
+    SLF --> SPD
+    SPD --> QV
+    SPD --> Spark
+    Spark --> Iceberg
+    Iceberg --> LF
+    LF --> Glue
+    Glue --> S3
+    SL --> S3
+    Spark --> FI
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User Query] --> B{Query Validator}
+    B -->|SELECT/Flint| C[SparkQueryDispatcher]
+    B -->|Other| D[Reject Query]
+    C --> E[EMR Serverless]
+    E --> F[Lake Formation Auth]
+    F --> G[Glue Catalog]
+    G --> H[S3 Data]
+    H --> I[Query Results]
+    I --> J[OpenSearch Index]
+    J --> K[Return to User]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SecurityLakeDataSourceFactory` | Creates Security Lake data sources with automatic Iceberg/LF configuration |
+| `SparkSqlSecurityLakeValidatorVisitor` | ANTLR-based query validator that restricts queries to SELECT and Flint commands |
+| `S3GlueDataSourceSparkParameterComposer` | Configures Spark parameters for Iceberg and Lake Formation |
+| `DataSourceType.SECURITY_LAKE` | Data source type identifier |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `glue.auth.type` | Authentication type (must be `iam_role`) | Required |
+| `glue.auth.role_arn` | IAM role ARN for accessing Security Lake | Required |
+| `glue.indexstore.opensearch.uri` | OpenSearch URI for index storage | Required |
+| `glue.indexstore.opensearch.auth` | Authentication for OpenSearch (`noauth`, `basicauth`, `awssigv4`) | Required |
+| `glue.indexstore.opensearch.region` | AWS region for OpenSearch (required for awssigv4) | - |
+| `glue.lakeformation.session_tag` | Session tag for Lake Formation role assumption | Required |
+| `glue.iceberg.enabled` | Enable Iceberg support (auto-set to `true`) | `true` |
+| `glue.lakeformation.enabled` | Enable Lake Formation (auto-set to `true`) | `true` |
+
+### Usage Example
+
+#### Create Data Source
+
+```json
+POST /_plugins/_query/_datasources
+{
+  "name": "my_security_lake",
+  "connector": "security_lake",
+  "properties": {
+    "glue.auth.type": "iam_role",
+    "glue.auth.role_arn": "arn:aws:iam::123456789012:role/SecurityLakeQueryRole",
+    "glue.indexstore.opensearch.uri": "https://search-domain.us-west-2.es.amazonaws.com:443",
+    "glue.indexstore.opensearch.auth": "awssigv4",
+    "glue.indexstore.opensearch.auth.region": "us-west-2",
+    "glue.lakeformation.session_tag": "opensearch-security-analytics"
+  },
+  "resultIndex": "security_lake_results"
+}
+```
+
+#### Query VPC Flow Logs
+
+```sql
+SELECT 
+  src_endpoint.ip AS source_ip,
+  dst_endpoint.ip AS dest_ip,
+  traffic.packets,
+  time
+FROM my_security_lake.amazon_security_lake_glue_db_us_west_2.amazon_security_lake_table_us_west_2_vpc_flow_2_0
+WHERE time > '2024-01-01'
+LIMIT 100
+```
+
+#### Create Covering Index
+
+```sql
+CREATE INDEX srcip_time 
+ON my_security_lake.amazon_security_lake_glue_db_us_west_2.amazon_security_lake_table_us_west_2_vpc_flow_2_0 
+(src_endpoint.ip, time) 
+WITH (auto_refresh=true)
+```
+
+## Limitations
+
+- Only SELECT queries and Flint index operations are allowed
+- DDL operations (CREATE TABLE, DROP TABLE) are blocked
+- DML operations (INSERT, UPDATE, DELETE) are blocked
+- Covering index acceleration is disabled when Lake Formation is enabled
+- Requires EMR Serverless as the Spark execution engine
+- Session tag is required for Lake Formation authorization
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#2858](https://github.com/opensearch-project/sql/pull/2858) | Add flags for Iceberg and Lake Formation and Security Lake as a data source type |
+| v2.17.0 | [#2959](https://github.com/opensearch-project/sql/pull/2959) | Adds validation to allow only flint queries and sql SELECT queries to security lake type datasource |
+
+## References
+
+- [Issue #2907](https://github.com/opensearch-project/sql/issues/2907): Original feature request
+- [Amazon Security Lake Documentation](https://docs.aws.amazon.com/security-lake/latest/userguide/what-is-security-lake.html)
+- [OpenSearch S3 Data Source Documentation](https://docs.opensearch.org/2.17/dashboards/management/S3-data-source/)
+- [Security Lake Connector Documentation](https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/admin/connectors/security_lake_connector.rst)
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Initial implementation with SECURITY_LAKE data source type and query validation

--- a/docs/releases/v2.17.0/features/sql/security-lake-data-source.md
+++ b/docs/releases/v2.17.0/features/sql/security-lake-data-source.md
@@ -1,0 +1,125 @@
+# Security Lake Data Source
+
+## Summary
+
+OpenSearch v2.17.0 introduces a new `SECURITY_LAKE` data source type that enables querying Amazon Security Lake tables directly from OpenSearch. This feature adds query validation to restrict Security Lake queries to SELECT statements and Flint index operations only, preventing privilege escalation beyond Lake Formation permissions.
+
+## Details
+
+### What's New in v2.17.0
+
+This release introduces two key enhancements:
+
+1. **New SECURITY_LAKE Data Source Type**: A dedicated connector for Amazon Security Lake that automatically enables Iceberg and Lake Formation integration
+2. **Query Validation for Security Lake**: Restricts queries to SELECT statements and Flint commands to prevent unauthorized data modifications
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "OpenSearch SQL Plugin"
+        DS[Data Source API]
+        SLF[SecurityLakeDataSourceFactory]
+        GDF[GlueDataSourceFactory]
+        QV[Query Validator]
+    end
+    
+    subgraph "Query Execution"
+        SPD[SparkQueryDispatcher]
+        SQU[SQLQueryUtils]
+        SLVV[SparkSqlSecurityLakeValidatorVisitor]
+    end
+    
+    subgraph "AWS Services"
+        SL[Amazon Security Lake]
+        LF[Lake Formation]
+        Glue[AWS Glue]
+        S3[Amazon S3]
+    end
+    
+    DS --> SLF
+    SLF --> GDF
+    SPD --> SQU
+    SQU --> SLVV
+    SLF --> LF
+    SLF --> Glue
+    Glue --> S3
+    SL --> S3
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `SecurityLakeDataSourceFactory` | Factory class for creating Security Lake data sources, extends `GlueDataSourceFactory` |
+| `SparkSqlSecurityLakeValidatorVisitor` | ANTLR visitor that validates queries for Security Lake, allowing only SELECT statements |
+| `DataSourceType.SECURITY_LAKE` | New data source type constant |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `glue.iceberg.enabled` | Enable Iceberg catalog support | `false` |
+| `glue.lakeformation.enabled` | Enable Lake Formation authorization | `false` |
+| `glue.lakeformation.session_tag` | Session tag for Lake Formation role assumption | Required when LF enabled |
+
+### Usage Example
+
+Create a Security Lake data source:
+
+```json
+POST /_plugins/_query/_datasources
+{
+  "name": "my_security_lake",
+  "connector": "security_lake",
+  "properties": {
+    "glue.auth.type": "iam_role",
+    "glue.auth.role_arn": "arn:aws:iam::123456789012:role/SecurityLakeRole",
+    "glue.indexstore.opensearch.uri": "https://opensearch.example.com:9200",
+    "glue.indexstore.opensearch.auth": "awssigv4",
+    "glue.indexstore.opensearch.auth.region": "us-west-2",
+    "glue.lakeformation.session_tag": "opensearch-query"
+  },
+  "resultIndex": "query_execution_result"
+}
+```
+
+Query Security Lake data:
+
+```sql
+SELECT * FROM my_security_lake.amazon_security_lake_glue_db_us_west_2.amazon_security_lake_table_us_west_2_vpc_flow_2_0 LIMIT 10
+```
+
+### Migration Notes
+
+- Security Lake data sources automatically enable Iceberg and Lake Formation
+- The `glue.lakeformation.session_tag` property is required for Security Lake data sources
+- Only SELECT queries and Flint index operations are allowed on Security Lake data sources
+
+## Limitations
+
+- Only SELECT statements and Flint index commands (CREATE INDEX, REFRESH INDEX) are supported
+- DDL operations (CREATE TABLE, DROP TABLE, etc.) are blocked
+- DML operations (INSERT, UPDATE, DELETE) are blocked
+- Covering index acceleration is disabled when Lake Formation is enabled
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2858](https://github.com/opensearch-project/sql/pull/2858) | Add flags for Iceberg and Lake Formation and Security Lake as a data source type |
+| [#2978](https://github.com/opensearch-project/sql/pull/2978) | Backport #2858 to 2.17 |
+| [#2959](https://github.com/opensearch-project/sql/pull/2959) | Adds validation to allow only flint queries and sql SELECT queries to security lake type datasource |
+| [#2977](https://github.com/opensearch-project/sql/pull/2977) | Backport #2959 to 2.17 |
+
+## References
+
+- [Issue #2907](https://github.com/opensearch-project/sql/issues/2907): Limit Spark SQL queries to SELECT + FLINT commands when Lake Formation is enabled
+- [Amazon Security Lake Documentation](https://docs.aws.amazon.com/security-lake/latest/userguide/what-is-security-lake.html)
+- [OpenSearch S3 Data Source Documentation](https://docs.opensearch.org/2.17/dashboards/management/S3-data-source/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/sql/security-lake-data-source.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -75,6 +75,7 @@
 
 ### sql
 - [Flint Index Operations](features/sql/flint-index-operations.md)
+- [Security Lake Data Source](features/sql/security-lake-data-source.md)
 - [SQL/PPL Bugfixes](features/sql/sql-ppl-bugfixes.md)
 
 ### k-nn


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security Lake Data Source feature introduced in OpenSearch v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/sql/security-lake-data-source.md`
- Feature report: `docs/features/sql/security-lake-data-source.md`

### Key Changes in v2.17.0
- New `SECURITY_LAKE` data source type for querying Amazon Security Lake tables
- Query validation to restrict Security Lake queries to SELECT statements and Flint index operations only
- Automatic Iceberg and Lake Formation integration
- New configuration properties: `glue.iceberg.enabled`, `glue.lakeformation.enabled`, `glue.lakeformation.session_tag`

### Related PRs
- [opensearch-project/sql#2858](https://github.com/opensearch-project/sql/pull/2858): Add flags for Iceberg and Lake Formation and Security Lake as a data source type
- [opensearch-project/sql#2959](https://github.com/opensearch-project/sql/pull/2959): Adds validation to allow only flint queries and sql SELECT queries to security lake type datasource

### Related Issue
- Closes #411