### PR TITLE
docs: add CI/CD & Build Improvements (Dashboards) report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -53,6 +53,7 @@
 - [Dashboards UI/UX Fixes](opensearch-dashboards/dashboards-ui-ux-fixes.md)
 - [Data Importer](opensearch-dashboards/data-importer.md)
 - [DOMPurify Sanitization](opensearch-dashboards/dompurify-sanitization.md)
+- [OSD Optimizer Cache](opensearch-dashboards/osd-optimizer-cache.md)
 - [Monaco Editor](opensearch-dashboards/monaco-editor.md)
 - [OpenSearch UI (OUI)](opensearch-dashboards/oui.md)
 - [Workspace](opensearch-dashboards/workspace.md)

--- a/docs/features/opensearch-dashboards/osd-optimizer-cache.md
+++ b/docs/features/opensearch-dashboards/osd-optimizer-cache.md
@@ -1,0 +1,118 @@
+# OSD Optimizer Cache
+
+## Summary
+
+The OSD Optimizer is the build system for OpenSearch Dashboards that compiles and bundles plugin code. It includes a caching mechanism to avoid unnecessary recompilation. Starting from v2.18.0, the cache uses content-based hashing instead of file modification times, enabling effective caching in CI/CD environments.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OSD Optimizer"
+        A[Source Files] --> B[Hash Computation]
+        B --> C{Cache Check}
+        C -->|Cache Hit| D[Load Cached Bundle]
+        C -->|Cache Miss| E[Webpack Compilation]
+        E --> F[Update Cache]
+        F --> G[Output Bundle]
+        D --> G
+    end
+    
+    subgraph "Cache Storage"
+        H[LMDB Database]
+        H --> I[codes]
+        H --> J[hashes]
+        H --> K[sourceMaps]
+        H --> L[atimes]
+    end
+    
+    F --> H
+    C --> H
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Plugin Source Files] --> B[getHashes]
+    B --> C[SHA-1 Hash per File]
+    C --> D[createCacheKey]
+    D --> E{Compare with Stored Key}
+    E -->|Match| F[Skip Compilation]
+    E -->|Mismatch| G[Run Webpack]
+    G --> H[Store New Cache Key]
+    H --> I[Store Compiled Output]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `get_hashes.ts` | Computes SHA-1 content hashes for files with concurrency limit of 100 |
+| `bundle.ts` | Bundle class with `createCacheKey()` method |
+| `cache.ts` | LMDB-based cache storage with codes, hashes, sourceMaps, and atimes databases |
+| `bundle_cache.ts` | Determines cache validity by comparing cache keys |
+| `cache_keys.ts` | Defines `OptimizerCacheKey` interface and diff logic |
+| `run_compilers.ts` | Webpack compilation runner with cache integration |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Cache location | `.osd-optimizer-cache` directory | Project root |
+| Hash algorithm | SHA-1 for content hashing | N/A |
+| Concurrency | Max concurrent file hash operations | 100 |
+
+### Usage Example
+
+The optimizer runs automatically during development and build:
+
+```bash
+# Development mode (watches for changes)
+yarn start
+
+# Production build
+yarn build
+
+# Clear cache if issues occur
+yarn osd clean
+```
+
+### Cache Key Structure
+
+```json
+{
+  "spec": {
+    "id": "plugin-name",
+    "type": "plugin",
+    "contextDir": "/path/to/plugin"
+  },
+  "hashes": {
+    "/path/to/file1.ts": "base64-sha1-hash",
+    "/path/to/file2.ts": "base64-sha1-hash"
+  }
+}
+```
+
+## Limitations
+
+- Cache is invalidated when upgrading from mtime-based versions
+- Hash computation has minor overhead compared to mtime checks
+- Large codebases may experience longer initial hash computation
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#8472](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8472) | Switch to content-based hashing |
+
+## References
+
+- [Issue #8428](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8428): Original feature request for improved cache strategy
+- [Issue #2188](https://github.com/opensearch-project/dashboards-observability/issues/2188): Related CI caching discussion
+
+## Change History
+
+- **v2.18.0** (2024-10-22): Switched from mtime-based caching to SHA-1 content hashing for CI compatibility

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/cicd-build-dashboards.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/cicd-build-dashboards.md
@@ -1,0 +1,105 @@
+# CI/CD & Build Improvements (Dashboards)
+
+## Summary
+
+This release improves the OSD Optimizer build cache by switching from file modification time (`mtime`) tracking to content-based hashing. This change enables effective build caching in CI environments where file timestamps are unreliable due to code checkout operations.
+
+## Details
+
+### What's New in v2.18.0
+
+The OSD Optimizer previously determined whether to rebuild files based on last-modified time (`mtime`). This approach failed in CI environments because pulling code always updates file timestamps, causing the cache to be invalidated on every run.
+
+The fix refactors the cache system to use SHA-1 content hashes instead of modification times, enabling proper cache hits even when files are moved between machines or checked out fresh.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v2.18.0"
+        A1[Source Files] --> B1[Get mtime]
+        B1 --> C1[Compare with cached mtime]
+        C1 -->|mtime changed| D1[Rebuild]
+        C1 -->|mtime same| E1[Use Cache]
+    end
+    
+    subgraph "After v2.18.0"
+        A2[Source Files] --> B2[Compute SHA-1 Hash]
+        B2 --> C2[Compare with cached hash]
+        C2 -->|hash changed| D2[Rebuild]
+        C2 -->|hash same| E2[Use Cache]
+    end
+```
+
+#### Modified Components
+
+| Component | Change |
+|-----------|--------|
+| `get_hashes.ts` | New file (renamed from `get_mtimes.ts`) - computes SHA-1 hashes of file contents |
+| `bundle.ts` | `createCacheKey()` now accepts hashes instead of mtimes |
+| `cache.ts` | Database schema changed from `mtimes` to `hashes` |
+| `cache_keys.ts` | `OptimizerCacheKey` interface uses `fileHashes` instead of `modifiedTimes` |
+| `bundle_cache.ts` | Uses `getHashes()` instead of `getMtimes()` |
+| `run_compilers.ts` | Async hash computation for cache updates |
+| `node_auto_tranpilation.ts` | Uses file hash for transpilation cache |
+
+#### Cache Key Format Change
+
+**Before:**
+```json
+{
+  "cacheKey": {
+    "mtimes": {
+      "/path/to/file.ts": 1689369687625
+    }
+  }
+}
+```
+
+**After:**
+```json
+{
+  "cacheKey": {
+    "hashes": {
+      "/path/to/file.ts": "OwCtruddjWkB6ROdbLRM0NnWOhs="
+    }
+  }
+}
+```
+
+### Usage Example
+
+No configuration changes required. The optimizer automatically uses content hashing.
+
+To clear the cache if migrating from an older version:
+```bash
+yarn osd clean
+```
+
+### Migration Notes
+
+- Existing cache will be invalidated on first run after upgrade (full recompilation)
+- No manual intervention required after initial rebuild
+- Use `yarn osd clean` if any cache-related issues occur
+
+## Limitations
+
+- Initial build after upgrade requires full recompilation
+- Hash computation adds minor overhead compared to mtime checks (offset by cache hit benefits in CI)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8472](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8472) | Switch OSD Optimizer to rely on file hashes instead of mtimes |
+
+## References
+
+- [Issue #8428](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8428): OSD Optimizer: Improve strategy for detecting stale compilation targets
+- [Issue #2188](https://github.com/opensearch-project/dashboards-observability/issues/2188): Related discussion on caching build artifacts
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/osd-optimizer-cache.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -8,5 +8,6 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### OpenSearch Dashboards
 
+- [CI/CD & Build Improvements](features/opensearch-dashboards/cicd-build-dashboards.md) - Switch OSD Optimizer to content-based hashing for CI compatibility
 - [Maintainers](features/opensearch-dashboards/maintainers.md) - Add Hailong-am as maintainer
 - [OUI Updates](features/opensearch-dashboards/oui-updates.md) - Updates to OpenSearch UI component library (1.13 → 1.15)


### PR DESCRIPTION
## Summary

This PR adds documentation for the CI/CD & Build Improvements in OpenSearch Dashboards v2.18.0.

### Key Change
The OSD Optimizer build cache was refactored to use SHA-1 content hashing instead of file modification times (`mtime`). This enables effective build caching in CI environments where file timestamps are unreliable.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch-dashboards/cicd-build-dashboards.md`
- Feature report: `docs/features/opensearch-dashboards/osd-optimizer-cache.md`

### Related
- Closes #695
- PR: opensearch-project/OpenSearch-Dashboards#8472
- Issue: opensearch-project/OpenSearch-Dashboards#8428