### PR TITLE
docs: add Observability Multi-Data Source Support report for v2.17.0

### DIFF
--- a/docs/features/dashboards-observability/observability-multi-data-source-support.md
+++ b/docs/features/dashboards-observability/observability-multi-data-source-support.md
@@ -1,0 +1,220 @@
+# Observability Multi-Data Source Support
+
+## Summary
+
+Multi-Data Source (MDS) support for the Observability plugin enables users to work with observability data from multiple OpenSearch clusters through a single OpenSearch Dashboards instance. This feature allows users to select target data sources when using Getting Started workflows, Integrations, and other Observability features, providing a unified interface for managing observability across distributed environments.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        OBS[Observability Plugin]
+        DSM[Data Source Management]
+        
+        subgraph "MDS-Enabled Components"
+            GS[Getting Started]
+            INT[Integrations]
+            TA[Trace Analytics]
+        end
+    end
+    
+    subgraph "Backend"
+        API[Observability API]
+        DSL[DSL Routes]
+        IM[Integrations Manager]
+    end
+    
+    subgraph "Data Sources"
+        LC[Local Cluster]
+        RC1[Remote Cluster 1]
+        RC2[Remote Cluster 2]
+    end
+    
+    OBS --> DSM
+    DSM --> GS
+    DSM --> INT
+    DSM --> TA
+    
+    GS --> API
+    INT --> IM
+    API --> DSL
+    IM --> DSL
+    
+    DSL --> LC
+    DSL --> RC1
+    DSL --> RC2
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User selects Data Source] --> B[DataSourceSelector Component]
+    B --> C{MDS Enabled?}
+    C -->|Yes| D[Store dataSourceMDSId]
+    C -->|No| E[Use Local Cluster]
+    D --> F[Pass to API calls]
+    E --> F
+    F --> G[Execute against target cluster]
+    G --> H[Return results with MDS reference]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `DataSourceSelector` | UI component for selecting target data source |
+| `DataSourceMenu` | Menu component for data source selection in headers |
+| `dataSourceMDSId` | State parameter tracking selected MDS ID |
+| `dataSourceMDSLabel` | State parameter for displaying data source name |
+| `featureFlagStatus` | Plugin-level flag tracking MDS enablement |
+| `IntegrationInstanceBuilder` | Builder class updated to include MDS references |
+| `IntegrationsManager` | Manager class with MDS-aware instance creation |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `data_source.enabled` | Enables multiple data source support in Dashboards | `false` |
+
+### API Endpoints
+
+#### Create Assets with MDS Support
+
+```
+POST /api/observability/gettingStarted/createAssets
+```
+
+Request:
+```json
+{
+  "mdsId": "data-source-uuid",
+  "mdsLabel": "Production Cluster",
+  "tutorialId": "nginx"
+}
+```
+
+Response:
+```json
+{
+  "message": "Objects loaded successfully"
+}
+```
+
+#### DSL Routes with MDS Support
+
+```
+POST /api/observability/dsl/integrations/refresh?dataSourceMDSId={id}
+POST /api/observability/dsl/integrations/mapping?dataSourceMDSId={id}
+```
+
+#### Integration Instance Creation
+
+```
+POST /api/integrations/repository/{templateName}/instances
+```
+
+Request:
+```json
+{
+  "dataSourceMDSId": "data-source-uuid",
+  "dataSourceMDSLabel": "Production Cluster",
+  "name": "my-integration",
+  "indexPattern": "ss4o_logs-nginx-*"
+}
+```
+
+### Usage Example
+
+#### Selecting Data Source in Getting Started
+
+```typescript
+// Data source selection handler
+const onSelectedDataSourceChange = (e: any) => {
+  const dataSourceId = e[0] ? e[0].id : undefined;
+  const dataSourceLabel = e[0] ? e[0].label : '';
+  setSelectedDataSourceId(dataSourceId);
+  setSelectedDataSourceLabel(dataSourceLabel);
+};
+
+// Render data source menu when MDS is enabled
+{dataSourceEnabled && (
+  <DataSourceMenu
+    setMenuMountPoint={setActionMenu}
+    componentType={'DataSourceSelectable'}
+    componentConfig={{
+      savedObjects: savedObjectsMDSClient.client,
+      notifications,
+      fullWidth: true,
+      onSelectedDataSources: onSelectedDataSourceChange,
+      dataSourceFilter: dataSourceFilterFn,
+    }}
+  />
+)}
+```
+
+#### Creating Integration with MDS
+
+```typescript
+await addIntegrationRequest({
+  addSample: true,
+  templateName: integration.name,
+  integration,
+  setToast,
+  dataSourceMDSId,
+  dataSourceMDSLabel,
+});
+```
+
+### Integration Instance Structure
+
+When MDS is enabled, integration instances include a `references` field:
+
+```json
+{
+  "name": "nginx-integration",
+  "templateName": "nginx",
+  "dataSource": "ss4o_logs-nginx-*",
+  "creationDate": "2024-08-19T17:39:48Z",
+  "assets": [...],
+  "references": [
+    {
+      "id": "data-source-uuid",
+      "name": "Production Cluster",
+      "type": "data-source"
+    }
+  ]
+}
+```
+
+## Limitations
+
+- When MDS is enabled, certain Observability plugins are deregistered:
+  - Applications
+  - Operational Panels (dashboards)
+  - Logs Explorer
+- S3 data source registration is disabled when MDS feature flag is enabled
+- Integration assets cannot be automatically migrated between data sources
+- Some visualization types may not fully support MDS
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#2048](https://github.com/opensearch-project/dashboards-observability/pull/2048) | Multi-data Source Support for Getting Started |
+| v2.17.0 | [#2051](https://github.com/opensearch-project/dashboards-observability/pull/2051) | MDS support in Integrations |
+| v2.17.0 | [#2097](https://github.com/opensearch-project/dashboards-observability/pull/2097) | Deregister plugins in MDS mode |
+| v2.17.0 | [#2140](https://github.com/opensearch-project/dashboards-observability/pull/2140) | Support for absent local cluster |
+
+## References
+
+- [Issue #1440](https://github.com/opensearch-project/dashboards-observability/issues/1440): Original feature request
+- [Multiple Data Sources Documentation](https://docs.opensearch.org/2.17/dashboards/management/multi-data-sources/): Official configuration guide
+- [Multiple Data Sources Blog](https://opensearch.org/blog/multiple-data-source/): Feature announcement and overview
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Initial MDS support for Getting Started, Integrations, and plugin deregistration

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -159,6 +159,7 @@
 ## dashboards-observability
 
 - [Getting Started Workflows](dashboards-observability/getting-started-workflows.md)
+- [Observability Multi-Data Source Support](dashboards-observability/observability-multi-data-source-support.md)
 - [Observability Notebooks](dashboards-observability/observability-notebooks.md)
 - [Observability Traces](dashboards-observability/observability-traces.md)
 - [Observability UI](dashboards-observability/observability-ui.md)

--- a/docs/releases/v2.17.0/features/observability/observability-multi-data-source-support.md
+++ b/docs/releases/v2.17.0/features/observability/observability-multi-data-source-support.md
@@ -1,0 +1,133 @@
+# Observability Multi-Data Source Support
+
+## Summary
+
+OpenSearch Dashboards v2.17.0 extends Multi-Data Source (MDS) support to the Observability plugin, enabling users to work with observability data from multiple OpenSearch clusters through a single Dashboards instance. This release adds MDS support to Getting Started workflows, Integrations, and includes enhancements for plugin registration when the local cluster is absent.
+
+## Details
+
+### What's New in v2.17.0
+
+This release introduces comprehensive MDS support across several Observability components:
+
+1. **Getting Started MDS Support**: Users can now select a data source when using Getting Started workflows, with assets created in the selected remote cluster.
+
+2. **Integrations MDS Support**: The Integrations feature now supports multiple data sources, allowing users to install and manage integrations across different OpenSearch clusters.
+
+3. **Plugin Deregistration in MDS Mode**: When MDS is enabled, certain plugins (dashboards, applications, logs) are deregistered to prevent conflicts with the multi-data source architecture.
+
+4. **Data Source Registration Without Local Cluster**: Added support for registering data sources when the local cluster is absent, resolving 500 errors that occurred when no backend plugins were available.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        UI[Observability UI]
+        DSS[Data Source Selector]
+        GS[Getting Started]
+        INT[Integrations]
+    end
+    
+    subgraph "Data Sources"
+        LC[Local Cluster]
+        RC1[Remote Cluster 1]
+        RC2[Remote Cluster 2]
+    end
+    
+    UI --> DSS
+    DSS --> GS
+    DSS --> INT
+    GS --> LC
+    GS --> RC1
+    GS --> RC2
+    INT --> LC
+    INT --> RC1
+    INT --> RC2
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `DataSourceSelector` | UI component for selecting target data source in Getting Started |
+| `dataSourceMDSId` | Parameter for tracking selected MDS ID across components |
+| `dataSourceMDSLabel` | Parameter for displaying selected data source name |
+| `featureFlagStatus` | Flag to track MDS enablement status |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `data_source.enabled` | Enables multiple data source support | `false` |
+
+#### API Changes
+
+New endpoint for creating assets with MDS support:
+
+```
+POST /api/observability/gettingStarted/createAssets
+```
+
+Request body:
+```json
+{
+  "mdsId": "data-source-id",
+  "mdsLabel": "Data Source Name",
+  "tutorialId": "tutorial-name"
+}
+```
+
+New DSL routes for MDS-aware operations:
+- `POST /api/observability/dsl/integrations/refresh` - Refresh indices with MDS support
+- `POST /api/observability/dsl/integrations/mapping` - Get mappings with MDS support
+
+### Usage Example
+
+When MDS is enabled, users see a data source selector in the Getting Started and Integrations pages:
+
+```typescript
+// Select data source and create assets
+const onSelectedDataSource = (e) => {
+  const dataSourceId = e[0] ? e[0].id : undefined;
+  const dataSourceLabel = e[0] ? e[0].label : undefined;
+  setDataSourceMDSId(dataSourceId);
+  setDataSourceMDSLabel(dataSourceLabel);
+};
+
+// Assets are created with MDS reference
+await UploadAssets(tutorialId, selectedDataSourceId, selectedDataSourceLabel);
+```
+
+### Migration Notes
+
+- When upgrading to v2.17.0 with MDS enabled, existing integrations will continue to work with the local cluster
+- New integrations can be installed to any configured data source
+- The `references` field in integration instances now includes data source information
+
+## Limitations
+
+- Some Observability features (dashboards, applications, logs) are deregistered when MDS is enabled
+- S3 data source registration is disabled when MDS feature flag is enabled
+- Integration assets must be manually migrated if moving between data sources
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2048](https://github.com/opensearch-project/dashboards-observability/pull/2048) | Multi-data Source Support for Getting Started |
+| [#2051](https://github.com/opensearch-project/dashboards-observability/pull/2051) | MDS support in Integrations for observability plugin |
+| [#2097](https://github.com/opensearch-project/dashboards-observability/pull/2097) | Deregister dashboards, applications, logs in MDS |
+| [#2140](https://github.com/opensearch-project/dashboards-observability/pull/2140) | Add support for register data sources during absence of local cluster |
+
+## References
+
+- [Issue #1440](https://github.com/opensearch-project/dashboards-observability/issues/1440): Feature request for MDS support in Trace Analytics
+- [Multiple Data Sources Documentation](https://docs.opensearch.org/2.17/dashboards/management/multi-data-sources/): Official docs
+- [Multiple Data Sources Blog](https://opensearch.org/blog/multiple-data-source/): Launch announcement
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/dashboards-observability/observability-multi-data-source-support.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -23,6 +23,7 @@
 
 ### dashboards-observability
 - [Observability Enhancements](features/dashboards-observability/observability-enhancements.md)
+- [Observability Multi-Data Source Support](features/observability/observability-multi-data-source-support.md)
 - [Observability Notebooks Bugfixes](features/dashboards-observability/observability-notebooks.md)
 - [Observability UI Updates](features/observability/observability-ui-updates.md)
 - [Observability Workspace Integration](features/observability/observability-workspace-integration.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Observability Multi-Data Source Support feature introduced in OpenSearch v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/observability/observability-multi-data-source-support.md`
- Feature report: `docs/features/dashboards-observability/observability-multi-data-source-support.md`

### Key Changes in v2.17.0
- Multi-Data Source support for Getting Started workflows
- MDS support in Integrations for observability plugin
- Plugin deregistration (dashboards, applications, logs) when MDS is enabled
- Support for registering data sources when local cluster is absent

### Related PRs
- [#2048](https://github.com/opensearch-project/dashboards-observability/pull/2048): Multi-data Source Support for Getting Started
- [#2051](https://github.com/opensearch-project/dashboards-observability/pull/2051): MDS support in Integrations
- [#2097](https://github.com/opensearch-project/dashboards-observability/pull/2097): Deregister plugins in MDS mode
- [#2140](https://github.com/opensearch-project/dashboards-observability/pull/2140): Support for absent local cluster

### Resources Used
- Issue: [#1440](https://github.com/opensearch-project/dashboards-observability/issues/1440)
- Docs: https://docs.opensearch.org/2.17/dashboards/management/multi-data-sources/
- Blog: https://opensearch.org/blog/multiple-data-source/