### PR TITLE
docs: add ML Commons Batch Ingestion report for v2.17.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -129,6 +129,7 @@
 
 ## ml-commons
 
+- [Batch Ingestion](ml-commons/batch-ingestion.md)
 - [ML Commons Connector](ml-commons/ml-commons-connector.md)
 - [ML Commons Connector Blueprints](ml-commons/ml-commons-blueprints.md)
 - [ML Commons MCP (Model Context Protocol)](ml-commons/ml-commons-mcp.md)

--- a/docs/features/ml-commons/batch-ingestion.md
+++ b/docs/features/ml-commons/batch-ingestion.md
@@ -1,0 +1,287 @@
+# ML Commons Batch Ingestion
+
+## Summary
+
+ML Commons Batch Ingestion enables offline ingestion of documents and their pre-generated embeddings from remote file servers into OpenSearch indexes. This feature completes the batch inference workflow by allowing users to ingest results from batch prediction jobs (from services like Amazon SageMaker, Amazon Bedrock, or OpenAI) back into OpenSearch for neural search applications. Unlike real-time ingestion pipelines that generate embeddings document-by-document, batch ingestion processes pre-computed embeddings in bulk, making it ideal for large-scale vector search applications.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Batch Inference Workflow"
+        direction TB
+        A[Source Documents] --> B[Batch Predict API]
+        B --> C[External ML Service]
+        C --> D[Embeddings Output File]
+    end
+    
+    subgraph "Batch Ingestion Workflow"
+        direction TB
+        D --> E[Batch Ingestion API]
+        E --> F[Data Ingester]
+        F --> G[Field Mapping]
+        G --> H[Bulk Indexing]
+        H --> I[k-NN Index]
+    end
+    
+    subgraph "External Data Sources"
+        S3[Amazon S3]
+        OpenAI[OpenAI Files]
+    end
+    
+    S3 --> F
+    OpenAI --> F
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Batch Ingestion Request] --> B{Validate Request}
+    B --> C[Create BATCH_INGEST Task]
+    C --> D{Data Source Type?}
+    
+    D -->|S3| E[S3DataIngestion]
+    D -->|OpenAI| F[OpenAIDataIngestion]
+    
+    E --> G[Authenticate with AWS]
+    F --> H[Authenticate with OpenAI]
+    
+    G --> I[Read JSONL File]
+    H --> I
+    
+    I --> J[Parse JSON Lines]
+    J --> K[Apply Field Mapping]
+    K --> L[Build Bulk Request]
+    L --> M[Execute Bulk Index]
+    M --> N{More Lines?}
+    N -->|Yes| J
+    N -->|No| O[Update Task Status]
+    O --> P[Return Success Rate]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `MLBatchIngestionInput` | Input class containing index name, field mappings, credentials, and data source configuration |
+| `MLBatchIngestionRequest` | Transport request wrapper for batch ingestion operations |
+| `MLBatchIngestionResponse` | Response containing task ID and initial status |
+| `AbstractIngestion` | Base class providing common bulk ingestion logic and success rate tracking |
+| `S3DataIngestion` | Ingester implementation for reading JSONL files from Amazon S3 buckets |
+| `OpenAIDataIngestion` | Ingester implementation for reading files from OpenAI's file storage API |
+| `BatchIngestionTransportAction` | Transport action handling the batch ingestion request |
+| `RestBatchIngestionAction` | REST handler for the batch ingestion endpoint |
+
+### Configuration
+
+#### Request Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `index_name` | String | Yes | Target OpenSearch index for ingestion |
+| `field_map` | Object | Yes | Maps source file fields to index fields using JSONPath |
+| `ingest_fields` | Array | No | Fields to ingest directly without transformation |
+| `credential` | Object | Yes | Authentication credentials for the data source |
+| `data_source` | Object | Yes | Specifies the type and location of source files |
+
+#### Credential Configuration
+
+For S3:
+| Field | Description |
+|-------|-------------|
+| `region` | AWS region |
+| `access_key` | AWS access key ID |
+| `secret_key` | AWS secret access key |
+| `session_token` | AWS session token (optional) |
+
+For OpenAI:
+| Field | Description |
+|-------|-------------|
+| `openAI_key` | OpenAI API key |
+
+#### Data Source Configuration
+
+| Field | Description |
+|-------|-------------|
+| `type` | Data source type: `s3` or `openAI` |
+| `source` | Array of file paths (S3) or file IDs (OpenAI) |
+
+### Usage Examples
+
+#### Single File Ingestion from S3
+
+First, create a k-NN index:
+
+```json
+PUT /my-nlp-index
+{
+  "settings": {
+    "index.knn": true
+  },
+  "mappings": {
+    "properties": {
+      "id": { "type": "text" },
+      "chapter": { "type": "text" },
+      "title": { "type": "text" },
+      "chapter_embedding": {
+        "type": "knn_vector",
+        "dimension": 384,
+        "method": {
+          "engine": "nmslib",
+          "space_type": "cosinesimil",
+          "name": "hnsw"
+        }
+      },
+      "title_embedding": {
+        "type": "knn_vector",
+        "dimension": 384,
+        "method": {
+          "engine": "nmslib",
+          "space_type": "cosinesimil",
+          "name": "hnsw"
+        }
+      }
+    }
+  }
+}
+```
+
+Then ingest data from S3:
+
+```json
+POST /_plugins/_ml/_batch_ingestion
+{
+  "index_name": "my-nlp-index",
+  "field_map": {
+    "chapter": "$.content[0]",
+    "title": "$.content[1]",
+    "chapter_embedding": "$.SageMakerOutput[0]",
+    "title_embedding": "$.SageMakerOutput[1]",
+    "_id": "$.id"
+  },
+  "ingest_fields": ["$.id"],
+  "credential": {
+    "region": "us-east-1",
+    "access_key": "<ACCESS_KEY>",
+    "secret_key": "<SECRET_KEY>"
+  },
+  "data_source": {
+    "type": "s3",
+    "source": ["s3://bucket/output/sagemaker_batch.json.out"]
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "task_id": "cbsPlpEBMHcagzGbOQOx",
+  "task_type": "BATCH_INGEST",
+  "status": "CREATED"
+}
+```
+
+#### Multi-File Ingestion from OpenAI
+
+When ingesting from multiple files, use `source[index]` prefix to reference specific files:
+
+```json
+POST /_plugins/_ml/_batch_ingestion
+{
+  "index_name": "my-nlp-index-openai",
+  "field_map": {
+    "question": "source[1].$.body.input[0]",
+    "answer": "source[1].$.body.input[1]",
+    "question_embedding": "source[0].$.response.body.data[0].embedding",
+    "answer_embedding": "source[0].$.response.body.data[1].embedding",
+    "_id": ["source[0].$.custom_id", "source[1].$.custom_id"]
+  },
+  "ingest_fields": ["source[2].$.custom_field1", "source[2].$.custom_field2"],
+  "credential": {
+    "openAI_key": "<OPENAI_KEY>"
+  },
+  "data_source": {
+    "type": "openAI",
+    "source": ["file-output-id", "file-input-id", "file-metadata-id"]
+  }
+}
+```
+
+#### Checking Ingestion Status
+
+```json
+GET /_plugins/_ml/tasks/cbsPlpEBMHcagzGbOQOx
+```
+
+Response when complete:
+
+```json
+{
+  "task_id": "cbsPlpEBMHcagzGbOQOx",
+  "task_type": "BATCH_INGEST",
+  "state": "COMPLETED",
+  "create_time": 1725496527958,
+  "last_update_time": 1725496600000
+}
+```
+
+### Integration with Batch Predict
+
+Batch ingestion is designed to work with the Batch Predict API for end-to-end offline inference workflows:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant OpenSearch
+    participant SageMaker
+    participant S3
+    
+    User->>OpenSearch: POST /_plugins/_ml/models/{id}/_batch_predict
+    OpenSearch->>SageMaker: Create Transform Job
+    SageMaker->>S3: Read input file
+    SageMaker->>SageMaker: Generate embeddings
+    SageMaker->>S3: Write output file
+    OpenSearch-->>User: Return task_id
+    
+    User->>OpenSearch: GET /_plugins/_ml/tasks/{task_id}
+    OpenSearch->>SageMaker: Check job status
+    OpenSearch-->>User: Return status (COMPLETED)
+    
+    User->>OpenSearch: POST /_plugins/_ml/_batch_ingestion
+    OpenSearch->>S3: Read output file
+    OpenSearch->>OpenSearch: Bulk index documents
+    OpenSearch-->>User: Return ingestion task_id
+```
+
+## Limitations
+
+- Supported data sources: S3 and OpenAI only
+- Source files must be in JSONL format (one JSON object per line)
+- Field mapping requires JSONPath syntax
+- Credentials provided in plaintext in request body
+- No automatic retry for failed documents
+- Large files may require sufficient memory on the coordinating node
+- No streaming support; entire file is processed in memory
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#2844](https://github.com/opensearch-project/ml-commons/pull/2844) | Offline batch ingestion API actions and data ingesters |
+| v2.17.0 | [#2825](https://github.com/opensearch-project/ml-commons/pull/2825) | Support get batch transform job status in get task API |
+
+## References
+
+- [Issue #2840](https://github.com/opensearch-project/ml-commons/issues/2840): Offline Batch Inference and Batch Ingestion
+- [Asynchronous Batch Ingestion Documentation](https://docs.opensearch.org/2.17/ml-commons-plugin/remote-models/async-batch-ingestion/): Official documentation
+- [Asynchronous Batch Ingestion API](https://docs.opensearch.org/2.17/ml-commons-plugin/api/async-batch-ingest/): API reference
+- [Batch Predict API](https://docs.opensearch.org/2.17/ml-commons-plugin/api/model-apis/batch-predict/): Related batch prediction API
+- [Scaling Vector Generation Blog](https://opensearch.org/blog/scaling-vector-generation-batch-ml-inference-with-opensearch-ingestion-and-ml-commons/): Blog post on batch ML inference integration
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Initial implementation with S3 and OpenAI data source support, JSONPath field mapping, and batch job status tracking

--- a/docs/releases/v2.17.0/features/ml-commons/batch-ingestion.md
+++ b/docs/releases/v2.17.0/features/ml-commons/batch-ingestion.md
@@ -1,0 +1,184 @@
+# ML Commons Batch Ingestion
+
+## Summary
+
+OpenSearch 2.17 introduces Asynchronous Batch Ingestion, a new capability in ML Commons that enables offline ingestion of documents and their pre-generated embeddings from remote file servers (Amazon S3 or OpenAI) into OpenSearch indexes. This feature completes the batch inference workflow by allowing users to ingest results from batch prediction jobs back into OpenSearch for neural search, eliminating the need for real-time embedding generation during ingestion.
+
+## Details
+
+### What's New in v2.17.0
+
+- New Asynchronous Batch Ingestion API (`POST /_plugins/_ml/_batch_ingestion`)
+- Support for S3 and OpenAI as data sources
+- JSONPath-based field mapping for flexible data transformation
+- New task type `BATCH_INGEST` for tracking ingestion progress
+- Support for ingesting from multiple files with cross-file field mapping
+- New connector action types: `CANCEL_BATCH_PREDICT` and `BATCH_PREDICT_STATUS`
+- Enhanced Get Task API to fetch real-time batch job status from remote services
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "External Data Sources"
+        S3[Amazon S3]
+        OpenAI[OpenAI Files]
+    end
+    
+    subgraph "OpenSearch ML Commons"
+        API[Batch Ingestion API]
+        Input[MLBatchIngestionInput]
+        Request[MLBatchIngestionRequest]
+        
+        subgraph "Data Ingesters"
+            Abstract[AbstractIngestion]
+            S3Ingester[S3DataIngestion]
+            OpenAIIngester[OpenAIDataIngestion]
+        end
+        
+        TaskMgr[Task Manager]
+        BulkAPI[Bulk API]
+    end
+    
+    subgraph "OpenSearch Index"
+        KNN[k-NN Index]
+    end
+    
+    S3 --> S3Ingester
+    OpenAI --> OpenAIIngester
+    API --> Input --> Request
+    Request --> Abstract
+    Abstract --> S3Ingester
+    Abstract --> OpenAIIngester
+    S3Ingester --> BulkAPI
+    OpenAIIngester --> BulkAPI
+    BulkAPI --> KNN
+    TaskMgr --> API
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `MLBatchIngestionInput` | Input class containing index name, field mappings, credentials, and data source configuration |
+| `MLBatchIngestionRequest` | Transport request wrapper for batch ingestion operations |
+| `MLBatchIngestionResponse` | Response containing task ID and status |
+| `AbstractIngestion` | Base class for data ingesters with common bulk ingestion logic |
+| `S3DataIngestion` | Ingester for reading JSONL files from Amazon S3 |
+| `OpenAIDataIngestion` | Ingester for reading files from OpenAI's file storage |
+| `CancelBatchJobTransportAction` | Transport action for canceling batch transform jobs |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index_name` | Target OpenSearch index for ingestion | Required |
+| `field_map` | Maps source file fields to index fields using JSONPath | Required |
+| `ingest_fields` | Fields to ingest directly without transformation | Optional |
+| `credential` | Authentication credentials for data source | Required |
+| `data_source.type` | Data source type (`s3` or `openAI`) | Required |
+| `data_source.source` | Array of file paths or file IDs | Required |
+
+#### API Changes
+
+New endpoint for batch ingestion:
+
+```
+POST /_plugins/_ml/_batch_ingestion
+```
+
+New endpoint for canceling batch jobs:
+
+```
+POST /_plugins/_ml/tasks/{task_id}/_cancel_batch
+```
+
+### Usage Example
+
+#### Ingesting from S3
+
+```json
+POST /_plugins/_ml/_batch_ingestion
+{
+  "index_name": "my-nlp-index",
+  "field_map": {
+    "chapter": "$.content[0]",
+    "title": "$.content[1]",
+    "chapter_embedding": "$.SageMakerOutput[0]",
+    "title_embedding": "$.SageMakerOutput[1]",
+    "_id": "$.id"
+  },
+  "ingest_fields": ["$.id"],
+  "credential": {
+    "region": "us-east-1",
+    "access_key": "<ACCESS_KEY>",
+    "secret_key": "<SECRET_KEY>",
+    "session_token": "<SESSION_TOKEN>"
+  },
+  "data_source": {
+    "type": "s3",
+    "source": ["s3://bucket/output/batch_results.json.out"]
+  }
+}
+```
+
+#### Ingesting from Multiple OpenAI Files
+
+```json
+POST /_plugins/_ml/_batch_ingestion
+{
+  "index_name": "my-nlp-index-openai",
+  "field_map": {
+    "question": "source[1].$.body.input[0]",
+    "answer": "source[1].$.body.input[1]",
+    "question_embedding": "source[0].$.response.body.data[0].embedding",
+    "answer_embedding": "source[0].$.response.body.data[1].embedding",
+    "_id": ["source[0].$.custom_id", "source[1].$.custom_id"]
+  },
+  "ingest_fields": ["source[2].$.custom_field1"],
+  "credential": {
+    "openAI_key": "<OPENAI_KEY>"
+  },
+  "data_source": {
+    "type": "openAI",
+    "source": ["file-output-id", "file-input-id", "file-metadata-id"]
+  }
+}
+```
+
+### Migration Notes
+
+This is a new feature with no migration required. To use batch ingestion:
+
+1. Generate embeddings using the Batch Predict API (introduced in v2.16)
+2. Store results in S3 or use OpenAI's batch API
+3. Create a k-NN index with appropriate vector field mappings
+4. Call the Batch Ingestion API with field mappings
+
+## Limitations
+
+- Supported data sources limited to S3 and OpenAI in this release
+- Source files must be in JSONL format (one JSON object per line)
+- Field mapping requires JSONPath syntax knowledge
+- Credentials must be provided in plaintext in the request body
+- No automatic retry mechanism for failed document ingestion
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2844](https://github.com/opensearch-project/ml-commons/pull/2844) | Offline batch ingestion API actions and data ingesters |
+| [#2825](https://github.com/opensearch-project/ml-commons/pull/2825) | Support get batch transform job status in get task API |
+
+## References
+
+- [Issue #2840](https://github.com/opensearch-project/ml-commons/issues/2840): Offline Batch Inference and Batch Ingestion
+- [Asynchronous Batch Ingestion Documentation](https://docs.opensearch.org/2.17/ml-commons-plugin/remote-models/async-batch-ingestion/): Official documentation
+- [Asynchronous Batch Ingestion API](https://docs.opensearch.org/2.17/ml-commons-plugin/api/async-batch-ingest/): API reference
+- [Batch Predict API](https://docs.opensearch.org/2.17/ml-commons-plugin/api/model-apis/batch-predict/): Related batch prediction API
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/batch-ingestion.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -79,6 +79,7 @@
 - [CVE Fixes](features/dashboards-plugins/cve-fixes.md)
 
 ### ml-commons
+- [Batch Ingestion](features/ml-commons/batch-ingestion.md)
 - [ML Commons Bugfixes](features/ml-commons/ml-commons-bugfixes.md)
 - [ML Commons Connector Enhancements](features/ml-commons/ml-commons-connector-enhancements.md)
 - [ML Commons Memory Metadata](features/ml-commons/ml-commons-memory-metadata.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the ML Commons Batch Ingestion feature introduced in OpenSearch v2.17.0.

## Reports Created

- **Release report**: `docs/releases/v2.17.0/features/ml-commons/batch-ingestion.md`
- **Feature report**: `docs/features/ml-commons/batch-ingestion.md`

## Feature Overview

Asynchronous Batch Ingestion enables offline ingestion of documents and their pre-generated embeddings from remote file servers (Amazon S3 or OpenAI) into OpenSearch indexes. This completes the batch inference workflow by allowing users to ingest results from batch prediction jobs back into OpenSearch for neural search.

### Key Changes in v2.17.0

- New Asynchronous Batch Ingestion API (`POST /_plugins/_ml/_batch_ingestion`)
- Support for S3 and OpenAI as data sources
- JSONPath-based field mapping for flexible data transformation
- New task type `BATCH_INGEST` for tracking ingestion progress
- Support for ingesting from multiple files with cross-file field mapping
- New connector action types: `CANCEL_BATCH_PREDICT` and `BATCH_PREDICT_STATUS`

## Related PRs

- [ml-commons#2844](https://github.com/opensearch-project/ml-commons/pull/2844): Offline batch ingestion API actions and data ingesters
- [ml-commons#2825](https://github.com/opensearch-project/ml-commons/pull/2825): Support get batch transform job status in get task API

## Resources Used

- [Asynchronous Batch Ingestion Documentation](https://docs.opensearch.org/2.17/ml-commons-plugin/remote-models/async-batch-ingestion/)
- [Asynchronous Batch Ingestion API](https://docs.opensearch.org/2.17/ml-commons-plugin/api/async-batch-ingest/)
- [Issue #2840](https://github.com/opensearch-project/ml-commons/issues/2840): Offline Batch Inference and Batch Ingestion