### PR TITLE
docs: add common-infrastructure report for v2.17.0

### DIFF
--- a/docs/features/common/pr-template-api-spec.md
+++ b/docs/features/common/pr-template-api-spec.md
@@ -1,0 +1,102 @@
+# PR Template API Specification Checkbox
+
+## Summary
+
+The OpenSearch project maintains standardized pull request templates across all repositories to ensure consistent contribution workflows. A key enhancement was the addition of an API specification checkbox that reminds contributors to document API changes in the central OpenAPI specification repository, ensuring language client libraries remain synchronized with API changes.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Contribution Workflow"
+        PR[Pull Request] --> Template[PR Template]
+        Template --> Checklist[Checklist Items]
+    end
+    
+    subgraph "API Documentation"
+        Checklist --> APISpec[API Specification PR]
+        APISpec --> OpenAPI[OpenAPI Spec Repository]
+        OpenAPI --> Clients[Language Clients]
+    end
+    
+    subgraph "Documentation"
+        Checklist --> Docs[Documentation PR]
+        Docs --> Website[Documentation Website]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Contributor] --> B[Create PR]
+    B --> C[PR Template Displayed]
+    C --> D{API Changes?}
+    D -->|Yes| E[Create API Spec PR]
+    D -->|No| F[Skip]
+    E --> G[Check Checkbox]
+    F --> G
+    G --> H[Submit PR]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| PULL_REQUEST_TEMPLATE.md | GitHub template displayed when creating PRs |
+| API Spec Checkbox | Checklist item for API documentation |
+| DCO Signoff | Developer Certificate of Origin requirement |
+| Documentation Checkbox | Reminder for public documentation |
+
+### Configuration
+
+The PR template is located at `.github/PULL_REQUEST_TEMPLATE.md` in each repository.
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Template Location | Path to PR template | `.github/PULL_REQUEST_TEMPLATE.md` |
+| API Spec Link | Link to developer guide | opensearch-api-specification DEVELOPER_GUIDE.md |
+| Docs Link | Link to create documentation issue | documentation-website issues |
+
+### Usage Example
+
+```markdown
+### Description
+[Describe what this change achieves]
+
+### Related Issues
+Resolves #[Issue number to be closed when this PR is merged]
+
+### Check List
+- [x] New functionality includes testing.
+- [x] New functionality has been documented.
+- [x] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
+- [x] Commits are signed per the DCO using `--signoff`.
+- [x] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).
+
+By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
+```
+
+## Limitations
+
+- No automated enforcement of the API spec checkbox
+- Relies on contributor and reviewer diligence
+- Each repository maintains its own template copy
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#696](https://github.com/opensearch-project/common-utils/pull/696) | Add API spec checkbox to common-utils |
+
+## References
+
+- [Issue #387](https://github.com/opensearch-project/opensearch-api-specification/issues/387): Original proposal for API spec checkbox
+- [OpenSearch API Specification](https://github.com/opensearch-project/opensearch-api-specification): Central API specification repository
+- [Developer Guide](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md): Guide for contributing API specs
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Added API specification checkbox to PR template

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -211,6 +211,10 @@
 
 - [Index Management Dashboards](index-management-dashboards/index-management-dashboards.md)
 
+## common
+
+- [PR Template API Specification Checkbox](common/pr-template-api-spec.md)
+
 ## common-utils
 
 - [Alerting Context Variables](common-utils/alerting-context-variables.md)

--- a/docs/releases/v2.17.0/features/common/common-infrastructure.md
+++ b/docs/releases/v2.17.0/features/common/common-infrastructure.md
@@ -1,0 +1,67 @@
+# Common Infrastructure
+
+## Summary
+
+This release item updates the pull request template across OpenSearch repositories to include a checkbox requiring contributors to document API changes in the OpenAPI specification. This enhancement improves the consistency of API documentation and ensures that language client libraries stay synchronized with API changes.
+
+## Details
+
+### What's New in v2.17.0
+
+The `PULL_REQUEST_TEMPLATE.md` in the common-utils repository was updated to include a new checklist item that prompts contributors to create companion pull requests for API specification changes.
+
+### Technical Changes
+
+#### Template Updates
+
+The pull request template was restructured with the following changes:
+
+| Section | Before | After |
+|---------|--------|-------|
+| Issues Section | "Issues Resolved" | "Related Issues" with clearer format |
+| Checklist | Basic testing/docs items | Added API spec change checkbox |
+| DCO Reference | Linked to OpenSearch repo | Linked to common-utils repo |
+
+#### New Checklist Items
+
+```markdown
+### Check List
+- [ ] New functionality includes testing.
+- [ ] New functionality has been documented.
+- [ ] API changes companion pull request [created](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md).
+- [ ] Commits are signed per the DCO using `--signoff`.
+- [ ] Public documentation issue/PR [created](https://github.com/opensearch-project/documentation-website/issues/new/choose).
+```
+
+### Usage Example
+
+When creating a pull request that includes API changes, contributors should:
+
+1. Create the main PR in the plugin repository
+2. Create a companion PR in [opensearch-api-specification](https://github.com/opensearch-project/opensearch-api-specification) with the OpenAPI spec changes
+3. Check the "API changes companion pull request created" checkbox
+
+### Migration Notes
+
+No migration required. This is a process improvement that applies to new pull requests.
+
+## Limitations
+
+- The checkbox is a reminder only; there is no automated enforcement
+- Contributors must manually create companion PRs for API changes
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#696](https://github.com/opensearch-project/common-utils/pull/696) | Update PULL_REQUEST_TEMPLATE to include API spec change checkbox |
+
+## References
+
+- [Issue #387](https://github.com/opensearch-project/opensearch-api-specification/issues/387): Proposal to add checkbox in plugin PR templates
+- [OpenSearch API Specification](https://github.com/opensearch-project/opensearch-api-specification): Central repository for API specifications
+- [Developer Guide](https://github.com/opensearch-project/opensearch-api-specification/blob/main/DEVELOPER_GUIDE.md): Guide for contributing API specs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/common/pr-template-api-spec.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -10,6 +10,9 @@
 ### anomaly-detection
 - [Anomaly Detection Bugfixes](features/anomaly-detection/anomaly-detection-bugfixes.md)
 
+### common
+- [Common Infrastructure](features/common/common-infrastructure.md)
+
 ### dashboards-maps
 - [Maps Plugin Bugfixes](features/dashboards-maps/maps-plugin-bugfixes.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Common Infrastructure enhancement in OpenSearch v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/common/common-infrastructure.md`
- Feature report: `docs/features/common/pr-template-api-spec.md`

### Key Changes in v2.17.0
- Updated PR template to include API specification checkbox
- Added checklist item for public documentation
- Restructured "Issues Resolved" section to "Related Issues"

### Resources Used
- PR: [#696](https://github.com/opensearch-project/common-utils/pull/696)
- Issue: [#387](https://github.com/opensearch-project/opensearch-api-specification/issues/387)

Closes #388