### PR TITLE
docs: add Observability Enhancements report for v2.17.0

### DIFF
--- a/docs/features/dashboards-observability/getting-started-workflows.md
+++ b/docs/features/dashboards-observability/getting-started-workflows.md
@@ -1,0 +1,116 @@
+# Observability Getting Started Workflows
+
+## Summary
+
+The Getting Started workflows in OpenSearch Dashboards Observability provide pre-configured templates and sample data to help users quickly set up observability pipelines. These workflows include index patterns, dashboards, and visualizations for common data sources like CSV files and OpenTelemetry (OTel) services.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Getting Started UI"
+        GS[Getting Started Component]
+        WF[Workflow Selector]
+    end
+    
+    subgraph "Workflow Artifacts"
+        CSV[CSV File Workflow]
+        OTEL[OTel Services Workflow]
+    end
+    
+    subgraph "Assets"
+        NDJSON[NDJSON Files]
+        IP[Index Patterns]
+        DASH[Dashboards]
+        VIS[Visualizations]
+    end
+    
+    GS --> WF
+    WF --> CSV
+    WF --> OTEL
+    CSV --> NDJSON
+    OTEL --> NDJSON
+    NDJSON --> IP
+    NDJSON --> DASH
+    NDJSON --> VIS
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `fluent-bit-csv-upload-1.0.0.ndjson` | Assets for CSV file upload workflow using Fluent Bit |
+| `otel-index-patterns-1.0.0.ndjson` | Index patterns for OpenTelemetry services |
+| Getting Started UI | Interactive wizard for selecting and configuring workflows |
+
+### Supported Workflows
+
+| Workflow | Index Pattern | Description |
+|----------|---------------|-------------|
+| CSV File Upload | `logs-*` | Upload CSV files using Fluent Bit agent |
+| OTel Services | `otel-v1-apm-span-*`, `otel-v1-apm-service-map` | OpenTelemetry traces and service maps |
+
+### Configuration
+
+The workflows use NDJSON (Newline Delimited JSON) files containing:
+
+| Asset Type | Description |
+|------------|-------------|
+| `index-pattern` | Defines the index pattern for data discovery |
+| `visualization` | Markdown or chart visualizations |
+| `dashboard` | Dashboard layouts referencing visualizations |
+
+### Usage Example
+
+Using the CSV File Upload workflow:
+
+1. Navigate to **Observability** > **Getting Started**
+2. Select **CSV File Upload**
+3. Follow the Fluent Bit configuration instructions
+4. View ingested data in the created dashboard
+
+Fluent Bit configuration example:
+
+```ini
+[SERVICE]
+    Flush        1
+    Log_Level    info
+    Parsers_File parsers.conf
+
+[INPUT]
+    Name         tail
+    Path         /path/to/your/csv/files/*.csv
+    Parser       csv
+    Tag          csv
+
+[OUTPUT]
+    Name         opensearch
+    Match        *
+    Host         your-opensearch-host
+    Port         9200
+    Index        logs
+```
+
+## Limitations
+
+- Workflows are designed for specific data formats and may require customization
+- Index patterns must match the actual indices created by data ingestion pipelines
+- Sample data is for demonstration purposes only
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#2016](https://github.com/opensearch-project/dashboards-observability/pull/2016) | Update ndjson so workflow matches patterns created |
+
+## References
+
+- [Observability Documentation](https://docs.opensearch.org/2.17/observing-your-data/)
+- [Fluent Bit OpenSearch Output](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch)
+- [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/)
+
+## Change History
+
+- **v2.17.0** (2024-10-22): Fixed index pattern mismatches - CSV workflow now uses `logs-*` pattern, removed unused `otel-metrics*` from OTel workflow

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -146,6 +146,7 @@
 
 ## dashboards-observability
 
+- [Getting Started Workflows](dashboards-observability/getting-started-workflows.md)
 - [Observability Notebooks](dashboards-observability/observability-notebooks.md)
 - [Observability Traces](dashboards-observability/observability-traces.md)
 - [Trace Analytics](dashboards-observability/trace-analytics.md)

--- a/docs/releases/v2.17.0/features/dashboards-observability/observability-enhancements.md
+++ b/docs/releases/v2.17.0/features/dashboards-observability/observability-enhancements.md
@@ -1,0 +1,88 @@
+# Observability Enhancements
+
+## Summary
+
+This release includes maintenance and bug fix improvements for the OpenSearch Observability plugin and Dashboards Observability plugin. The changes address CI/CD build issues, navigation group registration errors, and index pattern mismatches in the Getting Started workflows.
+
+## Details
+
+### What's New in v2.17.0
+
+Three enhancements improve the stability and usability of the Observability plugins:
+
+1. **CI Build Fix**: Added support for unsecure Node.js versions in CI workflows to resolve GLIBC compatibility issues
+2. **Navigation Fix**: Removed incorrect Notebook registration from the Analytics navigation group
+3. **Index Pattern Fix**: Updated Getting Started workflow ndjson files to match actual index patterns
+
+### Technical Changes
+
+#### CI Workflow Updates
+
+The observability plugin's CI workflow was updated to handle GLIBC version incompatibilities:
+
+```yaml
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+```
+
+This resolves build errors like:
+```
+/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found
+/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found
+```
+
+#### Navigation Group Registration Fix
+
+Removed accidental registration of Notebooks to the Analytics navigation group. Notebooks remain visible only under the Observability navigation group as intended:
+
+```typescript
+// Removed from plugin_nav.tsx
+core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.analytics, [
+  {
+    id: observabilityNotebookID,
+    category: DEFAULT_APP_CATEGORIES.visualizeAndReport,
+    order: 400,
+  },
+]);
+```
+
+#### Index Pattern Corrections
+
+| Workflow | Before | After |
+|----------|--------|-------|
+| CSV File Upload | `logs-index` | `logs-*` |
+| OTel Services | Included `otel-metrics*` | Removed `otel-metrics*` |
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `.github/workflows/opensearch-observability-test-and-build-workflow.yml` | Added `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` env var |
+| `public/plugin_nav.tsx` | Removed Notebook from Analytics nav group |
+| `public/components/getting_started/.../fluent-bit-csv-upload-1.0.0.ndjson` | Changed index pattern to `logs-*` |
+| `server/routes/getting_started/assets/fluent-bit-csv-upload-1.0.0.ndjson` | Changed index pattern to `logs-*` |
+| `public/components/getting_started/.../otel-index-patterns-1.0.0.ndjson` | Removed `otel-metrics*` pattern |
+| `server/routes/getting_started/assets/otel-index-patterns-1.0.0.ndjson` | Removed `otel-metrics*` pattern |
+
+## Limitations
+
+- The CI fix uses `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` which may have security implications for CI environments
+- These are maintenance fixes with no new user-facing features
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#1861](https://github.com/opensearch-project/observability/pull/1861) | observability | Add allow unsecure node versions to CI .env |
+| [#2044](https://github.com/opensearch-project/dashboards-observability/pull/2044) | dashboards-observability | Remove useless registration of Notebook to analytics nav group |
+| [#2016](https://github.com/opensearch-project/dashboards-observability/pull/2016) | dashboards-observability | Update ndjson so workflow matches patterns created |
+
+## References
+
+- [Observability Documentation](https://docs.opensearch.org/2.17/observing-your-data/)
+- [OpenSearch Dashboards Observability Plugin](https://github.com/opensearch-project/dashboards-observability)
+- [OpenSearch Observability Plugin](https://github.com/opensearch-project/observability)
+
+## Related Feature Report
+
+- [Observability Integrations](../../../features/observability/observability-integrations.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -17,6 +17,7 @@
 - [Notifications Bugfixes](features/dashboards-notifications/notifications-bugfixes.md)
 
 ### dashboards-observability
+- [Observability Enhancements](features/dashboards-observability/observability-enhancements.md)
 - [Observability Notebooks Bugfixes](features/dashboards-observability/observability-notebooks.md)
 - [Trace Analytics Custom Source](features/dashboards-observability/trace-analytics.md)
 - [Trace Analytics Bugfixes](features/observability/trace-analytics-bugfixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Observability Enhancements release item in OpenSearch v2.17.0.

## Changes

### Release Report
- `docs/releases/v2.17.0/features/dashboards-observability/observability-enhancements.md`

### Feature Report
- `docs/features/dashboards-observability/getting-started-workflows.md` (new)

### Index Updates
- Updated `docs/releases/v2.17.0/index.md`
- Updated `docs/features/index.md`

## PRs Investigated

| PR | Repository | Description |
|----|------------|-------------|
| [#1861](https://github.com/opensearch-project/observability/pull/1861) | observability | Add allow unsecure node versions to CI .env |
| [#2044](https://github.com/opensearch-project/dashboards-observability/pull/2044) | dashboards-observability | Remove useless registration of Notebook to analytics nav group |
| [#2016](https://github.com/opensearch-project/dashboards-observability/pull/2016) | dashboards-observability | Update ndjson so workflow matches patterns created |

## Key Changes in v2.17.0

- CI build fix for GLIBC compatibility issues
- Navigation fix removing Notebook from Analytics nav group
- Index pattern fixes for Getting Started workflows

Closes #398