### PR TITLE
docs: add k-NN Lucene Vector Integration report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -194,6 +194,7 @@
 - [Vector Search (k-NN)](k-nn/vector-search-k-nn.md)
 - [k-NN Explain API](k-nn/explain-api.md)
 - [k-NN Iterative Graph Build](k-nn/k-nn-iterative-graph-build.md)
+- [k-NN Lucene Vector Integration](k-nn/k-nn-lucene-vector-integration.md)
 - [k-NN Model Metadata](k-nn/k-nn-model-metadata.md)
 - [k-NN Query Rescore](k-nn/k-nn-query-rescore.md)
 - [k-NN Space Type Configuration](k-nn/k-nn-space-type-configuration.md)

--- a/docs/features/k-nn/k-nn-lucene-vector-integration.md
+++ b/docs/features/k-nn/k-nn-lucene-vector-integration.md
@@ -1,0 +1,141 @@
+# k-NN Lucene Vector Integration
+
+## Summary
+
+The k-NN Lucene Vector Integration feature enables native vector search engines (FAISS and NMSLIB) to use Lucene's optimized KNNVectorsFormat for vector storage instead of BinaryDocValues. This architectural improvement provides significant performance benefits for vector deserialization, enabling faster exact search, improved index build times, and laying the foundation for memory-optimized vector search capabilities.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Indexing Flow"
+        A[Vector Data] --> B[KNNVectorFieldMapper]
+        B --> C{Determine Field Type}
+        C -->|Lucene Format| D[KnnFloatVectorField/KnnByteVectorField]
+        C -->|Legacy Format| E[VectorField with BinaryDocValues]
+        D --> F[NativeEngineKNNVectorsFormat]
+        E --> G[KNN80DocValuesFormat]
+        F --> H[Native Index Build via JNI]
+        G --> H
+    end
+    
+    subgraph "Search Flow"
+        I[k-NN Query] --> J[KNNWeight]
+        J --> K{Vector Values Available?}
+        K -->|KNNVectorValues| L[Optimized Read]
+        K -->|BinaryDocValues| M[Legacy Read]
+        L --> N[Score Calculation]
+        M --> N
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Vector Storage Decision"
+        A[Index Creation] --> B{Version >= 2.17.0?}
+        B -->|Yes| C{knn.use.format.enabled?}
+        B -->|No| D[Use BinaryDocValues]
+        C -->|Yes| E[Use KNNVectorsFormat]
+        C -->|No| D
+    end
+    
+    subgraph "Format Benefits"
+        E --> F[Direct Float Array Mapping]
+        D --> G[Byte-to-Float Conversion]
+        F --> H[3.3x Faster Reads]
+        G --> I[Standard Performance]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `NativeEngineKNNVectorsFormat` | Custom VectorsFormat implementation for native engines providing readers and writers |
+| `NativeEngineKNNVectorsFormatWriter` | Writes vector fields using Lucene's optimized format |
+| `NativeEngineKNNVectorsFormatReader` | Reads vector fields with efficient memory mapping |
+| `KNNVectorValues` | Abstraction layer over FloatVectorValues, ByteVectorValues, and BinaryDocValues |
+| `NativeIndexBuilderComponent` | Decoupled component for building native indices via JNI layer |
+
+### Configuration
+
+| Setting | Description | Default | Scope |
+|---------|-------------|---------|-------|
+| `knn.use.format.enabled` | Enable Lucene KNNVectorsFormat for native engines | `false` | Cluster |
+| `index.knn` | Enable k-NN functionality for the index | `false` | Index |
+
+### Usage Example
+
+```yaml
+# Index creation (no changes required)
+PUT my-vector-index
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "embedding": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "space_type": "l2",
+          "parameters": {
+            "ef_construction": 128,
+            "m": 16
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Supported Vector Data Types
+
+| Data Type | Lucene Field Type | Vector Encoding |
+|-----------|-------------------|-----------------|
+| `float` | `KnnFloatVectorField` | `FLOAT32` |
+| `byte` | `KnnByteVectorField` | `BYTE` |
+| `binary` | `KnnByteVectorField` | `BYTE` |
+
+### Performance Characteristics
+
+| Operation | BinaryDocValues | KNNVectorsFormat | Improvement |
+|-----------|-----------------|------------------|-------------|
+| Vector Read (p99, 1M 768D) | 416ms | 124ms | 3.3x |
+| Index Build Time | Baseline | 5-10% faster | - |
+| Efficient Filter Exact Search | Standard | Improved | Significant |
+
+## Limitations
+
+- Cluster setting `knn.use.format.enabled` is temporary and will be removed in future releases
+- Old KNN80DocValuesFormat must be maintained for backward compatibility until next major release
+- Search interface not yet migrated to use codec search interface (planned for future)
+- Iterative graph builds during indexing require additional implementation
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#1945](https://github.com/opensearch-project/k-NN/pull/1945) | Integrate Lucene Vector field with native engines |
+| v2.17.0 | [#1939](https://github.com/opensearch-project/k-NN/pull/1939) | Restructure mappers for FlatVectorsMapper |
+
+## References
+
+- [Issue #1853](https://github.com/opensearch-project/k-NN/issues/1853): RFC - Integrating KNNVectorsFormat in Native Vector Search Engine
+- [Issue #1087](https://github.com/opensearch-project/k-NN/issues/1087): Original investigation on KNNVectorsFormat migration
+- [k-NN Index Documentation](https://docs.opensearch.org/2.17/search-plugins/knn/knn-index/)
+- [k-NN Vector Field Types](https://docs.opensearch.org/2.17/field-types/supported-field-types/knn-vector/)
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Initial implementation - Lucene KNNVectorsFormat integration for native engines behind cluster setting

--- a/docs/releases/v2.17.0/features/k-nn/k-nn-lucene-vector-integration.md
+++ b/docs/releases/v2.17.0/features/k-nn/k-nn-lucene-vector-integration.md
@@ -1,0 +1,120 @@
+# k-NN Lucene Vector Integration
+
+## Summary
+
+This release integrates Lucene's KNNVectorsFormat with native vector search engines (FAISS and NMSLIB), replacing the previous BinaryDocValues-based storage. This architectural change provides significant performance improvements for vector deserialization, with up to 3.3x better p99 latency when reading vectors from disk.
+
+## Details
+
+### What's New in v2.17.0
+
+The k-NN plugin now uses Lucene's native KNNVectorsFormat for storing vectors when using native engines (FAISS, NMSLIB), instead of the previous BinaryDocValues format. This change is foundational for future memory-optimized vector search capabilities.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v2.17.0"
+        A1[Vector Data] --> B1[BinaryDocValues]
+        B1 --> C1[KNN80DocValuesFormat]
+        C1 --> D1[Native Index Build]
+    end
+    
+    subgraph "v2.17.0+"
+        A2[Vector Data] --> B2{index.knn?}
+        B2 -->|true| C2[KnnFloatVectorField/KnnByteVectorField]
+        B2 -->|false| D2[DocValues-based Field]
+        C2 --> E2[NativeEngineKNNVectorsFormat]
+        E2 --> F2[Native Index Build]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `NativeEngineKNNVectorsFormat` | Per-field vectors format for native engine vector fields |
+| `KNNVectorValues` | Abstraction layer over FloatVectorValues, ByteVectorValues, and BinaryDocValues |
+| `useLuceneBasedVectorField` | Flag in field mapper to determine vector field type |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `knn.use.format.enabled` | Cluster setting to enable Lucene vector format (temporary) | `false` |
+
+**Note**: The `knn.use.format.enabled` setting is temporary and will be removed once all related changes are complete.
+
+#### Field Mapper Changes
+
+The `KNNVectorFieldMapper` now conditionally creates different field types:
+
+- **Lucene format enabled**: Uses `KnnFloatVectorField` or `KnnByteVectorField`
+- **Lucene format disabled**: Uses `VectorField` with BinaryDocValues
+
+### Usage Example
+
+No changes to user-facing APIs. The format selection is automatic based on:
+1. Index created version (>= 2.17.0)
+2. Cluster setting `knn.use.format.enabled`
+
+```json
+PUT my-knn-index
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 128,
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss"
+        }
+      }
+    }
+  }
+}
+```
+
+### Performance Improvements
+
+| Metric | BinaryDocValues | KNNVectorsFormat | Improvement |
+|--------|-----------------|------------------|-------------|
+| p99 Vector Read Latency (1M 768D) | 416ms | 124ms | 3.3x |
+| Index Build Time | Baseline | 5-10% faster | - |
+
+### Migration Notes
+
+- **Backward Compatible**: Existing indices continue to use BinaryDocValues
+- **New Indices**: Automatically use KNNVectorsFormat when conditions are met
+- **No User Action Required**: Format selection is automatic
+
+## Limitations
+
+- Feature is behind a cluster setting (`knn.use.format.enabled`) in v2.17.0
+- Old KNN80DocValuesFormat must be maintained until next major release
+- Search interface migration to codec search interface is planned for future releases
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1945](https://github.com/opensearch-project/k-NN/pull/1945) | Integrate Lucene Vector field with native engines |
+| [#1939](https://github.com/opensearch-project/k-NN/pull/1939) | Restructure mappers (dependency) |
+
+## References
+
+- [Issue #1853](https://github.com/opensearch-project/k-NN/issues/1853): RFC - Integrating KNNVectorsFormat in Native Vector Search Engine
+- [Issue #1087](https://github.com/opensearch-project/k-NN/issues/1087): Original investigation
+- [k-NN Index Documentation](https://docs.opensearch.org/2.17/search-plugins/knn/knn-index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/k-nn/k-nn-lucene-vector-integration.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -116,6 +116,7 @@
 - [k-NN Bugfixes](features/k-nn/k-nn-bugfixes.md)
 - [k-NN Byte Vector Support](features/k-nn/k-nn-byte-vector-support.md)
 - [k-NN Iterative Graph Build](features/k-nn/k-nn-iterative-graph-build.md)
+- [k-NN Lucene Vector Integration](features/k-nn/k-nn-lucene-vector-integration.md)
 - [k-NN Model Metadata](features/k-nn/k-nn-model-metadata.md)
 - [k-NN Query Rescore](features/k-nn/k-nn-query-rescore.md)
 - [k-NN Space Type Configuration](features/k-nn/k-nn-space-type-configuration.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the k-NN Lucene Vector Integration feature introduced in OpenSearch v2.17.0.

## Changes

- **Release Report**: `docs/releases/v2.17.0/features/k-nn/k-nn-lucene-vector-integration.md`
- **Feature Report**: `docs/features/k-nn/k-nn-lucene-vector-integration.md`
- Updated release and feature indexes

## Feature Overview

The k-NN Lucene Vector Integration enables native vector search engines (FAISS and NMSLIB) to use Lucene's optimized KNNVectorsFormat for vector storage instead of BinaryDocValues. Key benefits:

- **3.3x better p99 latency** for reading vectors from disk
- **5-10% faster index build times**
- Foundation for memory-optimized vector search

## Related

- Closes #380
- PR: [opensearch-project/k-NN#1945](https://github.com/opensearch-project/k-NN/pull/1945)
- RFC: [opensearch-project/k-NN#1853](https://github.com/opensearch-project/k-NN/issues/1853)