### PR TITLE
docs: add Dashboards UI Updates report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -49,6 +49,7 @@
 - [Dashboards CI/CD & Documentation](opensearch-dashboards/dashboards-ci-cd-documentation.md)
 - [Dashboards Cypress Testing](opensearch-dashboards/dashboards-cypress-testing.md)
 - [Dashboards Frontend Cleanup](opensearch-dashboards/dashboards-frontend-cleanup.md)
+- [Dashboards UI Updates (OUI)](opensearch-dashboards/dashboards-ui-updates.md)
 - [Dashboards UI/UX Fixes](opensearch-dashboards/dashboards-ui-ux-fixes.md)
 - [Data Importer](opensearch-dashboards/data-importer.md)
 - [DOMPurify Sanitization](opensearch-dashboards/dompurify-sanitization.md)

--- a/docs/features/opensearch-dashboards/dashboards-ui-updates.md
+++ b/docs/features/opensearch-dashboards/dashboards-ui-updates.md
@@ -1,0 +1,117 @@
+# Dashboards UI Updates (OUI)
+
+## Summary
+
+OpenSearch Dashboards uses the OpenSearch UI (OUI) component library for consistent visual design. This feature tracks OUI library upgrades and associated header/navigation styling improvements that enhance the look and feel of the application.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        subgraph "OUI Component Library"
+            OUI[OUI Package]
+            THEME[Theme System]
+            COMP[UI Components]
+        end
+        
+        subgraph "Header Components"
+            HEADER[Application Header]
+            TITLE[Page Title]
+            NAV[Navigation Controls]
+            RECENT[Recent Items]
+        end
+        
+        subgraph "Styling"
+            SCSS[SCSS Styles]
+            CSS[CSS Variables]
+        end
+    end
+    
+    OUI --> THEME
+    OUI --> COMP
+    COMP --> HEADER
+    HEADER --> TITLE
+    HEADER --> NAV
+    HEADER --> RECENT
+    THEME --> SCSS
+    SCSS --> CSS
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| OUI Package | OpenSearch UI component library (`@opensearch-project/oui`) |
+| Theme System | Light/dark theme support with CSS variables |
+| Application Header | Top navigation bar with title, breadcrumbs, and controls |
+| Page Title | Application/page title display using `EuiTitle` |
+| Recent Items | Quick access to recently viewed items |
+| Navigation Controls | Action buttons and menu items in header |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `home:useNewHomePage` | Enable new home page with updated header | `false` |
+| Theme selection | Light/dark theme via Advanced Settings | System default |
+
+### Usage Example
+
+The OUI components are used throughout the application:
+
+```typescript
+import { EuiTitle, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
+
+// Page title in header
+<EuiTitle size="l" className="newTopNavHeaderTitle">
+  <h1>{pageTitle}</h1>
+</EuiTitle>
+
+// Recent items button with tooltip
+<EuiToolTip content="Recents" delay="long" position="bottom">
+  <EuiButtonIcon
+    iconType="recent"
+    color="text"
+    size="xs"
+    aria-label="View recents"
+    onClick={handleClick}
+  />
+</EuiToolTip>
+```
+
+### CSS Classes
+
+| Class | Purpose |
+|-------|---------|
+| `.newTopNavHeader` | Main header container with updated spacing |
+| `.newTopNavHeaderTitle` | Page title styling (font-size: 2rem) |
+| `.headerAppActionMenu` | Action menu container with gap spacing |
+| `.headerRecentItemsButton` | Recent items button styling |
+| `.primaryApplicationHeader` | Application-specific header with border |
+
+## Limitations
+
+- OUI upgrades may require snapshot test updates
+- CSS `:has()` selector used in some styles may not work in older browsers
+- Custom themes may need adjustment for new header styling
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#7741](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7741) | Revisit updated header spacing, bump OUI to 1.10.0 |
+| v2.17.0 | [#7799](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7799) | Add iconGap to TopNavControl, bump OUI to 1.11.0 |
+| v2.17.0 | [#7865](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7865) | Update OUI to 1.12 |
+| v2.17.0 | [#7637](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7637) | Introduce redesign page and application headers, update OUI to 1.9.0 |
+
+## References
+
+- [OUI Repository](https://github.com/opensearch-project/oui)
+- [OpenSearch Dashboards Repository](https://github.com/opensearch-project/OpenSearch-Dashboards)
+
+## Change History
+
+- **v2.17.0** (2024-09-17): OUI upgrades from 1.9.0 to 1.12.0, header spacing improvements, recent items button refactoring

--- a/docs/releases/v2.17.0/features/opensearch-dashboards/dashboards-ui-updates.md
+++ b/docs/releases/v2.17.0/features/opensearch-dashboards/dashboards-ui-updates.md
@@ -1,0 +1,87 @@
+# Dashboards UI Updates
+
+## Summary
+
+OpenSearch Dashboards v2.17.0 includes UI updates focused on header spacing improvements and OUI (OpenSearch UI) library upgrade to version 1.10.0. These changes enhance the visual consistency and user experience of the application header and navigation components.
+
+## Details
+
+### What's New in v2.17.0
+
+This release updates the OpenSearch UI (OUI) component library from version 1.9.0 to 1.10.0 and refines header spacing throughout the application.
+
+### Technical Changes
+
+#### OUI Library Upgrade
+
+The `@opensearch-project/oui` package was upgraded from 1.9.0 to 1.10.0 across multiple packages:
+
+| Package | Change |
+|---------|--------|
+| `package.json` | OUI 1.9.0 → 1.10.0 |
+| `packages/osd-ui-framework/package.json` | OUI 1.9.0 → 1.10.0 |
+| `packages/osd-ui-shared-deps/package.json` | OUI 1.9.0 → 1.10.0 |
+| Test plugin packages | OUI 1.9.0 → 1.10.0 |
+
+#### Header Spacing Improvements
+
+The new top navigation header received significant styling updates:
+
+| Component | Change |
+|-----------|--------|
+| `.newTopNavHeader` | Added padding, gap spacing, and border-bottom for application header |
+| `.newTopNavHeaderTitle` | New class for consistent title styling with `font-size: 2rem` |
+| `.headerAppActionMenu` | Improved gap spacing for action menu items |
+| `.headerRecentItemsButton` | Simplified styling with margin adjustments |
+
+#### Recent Items Button Refactoring
+
+The recent items button was refactored from `EuiHeaderSectionItemButton` to `EuiButtonIcon` with `EuiToolTip`:
+
+- Changed icon from `recentlyViewedApp` to `recent`
+- Added tooltip with "Recents" label
+- Improved accessibility with `aria-label` and `aria-expanded` attributes
+- Consistent button sizing with `size="xs"`
+
+#### Application Title Changes
+
+The application title in the header was updated:
+
+- Changed from `EuiText` with `<h2>` to `EuiTitle` with `<h1>`
+- Added `newTopNavHeaderTitle` class for consistent styling
+- Improved semantic HTML structure
+
+### Usage Example
+
+The header changes are automatically applied when using the new top navigation. No configuration changes are required.
+
+```typescript
+// The header automatically uses the updated styling
+// when useNewHomePage is enabled
+```
+
+### Migration Notes
+
+- No breaking changes for existing implementations
+- Snapshot tests may need updating due to component structure changes
+- Custom CSS targeting old header classes may need adjustment
+
+## Limitations
+
+- Header spacing changes are specific to the new top navigation design
+- Some styling uses CSS `:has()` selector which may not work in older browsers
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#7741](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7741) | Revisit updated header spacing, bump OUI to 1.10.0 |
+
+## References
+
+- [OUI 1.10.0 Release](https://github.com/opensearch-project/oui/releases)
+- [OpenSearch Dashboards Repository](https://github.com/opensearch-project/OpenSearch-Dashboards)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/dashboards-ui-updates.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -29,6 +29,9 @@
 - [Dashboards Bugfixes](features/dashboards-search-relevance/dashboards-bugfixes.md)
 - [Documentation Link Updates](features/dashboards-search-relevance/documentation-link-updates.md)
 
+### opensearch-dashboards
+- [Dashboards UI Updates](features/opensearch-dashboards/dashboards-ui-updates.md)
+
 ### documentation-website
 - [Top N API Documentation Update](features/documentation-website/top-n-api-documentation.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dashboards UI Updates feature in OpenSearch v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/opensearch-dashboards/dashboards-ui-updates.md`
- Feature report: `docs/features/opensearch-dashboards/dashboards-ui-updates.md`

### Key Changes in v2.17.0
- OUI (OpenSearch UI) library upgrade from 1.9.0 to 1.10.0
- Header spacing improvements for new top navigation
- Recent items button refactoring with tooltip and improved accessibility
- Application title styling updates (EuiText → EuiTitle)

### Resources Used
- PR: [#7741](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7741) - Revisit updated header spacing, bump OUI to 1.10.0

Closes #390