### PR TITLE
docs: add ML Config API report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -130,6 +130,7 @@
 - [ML Commons MCP (Model Context Protocol)](ml-commons/ml-commons-mcp.md)
 - [ML Commons Stability and Reliability](ml-commons/ml-commons-stability.md)
 - [ML Commons Test Fixes](ml-commons/ml-commons-test-fixes.md)
+- [ML Config API](ml-commons/ml-config-api.md)
 - [Query Assist](ml-commons/query-assist.md)
 
 ## ml-commons-dashboards

--- a/docs/features/ml-commons/ml-config-api.md
+++ b/docs/features/ml-commons/ml-config-api.md
@@ -1,0 +1,137 @@
+# ML Config API
+
+## Summary
+
+The ML Config API provides programmatic access to ML configuration documents stored in OpenSearch's `.plugins-ml-config` index. This API enables applications to retrieve configuration settings for ML features such as agent configurations, model settings, and other ML-related parameters through the Java client interface.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Client Interface"
+        MLC[MachineLearningClient]
+        MLNC[MachineLearningNodeClient]
+    end
+    
+    subgraph "Transport Actions"
+        MLCGA[MLConfigGetAction]
+        MLCGR[MLConfigGetRequest]
+        MLCGRes[MLConfigGetResponse]
+    end
+    
+    subgraph "Server Actions"
+        GCTA[GetConfigTransportAction]
+    end
+    
+    subgraph "Data Storage"
+        CI[".plugins-ml-config Index"]
+    end
+    
+    MLC -->|"getConfig()"| MLNC
+    MLNC -->|"execute()"| MLCGA
+    MLCGA --> MLCGR
+    MLCGR --> GCTA
+    GCTA -->|"GET"| CI
+    CI --> GCTA
+    GCTA --> MLCGRes
+    MLCGRes --> MLNC
+    MLNC --> MLC
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Client Application] -->|"getConfig(configId)"| B[MachineLearningNodeClient]
+    B -->|"MLConfigGetRequest"| C[GetConfigTransportAction]
+    C -->|"Security Check"| D{Is MASTER_KEY?}
+    D -->|Yes| E[Return FORBIDDEN]
+    D -->|No| F[Fetch from Index]
+    F -->|"MLConfig"| G[MLConfigGetResponse]
+    G --> B
+    B --> A
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `MachineLearningClient` | Interface defining the getConfig method |
+| `MachineLearningNodeClient` | Implementation that executes the transport action |
+| `MLConfigGetAction` | Transport action for config retrieval |
+| `MLConfigGetRequest` | Request object containing the config ID |
+| `MLConfigGetResponse` | Response object containing the MLConfig |
+| `GetConfigTransportAction` | Server-side action handler |
+| `MLConfig` | Data model for configuration documents |
+
+### Configuration
+
+The `MLConfig` object structure:
+
+| Field | Type | Description | Since |
+|-------|------|-------------|-------|
+| `type` | String | Configuration type identifier | v2.0.0 |
+| `configType` | String | Alternative type field with correct data type | v2.15.0 |
+| `configuration` | Configuration | Configuration object containing settings | v2.0.0 |
+| `mlConfiguration` | Configuration | Alternative configuration field | v2.15.0 |
+| `createTime` | Instant | Document creation timestamp | v2.0.0 |
+| `lastUpdateTime` | Instant | Last modification timestamp | v2.0.0 |
+| `lastUpdatedTime` | Instant | Alternative timestamp field | v2.15.0 |
+| `tenantId` | String | Multi-tenancy tenant identifier | v2.19.0 |
+
+### Usage Example
+
+```java
+// Initialize the ML client
+MachineLearningNodeClient mlClient = new MachineLearningNodeClient(client);
+
+// Synchronous retrieval
+ActionFuture<MLConfig> future = mlClient.getConfig("agent_config");
+MLConfig config = future.actionGet();
+
+// Access configuration data
+String type = config.getType();
+Configuration configuration = config.getConfiguration();
+String agentId = configuration.getAgentId();
+
+// Asynchronous retrieval
+mlClient.getConfig("agent_config", ActionListener.wrap(
+    mlConfig -> {
+        log.info("Config type: {}", mlConfig.getType());
+        log.info("Agent ID: {}", mlConfig.getConfiguration().getAgentId());
+    },
+    exception -> {
+        log.error("Failed to get config", exception);
+    }
+));
+```
+
+### Security
+
+The API includes built-in security measures:
+
+1. **MASTER_KEY Protection**: Access to the `MASTER_KEY` configuration document is blocked with a `FORBIDDEN` response to prevent exposure of encryption keys
+2. **Index-level Security**: Standard OpenSearch security controls apply to the `.plugins-ml-config` index
+
+## Limitations
+
+- No REST API endpoint available; access is limited to Java client
+- Cannot retrieve the `MASTER_KEY` configuration for security reasons
+- Requires the ML Commons plugin to be installed and enabled
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#2850](https://github.com/opensearch-project/ml-commons/pull/2850) | Expose ML Config API |
+
+## References
+
+- [ML Commons APIs](https://docs.opensearch.org/latest/ml-commons-plugin/api/index/): Official API documentation
+- [ML Commons cluster settings](https://docs.opensearch.org/latest/ml-commons-plugin/cluster-settings/): Configuration settings reference
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Initial exposure of ML Config API through MachineLearningClient interface

--- a/docs/releases/v2.17.0/features/ml-commons/ml-config-api.md
+++ b/docs/releases/v2.17.0/features/ml-commons/ml-config-api.md
@@ -1,0 +1,138 @@
+# ML Config API
+
+## Summary
+
+OpenSearch v2.17.0 exposes the ML Config API through the MachineLearningClient, enabling programmatic access to ML configuration documents. This enhancement allows applications to retrieve ML configuration settings via the Java client API, with built-in security to prevent access to sensitive internal configuration keys.
+
+## Details
+
+### What's New in v2.17.0
+
+The ML Config API is now accessible through the `MachineLearningClient` interface, providing a standardized way to retrieve ML configuration documents stored in the `.plugins-ml-config` index.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Client Layer"
+        MLC[MachineLearningClient]
+        MLNC[MachineLearningNodeClient]
+    end
+    
+    subgraph "Transport Layer"
+        MLCGA[MLConfigGetAction]
+        MLCGR[MLConfigGetRequest]
+        MLCGRes[MLConfigGetResponse]
+    end
+    
+    subgraph "Action Layer"
+        GCTA[GetConfigTransportAction]
+    end
+    
+    subgraph "Storage"
+        CI[.plugins-ml-config Index]
+    end
+    
+    MLC --> MLNC
+    MLNC --> MLCGA
+    MLCGA --> MLCGR
+    MLCGR --> GCTA
+    GCTA --> CI
+    GCTA --> MLCGRes
+    MLCGRes --> MLNC
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `MachineLearningClient.getConfig()` | New method to retrieve ML config by ID |
+| `MachineLearningNodeClient.getConfig()` | Implementation of getConfig for node client |
+| `MLConfigGetResponse.getMlConfig()` | Getter method exposed via Lombok annotation |
+
+#### API Changes
+
+New methods added to `MachineLearningClient`:
+
+```java
+// Synchronous retrieval
+ActionFuture<MLConfig> getConfig(String configId);
+
+// Asynchronous retrieval with listener
+void getConfig(String configId, ActionListener<MLConfig> listener);
+```
+
+#### Security Enhancement
+
+Access to the `MASTER_KEY` configuration document is explicitly blocked to prevent exposure of sensitive encryption keys:
+
+```java
+if (configId.equals(MASTER_KEY)) {
+    actionListener.onFailure(
+        new OpenSearchStatusException(
+            "You are not allowed to access this config doc", 
+            RestStatus.FORBIDDEN
+        )
+    );
+    return;
+}
+```
+
+### Usage Example
+
+```java
+// Using MachineLearningNodeClient
+MachineLearningNodeClient mlClient = new MachineLearningNodeClient(client);
+
+// Synchronous call
+MLConfig config = mlClient.getConfig("my-config-id").actionGet();
+String agentId = config.getConfiguration().getAgentId();
+
+// Asynchronous call
+mlClient.getConfig("my-config-id", ActionListener.wrap(
+    mlConfig -> {
+        // Handle successful response
+        Configuration configuration = mlConfig.getConfiguration();
+    },
+    exception -> {
+        // Handle error
+    }
+));
+```
+
+### MLConfig Structure
+
+The `MLConfig` object contains:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | String | Configuration type identifier |
+| `configType` | String | Alternative type field (v2.15.0+) |
+| `configuration` | Configuration | Configuration object with settings |
+| `mlConfiguration` | Configuration | Alternative configuration field (v2.15.0+) |
+| `createTime` | Instant | Creation timestamp |
+| `lastUpdateTime` | Instant | Last modification timestamp |
+| `tenantId` | String | Tenant identifier (v2.19.0+) |
+
+## Limitations
+
+- The `MASTER_KEY` configuration document cannot be accessed via this API for security reasons
+- No REST API endpoint is exposed; access is only through the Java client
+- Configuration documents must already exist in the `.plugins-ml-config` index
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2850](https://github.com/opensearch-project/ml-commons/pull/2850) | Expose ML Config API |
+
+## References
+
+- [ML Commons APIs](https://docs.opensearch.org/2.17/ml-commons-plugin/api/index/): Official API documentation
+- [ML Commons cluster settings](https://docs.opensearch.org/2.17/ml-commons-plugin/cluster-settings/): Configuration settings reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/ml-config-api.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -63,6 +63,7 @@
 ### ml-commons
 - [ML Commons Bugfixes](features/ml-commons/ml-commons-bugfixes.md)
 - [ML Commons Test Fixes](features/ml-commons/ml-commons-test-fixes.md)
+- [ML Config API](features/ml-commons/ml-config-api.md)
 - [Query Assist](features/ml-commons/query-assist.md)
 
 ### ml-commons-dashboards


### PR DESCRIPTION
## Summary

This PR adds documentation for the ML Config API enhancement introduced in OpenSearch v2.17.0.

## Changes

### Release Report
- `docs/releases/v2.17.0/features/ml-commons/ml-config-api.md`

### Feature Report
- `docs/features/ml-commons/ml-config-api.md`

## Key Points

The ML Config API exposes configuration retrieval through the `MachineLearningClient` interface:
- New `getConfig(configId)` method for synchronous and asynchronous retrieval
- Security protection blocking access to `MASTER_KEY` configuration
- Returns `MLConfig` objects containing type, configuration, and timestamps

## Related Issue
Closes #395

## PR Reference
- [opensearch-project/ml-commons#2850](https://github.com/opensearch-project/ml-commons/pull/2850)