### PR TITLE
docs: add ML Commons Memory Metadata report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -129,6 +129,7 @@
 - [ML Commons Connector](ml-commons/ml-commons-connector.md)
 - [ML Commons Connector Blueprints](ml-commons/ml-commons-blueprints.md)
 - [ML Commons MCP (Model Context Protocol)](ml-commons/ml-commons-mcp.md)
+- [ML Commons Memory Metadata](ml-commons/ml-commons-memory-metadata.md)
 - [ML Commons Stability and Reliability](ml-commons/ml-commons-stability.md)
 - [ML Commons Test Fixes](ml-commons/ml-commons-test-fixes.md)
 - [ML Config API](ml-commons/ml-config-api.md)

--- a/docs/features/ml-commons/ml-commons-memory-metadata.md
+++ b/docs/features/ml-commons/ml-commons-memory-metadata.md
@@ -1,0 +1,180 @@
+# ML Commons Memory Metadata
+
+## Summary
+
+ML Commons Memory Metadata provides a flexible mechanism to store custom key-value pairs alongside conversational memory in OpenSearch. This feature enables applications to associate arbitrary metadata—such as agent IDs, prompt templates, session context, or application-specific data—with conversation memories, enhancing context management for conversational search and AI agent workflows.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Memory API"
+        API[Memory REST API]
+        Handler[ConversationalMemoryHandler]
+        MetaIndex[ConversationMetaIndex]
+    end
+    
+    subgraph "Storage"
+        Index[".plugins-ml-memory-meta"]
+    end
+    
+    subgraph "Memory Document"
+        ID[memory_id]
+        Name[name]
+        User[user]
+        AppType[application_type]
+        AdditionalInfo[additional_info]
+        Timestamps[create_time / updated_time]
+    end
+    
+    API --> Handler
+    Handler --> MetaIndex
+    MetaIndex --> Index
+    Index --> ID
+    Index --> Name
+    Index --> User
+    Index --> AppType
+    Index --> AdditionalInfo
+    Index --> Timestamps
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Client Request] --> B{Create/Update Memory}
+    B --> C[CreateConversationRequest]
+    C --> D[Parse additional_info]
+    D --> E[ConversationalMemoryHandler]
+    E --> F[ConversationMetaIndex]
+    F --> G[Index Document]
+    G --> H[Return memory_id]
+    
+    I[Search Request] --> J[Query additional_info fields]
+    J --> K[flat_object query]
+    K --> L[Return matching memories]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ConversationMeta` | Data class holding memory metadata including additional_info |
+| `ConversationalIndexConstants` | Constants including META_ADDITIONAL_INFO_FIELD |
+| `CreateConversationRequest` | Request class with additional_info parameter |
+| `CreateConversationTransportAction` | Transport action handling memory creation |
+| `ConversationMetaIndex` | Index operations for memory metadata |
+| `OpenSearchConversationalMemoryHandler` | High-level handler for memory operations |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ml_commons.memory_feature_enabled` | Enable/disable memory feature | `true` |
+
+### Index Mapping
+
+The memory metadata index uses the following mapping for the `additional_info` field:
+
+```json
+{
+  ".plugins-ml-memory-meta": {
+    "mappings": {
+      "_meta": {
+        "schema_version": 2
+      },
+      "properties": {
+        "additional_info": {
+          "type": "flat_object"
+        },
+        "application_type": {
+          "type": "keyword"
+        },
+        "create_time": {
+          "type": "date",
+          "format": "strict_date_time||epoch_millis"
+        },
+        "name": {
+          "type": "text"
+        },
+        "updated_time": {
+          "type": "date",
+          "format": "strict_date_time||epoch_millis"
+        },
+        "user": {
+          "type": "keyword"
+        }
+      }
+    }
+  }
+}
+```
+
+### Usage Example
+
+**Create Memory with Additional Info:**
+
+```bash
+curl -X POST "http://localhost:9200/_plugins/_ml/memory" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Customer Support Session",
+    "additional_info": {
+      "agent_id": "support-agent-v1",
+      "customer_tier": "premium",
+      "session_source": "web-chat"
+    }
+  }'
+```
+
+**Search Memories by Additional Info:**
+
+```bash
+curl -X POST "http://localhost:9200/_plugins/_ml/memory/_search" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "query": {
+      "match": {
+        "additional_info.agent_id": "support-agent-v1"
+      }
+    }
+  }'
+```
+
+**Update Memory Additional Info:**
+
+```bash
+curl -X PUT "http://localhost:9200/_plugins/_ml/memory/{memory_id}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "additional_info": {
+      "agent_id": "support-agent-v2",
+      "escalated": "true"
+    }
+  }'
+```
+
+## Limitations
+
+- The `additional_info` field stores values as strings (`Map<String, String>`)
+- Uses `flat_object` field type which has specific query behavior compared to nested objects
+- Security mode is `private` - only the creating user can access their memories
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#2750](https://github.com/opensearch-project/ml-commons/pull/2750) | Adding additional info for memory metadata |
+
+## References
+
+- [Issue #2755](https://github.com/opensearch-project/ml-commons/issues/2755): Original feature request
+- [Issue #2632](https://github.com/opensearch-project/ml-commons/issues/2632): Related application_type discussion
+- [Memory APIs Documentation](https://docs.opensearch.org/latest/ml-commons-plugin/api/memory-apis/index/): Official Memory API documentation
+- [Conversational Search](https://docs.opensearch.org/latest/search-plugins/conversational-search/): Conversational search overview
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Added `additional_info` field to memory metadata for storing custom key-value pairs

--- a/docs/releases/v2.17.0/features/ml-commons/ml-commons-memory-metadata.md
+++ b/docs/releases/v2.17.0/features/ml-commons/ml-commons-memory-metadata.md
@@ -1,0 +1,139 @@
+# ML Commons Memory Metadata
+
+## Summary
+
+This enhancement adds a new `additional_info` field to the memory metadata in ML Commons, allowing users to store custom key-value pairs alongside conversational memory. This enables applications to associate arbitrary metadata (such as agent IDs, prompt information, or application-specific data) with conversation memories for better context management in conversational search scenarios.
+
+## Details
+
+### What's New in v2.17.0
+
+The Memory API now supports an `additional_info` field that can store flexible key-value metadata using the `flat_object` field type. This field can be set during memory creation, updated later, and queried using standard OpenSearch queries.
+
+### Technical Changes
+
+#### Index Schema Update
+
+The memory metadata index (`.plugins-ml-memory-meta`) schema version was bumped from 1 to 2 with the new field:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `additional_info` | `flat_object` | Stores arbitrary key-value pairs as metadata |
+
+#### API Changes
+
+**Create Memory with Additional Info:**
+
+```json
+POST /_plugins/_ml/memory
+{
+  "name": "test memory",
+  "additional_info": {
+    "agent_id": "abc123",
+    "prompt_template": "default"
+  }
+}
+```
+
+**Response:**
+
+```json
+{
+  "memory_id": "ZTjeBpEB_JGSOCuj5ARu"
+}
+```
+
+**Get Memory Response:**
+
+```json
+{
+  "memory_id": "ZTjeBpEB_JGSOCuj5ARu",
+  "create_time": "2024-07-31T03:39:16.462676Z",
+  "updated_time": "2024-07-31T03:39:16.462676Z",
+  "name": "test memory",
+  "user": "admin",
+  "additional_info": {
+    "agent_id": "abc123",
+    "prompt_template": "default"
+  }
+}
+```
+
+**Search Memory by Additional Info:**
+
+```json
+POST /_plugins/_ml/memory/_search
+{
+  "query": {
+    "match": {
+      "additional_info.agent_id": "abc123"
+    }
+  }
+}
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ConversationalIndexConstants.META_ADDITIONAL_INFO_FIELD` | Constant for the new field name |
+| `ConversationMeta.additionalInfos` | Field in the ConversationMeta class |
+| `CreateConversationRequest.additionalInfos` | Request parameter for additional info |
+
+#### Version Compatibility
+
+The `additional_info` field is supported from version 2.17.0 onwards. The implementation includes version checks (`MINIMAL_SUPPORTED_VERSION_FOR_ADDITIONAL_INFO`) to ensure backward compatibility during rolling upgrades.
+
+### Usage Example
+
+```bash
+# Create memory with additional info
+curl -X POST "http://localhost:9200/_plugins/_ml/memory" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "RAG conversation",
+    "additional_info": {
+      "agent_id": "my-agent",
+      "session_type": "customer-support"
+    }
+  }'
+
+# Update memory with additional info
+curl -X PUT "http://localhost:9200/_plugins/_ml/memory/{memory_id}" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "Updated conversation",
+    "additional_info": {
+      "agent_id": "my-agent",
+      "session_type": "sales"
+    }
+  }'
+```
+
+### Migration Notes
+
+- Existing memories created before v2.17.0 will have an empty `additional_info` object (`{}`)
+- No migration is required; the field is automatically available after upgrade
+- The `flat_object` type allows flexible schema for the additional info content
+
+## Limitations
+
+- The `additional_info` field values must be strings (stored as `Map<String, String>`)
+- The field uses `flat_object` type which has specific query limitations compared to nested objects
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2750](https://github.com/opensearch-project/ml-commons/pull/2750) | Adding additional info for memory metadata |
+
+## References
+
+- [Issue #2755](https://github.com/opensearch-project/ml-commons/issues/2755): Feature request for additional_info field
+- [Issue #2632](https://github.com/opensearch-project/ml-commons/issues/2632): Related discussion on application_type field
+- [Memory APIs Documentation](https://docs.opensearch.org/2.17/ml-commons-plugin/api/memory-apis/index/): Official Memory API docs
+- [Create Memory API](https://docs.opensearch.org/2.17/ml-commons-plugin/api/memory-apis/create-memory/): Create memory documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/ml-commons/ml-commons-memory-metadata.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -63,6 +63,7 @@
 ### ml-commons
 - [ML Commons Bugfixes](features/ml-commons/ml-commons-bugfixes.md)
 - [ML Commons Connector Enhancements](features/ml-commons/ml-commons-connector-enhancements.md)
+- [ML Commons Memory Metadata](features/ml-commons/ml-commons-memory-metadata.md)
 - [ML Commons Test Fixes](features/ml-commons/ml-commons-test-fixes.md)
 - [ML Config API](features/ml-commons/ml-config-api.md)
 - [ML Inference Processor - One-to-One Support](features/ml-commons/ml-inference-processor.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the ML Commons Memory Metadata enhancement introduced in v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/ml-commons/ml-commons-memory-metadata.md`
- Feature report: `docs/features/ml-commons/ml-commons-memory-metadata.md`

### Key Changes in v2.17.0
- Added `additional_info` field to memory metadata for storing custom key-value pairs
- Index schema version bumped from 1 to 2
- New field uses `flat_object` type for flexible metadata storage
- Supports create, update, and search operations on additional info

### Resources Used
- PR: [opensearch-project/ml-commons#2750](https://github.com/opensearch-project/ml-commons/pull/2750)
- Issue: [opensearch-project/ml-commons#2755](https://github.com/opensearch-project/ml-commons/issues/2755)
- Docs: [Memory APIs](https://docs.opensearch.org/2.17/ml-commons-plugin/api/memory-apis/index/)

Closes #392