### PR TITLE
docs: add Observability Workspace Integration report for v2.17.0

### DIFF
--- a/docs/features/dashboards-observability/observability-workspace-integration.md
+++ b/docs/features/dashboards-observability/observability-workspace-integration.md
@@ -1,0 +1,174 @@
+# Observability Workspace Integration
+
+## Summary
+
+The Observability Workspace Integration feature enables the OpenSearch Dashboards Observability plugin to work seamlessly in multi-workspace environments. It provides workspace-aware asset creation and a dynamic Overview page built with the Content Management framework, allowing users to customize their observability experience with embedded dashboards and quick-access cards.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        WS[Workspace Context]
+        CM[Content Management Plugin]
+    end
+    
+    subgraph "Observability Plugin"
+        subgraph "Server"
+            API[createAssets API]
+            Router[Getting Started Router]
+        end
+        
+        subgraph "Client"
+            OP[Overview Page]
+            DC[Dashboard Controls]
+            SF[Select Flyout]
+            SM[State Manager]
+        end
+    end
+    
+    subgraph "Saved Objects"
+        SO[Dashboards]
+        IP[Index Patterns]
+        VIS[Visualizations]
+    end
+    
+    WS --> API
+    API --> SO
+    CM --> OP
+    OP --> DC
+    DC --> SF
+    DC --> SM
+    SM --> SO
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Asset Creation"
+        REQ[Request] --> WS{Workspace?}
+        WS -->|Yes| PREFIX[Prefix IDs]
+        WS -->|No| DIRECT[Use Original IDs]
+        PREFIX --> SAVE[Save Objects]
+        DIRECT --> SAVE
+    end
+    
+    subgraph "Overview Page"
+        LOAD[Load Page] --> REG[Register Content]
+        REG --> RENDER[Render Page]
+        RENDER --> DASH[Display Dashboard]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `getting_started_router.ts` | Server-side router handling asset creation with workspace support |
+| `DashboardControls` | React component for dashboard selection and date range controls |
+| `SelectDashboardFlyout` | Flyout component for selecting dashboards from saved objects |
+| `AddDashboardCallout` | Callout component prompting users to select a dashboard |
+| `ObsDashboardStateManager` | RxJS-based state manager for dashboard state |
+| `cardConfigs` | Configuration array defining Getting Started cards |
+| `home.tsx` | Main Overview page component using Content Management |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `observability:defaultDashboard` | Saved object ID of the default dashboard to display | (none) |
+
+### Usage Example
+
+#### Workspace-Aware Asset Creation
+
+When creating assets in a workspace context, IDs are automatically prefixed:
+
+```typescript
+// Server-side ID transformation
+const { requestWorkspaceId } = getWorkspaceState(request);
+
+if (requestWorkspaceId) {
+  newId = `workspaceId-${requestWorkspaceId}-${newId}`;
+  references = references?.map((ref) => ({
+    ...ref,
+    id: `workspaceId-${requestWorkspaceId}-${ref.id}`,
+  }));
+}
+```
+
+#### Content Management Registration
+
+```typescript
+// Register Getting Started cards
+coreRefs.contentManagement?.registerContentProvider({
+  id: card.id,
+  getContent: () => ({
+    id: card.id,
+    kind: 'card',
+    order: card.order,
+    description: card.description,
+    title: card.title,
+    onClick: () => coreRefs.application?.navigateToApp(card.url),
+    getFooter: () => <EuiText size="s">{card.footer}</EuiText>,
+  }),
+  getTargetArea: () => HOME_CONTENT_AREAS.GET_STARTED,
+});
+
+// Register embedded dashboard
+coreRefs.contentManagement?.registerContentProvider({
+  id: 'dashboard_content',
+  getContent: () => ({
+    id: 'dashboard_content',
+    kind: 'dashboard',
+    order: 1000,
+    input: {
+      kind: 'dynamic',
+      get: () => Promise.resolve(getObservabilityDashboardsId()),
+    },
+  }),
+  getTargetArea: () => HOME_CONTENT_AREAS.DASHBOARD,
+});
+```
+
+#### Dashboard State Management
+
+```typescript
+// State manager using RxJS BehaviorSubjects
+class ObsDashboardStateManager {
+  static isDashboardSelected$ = new BehaviorSubject<boolean>(false);
+  static dashboardState$ = new BehaviorSubject<DashboardState>({
+    startDate: '',
+    endDate: '',
+    dashboardTitle: '',
+    dashboardId: '',
+  });
+  static showFlyout$ = new BehaviorSubject<() => void>(() => {});
+}
+```
+
+## Limitations
+
+- State management uses RxJS BehaviorSubjects as a temporary solution; planned migration to Redux or React Context
+- Workspace ID prefixing only applies to newly created assets, not existing ones
+- The embedded dashboard inherits the time range from the Overview page controls, not from the dashboard's saved time range
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#2101](https://github.com/opensearch-project/dashboards-observability/pull/2101) | Make createAssets API compatible with workspace |
+| v2.17.0 | [#2077](https://github.com/opensearch-project/dashboards-observability/pull/2077) | OverviewPage made with Content Management |
+| v2.16.0 | [#7201](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7201) | Content Management plugin introduction (dependency) |
+
+## References
+
+- [OpenSearch-Dashboards #7201](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7201): Content Management plugin RFC and implementation
+- [Observability Documentation](https://docs.opensearch.org/2.17/observing-your-data/): Official observability documentation
+
+## Change History
+
+- **v2.17.0** (2024-10-15): Initial implementation - workspace-compatible createAssets API and Content Management-based Overview page

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -161,6 +161,7 @@
 - [Getting Started Workflows](dashboards-observability/getting-started-workflows.md)
 - [Observability Notebooks](dashboards-observability/observability-notebooks.md)
 - [Observability Traces](dashboards-observability/observability-traces.md)
+- [Observability Workspace Integration](dashboards-observability/observability-workspace-integration.md)
 - [Trace Analytics](dashboards-observability/trace-analytics.md)
 
 ## dashboards-maps

--- a/docs/releases/v2.17.0/features/observability/observability-workspace-integration.md
+++ b/docs/releases/v2.17.0/features/observability/observability-workspace-integration.md
@@ -1,0 +1,151 @@
+# Observability Workspace Integration
+
+## Summary
+
+OpenSearch Dashboards v2.17.0 introduces workspace integration for the Observability plugin. This release includes two key enhancements: making the `createAssets` API compatible with workspaces and rebuilding the Overview page using the Content Management framework. These changes enable better multi-tenant support and provide a more dynamic, customizable overview experience.
+
+## Details
+
+### What's New in v2.17.0
+
+#### 1. Workspace-Compatible createAssets API
+
+The `/api/observability/gettingStarted/createAssets` API now supports workspace isolation. Previously, this API used static IDs for created objects, which caused conflicts in multi-workspace environments.
+
+**Key Changes:**
+- Detects `workspaceId` from the request context
+- Prepends workspace ID to object IDs and their references when workspace is active
+- Maintains backward compatibility for non-workspace environments
+
+```typescript
+// ID transformation logic
+if (requestWorkspaceId) {
+  newId = `workspaceId-${requestWorkspaceId}-${newId}`;
+  references = references?.map((ref) => ({
+    ...ref,
+    id: `workspaceId-${requestWorkspaceId}-${ref.id}`,
+  }));
+}
+```
+
+#### 2. Overview Page with Content Management
+
+The Observability Overview page has been rebuilt using the Content Management plugin, providing a dynamic and extensible page structure.
+
+```mermaid
+graph TB
+    subgraph "Content Management Framework"
+        CM[Content Management Plugin]
+        CP[Content Providers]
+        PA[Page Areas]
+    end
+    
+    subgraph "Observability Overview"
+        GS[Getting Started Cards]
+        DC[Dashboard Controls]
+        DB[Embedded Dashboard]
+        SF[Select Dashboard Flyout]
+    end
+    
+    CM --> PA
+    CP --> CM
+    GS --> CP
+    DC --> CP
+    DB --> CP
+    SF --> DC
+```
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `DashboardControls` | Controls for selecting and managing the embedded dashboard |
+| `SelectDashboardFlyout` | Flyout UI for selecting a dashboard to display |
+| `AddDashboardCallout` | Callout prompting users to select a dashboard |
+| `ObsDashboardStateManager` | RxJS-based state manager for dashboard state |
+| `cardConfigs` | Configuration for Getting Started cards |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `observability:defaultDashboard` | ID of the default dashboard to display on Overview page | (none) |
+
+#### Architecture Changes
+
+The Overview page now uses Content Management's page rendering system:
+
+```mermaid
+flowchart TB
+    subgraph "Page Registration"
+        HP[HOME_PAGE_ID]
+        HA[HOME_CONTENT_AREAS]
+    end
+    
+    subgraph "Content Areas"
+        GS[GET_STARTED Area]
+        SEL[SELECTOR Area]
+        DASH[DASHBOARD Area]
+    end
+    
+    subgraph "Registered Content"
+        Cards[Getting Started Cards]
+        Controls[Dashboard Controls]
+        Dashboard[Embedded Dashboard]
+    end
+    
+    HP --> HA
+    HA --> GS
+    HA --> SEL
+    HA --> DASH
+    Cards --> GS
+    Controls --> SEL
+    Dashboard --> DASH
+```
+
+### Usage Example
+
+The Overview page automatically displays:
+
+1. **Getting Started Cards** - Quick links to key Observability features:
+   - Add your data (Getting Started Guide)
+   - Discover insights
+   - Monitor system performance (Metrics)
+   - Identify performance issues (Traces)
+   - Monitor service health (Services)
+   - Get notified (Alerting) - if plugin installed
+   - Detect anomalies (Anomaly Detection) - if plugin installed
+
+2. **Dashboard Section** - Embeddable dashboard with:
+   - Dashboard selector flyout
+   - Date range picker
+   - Link to full dashboard view
+
+### Migration Notes
+
+- Existing Observability assets created before v2.17.0 will continue to work
+- New assets created in workspaces will have workspace-prefixed IDs
+- The Overview page setting `observability:defaultDashboard` can be configured in Advanced Settings
+
+## Limitations
+
+- Dashboard state management uses RxJS BehaviorSubjects (temporary solution, planned migration to Redux or React Context)
+- The `createAssets` API workspace support only applies to new asset creation, not existing assets
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2101](https://github.com/opensearch-project/dashboards-observability/pull/2101) | Make createAssets API compatible with workspace |
+| [#2077](https://github.com/opensearch-project/dashboards-observability/pull/2077) | OverviewPage made with Content Management |
+
+## References
+
+- [OpenSearch-Dashboards #7201](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7201): Content Management plugin introduction
+- [Observability Documentation](https://docs.opensearch.org/2.17/observing-your-data/): Official observability docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-observability/observability-workspace-integration.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -24,6 +24,7 @@
 ### dashboards-observability
 - [Observability Enhancements](features/dashboards-observability/observability-enhancements.md)
 - [Observability Notebooks Bugfixes](features/dashboards-observability/observability-notebooks.md)
+- [Observability Workspace Integration](features/observability/observability-workspace-integration.md)
 - [Trace Analytics Custom Source](features/dashboards-observability/trace-analytics.md)
 - [Trace Analytics Bugfixes](features/observability/trace-analytics-bugfixes.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Observability Workspace Integration feature in OpenSearch Dashboards v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/observability/observability-workspace-integration.md`
- Feature report: `docs/features/dashboards-observability/observability-workspace-integration.md`

### Key Changes in v2.17.0
- **Workspace-compatible createAssets API**: The `/api/observability/gettingStarted/createAssets` API now supports workspace isolation by prefixing object IDs with workspace ID
- **Content Management-based Overview Page**: The Observability Overview page has been rebuilt using the Content Management framework, providing dynamic content areas for Getting Started cards and embedded dashboards

### Related PRs
- [dashboards-observability#2101](https://github.com/opensearch-project/dashboards-observability/pull/2101): Make createAssets API compatible with workspace
- [dashboards-observability#2077](https://github.com/opensearch-project/dashboards-observability/pull/2077): OverviewPage made with Content Management

### Related Issue
Closes #376