### PR TITLE
docs: add k-NN Iterative Graph Build report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -170,6 +170,7 @@
 
 - [Vector Search (k-NN)](k-nn/vector-search-k-nn.md)
 - [k-NN Explain API](k-nn/explain-api.md)
+- [k-NN Iterative Graph Build](k-nn/k-nn-iterative-graph-build.md)
 - [k-NN Model Metadata](k-nn/k-nn-model-metadata.md)
 - [Lucene On Faiss (Memory Optimized Search)](k-nn/lucene-on-faiss.md)
 - [Remote Vector Index Build](k-nn/remote-vector-index-build.md)

--- a/docs/features/k-nn/k-nn-iterative-graph-build.md
+++ b/docs/features/k-nn/k-nn-iterative-graph-build.md
@@ -1,0 +1,147 @@
+# k-NN Iterative Graph Build
+
+## Summary
+
+The k-NN Iterative Graph Build feature enables memory-optimized index construction for FAISS-based k-NN indexes in OpenSearch. Instead of loading all vectors into memory before building the graph, vectors are transferred and indexed in batches, significantly reducing peak memory consumption during indexing operations. This is particularly beneficial for large-scale vector datasets where memory constraints are a concern.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Index Creation Flow"
+        KVV[KNNVectorValues] --> NIW[NativeIndexWriter]
+        NIW --> |"FAISS + No Model"| MEM[MemOptimizedNativeIndexBuildStrategy]
+        NIW --> |"Other Cases"| DEF[DefaultIndexBuildStrategy]
+        
+        subgraph "Iterative Build"
+            MEM --> INIT[initIndex]
+            INIT --> BATCH[Transfer Batch]
+            BATCH --> INSERT[insertToIndex]
+            INSERT --> CHECK{More Vectors?}
+            CHECK -->|Yes| BATCH
+            CHECK -->|No| WRITE[writeIndex]
+        end
+        
+        subgraph "Bulk Build"
+            DEF --> TRANSFER[Transfer All Vectors]
+            TRANSFER --> CREATE[createIndex / createIndexFromTemplate]
+        end
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Java
+        VV[VectorValues] --> OHT[OffHeapVectorTransfer]
+        OHT --> |"Batch"| JNI[JNI Layer]
+    end
+    
+    subgraph Native
+        JNI --> FAISS[FAISS Index]
+        FAISS --> DISK[Disk]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `NativeIndexBuildStrategy` | Interface defining the contract for index building strategies |
+| `MemOptimizedNativeIndexBuildStrategy` | Implements iterative graph build for FAISS, transferring vectors in batches |
+| `DefaultIndexBuildStrategy` | Traditional bulk build strategy, transfers all vectors before building |
+| `NativeIndexWriter` | Orchestrates index creation, selects appropriate strategy based on engine and configuration |
+| `OffHeapVectorTransfer` | Abstract class managing vector transfer to off-heap memory with configurable batch sizes |
+| `OffHeapFloatVectorTransfer` | Transfers float vectors to off-heap memory |
+| `OffHeapByteVectorTransfer` | Transfers byte vectors to off-heap memory |
+| `BuildIndexParams` | Value object containing all parameters needed for index construction |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `knn.memory.circuit_breaker.limit` | Controls the streaming memory limit for vector transfers | 50% of available memory |
+
+The batch size for vector transfers is calculated as:
+```
+transferLimit = max(1, streamingMemoryLimit / bytesPerVector)
+```
+
+### JNI Layer Changes
+
+The JNI layer was refactored to support three-phase index creation:
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `initIndex` | `(numDocs, dim, parameters) → indexAddress` | Initialize index structure in memory |
+| `insertToIndex` | `(ids, vectorAddress, dim, indexAddress, threadCount)` | Add vectors to existing index |
+| `writeIndex` | `(indexPath, indexAddress)` | Persist index to disk |
+
+### Usage Example
+
+The iterative build is automatically enabled for FAISS indexes. No configuration changes are required:
+
+```json
+PUT /my-vector-index
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "embedding": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "parameters": {
+            "ef_construction": 128,
+            "m": 16
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Strategy Selection Logic
+
+```mermaid
+flowchart TD
+    START[Get Writer] --> MODEL{Has Model ID?}
+    MODEL -->|Yes| DEFAULT[DefaultIndexBuildStrategy]
+    MODEL -->|No| ENGINE{Engine = FAISS?}
+    ENGINE -->|Yes| ITERATIVE[MemOptimizedNativeIndexBuildStrategy]
+    ENGINE -->|No| DEFAULT
+```
+
+## Limitations
+
+- Only available for FAISS engine (nmslib and Lucene use default strategy)
+- Model-based indexes (using `model_id`) use the traditional bulk build approach
+- Binary vector indexes currently use the default build strategy
+- The `append` parameter in vector transfer must be managed carefully to avoid memory issues
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#1950](https://github.com/opensearch-project/k-NN/pull/1950) | Integrates FAISS iterative builds with NativeEngines990KnnVectorsFormat |
+
+## References
+
+- [Issue #1853](https://github.com/opensearch-project/k-NN/issues/1853): RFC - Integrating KNNVectorsFormat in Native Vector Search Engine
+- [Issue #1087](https://github.com/opensearch-project/k-NN/issues/1087): Original investigation on KNNVectorsFormat migration
+- [k-NN Index Documentation](https://docs.opensearch.org/2.17/search-plugins/knn/knn-index/): Official k-NN index documentation
+- [FAISS Documentation](https://github.com/facebookresearch/faiss/wiki): FAISS library documentation
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Initial implementation of iterative graph build for FAISS indexes

--- a/docs/releases/v2.17.0/features/k-nn/k-nn-iterative-graph-build.md
+++ b/docs/releases/v2.17.0/features/k-nn/k-nn-iterative-graph-build.md
@@ -1,0 +1,127 @@
+# k-NN Iterative Graph Build
+
+## Summary
+
+OpenSearch 2.17.0 introduces iterative graph build capability for FAISS indexes, significantly improving memory efficiency during k-NN index creation. Instead of loading all vectors into memory before building the graph, vectors are now transferred and indexed in batches, reducing peak memory consumption during indexing operations.
+
+## Details
+
+### What's New in v2.17.0
+
+This release integrates FAISS iterative graph builds with the `NativeEngines990KnnVectorsFormat`, enabling memory-optimized index construction for native k-NN engines.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v2.17.0"
+        A1[Vectors] --> B1[Load All to Off-Heap]
+        B1 --> C1[Build Index]
+        C1 --> D1[Write to Disk]
+    end
+    
+    subgraph "v2.17.0 Iterative Build"
+        A2[Vectors] --> B2[Transfer Batch]
+        B2 --> C2[Insert to Index]
+        C2 --> D2{More Vectors?}
+        D2 -->|Yes| B2
+        D2 -->|No| E2[Write Index to Disk]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `NativeIndexBuildStrategy` | Interface defining how indexes are built |
+| `MemOptimizedNativeIndexBuildStrategy` | Iterative build strategy for FAISS |
+| `DefaultIndexBuildStrategy` | Traditional bulk build strategy |
+| `NativeIndexWriter` | Unified writer for native k-NN indexes |
+| `OffHeapVectorTransfer` | Manages vector transfer to off-heap memory |
+| `BuildIndexParams` | Parameters container for index building |
+
+#### New JNI Methods
+
+| Method | Description |
+|--------|-------------|
+| `initIndex` | Initialize a FAISS index in memory |
+| `insertToIndex` | Add vectors to an existing index |
+| `writeIndex` | Write the completed index to disk |
+
+#### API Changes
+
+The JNI layer now supports three-phase index creation:
+
+1. **Initialize**: Create index structure with `initIndex()`
+2. **Insert**: Add vectors in batches with `insertToIndex()`
+3. **Write**: Persist to disk with `writeIndex()`
+
+### Usage Example
+
+No user-facing API changes are required. The iterative build is automatically used for FAISS indexes when:
+- The engine is FAISS
+- No model template is used
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "parameters": {
+            "ef_construction": 128,
+            "m": 16
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Memory Optimization
+
+The `knn.memory.circuit_breaker.limit` setting controls the streaming memory limit for vector transfers. Vectors are transferred in batches calculated as:
+
+```
+transferLimit = max(1, streamingMemoryLimit / bytesPerVector)
+```
+
+### Migration Notes
+
+- No migration required - the feature is automatically enabled for FAISS indexes
+- Existing indexes continue to work without changes
+- Model-based indexes still use the traditional bulk build approach
+
+## Limitations
+
+- Only available for FAISS engine (not nmslib or Lucene)
+- Model-based indexes (using `model_id`) use the traditional bulk build
+- Binary vector indexes use the default build strategy
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1950](https://github.com/opensearch-project/k-NN/pull/1950) | Integrates FAISS iterative builds with NativeEngines990KnnVectorsFormat |
+
+## References
+
+- [Issue #1853](https://github.com/opensearch-project/k-NN/issues/1853): RFC - Integrating KNNVectorsFormat in Native Vector Search Engine
+- [k-NN Index Documentation](https://docs.opensearch.org/2.17/search-plugins/knn/knn-index/): Official k-NN index documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/k-nn/k-nn-iterative-graph-build.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -81,6 +81,7 @@
 
 ### k-nn
 - [k-NN Bugfixes](features/k-nn/k-nn-bugfixes.md)
+- [k-NN Iterative Graph Build](features/k-nn/k-nn-iterative-graph-build.md)
 - [k-NN Model Metadata](features/k-nn/k-nn-model-metadata.md)
 
 ### cross-cluster-replication


### PR DESCRIPTION
## Summary

This PR adds documentation for the k-NN Iterative Graph Build feature introduced in OpenSearch v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/k-nn/k-nn-iterative-graph-build.md`
- Feature report: `docs/features/k-nn/k-nn-iterative-graph-build.md`

### Key Changes in v2.17.0
- Integrates FAISS iterative graph builds with `NativeEngines990KnnVectorsFormat`
- Enables memory-optimized index construction by transferring vectors in batches
- Adds new JNI methods: `initIndex`, `insertToIndex`, `writeIndex`
- Introduces `MemOptimizedNativeIndexBuildStrategy` for FAISS indexes

### Resources Used
- PR: [#1950](https://github.com/opensearch-project/k-NN/pull/1950)
- Issue: [#1853](https://github.com/opensearch-project/k-NN/issues/1853)
- Docs: https://docs.opensearch.org/2.17/search-plugins/knn/knn-index/

Related to #408