### PR TITLE
docs: add ML Inference Processor report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -131,6 +131,7 @@
 - [ML Commons Stability and Reliability](ml-commons/ml-commons-stability.md)
 - [ML Commons Test Fixes](ml-commons/ml-commons-test-fixes.md)
 - [ML Config API](ml-commons/ml-config-api.md)
+- [ML Inference Processor](ml-commons/ml-inference-processor.md)
 - [Query Assist](ml-commons/query-assist.md)
 
 ## ml-commons-dashboards

--- a/docs/features/ml-commons/ml-inference-processor.md
+++ b/docs/features/ml-commons/ml-inference-processor.md
@@ -1,0 +1,166 @@
+# ML Inference Processor
+
+## Summary
+
+The ML Inference Processor enables seamless integration of machine learning models into OpenSearch ingest and search pipelines. It allows documents to be enriched with ML model predictions during indexing or search operations, supporting use cases like semantic search, text embedding generation, document classification, reranking, and content summarization.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Ingest Pipeline"
+        D[Document] --> IP[ML Inference<br/>Ingest Processor]
+        IP --> M1[ML Model]
+        M1 --> IP
+        IP --> I[Index]
+    end
+    
+    subgraph "Search Pipeline"
+        Q[Query] --> SRP[ML Inference<br/>Search Request Processor]
+        SRP --> M2[ML Model]
+        M2 --> SRP
+        SRP --> E[Execute Search]
+        E --> SRSP[ML Inference<br/>Search Response Processor]
+        SRSP --> M3[ML Model]
+        M3 --> SRSP
+        SRSP --> R[Response]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| ML Inference Ingest Processor | Enriches documents during indexing with ML model predictions |
+| ML Inference Search Request Processor | Transforms search queries using ML models (e.g., query embedding) |
+| ML Inference Search Response Processor | Enriches search results with ML model predictions |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `model_id` | ID of the ML model to invoke | Required |
+| `function_name` | Function name (`remote`, `text_embedding`, `sparse_encoding`, etc.) | `remote` |
+| `input_map` | Maps document/query fields to model input parameters | Optional |
+| `output_map` | Maps model output to new document fields | Optional |
+| `model_config` | Additional model configuration parameters | Optional |
+| `model_input` | Template for model input format | Auto-generated |
+| `full_response_path` | Use JSON path for output field extraction | `false` (remote), `true` (local) |
+| `ignore_missing` | Skip documents with missing input fields | `false` |
+| `ignore_failure` | Continue on prediction failures | `false` |
+| `override` | Overwrite existing fields with same name | `false` |
+| `max_prediction_tasks` | Maximum concurrent model invocations | `10` |
+| `one_to_one` | Invoke model per document (search response only) | `false` |
+
+### Usage Examples
+
+#### Ingest Pipeline - Text Embedding
+
+```json
+PUT /_ingest/pipeline/embedding_pipeline
+{
+  "processors": [
+    {
+      "ml_inference": {
+        "model_id": "<embedding_model_id>",
+        "input_map": [
+          {
+            "inputText": "text_field"
+          }
+        ],
+        "output_map": [
+          {
+            "text_embedding": "embedding"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+#### Search Request Pipeline - Query Embedding
+
+```json
+PUT /_search/pipeline/semantic_search_pipeline
+{
+  "request_processors": [
+    {
+      "ml_inference": {
+        "model_id": "<embedding_model_id>",
+        "query_template": "{\"query\":{\"knn\":{\"embedding\":{\"vector\":${modelPredictionOutcome},\"k\":10}}}}",
+        "input_map": [
+          {
+            "inputText": "query.match.text.query"
+          }
+        ],
+        "output_map": [
+          {
+            "modelPredictionOutcome": "embedding"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+#### Search Response Pipeline - Summarization
+
+```json
+PUT /_search/pipeline/summarization_pipeline
+{
+  "response_processors": [
+    {
+      "ml_inference": {
+        "model_id": "<llm_model_id>",
+        "input_map": [
+          {
+            "context": "text_field"
+          }
+        ],
+        "output_map": [
+          {
+            "summary": "content[0].text"
+          }
+        ],
+        "model_config": {
+          "messages": "[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"Summarize: ${parameters.context}\"}]}]"
+        },
+        "one_to_one": true
+      }
+    }
+  ]
+}
+```
+
+## Limitations
+
+- Local models require explicit `function_name` and `model_input` configuration
+- `one_to_one` mode increases latency proportionally to document count
+- Model must be deployed and accessible before pipeline execution
+- Complex nested field mappings require JSON path syntax
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.14.0 | - | Initial ML Inference Ingest Processor |
+| v2.16.0 | - | ML Inference Search Request/Response Processors |
+| v2.17.0 | [#2801](https://github.com/opensearch-project/ml-commons/pull/2801) | Support one_to_one in ML Inference Search Response Processor |
+
+## References
+
+- [Issue #2173](https://github.com/opensearch-project/ml-commons/issues/2173): RFC - ML Inference Processors
+- [ML Inference Ingest Processor Documentation](https://docs.opensearch.org/latest/ingest-pipelines/processors/ml-inference/)
+- [ML Inference Search Request Processor Documentation](https://docs.opensearch.org/latest/search-plugins/search-pipelines/ml-inference-search-request/)
+- [ML Inference Search Response Processor Documentation](https://docs.opensearch.org/latest/search-plugins/search-pipelines/ml-inference-search-response/)
+- [Blog: Introduction to ML inference processors](https://opensearch.org/blog/introduction-to-ml-inference-processors-in-opensearch-review-summarization-and-semantic-search/)
+
+## Change History
+
+- **v2.17.0** (2024-10-15): Added `one_to_one` parameter for per-document inference in search response processor
+- **v2.16.0**: Added ML Inference Search Request and Search Response Processors
+- **v2.14.0**: Initial ML Inference Ingest Processor implementation

--- a/docs/releases/v2.17.0/features/ml-commons/ml-inference-processor.md
+++ b/docs/releases/v2.17.0/features/ml-commons/ml-inference-processor.md
@@ -1,0 +1,112 @@
+# ML Inference Processor - One-to-One Support
+
+## Summary
+
+OpenSearch v2.17.0 adds `one_to_one` inference mode to the ML Inference Search Response Processor. This enhancement enables per-document model predictions, where each document in search results triggers an individual model invocation rather than batching all documents into a single prediction call.
+
+## Details
+
+### What's New in v2.17.0
+
+The ML Inference Search Response Processor now supports a new `one_to_one` parameter that changes how documents are processed during inference:
+
+- **Default behavior (`one_to_one: false`)**: All documents from search hits are collected and sent to the model in a single prediction call (many-to-one)
+- **New behavior (`one_to_one: true`)**: Each document triggers a separate prediction call, with results mapped back to individual documents
+
+### Technical Changes
+
+#### Processing Flow
+
+```mermaid
+graph TB
+    subgraph "one_to_one: false (Default)"
+        A1[Search Response<br/>N documents] --> B1[Collect all inputs]
+        B1 --> C1[Single Predict API call]
+        C1 --> D1[Map outputs to documents]
+    end
+    
+    subgraph "one_to_one: true (New)"
+        A2[Search Response<br/>N documents] --> B2[Split into N responses]
+        B2 --> C2[N Predict API calls]
+        C2 --> D2[Combine responses]
+    end
+```
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `one_to_one` | When `true`, invokes the model once per document. When `false`, batches all documents into a single prediction. | `false` |
+
+#### Implementation Details
+
+The processor introduces:
+- `GroupedActionListener` to handle parallel predictions and combine results
+- `SearchResponseUtil.replaceHits()` to split/combine search responses
+- Atomic failure tracking to stop remaining predictions on first error
+- Enhanced error handling for `OpenSearchStatusException` and `MLResourceNotFoundException`
+
+### Usage Example
+
+```json
+PUT /_search/pipeline/rerank_pipeline
+{
+  "response_processors": [
+    {
+      "ml_inference": {
+        "model_id": "<rerank_model_id>",
+        "input_map": [
+          {
+            "text": "passage_text"
+          }
+        ],
+        "output_map": [
+          {
+            "score": "response"
+          }
+        ],
+        "one_to_one": true
+      }
+    }
+  ]
+}
+```
+
+### Use Cases
+
+The `one_to_one` mode is particularly useful for:
+
+1. **Reranking with XGBoost models**: Models that compare a single document against the search query and return a relevance score
+2. **Bedrock embedding models**: Models that accept a single string input rather than a list
+3. **Per-document classification**: When each document needs individual classification or scoring
+
+### Migration Notes
+
+Existing pipelines using the ML Inference Search Response Processor continue to work unchanged. To enable per-document inference:
+
+1. Add `"one_to_one": true` to your processor configuration
+2. Ensure your model accepts single-document input format
+3. Consider the increased number of API calls (N documents = N predictions)
+
+## Limitations
+
+- Increased latency due to multiple prediction calls (N documents = N API calls)
+- Higher resource consumption for large result sets
+- Error in any single prediction can fail the entire response (unless `ignore_failure: true`)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2801](https://github.com/opensearch-project/ml-commons/pull/2801) | Support one_to_one in ML Inference Search Response Processor |
+
+## References
+
+- [Issue #2173](https://github.com/opensearch-project/ml-commons/issues/2173): RFC - ML Inference Processors
+- [Issue #2444](https://github.com/opensearch-project/ml-commons/issues/2444): Related feature request
+- [Documentation](https://docs.opensearch.org/2.17/search-plugins/search-pipelines/ml-inference-search-response/): ML inference search response processor
+- [Blog](https://opensearch.org/blog/introduction-to-ml-inference-processors-in-opensearch-review-summarization-and-semantic-search/): Introduction to ML inference processors
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/ml-inference-processor.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -64,6 +64,7 @@
 - [ML Commons Bugfixes](features/ml-commons/ml-commons-bugfixes.md)
 - [ML Commons Test Fixes](features/ml-commons/ml-commons-test-fixes.md)
 - [ML Config API](features/ml-commons/ml-config-api.md)
+- [ML Inference Processor - One-to-One Support](features/ml-commons/ml-inference-processor.md)
 - [Query Assist](features/ml-commons/query-assist.md)
 
 ### ml-commons-dashboards


### PR DESCRIPTION
## Summary

This PR adds documentation for the ML Inference Processor enhancement in OpenSearch v2.17.0.

### Changes in v2.17.0

The ML Inference Search Response Processor now supports a new `one_to_one` parameter that enables per-document model predictions:

- **Default behavior (`one_to_one: false`)**: All documents are batched into a single prediction call
- **New behavior (`one_to_one: true`)**: Each document triggers a separate prediction call

### Use Cases

The `one_to_one` mode is particularly useful for:
- Reranking with XGBoost models
- Bedrock embedding models that accept single string input
- Per-document classification or scoring

### Reports Created

- Release report: `docs/releases/v2.17.0/features/ml-commons/ml-inference-processor.md`
- Feature report: `docs/features/ml-commons/ml-inference-processor.md` (new)

### Related PR

- [opensearch-project/ml-commons#2801](https://github.com/opensearch-project/ml-commons/pull/2801): Support one_to_one in ML Inference Search Response Processor

Closes #394