### PR TITLE
docs: add Trace Analytics custom source report for v2.17.0

### DIFF
--- a/docs/features/dashboards-observability/trace-analytics.md
+++ b/docs/features/dashboards-observability/trace-analytics.md
@@ -84,6 +84,8 @@ flowchart TB
 | Data Grid Table | Paginated traces table with column customization |
 | Multi-Data Source Support | Connect to multiple OpenSearch clusters |
 | Application Analytics | Integrated traces/spans view within app analytics |
+| Custom Index Flyout | Configuration panel for custom span/service indices |
+| Data Schema Picker | Mode selector for Jaeger, Data Prepper, or Custom source |
 
 ### Configuration
 
@@ -92,8 +94,10 @@ flowchart TB
 | Custom Log Source | User-defined log index for correlation | None |
 | Database Selector | Database name for integration setup | `default` |
 | Spans Limit | Maximum spans displayed in trace view | 3000 |
-| Trace Data Source | OTEL or Jaeger format | OTEL |
+| Trace Data Source | OTEL, Jaeger, or Custom format | OTEL |
 | MDS ID | Multi-Data Source identifier | Local cluster |
+| `observability:traceAnalyticsSpanIndices` | Custom span indices (supports wildcards and CCS) | Empty |
+| `observability:traceAnalyticsServiceIndices` | Custom service indices (supports wildcards and CCS) | Empty |
 
 ### Usage Example
 
@@ -143,6 +147,8 @@ http://host:port/app/observability-traces#/services
 | v3.0.0 | [#2398](https://github.com/opensearch-project/dashboards-observability/pull/2398) | Trace to logs correlation |
 | v3.0.0 | [#2410](https://github.com/opensearch-project/dashboards-observability/pull/2410) | Amazon Network Firewall Integration |
 | v3.0.0 | [#2432](https://github.com/opensearch-project/dashboards-observability/pull/2432) | OTEL attributes field support |
+| v2.17.0 | [#2112](https://github.com/opensearch-project/dashboards-observability/pull/2112) | Custom source support for trace analytics |
+| v2.17.0 | [#2125](https://github.com/opensearch-project/dashboards-observability/pull/2125) | Update landing page to traces |
 | v2.17.0 | [#2006](https://github.com/opensearch-project/dashboards-observability/pull/2006) | MDS fix for local cluster rendering |
 | v2.17.0 | [#2023](https://github.com/opensearch-project/dashboards-observability/pull/2023) | Traces/Spans tab fix for App Analytics |
 | v2.17.0 | [#2024](https://github.com/opensearch-project/dashboards-observability/pull/2024) | Fix direct URL load |
@@ -162,4 +168,4 @@ http://host:port/app/observability-traces#/services
 ## Change History
 
 - **v3.0.0** (2025-02-25): Custom logs correlation, data grid migration, OTEL attributes support, service view optimizations, Amazon Network Firewall integration, trace-to-logs correlation improvements
-- **v2.17.0** (2024-09-17): Multi-Data Source bug fixes, URL routing fixes, breadcrumb navigation improvements, Getting Started link fixes, org.json security update
+- **v2.17.0** (2024-09-17): Custom source support (experimental) for custom span/service indices with CCS support, landing page changed to Traces, Multi-Data Source bug fixes, URL routing fixes, breadcrumb navigation improvements

--- a/docs/releases/v2.17.0/features/dashboards-observability/trace-analytics.md
+++ b/docs/releases/v2.17.0/features/dashboards-observability/trace-analytics.md
@@ -1,0 +1,132 @@
+# Trace Analytics
+
+## Summary
+
+OpenSearch Dashboards Observability v2.17.0 introduces experimental support for custom trace sources in Trace Analytics. This enhancement allows users to configure custom span and service indices, enabling cross-cluster search (CCS) for tracing data and support for dynamically named indices from Data Prepper pipelines. The release also includes UX improvements such as changing the default landing page from Services to Traces.
+
+## Details
+
+### What's New in v2.17.0
+
+This release adds a new "Custom source" mode to Trace Analytics, enabling users to:
+- Configure custom span and service indices via user settings
+- Support cross-cluster search (CCS) patterns for trace data
+- Use wildcard patterns in index names for dynamic Data Prepper pipelines
+- Default landing page changed from Services to Traces for better user experience
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Mode Selection"
+        PICKER[Data Schema Picker]
+        JAEGER[Jaeger Mode]
+        DP[Data Prepper Mode]
+        CUSTOM[Custom Source Mode]
+    end
+    
+    subgraph "Custom Source Configuration"
+        FLYOUT[Custom Index Flyout]
+        SPAN_IDX[Custom Span Indices]
+        SVC_IDX[Custom Service Indices]
+        SETTINGS[UI Settings Storage]
+    end
+    
+    subgraph "Index Patterns"
+        LOCAL[Local Indices]
+        CCS[Cross-Cluster Indices]
+    end
+    
+    PICKER --> JAEGER
+    PICKER --> DP
+    PICKER --> CUSTOM
+    CUSTOM --> FLYOUT
+    FLYOUT --> SPAN_IDX
+    FLYOUT --> SVC_IDX
+    SPAN_IDX --> SETTINGS
+    SVC_IDX --> SETTINGS
+    SETTINGS --> LOCAL
+    SETTINGS --> CCS
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `CustomIndexFlyout` | Flyout panel for managing custom span and service indices |
+| `TraceAnalyticsMode` | Extended type to include `custom_data_prepper` mode |
+| `ServicesList` | New selectable services list component for filtering |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `observability:traceAnalyticsSpanIndices` | Custom span indices (supports wildcards and CCS patterns) | Empty |
+| `observability:traceAnalyticsServiceIndices` | Custom service indices (supports wildcards and CCS patterns) | Empty |
+
+#### API Changes
+
+New helper functions added:
+- `getSpanIndices(mode)` - Returns appropriate span index based on mode
+- `getServiceIndices(mode)` - Returns appropriate service index based on mode
+- `getTraceCustomSpanIndex()` - Retrieves custom span index from settings
+- `getTraceCustomServiceIndex()` - Retrieves custom service index from settings
+
+### Usage Example
+
+#### Configuring Custom Source
+
+1. Open Trace Analytics in OpenSearch Dashboards
+2. Click the data schema picker dropdown
+3. Select "Manage custom source" button
+4. In the flyout, configure:
+
+```
+Custom span indices: index1,cluster1:index2,cluster:index3
+Custom service indices: service-index1,cluster1:service-index2
+```
+
+5. Click Save
+6. Select "Custom source" from the mode picker
+
+#### Cross-Cluster Search Pattern
+
+```
+# Local index
+otel-v1-apm-span-*
+
+# Cross-cluster pattern
+cluster1:otel-v1-apm-span-*,cluster2:otel-v1-apm-span-*
+```
+
+### Migration Notes
+
+- The default landing page has changed from `/services` to `/traces`
+- Existing Data Prepper and Jaeger configurations continue to work unchanged
+- Custom source is marked as experimental and requires manual index configuration
+
+## Limitations
+
+- Custom source is an experimental feature
+- Custom indices must adhere to Data Prepper index mappings
+- No automatic index discovery for custom sources
+- Service map calculations require proper span relationships in custom indices
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2112](https://github.com/opensearch-project/dashboards-observability/pull/2112) | Trace Analytics support for custom sources |
+| [#2125](https://github.com/opensearch-project/dashboards-observability/pull/2125) | Update trace analytics landing page to traces |
+
+## References
+
+- [Issue #2052](https://github.com/opensearch-project/dashboards-observability/issues/2052): Feature request for trace overview page and CCS support
+- [Trace Analytics Documentation](https://docs.opensearch.org/2.17/observing-your-data/trace/index/): Official documentation
+- [Data Prepper Schema Documentation](https://github.com/opensearch-project/data-prepper/tree/main/docs/schemas/trace-analytics): Index mapping requirements
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-observability/trace-analytics.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -18,6 +18,7 @@
 
 ### dashboards-observability
 - [Observability Notebooks Bugfixes](features/dashboards-observability/observability-notebooks.md)
+- [Trace Analytics Custom Source](features/dashboards-observability/trace-analytics.md)
 - [Trace Analytics Bugfixes](features/observability/trace-analytics-bugfixes.md)
 
 ### dashboards-query-workbench


### PR DESCRIPTION
## Summary

This PR adds documentation for the Trace Analytics custom source feature introduced in OpenSearch v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/dashboards-observability/trace-analytics.md`
- Feature report: `docs/features/dashboards-observability/trace-analytics.md` (updated)

### Key Changes in v2.17.0
- **Custom Source Support (Experimental)**: New mode allowing users to configure custom span and service indices
- **Cross-Cluster Search (CCS)**: Support for CCS patterns in custom indices
- **Landing Page Change**: Default landing page changed from Services to Traces
- **Custom Index Flyout**: New UI component for managing custom indices
- **New Settings**: `observability:traceAnalyticsSpanIndices` and `observability:traceAnalyticsServiceIndices`

### Resources Used
- PR: #2112 (Trace Analytics support for custom sources)
- PR: #2125 (Update trace analytics landing page)
- Issue: #2052 (Feature request)
- Docs: https://docs.opensearch.org/2.17/observing-your-data/trace/index/

Closes #399