### PR TITLE
docs: add Flow Framework Connector Tools report for v2.17.0

### DIFF
--- a/docs/features/flow-framework/flow-framework-connector-tools.md
+++ b/docs/features/flow-framework/flow-framework-connector-tools.md
@@ -1,0 +1,141 @@
+# Flow Framework Connector Tools
+
+## Summary
+
+Flow Framework Connector Tools enables the automatic parsing of `connector_id` from previous workflow node outputs when creating tools. This feature allows seamless chaining of connector creation with tool creation in workflow templates, eliminating the need to manually specify connector IDs when building AI agent workflows.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Flow Framework Workflow"
+        A[Create Connector Node] -->|outputs connector_id| B[Create Tool Node]
+        B -->|outputs tools| C[Register Agent Node]
+    end
+    
+    subgraph "ToolStep Parameter Resolution"
+        D[previous_node_inputs] --> E[getToolsParametersMap]
+        F[outputs from previous nodes] --> E
+        E --> G{Check each key}
+        G -->|connector_id| H[Resolve from outputs]
+        G -->|model_id| H
+        G -->|agent_id| H
+        H --> I[Tool Parameters Map]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Connector Creation] -->|connector_id| B[Tool Creation]
+    B -->|MLToolSpec with connector_id| C[Agent Registration]
+    C -->|Agent with ConnectorTool| D[Ready for Execution]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ToolStep` | Workflow step that creates ML tools with automatic parameter resolution |
+| `getToolsParametersMap` | Method that resolves tool parameters from previous node outputs |
+| `toolParameterKeys` | Set of supported parameter keys: `connector_id`, `model_id`, `agent_id` |
+| `MLToolSpec` | ML Commons tool specification that holds the resolved parameters |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `previous_node_inputs` | Map of node IDs to parameter keys to resolve | Empty |
+| `parameters` | Explicit tool parameters (can be overridden by previous node inputs) | Empty |
+
+### Usage Example
+
+```json
+{
+  "name": "connector-tool-workflow",
+  "description": "Create a ConnectorTool with dynamic connector_id",
+  "workflows": {
+    "provision": {
+      "nodes": [
+        {
+          "id": "create_connector",
+          "type": "create_connector",
+          "user_inputs": {
+            "name": "OpenAI Chat Connector",
+            "description": "Connector to OpenAI GPT model",
+            "version": "1",
+            "protocol": "http",
+            "parameters": {
+              "endpoint": "api.openai.com",
+              "model": "gpt-3.5-turbo"
+            },
+            "credential": {
+              "openAI_key": "YOUR_API_KEY"
+            },
+            "actions": [
+              {
+                "action_type": "predict",
+                "method": "POST",
+                "url": "https://${parameters.endpoint}/v1/chat/completions"
+              }
+            ]
+          }
+        },
+        {
+          "id": "create_connector_tool",
+          "type": "create_tool",
+          "previous_node_inputs": {
+            "create_connector": "connector_id"
+          },
+          "user_inputs": {
+            "parameters": {},
+            "name": "ConnectorTool",
+            "type": "ConnectorTool"
+          }
+        },
+        {
+          "id": "create_flow_agent",
+          "type": "register_agent",
+          "previous_node_inputs": {
+            "create_connector_tool": "tools"
+          },
+          "user_inputs": {
+            "parameters": {},
+            "type": "flow",
+            "name": "OpenAI Chat Agent"
+          }
+        }
+      ],
+      "edges": [
+        { "source": "create_connector", "dest": "create_connector_tool" },
+        { "source": "create_connector_tool", "dest": "create_flow_agent" }
+      ]
+    }
+  }
+}
+```
+
+## Limitations
+
+- Only three parameter keys are supported for automatic resolution: `connector_id`, `model_id`, and `agent_id`
+- Custom parameters must be explicitly specified in the `parameters` field
+- If a parameter is already present in `parameters`, it will not be overwritten by previous node outputs
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#846](https://github.com/opensearch-project/flow-framework/pull/846) | Support parsing connector_id when creating tools |
+
+## References
+
+- [Issue #845](https://github.com/opensearch-project/flow-framework/issues/845): Original feature request
+- [Connector Tool Documentation](https://docs.opensearch.org/2.17/ml-commons-plugin/agents-tools/tools/connector-tool/): Official ConnectorTool documentation
+- [Flow Framework Workflow Steps](https://docs.opensearch.org/latest/automating-configurations/workflow-steps/): Workflow step reference
+
+## Change History
+
+- **v2.17.0** (2024-10-15): Added support for parsing `connector_id` from previous node inputs in ToolStep

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -93,6 +93,7 @@
 ## flow-framework
 
 - [Flow Framework](flow-framework/flow-framework.md)
+- [Flow Framework Connector Tools](flow-framework/flow-framework-connector-tools.md)
 - [Text-to-Visualization Templates](flow-framework/text-to-visualization-templates.md)
 
 ## sql

--- a/docs/releases/v2.17.0/features/flow-framework/flow-framework-connector-tools.md
+++ b/docs/releases/v2.17.0/features/flow-framework/flow-framework-connector-tools.md
@@ -1,0 +1,112 @@
+# Flow Framework Connector Tools
+
+## Summary
+
+This release adds support for parsing `connector_id` from previous workflow node inputs when creating tools in Flow Framework. Previously, only `model_id` and `agent_id` could be automatically passed from previous nodes to tool parameters. This enhancement enables seamless integration of ConnectorTool with dynamically created connectors in workflow templates.
+
+## Details
+
+### What's New in v2.17.0
+
+The `ToolStep` class now supports parsing `connector_id` from `previous_node_inputs`, allowing workflows to chain connector creation with tool creation without manually specifying the connector ID.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Workflow Execution"
+        A[create_connector] -->|connector_id| B[create_tool]
+        B -->|tools| C[register_agent]
+    end
+    subgraph "ToolStep Processing"
+        D[previous_node_inputs] --> E{Parse Parameters}
+        E -->|connector_id| F[Tool Parameters]
+        E -->|model_id| F
+        E -->|agent_id| F
+    end
+```
+
+#### Code Changes
+
+The `getToolsParametersMap` method in `ToolStep.java` was refactored to:
+1. Accept a set of tool parameter keys (`connector_id`, `model_id`, `agent_id`)
+2. Iterate through all keys and extract values from previous node outputs
+3. Automatically populate the tool's parameters map with resolved values
+
+| Component | Description |
+|-----------|-------------|
+| `ToolStep.java` | Refactored to support generic parameter key parsing |
+| `toolParameterKeys` | New set containing `CONNECTOR_ID`, `MODEL_ID`, `AGENT_ID` |
+
+### Usage Example
+
+```json
+{
+  "workflows": {
+    "provision": {
+      "nodes": [
+        {
+          "id": "create_connector",
+          "type": "create_connector",
+          "user_inputs": {
+            "name": "OpenAI Chat Connector",
+            "protocol": "http",
+            "parameters": { "endpoint": "api.openai.com" },
+            "credential": { "openAI_key": "..." },
+            "actions": [{ "action_type": "predict", "method": "POST", "url": "..." }]
+          }
+        },
+        {
+          "id": "create_tool",
+          "type": "create_tool",
+          "previous_node_inputs": {
+            "create_connector": "connector_id"
+          },
+          "user_inputs": {
+            "parameters": {},
+            "name": "ConnectorTool",
+            "type": "ConnectorTool"
+          }
+        },
+        {
+          "id": "create_flow_agent",
+          "type": "register_agent",
+          "previous_node_inputs": {
+            "create_tool": "tools"
+          },
+          "user_inputs": {
+            "type": "flow",
+            "name": "OpenAI Chat Agent"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+### Migration Notes
+
+No migration required. This is a backward-compatible enhancement. Existing workflows continue to work unchanged.
+
+## Limitations
+
+- Only `connector_id`, `model_id`, and `agent_id` are automatically parsed from previous node inputs
+- Other custom parameters must still be specified explicitly in the `parameters` field
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#846](https://github.com/opensearch-project/flow-framework/pull/846) | Support parsing connector_id when creating tools |
+
+## References
+
+- [Issue #845](https://github.com/opensearch-project/flow-framework/issues/845): Feature request for connector_id parsing
+- [Connector Tool Documentation](https://docs.opensearch.org/2.17/ml-commons-plugin/agents-tools/tools/connector-tool/): Official ConnectorTool documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/flow-framework/flow-framework-connector-tools.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -43,6 +43,9 @@
 ### documentation-website
 - [Top N API Documentation Update](features/documentation-website/top-n-api-documentation.md)
 
+### flow-framework
+- [Flow Framework Connector Tools](features/flow-framework/flow-framework-connector-tools.md)
+
 ### index-management
 - [Index Management Bugfixes](features/index-management/index-management-bugfixes.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Flow Framework Connector Tools feature introduced in v2.17.0.

### Changes
- Added release report: `docs/releases/v2.17.0/features/flow-framework/flow-framework-connector-tools.md`
- Added feature report: `docs/features/flow-framework/flow-framework-connector-tools.md`
- Updated release index and features index

### Feature Overview
This release adds support for parsing `connector_id` from previous workflow node inputs when creating tools in Flow Framework. Previously, only `model_id` and `agent_id` could be automatically passed from previous nodes to tool parameters.

### Related
- Resolves #372
- PR: [opensearch-project/flow-framework#846](https://github.com/opensearch-project/flow-framework/pull/846)
- Issue: [opensearch-project/flow-framework#845](https://github.com/opensearch-project/flow-framework/issues/845)