### PR TITLE
docs: add k-NN byte vector support report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -190,6 +190,7 @@
 ## k-nn
 
 - [Disk-Based Vector Search](k-nn/disk-based-vector-search.md)
+- [k-NN Byte Vector Support](k-nn/k-nn-byte-vector-support.md)
 - [Vector Search (k-NN)](k-nn/vector-search-k-nn.md)
 - [k-NN Explain API](k-nn/explain-api.md)
 - [k-NN Iterative Graph Build](k-nn/k-nn-iterative-graph-build.md)

--- a/docs/features/k-nn/k-nn-byte-vector-support.md
+++ b/docs/features/k-nn/k-nn-byte-vector-support.md
@@ -1,0 +1,244 @@
+# k-NN Byte Vector Support
+
+## Summary
+
+The k-NN byte vector support feature enables OpenSearch to index and search vectors using signed 8-bit integers (byte values ranging from -128 to 127) with the Faiss engine. This provides significant memory savings (up to 75%) compared to float vectors while maintaining high search quality, making it ideal for large-scale vector search applications where memory efficiency is critical.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Input Layer"
+        A[Byte Vectors<br/>int8: -128 to 127]
+    end
+    
+    subgraph "OpenSearch k-NN Plugin"
+        B[KNNVectorFieldMapper]
+        C[VectorDataType.BYTE]
+        D[JNIService]
+    end
+    
+    subgraph "JNI Layer"
+        E[FaissService]
+        F[ByteIndexService]
+        G[ByteTrainingDataConsumer]
+    end
+    
+    subgraph "Faiss Engine"
+        H[SQ8_direct_signed<br/>Scalar Quantizer]
+        I[HNSW Index]
+        J[IVF Index]
+    end
+    
+    A --> B
+    B --> C
+    C --> D
+    D --> E
+    E --> F
+    F --> G
+    G --> H
+    H --> I
+    H --> J
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Indexing"
+        A1[Input: int8 vector] --> A2[Cast to float]
+        A2 --> A3[Faiss SQ8_direct_signed]
+        A3 --> A4[Encode: add 128]
+        A4 --> A5[Store as uint8]
+    end
+    
+    subgraph "Search"
+        B1[Query: int8 vector] --> B2[Cast to float]
+        B2 --> B3[Decode stored vectors]
+        B3 --> B4[Distance computation]
+        B4 --> B5[Return k-NN results]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `VectorDataType.BYTE` | Enum value for byte vector data type |
+| `ByteIndexService` | Faiss index service handling byte vector operations |
+| `ByteTrainingDataConsumer` | Consumes training data for IVF byte indexes |
+| `BinaryTrainingDataConsumer` | Separated consumer for binary vectors |
+| `OffHeapByteVectorTransfer` | Transfers byte vectors to native memory |
+| `SQ8_direct_signed` | Faiss scalar quantizer for signed byte encoding |
+
+### Configuration
+
+| Setting | Description | Default | Supported Values |
+|---------|-------------|---------|------------------|
+| `data_type` | Vector data type for the field | `float` | `float`, `byte`, `binary` |
+| `method.name` | Algorithm for k-NN search | - | `hnsw`, `ivf` |
+| `method.engine` | Search engine | - | `faiss` (required for byte) |
+| `method.space_type` | Distance metric | `l2` | `l2`, `innerproduct` |
+
+### Supported Algorithms
+
+| Algorithm | Training Required | Use Case |
+|-----------|-------------------|----------|
+| HNSW | No | General purpose, high recall |
+| IVF | Yes | Large-scale datasets with clustering |
+
+### Usage Example
+
+#### Creating Index with HNSW
+
+```json
+PUT my-byte-index
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "data_type": "byte",
+        "method": {
+          "name": "hnsw",
+          "space_type": "l2",
+          "engine": "faiss",
+          "parameters": {
+            "ef_construction": 256,
+            "m": 16
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### Creating Index with IVF (Training Required)
+
+```json
+// Step 1: Create training index
+PUT train-index
+{
+  "settings": { "index": { "knn": true } },
+  "mappings": {
+    "properties": {
+      "train_field": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "data_type": "byte",
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss"
+        }
+      }
+    }
+  }
+}
+
+// Step 2: Ingest training data
+// Step 3: Train model
+POST /_plugins/_knn/models/{model_id}/_train
+{
+  "training_index": "train-index",
+  "training_field": "train_field",
+  "dimension": 768,
+  "description": "IVF byte model",
+  "method": {
+    "name": "ivf",
+    "engine": "faiss",
+    "space_type": "l2",
+    "parameters": {
+      "nlist": 128,
+      "nprobes": 8
+    }
+  }
+}
+
+// Step 4: Create index from model
+PUT my-ivf-byte-index
+{
+  "settings": { "index": { "knn": true } },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "model_id": "{model_id}"
+      }
+    }
+  }
+}
+```
+
+#### Indexing Documents
+
+```json
+PUT my-byte-index/_doc/1
+{
+  "my_vector": [-126, 28, 127, 0, 10, -45, 12, -110, ...]
+}
+```
+
+#### Searching
+
+```json
+GET my-byte-index/_search
+{
+  "size": 10,
+  "query": {
+    "knn": {
+      "my_vector": {
+        "vector": [-1, 45, -100, 125, -128, -8, 5, 10, ...],
+        "k": 10
+      }
+    }
+  }
+}
+```
+
+### Performance Benchmarks
+
+Based on OpenSearch Benchmark tests:
+
+| Metric | Float Vectors | Byte Vectors | Improvement |
+|--------|---------------|--------------|-------------|
+| Memory Usage | 100% | ~25-28% | 72-75% reduction |
+| Indexing Throughput | Baseline | 13-107% higher | Significant gain |
+| Search Latency | Baseline | Similar or better | Comparable |
+| Recall@100 | Baseline | 1-9% lower | Minimal loss |
+
+## Limitations
+
+- Vector values must be within signed byte range [-128, 127]
+- Encoders (SQ, PQ) cannot be combined with byte data type
+- External quantization required before ingestion
+- Some recall loss compared to float vectors
+- SIMD optimization (AVX2/NEON) recommended for best performance
+- Not supported with Lucene engine for Faiss-specific features
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#1823](https://github.com/opensearch-project/k-NN/pull/1823) | Add HNSW support for Faiss byte vector |
+| v2.17.0 | [#2002](https://github.com/opensearch-project/k-NN/pull/2002) | Add IVF support for Faiss byte vector |
+
+## References
+
+- [Issue #1659](https://github.com/opensearch-project/k-NN/issues/1659): Original feature request
+- [k-NN Vector Quantization Documentation](https://docs.opensearch.org/2.17/search-plugins/knn/knn-vector-quantization/)
+- [k-NN Vector Field Type](https://docs.opensearch.org/2.17/field-types/supported-field-types/knn-vector/)
+- [Blog: Introducing byte vector support for Faiss](https://opensearch.org/blog/faiss-byte-vector/)
+- [Faiss ScalarQuantizer Documentation](https://faiss.ai/cpp_api/struct/structfaiss_1_1ScalarQuantizer.html)
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Initial implementation with HNSW and IVF support for Faiss byte vectors

--- a/docs/releases/v2.17.0/features/k-nn/k-nn-byte-vector-support.md
+++ b/docs/releases/v2.17.0/features/k-nn/k-nn-byte-vector-support.md
@@ -1,0 +1,149 @@
+# k-NN Byte Vector Support
+
+## Summary
+
+OpenSearch 2.17.0 introduces byte vector support for the Faiss engine, enabling users to store quantized byte vector embeddings with significant memory savings. This feature allows vectors with signed 8-bit integer values (ranging from -128 to 127) to be indexed and searched using both HNSW and IVF algorithms, reducing memory consumption by up to 75% compared to float vectors.
+
+## Details
+
+### What's New in v2.17.0
+
+- **Faiss HNSW byte vector support**: Index and search byte vectors using the HNSW algorithm with Faiss engine
+- **Faiss IVF byte vector support**: Index and search byte vectors using the IVF algorithm with Faiss engine (requires training)
+- **Memory optimization**: Byte vectors use `SQ8_direct_signed` scalar quantizer internally, reducing memory footprint by 4x
+- **JNI layer enhancements**: New native methods for byte vector storage, training, and index creation
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Byte Vector Indexing Flow"
+        A[Byte Vector Input<br/>-128 to 127] --> B[JNI Layer]
+        B --> C[Faiss SQ8_direct_signed<br/>Scalar Quantizer]
+        C --> D[Encode to uint8<br/>add 128]
+        D --> E[Store in Index]
+    end
+    
+    subgraph "Search Flow"
+        F[Query Vector] --> G[Decode uint8 to int8<br/>subtract 128]
+        G --> H[Distance Computation]
+        H --> I[Return Results]
+    end
+    
+    E --> G
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ByteIndexService` | New Faiss index service for byte vector operations |
+| `ByteTrainingDataConsumer` | Handles training data for IVF byte indexes |
+| `BinaryTrainingDataConsumer` | Separated from byte consumer for binary vectors |
+| `OffHeapByteVectorTransfer` | Transfers byte vectors to native memory |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `data_type` | Vector data type (`float`, `byte`, `binary`) | `float` |
+
+#### API Changes
+
+New JNI methods added to `FaissService`:
+- `initByteIndex()` - Initialize byte vector index
+- `insertToByteIndex()` - Insert byte vectors into index
+- `writeByteIndex()` - Write byte index to disk
+- `createByteIndexFromTemplate()` - Create byte index from trained template (IVF)
+- `trainByteIndex()` - Train IVF index with byte vectors
+
+### Usage Example
+
+#### HNSW with Byte Vectors
+
+```json
+PUT test-index
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 8,
+        "data_type": "byte",
+        "method": {
+          "name": "hnsw",
+          "space_type": "l2",
+          "engine": "faiss",
+          "parameters": {
+            "ef_construction": 100,
+            "m": 16
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### Indexing Byte Vectors
+
+```json
+PUT test-index/_doc/1
+{
+  "my_vector": [-126, 28, 127, 0, 10, -45, 12, -110]
+}
+```
+
+#### Searching
+
+```json
+GET test-index/_search
+{
+  "size": 2,
+  "query": {
+    "knn": {
+      "my_vector": {
+        "vector": [-1, 45, -100, 125, -128, -8, 5, 10],
+        "k": 2
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- Vectors must be quantized to byte range [-128, 127] before ingestion
+- Encoders (SQ, PQ) are not supported with byte vectors
+- For IVF algorithm, training is required using byte vectors
+
+## Limitations
+
+- Vector values must be within signed byte range [-128, 127]
+- Encoders cannot be used with byte data type
+- Some recall loss compared to float vectors (typically 1-9% depending on dataset)
+- SIMD optimization recommended for best performance
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1823](https://github.com/opensearch-project/k-NN/pull/1823) | Add HNSW support for Faiss byte vector |
+| [#2002](https://github.com/opensearch-project/k-NN/pull/2002) | Add IVF support for Faiss byte vector |
+
+## References
+
+- [Issue #1659](https://github.com/opensearch-project/k-NN/issues/1659): Feature request for Faiss byte vector support
+- [Documentation](https://docs.opensearch.org/2.17/search-plugins/knn/knn-vector-quantization/): k-NN vector quantization
+- [Blog](https://opensearch.org/blog/faiss-byte-vector/): Introducing byte vector support for Faiss
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/k-nn/k-nn-byte-vector-support.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -114,6 +114,7 @@
 ### k-nn
 - [Disk-Based Vector Search](features/k-nn/disk-based-vector-search.md)
 - [k-NN Bugfixes](features/k-nn/k-nn-bugfixes.md)
+- [k-NN Byte Vector Support](features/k-nn/k-nn-byte-vector-support.md)
 - [k-NN Iterative Graph Build](features/k-nn/k-nn-iterative-graph-build.md)
 - [k-NN Model Metadata](features/k-nn/k-nn-model-metadata.md)
 - [k-NN Space Type Configuration](features/k-nn/k-nn-space-type-configuration.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the k-NN Byte Vector Support feature introduced in OpenSearch v2.17.0.

## Changes

### Release Report
- `docs/releases/v2.17.0/features/k-nn/k-nn-byte-vector-support.md`

### Feature Report
- `docs/features/k-nn/k-nn-byte-vector-support.md`

## Feature Overview

OpenSearch 2.17.0 introduces byte vector support for the Faiss engine, enabling:
- **HNSW algorithm** support for byte vectors (PR #1823)
- **IVF algorithm** support for byte vectors (PR #2002)
- **75% memory reduction** compared to float vectors
- Uses Faiss `SQ8_direct_signed` scalar quantizer internally

## Key Technical Details

- Vector values must be in signed byte range [-128, 127]
- Encoders (SQ, PQ) cannot be combined with byte data type
- New JNI methods: `initByteIndex`, `insertToByteIndex`, `writeByteIndex`, etc.
- New components: `ByteIndexService`, `ByteTrainingDataConsumer`

## Related

- Issue: #382
- PRs: opensearch-project/k-NN#1823, opensearch-project/k-NN#2002
- Feature Request: opensearch-project/k-NN#1659