### PR TITLE
docs: add k-NN query rescore report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -195,6 +195,7 @@
 - [k-NN Explain API](k-nn/explain-api.md)
 - [k-NN Iterative Graph Build](k-nn/k-nn-iterative-graph-build.md)
 - [k-NN Model Metadata](k-nn/k-nn-model-metadata.md)
+- [k-NN Query Rescore](k-nn/k-nn-query-rescore.md)
 - [k-NN Space Type Configuration](k-nn/k-nn-space-type-configuration.md)
 - [Lucene On Faiss (Memory Optimized Search)](k-nn/lucene-on-faiss.md)
 - [Remote Vector Index Build](k-nn/remote-vector-index-build.md)

--- a/docs/features/k-nn/k-nn-query-rescore.md
+++ b/docs/features/k-nn/k-nn-query-rescore.md
@@ -1,0 +1,163 @@
+# k-NN Query Rescore
+
+## Summary
+
+k-NN Query Rescore is a feature that improves search recall for quantized vector indexes by performing a two-phase search. In the first phase, an approximate nearest neighbor (ANN) search retrieves an oversampled set of candidates using quantized vectors. In the second phase, full-precision vectors are loaded from disk to recompute exact distances, returning the most accurate top-k results. This approach maintains the memory efficiency of quantization while recovering recall lost due to vector compression.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Query Processing"
+        Q[Query Vector] --> QP[KNNQueryBuilder]
+        QP --> RC[RescoreContext]
+    end
+    
+    subgraph "Two-Phase Search"
+        RC --> P1[Phase 1: ANN Search]
+        P1 --> OS[Oversample: k × factor]
+        OS --> P2[Phase 2: Exact Search]
+        P2 --> ES[ExactSearcher]
+        ES --> FP[Load Full-Precision Vectors]
+        FP --> DC[Distance Calculation]
+        DC --> RU[ResultUtil.reduceToTopK]
+    end
+    
+    subgraph "Result Processing"
+        RU --> TK[Top-k Results]
+        TK --> R[Response]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User Query with rescore parameter] --> B[Parse RescoreContext]
+    B --> C{Rescore Enabled?}
+    C -->|No| D[Standard ANN Search]
+    C -->|Yes| E[Calculate firstPassK = k × oversample_factor]
+    E --> F[ANN Search with firstPassK]
+    F --> G[Reduce to firstPassK across segments]
+    G --> H[Load full-precision vectors]
+    H --> I[Exact distance calculation]
+    I --> J[Reduce to final k results]
+    J --> K[Return results]
+    D --> K
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `RescoreContext` | Configuration holder for rescoring parameters including oversample factor |
+| `ExactSearcher` | Performs exact distance calculations using full-precision vectors from disk |
+| `ResultUtil` | Utility class for reducing results to top-k across multiple segments |
+| `NativeEngineKnnVectorQuery` | Orchestrates the two-phase search when rescoring is enabled |
+| `KNNWeight` | Extended to support exact search method for rescoring |
+
+### Configuration
+
+| Setting | Description | Default | Range |
+|---------|-------------|---------|-------|
+| `rescore.oversample_factor` | Multiplier for first-pass result count | 1.0 | 1.0 - 100.0 |
+
+Default rescoring behavior based on compression level (for `on_disk` mode):
+
+| Compression Level | Default Oversample Factor |
+|-------------------|---------------------------|
+| 32x | 3.0 |
+| 16x | 2.0 |
+| 8x | 2.0 |
+| 4x | No default rescoring |
+| 2x | No default rescoring |
+
+### Usage Example
+
+Basic rescoring with custom oversample factor:
+
+```json
+GET my-knn-index/_search
+{
+  "size": 10,
+  "query": {
+    "knn": {
+      "my_vector_field": {
+        "vector": [2.0, 3.0, 5.0, 6.0],
+        "k": 10,
+        "rescore": {
+          "oversample_factor": 3.0
+        }
+      }
+    }
+  }
+}
+```
+
+Enable rescoring with default oversample factor (1.0):
+
+```json
+GET my-knn-index/_search
+{
+  "size": 10,
+  "query": {
+    "knn": {
+      "my_vector_field": {
+        "vector": [2.0, 3.0, 5.0, 6.0],
+        "k": 10,
+        "rescore": true
+      }
+    }
+  }
+}
+```
+
+Rescoring with nested fields:
+
+```json
+GET my-knn-index/_search
+{
+  "query": {
+    "nested": {
+      "path": "nested_field",
+      "query": {
+        "knn": {
+          "nested_field.vector": {
+            "vector": [1.0, 2.0],
+            "k": 5,
+            "rescore": {
+              "oversample_factor": 2.0
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Only supported for the Faiss engine (not Lucene or NMSLIB)
+- First-pass results are bounded between 100 and 10,000 (MAX_FIRST_PASS_RESULTS)
+- Adds latency due to loading full-precision vectors and recomputing distances
+- Requires full-precision vectors to be stored alongside quantized vectors
+- Not beneficial for non-quantized indexes where scores are already fully precise
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#1984](https://github.com/opensearch-project/k-NN/pull/1984) | k-NN query rescore support for native engines |
+
+## References
+
+- [Approximate k-NN Search Documentation](https://docs.opensearch.org/2.17/search-plugins/knn/approximate-knn/)
+- [k-NN Vector Quantization](https://docs.opensearch.org/2.17/search-plugins/knn/knn-vector-quantization/)
+- [Disk-based Vector Search](https://docs.opensearch.org/2.17/search-plugins/knn/disk-based-vector-search/)
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Initial implementation of k-NN query rescore support for native engines

--- a/docs/releases/v2.17.0/features/k-nn/k-nn-query-rescore.md
+++ b/docs/releases/v2.17.0/features/k-nn/k-nn-query-rescore.md
@@ -1,0 +1,132 @@
+# k-NN Query Rescore
+
+## Summary
+
+This release introduces query-time rescoring support for k-NN searches using native engines (Faiss, NMSLIB). The feature enables a two-phase search approach where approximate nearest neighbor (ANN) results are first retrieved using quantized vectors, then rescored using full-precision vectors to improve recall while maintaining memory efficiency.
+
+## Details
+
+### What's New in v2.17.0
+
+The k-NN query rescore feature adds the ability to improve search recall for quantized vector indexes by performing a two-phase search:
+
+1. **First Phase (Oversampling)**: Retrieve `oversample_factor * k` results using the quantized ANN index
+2. **Second Phase (Rescoring)**: Load full-precision vectors for the oversampled results and recompute exact distances to return the final top-k results
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Two-Phase Search"
+        A[Query Vector] --> B[Phase 1: ANN Search]
+        B --> C[Oversample k * factor results]
+        C --> D[Phase 2: Exact Search]
+        D --> E[Load Full-Precision Vectors]
+        E --> F[Recompute Distances]
+        F --> G[Return Top-k Results]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `RescoreContext` | Holds rescoring configuration including oversample factor |
+| `ExactSearcher` | Performs exact distance calculations using full-precision vectors |
+| `ResultUtil` | Utility class for processing and reducing search results |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `rescore.oversample_factor` | Multiplier for first-pass result count | 1.0 |
+
+The `oversample_factor` must be between 1.0 and 100.0. The first-pass result count is calculated as `oversample_factor * k`, bounded between 100 and 10,000.
+
+#### API Changes
+
+New `rescore` parameter in k-NN query:
+
+```json
+{
+  "query": {
+    "knn": {
+      "my_vector_field": {
+        "vector": [1.0, 2.0, 3.0],
+        "k": 10,
+        "rescore": {
+          "oversample_factor": 2.0
+        }
+      }
+    }
+  }
+}
+```
+
+Alternatively, set `rescore: true` to use default oversample factor of 1.0:
+
+```json
+{
+  "query": {
+    "knn": {
+      "my_vector_field": {
+        "vector": [1.0, 2.0, 3.0],
+        "k": 10,
+        "rescore": true
+      }
+    }
+  }
+}
+```
+
+### Usage Example
+
+```json
+GET my-knn-index/_search
+{
+  "size": 10,
+  "query": {
+    "knn": {
+      "my_vector_field": {
+        "vector": [2.0, 3.0, 5.0, 6.0],
+        "k": 10,
+        "rescore": {
+          "oversample_factor": 3.0
+        }
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- Rescoring is only supported for the Faiss engine
+- Rescoring is most beneficial when used with quantized indexes (disk-based mode)
+- For non-quantized indexes, rescoring is not needed as scores are already fully precise
+- Works with nested field searches
+
+## Limitations
+
+- Only supported for Faiss engine (not Lucene or NMSLIB)
+- First-pass results are bounded between 100 and 10,000
+- Adds latency due to the second-phase exact search
+- Requires full-precision vectors to be stored for rescoring
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1984](https://github.com/opensearch-project/k-NN/pull/1984) | k-NN query rescore support for native engines |
+
+## References
+
+- [Approximate k-NN Search Documentation](https://docs.opensearch.org/2.17/search-plugins/knn/approximate-knn/)
+- [k-NN Vector Quantization](https://docs.opensearch.org/2.17/search-plugins/knn/knn-vector-quantization/)
+- [Disk-based Vector Search](https://docs.opensearch.org/2.17/search-plugins/knn/disk-based-vector-search/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/k-nn/k-nn-query-rescore.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -117,6 +117,7 @@
 - [k-NN Byte Vector Support](features/k-nn/k-nn-byte-vector-support.md)
 - [k-NN Iterative Graph Build](features/k-nn/k-nn-iterative-graph-build.md)
 - [k-NN Model Metadata](features/k-nn/k-nn-model-metadata.md)
+- [k-NN Query Rescore](features/k-nn/k-nn-query-rescore.md)
 - [k-NN Space Type Configuration](features/k-nn/k-nn-space-type-configuration.md)
 
 ### cross-cluster-replication


### PR DESCRIPTION
## Summary

This PR adds documentation for the k-NN Query Rescore feature introduced in OpenSearch v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/k-nn/k-nn-query-rescore.md`
- Feature report: `docs/features/k-nn/k-nn-query-rescore.md`

### Key Changes in v2.17.0
- Two-phase search approach for improved recall with quantized vectors
- New `rescore` parameter in k-NN query with configurable `oversample_factor`
- Support for nested field searches with rescoring
- New components: `RescoreContext`, `ExactSearcher`, `ResultUtil`

### Resources Used
- PR: opensearch-project/k-NN#1984
- Docs: https://docs.opensearch.org/2.17/search-plugins/knn/approximate-knn/

Related Issue: #381