### PR TITLE
docs: add sample-data-bugfixes report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -56,6 +56,7 @@
 - [OSD Optimizer Cache](opensearch-dashboards/osd-optimizer-cache.md)
 - [Monaco Editor](opensearch-dashboards/monaco-editor.md)
 - [OpenSearch UI (OUI)](opensearch-dashboards/oui.md)
+- [Sample Data](opensearch-dashboards/sample-data.md)
 - [Workspace](opensearch-dashboards/workspace.md)
 
 ## security

--- a/docs/features/opensearch-dashboards/sample-data.md
+++ b/docs/features/opensearch-dashboards/sample-data.md
@@ -1,0 +1,104 @@
+# Sample Data
+
+## Summary
+
+Sample Data in OpenSearch Dashboards provides pre-loaded datasets with visualizations and dashboards that allow users to explore OpenSearch features without importing their own data. The sample datasets include flight data, e-commerce data, web logs, and OpenTelemetry (OTEL) observability data for traces, metrics, and logs.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        Home[Home Plugin]
+        SD[Sample Data Service]
+        Registry[Dataset Registry]
+    end
+    
+    subgraph "Sample Datasets"
+        Flights[Sample Flights]
+        Ecommerce[Sample E-commerce]
+        Logs[Sample Web Logs]
+        OTEL[Sample OTEL Data]
+    end
+    
+    subgraph "OpenSearch"
+        Indices[Sample Indices]
+        Patterns[Index Patterns]
+    end
+    
+    Home --> SD
+    SD --> Registry
+    Registry --> Flights
+    Registry --> Ecommerce
+    Registry --> Logs
+    Registry --> OTEL
+    
+    SD --> Indices
+    SD --> Patterns
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Sample Data Service | Core service that manages sample dataset installation and removal |
+| Dataset Registry | Registry of available sample datasets with metadata |
+| Sample Flights | Flight data with delays, carriers, and destinations |
+| Sample E-commerce | E-commerce transaction data |
+| Sample Web Logs | Web server access logs |
+| Sample OTEL Data | OpenTelemetry traces, metrics, logs, and service maps |
+
+### OTEL Sample Data
+
+The OTEL sample data provides correlated observability signals for an e-commerce application in OpenTelemetry standard format. It includes:
+
+| Index | Description | Time Fields |
+|-------|-------------|-------------|
+| `otel-v1-apm-span-sample` | Trace spans | startTime, endTime |
+| `otel-v1-apm-service-map-sample` | Service dependency map | - |
+| `ss4o_metrics-otel-sample` | Metrics data | @timestamp, startTime, time |
+| `ss4o_logs-otel-sample` | Log data | time, observedTime |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `home.sampleData.otelSpecTitle` | OTEL sample data title | "Sample Observability Logs, Traces, and Metrics" |
+| `home.sampleData.otelSpecDescription` | OTEL sample data description | Includes compatibility note |
+
+### Usage
+
+1. Navigate to OpenSearch Dashboards Home page
+2. Click "Add sample data"
+3. Select the desired sample dataset
+4. Click "Add data" to install
+
+### App Links
+
+The OTEL sample data provides quick links to:
+
+- **View traces**: Navigate to `observability-traces#/traces`
+- **View services**: Navigate to `observability-traces#/services`
+
+## Limitations
+
+- OTEL sample data is compatible only with OpenSearch 2.13+ domains
+- Sample data is for demonstration and learning purposes only
+- Data is static and does not update in real-time
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#8693](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8693) | Update OTEL sample data description with compatible OS version |
+
+## References
+
+- [OpenSearch Dashboards Quickstart Guide](https://docs.opensearch.org/latest/dashboards/quickstart/): Official documentation on adding sample data
+- [Trace Analytics Getting Started](https://docs.opensearch.org/latest/observing-your-data/trace/getting-started/): Using OTEL data with trace analytics
+
+## Change History
+
+- **v2.18.0** (2024-11-12): Added compatibility warning to OTEL sample data description (OpenSearch 2.13+ required)

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/sample-data-bugfixes.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/sample-data-bugfixes.md
@@ -1,0 +1,56 @@
+# Sample Data Bugfixes
+
+## Summary
+
+This release updates the OTEL (OpenTelemetry) sample data description to inform users about OpenSearch version compatibility requirements. The OTEL sample data only works with OpenSearch 2.13+ domains, and this fix adds a clear warning message to help users understand this limitation.
+
+## Details
+
+### What's New in v2.18.0
+
+The OTEL sample data description now includes compatibility information, warning users that the sample data requires OpenSearch 2.13 or later.
+
+### Technical Changes
+
+#### Description Update
+
+The sample data description was updated from:
+
+```
+Correlated observability signals for an e-commerce application in OpenTelemetry standard.
+```
+
+To:
+
+```
+Correlated observability signals for an e-commerce application in OpenTelemetry standard (Compatible with 2.13+ OpenSearch domains)
+```
+
+#### Changed Files
+
+| File | Change |
+|------|--------|
+| `src/plugins/home/server/services/sample_data/data_sets/otel/index.ts` | Updated description text |
+
+### User Impact
+
+Users attempting to load OTEL sample data on OpenSearch versions prior to 2.13 will now see a clear compatibility warning before installation, preventing confusion when the sample data fails to work properly.
+
+## Limitations
+
+- OTEL sample data remains incompatible with OpenSearch versions prior to 2.13
+- Future releases plan to make the sample data compatible with all OpenSearch versions
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8693](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8693) | Update OTEL sample data description with compatible OS version |
+
+## References
+
+- [OpenSearch Dashboards Quickstart Guide](https://docs.opensearch.org/2.18/dashboards/quickstart/): Documentation on adding sample data
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/sample-data.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -11,3 +11,4 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [CI/CD & Build Improvements](features/opensearch-dashboards/cicd-build-dashboards.md) - Switch OSD Optimizer to content-based hashing for CI compatibility
 - [Maintainers](features/opensearch-dashboards/maintainers.md) - Add Hailong-am as maintainer
 - [OUI Updates](features/opensearch-dashboards/oui-updates.md) - Updates to OpenSearch UI component library (1.13 → 1.15)
+- [Sample Data Bugfixes](features/opensearch-dashboards/sample-data-bugfixes.md) - Update OTEL sample data description with compatible OS version


### PR DESCRIPTION
## Summary

This PR adds documentation for the Sample Data bugfix in OpenSearch Dashboards v2.18.0.

### Changes

- **Release Report**: `docs/releases/v2.18.0/features/opensearch-dashboards/sample-data-bugfixes.md`
  - Documents the OTEL sample data description update
  - Explains the compatibility warning for OpenSearch 2.13+

- **Feature Report**: `docs/features/opensearch-dashboards/sample-data.md`
  - New comprehensive feature documentation for Sample Data
  - Covers all sample datasets (Flights, E-commerce, Logs, OTEL)
  - Documents OTEL sample data indices and configuration

### Related Issue

Closes #694

### Related PR

- [opensearch-project/OpenSearch-Dashboards#8693](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8693)