### PR TITLE
docs: add Search Comparison report for v2.17.0

### DIFF
--- a/docs/features/dashboards-search-relevance/search-comparison.md
+++ b/docs/features/dashboards-search-relevance/search-comparison.md
@@ -1,0 +1,159 @@
+# Search Comparison (Compare Search Results)
+
+## Summary
+
+Compare Search Results is a search relevance tool in OpenSearch Dashboards that allows users to compare results from two different queries side by side. This feature helps search relevance engineers and business users evaluate and tune search quality by experimenting with different query configurations, field weightings, and search pipelines.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        UI[Compare Search Results UI]
+        Q1[Query 1 Panel]
+        Q2[Query 2 Panel]
+        CM[Content Management]
+        Card[Compare Queries Card]
+    end
+    
+    subgraph "OpenSearch Cluster"
+        Search[Search API]
+        Pipeline[Search Pipelines]
+        Index[Indexes]
+    end
+    
+    UI --> Q1
+    UI --> Q2
+    Q1 --> Search
+    Q2 --> Search
+    Search --> Pipeline
+    Pipeline --> Index
+    CM --> Card
+    Card --> UI
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    User[User] --> SearchText[Enter Search Text]
+    SearchText --> Q1Config[Configure Query 1]
+    SearchText --> Q2Config[Configure Query 2]
+    Q1Config --> SelectIndex1[Select Index]
+    Q2Config --> SelectIndex2[Select Index]
+    SelectIndex1 --> WriteDSL1[Write DSL Query]
+    SelectIndex2 --> WriteDSL2[Write DSL Query]
+    WriteDSL1 --> Execute[Execute Search]
+    WriteDSL2 --> Execute
+    Execute --> Results[Compare Results Side by Side]
+    Results --> Analyze[Analyze Ranking Differences]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Search Bar | Input field for the search text that gets substituted into queries via `%SearchText%` |
+| Query Panel | Two side-by-side panels for configuring and viewing query results |
+| Index Selector | Dropdown to select the target index for each query |
+| Query Editor | JSON editor for writing OpenSearch Query DSL |
+| Pipeline Selector | Optional dropdown to select a search pipeline |
+| Results Panel | Displays search results with ranking position indicators |
+| Compare Queries Card | Service card on Search use case overview page (v2.17.0+) |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `size` | Number of results to return per query | 10 |
+| Search Pipeline | Optional search pipeline to apply to the query | None |
+
+### Usage Example
+
+**Basic Query Comparison:**
+
+Query 1 - Standard multi-match:
+```json
+{
+  "query": {
+    "multi_match": {
+      "query": "%SearchText%",
+      "fields": ["description", "item_name"]
+    }
+  }
+}
+```
+
+Query 2 - Boosted field:
+```json
+{
+  "query": {
+    "multi_match": {
+      "query": "%SearchText%",
+      "fields": ["description", "item_name^3"]
+    }
+  }
+}
+```
+
+**With Search Pipeline:**
+```json
+{
+  "query": {
+    "match": {
+      "bullet_point": "%SearchText%"
+    }
+  },
+  "size": 25,
+  "ext": {
+    "search_configuration": {
+      "result_transformer": {
+        "kendra_intelligent_ranking": {
+          "order": 1,
+          "properties": {
+            "title_field": "item_name",
+            "body_field": "bullet_point"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Key Features
+
+1. **Side-by-Side Comparison**: View results from two queries simultaneously
+2. **Ranking Indicators**: Up/Down arrows show how document positions changed between queries
+3. **Variable Substitution**: Use `%SearchText%` to reference the search bar input
+4. **Search Pipeline Support**: Apply search pipelines including rerankers (v2.14.0+)
+5. **Multi-Data Source Support**: Query different data sources (v2.14.0+)
+6. **Workspace Integration**: Access via Compare Queries card in Search workspace (v2.17.0+)
+
+## Limitations
+
+- Cannot save comparisons for future use - not suitable for systematic testing
+- Setting `size` to values larger than 250 may degrade performance
+- Requires manual query construction in OpenSearch Query DSL
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#427](https://github.com/opensearch-project/dashboards-search-relevance/pull/427) | Add compare queries card to search use case overview page |
+| v2.14.0 | [#383](https://github.com/opensearch-project/dashboards-search-relevance/pull/383) | Multi-datasource support for Search-relevance |
+| v2.14.0 | [#352](https://github.com/opensearch-project/dashboards-search-relevance/pull/352) | Add ability to select a search pipeline in comparison tool |
+
+## References
+
+- [Documentation](https://docs.opensearch.org/latest/search-plugins/search-relevance/compare-search-results/): Comparing search results
+- [Issue #7807](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7807): Search use case overview page
+- [Search Relevance Stats API](https://docs.opensearch.org/latest/search-plugins/search-relevance/stats-api/): API for search relevance statistics
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Added Compare Queries card to Search use case overview page via Content Management integration
+- **v2.14.0** (2024-05-02): Added multi-datasource support and search pipeline selection
+- **v2.11.0** (2023-10-16): Fixed ace editor theme consistency for dark mode

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -83,6 +83,7 @@
 
 - [Build Maintenance](dashboards-search-relevance/build-maintenance.md)
 - [Documentation Maintenance](dashboards-search-relevance/documentation-maintenance.md)
+- [Search Comparison](dashboards-search-relevance/search-comparison.md)
 
 ## dashboards-flow-framework
 

--- a/docs/releases/v2.17.0/features/dashboards-search-relevance/search-comparison.md
+++ b/docs/releases/v2.17.0/features/dashboards-search-relevance/search-comparison.md
@@ -1,0 +1,83 @@
+# Search Comparison Card for Search Use Case Overview
+
+## Summary
+
+This release adds a "Compare queries" card to the Search use case overview page in OpenSearch Dashboards. The card provides quick access to the Compare Search Results tool, enabling users to easily navigate to the search comparison functionality from the workspace overview.
+
+## Details
+
+### What's New in v2.17.0
+
+The dashboards-search-relevance plugin now integrates with the Content Management plugin to register a service card on the Search use case overview page. This card appears when workspaces are enabled and provides a direct link to the Compare Search Results tool.
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `compare_query_card.tsx` | React component that registers the Compare Queries card with Content Management |
+| `icon.svg` | Custom SVG icon for the Compare Queries card |
+
+#### Plugin Integration
+
+The plugin now declares `contentManagement` as an optional dependency in `opensearch_dashboards.json`:
+
+```json
+{
+  "optionalPlugins": ["dataSource", "dataSourceManagement", "contentManagement"]
+}
+```
+
+During the plugin start phase, if the Content Management plugin is available, the Compare Queries card is registered:
+
+```typescript
+public start(
+  core: CoreStart,
+  { dataSource, contentManagement }: SearchRelevanceStartDependencies
+): SearchRelevancePluginStart {
+  if (contentManagement) {
+    registerCompareQueryCard(contentManagement, core);
+  }
+  return {};
+}
+```
+
+#### Card Configuration
+
+The card is registered with the following properties:
+
+| Property | Value |
+|----------|-------|
+| Target Area | `search_overview/config_evaluate_search` |
+| Order | 20 |
+| Layout | horizontal |
+
+### Usage Example
+
+When users navigate to a Search workspace overview page, they will see the "Compare queries" card with:
+
+- A custom icon representing search comparison
+- Title: "Compare queries"
+- Description: "The search comparison tool lets you compare the results of two different DSL queries applied to the same user query."
+- A "Compare search results" button that navigates to the Search Relevance plugin
+
+## Limitations
+
+- The card only appears when the Content Management plugin is available
+- Requires workspace feature to be enabled to see the Search use case overview page
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#427](https://github.com/opensearch-project/dashboards-search-relevance/pull/427) | Add compare queries card to search use case overview page |
+
+## References
+
+- [Issue #7807](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7807): Search use case overview page
+- [Documentation](https://docs.opensearch.org/2.17/search-plugins/search-relevance/compare-search-results/): Comparing search results
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-search-relevance/search-comparison.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -36,6 +36,7 @@
 ### dashboards-search-relevance
 - [Dashboards Bugfixes](features/dashboards-search-relevance/dashboards-bugfixes.md)
 - [Documentation Link Updates](features/dashboards-search-relevance/documentation-link-updates.md)
+- [Search Comparison Card](features/dashboards-search-relevance/search-comparison.md)
 
 ### opensearch-dashboards
 - [Dashboards UI Updates](features/opensearch-dashboards/dashboards-ui-updates.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Search Comparison feature in v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/dashboards-search-relevance/search-comparison.md`
- Feature report: `docs/features/dashboards-search-relevance/search-comparison.md`

### Key Changes in v2.17.0
- Added "Compare queries" card to Search use case overview page
- Integration with Content Management plugin for workspace support
- Custom icon and navigation to Compare Search Results tool

### Related Issue
- Closes #369