### PR TITLE
docs: add OUI updates report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -54,6 +54,7 @@
 - [Data Importer](opensearch-dashboards/data-importer.md)
 - [DOMPurify Sanitization](opensearch-dashboards/dompurify-sanitization.md)
 - [Monaco Editor](opensearch-dashboards/monaco-editor.md)
+- [OpenSearch UI (OUI)](opensearch-dashboards/oui.md)
 - [Workspace](opensearch-dashboards/workspace.md)
 
 ## security

--- a/docs/features/opensearch-dashboards/oui.md
+++ b/docs/features/opensearch-dashboards/oui.md
@@ -1,0 +1,100 @@
+# OpenSearch UI (OUI)
+
+## Summary
+
+OpenSearch UI (OUI) is the component library that provides the visual foundation for OpenSearch Dashboards. It is a fork of Elastic UI (EUI) maintained by the OpenSearch project, offering React components, SCSS styling, and design patterns specifically tailored for OpenSearch's user interface needs.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        OSD[Dashboard Application]
+        Plugins[Plugins]
+    end
+    
+    subgraph "OUI Library"
+        Components[React Components]
+        SCSS[SCSS Variables & Mixins]
+        Themes[Theme System]
+    end
+    
+    OSD --> Components
+    OSD --> SCSS
+    Plugins --> Components
+    Plugins --> SCSS
+    Themes --> Components
+    Themes --> SCSS
+```
+
+### Components
+
+| Component Category | Description |
+|-------------------|-------------|
+| Layout | Page layouts, grids, flex groups, panels |
+| Navigation | Side nav, breadcrumbs, tabs, pagination |
+| Forms | Inputs, selects, checkboxes, buttons |
+| Display | Tables, cards, badges, tooltips |
+| Feedback | Toasts, modals, loading indicators |
+
+### Configuration
+
+OUI is configured through package dependencies in OpenSearch Dashboards:
+
+| Setting | Description | Example |
+|---------|-------------|---------|
+| `@elastic/eui` | NPM alias pointing to OUI | `npm:@opensearch-project/oui@1.15.0` |
+
+### Theme System
+
+OUI supports multiple themes through SCSS variables:
+
+```scss
+// Light theme colors
+$euiColorPrimary: #006BB4;
+$euiColorSuccess: #017D73;
+
+// Side navigation
+$euiSideNavBackgroundColor: lightOrDarkTheme(#ebe4df, #001c28);
+```
+
+### Usage Example
+
+```tsx
+import { EuiButton, EuiFlexGroup, EuiFlexItem } from '@elastic/eui';
+
+function MyComponent() {
+  return (
+    <EuiFlexGroup>
+      <EuiFlexItem>
+        <EuiButton fill>Primary Action</EuiButton>
+      </EuiFlexItem>
+    </EuiFlexGroup>
+  );
+}
+```
+
+## Limitations
+
+- OUI is a fork of EUI and may diverge from upstream changes
+- Custom themes require understanding of SCSS variable system
+- Breaking changes between major versions may require plugin updates
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#8246](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8246) | Update OUI to 1.13 |
+| v2.18.0 | [#8372](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8372) | Update OUI to 1.14 |
+| v2.18.0 | [#8480](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8480) | Update OUI to 1.15 |
+
+## References
+
+- [OUI Repository](https://github.com/opensearch-project/oui): OpenSearch UI component library source code
+- [OpenSearch Dashboards](https://docs.opensearch.org/latest/dashboards/): Official documentation
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Updated to OUI 1.15 with new `$euiSideNavBackgroundColor` variable, font changes from Fira Code to Source Code Pro

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/oui-updates.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/oui-updates.md
@@ -1,0 +1,79 @@
+# OUI Updates
+
+## Summary
+
+OpenSearch Dashboards v2.18.0 includes a series of updates to the OpenSearch UI (OUI) component library, upgrading from version 1.12 to 1.15. These updates bring visual improvements, font changes, and new SCSS variables for better theming consistency across the dashboard interface.
+
+## Details
+
+### What's New in v2.18.0
+
+The OUI library was incrementally updated through three PRs:
+
+1. **OUI 1.13** - Initial update with general improvements
+2. **OUI 1.14** - Removed Fira Code font in favor of Source Code Pro for the v9 theme
+3. **OUI 1.15** - Introduced official `$euiSideNavBackgroundColor` SCSS variable
+
+### Technical Changes
+
+#### Font Changes
+
+OUI 1.14 replaced the Fira Code monospace font with Source Code Pro as part of the v9 theme standardization. This change affects code blocks, console output, and other monospace text throughout the dashboard.
+
+#### New SCSS Variables
+
+OUI 1.15 introduced the `$euiSideNavBackgroundColor` variable, replacing the temporary `$ouiSideNavBackgroundColorTemp` variable that was previously defined locally in OpenSearch Dashboards.
+
+| Old Variable | New Variable | Purpose |
+|--------------|--------------|---------|
+| `$ouiSideNavBackgroundColorTemp` | `$euiSideNavBackgroundColor` | Side navigation background color |
+
+#### Files Updated
+
+The following components were updated to use the new official OUI variable:
+
+- `src/core/public/chrome/ui/header/collapsible_nav_group_enabled.scss` - Main navigation styling
+- `src/plugins/workspace/public/components/workspace_selector/workspace_selector.scss` - Workspace selector styling
+
+#### Package Updates
+
+All OUI package references were updated across multiple `package.json` files:
+
+```json
+"@elastic/eui": "npm:@opensearch-project/oui@1.15.0"
+```
+
+### Usage Example
+
+The side navigation background color is now applied using the official OUI variable:
+
+```scss
+.context-nav-wrapper {
+  background-color: $euiSideNavBackgroundColor;
+}
+```
+
+### Migration Notes
+
+If you have custom plugins or themes that reference `$ouiSideNavBackgroundColorTemp`, update them to use `$euiSideNavBackgroundColor` instead.
+
+## Limitations
+
+- These are maintenance updates with no new UI components
+- Font changes may affect the visual appearance of code blocks in existing dashboards
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8246](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8246) | Update OUI to 1.13 |
+| [#8372](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8372) | Update OUI to 1.14 (font changes) |
+| [#8480](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8480) | Update OUI to 1.15 and consume $euiSideNavBackgroundColor |
+
+## References
+
+- [OUI Repository](https://github.com/opensearch-project/oui): OpenSearch UI component library
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/oui.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -1,0 +1,11 @@
+# OpenSearch v2.18.0 Release
+
+## Overview
+
+This page contains feature reports for OpenSearch v2.18.0.
+
+## Features by Repository
+
+### OpenSearch Dashboards
+
+- [OUI Updates](features/opensearch-dashboards/oui-updates.md) - Updates to OpenSearch UI component library (1.13 → 1.15)


### PR DESCRIPTION
## Summary

This PR adds documentation for the OUI (OpenSearch UI) updates in v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch-dashboards/oui-updates.md`
- Feature report: `docs/features/opensearch-dashboards/oui.md`
- Release index: `docs/releases/v2.18.0/index.md`

### Key Changes in v2.18.0
- Updated OUI from 1.12 to 1.15
- Replaced Fira Code font with Source Code Pro for v9 theme
- Introduced official `$euiSideNavBackgroundColor` SCSS variable

### Related PRs
- opensearch-project/OpenSearch-Dashboards#8246
- opensearch-project/OpenSearch-Dashboards#8372
- opensearch-project/OpenSearch-Dashboards#8480

Closes #697