### PR TITLE
docs: add notifications-navigation report for v2.17.0

### DIFF
--- a/docs/features/dashboards-notifications/dashboards-notifications.md
+++ b/docs/features/dashboards-notifications/dashboards-notifications.md
@@ -89,6 +89,7 @@ The plugin uses the following URL parameters for state management:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.17.0 | [#234](https://github.com/opensearch-project/dashboards-notifications/pull/234) | Change parent item name for new navigation |
 | v2.17.0 | [#242](https://github.com/opensearch-project/dashboards-notifications/pull/242) | Fix link checker |
 | v2.17.0 | [#244](https://github.com/opensearch-project/dashboards-notifications/pull/244) | Persist dataSourceId across applications |
 | v2.14.0 | [#186](https://github.com/opensearch-project/dashboards-notifications/pull/186) | Added MDS Support |
@@ -102,6 +103,6 @@ The plugin uses the following URL parameters for state management:
 
 ## Change History
 
-- **v2.17.0** (2024-09-17): Fixed link checker CI, added dataSourceId persistence for new navigation
+- **v2.17.0** (2024-09-17): Changed navigation parent item name to "Notification channels", added description for left navigation, fixed link checker CI, added dataSourceId persistence for new navigation
 - **v2.15.0**: Bug fixes for MDS support in getServerFeatures API
 - **v2.14.0**: Added Multi-Data-Source (MDS) support

--- a/docs/releases/v2.17.0/features/dashboards-notifications/notifications-navigation.md
+++ b/docs/releases/v2.17.0/features/dashboards-notifications/notifications-navigation.md
@@ -1,0 +1,78 @@
+# Notifications Navigation
+
+## Summary
+
+This enhancement updates the navigation display name for the Notifications plugin in OpenSearch Dashboards. When the new navigation system is enabled, the plugin now appears as "Notification channels" instead of "Notifications" in the Settings and Setup navigation group. Additionally, a description has been added to help users understand the plugin's purpose.
+
+## Details
+
+### What's New in v2.17.0
+
+The PR introduces two key changes to improve the navigation experience:
+
+1. **Renamed navigation item**: The parent item name in the Settings and Setup nav group is changed from "Notifications" to "Notification channels" for better clarity
+2. **Added description**: A new description "Configure and organize notification channels" is displayed in the left navigation panel
+
+### Technical Changes
+
+#### Navigation Registration Changes
+
+The plugin registration now includes a description for the left navigation:
+
+```typescript
+core.application.register({
+  id: PLUGIN_NAME,
+  title: this.title,
+  category: core.chrome?.navGroup?.getNavGroupEnabled() ? undefined : DEFAULT_APP_CATEGORIES.management,
+  order: 9060,
+  description: i18n.translate('dashboards-notifications.leftNav.notifications.description', {
+    defaultMessage: 'Configure and organize notification channels.'
+  }),
+  // ...
+});
+```
+
+When adding nav links to the Settings and Setup group, the title is now explicitly set:
+
+```typescript
+core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.settingsAndSetup, [
+  {
+    id: PLUGIN_NAME,
+    title: 'Notification channels'
+  }
+]);
+```
+
+### Usage Example
+
+When the new navigation is enabled (`navGroup.getNavGroupEnabled()` returns `true`), users will see:
+
+- **Settings and Setup** (nav group)
+  - **Notification channels** (parent item with description)
+    - Channels
+    - Email senders
+    - Email recipient groups
+
+### Migration Notes
+
+No migration required. This is a UI-only change that takes effect automatically when using the new navigation system.
+
+## Limitations
+
+- The renamed navigation item only appears when the new navigation system is enabled
+- Legacy navigation continues to show "Notifications" under the Management category
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#234](https://github.com/opensearch-project/dashboards-notifications/pull/234) | Change parent item name for new navigation |
+
+## References
+
+- [OpenSearch Notifications Documentation](https://docs.opensearch.org/2.17/observing-your-data/notifications/index/)
+- [dashboards-notifications Repository](https://github.com/opensearch-project/dashboards-notifications)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-notifications/dashboards-notifications.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -19,6 +19,7 @@
 
 ### dashboards-notifications
 - [Notifications Bugfixes](features/dashboards-notifications/notifications-bugfixes.md)
+- [Notifications Navigation](features/dashboards-notifications/notifications-navigation.md)
 
 ### dashboards-observability
 - [Observability Enhancements](features/dashboards-observability/observability-enhancements.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Notifications Navigation enhancement in OpenSearch v2.17.0.

### Changes
- **Release report**: `docs/releases/v2.17.0/features/dashboards-notifications/notifications-navigation.md`
- **Feature report update**: Updated `docs/features/dashboards-notifications/dashboards-notifications.md` with PR #234 and change history

### Key Changes in v2.17.0
- Changed navigation parent item name from "Notifications" to "Notification channels" in Settings and Setup nav group
- Added description "Configure and organize notification channels" for the left navigation panel

### Source PR
- [opensearch-project/dashboards-notifications#234](https://github.com/opensearch-project/dashboards-notifications/pull/234)