### PR TITLE
docs: add Maps Plugin UI Updates report for v2.17.0

### DIFF
--- a/docs/features/dashboards-maps/maps-plugin-ui-updates.md
+++ b/docs/features/dashboards-maps/maps-plugin-ui-updates.md
@@ -1,0 +1,179 @@
+# Maps Plugin UI Updates
+
+## Summary
+
+The Maps Plugin UI Updates feature enables the OpenSearch Dashboards Maps plugin to conditionally use the new header design system (TriNeo project). This provides a more consistent and modern user experience when the new home page UI is enabled, including updated Page Header and Application Header variants, as well as full-width table layouts.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        A[Advanced Settings] -->|home:useNewHomePage| B[UI Settings Service]
+    end
+    
+    subgraph "Maps Plugin"
+        B --> C{Check Setting}
+        C -->|true| D[New Header Mode]
+        C -->|false| E[Legacy Mode]
+        
+        subgraph "New Header Mode"
+            D --> F[Maps Listing Page]
+            D --> G[Maps Visualization Page]
+            
+            F --> H[HeaderControl]
+            F --> I[Full-Width Table]
+            F --> J[No Table Title]
+            
+            G --> K[HeaderVariant.APPLICATION]
+            G --> L[Icon-Based Actions]
+            G --> M[Screen Title in Header]
+        end
+        
+        subgraph "Legacy Mode"
+            E --> N[Standard Table Actions]
+            E --> O[Restricted Width]
+            E --> P[Standard Top Nav]
+        end
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[User Action] --> B{Page Type}
+    B -->|Listing| C[Maps List]
+    B -->|Visualization| D[Map Editor]
+    
+    C --> E{New UI?}
+    E -->|Yes| F[Header Create Button]
+    E -->|No| G[Table Create Button]
+    
+    D --> H{New UI?}
+    H -->|Yes| I[Application Header + Icon Save]
+    H -->|No| J[Standard Top Nav + Text Save]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `HeaderControl` | OSD navigation component for placing controls in the application header |
+| `HeaderVariant.APPLICATION` | Chrome header variant for application-style pages with grouped actions |
+| `TopNavMenuIconData` | Configuration type for icon-based top navigation menu items |
+| `TopNavMenuItemRenderType.IN_PORTAL` | Render type for search bar in portal mode |
+| `TableListView` | Enhanced table component with `restrictWidth` prop support |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `home:useNewHomePage` | Enables the new home page UI including header changes across all plugins | `false` |
+
+### Usage Example
+
+#### Enabling the New UI
+
+```yaml
+# In OpenSearch Dashboards Advanced Settings
+home:useNewHomePage: true
+```
+
+#### Maps Listing Page Implementation
+
+```typescript
+// Check if new UI is enabled
+const newHomePageEnabled = uiSettings.get('home:useNewHomePage');
+
+// Conditionally render HeaderControl
+{newHomePageEnabled &&
+  <HeaderControl
+    setMountPoint={application.setAppRightControls}
+    controls={[
+      {
+        id: 'Create map',
+        label: 'Create map',
+        iconType: 'plus',
+        fill: true,
+        href: `${MAPS_APP_ID}${APP_PATH.CREATE_MAP}`,
+        testId: 'createButton',
+        controlType: 'button',
+      },
+    ]}
+  />
+}
+
+// TableListView with conditional width
+<TableListView
+  createItem={newHomePageEnabled ? undefined : navigateToCreateMapPage}
+  tableListTitle={newHomePageEnabled ? '' : 'Maps'}
+  restrictWidth={newHomePageEnabled ? false : true}
+  // ... other props
+/>
+```
+
+#### Maps Visualization Page Implementation
+
+```typescript
+// Set header variant when new UI is enabled
+useEffect(() => {
+  if (showActionsInGroup) {
+    chrome.setHeaderVariant?.(HeaderVariant.APPLICATION);
+  }
+  return () => {
+    chrome.setHeaderVariant?.();
+  };
+}, [chrome.setHeaderVariant, showActionsInGroup]);
+
+// Icon-based top nav configuration
+if (showActionsInGroup) {
+  const topNavConfig: TopNavMenuIconData[] = [
+    {
+      tooltip: 'Save',
+      ariaLabel: 'Save your map',
+      testId: 'mapSaveButton',
+      run: onSaveButtonClick,
+      iconType: 'save',
+      controlType: 'icon',
+    },
+  ];
+  return topNavConfig;
+}
+
+// TopNavMenu with grouped actions
+<TopNavMenu
+  config={config}
+  showSearchBar={TopNavMenuItemRenderType.IN_PORTAL}
+  groupActions={showActionsInGroup}
+  screenTitle={title}
+  // ... other props
+/>
+```
+
+## Limitations
+
+- Requires OpenSearch Dashboards core support for `HeaderControl` and `HeaderVariant` APIs
+- The new UI is opt-in and disabled by default
+- Integration tests for the new header UI are implemented separately
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#653](https://github.com/opensearch-project/dashboards-maps/pull/653) | Conditionally use the new Page Header variant on the Maps listing page |
+| v2.17.0 | [#654](https://github.com/opensearch-project/dashboards-maps/pull/654) | Conditionally use the new Application Header variant on the Maps visualization page |
+| v2.17.0 | [#655](https://github.com/opensearch-project/dashboards-maps/pull/655) | Conditionally use full width for Maps listing page table |
+
+## References
+
+- [Issue #649](https://github.com/opensearch-project/dashboards-maps/issues/649): Support Trineo new headers change in maps
+- [OpenSearch Dashboards PR #7691](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7691): Full width table support in OSD core
+- [Maps Documentation](https://docs.opensearch.org/2.17/dashboards/visualize/maps/): Official Maps plugin documentation
+- [Getting started with multilayer maps](https://opensearch.org/blog/multilayer-maps/): Maps plugin blog post
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Initial implementation of conditional new header UI support

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -173,6 +173,7 @@
 ## dashboards-maps
 
 - [Maps & Geospatial](dashboards-maps/maps-geospatial.md)
+- [Maps Plugin UI Updates](dashboards-maps/maps-plugin-ui-updates.md)
 
 ## dashboards-notifications
 

--- a/docs/releases/v2.17.0/features/dashboards-maps/maps-plugin-ui-updates.md
+++ b/docs/releases/v2.17.0/features/dashboards-maps/maps-plugin-ui-updates.md
@@ -1,0 +1,134 @@
+# Maps Plugin UI Updates
+
+## Summary
+
+OpenSearch Dashboards Maps plugin v2.17.0 introduces conditional support for the new header UI design (TriNeo project). When the `home:useNewHomePage` setting is enabled, the Maps plugin adapts its listing page and visualization page to use the new Page Header and Application Header variants, providing a more consistent and modern user experience across OpenSearch Dashboards.
+
+## Details
+
+### What's New in v2.17.0
+
+This release adds three key UI improvements to the Maps plugin:
+
+1. **New Page Header on Maps Listing Page** - The "Create map" button moves from the table to the header using `HeaderControl`
+2. **New Application Header on Maps Visualization Page** - The visualization page uses `HeaderVariant.APPLICATION` with grouped actions
+3. **Full-Width Table Layout** - The Maps listing table uses full width when the new home page UI is enabled
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Maps Plugin UI"
+        A[uiSettings] -->|home:useNewHomePage| B{Check Setting}
+        B -->|true| C[New Header UI]
+        B -->|false| D[Legacy UI]
+        
+        subgraph "New Header UI"
+            C --> E[HeaderControl]
+            C --> F[HeaderVariant.APPLICATION]
+            C --> G[Full-Width Table]
+        end
+        
+        subgraph "Legacy UI"
+            D --> H[Table Actions]
+            D --> I[Standard Header]
+            D --> J[Restricted Width]
+        end
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `HeaderControl` | OSD navigation component for placing controls in the application header |
+| `HeaderVariant.APPLICATION` | Chrome header variant for application-style pages |
+| `TopNavMenuIconData` | Icon-based top nav menu configuration for grouped actions |
+
+#### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `home:useNewHomePage` | Enables the new home page UI including header changes | `false` |
+
+### Usage Example
+
+The new header UI is automatically enabled when the `home:useNewHomePage` advanced setting is turned on:
+
+1. Navigate to **Management** > **Advanced Settings**
+2. Search for `home:useNewHomePage`
+3. Set the value to `true`
+4. The Maps plugin will automatically use the new header UI
+
+#### Maps Listing Page (New UI)
+
+When enabled, the "Create map" button appears in the header:
+
+```typescript
+<HeaderControl
+  setMountPoint={application.setAppRightControls}
+  controls={[
+    {
+      id: 'Create map',
+      label: 'Create map',
+      iconType: 'plus',
+      fill: true,
+      href: `${MAPS_APP_ID}${APP_PATH.CREATE_MAP}`,
+      testId: 'createButton',
+      controlType: 'button',
+    },
+  ]}
+/>
+```
+
+#### Maps Visualization Page (New UI)
+
+The visualization page uses the Application header variant with icon-based actions:
+
+```typescript
+// Set header variant
+chrome.setHeaderVariant?.(HeaderVariant.APPLICATION);
+
+// Configure icon-based save button
+const topNavConfig: TopNavMenuIconData[] = [
+  {
+    tooltip: 'Save',
+    ariaLabel: 'Save your map',
+    testId: 'mapSaveButton',
+    run: onSaveButtonClick,
+    iconType: 'save',
+    controlType: 'icon',
+  },
+];
+```
+
+### Migration Notes
+
+- No migration required - the feature is backward compatible
+- The new UI is opt-in via the `home:useNewHomePage` setting
+- When disabled, the Maps plugin continues to use the legacy UI
+
+## Limitations
+
+- The new header UI requires OpenSearch Dashboards core support for `HeaderControl` and `HeaderVariant`
+- Integration tests for the new header UI are planned for a separate PR
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#653](https://github.com/opensearch-project/dashboards-maps/pull/653) | Conditionally use the new Page Header variant on the Maps listing page |
+| [#654](https://github.com/opensearch-project/dashboards-maps/pull/654) | Conditionally use the new Application Header variant on the Maps visualization page |
+| [#655](https://github.com/opensearch-project/dashboards-maps/pull/655) | Conditionally use full width for Maps listing page table |
+
+## References
+
+- [Issue #649](https://github.com/opensearch-project/dashboards-maps/issues/649): Support Trineo new headers change in maps
+- [OpenSearch Dashboards PR #7691](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7691): Full width table support
+- [Maps Documentation](https://docs.opensearch.org/2.17/dashboards/visualize/maps/): Official Maps plugin documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-maps/maps-plugin-ui-updates.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -16,6 +16,7 @@
 
 ### dashboards-maps
 - [Maps Plugin Bugfixes](features/dashboards-maps/maps-plugin-bugfixes.md)
+- [Maps Plugin UI Updates](features/dashboards-maps/maps-plugin-ui-updates.md)
 
 ### dashboards-notifications
 - [Notifications Bugfixes](features/dashboards-notifications/notifications-bugfixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Maps Plugin UI Updates feature in OpenSearch v2.17.0.

### Reports Created
- Release report: `docs/releases/v2.17.0/features/dashboards-maps/maps-plugin-ui-updates.md`
- Feature report: `docs/features/dashboards-maps/maps-plugin-ui-updates.md`

### Key Changes in v2.17.0
- Conditional support for new Page Header variant on Maps listing page
- Conditional support for new Application Header variant on Maps visualization page
- Full-width table layout when new home page UI is enabled

### Related PRs
- [dashboards-maps#653](https://github.com/opensearch-project/dashboards-maps/pull/653): New Page Header on listing page
- [dashboards-maps#654](https://github.com/opensearch-project/dashboards-maps/pull/654): New Application Header on visualization page
- [dashboards-maps#655](https://github.com/opensearch-project/dashboards-maps/pull/655): Full-width table layout

Closes #368