### PR TITLE
docs: add ML Commons Connector Enhancements report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -126,6 +126,7 @@
 
 ## ml-commons
 
+- [ML Commons Connector](ml-commons/ml-commons-connector.md)
 - [ML Commons Connector Blueprints](ml-commons/ml-commons-blueprints.md)
 - [ML Commons MCP (Model Context Protocol)](ml-commons/ml-commons-mcp.md)
 - [ML Commons Stability and Reliability](ml-commons/ml-commons-stability.md)

--- a/docs/features/ml-commons/ml-commons-connector.md
+++ b/docs/features/ml-commons/ml-commons-connector.md
@@ -1,0 +1,141 @@
+# ML Commons Connector
+
+## Summary
+
+ML Commons Connectors enable OpenSearch to connect to externally hosted machine learning models and services. Connectors define the protocol, credentials, parameters, and actions needed to communicate with remote ML platforms such as Amazon SageMaker, Amazon Bedrock, OpenAI, and Cohere. This feature allows users to leverage powerful external ML models for tasks like text embedding, text generation, and other inference operations without hosting models locally.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Cluster"
+        A[ML Commons Plugin] --> B[Connector Framework]
+        B --> C[RemoteConnectorExecutor]
+        C --> D[Payload Preparation]
+        D --> E{Validate Payload?}
+        E -->|Yes| F[validatePayload]
+        E -->|No| G[Skip Validation]
+        F --> H[Invoke Remote Service]
+        G --> H
+    end
+    
+    subgraph "External Services"
+        H --> I[Amazon SageMaker]
+        H --> J[Amazon Bedrock]
+        H --> K[OpenAI]
+        H --> L[Cohere]
+        H --> M[Other ML Services]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User Request] --> B[ML Commons API]
+    B --> C[Load Connector Config]
+    C --> D[Merge Parameters]
+    D --> E[Create Payload from Template]
+    E --> F{skip_validating_missing_parameters?}
+    F -->|false| G[Validate All Placeholders Filled]
+    F -->|true| H[Skip Validation]
+    G --> I[Send to Remote Service]
+    H --> I
+    I --> J[Process Response]
+    J --> K[Return to User]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ConnectorUtils` | Utility class containing constants and helper methods for connector operations |
+| `RemoteConnectorExecutor` | Interface defining the execution flow for remote connector invocations |
+| `AwsConnectorExecutor` | Implementation for AWS services using SigV4 authentication |
+| `HttpConnector` | Base connector implementation for HTTP-based services |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `name` | The name of the connector | Required |
+| `description` | A description of the connector | Required |
+| `version` | The connector version | Required |
+| `protocol` | Connection protocol (`aws_sigv4` for AWS, `http` for others) | Required |
+| `parameters.skip_validating_missing_parameters` | Skip validation of unfilled parameter placeholders | `false` |
+| `parameters.region` | AWS region (for AWS services) | - |
+| `parameters.service_name` | AWS service name (e.g., `sagemaker`, `bedrock`) | - |
+| `credential` | Authentication credentials (encrypted at rest) | Required |
+| `actions` | Array of actions the connector can perform | Required |
+
+### Usage Example
+
+#### Creating a Connector with Skip Validation
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "BedRock Claude Connector",
+  "description": "Connector to Amazon Bedrock Claude model",
+  "version": 1,
+  "protocol": "aws_sigv4",
+  "parameters": {
+    "region": "us-east-1",
+    "service_name": "bedrock",
+    "skip_validating_missing_parameters": "true"
+  },
+  "credential": {
+    "access_key": "<ACCESS_KEY>",
+    "secret_key": "<SECRET_KEY>"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-v2/invoke",
+      "headers": {
+        "content-type": "application/json"
+      },
+      "request_body": "{\"prompt\": \"${parameters.prompt}\"}"
+    }
+  ]
+}
+```
+
+#### Using the Connector for Prediction
+
+```json
+POST /_plugins/_ml/models/<model_id>/_predict
+{
+  "parameters": {
+    "prompt": "You are a ${parameters.role}"
+  }
+}
+```
+
+When `skip_validating_missing_parameters` is `true`, the `${parameters.role}` placeholder will be passed through to the model without triggering a validation error.
+
+## Limitations
+
+- Credentials are encrypted using AES/GCM/NoPadding but must be provided in plaintext during connector creation
+- When validation is skipped, malformed payloads may be sent to remote services
+- Connection limits and timeouts should be configured appropriately to avoid throttling from remote services
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#2830](https://github.com/opensearch-project/ml-commons/pull/2830) | Backport: Support skip_validating_missing_parameters in connector |
+| v2.17.0 | [#2812](https://github.com/opensearch-project/ml-commons/pull/2812) | Support skip_validating_missing_parameters in connector |
+
+## References
+
+- [Issue #2712](https://github.com/opensearch-project/ml-commons/issues/2712): KnowledgeBaseTool parameter placeholder error
+- [Connector Blueprints Documentation](https://docs.opensearch.org/2.17/ml-commons-plugin/remote-models/blueprints/): Official connector configuration guide
+- [Connectors Documentation](https://docs.opensearch.org/2.17/ml-commons-plugin/remote-models/connectors/): Connector overview and examples
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Added `skip_validating_missing_parameters` parameter to allow bypassing payload validation for unfilled parameter placeholders

--- a/docs/releases/v2.17.0/features/ml-commons/ml-commons-connector-enhancements.md
+++ b/docs/releases/v2.17.0/features/ml-commons/ml-commons-connector-enhancements.md
@@ -1,0 +1,108 @@
+# ML Commons Connector Enhancements
+
+## Summary
+
+This release adds a new `skip_validating_missing_parameters` parameter to ML Commons connectors, allowing users to bypass payload validation for missing parameter placeholders. This is particularly useful when using LLMs where prompts may intentionally contain unresolved `${parameters.xxx}` placeholders that should be passed through to the model.
+
+## Details
+
+### What's New in v2.17.0
+
+A new connector parameter `skip_validating_missing_parameters` has been introduced to control whether the connector validates that all parameter placeholders in the request payload have been filled.
+
+### Technical Changes
+
+#### Problem Solved
+
+When using ML Commons connectors with LLMs (e.g., Amazon Bedrock, OpenAI), prompts may contain substrings like `${parameters.role}` that are intended to be passed through to the model rather than being substituted. Previously, the connector's `validatePayload` function would throw an error: "Some parameter placeholder not filled in payload: xxx".
+
+This was particularly problematic when using tools like `KnowledgeBaseTool` where the output from one tool might contain parameter-like patterns that triggered validation errors.
+
+#### Solution
+
+The `skip_validating_missing_parameters` parameter allows users to disable this validation when needed.
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Remote Connector Execution"
+        A[Prepare Payload] --> B{skip_validating_missing_parameters?}
+        B -->|false/default| C[Validate Payload]
+        B -->|true| D[Skip Validation]
+        C --> E[Invoke Remote Service]
+        D --> E
+    end
+```
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `parameters.skip_validating_missing_parameters` | When set to `true`, skips validation of unfilled parameter placeholders in the request payload | `false` |
+
+### Usage Example
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "BedRock test connector",
+  "description": "The connector to BedRock service for claude model",
+  "version": 1,
+  "protocol": "aws_sigv4",
+  "parameters": {
+    "region": "us-east-1",
+    "service_name": "bedrock",
+    "anthropic_version": "bedrock-2023-05-31",
+    "endpoint": "bedrock-runtime.us-east-1.amazonaws.com",
+    "auth": "Sig_V4",
+    "content_type": "application/json",
+    "max_tokens_to_sample": 8000,
+    "temperature": 0.00001,
+    "skip_validating_missing_parameters": "true"
+  },
+  "credential": {
+    "access_key": "<YOUR_ACCESS_KEY>",
+    "secret_key": "<YOUR_SECRET_KEY>"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-instant-v1/invoke",
+      "headers": { 
+        "content-type": "application/json",
+        "x-amz-content-sha256": "required"
+      },
+      "request_body": "{\"prompt\":\"${parameters.prompt}\", \"max_tokens_to_sample\":${parameters.max_tokens_to_sample}, \"temperature\":${parameters.temperature}, \"anthropic_version\":\"${parameters.anthropic_version}\" }"
+    }
+  ]
+}
+```
+
+### Migration Notes
+
+- Existing connectors are unaffected as the default behavior (`false`) maintains backward compatibility
+- To enable the new behavior, add `"skip_validating_missing_parameters": "true"` to the connector's `parameters` section
+- The parameter value should be a string `"true"` or `"false"`
+
+## Limitations
+
+- When validation is skipped, malformed payloads with unfilled placeholders will be sent to the remote service, which may result in errors from the external API
+- Users should ensure their prompts and payloads are correctly formatted when using this option
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2830](https://github.com/opensearch-project/ml-commons/pull/2830) | Backport to 2.x: Support skip_validating_missing_parameters in connector |
+| [#2812](https://github.com/opensearch-project/ml-commons/pull/2812) | Original implementation: Support skip_validating_missing_parameters in connector |
+
+## References
+
+- [Issue #2712](https://github.com/opensearch-project/ml-commons/issues/2712): KnowledgeBaseTool may return parameter placeholder not filled error
+- [Connector Blueprints Documentation](https://docs.opensearch.org/2.17/ml-commons-plugin/remote-models/blueprints/): Official documentation for connector configuration
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/ml-commons-connector.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -62,6 +62,7 @@
 
 ### ml-commons
 - [ML Commons Bugfixes](features/ml-commons/ml-commons-bugfixes.md)
+- [ML Commons Connector Enhancements](features/ml-commons/ml-commons-connector-enhancements.md)
 - [ML Commons Test Fixes](features/ml-commons/ml-commons-test-fixes.md)
 - [ML Config API](features/ml-commons/ml-config-api.md)
 - [ML Inference Processor - One-to-One Support](features/ml-commons/ml-inference-processor.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the ML Commons Connector Enhancements feature introduced in OpenSearch v2.17.0.

### Changes

- **Release Report**: `docs/releases/v2.17.0/features/ml-commons/ml-commons-connector-enhancements.md`
  - Documents the new `skip_validating_missing_parameters` parameter
  - Includes usage examples and migration notes

- **Feature Report**: `docs/features/ml-commons/ml-commons-connector.md`
  - Comprehensive documentation of ML Commons Connector functionality
  - Architecture diagrams and configuration reference

### Key Feature

The `skip_validating_missing_parameters` parameter allows users to bypass payload validation for missing parameter placeholders in ML Commons connectors. This is useful when using LLMs where prompts may intentionally contain unresolved `${parameters.xxx}` placeholders.

### Related

- Closes #393
- PR: [opensearch-project/ml-commons#2830](https://github.com/opensearch-project/ml-commons/pull/2830)
- Issue: [opensearch-project/ml-commons#2712](https://github.com/opensearch-project/ml-commons/issues/2712)