### PR TITLE
docs: add Multi-Data Source Support report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -119,6 +119,7 @@
 - [Dependency Bumps](multi-plugin/dependency-bumps.md)
 - [JDK 21 & Java Agent Migration](multi-plugin/jdk-21-java-agent-migration.md)
 - [Maintainer Updates](multi-plugin/maintainer-updates.md)
+- [Multi-Data Source Support](multi-plugin/multi-data-source-support.md)
 - [Version Bumps & Release Notes](multi-plugin/version-bumps-release-notes.md)
 
 ## opensearch-remote-metadata-sdk

--- a/docs/features/multi-plugin/multi-data-source-support.md
+++ b/docs/features/multi-plugin/multi-data-source-support.md
@@ -1,0 +1,160 @@
+# Multi-Data Source Support
+
+## Summary
+
+Multi-Data Source (MDS) is a feature in OpenSearch Dashboards that allows users to connect to and manage multiple OpenSearch clusters from a single Dashboards instance. This enables centralized monitoring, querying, and visualization across different data sources without switching between multiple Dashboards deployments.
+
+MDS support has been progressively added to various OpenSearch Dashboards plugins, allowing each plugin to work with data from different connected clusters.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        DSP[Data Source Plugin]
+        DSM[Data Source Management Plugin]
+        
+        subgraph "MDS-Enabled Plugins"
+            NOT[Notifications]
+            SEC[Security]
+            AD[Anomaly Detection]
+            ISM[Index Management]
+            ML[Machine Learning]
+            MAPS[Maps]
+            SR[Search Relevance]
+            SA[Security Analytics]
+            ALT[Alerting]
+        end
+        
+        subgraph "MDS-Incompatible Plugins"
+            REP[Reporting - De-registered]
+        end
+    end
+    
+    subgraph "Data Sources"
+        LC[Local Cluster]
+        RC1[Remote Cluster 1]
+        RC2[Remote Cluster 2]
+    end
+    
+    DSP --> DSM
+    DSM --> NOT
+    DSM --> SEC
+    DSM --> AD
+    DSM --> ISM
+    DSM --> ML
+    DSM --> MAPS
+    DSM --> SR
+    DSM --> SA
+    DSM --> ALT
+    
+    DSP -.->|disabled| REP
+    
+    NOT --> LC
+    NOT --> RC1
+    NOT --> RC2
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    User[User] --> Select[Select Data Source]
+    Select --> DSPicker[Data Source Picker]
+    DSPicker --> URL[URL with dataSourceId]
+    URL --> Plugin[Plugin Component]
+    Plugin --> API[API Call with dataSourceId]
+    API --> Router[Server Router]
+    Router --> Client[OpenSearch Client]
+    Client --> Cluster[Target Cluster]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Data Source Plugin | Core plugin that manages data source connections and authentication |
+| Data Source Management Plugin | UI for creating, editing, and managing data source connections |
+| Data Source Picker | Dropdown component for selecting active data source |
+| `dataSourceId` | Unique identifier for each connected data source |
+| `DataSourceMenuContext` | React context for sharing data source state across components |
+| `dataSourceObservable` | RxJS BehaviorSubject for reactive data source state management |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `data_source.enabled` | Enable/disable MDS feature | `false` |
+| `data_source.hideLocalCluster` | Hide local cluster from data source picker | `false` |
+| `data_source.authTypes.NoAuthentication.enabled` | Show/hide no authentication option | `true` |
+| `data_source.authTypes.UsernamePassword.enabled` | Show/hide username/password authentication | `true` |
+| `data_source.authTypes.AWSSigV4.enabled` | Show/hide AWS SigV4 authentication | `true` |
+
+### Usage Example
+
+Enable MDS in `opensearch_dashboards.yml`:
+
+```yaml
+data_source.enabled: true
+```
+
+Create a data source connection via API:
+
+```json
+POST /_plugins/_query/_datasources
+{
+  "name": "remote-cluster",
+  "connector": "OPENSEARCH",
+  "properties": {
+    "opensearch.host": "https://remote-cluster:9200",
+    "opensearch.auth.type": "basicauth",
+    "opensearch.auth.username": "admin",
+    "opensearch.auth.password": "admin"
+  }
+}
+```
+
+### Plugin Support Matrix
+
+| Plugin | MDS Support | Version Introduced |
+|--------|-------------|-------------------|
+| Index Management | ✅ Yes | v2.14.0 |
+| Anomaly Detection | ✅ Yes | v2.14.0 |
+| Security | ✅ Yes | v2.14.0 |
+| Maps | ✅ Yes | v2.14.0 |
+| Machine Learning | ✅ Yes | v2.14.0 |
+| Notifications | ✅ Yes | v2.14.0 |
+| Search Relevance | ✅ Yes | v2.14.0 |
+| Security Analytics | ✅ Yes | v2.15.0 |
+| Alerting | ✅ Yes | v2.15.0 |
+| Reporting | ❌ No | N/A (de-registered when MDS enabled) |
+
+## Limitations
+
+- Timeline visualization types are not supported with MDS
+- The `gantt-chart` plugin is not supported with MDS
+- Reporting plugin is automatically de-registered when MDS is enabled
+- Some plugins may have version compatibility requirements between Dashboards and connected clusters
+- Data source connections require appropriate network access and authentication credentials
+
+## Related PRs
+
+| Version | PR | Repository | Description |
+|---------|-----|------------|-------------|
+| v2.17.0 | [#411](https://github.com/opensearch-project/dashboards-reporting/pull/411) | dashboards-reporting | De-register reporting when MDS is enabled |
+| v2.17.0 | [#249](https://github.com/opensearch-project/dashboards-notifications/pull/249) | dashboards-notifications | Persist dataSourceId across applications |
+| v2.14.0 | [#186](https://github.com/opensearch-project/dashboards-notifications/pull/186) | dashboards-notifications | Initial MDS support in Notifications |
+
+## References
+
+- [Documentation](https://docs.opensearch.org/2.17/dashboards/management/multi-data-sources/): Configuring and using multiple data sources
+- [Data Sources Overview](https://docs.opensearch.org/2.17/dashboards/management/data-sources/): Data sources management
+- [Issue #159](https://github.com/opensearch-project/dashboards-notifications/issues/159): Original MDS feature request for Notifications
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Reporting plugin de-registers when MDS enabled; Notifications persists dataSourceId in URL for new navigation
+- **v2.15.0** (2024-06-25): Added MDS support to Security Analytics and Alerting plugins
+- **v2.14.0** (2024-05-02): Initial MDS support added to multiple plugins including Notifications, Index Management, Anomaly Detection, Security, Maps, Machine Learning, and Search Relevance

--- a/docs/releases/v2.17.0/features/multi-plugin/multi-data-source-support.md
+++ b/docs/releases/v2.17.0/features/multi-plugin/multi-data-source-support.md
@@ -1,0 +1,110 @@
+# Multi-Data Source Support
+
+## Summary
+
+OpenSearch Dashboards v2.17.0 enhances Multi-Data Source (MDS) support across multiple plugins. The Reporting plugin now de-registers when MDS is enabled (since reporting doesn't support MDS), and the Notifications plugin improves data source ID persistence across application navigation with the new navigation experience.
+
+## Details
+
+### What's New in v2.17.0
+
+This release includes two key MDS-related enhancements:
+
+1. **Reporting Plugin De-registration**: The dashboards-reporting plugin now automatically de-registers itself when MDS is enabled, preventing users from accessing unsupported functionality.
+
+2. **Notifications Data Source Persistence**: The dashboards-notifications plugin now persists the selected `dataSourceId` in the URL when navigating between pages under the new navigation experience.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        DS[Data Source Plugin]
+        DSM[Data Source Management]
+        
+        subgraph "Plugin Behavior with MDS"
+            REP[Reporting Plugin]
+            NOT[Notifications Plugin]
+        end
+    end
+    
+    DS -->|enabled| REP
+    REP -->|de-registers| HIDDEN[Hidden from UI]
+    
+    DS -->|enabled| NOT
+    NOT -->|persists dataSourceId| URL[URL State]
+    URL -->|maintains context| NAV[Cross-App Navigation]
+```
+
+#### Reporting Plugin Changes
+
+The reporting plugin checks for the presence of the `dataSource` plugin during setup. If MDS is enabled, the plugin skips application registration:
+
+| Behavior | MDS Disabled | MDS Enabled |
+|----------|--------------|-------------|
+| Application Registration | Registered | Skipped |
+| Side Navigation | Visible | Hidden |
+| Report Generation | Available | Unavailable |
+
+#### Notifications Plugin Changes
+
+| Component | Change | Purpose |
+|-----------|--------|---------|
+| `MDSEnabledComponent` | Added `useUpdateUrlWithDataSourceProperties` hook | Persist dataSourceId in URL |
+| `PageHeader` | Integrated URL update hook | Automatic URL sync on page load |
+| `EmailSenders` | Integrated URL update hook | Maintain context in email sender pages |
+| `Main.tsx` | Added `dataSourceObservable` subscription | Track data source changes |
+| `plugin.ts` | Added `appStateUpdater` with `updater$` | Update default routes with dataSourceId |
+| `constants.ts` | Added `dataSourceObservable` BehaviorSubject | Global data source state management |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `data_source.enabled` | Enable/disable MDS feature | `false` |
+| `data_source.hideLocalCluster` | Hide local cluster option | `false` |
+
+### Usage Example
+
+When MDS is enabled, the Notifications plugin automatically appends the `dataSourceId` to URLs:
+
+```
+# Before navigation
+/app/notifications#/channels
+
+# After selecting a data source
+/app/notifications#/channels?dataSourceId=abc123
+```
+
+This ensures that when users navigate between Channels, Email Senders, and Email Recipient Groups, the selected data source context is preserved.
+
+### Migration Notes
+
+- **Reporting users**: If you rely on the Reporting plugin and plan to enable MDS, note that reporting functionality will be unavailable. Consider disabling MDS or using alternative reporting methods.
+- **Notifications users**: No action required. The data source persistence is automatic when MDS is enabled.
+
+## Limitations
+
+- The Reporting plugin does not support MDS and is completely hidden when MDS is enabled
+- Data source persistence in Notifications requires the new navigation experience to be enabled
+- The `dataSourceId` URL parameter is only added when `multiDataSourceEnabled` is true
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#411](https://github.com/opensearch-project/dashboards-reporting/pull/411) | dashboards-reporting | De-register reporting when MDS is enabled |
+| [#249](https://github.com/opensearch-project/dashboards-notifications/pull/249) | dashboards-notifications | Persist dataSourceId across applications under new Nav change |
+
+## References
+
+- [PR #411](https://github.com/opensearch-project/dashboards-reporting/pull/411): De-register reporting when MDS is enabled
+- [PR #249](https://github.com/opensearch-project/dashboards-notifications/pull/249): Persist dataSourceId across applications
+- [PR #244](https://github.com/opensearch-project/dashboards-notifications/pull/244): Original implementation (main branch)
+- [Documentation](https://docs.opensearch.org/2.17/dashboards/management/multi-data-sources/): Configuring and using multiple data sources
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/multi-plugin/multi-data-source-support.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -86,6 +86,7 @@
 ### multi-plugin
 - [CI/Infrastructure Fixes](features/multi-plugin/ci-infrastructure-fixes.md)
 - [Maintainer Updates](features/multi-plugin/maintainer-updates.md)
+- [Multi-Data Source Support](features/multi-plugin/multi-data-source-support.md)
 - [Release Notes and Version Updates](features/multi-plugin/release-notes-and-version-updates.md)
 
 ### performance-analyzer


### PR DESCRIPTION
## Summary

This PR adds documentation for the Multi-Data Source Support enhancement in OpenSearch v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/multi-plugin/multi-data-source-support.md`
- Feature report: `docs/features/multi-plugin/multi-data-source-support.md`

### Key Changes in v2.17.0
- **Reporting Plugin De-registration**: The dashboards-reporting plugin now automatically de-registers when MDS is enabled
- **Notifications Data Source Persistence**: The dashboards-notifications plugin now persists the selected `dataSourceId` in the URL when navigating between pages

### Related PRs
- [dashboards-reporting#411](https://github.com/opensearch-project/dashboards-reporting/pull/411): De-register reporting when MDS is enabled
- [dashboards-notifications#249](https://github.com/opensearch-project/dashboards-notifications/pull/249): Persist dataSourceId across applications

### Related Issue
Closes #389