### PR TITLE
docs: add Query Enhancements (2) report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -58,6 +58,7 @@
 - [OSD Optimizer Cache](opensearch-dashboards/osd-optimizer-cache.md)
 - [Monaco Editor](opensearch-dashboards/monaco-editor.md)
 - [OpenSearch UI (OUI)](opensearch-dashboards/oui.md)
+- [Query Enhancements](opensearch-dashboards/query-enhancements.md)
 - [Sample Data](opensearch-dashboards/sample-data.md)
 - [Workspace](opensearch-dashboards/workspace.md)
 

--- a/docs/features/opensearch-dashboards/query-enhancements.md
+++ b/docs/features/opensearch-dashboards/query-enhancements.md
@@ -1,0 +1,134 @@
+# Query Enhancements
+
+## Summary
+
+Query Enhancements is an experimental feature in OpenSearch Dashboards that extends the query capabilities in Discover and other applications. It enables support for SQL and PPL (Piped Processing Language) queries alongside the traditional DQL (Dashboards Query Language) and Lucene query syntaxes, and provides enhanced data source connectivity including S3 connections.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        subgraph "Query Enhancements Plugin"
+            QE[Query Editor]
+            LS[Language Selector]
+            DS[Dataset Selector]
+            SQ[Saved Queries]
+        end
+        subgraph "Search Services"
+            SI[Search Interceptor]
+            PPL[PPL Search Strategy]
+            SQL[SQL Search Strategy]
+            FACET[Facet Utility]
+        end
+        subgraph "Data Services"
+            QSM[Query String Manager]
+            DSS[Dataset Service]
+            LangS[Language Service]
+        end
+    end
+    subgraph "OpenSearch"
+        IDX[Indexes]
+        SQLP[SQL Plugin]
+    end
+    subgraph "External"
+        S3[S3 Data Sources]
+    end
+    
+    QE --> QSM
+    LS --> LangS
+    DS --> DSS
+    SQ --> QSM
+    QSM --> SI
+    SI --> PPL
+    SI --> SQL
+    PPL --> FACET
+    SQL --> FACET
+    FACET --> SQLP
+    SQLP --> IDX
+    SQLP --> S3
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User enters query] --> B{Query Language}
+    B -->|DQL| C[DQL Parser]
+    B -->|Lucene| D[Lucene Parser]
+    B -->|SQL| E[SQL Search Interceptor]
+    B -->|PPL| F[PPL Search Interceptor]
+    C --> G[OpenSearch Query DSL]
+    D --> G
+    E --> H[SQL Plugin]
+    F --> H
+    G --> I[OpenSearch]
+    H --> I
+    I --> J{Async Query?}
+    J -->|Yes| K[Poll for Results]
+    K --> L[Return Results]
+    J -->|No| L
+    L --> M[Display in Discover]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Query String Manager | Manages query state, language selection, and dataset binding |
+| Language Service | Registers and manages query languages (DQL, Lucene, SQL, PPL) |
+| Dataset Service | Manages data sources and their supported languages |
+| Search Interceptor | Routes queries to appropriate search strategies |
+| PPL Search Strategy | Handles PPL query execution and result polling |
+| SQL Search Strategy | Handles SQL query execution |
+| Facet Utility | Processes query results and handles aggregations |
+| Saved Query Service | Persists queries with dataset context |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `query:enhancements:enabled` | Enable query enhancements feature | false |
+| `data.search.polling.interval` | Polling interval for async queries (ms) | 5000 |
+
+### Usage Example
+
+```
+# Enable Query Enhancements in Advanced Settings
+query:enhancements:enabled = true
+
+# SQL Query Example
+SELECT * FROM logs-* WHERE status >= 400 LIMIT 100
+
+# PPL Query Example
+source = logs-* | where status >= 400 | head 100
+```
+
+## Limitations
+
+- Query Enhancements is an experimental feature
+- Not all data source types support all query languages
+- S3 connections only support SQL and PPL (not DQL or Lucene)
+- Async query polling may have latency depending on query complexity
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#8555](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8555) | Refactored polling logic to poll for results once current request completes |
+| v2.18.0 | [#8650](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8650) | Fix random big number when loading in query result |
+| v2.18.0 | [#8724](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8724) | Polling for PPL results; Saved dataset to saved queries |
+| v2.18.0 | [#8743](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8743) | Fix error handling in query enhancement facet |
+| v2.18.0 | [#8749](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8749) | Updates query and language if language is not supported by query data |
+| v2.18.0 | [#8771](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8771) | Fix error handling for ppl jobs API |
+
+## References
+
+- [Dashboards Query Language (DQL)](https://docs.opensearch.org/2.18/dashboards/dql/): Official DQL documentation
+- [Query Workbench](https://docs.opensearch.org/2.18/dashboards/query-workbench/): SQL/PPL query interface documentation
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Bug fixes for async polling, error handling, language compatibility, and saved query persistence

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/query-enhancements-2.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/query-enhancements-2.md
@@ -1,0 +1,102 @@
+# Query Enhancements (2)
+
+## Summary
+
+This release item includes bug fixes for the Query Enhancements feature in OpenSearch Dashboards v2.18.0. The fixes address issues with async query polling, error handling, language compatibility when switching datasets, and saved query persistence.
+
+## Details
+
+### What's New in v2.18.0
+
+This batch of fixes improves the stability and usability of the Query Enhancements feature, particularly for SQL/PPL query execution in Discover.
+
+### Technical Changes
+
+#### Polling Logic Refactoring
+
+The async search polling mechanism was refactored to poll for results only after the current request completes, rather than firing requests at fixed intervals regardless of completion status.
+
+**Before:**
+```typescript
+// Fired polling request every 5 seconds regardless of previous call status
+return timer(0, interval)
+  .pipe(
+    mergeMap(() => pollQueryResults()),
+    // ...
+  )
+```
+
+**After:**
+```typescript
+// Wait for current request to complete before polling again
+do {
+  await delay(interval);
+  queryResultsRes = await pollQueryResults();
+  queryStatus = queryResultsRes?.status?.toUpperCase();
+} while (queryStatus !== 'SUCCESS' && queryStatus !== 'FAILED');
+```
+
+#### Error Handling Improvements
+
+| Component | Fix |
+|-----------|-----|
+| Facet utility | Added success check before processing response in `describeQuery` |
+| Error handler | Added `statusCode` fallback and explicit `status` property on errors |
+| PPL jobs API | Added proper error handling for async PPL job failures |
+
+#### Language Compatibility
+
+When switching datasets (e.g., from index pattern to S3 connection), the system now automatically updates the query language if the current language is not supported by the new dataset type.
+
+```typescript
+// Check if new dataset supports current language
+const supportedLanguages = this.datasetService
+  .getType(newDataset.type)
+  ?.supportedLanguages(newDataset);
+
+if (supportedLanguages && !supportedLanguages.includes(newQuery.language)) {
+  // Switch to first supported language and show warning
+  newQuery = this.getInitialQuery({
+    language: supportedLanguages[0],
+    dataset: newQuery.dataset,
+  });
+}
+```
+
+#### Saved Query Dataset Persistence
+
+Fixed saved queries to properly persist the dataset when query enhancements are enabled, ensuring queries can be restored with their original data source context.
+
+### Usage Example
+
+When switching from an index pattern (supporting DQL) to an S3 connection (supporting only SQL/PPL):
+
+1. User is on index pattern with DQL query
+2. User selects S3 connection from recent datasets
+3. System detects DQL is not supported by S3
+4. Language automatically switches to SQL
+5. Warning toast notifies user: "Query language changed to SQL"
+
+## Limitations
+
+- The SQL PR #8708 mentioned in the issue body appears to reference a different repository or numbering scheme and could not be verified
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8555](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8555) | Refactored polling logic to poll for results once current request completes |
+| [#8650](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8650) | Fix random big number when loading in query result |
+| [#8724](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8724) | Polling for PPL results; Saved dataset to saved queries |
+| [#8743](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8743) | Fix error handling in query enhancement facet |
+| [#8749](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8749) | Updates query and language if language is not supported by query data |
+| [#8771](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8771) | Fix error handling for ppl jobs API |
+
+## References
+
+- [Dashboards Query Language (DQL)](https://docs.opensearch.org/2.18/dashboards/dql/): Official documentation
+- [Query Workbench](https://docs.opensearch.org/2.18/dashboards/query-workbench/): SQL/PPL query interface
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/query-enhancements.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -13,4 +13,5 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Discover Bugfixes (2)](features/opensearch-dashboards/discover-bugfixes-2.md) - S3 fields support, deleted index pattern handling, time field display, saved query loading
 - [Maintainers](features/opensearch-dashboards/maintainers.md) - Add Hailong-am as maintainer
 - [OUI Updates](features/opensearch-dashboards/oui-updates.md) - Updates to OpenSearch UI component library (1.13 → 1.15)
+- [Query Enhancements (2)](features/opensearch-dashboards/query-enhancements-2.md) - Async polling, error handling, language compatibility, saved query fixes
 - [Sample Data Bugfixes](features/opensearch-dashboards/sample-data-bugfixes.md) - Update OTEL sample data description with compatible OS version


### PR DESCRIPTION
## Summary

This PR adds documentation for the Query Enhancements (2) bugfix release item in OpenSearch Dashboards v2.18.0.

## Reports Created

- Release report: `docs/releases/v2.18.0/features/opensearch-dashboards/query-enhancements-2.md`
- Feature report: `docs/features/opensearch-dashboards/query-enhancements.md` (new)

## Key Changes in v2.18.0

- Refactored async query polling to wait for current request completion
- Fixed error handling in query enhancement facet
- Added automatic language switching when dataset doesn't support current language
- Fixed saved query dataset persistence

## Related PRs

- #8555: Refactored polling logic
- #8650: Fix random big number when loading
- #8724: PPL polling and saved dataset fixes
- #8743: Error handling in facet
- #8749: Language compatibility updates
- #8771: PPL jobs API error handling

Closes #691