### PR TITLE
docs: add k-NN Space Type Configuration report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -193,6 +193,7 @@
 - [k-NN Explain API](k-nn/explain-api.md)
 - [k-NN Iterative Graph Build](k-nn/k-nn-iterative-graph-build.md)
 - [k-NN Model Metadata](k-nn/k-nn-model-metadata.md)
+- [k-NN Space Type Configuration](k-nn/k-nn-space-type-configuration.md)
 - [Lucene On Faiss (Memory Optimized Search)](k-nn/lucene-on-faiss.md)
 - [Remote Vector Index Build](k-nn/remote-vector-index-build.md)
 

--- a/docs/features/k-nn/k-nn-space-type-configuration.md
+++ b/docs/features/k-nn/k-nn-space-type-configuration.md
@@ -1,0 +1,167 @@
+# k-NN Space Type Configuration
+
+## Summary
+
+The k-NN Space Type Configuration feature allows users to specify the `space_type` parameter at the top level of a `knn_vector` field mapping, rather than only within the `method` block. This simplifies index creation, especially when using the `mode` and `compression_level` parameters for disk-based vector search, where users may not need to define the full method configuration.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Field Mapping"
+        A[knn_vector field] --> B{space_type location}
+        B -->|Top-level| C[Top-level space_type]
+        B -->|Method-level| D[method.space_type]
+    end
+    
+    subgraph "Resolution"
+        C --> E[SpaceType Resolver]
+        D --> E
+        E --> F{Validation}
+        F -->|Both defined| G[Must match]
+        F -->|One defined| H[Use defined value]
+        F -->|None defined| I[Use default]
+    end
+    
+    subgraph "Defaults"
+        I --> J{data_type}
+        J -->|float/byte| K[l2]
+        J -->|binary| L[hamming]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User Mapping Request] --> B[KNNVectorFieldMapper.Builder]
+    B --> C[Parse topLevelSpaceType]
+    B --> D[Parse KNNMethodContext]
+    C --> E[validateSpaceType]
+    D --> E
+    E --> F{Both defined?}
+    F -->|Yes| G{Match?}
+    G -->|No| H[Throw MapperParsingException]
+    G -->|Yes| I[Continue]
+    F -->|No| I
+    I --> J[setSpaceType]
+    J --> K[Resolve final SpaceType]
+    K --> L[Build KNNMethodContext]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `KNNVectorFieldMapper.Builder` | Extended to include `topLevelSpaceType` parameter |
+| `OriginalMappingParameters` | Stores the original top-level space type value |
+| `ModeBasedResolver` | Updated to accept space type when resolving method context |
+| `KNNVectorFieldMapperUtil` | Updated to handle top-level space type in legacy mappings |
+| `RestTrainModelHandler` | Extended to support top-level space type in training API |
+| `TrainingModelRequest` | Updated to include space type parameter |
+
+### Configuration
+
+| Parameter | Location | Type | Default | Description |
+|-----------|----------|------|---------|-------------|
+| `space_type` | Top-level | String | `l2` | Distance metric for vector similarity calculation |
+| `space_type` | method | String | `l2` | Distance metric (existing location) |
+
+### Supported Space Types
+
+| Space Type | Description | Supported Engines |
+|------------|-------------|-------------------|
+| `l2` | Euclidean distance | nmslib, faiss, lucene |
+| `cosinesimil` | Cosine similarity | nmslib, faiss, lucene |
+| `innerproduct` | Inner product (dot product) | nmslib, faiss, lucene |
+| `l1` | Manhattan distance | nmslib |
+| `linf` | Chebyshev distance | nmslib |
+| `hamming` | Hamming distance | faiss (binary vectors) |
+
+### Usage Example
+
+**Basic usage with top-level space_type:**
+```json
+PUT my-vector-index
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 128,
+        "space_type": "cosinesimil"
+      }
+    }
+  }
+}
+```
+
+**With disk-based mode:**
+```json
+PUT my-vector-index
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "mode": "on_disk",
+        "compression_level": "32x",
+        "space_type": "innerproduct"
+      }
+    }
+  }
+}
+```
+
+**Training API with top-level space_type:**
+```json
+POST _plugins/_knn/models/my-model/_train
+{
+  "training_index": "train-index",
+  "training_field": "train-field",
+  "dimension": 128,
+  "space_type": "l2",
+  "method": {
+    "name": "ivf",
+    "engine": "faiss",
+    "parameters": {
+      "nlist": 16
+    }
+  }
+}
+```
+
+## Limitations
+
+- Top-level `space_type` cannot be used together with `model_id` parameter
+- If both top-level and method-level `space_type` are specified, they must be identical
+- Only supported for OpenSearch version 2.17.0 and later
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#2044](https://github.com/opensearch-project/k-NN/pull/2044) | Add spaceType as a top level parameter while creating vector field |
+
+## References
+
+- [Issue #1949](https://github.com/opensearch-project/k-NN/issues/1949): RFC - Disk-based Mode Design
+- [k-NN Vector Field Type](https://docs.opensearch.org/2.17/field-types/supported-field-types/knn-vector/): Official documentation
+- [k-NN Index](https://docs.opensearch.org/2.17/search-plugins/knn/knn-index/): Index configuration guide
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Initial implementation - Added `space_type` as top-level parameter for knn_vector field mappings

--- a/docs/releases/v2.17.0/features/k-nn/k-nn-space-type-configuration.md
+++ b/docs/releases/v2.17.0/features/k-nn/k-nn-space-type-configuration.md
@@ -1,0 +1,139 @@
+# k-NN Space Type Configuration
+
+## Summary
+
+OpenSearch 2.17.0 introduces the ability to specify `space_type` as a top-level parameter when creating k-NN vector fields. Previously, `space_type` could only be defined within the `method` parameter block. This enhancement simplifies the mapping configuration, especially for disk-based vector search where users may not need to specify the full `method` definition.
+
+## Details
+
+### What's New in v2.17.0
+
+This release adds `space_type` as a top-level optional parameter for `knn_vector` field mappings. Users can now configure the distance metric without defining the complete `method` block, improving the out-of-box experience for disk-based vector search.
+
+### Technical Changes
+
+#### New Mapping Parameter
+
+| Parameter | Location | Description | Default |
+|-----------|----------|-------------|---------|
+| `space_type` | Top-level | Distance metric for vector similarity | `l2` |
+
+The `space_type` parameter can now be specified at two locations:
+1. **Top-level** (new): Directly in the field mapping
+2. **Method-level** (existing): Inside the `method` parameter block
+
+#### Supported Space Types
+
+| Space Type | Description |
+|------------|-------------|
+| `l2` | Euclidean distance (default) |
+| `cosinesimil` | Cosine similarity |
+| `innerproduct` | Inner product (dot product) |
+| `l1` | Manhattan distance |
+| `linf` | Chebyshev distance |
+| `hamming` | Hamming distance (for binary vectors) |
+
+#### Validation Rules
+
+- If `space_type` is specified at both top-level and method-level, they must match
+- If only one is specified, that value is used
+- If neither is specified, defaults to `l2` (or `hamming` for binary vectors)
+- Top-level `space_type` cannot be used with `model_id` (model-based indices)
+
+### Usage Example
+
+**Before v2.17.0** (method-level only):
+```json
+PUT my-vector-index
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 4,
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "space_type": "innerproduct"
+        }
+      }
+    }
+  }
+}
+```
+
+**With v2.17.0** (top-level):
+```json
+PUT my-vector-index
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 4,
+        "space_type": "innerproduct"
+      }
+    }
+  }
+}
+```
+
+**With mode and compression (disk-based search)**:
+```json
+PUT my-vector-index
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 4,
+        "mode": "on_disk",
+        "compression_level": "32x",
+        "space_type": "innerproduct"
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- No migration required; this is a backward-compatible addition
+- Existing indices with method-level `space_type` continue to work unchanged
+- New indices can use either top-level or method-level specification
+
+## Limitations
+
+- Cannot use top-level `space_type` with model-based indices (`model_id` parameter)
+- If both top-level and method-level `space_type` are specified, they must be identical
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2044](https://github.com/opensearch-project/k-NN/pull/2044) | Add spaceType as a top level parameter while creating vector field |
+
+## References
+
+- [Issue #1949](https://github.com/opensearch-project/k-NN/issues/1949): RFC - Disk-based Mode Design
+- [k-NN Vector Documentation](https://docs.opensearch.org/2.17/field-types/supported-field-types/knn-vector/): Official field type documentation
+- [k-NN Index Documentation](https://docs.opensearch.org/2.17/search-plugins/knn/knn-index/): Index configuration guide
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/k-nn/k-nn-space-type-configuration.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -115,6 +115,7 @@
 - [k-NN Bugfixes](features/k-nn/k-nn-bugfixes.md)
 - [k-NN Iterative Graph Build](features/k-nn/k-nn-iterative-graph-build.md)
 - [k-NN Model Metadata](features/k-nn/k-nn-model-metadata.md)
+- [k-NN Space Type Configuration](features/k-nn/k-nn-space-type-configuration.md)
 
 ### cross-cluster-replication
 - [Cross-Cluster Replication Bugfixes](features/cross-cluster-replication/cross-cluster-replication-bugfixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the k-NN Space Type Configuration feature introduced in OpenSearch v2.17.0.

## Changes

- **Release Report**: `docs/releases/v2.17.0/features/k-nn/k-nn-space-type-configuration.md`
- **Feature Report**: `docs/features/k-nn/k-nn-space-type-configuration.md`
- Updated release index and features index

## Feature Overview

OpenSearch 2.17.0 introduces the ability to specify `space_type` as a top-level parameter when creating k-NN vector fields. This simplifies the mapping configuration, especially for disk-based vector search where users may not need to specify the full `method` definition.

### Key Changes
- Added `space_type` as a top-level optional parameter for `knn_vector` field mappings
- Improved out-of-box experience for disk-based vector search
- Extended Training API to support top-level space type

## Related
- Closes #384
- PR: [opensearch-project/k-NN#2044](https://github.com/opensearch-project/k-NN/pull/2044)
- Issue: [opensearch-project/k-NN#1949](https://github.com/opensearch-project/k-NN/issues/1949)