### PR TITLE
docs: add k-NN Model Metadata report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -170,6 +170,7 @@
 
 - [Vector Search (k-NN)](k-nn/vector-search-k-nn.md)
 - [k-NN Explain API](k-nn/explain-api.md)
+- [k-NN Model Metadata](k-nn/k-nn-model-metadata.md)
 - [Lucene On Faiss (Memory Optimized Search)](k-nn/lucene-on-faiss.md)
 - [Remote Vector Index Build](k-nn/remote-vector-index-build.md)
 

--- a/docs/features/k-nn/k-nn-model-metadata.md
+++ b/docs/features/k-nn/k-nn-model-metadata.md
@@ -1,0 +1,181 @@
+# k-NN Model Metadata
+
+## Summary
+
+The k-NN Model Metadata feature provides comprehensive metadata tracking for trained k-NN models in OpenSearch. Model metadata includes information about the model's configuration, state, training parameters, and version history. This metadata is essential for managing models in production environments, enabling version compatibility checks, and supporting features like disk-based vector search.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Model Training"
+        TJ[Training Job] --> MM[ModelMetadata]
+        MM --> MD[ModelDao]
+        MD --> MI[Model System Index]
+    end
+    
+    subgraph "Model Metadata"
+        MM --> KE[KNN Engine]
+        MM --> ST[Space Type]
+        MM --> DIM[Dimension]
+        MM --> STATE[Model State]
+        MM --> VER[Model Version]
+        MM --> MCC[Method Component Context]
+    end
+    
+    subgraph "Model Usage"
+        FM[Field Mapper] --> MU[ModelUtil]
+        MU --> MD
+        MD --> CM[Cluster Metadata]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Train Model Request] --> B[TrainingJob Created]
+    B --> C[Training Executes]
+    C --> D{Training Success?}
+    D -->|Yes| E[Model State: CREATED]
+    D -->|No| F[Model State: FAILED]
+    E --> G[Serialize to Model Index]
+    F --> G
+    G --> H[Metadata in Cluster State]
+    H --> I[Available for Index Creation]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ModelMetadata` | Core class storing all model metadata fields |
+| `ModelDao` | Data access object for model CRUD operations |
+| `ModelCache` | In-memory cache for frequently accessed models |
+| `ModelUtil` | Utility class for model metadata retrieval |
+| `TrainingJob` | Handles model training and metadata creation |
+| `TrainingJobRunner` | Executes training jobs and manages state transitions |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `knn_engine` | The native library engine (faiss, nmslib, lucene) | Required |
+| `space_type` | Distance function (l2, cosinesimil, innerproduct) | Required |
+| `dimension` | Vector dimensionality | Required |
+| `state` | Model state (created, failed, training) | training |
+| `timestamp` | Creation timestamp | Auto-generated |
+| `description` | User-provided description | Empty |
+| `error` | Error message if training failed | Empty |
+| `training_node_assignment` | Node where training occurred | Auto-assigned |
+| `method_component_context` | Method-specific parameters | Empty |
+| `vector_data_type` | Data type (float, byte, binary) | float |
+| `mode` | Search mode (on_disk, not_configured) | not_configured |
+| `compression_level` | Compression level for disk-based search | not_configured |
+| `model_version` | OpenSearch version at training time | Current version |
+
+### Usage Example
+
+#### Training a Model
+
+```json
+POST /_plugins/_knn/models/my-model/_train
+{
+  "training_index": "train-data",
+  "training_field": "embedding",
+  "dimension": 768,
+  "description": "Product embedding model",
+  "method": {
+    "name": "ivf",
+    "engine": "faiss",
+    "space_type": "l2",
+    "parameters": {
+      "nlist": 128,
+      "encoder": {
+        "name": "pq",
+        "parameters": {
+          "code_size": 8,
+          "m": 8
+        }
+      }
+    }
+  }
+}
+```
+
+#### Retrieving Model Metadata
+
+```json
+GET /_plugins/_knn/models/my-model
+{
+  "model_id": "my-model",
+  "model_blob": "...",
+  "state": "created",
+  "timestamp": "2024-09-05T17:29:20Z",
+  "description": "Product embedding model",
+  "error": "",
+  "space_type": "l2",
+  "dimension": 768,
+  "engine": "faiss",
+  "training_node_assignment": "node-1",
+  "model_definition": {
+    "name": "ivf",
+    "parameters": {
+      "nlist": 128,
+      "encoder": {
+        "name": "pq",
+        "parameters": {
+          "code_size": 8,
+          "m": 8
+        }
+      }
+    }
+  },
+  "data_type": "float",
+  "model_version": "2.17.0"
+}
+```
+
+#### Using a Model for Index Creation
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index.knn": true
+  },
+  "mappings": {
+    "properties": {
+      "embedding": {
+        "type": "knn_vector",
+        "model_id": "my-model"
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Model metadata is immutable after training completes
+- Models created before v2.17.0 lack version information
+- Model blob size is limited by the model cache size setting
+- Training requires sufficient native memory on the assigned node
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#2005](https://github.com/opensearch-project/k-NN/pull/2005) | Add model version to model metadata and change model metadata reads to be from cluster metadata |
+
+## References
+
+- [k-NN Plugin API](https://docs.opensearch.org/latest/search-plugins/knn/api/): Official API documentation
+- [Approximate k-NN Search](https://docs.opensearch.org/latest/search-plugins/knn/approximate-knn/): Training and using models
+- [k-NN Vector Quantization](https://docs.opensearch.org/latest/search-plugins/knn/knn-vector-quantization/): PQ and quantization methods
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Added model version tracking to metadata; optimized metadata reads to use cluster metadata directly instead of full model retrieval

--- a/docs/releases/v2.17.0/features/k-nn/k-nn-model-metadata.md
+++ b/docs/releases/v2.17.0/features/k-nn/k-nn-model-metadata.md
@@ -1,0 +1,130 @@
+# k-NN Model Metadata
+
+## Summary
+
+This enhancement adds OpenSearch version tracking to k-NN model metadata and optimizes how model metadata is retrieved. When a model is trained, the OpenSearch version used during training is now stored as part of the model's metadata. Additionally, model metadata reads have been changed to retrieve data directly from cluster metadata instead of making separate model retrieval calls.
+
+## Details
+
+### What's New in v2.17.0
+
+The k-NN plugin now tracks the OpenSearch version with which a model was created. This version information is stored in the model metadata and persisted in the k-NN model system index.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v2.17.0"
+        A1[Training Job] --> B1[Model Metadata]
+        C1[Field Mapper] --> D1[ModelCache.get]
+        D1 --> E1[ModelDao.get]
+        E1 --> F1[Full Model Retrieval]
+    end
+    
+    subgraph "After v2.17.0"
+        A2[Training Job] --> B2[Model Metadata + Version]
+        C2[Field Mapper] --> D2[ModelDao.getMetadata]
+        D2 --> E2[Cluster Metadata Read]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `MODEL_VERSION` constant | New constant in `KNNConstants.java` for the model version field key |
+| `getModelVersion()` method | New getter in `ModelMetadata` class to retrieve the stored version |
+| Version serialization | Model version is now serialized/deserialized with model metadata |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `model_version` | OpenSearch version when model was created | Current OpenSearch version |
+
+The `model_version` field is automatically populated during model training and stored in the model index mapping.
+
+#### API Changes
+
+The model metadata response now includes a `model_version` field:
+
+```json
+GET /_plugins/_knn/models/my-model
+{
+  "model_id": "my-model",
+  "model_blob": "...",
+  "state": "created",
+  "timestamp": "2024-09-05T17:29:20Z",
+  "description": "My trained model",
+  "error": "",
+  "space_type": "l2",
+  "dimension": 128,
+  "engine": "faiss",
+  "model_version": "2.17.0"
+}
+```
+
+### Usage Example
+
+When training a new model, the version is automatically captured:
+
+```json
+POST /_plugins/_knn/models/my-model/_train
+{
+  "training_index": "train-index",
+  "training_field": "train-field",
+  "dimension": 128,
+  "method": {
+    "name": "ivf",
+    "engine": "faiss",
+    "parameters": {
+      "nlist": 128,
+      "encoder": {
+        "name": "pq",
+        "parameters": {
+          "code_size": 8
+        }
+      }
+    }
+  }
+}
+```
+
+After training completes, the model metadata will include the version:
+
+```json
+GET /_plugins/_knn/models/my-model?filter_path=model_id,state,model_version
+{
+  "model_id": "my-model",
+  "state": "created",
+  "model_version": "2.17.0"
+}
+```
+
+### Migration Notes
+
+- Existing models created before v2.17.0 will have an empty version (`Version.V_EMPTY`)
+- The version field is backward compatible - older clusters can still read model metadata
+- No manual migration is required; the version is automatically populated for new models
+
+## Limitations
+
+- Models created before v2.17.0 will not have version information
+- The version reflects the OpenSearch version at training time, not the current cluster version
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2005](https://github.com/opensearch-project/k-NN/pull/2005) | Add model version to model metadata and change model metadata reads to be from cluster metadata |
+
+## References
+
+- [k-NN Plugin API Documentation](https://docs.opensearch.org/2.17/search-plugins/knn/api/): Official API documentation for k-NN models
+- [Approximate k-NN Search](https://docs.opensearch.org/2.17/search-plugins/knn/approximate-knn/): Guide on training and using k-NN models
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/k-nn/k-nn-model-metadata.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -81,6 +81,7 @@
 
 ### k-nn
 - [k-NN Bugfixes](features/k-nn/k-nn-bugfixes.md)
+- [k-NN Model Metadata](features/k-nn/k-nn-model-metadata.md)
 
 ### cross-cluster-replication
 - [Cross-Cluster Replication Bugfixes](features/cross-cluster-replication/cross-cluster-replication-bugfixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the k-NN Model Metadata enhancement introduced in OpenSearch v2.17.0.

## Changes

### Release Report
- `docs/releases/v2.17.0/features/k-nn/k-nn-model-metadata.md`

### Feature Report
- `docs/features/k-nn/k-nn-model-metadata.md`

## Key Changes in v2.17.0

- Added `model_version` field to model metadata to track the OpenSearch version used during model training
- Changed model metadata reads to retrieve data directly from cluster metadata instead of making separate model retrieval calls
- This helps prevent null pointer exceptions by enabling version-based field presence detection
- Required for re-scoring features in disk-based vector search

## Related

- Closes #409
- PR: [opensearch-project/k-NN#2005](https://github.com/opensearch-project/k-NN/pull/2005)