### PR TITLE
docs: add alerting-comments report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -56,6 +56,7 @@
 
 ## security
 
+- [Alerting Comments Security](security/alerting-comments-security.md)
 - [Security Configuration](security/security-configuration.md)
 - [Security Plugin](security/security-plugin.md)
 

--- a/docs/features/security/alerting-comments-security.md
+++ b/docs/features/security/alerting-comments-security.md
@@ -1,0 +1,134 @@
+# Alerting Comments Security
+
+## Summary
+
+Alerting Comments Security provides role-based access control for the Alerting Comments feature in OpenSearch. It defines permissions that control who can view, create, edit, and delete comments on alerts, integrating with the Security plugin's predefined alerting roles.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Security Plugin"
+        Roles[roles.yml]
+        RolesMapping[roles_mapping.yml]
+    end
+    
+    subgraph "Alerting Roles"
+        ReadAccess[alerting_read_access]
+        AckAlerts[alerting_ack_alerts]
+        FullAccess[alerting_full_access]
+    end
+    
+    subgraph "Comments Permissions"
+        Search[comments/search]
+        Write[comments/write]
+        Delete[comments/delete]
+        All[comments/*]
+    end
+    
+    subgraph "Alerting Plugin"
+        CommentsAPI[Comments API]
+        Alerts[Alerts]
+    end
+    
+    Roles --> ReadAccess
+    Roles --> AckAlerts
+    Roles --> FullAccess
+    
+    ReadAccess --> Search
+    AckAlerts --> All
+    FullAccess --> All
+    
+    Search --> CommentsAPI
+    All --> CommentsAPI
+    CommentsAPI --> Alerts
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `alerting_read_access` | Role for read-only access to alerting, includes comment search |
+| `alerting_ack_alerts` | Role for acknowledging alerts, includes full comment access |
+| `alerting_full_access` | Role for full alerting functionality, includes full comment access |
+| Comments API | REST API for managing comments on alerts |
+
+### Configuration
+
+| Permission | Description | Roles |
+|------------|-------------|-------|
+| `cluster:admin/opensearch/alerting/comments/search` | Search/view comments | `alerting_read_access`, `alerting_ack_alerts`, `alerting_full_access` |
+| `cluster:admin/opensearch/alerting/comments/write` | Create/update comments | `alerting_ack_alerts`, `alerting_full_access` |
+| `cluster:admin/opensearch/alerting/comments/delete` | Delete comments | `alerting_ack_alerts`, `alerting_full_access` |
+| `cluster:admin/opensearch/alerting/comments/*` | All comment operations | `alerting_ack_alerts`, `alerting_full_access` |
+
+### Role Permissions Matrix
+
+| Role | View Comments | Create Comments | Edit Comments | Delete Comments |
+|------|---------------|-----------------|---------------|-----------------|
+| `alerting_read_access` | ✓ | ✗ | ✗ | ✗ |
+| `alerting_ack_alerts` | ✓ | ✓ | ✓ | ✓ |
+| `alerting_full_access` | ✓ | ✓ | ✓ | ✓ |
+
+### Usage Example
+
+Mapping a user to the `alerting_ack_alerts` role:
+
+```yaml
+# roles_mapping.yml
+alerting_ack_alerts:
+  reserved: false
+  users:
+    - "ops_user"
+  backend_roles:
+    - "ops_team"
+```
+
+Using the Comments API:
+
+```bash
+# Search comments on an alert
+GET _plugins/_alerting/comments/_search
+{
+  "query": {
+    "term": {
+      "alert_id": "alert-123"
+    }
+  }
+}
+
+# Create a comment
+POST _plugins/_alerting/comments
+{
+  "alert_id": "alert-123",
+  "content": "Investigating root cause"
+}
+```
+
+## Limitations
+
+- Comment permissions are inherited from the monitor's backend roles
+- If the Security plugin is not installed, comment authors display as "Unknown"
+- Comments feature requires `plugins.alerting.comments_enabled` to be set to `true`
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [security#4700](https://github.com/opensearch-project/security/pull/4700) | Adding alerting comments security actions to roles.yml |
+| v2.17.0 | [security#4724](https://github.com/opensearch-project/security/pull/4724) | Changing comments permission for alerting_ack_alerts role |
+| v2.15.0 | [alerting#1561](https://github.com/opensearch-project/alerting/pull/1561) | Alerting Comments feature (experimental) |
+
+## References
+
+- [Alerting Comments Documentation](https://docs.opensearch.org/2.17/observing-your-data/alerting/comments/): Official documentation
+- [Alerting Security Documentation](https://docs.opensearch.org/2.17/observing-your-data/alerting/security/): Security configuration
+- [Predefined Roles](https://docs.opensearch.org/2.17/security/access-control/users-roles/): Security plugin predefined roles
+- [GitHub Issue #6999](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6999): Alerting Comments feature tracking
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Added comments search permission to `alerting_read_access`, expanded `alerting_ack_alerts` to full comment access
+- **v2.15.0** (2024-06-25): Initial Alerting Comments feature (experimental)

--- a/docs/releases/v2.17.0/features/security/alerting-comments.md
+++ b/docs/releases/v2.17.0/features/security/alerting-comments.md
@@ -1,0 +1,92 @@
+# Alerting Comments Security Actions
+
+## Summary
+
+This bugfix adds and corrects security actions for the Alerting Comments feature in the Security plugin's `roles.yml`. The changes ensure proper role-based access control for alerting comments, allowing users with appropriate roles to create, read, update, and delete comments on alerts.
+
+## Details
+
+### What's New in v2.17.0
+
+Two key changes were made to the security roles configuration:
+
+1. **Added comments search permission to alerting roles**: The `alerting_read_access` and `alerting_ack_alerts` roles now include the `cluster:admin/opensearch/alerting/comments/search` permission, enabling users to view comments on alerts.
+
+2. **Expanded comments permission for `alerting_ack_alerts` role**: Changed from search-only (`cluster:admin/opensearch/alerting/comments/search`) to full access (`cluster:admin/opensearch/alerting/comments/*`), allowing users who can acknowledge alerts to also create, edit, and delete comments.
+
+### Technical Changes
+
+#### Security Role Updates
+
+| Role | Before | After |
+|------|--------|-------|
+| `alerting_read_access` | No comments permission | `cluster:admin/opensearch/alerting/comments/search` |
+| `alerting_ack_alerts` | `cluster:admin/opensearch/alerting/comments/search` | `cluster:admin/opensearch/alerting/comments/*` |
+| `alerting_full_access` | Already has full access | No change |
+
+#### Configuration Changes
+
+The `config/roles.yml` file was updated:
+
+```yaml
+# alerting_read_access role - added:
+- 'cluster:admin/opensearch/alerting/comments/search'
+
+# alerting_ack_alerts role - changed from:
+- 'cluster:admin/opensearch/alerting/comments/search'
+# to:
+- 'cluster:admin/opensearch/alerting/comments/*'
+```
+
+### Usage Example
+
+Users with the `alerting_ack_alerts` role can now perform all comment operations:
+
+```bash
+# Search comments (was already possible)
+GET _plugins/_alerting/comments/_search
+
+# Create comment (now possible with alerting_ack_alerts)
+POST _plugins/_alerting/comments
+{
+  "alert_id": "alert-123",
+  "content": "Investigating this alert"
+}
+
+# Update comment (now possible with alerting_ack_alerts)
+PUT _plugins/_alerting/comments/{comment_id}
+{
+  "content": "Updated investigation notes"
+}
+
+# Delete comment (now possible with alerting_ack_alerts)
+DELETE _plugins/_alerting/comments/{comment_id}
+```
+
+### Migration Notes
+
+No migration required. The updated roles are automatically applied when upgrading to v2.17.0. Existing users mapped to `alerting_ack_alerts` will gain full comment access.
+
+## Limitations
+
+- Comment permissions are inherited from the monitor's backend roles
+- If the Security plugin is not installed, comment authors display as "Unknown"
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [security#4700](https://github.com/opensearch-project/security/pull/4700) | [Backport 2.x] Adding alerting comments security actions to roles.yml |
+| [security#4724](https://github.com/opensearch-project/security/pull/4724) | [Backport 2.17] Changing comments permission for alerting_ack_alerts role |
+| [security#4699](https://github.com/opensearch-project/security/pull/4699) | Adding alerting comments security actions to roles.yml (main) |
+| [security#4709](https://github.com/opensearch-project/security/pull/4709) | Changing comments permission for alerting_ack_alerts role (main) |
+
+## References
+
+- [Alerting Comments Documentation](https://docs.opensearch.org/2.17/observing-your-data/alerting/comments/): Official documentation for alerting comments
+- [Alerting Security Documentation](https://docs.opensearch.org/2.17/observing-your-data/alerting/security/): Security configuration for alerting
+- [alerting#1561](https://github.com/opensearch-project/alerting/pull/1561): Alerting Comments feature implementation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/security/alerting-comments-security.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -35,6 +35,7 @@
 - [Job Scheduler Bugfixes](features/job-scheduler/job-scheduler-bugfixes.md)
 
 ### security
+- [Alerting Comments Security](features/security/alerting-comments.md)
 - [Dependency Bumps](features/security/dependency-bumps.md)
 - [Security Plugin Bugfixes](features/security/security-plugin-bugfixes.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Alerting Comments security bugfix in OpenSearch v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/security/alerting-comments.md`
- Feature report: `docs/features/security/alerting-comments-security.md`

### Key Changes in v2.17.0
- Added `cluster:admin/opensearch/alerting/comments/search` permission to `alerting_read_access` role
- Expanded `alerting_ack_alerts` role from search-only to full comment access (`cluster:admin/opensearch/alerting/comments/*`)

### Related PRs
- [security#4700](https://github.com/opensearch-project/security/pull/4700): Adding alerting comments security actions to roles.yml
- [security#4724](https://github.com/opensearch-project/security/pull/4724): Changing comments permission for alerting_ack_alerts role

### Resources Used
- [Alerting Comments Documentation](https://docs.opensearch.org/2.17/observing-your-data/alerting/comments/)
- [Alerting Security Documentation](https://docs.opensearch.org/2.17/observing-your-data/alerting/security/)

Closes #405