### PR TITLE
docs: add maintainers report for v2.18.0

### DIFF
--- a/docs/features/multi-plugin/maintainer-updates.md
+++ b/docs/features/multi-plugin/maintainer-updates.md
@@ -54,6 +54,7 @@ Each OpenSearch repository contains a MAINTAINERS.md file with:
 
 | Version | PR | Repository | Description |
 |---------|-----|------------|-------------|
+| v2.18.0 | [#8415](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8415) | opensearch-dashboards | Add Hailong-am as maintainer |
 | v2.17.0 | [#4673](https://github.com/opensearch-project/security/pull/4673) | security | Add Nils Bandener as maintainer |
 | v2.17.0 | [#1233](https://github.com/opensearch-project/index-management/pull/1233) | index-management | Move inactive maintainers to emeritus |
 
@@ -64,4 +65,5 @@ Each OpenSearch repository contains a MAINTAINERS.md file with:
 
 ## Change History
 
+- **v2.18.0** (2024-10-22): Added Hailong Cui (Hailong-am) as maintainer for OpenSearch Dashboards
 - **v2.17.0** (2024-09-17): Added maintainers (nibix to security, sumukhswamy to dashboards, riysaxen to notifications); moved inactive index-management maintainers to emeritus

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/maintainers.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/maintainers.md
@@ -1,0 +1,39 @@
+# Maintainers
+
+## Summary
+
+This release adds Hailong Cui ([@Hailong-am](https://github.com/Hailong-am)) as a new maintainer for OpenSearch Dashboards. Maintainer updates are administrative changes that recognize contributors who have demonstrated sustained commitment to the project.
+
+## Details
+
+### What's New in v2.18.0
+
+Hailong Cui has been added to the OpenSearch Dashboards maintainer list. As a maintainer, Hailong will have responsibilities including code review, release management, and project direction.
+
+### Changes to MAINTAINERS.md
+
+The following entry was added to the Current Maintainers table:
+
+| Maintainer | GitHub ID | Affiliation |
+|------------|-----------|-------------|
+| Hailong Cui | [Hailong-am](https://github.com/Hailong-am) | Amazon |
+
+## Limitations
+
+- Maintainer updates are administrative and do not affect software functionality
+- Changes require consensus from existing maintainers
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8415](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8415) | Add Hailong-am as maintainer |
+
+## References
+
+- [MAINTAINERS.md](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/MAINTAINERS.md): Current maintainer list
+- [OpenSearch Project Governance](https://github.com/opensearch-project/.github/blob/main/GOVERNANCE.md): Governance documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/multi-plugin/maintainer-updates.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -8,4 +8,5 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### OpenSearch Dashboards
 
+- [Maintainers](features/opensearch-dashboards/maintainers.md) - Add Hailong-am as maintainer
 - [OUI Updates](features/opensearch-dashboards/oui-updates.md) - Updates to OpenSearch UI component library (1.13 → 1.15)


### PR DESCRIPTION
## Summary

Add documentation for maintainer update in OpenSearch Dashboards v2.18.0.

### Changes
- Added Hailong Cui (Hailong-am) as maintainer for OpenSearch Dashboards

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch-dashboards/maintainers.md`
- Feature report updated: `docs/features/multi-plugin/maintainer-updates.md`

### Related
- Closes #696
- PR: opensearch-project/OpenSearch-Dashboards#8415