### PR TITLE
docs: add Discover bugfixes (2) report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -52,6 +52,7 @@
 - [Dashboards UI Updates (OUI)](opensearch-dashboards/dashboards-ui-updates.md)
 - [Dashboards UI/UX Fixes](opensearch-dashboards/dashboards-ui-ux-fixes.md)
 - [Data Importer](opensearch-dashboards/data-importer.md)
+- [Discover](opensearch-dashboards/discover.md)
 - [DOMPurify Sanitization](opensearch-dashboards/dompurify-sanitization.md)
 - [OSD Optimizer Cache](opensearch-dashboards/osd-optimizer-cache.md)
 - [Monaco Editor](opensearch-dashboards/monaco-editor.md)

--- a/docs/features/opensearch-dashboards/discover.md
+++ b/docs/features/opensearch-dashboards/discover.md
@@ -1,0 +1,117 @@
+# Discover
+
+## Summary
+
+Discover is the data exploration application in OpenSearch Dashboards that allows users to interactively search, filter, and analyze data stored in OpenSearch indexes. It provides a powerful interface for ad-hoc data exploration with support for multiple query languages (DQL, Lucene, SQL, PPL), time-based filtering, field selection, and document inspection.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        subgraph "Discover Application"
+            QE[Query Editor]
+            TF[Time Filter]
+            FS[Field Selector]
+            DT[Document Table]
+            SQ[Saved Queries]
+        end
+        subgraph "Data Services"
+            QS[Query Service]
+            SS[Search Service]
+            IP[Index Patterns]
+            FM[Filter Manager]
+        end
+    end
+    subgraph "OpenSearch"
+        IDX[Indexes]
+        S3[S3 Data Sources]
+    end
+    
+    QE --> QS
+    TF --> FM
+    FS --> IP
+    DT --> SS
+    SQ --> QS
+    QS --> IDX
+    SS --> IDX
+    IP --> IDX
+    IP --> S3
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User enters query] --> B[Query Editor]
+    B --> C{Query Language}
+    C -->|DQL| D[DQL Parser]
+    C -->|Lucene| E[Lucene Parser]
+    C -->|SQL/PPL| F[SQL/PPL Engine]
+    D --> G[Search Service]
+    E --> G
+    F --> G
+    G --> H[OpenSearch]
+    H --> I[Results]
+    I --> J[Document Table]
+    J --> K[Field Selector filters columns]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Query Editor | Input area for search queries with language selection |
+| Time Filter | Controls time range for time-based indexes |
+| Field Selector | Sidebar for selecting and filtering visible fields |
+| Document Table | Displays search results with expandable documents |
+| Saved Queries | Stores and loads frequently used queries |
+| Index Pattern Selector | Selects data source for exploration |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `discover:searchOnPageLoad` | Run search when Discover loads | On |
+| `discover:sort:defaultOrder` | Default sort order for time-based indexes | desc |
+| `discover:sampleSize` | Number of documents to show | 500 |
+| `query:enhancements:enabled` | Enable query enhancements (SQL/PPL support) | Off |
+
+### Usage Example
+
+```
+# DQL Query Example
+status:error AND response.code >= 500
+
+# Time Filter
+Last 15 minutes, Last 24 hours, Custom range
+
+# Field Selection
+Select fields from sidebar to customize table columns
+```
+
+## Limitations
+
+- Time field display may have rendering issues when switching query languages (workaround applied in v2.18.0)
+- S3 field support requires query enhancements to be enabled
+- Recently selected data list may show stale entries after index pattern deletion (fixed in v2.18.0)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#8609](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8609) | Add support for S3 fields in Discover |
+| v2.18.0 | [#8659](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8659) | Fix UI stuck on searching after deleting index pattern |
+| v2.18.0 | [#8755](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8755) | Fix time field wrapping overlap on language change |
+| v2.18.0 | [#8707](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8707) | Ensure saved query loaded properly from asset |
+
+## References
+
+- [Analyzing data in Discover](https://docs.opensearch.org/2.18/dashboards/discover/index-discover/): Official documentation
+- [Issue #8612](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8612): Bug report for deleted index pattern issue
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Bug fixes for S3 fields support, deleted index pattern handling, time field display, and saved query loading

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/discover-bugfixes-2.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/discover-bugfixes-2.md
@@ -1,0 +1,104 @@
+# Discover Bugfixes (2)
+
+## Summary
+
+OpenSearch Dashboards v2.18.0 includes four bug fixes for the Discover application, addressing issues with S3 field support, deleted index pattern handling, time field display, and saved query loading. These fixes improve the stability and usability of Discover, particularly when using the query enhancement feature.
+
+## Details
+
+### What's New in v2.18.0
+
+This release addresses several bugs in the Discover application:
+
+1. **S3 Fields Support**: Added support for S3 fields in Discover 2.0
+2. **Deleted Index Pattern Handling**: Fixed UI getting stuck when a selected index pattern is deleted
+3. **Time Field Display**: Fixed time field wrapping overlap when changing query languages
+4. **Saved Query Loading**: Fixed saved queries not loading properly from assets
+
+### Technical Changes
+
+#### S3 Fields Support (PR #8609)
+
+Added async loaders to field selectors in the sidebar to support S3 data sources:
+
+| Component | Change |
+|-----------|--------|
+| Field Selectors | Added async loaders for S3 fields |
+| Index Pattern | Added `areFieldsLoading` flag to show loading state |
+| Dataset Config | Added `supportsTimeFilter` flag |
+| Field Types | Added SQL/PPL to OSD field type conversion |
+
+Key improvements:
+- On page reload, fields are fetched for selected datasets
+- Field type conversion from SQL/PPL to OSD field types
+- Loading indicator in sidebar while fields are being fetched
+
+#### Deleted Index Pattern Handling (PR #8659)
+
+Fixed the issue where Discover UI becomes stuck in "Searching" state after deleting an index pattern:
+
+```mermaid
+flowchart TB
+    A[User deletes index pattern] --> B{Index pattern in recently selected?}
+    B -->|Yes| C[Error caught in useIndexPatterns hook]
+    C --> D[Fallback to next available index pattern]
+    D --> E[UI continues normally]
+    B -->|No| E
+```
+
+The fix handles the error case in the `useIndexPatterns` hook when query enhancements are enabled, automatically falling back to the next available index pattern.
+
+#### Time Field Display Fix (PR #8755)
+
+Fixed time field wrapping overlap that occurred when changing languages in the query editor:
+
+| Issue | Solution |
+|-------|----------|
+| Time fields wrapped incorrectly | Added CSS to prevent wrapping |
+| Overlap on language change | Applied `white-space: nowrap` style |
+
+Note: A complete solution would require Discover to trigger a re-render on language change.
+
+#### Saved Query Loading Fix (PR #8707)
+
+Fixed the workflow where saved queries were being overwritten during Discover initialization:
+
+**Before fix:**
+1. `useSavedQuery` → `populateStateFromSavedQuery` with new saved query
+2. `useSearch` effect runs → overwrites query with saved search defaults
+
+**After fix:**
+- Proper sequencing ensures saved query state is preserved
+- Works correctly in both legacy mode and with query enhancements enabled
+
+### Usage Example
+
+These are bug fixes that require no configuration changes. Users will automatically benefit from:
+
+- S3 data sources showing fields correctly in Discover sidebar
+- Graceful handling when index patterns are deleted
+- Proper time field display regardless of query language
+- Saved queries loading correctly when accessed from assets
+
+## Limitations
+
+- Time field display fix is a workaround; full solution requires Discover re-render capability
+- S3 field support requires query enhancements to be enabled
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8609](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8609) | Add support for S3 fields in Discover |
+| [#8659](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8659) | Fix Discover UI stuck on searching after deleting index pattern |
+| [#8755](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8755) | Fix time field wrapping overlap on language change |
+| [#8707](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8707) | Ensure saved query loaded properly from asset |
+
+## References
+
+- [Issue #8612](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8612): Bug report for deleted index pattern issue
+- [Analyzing data in Discover](https://docs.opensearch.org/2.18/dashboards/discover/index-discover/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/discover.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -9,6 +9,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### OpenSearch Dashboards
 
 - [CI/CD & Build Improvements](features/opensearch-dashboards/cicd-build-dashboards.md) - Switch OSD Optimizer to content-based hashing for CI compatibility
+- [Discover Bugfixes (2)](features/opensearch-dashboards/discover-bugfixes-2.md) - S3 fields support, deleted index pattern handling, time field display, saved query loading
 - [Maintainers](features/opensearch-dashboards/maintainers.md) - Add Hailong-am as maintainer
 - [OUI Updates](features/opensearch-dashboards/oui-updates.md) - Updates to OpenSearch UI component library (1.13 → 1.15)
 - [Sample Data Bugfixes](features/opensearch-dashboards/sample-data-bugfixes.md) - Update OTEL sample data description with compatible OS version


### PR DESCRIPTION
## Summary

This PR adds documentation for Discover bugfixes in OpenSearch Dashboards v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch-dashboards/discover-bugfixes-2.md`
- Feature report: `docs/features/opensearch-dashboards/discover.md` (new)

### Key Changes in v2.18.0
- **S3 Fields Support** (PR #8609): Added async loaders for S3 fields in Discover sidebar
- **Deleted Index Pattern Handling** (PR #8659): Fixed UI getting stuck when selected index pattern is deleted
- **Time Field Display** (PR #8755): Fixed time field wrapping overlap on language change
- **Saved Query Loading** (PR #8707): Fixed saved queries not loading properly from assets

### Resources Used
- PR: #8609, #8659, #8755, #8707
- Issue: #8612
- Docs: https://docs.opensearch.org/2.18/dashboards/discover/index-discover/