### PR TITLE
docs: add Security Analytics Detectors report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -206,6 +206,7 @@
 
 ## security-analytics
 
+- [Security Analytics Detectors](security-analytics/security-analytics-detectors.md)
 - [Threat Intelligence](security-analytics/threat-intelligence.md)
 
 ## security-analytics-dashboards

--- a/docs/features/security-analytics/security-analytics-detectors.md
+++ b/docs/features/security-analytics/security-analytics-detectors.md
@@ -1,0 +1,176 @@
+# Security Analytics Detectors
+
+## Summary
+
+Security Analytics detectors are the core components that monitor log data sources for security threats. Detectors use detection rules (Sigma-based) to identify suspicious activities and can trigger alerts when threats are detected. The Detector APIs provide programmatic access to create, update, search, and manage detectors.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Security Analytics"
+        DA[Detector APIs]
+        DM[Detector Manager]
+        RE[Rule Engine]
+        TI[Threat Intelligence]
+    end
+    
+    subgraph "Data Sources"
+        LI[Log Indexes]
+        DS[Data Streams]
+    end
+    
+    subgraph "Outputs"
+        FI[Findings]
+        AL[Alerts]
+        TR[Triggers]
+    end
+    
+    LI --> DM
+    DS --> DM
+    DA --> DM
+    DM --> RE
+    DM --> TI
+    RE --> FI
+    TI --> FI
+    FI --> TR
+    TR --> AL
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Detector | Core entity that defines what to monitor and how to respond |
+| Detection Rules | Sigma-based rules that define threat patterns |
+| Triggers | Conditions that generate alerts when matched |
+| Actions | Notifications sent when triggers fire |
+| Findings | Security events detected by the detector |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `enabled` | Whether the detector is active | `true` |
+| `schedule.period.interval` | How often the detector runs | 1 |
+| `schedule.period.unit` | Time unit for schedule | `MINUTES` |
+| `threat_intel_enabled` | Enable threat intelligence feeds | `false` |
+
+### Detector Types
+
+Detectors support multiple log types:
+- `windows` - Windows event logs
+- `linux` - Linux system logs
+- `network` - Network traffic logs
+- `ad_ldap` - Active Directory/LDAP logs
+- `apache_access` - Apache web server logs
+- `cloudtrail` - AWS CloudTrail logs
+- `dns` - DNS query logs
+- `s3` - Amazon S3 access logs
+
+### API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/_plugins/_security_analytics/detectors` | POST | Create detector |
+| `/_plugins/_security_analytics/detectors/{id}` | GET | Get detector |
+| `/_plugins/_security_analytics/detectors/{id}` | PUT | Update detector |
+| `/_plugins/_security_analytics/detectors/{id}` | DELETE | Delete detector |
+| `/_plugins/_security_analytics/detectors/_search` | POST | Search detectors |
+
+### Usage Example
+
+Create a detector with triggers:
+
+```json
+POST /_plugins/_security_analytics/detectors
+{
+  "enabled": true,
+  "name": "windows_detector",
+  "detector_type": "windows",
+  "schedule": {
+    "period": {
+      "interval": 1,
+      "unit": "MINUTES"
+    }
+  },
+  "inputs": [
+    {
+      "detector_input": {
+        "description": "Windows security monitoring",
+        "indices": ["windows-logs-*"],
+        "pre_packaged_rules": [
+          {"id": "rule-uuid-here"}
+        ]
+      }
+    }
+  ],
+  "triggers": [
+    {
+      "name": "High Severity Alert",
+      "severity": "1",
+      "types": ["windows"],
+      "sev_levels": ["high", "critical"],
+      "actions": [
+        {
+          "name": "notify-security-team",
+          "destination_id": "notification-channel-id",
+          "message_template": {
+            "source": "Security alert triggered: {{ctx.trigger.name}}",
+            "lang": "mustache"
+          }
+        }
+      ]
+    }
+  ]
+}
+```
+
+Get detector with triggers (v2.17.0+):
+
+```json
+GET /_plugins/_security_analytics/detectors/{detector_id}
+
+// Response includes triggers field
+{
+  "_id": "detector-id",
+  "_version": 1,
+  "detector": {
+    "name": "windows_detector",
+    "triggers": [
+      {
+        "id": "trigger-id",
+        "name": "High Severity Alert",
+        "severity": "1",
+        "detection_types": ["rules", "threat_intel"]
+      }
+    ]
+  }
+}
+```
+
+## Limitations
+
+- Only one log data source per detector is currently supported
+- Threat intelligence feeds only work with standard log types
+- At least one detection rule (custom or pre-packaged) is required
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#1226](https://github.com/opensearch-project/security-analytics/pull/1226) | Added triggers in getDetectors API response |
+| v2.17.0 | [#1212](https://github.com/opensearch-project/security-analytics/pull/1212) | Secure rest tests for threat intel monitor APIs |
+
+## References
+
+- [Detector APIs Documentation](https://docs.opensearch.org/latest/security-analytics/api-tools/detector-api/)
+- [Creating Detectors](https://docs.opensearch.org/latest/security-analytics/sec-analytics-config/detectors-config/)
+- [About Security Analytics](https://docs.opensearch.org/latest/security-analytics/)
+- [Working with Detectors](https://docs.opensearch.org/latest/security-analytics/usage/detectors/)
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Added triggers field to Get Detectors API response; Added secure REST tests for threat intel monitor APIs

--- a/docs/releases/v2.17.0/features/security-analytics/security-analytics-detectors.md
+++ b/docs/releases/v2.17.0/features/security-analytics/security-analytics-detectors.md
@@ -1,0 +1,111 @@
+# Security Analytics Detectors
+
+## Summary
+
+OpenSearch v2.17.0 enhances Security Analytics detectors with two key improvements: the Get Detectors API now includes trigger information in its response, and secure REST tests have been added for threat intelligence monitor APIs. These changes improve the usability of the Detector API and strengthen security testing coverage.
+
+## Details
+
+### What's New in v2.17.0
+
+#### Triggers in Get Detectors API Response
+
+The Get Detectors API (`GET /_plugins/_security_analytics/detectors/{detector_id}`) now includes the `triggers` field in its response. This enhancement fixes an issue where Security Analytics would crash when users attempted to create alerts in the Detector Details Page while viewing Findings.
+
+Previously, the API response only included basic detector information. Now it returns complete trigger configuration including:
+- Trigger ID, name, and severity
+- Detection types (rules, threat_intel)
+- Associated rule IDs and tags
+- Action configurations with notification templates
+
+#### Secure REST Tests for Threat Intel Monitor APIs
+
+New secure REST integration tests have been added for threat intelligence monitor APIs, ensuring proper access control and security validation. The tests cover:
+- Creating threat intel monitors with and without backend roles
+- Full access role permissions for monitor creation
+- Index-level access control for monitor operations
+
+### Technical Changes
+
+#### API Response Enhancement
+
+The `GetDetectorResponse` class now serializes the triggers field:
+
+```java
+.field(Detector.TRIGGERS_FIELD, detector.getTriggers())
+```
+
+#### Example API Response
+
+```json
+{
+    "_id": "akpmM5EB3Y4wm-vZ4JFZ",
+    "_version": 1,
+    "detector": {
+        "name": "detector1",
+        "detector_type": "ad_ldap",
+        "enabled": true,
+        "schedule": {
+            "period": {
+                "interval": 1,
+                "unit": "MINUTES"
+            }
+        },
+        "inputs": [...],
+        "last_update_time": "2024-08-08T19:10:59.741Z",
+        "enabled_time": "2024-08-08T19:10:59.738Z",
+        "threat_intel_enabled": true,
+        "triggers": [
+            {
+                "id": "W0pmM5EB3Y4wm-vZyJGY",
+                "name": "Trigger 1",
+                "severity": "1",
+                "types": ["ad_ldap"],
+                "ids": [],
+                "sev_levels": [],
+                "tags": [],
+                "actions": [...],
+                "detection_types": ["rules", "threat_intel"]
+            }
+        ]
+    }
+}
+```
+
+#### New Security Permissions
+
+The secure REST tests added new cluster permissions for threat intelligence:
+- `cluster:admin/opensearch/securityanalytics/threatintel/*`
+- `cluster:admin/opensearch/securityanalytics/connections/*`
+
+### Usage Example
+
+Retrieve a detector with its triggers:
+
+```bash
+GET /_plugins/_security_analytics/detectors/{detector_id}
+```
+
+The response now includes the complete trigger configuration, enabling UI components to properly display and manage alert triggers without additional API calls.
+
+## Limitations
+
+- The trigger information is only included when fetching individual detectors, not in bulk search operations
+- Trigger actions require proper notification channel configuration
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1226](https://github.com/opensearch-project/security-analytics/pull/1226) | Added triggers in getDetectors API response |
+| [#1212](https://github.com/opensearch-project/security-analytics/pull/1212) | Secure rest tests for threat intel monitor APIs |
+
+## References
+
+- [Detector APIs Documentation](https://docs.opensearch.org/2.17/security-analytics/api-tools/detector-api/)
+- [Creating Detectors](https://docs.opensearch.org/2.17/security-analytics/sec-analytics-config/detectors-config/)
+- [About Security Analytics](https://docs.opensearch.org/2.17/security-analytics/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/security-analytics/security-analytics-detectors.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -39,6 +39,7 @@
 - [Security Plugin Bugfixes](features/security/security-plugin-bugfixes.md)
 
 ### security-analytics
+- [Security Analytics Detectors](features/security-analytics/security-analytics-detectors.md)
 - [Threat Intel Bugfixes](features/security-analytics/threat-intel-bugfixes.md)
 
 ### security-analytics-dashboards


### PR DESCRIPTION
## Summary

This PR adds documentation for Security Analytics Detectors enhancements in OpenSearch v2.17.0.

### Changes in v2.17.0

1. **Triggers in Get Detectors API Response** (PR #1226)
   - The Get Detectors API now includes the `triggers` field in its response
   - Fixes an issue where Security Analytics would crash when creating alerts in Detector Details Page while viewing Findings

2. **Secure REST Tests for Threat Intel Monitor APIs** (PR #1212)
   - Added secure REST integration tests for threat intelligence monitor APIs
   - Tests cover access control and security validation for monitor operations

### Reports Created

- Release report: `docs/releases/v2.17.0/features/security-analytics/security-analytics-detectors.md`
- Feature report: `docs/features/security-analytics/security-analytics-detectors.md` (new)

### Related Issue

Closes #406