### PR TITLE
docs: add Anomaly Detection Missing Data Handling report for v2.17.0

### DIFF
--- a/docs/features/anomaly-detection/anomaly-detection-missing-data-handling.md
+++ b/docs/features/anomaly-detection/anomaly-detection-missing-data-handling.md
@@ -1,0 +1,317 @@
+# Anomaly Detection Missing Data Handling
+
+## Summary
+
+OpenSearch Anomaly Detection provides flexible missing data handling capabilities, allowing users to choose how to address gaps in time-series data. This feature improves anomaly detection recall by treating missing data as meaningful signals rather than simply ignoring them. Users can configure imputation methods including ignoring missing data, filling with fixed values, zeros, or previous values.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Data Input"
+        DATA[Time-series Data]
+        MISSING[Missing Data Points]
+    end
+    
+    subgraph "Imputation Layer"
+        IMP[Imputation Handler]
+        subgraph "Methods"
+            IGN[Ignore - Default]
+            FIX[Fixed Value]
+            ZERO[Zero Fill]
+            PREV[Previous Value]
+        end
+    end
+    
+    subgraph "Model Processing"
+        TRCF[ThresholdedRandomCutForest]
+        PROCESS["process(point, timestamp, missingValues)"]
+    end
+    
+    subgraph "Results"
+        RESULT[Anomaly Result]
+        IMPUTED[feature_imputed Array]
+        ACTUAL[Actual/Imputed Values]
+    end
+    
+    DATA --> IMP
+    MISSING --> IMP
+    IMP --> IGN
+    IMP --> FIX
+    IMP --> ZERO
+    IMP --> PREV
+    IGN --> TRCF
+    FIX --> TRCF
+    ZERO --> TRCF
+    PREV --> TRCF
+    TRCF --> PROCESS
+    PROCESS --> RESULT
+    RESULT --> IMPUTED
+    RESULT --> ACTUAL
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph Input
+        RAW[Raw Data Stream]
+        GAP[Data Gap Detected]
+    end
+    
+    subgraph Imputation
+        CHECK{Has Imputation Config?}
+        METHOD{Method Type}
+        IGNORE[Skip Point]
+        FIXED[Apply Fixed Value]
+        ZERO[Apply Zero]
+        PREVIOUS[Apply Last Value]
+    end
+    
+    subgraph Processing
+        RCF[RCF Model]
+        SCORE[Calculate Score]
+    end
+    
+    subgraph Output
+        GRADE[Anomaly Grade]
+        FLAG[Imputation Flag]
+        VALUE[Feature Value]
+    end
+    
+    RAW --> CHECK
+    GAP --> CHECK
+    CHECK -->|No| IGNORE
+    CHECK -->|Yes| METHOD
+    METHOD -->|FIXED| FIXED
+    METHOD -->|ZERO| ZERO
+    METHOD -->|PREVIOUS| PREVIOUS
+    IGNORE --> RCF
+    FIXED --> RCF
+    ZERO --> RCF
+    PREVIOUS --> RCF
+    RCF --> SCORE
+    SCORE --> GRADE
+    SCORE --> FLAG
+    SCORE --> VALUE
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ImputationOption` | Configuration model for imputation method and default values |
+| `ADRealTimeInferencer` | Real-time inference handler with imputation support |
+| `ADHCImputeTransportAction` | Broadcast action for high-cardinality detector imputation |
+| `FeatureImputed` | Model class tracking imputation status per feature |
+| `ImputedFeatureResult` | Result class containing imputed values and boolean flags |
+| `Inferencer` | Refactored base class for imputation processing and statistics |
+
+### Imputation Methods
+
+| Method | Description | Use Case |
+|--------|-------------|----------|
+| `IGNORE` | Skip missing data points (default) | When gaps are expected and not meaningful |
+| `FIXED` | Replace with user-specified values | When a baseline value is known |
+| `ZERO` | Replace with zeros | When absence indicates zero activity (e.g., event counts) |
+| `PREVIOUS` | Carry forward last observed value | When continuity is expected |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `imputation_option.method` | Imputation method to use | `IGNORE` |
+| `imputation_option.default_fill` | Array of feature-value pairs for FIXED method | None |
+
+### API Configuration
+
+```json
+{
+  "imputation_option": {
+    "method": "FIXED",
+    "default_fill": [
+      {
+        "feature_name": "feature1",
+        "data": 100.0
+      },
+      {
+        "feature_name": "feature2", 
+        "data": 50.0
+      }
+    ]
+  }
+}
+```
+
+### Usage Examples
+
+#### Zero Fill for Event Counting
+
+```json
+POST _plugins/_anomaly_detection/detectors
+{
+  "name": "login-event-detector",
+  "description": "Detect unusual login patterns including complete drops",
+  "time_field": "@timestamp",
+  "indices": ["login-events-*"],
+  "feature_attributes": [
+    {
+      "feature_name": "login_count",
+      "feature_enabled": true,
+      "aggregation_query": {
+        "login_count": {
+          "value_count": {
+            "field": "user_id"
+          }
+        }
+      }
+    }
+  ],
+  "detection_interval": {
+    "period": {
+      "interval": 5,
+      "unit": "Minutes"
+    }
+  },
+  "imputation_option": {
+    "method": "ZERO"
+  }
+}
+```
+
+#### Previous Value for Metric Continuity
+
+```json
+POST _plugins/_anomaly_detection/detectors
+{
+  "name": "temperature-detector",
+  "description": "Monitor temperature with gap handling",
+  "time_field": "timestamp",
+  "indices": ["sensor-data-*"],
+  "feature_attributes": [
+    {
+      "feature_name": "avg_temp",
+      "feature_enabled": true,
+      "aggregation_query": {
+        "avg_temp": {
+          "avg": {
+            "field": "temperature"
+          }
+        }
+      }
+    }
+  ],
+  "detection_interval": {
+    "period": {
+      "interval": 1,
+      "unit": "Minutes"
+    }
+  },
+  "imputation_option": {
+    "method": "PREVIOUS"
+  }
+}
+```
+
+#### Fixed Value for Known Baselines
+
+```json
+POST _plugins/_anomaly_detection/detectors
+{
+  "name": "throughput-detector",
+  "description": "Monitor throughput with baseline imputation",
+  "time_field": "timestamp",
+  "indices": ["network-metrics-*"],
+  "feature_attributes": [
+    {
+      "feature_name": "bytes_per_sec",
+      "feature_enabled": true,
+      "aggregation_query": {
+        "bytes_per_sec": {
+          "avg": {
+            "field": "throughput"
+          }
+        }
+      }
+    }
+  ],
+  "detection_interval": {
+    "period": {
+      "interval": 1,
+      "unit": "Minutes"
+    }
+  },
+  "imputation_option": {
+    "method": "FIXED",
+    "default_fill": [
+      {
+        "feature_name": "bytes_per_sec",
+        "data": 1000000
+      }
+    ]
+  }
+}
+```
+
+### Result Format with Imputation
+
+```json
+{
+  "detector_id": "kzcZ43wBgEQAbjDnhzGF",
+  "schema_version": 5,
+  "data_start_time": 1635898161367,
+  "data_end_time": 1635898221367,
+  "feature_data": [
+    {
+      "feature_id": "processing_bytes_max",
+      "feature_name": "processing bytes max",
+      "data": 2322
+    },
+    {
+      "feature_id": "processing_bytes_avg",
+      "feature_name": "processing bytes avg",
+      "data": 1718.67
+    }
+  ],
+  "anomaly_score": 1.81,
+  "anomaly_grade": 0,
+  "confidence": 0.98,
+  "feature_imputed": [
+    {
+      "feature_id": "processing_bytes_max",
+      "imputed": true
+    },
+    {
+      "feature_id": "processing_bytes_avg",
+      "imputed": false
+    }
+  ]
+}
+```
+
+## Limitations
+
+- Imputation with shingle size 1 is not meaningful; requires shingle size > 1
+- Extensive imputation can compromise model accuracy - quality input is critical
+- Confidence score decreases when imputations occur
+- Preview mode uses linear interpolation instead of configured imputation for efficiency
+- First imputation in a continuous missing area may generate NaN values that are not saved
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#1274](https://github.com/opensearch-project/anomaly-detection/pull/1274) | Add Support for Handling Missing Data in Anomaly Detection |
+
+## References
+
+- [Forum Discussion](https://forum.opensearch.org/t/do-missing-buckets-ruin-anomaly-detection/16535): Original feature request
+- [Anomaly Detection Documentation](https://docs.opensearch.org/2.17/observing-your-data/ad/index/): Setting imputation options
+- [Anomaly Result Mapping](https://docs.opensearch.org/2.17/observing-your-data/ad/result-mapping/): feature_imputed field documentation
+- [Random Cut Forest Library](https://github.com/aws/random-cut-forest-by-aws): RCF 4.1.0 with missing data support
+
+## Change History
+
+- **v2.17.0** (2024-09-17): Initial implementation with four imputation methods, feature_imputed tracking, HC detector broadcast support, historical analysis integration

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -152,6 +152,7 @@
 
 - [Anomaly Detection](anomaly-detection/anomaly-detection.md)
 - [Anomaly Detection Admin Backend Role Bypass](anomaly-detection/anomaly-detection-admin-backend-role-bypass.md)
+- [Anomaly Detection Missing Data Handling](anomaly-detection/anomaly-detection-missing-data-handling.md)
 - [Dual Cluster Development Environment](anomaly-detection/dual-cluster-development.md)
 - [Remote/Multi-Index Support](anomaly-detection/remote-multi-index-support.md)
 

--- a/docs/releases/v2.17.0/features/anomaly-detection/anomaly-detection-missing-data-handling.md
+++ b/docs/releases/v2.17.0/features/anomaly-detection/anomaly-detection-missing-data-handling.md
@@ -1,0 +1,215 @@
+# Anomaly Detection Missing Data Handling
+
+## Summary
+
+OpenSearch 2.17.0 introduces enhanced missing data handling for anomaly detection, giving users flexibility to choose how to address gaps in their time-series data. Options include ignoring missing data (default), filling with fixed values, zeros, or previous values. This feature improves recall in anomaly detection scenarios where data gaps are meaningful signals.
+
+## Details
+
+### What's New in v2.17.0
+
+This release adds comprehensive missing data imputation capabilities to the anomaly detection plugin:
+
+- **Imputation Options**: Four methods to handle missing data points
+- **Feature Imputation Tracking**: New `feature_imputed` field in anomaly results to indicate which features were imputed
+- **High-Cardinality Support**: Broadcast mechanism for HC detectors to identify entity models without data
+- **Historical Analysis Support**: Imputation works in both real-time and historical analysis modes
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Data Input"
+        DATA[Time-series Data]
+        MISSING[Missing Data Points]
+    end
+    
+    subgraph "Imputation Layer"
+        IMP[Imputation Handler]
+        OPTS[Imputation Options]
+        OPTS --> |Ignore| IGN[Skip Missing]
+        OPTS --> |Fixed| FIX[Custom Value]
+        OPTS --> |Zero| ZERO[Fill with 0]
+        OPTS --> |Previous| PREV[Last Value]
+    end
+    
+    subgraph "Detection"
+        TRCF[ThresholdedRandomCutForest]
+        SCORE[Anomaly Scoring]
+    end
+    
+    subgraph "Results"
+        RESULT[Anomaly Result]
+        IMPUTED[feature_imputed Array]
+    end
+    
+    DATA --> IMP
+    MISSING --> IMP
+    IMP --> TRCF
+    TRCF --> SCORE
+    SCORE --> RESULT
+    SCORE --> IMPUTED
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ADRealTimeInferencer` | Handles real-time inference with imputation support |
+| `ADHCImputeTransportAction` | Broadcast action for HC detector imputation |
+| `FeatureImputed` | Model class tracking imputation status per feature |
+| `ImputedFeatureResult` | Result class containing imputed values and flags |
+| `ActionListenerExecutor` | Async handler for imputation responses in AD thread pool |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `imputation_option.method` | Imputation method: `ignore`, `fixed`, `zero`, `previous` | `ignore` |
+| `imputation_option.default_fill` | Custom values for fixed imputation | None |
+
+#### API Changes
+
+The detector creation/update API now accepts an `imputation_option` field:
+
+```json
+{
+  "imputation_option": {
+    "method": "FIXED",
+    "default_fill": [
+      {
+        "feature_name": "cpu_usage",
+        "data": 0.5
+      }
+    ]
+  }
+}
+```
+
+### Usage Example
+
+#### Create Detector with Zero Fill Imputation
+
+```json
+POST _plugins/_anomaly_detection/detectors
+{
+  "name": "event-count-detector",
+  "description": "Detect drops in event counts including missing data",
+  "time_field": "timestamp",
+  "indices": ["events-*"],
+  "feature_attributes": [
+    {
+      "feature_name": "event_count",
+      "feature_enabled": true,
+      "aggregation_query": {
+        "event_count": {
+          "value_count": {
+            "field": "event_id"
+          }
+        }
+      }
+    }
+  ],
+  "detection_interval": {
+    "period": {
+      "interval": 5,
+      "unit": "Minutes"
+    }
+  },
+  "imputation_option": {
+    "method": "ZERO"
+  }
+}
+```
+
+#### Create Detector with Previous Value Imputation
+
+```json
+POST _plugins/_anomaly_detection/detectors
+{
+  "name": "metric-detector",
+  "description": "Maintain continuity with previous values",
+  "time_field": "timestamp",
+  "indices": ["metrics-*"],
+  "feature_attributes": [
+    {
+      "feature_name": "avg_latency",
+      "feature_enabled": true,
+      "aggregation_query": {
+        "avg_latency": {
+          "avg": {
+            "field": "latency"
+          }
+        }
+      }
+    }
+  ],
+  "detection_interval": {
+    "period": {
+      "interval": 1,
+      "unit": "Minutes"
+    }
+  },
+  "imputation_option": {
+    "method": "PREVIOUS"
+  }
+}
+```
+
+### Anomaly Result with Imputation
+
+When imputation occurs, the anomaly result includes a `feature_imputed` array:
+
+```json
+{
+  "detector_id": "abc123",
+  "anomaly_score": 1.81,
+  "anomaly_grade": 0.03,
+  "confidence": 0.98,
+  "feature_data": [
+    {
+      "feature_id": "processing_bytes_max",
+      "feature_name": "processing bytes max",
+      "data": 2322
+    }
+  ],
+  "feature_imputed": [
+    {
+      "feature_id": "processing_bytes_max",
+      "imputed": true
+    }
+  ]
+}
+```
+
+### Migration Notes
+
+- Existing detectors continue to work with default "ignore" behavior
+- To enable imputation, update detector configuration with `imputation_option`
+- The `feature_imputed` field only appears when imputation is enabled and occurs
+- Confidence scores decrease when imputations occur
+
+## Limitations
+
+- Extensive imputation of missing data can compromise model accuracy
+- Imputation with shingle size 1 is not meaningful (requires shingle size > 1)
+- Preview mode uses linear interpolation instead of configured imputation for efficiency
+- Quality of imputed data directly affects model performance
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1274](https://github.com/opensearch-project/anomaly-detection/pull/1274) | Add Support for Handling Missing Data in Anomaly Detection |
+
+## References
+
+- [Forum Discussion](https://forum.opensearch.org/t/do-missing-buckets-ruin-anomaly-detection/16535): Original feature request
+- [Anomaly Detection Documentation](https://docs.opensearch.org/2.17/observing-your-data/ad/index/): Setting imputation options
+- [Anomaly Result Mapping](https://docs.opensearch.org/2.17/observing-your-data/ad/result-mapping/): feature_imputed field documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/anomaly-detection/anomaly-detection-missing-data-handling.md)

--- a/docs/releases/v2.17.0/index.md
+++ b/docs/releases/v2.17.0/index.md
@@ -11,6 +11,7 @@
 - [Anomaly Detection Admin Backend Role Bypass](features/anomaly-detection/anomaly-detection-admin-backend-role-bypass.md)
 - [Anomaly Detection Bugfixes](features/anomaly-detection/anomaly-detection-bugfixes.md)
 - [Anomaly Detection Enhancements](features/anomaly-detection/anomaly-detection-enhancements.md)
+- [Anomaly Detection Missing Data Handling](features/anomaly-detection/anomaly-detection-missing-data-handling.md)
 - [Remote/Multi-Index Support](features/anomaly-detection/remote-multi-index-support.md)
 
 ### common


### PR DESCRIPTION
## Summary

This PR adds documentation for the Anomaly Detection Missing Data Handling feature introduced in OpenSearch v2.17.0.

## Changes

### Release Report
- `docs/releases/v2.17.0/features/anomaly-detection/anomaly-detection-missing-data-handling.md`

### Feature Report
- `docs/features/anomaly-detection/anomaly-detection-missing-data-handling.md`

### Index Updates
- Updated `docs/releases/v2.17.0/index.md`
- Updated `docs/features/index.md`

## Feature Overview

OpenSearch 2.17.0 introduces enhanced missing data handling for anomaly detection with four imputation methods:
- **Ignore** (default): Skip missing data points
- **Fixed**: Replace with user-specified values
- **Zero**: Replace with zeros (useful for event counting)
- **Previous**: Carry forward last observed value

Key technical changes:
- New `imputation_option` configuration in detector API
- `feature_imputed` array in anomaly results to track imputed features
- Broadcast mechanism for high-cardinality detectors
- RCF library upgraded to 4.1.0 with missing data support

## Related Issue
Closes #364