### PR TITLE
docs: add dependency-updates-dashboards report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -52,6 +52,7 @@
 - [Dashboards UI Updates (OUI)](opensearch-dashboards/dashboards-ui-updates.md)
 - [Dashboards UI/UX Fixes](opensearch-dashboards/dashboards-ui-ux-fixes.md)
 - [Data Importer](opensearch-dashboards/data-importer.md)
+- [Dependency Updates](opensearch-dashboards/dependency-updates.md)
 - [Discover](opensearch-dashboards/discover.md)
 - [DOMPurify Sanitization](opensearch-dashboards/dompurify-sanitization.md)
 - [OSD Optimizer Cache](opensearch-dashboards/osd-optimizer-cache.md)

--- a/docs/features/opensearch-dashboards/dependency-updates.md
+++ b/docs/features/opensearch-dashboards/dependency-updates.md
@@ -1,0 +1,82 @@
+# Dependency Updates (OpenSearch Dashboards)
+
+## Summary
+
+OpenSearch Dashboards maintains a set of core dependencies that are regularly updated to address security vulnerabilities, improve performance, and ensure compatibility. This feature tracks significant dependency updates that impact the stability and security of the Dashboards application.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        App[Application Code]
+        subgraph "Core Dependencies"
+            JSON11[json11<br/>JSON Parsing]
+            Chokidar[chokidar<br/>File Watching]
+            Axios[axios<br/>HTTP Client]
+            Mocha[mocha<br/>Testing]
+            Elliptic[elliptic<br/>Cryptography]
+        end
+    end
+    App --> JSON11
+    App --> Chokidar
+    App --> Axios
+    App --> Mocha
+    App --> Elliptic
+```
+
+### Key Dependencies
+
+| Dependency | Purpose | Security Impact |
+|------------|---------|-----------------|
+| json11 | JSON parsing with extended features | UTF-8 safety in JSON stringification |
+| chokidar | File system watching for development | Development tooling |
+| axios | HTTP client for API requests | CVE-2024-39338 |
+| mocha | Test framework | SNYK-JS-MOCHA-2863123 |
+| elliptic | Elliptic curve cryptography | CVE-2024-42459, CVE-2024-42460, CVE-2024-42461 |
+
+### Configuration
+
+Dependencies are managed through:
+
+| File | Purpose |
+|------|---------|
+| `package.json` | Direct dependency declarations |
+| `yarn.lock` | Locked dependency versions |
+| `packages/*/package.json` | Package-specific dependencies |
+
+### Usage Example
+
+Dependencies are automatically resolved during installation:
+
+```bash
+# Install all dependencies
+yarn install
+
+# Update a specific dependency
+yarn upgrade json11@^2.0.0
+```
+
+## Limitations
+
+- Dependency updates may introduce breaking changes requiring code modifications
+- Security patches should be applied promptly but require testing
+- Some dependencies are pinned to specific versions for compatibility
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#8603](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8603) | Upgrade JSON11 from 1.1.2 to 2.0.0 |
+| v2.18.0 | [#8490](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8490) | Bump chokidar from 3.5.3 to 3.6.0 |
+
+## References
+
+- [Issue #7367](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7367): JSON.parse bad escaped character bug
+- [OpenSearch Forum](https://forum.opensearch.org/t/json-parse-bad-escaped-character/20211): Community discussion
+
+## Change History
+
+- **v2.18.0** (2024-10-22): JSON11 upgrade to 2.0.0 for UTF-8 safety, chokidar bump to 3.6.0

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/dependency-updates-dashboards.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/dependency-updates-dashboards.md
@@ -1,0 +1,61 @@
+# Dependency Updates (Dashboards)
+
+## Summary
+
+This release includes critical dependency updates for OpenSearch Dashboards that address security vulnerabilities and improve UTF-8 handling in JSON operations. The updates fix a significant bug where Discover became unusable due to JSON parsing errors with certain character encodings.
+
+## Details
+
+### What's New in v2.18.0
+
+Two key dependency updates were made to improve security and stability:
+
+1. **JSON11 Upgrade (1.1.2 → 2.0.0)**: Fixes UTF-8 safety issues when stringifying JSON data, resolving the "Bad escaped character in JSON" error that made Discover unusable after upgrading from v2.13 to v2.15.
+
+2. **Chokidar Bump (3.5.3 → 3.6.0)**: Updates the file watching library used during development.
+
+### Technical Changes
+
+#### Bug Fix: JSON Parsing Error
+
+The JSON11 upgrade resolves [Issue #7367](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7367) where users experienced:
+
+```
+SyntaxError: Bad escaped character in JSON at position 911476 (line 1 column 911477)
+    at fetch_Fetch.fetchResponse
+```
+
+This error occurred in Discover when processing documents containing certain UTF-8 characters that were not properly escaped during JSON stringification.
+
+#### Changed Files
+
+| File | Change |
+|------|--------|
+| `package.json` | Updated `**/json11` from `^1.1.2` to `^2.0.0` |
+| `packages/osd-std/package.json` | Updated `json11` dependency to `^2.0.0` |
+| `yarn.lock` | Updated lockfile with new dependency versions |
+
+### Migration Notes
+
+No migration steps required. The dependency updates are backward compatible.
+
+## Limitations
+
+- These are development/build-time dependency updates
+- The JSON11 fix specifically addresses UTF-8 encoding issues in JSON stringification
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8603](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8603) | Upgrade JSON11 from 1.1.2 to 2.0.0 to ensure UTF-8 safety |
+| [#8490](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8490) | Bump chokidar from 3.5.3 to 3.6.0 |
+
+## References
+
+- [Issue #7367](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7367): JSON.parse: bad escaped character bug report
+- [OpenSearch Forum Discussion](https://forum.opensearch.org/t/json-parse-bad-escaped-character/20211): Community report of the issue
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/dependency-updates.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -9,6 +9,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### OpenSearch Dashboards
 
 - [CI/CD & Build Improvements](features/opensearch-dashboards/cicd-build-dashboards.md) - Switch OSD Optimizer to content-based hashing for CI compatibility
+- [Dependency Updates](features/opensearch-dashboards/dependency-updates-dashboards.md) - JSON11 upgrade for UTF-8 safety, chokidar bump
 - [Discover Bugfixes (2)](features/opensearch-dashboards/discover-bugfixes-2.md) - S3 fields support, deleted index pattern handling, time field display, saved query loading
 - [Maintainers](features/opensearch-dashboards/maintainers.md) - Add Hailong-am as maintainer
 - [OUI Updates](features/opensearch-dashboards/oui-updates.md) - Updates to OpenSearch UI component library (1.13 → 1.15)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dependency Updates (Dashboards) release item in v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch-dashboards/dependency-updates-dashboards.md`
- Feature report: `docs/features/opensearch-dashboards/dependency-updates.md`

### Key Changes in v2.18.0
- JSON11 upgrade from 1.1.2 to 2.0.0 for UTF-8 safety when stringifying JSON data
- Chokidar bump from 3.5.3 to 3.6.0

### Bug Fixed
- Resolves Issue #7367: "Bad escaped character in JSON" error that made Discover unusable

### Related PRs
- [#8603](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8603): JSON11 upgrade
- [#8490](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8490): Chokidar bump

Closes #692