### PR TITLE
docs: add Query Assist report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -129,6 +129,7 @@
 - [ML Commons MCP (Model Context Protocol)](ml-commons/ml-commons-mcp.md)
 - [ML Commons Stability and Reliability](ml-commons/ml-commons-stability.md)
 - [ML Commons Test Fixes](ml-commons/ml-commons-test-fixes.md)
+- [Query Assist](ml-commons/query-assist.md)
 
 ## anomaly-detection
 

--- a/docs/features/ml-commons/query-assist.md
+++ b/docs/features/ml-commons/query-assist.md
@@ -1,0 +1,164 @@
+# Query Assist
+
+## Summary
+
+Query Assist is an AI-powered feature in OpenSearch Dashboards that enables users to convert natural language questions into PPL (Piped Processing Language) queries. It leverages ML Commons agents and the PPL tool to generate executable queries from plain English questions, making data exploration accessible to users without specialized query skills.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        Discover[Discover Page]
+        QABar[Query Assist Bar]
+        QAInput[Query Assist Input]
+        ErrorBadge[Warning Badge]
+        Callouts[Callout Messages]
+    end
+    
+    subgraph "Query Enhancements Plugin"
+        Extension[Query Editor Extension]
+        SearchInterceptor[PPL Search Interceptor]
+        Routes[Query Assist Routes]
+    end
+    
+    subgraph "ML Commons"
+        Agent[PPL Agent]
+        PPLTool[PPL Tool]
+        LLM[Language Model]
+    end
+    
+    subgraph "OpenSearch"
+        Index[Index Mappings]
+        PPLEngine[PPL Engine]
+    end
+    
+    Discover --> QABar
+    QABar --> QAInput
+    QAInput --> Extension
+    Extension --> Routes
+    Routes --> Agent
+    Agent --> PPLTool
+    PPLTool --> LLM
+    PPLTool --> Index
+    LLM --> Routes
+    Routes --> QABar
+    QABar --> ErrorBadge
+    QABar --> Callouts
+    SearchInterceptor --> PPLEngine
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    User[User enters question] --> Input[Query Assist Input]
+    Input --> Validate{Validate Input}
+    Validate -->|Empty| EmptyCallout[Show empty query callout]
+    Validate -->|No Dataset| DatasetCallout[Show select index callout]
+    Validate -->|Valid| Generate[Generate Query API]
+    Generate --> Agent[ML Agent executes PPL Tool]
+    Agent --> LLM[LLM generates PPL]
+    LLM --> Response{Response Type}
+    Response -->|Success| UpdateQuery[Update query string]
+    Response -->|Guardrail| GuardCallout[Show guard callout]
+    Response -->|AgentError| Badge[Show error badge]
+    Response -->|Error| Toast[Show error toast]
+    UpdateQuery --> Execute[Execute PPL query]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Query Assist Bar | Main container component managing state and form submission |
+| Query Assist Input | Text input with autocomplete suggestions from persisted history |
+| Warning Badge | Displays agent errors inline with expandable details |
+| Query Assist Callouts | Contextual messages for validation errors and guardrails |
+| Query Editor Extension | Integrates Query Assist into the query editor UI |
+| PPL Search Interceptor | Handles PPL query execution |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `queryEnhancements.queryAssist.enabled` | Enable/disable Query Assist feature | `true` |
+| `queryEnhancements.queryAssist.summary.enabled` | Enable data summary panel | `false` |
+
+### Prerequisites
+
+1. ML Commons plugin must be installed and configured
+2. A PPL agent must be registered with ml-commons:
+
+```json
+POST .plugins-ml-config/_doc/os_query_assist
+{
+    "type": "os_query_assist_root_agent",
+    "configuration": {
+        "agent_id": "your_ppl_agent_id"
+    }
+}
+```
+
+### Usage Example
+
+1. Navigate to Discover in OpenSearch Dashboards
+2. Select an index pattern
+3. Switch to PPL language mode
+4. Click the Query Assist icon (sparkle) to expand the input
+5. Enter a natural language question:
+
+```
+Show me the top 10 hosts with the most errors in the last 24 hours
+```
+
+6. Press Enter or click Submit
+7. The generated PPL query appears in the query bar:
+
+```sql
+source = logs | where level = 'error' | stats count() as error_count by host | sort - error_count | head 10
+```
+
+### Error Handling
+
+Query Assist provides clear feedback for different error scenarios:
+
+| Error Type | Display | Description |
+|------------|---------|-------------|
+| Empty Query | Callout | User submitted without entering a question |
+| No Dataset | Callout | No index pattern selected |
+| Guardrail Triggered | Callout | Query violates content guardrails |
+| Agent Error | Badge | ML agent returned an error (e.g., unsupported index) |
+| Other Errors | Toast | Unexpected errors shown as toast notifications |
+
+## Limitations
+
+- Requires ML Commons plugin with configured PPL agent
+- Only supports OpenSearch data sources (not external sources like S3)
+- System indexes (starting with `.`) are not supported
+- Query quality depends on the underlying language model
+- Index patterns without data sources have limited support
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#7998](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7998) | Agent error badge, ml-commons response schema update |
+| v2.16.0 | [#7212](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7212) | Add query enhancements plugin as core plugin |
+| v2.13.0 | - | Initial Query Assist implementation |
+
+## References
+
+- [OpenSearch Assistant Documentation](https://docs.opensearch.org/latest/dashboards/dashboards-assistant/index/)
+- [PPL Tool Documentation](https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/tools/ppl-tool/)
+- [Event Analytics - Query Assist](https://docs.opensearch.org/latest/observing-your-data/event-analytics/)
+- [OpenSearch Assistant Toolkit](https://docs.opensearch.org/latest/ml-commons-plugin/opensearch-assistant/)
+- [dashboards-assistant Getting Started Guide](https://github.com/opensearch-project/dashboards-assistant/blob/main/GETTING_STARTED_GUIDE.md)
+
+## Change History
+
+- **v2.17.0** (2024-10-08): Enhanced error handling with agent error badge, updated ml-commons response schema processing, improved index pattern support
+- **v2.16.0** (2024-08-06): Query enhancements plugin added as core plugin with Query Assist feature
+- **v2.13.0** (2024-02-20): Initial introduction of Query Assist in OpenSearch Dashboards

--- a/docs/releases/v2.17.0/features/ml-commons/query-assist.md
+++ b/docs/releases/v2.17.0/features/ml-commons/query-assist.md
@@ -1,0 +1,122 @@
+# Query Assist
+
+## Summary
+
+This release enhances the Query Assist feature in OpenSearch Dashboards with improved error handling, updated ml-commons response schema processing, and better support for index patterns without data sources. Query Assist enables users to convert natural language questions into PPL queries using AI-powered agents.
+
+## Details
+
+### What's New in v2.17.0
+
+The v2.17.0 release focuses on compatibility improvements and enhanced error handling for the Query Assist feature:
+
+1. **Updated ml-commons Response Schema Processing**: The ml-commons API now returns `error.body` as a JSON object instead of a string. The frontend has been updated to handle both formats for backward compatibility with older ml-commons versions through Multi-Data Source (MDS).
+
+2. **Agent Error Badge Display**: Errors from the ML agent are now displayed as a badge in the Query Assist input field, providing clearer feedback to users when query generation fails.
+
+3. **Index Pattern Support**: Query Assist now works with index patterns that don't have an associated data source, expanding compatibility.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        QAInput[Query Assist Input]
+        QABar[Query Assist Bar]
+        ErrorBadge[Warning Badge]
+    end
+    
+    subgraph "Backend"
+        Routes[Query Assist Routes]
+        ErrorHandler[Error Handler]
+    end
+    
+    subgraph "ML Commons"
+        Agent[PPL Agent]
+        Response[Response Schema]
+    end
+    
+    QAInput --> QABar
+    QABar --> Routes
+    Routes --> Agent
+    Agent --> Response
+    Response --> ErrorHandler
+    ErrorHandler --> ErrorBadge
+    ErrorHandler --> QABar
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `WarningBadge` | New UI component to display agent errors inline in the input field |
+| `AgentError` | New error class for parsing and handling ML agent errors |
+
+#### Error Handling Flow
+
+```mermaid
+flowchart TB
+    Request[User Query] --> Generate[Generate Query]
+    Generate --> Response{Response Type}
+    Response -->|Success| UpdateQuery[Update Query String]
+    Response -->|ProhibitedQuery| Callout[Show Guard Callout]
+    Response -->|AgentError| Badge[Show Error Badge]
+    Response -->|OtherError| Toast[Show Toast Notification]
+```
+
+#### API Changes
+
+The server-side route handler now properly handles the updated ml-commons response format:
+
+- On OpenSearch >= 2.17, `error.body` is returned as a JSON object
+- For consistency, the frontend always receives the error in `error.body.message` as a JSON string
+- The `AgentError` class parses this JSON to extract `reason`, `details`, `type`, and `status`
+
+### Usage Example
+
+Query Assist continues to work the same way for end users:
+
+1. Select an index pattern in Discover
+2. Switch to PPL language mode
+3. Click the Query Assist icon to expand the natural language input
+4. Enter a question like "Show me the top 10 error logs from yesterday"
+5. The system generates a PPL query from your natural language input
+
+When errors occur, they are now displayed more clearly:
+
+```
+// Error badge shows:
+- Reason: Invalid Request
+- Details: PPLTool doesn't support searching indexes starting with '.'
+- Type: IllegalArgumentException
+- Status: 400
+```
+
+### Migration Notes
+
+No migration required. The changes are backward compatible with older ml-commons versions.
+
+## Limitations
+
+- Query Assist requires a configured PPL agent in ml-commons
+- System indexes (starting with `.`) are not supported by the PPL tool
+- External data source types (e.g., S3) are not supported as Query Assist relies on OpenSearch API for index mappings
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#7998](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7998) | Use badge to show agent errors, update ml-commons response schema processing |
+| [#8146](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8146) | Backport to 2.x branch |
+
+## References
+
+- [OpenSearch Assistant Documentation](https://docs.opensearch.org/2.17/dashboards/dashboards-assistant/index/)
+- [PPL Tool Documentation](https://docs.opensearch.org/2.17/ml-commons-plugin/agents-tools/tools/ppl-tool/)
+- [Event Analytics - Query Assist](https://docs.opensearch.org/2.17/observing-your-data/event-analytics/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/query-assist.md)

--- a/docs/releases/v2.17.0/features/query-insights/query-shape-generation.md
+++ b/docs/releases/v2.17.0/features/query-insights/query-shape-generation.md
@@ -1,0 +1,169 @@
+# Query Shape Generation
+
+## Summary
+
+OpenSearch v2.17.0 introduces query shape generation and query grouping by similarity to the Query Insights plugin. This enhancement allows users to group similar queries together based on their structural shape, reducing noise from duplicate queries in Top N results and providing better visibility into query patterns. The feature computes a normalized query shape that captures the query structure (query types, aggregations, sorts) while removing specific field values, enabling effective deduplication of similar queries.
+
+## Details
+
+### What's New in v2.17.0
+
+- **Query Shape Generator**: New `QueryShapeGenerator` class that builds a normalized string representation of search queries including query builders, aggregations, and sort builders
+- **Query Grouping Framework**: `MinMaxHeapQueryGrouper` implements efficient grouping using min/max heap data structures to track Top N query groups
+- **Similarity-based Grouping**: Queries can be grouped by structural similarity using MurmurHash3 hash codes of their query shapes
+- **Aggregate Measurements**: New `Measurement` class supports aggregation types (NONE, SUM, AVERAGE) for grouped query metrics
+- **Configurable Group Limits**: Settings to control maximum number of tracked groups
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Query Insights Plugin"
+        A[Search Request] --> B[QueryInsightsListener]
+        B --> C[QueryShapeGenerator]
+        C --> D[Generate Query Shape]
+        D --> E[Compute Hash Code]
+        
+        E --> F{Grouping Enabled?}
+        F -->|Yes| G[QueryGroupingService]
+        F -->|No| H[TopQueriesService]
+        
+        G --> I[MinMaxHeapQueryGrouper]
+        I --> J[Min Heap - Top N]
+        I --> K[Max Heap - Overflow]
+        
+        J --> L[Aggregate Measurements]
+        K --> L
+        
+        H --> M[Individual Records]
+        
+        L --> N[/_insights/top_queries]
+        M --> N
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `QueryShapeGenerator` | Generates normalized query shape strings from SearchSourceBuilder |
+| `QueryShapeVisitor` | Visitor pattern implementation for traversing query builder trees |
+| `MinMaxHeapQueryGrouper` | Groups queries using min/max heap algorithm for efficient Top N tracking |
+| `QueryGrouper` | Interface for query grouping implementations |
+| `Measurement` | Encapsulates metric values with aggregation type support |
+| `GroupingType` | Enum defining grouping options: `NONE`, `SIMILARITY` |
+| `AggregationType` | Enum defining aggregation options: `NONE`, `SUM`, `AVERAGE` |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `search.insights.top_queries.group_by` | Grouping type: `none` or `similarity` | `none` |
+| `search.insights.top_queries.max_groups_excluding_topn` | Maximum groups to track beyond Top N | `100` |
+
+#### API Changes
+
+The Top N queries response now includes aggregate measurements when grouping is enabled:
+
+```json
+{
+  "top_queries": [
+    {
+      "timestamp": 1725495127359,
+      "query_hashcode": "b4c4f69290df756021ca6276be5cbb75",
+      "source": { "query": { "match_all": {} } },
+      "measurements": {
+        "latency": {
+          "number": 160,
+          "count": 10,
+          "aggregationType": "AVERAGE"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Usage Example
+
+**Enable query grouping by similarity:**
+
+```bash
+PUT _cluster/settings
+{
+  "persistent": {
+    "search.insights.top_queries.latency.enabled": true,
+    "search.insights.top_queries.group_by": "similarity"
+  }
+}
+```
+
+**Configure maximum tracked groups:**
+
+```bash
+PUT _cluster/settings
+{
+  "persistent": {
+    "search.insights.top_queries.max_groups_excluding_topn": 100
+  }
+}
+```
+
+**Query shape example:**
+
+For a query like:
+```json
+{
+  "query": {
+    "bool": {
+      "must": [{ "term": { "field1": "value" } }],
+      "filter": [{ "range": { "date": { "gte": "2024-01-01" } } }]
+    }
+  },
+  "sort": [{ "timestamp": "desc" }]
+}
+```
+
+The generated query shape is:
+```
+bool []
+  must:
+    term [field1]
+  filter:
+    range [date]
+sort:
+  desc [timestamp]
+```
+
+### Migration Notes
+
+- Existing Top N queries configurations continue to work without changes
+- To enable grouping, set `search.insights.top_queries.group_by` to `similarity`
+- When grouping is enabled, the response format changes to include aggregate measurements
+- The `query_hashcode` field is added to identify query groups
+
+## Limitations
+
+- Grouping applies to all metric types (latency, CPU, memory) simultaneously
+- Maximum groups limit (default 100) may cause some query groups to be discarded in high-cardinality environments
+- Query shape generation adds minimal overhead but should be monitored in high-throughput scenarios
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#44](https://github.com/opensearch-project/query-insights/pull/44) | Add ability to generate query shape for aggregation and sort |
+| [#66](https://github.com/opensearch-project/query-insights/pull/66) | Query grouping framework for Top N queries and group by query similarity |
+| [#73](https://github.com/opensearch-project/query-insights/pull/73) | Minor enhancements to query categorization on tags and unit types |
+
+## References
+
+- [Issue #13357](https://github.com/opensearch-project/OpenSearch/issues/13357): RFC - Grouping similar Top N Queries by Latency and Resource Usage
+- [Grouping Top N Queries Documentation](https://docs.opensearch.org/2.17/observing-your-data/query-insights/grouping-top-n-queries/)
+- [Query Insights Blog](https://opensearch.org/blog/query-insights/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/query-insights/query-insights.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -61,6 +61,7 @@
 ### ml-commons
 - [ML Commons Bugfixes](features/ml-commons/ml-commons-bugfixes.md)
 - [ML Commons Test Fixes](features/ml-commons/ml-commons-test-fixes.md)
+- [Query Assist](features/ml-commons/query-assist.md)
 
 ### neural-search
 - [Neural Search Bugfixes](features/neural-search/neural-search-bugfixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Query Assist enhancement in v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/ml-commons/query-assist.md`
- Feature report: `docs/features/ml-commons/query-assist.md`

### Key Changes in v2.17.0
- Updated ml-commons response schema processing (error.body now returns JSON object)
- Added agent error badge display for clearer error feedback
- Improved index pattern support without data sources

### Resources Used
- PR: [#7998](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7998)
- Docs: https://docs.opensearch.org/2.17/dashboards/dashboards-assistant/index/

Closes #400