### PR TITLE
docs: add Neural Search Rescore report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -5,6 +5,7 @@
 - [Batch Ingestion](neural-search/batch-ingestion.md)
 - [Hybrid Query](neural-search/hybrid-query.md)
 - [Neural Search Compatibility](neural-search/neural-search-compatibility.md)
+- [Neural Search Rescore](neural-search/neural-search-rescore.md)
 - [Neural Sparse Search](neural-search/neural-sparse-search.md)
 - [Semantic Field](neural-search/semantic-field.md)
 

--- a/docs/features/neural-search/neural-search-rescore.md
+++ b/docs/features/neural-search/neural-search-rescore.md
@@ -1,0 +1,146 @@
+# Neural Search Rescore
+
+## Summary
+
+Neural Search Rescore enables rescoring functionality for neural queries when searching quantized k-NN indexes. This feature improves search recall by performing a two-phase search: first searching the compressed index, then rescoring results using full-precision vectors. It is particularly valuable for disk-based vector search scenarios where memory optimization through binary quantization is used.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Neural Search with Rescore"
+        Q[Query Text] --> ML[ML Model]
+        ML --> |"Generate embedding"| V[Query Vector]
+        V --> NQB[NeuralQueryBuilder]
+        NQB --> |"Rewrite"| KQB[KNNQueryBuilder]
+        
+        subgraph "Two-Phase Search"
+            KQB --> P1[Phase 1: Search Compressed Index]
+            P1 --> |"k × oversample_factor results"| P2[Phase 2: Rescore]
+            P2 --> |"Load full-precision vectors"| FR[Final k Results]
+        end
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Input
+        QT[Query Text]
+        RC[Rescore Config]
+    end
+    
+    subgraph Processing
+        NQ[Neural Query]
+        KNN[k-NN Query]
+        QI[Quantized Index]
+        FP[Full Precision Vectors]
+    end
+    
+    subgraph Output
+        R[Rescored Results]
+    end
+    
+    QT --> NQ
+    RC --> NQ
+    NQ --> KNN
+    KNN --> QI
+    QI --> |"Oversample"| FP
+    FP --> |"Rescore"| R
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `NeuralQueryBuilder` | Extended to support `rescoreContext` parameter |
+| `RescoreContext` | Configuration object for rescoring behavior |
+| `RescoreParser` | Parses rescore configuration from query DSL |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `rescore` | Object containing rescoring configuration | `null` |
+| `rescore.oversample_factor` | Multiplier for initial result set size before rescoring | `3.0` (for disk-optimized indexes) |
+
+### Usage Example
+
+Basic neural query with rescore:
+
+```json
+GET /my-nlp-index/_search
+{
+  "query": {
+    "neural": {
+      "passage_embedding": {
+        "query_text": "semantic search query",
+        "model_id": "my-model-id",
+        "k": 10,
+        "rescore": {
+          "oversample_factor": 5.0
+        }
+      }
+    }
+  }
+}
+```
+
+Combined with method parameters for hybrid search:
+
+```json
+GET /my-nlp-index/_search
+{
+  "query": {
+    "hybrid": {
+      "queries": [
+        {
+          "neural": {
+            "passage_embedding": {
+              "query_text": "semantic search",
+              "model_id": "my-model-id",
+              "k": 10,
+              "method_parameters": {
+                "ef_search": 100
+              },
+              "rescore": {
+                "oversample_factor": 10.0
+              }
+            }
+          }
+        },
+        {
+          "match": {
+            "text": "semantic search"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+## Limitations
+
+- Rescore is designed for quantized/disk-based vector indexes
+- Radial search does not support rescoring
+- Only works with `float` data type vectors
+- Increases search latency due to two-phase processing
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#885](https://github.com/opensearch-project/neural-search/pull/885) | Adds rescore parameter support in neural search |
+
+## References
+
+- [Neural Query Documentation](https://docs.opensearch.org/2.17/query-dsl/specialized/neural/): Official neural query reference
+- [Disk-based Vector Search](https://docs.opensearch.org/2.17/search-plugins/knn/disk-based-vector-search/): Documentation on disk-based vector search
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Initial implementation - added rescore parameter support to neural query

--- a/docs/releases/v2.17.0/features/neural-search/neural-search-rescore.md
+++ b/docs/releases/v2.17.0/features/neural-search/neural-search-rescore.md
@@ -1,0 +1,103 @@
+# Neural Search Rescore
+
+## Summary
+
+OpenSearch 2.17.0 adds rescore parameter support to the neural query, enabling rescoring functionality for k-NN indexes built using quantization. This enhancement allows neural search queries to leverage the same rescoring capabilities available in k-NN queries, improving search recall for disk-based vector search scenarios.
+
+## Details
+
+### What's New in v2.17.0
+
+The `rescore` parameter is now available in the `neural` query, allowing users to configure rescoring behavior when searching quantized vector indexes. This is particularly useful for disk-based vector search where vectors are compressed using binary quantization.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Neural Query Processing"
+        NQ[Neural Query] --> NQB[NeuralQueryBuilder]
+        NQB --> |"with rescore"| KQB[KNNQueryBuilder]
+        KQB --> |"two-phase search"| QI[Quantized Index]
+        QI --> |"1. Search compressed"| CR[Compressed Results]
+        CR --> |"2. Rescore with full precision"| FR[Final Results]
+    end
+```
+
+#### New Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `rescore` | Object containing rescoring configuration | `null` |
+| `rescore.oversample_factor` | Factor to oversample results before rescoring | `3.0` (for disk-optimized indexes) |
+
+### Usage Example
+
+```json
+GET /my-nlp-index/_search
+{
+  "query": {
+    "neural": {
+      "passage_embedding": {
+        "query_text": "semantic search query",
+        "model_id": "my-model-id",
+        "k": 10,
+        "rescore": {
+          "oversample_factor": 5.0
+        }
+      }
+    }
+  }
+}
+```
+
+The rescore parameter can be combined with other neural query parameters:
+
+```json
+GET /my-nlp-index/_search
+{
+  "query": {
+    "neural": {
+      "passage_embedding": {
+        "query_text": "semantic search query",
+        "model_id": "my-model-id",
+        "k": 10,
+        "method_parameters": {
+          "ef_search": 100
+        },
+        "rescore": {
+          "oversample_factor": 10.0
+        }
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- The rescore parameter is optional and backward compatible
+- Existing neural queries continue to work without modification
+- For disk-optimized indexes, rescoring is enabled by default with an `oversample_factor` of `3.0`
+
+## Limitations
+
+- Rescore is primarily designed for quantized/disk-based vector indexes
+- Radial search does not support disk-based vector search with rescoring
+- The `on_disk` mode only works with the `float` data type
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#885](https://github.com/opensearch-project/neural-search/pull/885) | Adds rescore parameter support in neural search |
+
+## References
+
+- [Neural Query Documentation](https://docs.opensearch.org/2.17/query-dsl/specialized/neural/): Official neural query reference
+- [Disk-based Vector Search](https://docs.opensearch.org/2.17/search-plugins/knn/disk-based-vector-search/): Documentation on disk-based vector search and rescoring
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/neural-search/neural-search-rescore.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -68,6 +68,7 @@
 ### neural-search
 - [Neural Search Bugfixes](features/neural-search/neural-search-bugfixes.md)
 - [Neural Search Hybrid Query Bugfixes](features/neural-search/neural-search-hybrid-query.md)
+- [Neural Search Rescore](features/neural-search/neural-search-rescore.md)
 
 ### multi-plugin
 - [CI/Infrastructure Fixes](features/multi-plugin/ci-infrastructure-fixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Neural Search Rescore feature introduced in OpenSearch v2.17.0.

### Changes
- Added release report: `docs/releases/v2.17.0/features/neural-search/neural-search-rescore.md`
- Added feature report: `docs/features/neural-search/neural-search-rescore.md`
- Updated release index and features index

### Feature Overview
The `rescore` parameter was added to the neural query in v2.17.0, enabling rescoring functionality for k-NN indexes built using quantization. This is particularly useful for disk-based vector search scenarios.

### Related
- Closes #397
- PR: [opensearch-project/neural-search#885](https://github.com/opensearch-project/neural-search/pull/885)