### PR TITLE
docs: add Neural Search / Hybrid Query report for v3.0.0

### DIFF
--- a/docs/features/neural-search/hybrid-query.md
+++ b/docs/features/neural-search/hybrid-query.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Hybrid query is a compound query type in OpenSearch that combines lexical (keyword) search with neural (vector) search to improve search relevance. It was introduced in OpenSearch 2.11 as part of the neural-search plugin and enables users to leverage both traditional BM25 scoring and semantic similarity in a single query.
+Hybrid query is a compound query type in OpenSearch that combines lexical (keyword) search with neural (vector) search to improve search relevance. It was introduced in OpenSearch 2.11 as part of the neural-search plugin and enables users to leverage both traditional BM25 scoring and semantic similarity in a single query. The hybrid query requires a search pipeline with normalization and combination processors to merge results from different query types.
 
 ## Details
 
@@ -13,6 +13,7 @@ graph TB
     subgraph "Hybrid Query Execution"
         HQ[Hybrid Query] --> LQ[Lexical Sub-query]
         HQ --> NQ[Neural Sub-query]
+        HQ --> Filter[Filter Push-down]
         
         LQ --> LC[Lucene Collector]
         NQ --> VC[Vector Collector]
@@ -24,16 +25,24 @@ graph TB
         TDM --> NP[Normalization Processor]
         NP --> Results[Combined Results]
     end
+    
+    subgraph "Normalization Techniques"
+        NP --> MM[Min-Max]
+        NP --> L2[L2]
+        NP --> ZS[Z-Score]
+    end
 ```
 
 ### Data Flow
 
 ```mermaid
-flowchart LR
+flowchart TB
     Query[Search Request] --> Parse[Parse Hybrid Query]
-    Parse --> Execute[Execute Sub-queries]
+    Parse --> ApplyFilter[Apply Filter Push-down]
+    ApplyFilter --> Execute[Execute Sub-queries]
     Execute --> Collect[Collect Results per Shard]
-    Collect --> Merge[Merge Shard Results]
+    Collect --> InnerHits[Process Inner Hits]
+    InnerHits --> Merge[Merge Shard Results]
     Merge --> Normalize[Score Normalization]
     Normalize --> Combine[Score Combination]
     Combine --> Response[Search Response]
@@ -44,11 +53,15 @@ flowchart LR
 | Component | Description |
 |-----------|-------------|
 | `HybridQuery` | Compound query containing multiple sub-queries |
+| `HybridQueryBuilder` | Builder for hybrid queries with filter support |
 | `HybridQueryPhaseSearcher` | Custom query phase searcher for hybrid execution |
 | `HybridTopScoreDocCollector` | Collector that maintains results from all sub-queries |
 | `TopDocsMerger` | Merges results from multiple shards/segments |
 | `NormalizationProcessor` | Search pipeline processor for score normalization |
-| `ScoreCombinationTechnique` | Combines normalized scores (arithmetic_mean, geometric_mean, harmonic_mean) |
+| `ScoreCombinationTechnique` | Combines normalized scores |
+| `ZScoreNormalizationTechnique` | Z-Score based normalization |
+| `SemanticHighlighter` | ML-based semantic highlighting for hybrid results |
+| `NeuralStatsAction` | Stats API for neural search observability |
 
 ### Configuration
 
@@ -62,7 +75,13 @@ PUT /_search/pipeline/hybrid-pipeline
     {
       "normalization-processor": {
         "normalization": {
-          "technique": "min_max"
+          "technique": "min_max",
+          "parameters": {
+            "lower_bounds": [
+              { "mode": "apply", "min_score": 0.1 },
+              { "mode": "ignore" }
+            ]
+          }
         },
         "combination": {
           "technique": "arithmetic_mean",
@@ -78,9 +97,18 @@ PUT /_search/pipeline/hybrid-pipeline
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `normalization.technique` | Score normalization method (`min_max`, `l2`) | `min_max` |
+| `normalization.technique` | Score normalization method (`min_max`, `l2`, `z_score`) | `min_max` |
+| `normalization.parameters.lower_bounds` | Lower bound configuration per sub-query | None |
 | `combination.technique` | Score combination method (`arithmetic_mean`, `geometric_mean`, `harmonic_mean`) | `arithmetic_mean` |
 | `combination.parameters.weights` | Weights for each sub-query | Equal weights |
+
+#### Lower Bounds Modes
+
+| Mode | Description |
+|------|-------------|
+| `apply` | Apply the min_score as the lower bound for normalization |
+| `clip` | Clip scores below min_score to min_score value |
+| `ignore` | No lower bound applied to this sub-query |
 
 ### Usage Example
 
@@ -104,10 +132,31 @@ GET /my-index/_search?search_pipeline=hybrid-pipeline
             }
           }
         }
-      ]
+      ],
+      "filter": {
+        "term": { "category": "technology" }
+      }
+    }
+  },
+  "highlight": {
+    "fields": {
+      "text_field": { "type": "semantic" }
+    },
+    "options": {
+      "model_id": "highlighter-model"
     }
   }
 }
+```
+
+### Stats API
+
+Monitor neural search operations:
+
+```
+GET /_plugins/_neural/stats
+GET /_plugins/_neural/stats?include_metadata=true
+GET /_plugins/_neural/stats/text_embedding_executions
 ```
 
 ## Limitations
@@ -115,24 +164,45 @@ GET /my-index/_search?search_pipeline=hybrid-pipeline
 - **Pagination**: The `from` parameter is not supported with hybrid queries. Use `search_after` for pagination instead.
 - **Explain API**: The `explain` parameter is not fully supported for hybrid queries.
 - **Nested queries**: Hybrid queries cannot be nested inside other compound queries.
+- **Nested filter**: Nested HybridQueryBuilder does not support the filter function.
 - **Concurrent segment search**: Results may vary due to non-deterministic merge order when concurrent segment search is enabled.
+- **Semantic highlighter**: Requires a deployed sentence highlighting model.
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.0.0 | [#1224](https://github.com/opensearch-project/neural-search/pull/1224) | Add Z Score normalization technique |
+| v3.0.0 | [#1195](https://github.com/opensearch-project/neural-search/pull/1195) | Lower bounds for min-max normalization |
+| v3.0.0 | [#1206](https://github.com/opensearch-project/neural-search/pull/1206) | Filter support for HybridQueryBuilder and NeuralQueryBuilder |
+| v3.0.0 | [#1253](https://github.com/opensearch-project/neural-search/pull/1253) | Inner hits support with hybrid query |
+| v3.0.0 | [#1256](https://github.com/opensearch-project/neural-search/pull/1256) | Add stats API |
+| v3.0.0 | [#1193](https://github.com/opensearch-project/neural-search/pull/1193) | Support semantic sentence highlighter |
+| v3.0.0 | [#1088](https://github.com/opensearch-project/neural-search/pull/1088) | Analyzer-based neural sparse query |
+| v3.0.0 | [#1191](https://github.com/opensearch-project/neural-search/pull/1191) | Optimize embedding generation in Text Embedding Processor |
+| v3.0.0 | [#1246](https://github.com/opensearch-project/neural-search/pull/1246) | Optimize embedding generation in Sparse Encoding Processor |
+| v3.0.0 | [#1249](https://github.com/opensearch-project/neural-search/pull/1249) | Optimize embedding generation in Text/Image Embedding Processor |
 | v2.17.0 | [#867](https://github.com/opensearch-project/neural-search/pull/867) | Removed misleading pagination code, added clear error |
 | v2.17.0 | [#877](https://github.com/opensearch-project/neural-search/pull/877) | Fixed merge logic for empty shard results |
+| v2.11.0 | - | Initial implementation of hybrid search |
 
 ## References
 
-- [Hybrid Search Documentation](https://docs.opensearch.org/latest/search-plugins/hybrid-search/)
-- [Hybrid Query DSL](https://docs.opensearch.org/latest/query-dsl/compound/hybrid/)
-- [Neural Search Tutorial](https://docs.opensearch.org/latest/search-plugins/neural-search-tutorial/)
+- [Hybrid Search Documentation](https://docs.opensearch.org/3.0/vector-search/ai-search/hybrid-search/index/)
+- [Hybrid Query DSL](https://docs.opensearch.org/3.0/query-dsl/compound/hybrid/)
+- [Neural Search API](https://docs.opensearch.org/3.0/vector-search/api/neural/)
+- [Normalization Processor](https://docs.opensearch.org/3.0/search-plugins/search-pipelines/normalization-processor/)
+- [Neural Search Tutorial](https://docs.opensearch.org/3.0/tutorials/vector-search/neural-search-tutorial/)
+- [Issue #376](https://github.com/opensearch-project/neural-search/issues/376): Z-Score normalization request
+- [Issue #718](https://github.com/opensearch-project/neural-search/issues/718): Inner hits support request
+- [Issue #1138](https://github.com/opensearch-project/neural-search/issues/1138): Embedding optimization RFC
+- [Issue #1182](https://github.com/opensearch-project/neural-search/issues/1182): Semantic highlighter tracking
+- [Issue #1196](https://github.com/opensearch-project/neural-search/issues/1196): Stats API RFC
 - [Issue #875](https://github.com/opensearch-project/neural-search/issues/875): Unable to merge results from shards
 - [Issue #280](https://github.com/opensearch-project/neural-search/issues/280): Pagination support tracking
 
 ## Change History
 
+- **v3.0.0** (2025-05-13): Z-Score normalization, lower bounds for min-max, filter support, inner hits, Stats API, semantic highlighter, analyzer-based neural sparse query, optimized embedding generation
 - **v2.17.0** (2024-09-17): Fixed pagination error handling and multi-shard merge logic
 - **v2.11.0** (2023-10-16): Initial implementation of hybrid search

--- a/docs/releases/v3.0.0/features/neural-search/hybrid-query.md
+++ b/docs/releases/v3.0.0/features/neural-search/hybrid-query.md
@@ -1,0 +1,315 @@
+# Neural Search / Hybrid Query
+
+## Summary
+
+OpenSearch 3.0.0 brings significant enhancements to the neural-search plugin's hybrid query capabilities, including new normalization techniques (Z-Score, lower bounds for min-max), filter support for HybridQueryBuilder and NeuralQueryBuilder, inner hits support, a new Stats API, semantic sentence highlighting, analyzer-based neural sparse queries, and optimized embedding generation across multiple processors. These improvements enhance search relevance, performance, and observability.
+
+## Details
+
+### What's New in v3.0.0
+
+#### 1. Z-Score Normalization Technique
+A new Z-Score normalization technique for hybrid queries that standardizes scores based on statistical distribution.
+
+```json
+PUT /_search/pipeline/zscore-pipeline
+{
+  "phase_results_processors": [
+    {
+      "normalization-processor": {
+        "normalization": {
+          "technique": "z_score"
+        },
+        "combination": {
+          "technique": "arithmetic_mean"
+        }
+      }
+    }
+  ]
+}
+```
+
+#### 2. Lower Bounds for Min-Max Normalization
+Added `lower_bounds` parameter for min-max normalization to control score floor behavior per sub-query.
+
+```json
+PUT /_search/pipeline/minmax-lower-bounds
+{
+  "phase_results_processors": [
+    {
+      "normalization-processor": {
+        "normalization": {
+          "technique": "min_max",
+          "parameters": {
+            "lower_bounds": [
+              { "mode": "apply", "min_score": 0.1 },
+              { "mode": "clip", "min_score": 0.1 },
+              { "mode": "ignore" }
+            ]
+          }
+        },
+        "combination": {
+          "technique": "arithmetic_mean"
+        }
+      }
+    }
+  ]
+}
+```
+
+| Mode | Description |
+|------|-------------|
+| `apply` | Apply the min_score as the lower bound |
+| `clip` | Clip scores below min_score to min_score |
+| `ignore` | No lower bound applied |
+
+#### 3. Filter Support for Query Builders
+HybridQueryBuilder and NeuralQueryBuilder now support a `filter` function for pushing down filters.
+
+```json
+GET /my-index/_search
+{
+  "query": {
+    "hybrid": {
+      "queries": [
+        { "match": { "text": "search query" } },
+        { "neural": { "embedding": { "query_text": "semantic query", "model_id": "xxx" } } }
+      ],
+      "filter": {
+        "term": { "category": "electronics" }
+      }
+    }
+  }
+}
+```
+
+#### 4. Inner Hits Support
+Hybrid queries now support `inner_hits` for nested queries, enabling retrieval of matching nested documents.
+
+```json
+GET /my-index/_search
+{
+  "query": {
+    "hybrid": {
+      "queries": [
+        {
+          "nested": {
+            "path": "comments",
+            "query": { "match": { "comments.text": "great" } },
+            "inner_hits": {}
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+#### 5. Neural Stats API
+A new Stats API provides observability into neural search operations.
+
+```
+GET /_plugins/_neural/stats
+```
+
+Response includes:
+- Cluster-level information (version, processor counts)
+- Node-level event statistics (processor executions)
+- Aggregated statistics across all nodes
+
+```json
+{
+  "_nodes": { "total": 1, "successful": 1, "failed": 0 },
+  "cluster_name": "my-cluster",
+  "info": {
+    "cluster_version": "3.0.0",
+    "processors": {
+      "ingest": { "text_embedding_processors_in_pipelines": 2 }
+    }
+  },
+  "all_nodes": {
+    "processors": {
+      "ingest": { "text_embedding_executions": 1500 }
+    }
+  }
+}
+```
+
+#### 6. Semantic Sentence Highlighter
+A new `semantic` highlighter type uses ML models to identify and highlight semantically relevant text spans.
+
+```json
+GET /my-index/_search
+{
+  "query": {
+    "neural": {
+      "embedding": { "query_text": "AI image generation", "model_id": "xxx" }
+    }
+  },
+  "highlight": {
+    "fields": {
+      "text": { "type": "semantic" }
+    },
+    "options": {
+      "model_id": "sentence-highlighting-model"
+    }
+  }
+}
+```
+
+#### 7. Analyzer-Based Neural Sparse Query
+Support for using analyzers with neural sparse queries, enabling token-based sparse vector search without ML model inference at query time.
+
+#### 8. Optimized Embedding Generation
+The `skip_existing` parameter reduces redundant ML inference calls during document updates:
+
+| Processor | Improvement |
+|-----------|-------------|
+| Text Embedding | Up to 82% latency reduction on updates |
+| Sparse Encoding | Up to 85% latency reduction on updates |
+| Text/Image Embedding | Up to 56% latency reduction on updates |
+
+```json
+PUT /_ingest/pipeline/optimized-pipeline
+{
+  "processors": [
+    {
+      "text_embedding": {
+        "model_id": "xxx",
+        "field_map": { "text": "embedding" },
+        "skip_existing": true
+      }
+    }
+  ]
+}
+```
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "v3.0.0 Enhancements"
+        HQ[Hybrid Query] --> Filter[Filter Push-down]
+        HQ --> IH[Inner Hits Support]
+        
+        NP[Normalization Processor] --> ZS[Z-Score Technique]
+        NP --> LB[Lower Bounds Config]
+        
+        Stats[Stats API] --> Event[Event Stats]
+        Stats --> State[State Stats]
+        
+        HL[Semantic Highlighter] --> ML[ML Model Integration]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ZScoreNormalizationTechnique` | Z-Score normalization for hybrid queries |
+| `LowerBoundsConfiguration` | Lower bounds config for min-max normalization |
+| `NeuralStatsAction` | Transport action for stats API |
+| `SemanticHighlighter` | ML-based semantic highlighting |
+| `SemanticHighlighterEngine` | Engine for semantic highlight processing |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `normalization.technique` | Now supports `z_score` | `min_max` |
+| `normalization.parameters.lower_bounds` | Array of lower bound configs | None |
+| `skip_existing` | Skip embedding generation if unchanged | `false` |
+
+### Usage Example
+
+Complete hybrid search with v3.0.0 features:
+
+```json
+PUT /_search/pipeline/v3-hybrid-pipeline
+{
+  "phase_results_processors": [
+    {
+      "normalization-processor": {
+        "normalization": {
+          "technique": "z_score"
+        },
+        "combination": {
+          "technique": "arithmetic_mean",
+          "parameters": { "weights": [0.3, 0.7] }
+        }
+      }
+    }
+  ]
+}
+```
+
+```json
+GET /my-index/_search?search_pipeline=v3-hybrid-pipeline
+{
+  "query": {
+    "hybrid": {
+      "queries": [
+        { "match": { "title": "machine learning" } },
+        { "neural": { "embedding": { "query_text": "AI algorithms", "model_id": "xxx", "k": 10 } } }
+      ],
+      "filter": { "range": { "date": { "gte": "2024-01-01" } } }
+    }
+  },
+  "highlight": {
+    "fields": { "content": { "type": "semantic" } },
+    "options": { "model_id": "highlighter-model" }
+  }
+}
+```
+
+### Migration Notes
+
+- **Z-Score normalization**: Consider switching from `min_max` to `z_score` for datasets with outlier scores
+- **Lower bounds**: Use `lower_bounds` to handle sub-queries with different score distributions
+- **skip_existing**: Enable on ingest pipelines for workloads with frequent document updates
+- **Stats API**: Use for monitoring and debugging neural search operations
+
+## Limitations
+
+- Nested HybridQueryBuilder does not support the filter function (throws `UnsupportedOperationException`)
+- Semantic highlighter requires a deployed sentence highlighting model
+- `skip_existing` optimization requires document ID to be present for comparison
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#838](https://github.com/opensearch-project/neural-search/pull/838) | Set neural-search plugin 3.0.0 baseline JDK version to JDK-21 |
+| [#1007](https://github.com/opensearch-project/neural-search/pull/1007) | Support different embedding types in model's response |
+| [#1088](https://github.com/opensearch-project/neural-search/pull/1088) | Implement analyzer based neural sparse query |
+| [#1191](https://github.com/opensearch-project/neural-search/pull/1191) | Optimize embedding generation in Text Embedding Processor |
+| [#1193](https://github.com/opensearch-project/neural-search/pull/1193) | Support semantic sentence highlighter |
+| [#1195](https://github.com/opensearch-project/neural-search/pull/1195) | Lower bound for min-max normalization technique |
+| [#1204](https://github.com/opensearch-project/neural-search/pull/1204) | Fix unflatten doc with list of map |
+| [#1206](https://github.com/opensearch-project/neural-search/pull/1206) | Support filter function for HybridQueryBuilder and NeuralQueryBuilder |
+| [#1224](https://github.com/opensearch-project/neural-search/pull/1224) | Add Z Score normalization technique |
+| [#1230](https://github.com/opensearch-project/neural-search/pull/1230) | Remove validations for unmapped fields in TextImageEmbeddingProcessor |
+| [#1246](https://github.com/opensearch-project/neural-search/pull/1246) | Optimize embedding generation in Sparse Encoding Processor |
+| [#1249](https://github.com/opensearch-project/neural-search/pull/1249) | Optimize embedding generation in Text/Image Embedding Processor |
+| [#1253](https://github.com/opensearch-project/neural-search/pull/1253) | Inner hits support with hybrid query |
+| [#1254](https://github.com/opensearch-project/neural-search/pull/1254) | Support custom tags in semantic highlighter |
+| [#1256](https://github.com/opensearch-project/neural-search/pull/1256) | Add stats API |
+| [#1257](https://github.com/opensearch-project/neural-search/pull/1257) | Add validations for TextImageEmbeddingProcessor |
+| [#1277](https://github.com/opensearch-project/neural-search/pull/1277) | Fix score value as null for single shard sorting |
+
+## References
+
+- [Hybrid Search Documentation](https://docs.opensearch.org/3.0/vector-search/ai-search/hybrid-search/index/)
+- [Neural Search API](https://docs.opensearch.org/3.0/vector-search/api/neural/)
+- [Normalization Processor](https://docs.opensearch.org/3.0/search-plugins/search-pipelines/normalization-processor/)
+- [Issue #376](https://github.com/opensearch-project/neural-search/issues/376): Z-Score normalization request
+- [Issue #718](https://github.com/opensearch-project/neural-search/issues/718): Inner hits support request
+- [Issue #1138](https://github.com/opensearch-project/neural-search/issues/1138): Embedding optimization RFC
+- [Issue #1182](https://github.com/opensearch-project/neural-search/issues/1182): Semantic highlighter tracking
+- [Issue #1196](https://github.com/opensearch-project/neural-search/issues/1196): Stats API RFC
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/neural-search/hybrid-query.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -7,6 +7,7 @@
 ### neural-search
 
 - [Analyzer-Based Neural Sparse Query](features/neural-search/analyzer-based-neural-sparse-query.md)
+- [Hybrid Query](features/neural-search/hybrid-query.md)
 - [Neural Search Compatibility](features/neural-search/neural-search-compatibility.md)
 - [Semantic Field](features/neural-search/semantic-field.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Neural Search / Hybrid Query feature in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/neural-search/hybrid-query.md`
- Feature report: `docs/features/neural-search/hybrid-query.md` (updated)

### Key Changes in v3.0.0
- Z-Score normalization technique for hybrid queries
- Lower bounds configuration for min-max normalization
- Filter support for HybridQueryBuilder and NeuralQueryBuilder
- Inner hits support with hybrid query
- Neural Stats API for observability
- Semantic sentence highlighter
- Analyzer-based neural sparse query
- Optimized embedding generation (up to 85% latency reduction on updates)

### PRs Investigated
- #838, #1007, #1088, #1191, #1193, #1195, #1204, #1206, #1224, #1230, #1246, #1249, #1253, #1254, #1256, #1257, #1277

Closes #163