### PR TITLE
docs: add System Templates report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -246,3 +246,7 @@
 ## security-analytics-dashboards
 
 - [Security Analytics Dashboards Plugin](security-analytics-dashboards/security-analytics-dashboards-plugin.md)
+
+## opensearch-system-templates
+
+- [System Templates](opensearch-system-templates/system-templates.md)

--- a/docs/features/opensearch-system-templates/system-templates.md
+++ b/docs/features/opensearch-system-templates/system-templates.md
@@ -1,0 +1,143 @@
+# System Templates (Application-Based Configuration)
+
+## Summary
+
+System Templates provide pre-configured index templates optimized for specific use cases like logs and metrics. Instead of manually configuring index settings, users specify an application context (e.g., `logs`, `metrics`, `nginx-logs`) and OpenSearch automatically applies optimized settings including compression codecs, merge policies, and refresh intervals.
+
+Key benefits:
+- ~20% storage reduction with `zstd_no_dict` codec
+- ~6% p99 latency improvement
+- Simplified index configuration for common use cases
+- Consistent best practices across deployments
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "opensearch-system-templates Plugin"
+        LR[LocalSystemTemplateRepository]
+        JSON[JSON Template Files]
+        JSON --> LR
+    end
+    
+    subgraph "OpenSearch Core"
+        CSTL[ClusterStateSystemTemplateLoader]
+        CS[Cluster State]
+        MT[Metadata Templates]
+    end
+    
+    LR --> CSTL
+    CSTL --> CS
+    CS --> MT
+    
+    subgraph "Index Creation"
+        API[Create Index API]
+        CT[Component Templates]
+        IDX[Index]
+    end
+    
+    MT --> CT
+    API --> CT
+    CT --> IDX
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User: Create Index with context] --> B{Context specified?}
+    B -->|Yes| C[Lookup System Template]
+    B -->|No| D[Use default settings]
+    C --> E[Apply Component Templates]
+    E --> F[Apply optimized settings]
+    F --> G[Create Index]
+    D --> G
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `LocalSystemTemplateRepository` | Loads JSON template definitions from plugin resources |
+| `ClusterStateSystemTemplateLoader` | Applies templates to cluster state on startup |
+| `SystemTemplateMetadata` | Stores template metadata in cluster state |
+| `SystemTemplatesPlugin` | Main plugin entry point |
+
+### Available Templates
+
+| Template | Context | Use Case |
+|----------|---------|----------|
+| `logs` | `logs` | General log data |
+| `metrics` | `metrics` | Time-series metrics |
+| `nginx-logs` | `nginx-logs` | Nginx access/error logs |
+| `apache-web-logs` | `apache-web-logs` | Apache HTTP server logs |
+| `amazon-cloudtrail-logs` | `amazon-cloudtrail-logs` | AWS CloudTrail audit logs |
+| `amazon-elb-logs` | `amazon-elb-logs` | AWS Elastic Load Balancer logs |
+| `amazon-s3-logs` | `amazon-s3-logs` | AWS S3 access logs |
+| `k8s-logs` | `k8s-logs` | Kubernetes container logs |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.application_templates.enabled` | Enable system templates feature | `false` |
+
+### Optimized Settings Applied
+
+Templates apply these optimizations:
+
+| Setting | Value | Benefit |
+|---------|-------|---------|
+| `index.codec` | `zstd_no_dict` | ~20% storage reduction |
+| `index.merge.policy` | `log_byte_size` | Improved merge efficiency |
+| `index.refresh_interval` | `60s` | Reduced refresh overhead |
+
+### Usage Example
+
+Enable the feature:
+```yaml
+# opensearch.yml
+cluster.application_templates.enabled: true
+```
+
+Create an index with application context:
+```json
+PUT /my-nginx-logs
+{
+  "settings": {
+    "index.context.created": "nginx-logs"
+  }
+}
+```
+
+The index automatically inherits optimized settings from the `nginx-logs` template.
+
+### Dependencies
+
+- Requires `opensearch-custom-codecs` plugin for `zstd_no_dict` codec support
+
+## Limitations
+
+- Feature is experimental in v2.17.0
+- Context cannot be changed after index creation
+- Requires explicit enablement via cluster setting
+- Custom codec requires additional plugin installation
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [opensearch-system-templates#3](https://github.com/opensearch-project/opensearch-system-templates/pull/3) | Initial implementation with basic templates |
+| v2.17.0 | [opensearch-system-templates#8](https://github.com/opensearch-project/opensearch-system-templates/pull/8) | Add nginx, apache, AWS, k8s templates + zstd support |
+| v2.17.0 | [opensearch-system-templates#11](https://github.com/opensearch-project/opensearch-system-templates/pull/11) | Backport to 2.x branch |
+
+## References
+
+- [OpenSearch Blog: Application-Based Configuration Templates](https://opensearch.org/blog/abc-templates/): Feature announcement and details
+- [opensearch-system-templates Repository](https://github.com/opensearch-project/opensearch-system-templates): Source code
+
+## Change History
+
+- **v2.17.0** (2024-10-22): Initial experimental release with 8 templates (logs, metrics, nginx-logs, apache-web-logs, amazon-cloudtrail-logs, amazon-elb-logs, amazon-s3-logs, k8s-logs)

--- a/docs/releases/v2.17.0/features/opensearch-system-templates/system-templates.md
+++ b/docs/releases/v2.17.0/features/opensearch-system-templates/system-templates.md
@@ -1,0 +1,114 @@
+# System Templates
+
+## Summary
+
+OpenSearch 2.17.0 introduces Application-Based Configuration (ABC) templates through the `opensearch-system-templates` plugin. This feature provides predefined system templates that simplify index configuration for various use cases like logs, metrics, and application-specific logging. Templates automatically apply optimized settings including `zstd_no_dict` compression and `log_byte_size` merge policy.
+
+## Details
+
+### What's New in v2.17.0
+
+The `opensearch-system-templates` plugin was introduced as a new repository for system templates loaded during cluster setup. These templates provide sensible defaults for common OpenSearch use cases.
+
+### Technical Changes
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph Plugin["opensearch-system-templates Plugin"]
+        Loader["SystemTemplateLoader"]
+        Repo["LocalSystemTemplateRepository"]
+        Templates["Template JSON Files"]
+    end
+    
+    subgraph OpenSearch["OpenSearch Core"]
+        ClusterState["Cluster State"]
+        IndexTemplate["Index Template"]
+        Index["Index"]
+    end
+    
+    Repo --> Templates
+    Loader --> Repo
+    Loader --> ClusterState
+    IndexTemplate -->|context| ClusterState
+    ClusterState --> Index
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ApplicationBasedConfigurationSystemTemplatesPlugin` | Main plugin class implementing `SystemTemplatesPlugin` |
+| `LocalSystemTemplateRepository` | Repository implementation that loads templates from plugin resources |
+| Template JSON files | Predefined configurations for various use cases |
+
+#### Available Templates
+
+| Template | Use Case | Settings |
+|----------|----------|----------|
+| `logs` | General log data | `zstd_no_dict` codec, `log_byte_size` merge policy, 60s refresh |
+| `metrics` | Metrics data | `zstd_no_dict` codec, `log_byte_size` merge policy, 60s refresh |
+| `nginx-logs` | Nginx access logs | Full mapping with HTTP fields |
+| `apache-web-logs` | Apache web server logs | HTTP communication mappings |
+| `amazon-cloudtrail-logs` | AWS CloudTrail logs | AWS-specific field mappings |
+| `amazon-elb-logs` | AWS ELB logs | Load balancer field mappings |
+| `amazon-s3-logs` | AWS S3 access logs | S3-specific field mappings |
+| `k8s-logs` | Kubernetes logs | Container and pod field mappings |
+
+#### Template Settings
+
+All templates include optimized settings:
+
+| Setting | Value | Benefit |
+|---------|-------|---------|
+| `index.codec` | `zstd_no_dict` | ~20% storage improvement |
+| `index.merge.policy` | `log_byte_size` | Better time-range query performance |
+| `index.refresh_interval` | `60s` | Reduced indexing overhead |
+| `index.mapping.total_fields.limit` | `10000` | Support for complex mappings |
+
+### Usage Example
+
+```json
+PUT /_index_template/my-metrics-template
+{
+  "index_patterns": ["my-metrics-*"],
+  "context": {
+    "name": "metrics"
+  }
+}
+```
+
+When an index matching the pattern is created, it automatically inherits the optimized settings from the `metrics` template.
+
+### Performance Benefits
+
+Based on testing with HTTP logs dataset:
+- **Storage**: ~20% improvement with `zstd_no_dict` vs default compression
+- **Indexing p99 latency**: ~6% improvement due to smaller segments
+- **Query performance**: Improved time-range filter queries due to `log_byte_size` merge policy
+
+## Limitations
+
+- Templates are experimental in v2.17.0
+- Requires `cluster.application_templates.enabled: true` setting
+- Context cannot be removed once configured for an index
+- Cannot override template-defined settings during index creation
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3](https://github.com/opensearch-project/opensearch-system-templates/pull/3) | Basic templates and addition of build steps |
+| [#11](https://github.com/opensearch-project/opensearch-system-templates/pull/11) | Backport: Onboarding new templates and adding zstd support |
+| [#8](https://github.com/opensearch-project/opensearch-system-templates/pull/8) | Onboarding new templates and adding zstd support (main) |
+
+## References
+
+- [Blog: OpenSearch simplified: The power of ABC templates](https://opensearch.org/blog/opensearch-simplified-the-power-of-application-based-templates/)
+- [Documentation: Index context](https://opensearch.org/docs/latest/im-plugin/index-context/)
+- [Repository: opensearch-system-templates](https://github.com/opensearch-project/opensearch-system-templates)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-system-templates/system-templates.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -68,6 +68,9 @@
 - [Security Dashboards Bugfixes](features/security-dashboards/security-dashboards-bugfixes.md)
 - [Security Dashboards UI Enhancements](features/security-dashboards/security-dashboards-ui.md)
 
+### opensearch-system-templates
+- [System Templates](features/opensearch-system-templates/system-templates.md)
+
 ### dashboards-plugins
 - [CVE Fixes](features/dashboards-plugins/cve-fixes.md)
 


### PR DESCRIPTION
## Summary

Add documentation for System Templates (Application-Based Configuration) feature introduced in OpenSearch v2.17.0.

## Reports Created

- **Release report**: `docs/releases/v2.17.0/features/opensearch-system-templates/system-templates.md`
- **Feature report**: `docs/features/opensearch-system-templates/system-templates.md`

## Key Changes in v2.17.0

- Initial experimental release of System Templates via `opensearch-system-templates` plugin
- 8 pre-configured templates: logs, metrics, nginx-logs, apache-web-logs, amazon-cloudtrail-logs, amazon-elb-logs, amazon-s3-logs, k8s-logs
- Optimized settings: `zstd_no_dict` codec (~20% storage reduction), `log_byte_size` merge policy, 60s refresh interval
- Requires `cluster.application_templates.enabled: true` to enable

## Resources Used

- PR: opensearch-project/opensearch-system-templates#3, #8, #11
- Blog: https://opensearch.org/blog/abc-templates/

Closes #379