### PR TITLE
docs: add TSVB visualization report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -60,6 +60,7 @@
 - [OpenSearch UI (OUI)](opensearch-dashboards/oui.md)
 - [Query Enhancements](opensearch-dashboards/query-enhancements.md)
 - [Sample Data](opensearch-dashboards/sample-data.md)
+- [TSVB Visualization](opensearch-dashboards/tsvb-visualization.md)
 - [Workspace](opensearch-dashboards/workspace.md)
 
 ## security

--- a/docs/features/opensearch-dashboards/tsvb-visualization.md
+++ b/docs/features/opensearch-dashboards/tsvb-visualization.md
@@ -1,0 +1,143 @@
+# TSVB Visualization
+
+## Summary
+
+The Time-Series Visual Builder (TSVB) is a powerful data visualization tool in OpenSearch Dashboards for creating detailed time-series visualizations. It supports multiple visualization types including Area, Line, Metric, Gauge, Markdown, and Data Table, with features for annotations, multiple data sources, and flexible axis configuration.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        subgraph "TSVB Plugin"
+            UI[TSVB UI Components]
+            Config[Panel Configuration]
+            Vis[Visualization Renderer]
+        end
+        
+        subgraph "Data Layer"
+            Query[Query Builder]
+            Agg[Aggregation Engine]
+        end
+    end
+    
+    subgraph "OpenSearch"
+        Index[Index Data]
+        Search[Search API]
+    end
+    
+    UI --> Config
+    Config --> Query
+    Query --> Search
+    Search --> Index
+    Agg --> Vis
+    Query --> Agg
+```
+
+### Visualization Types
+
+| Type | Description |
+|------|-------------|
+| Time Series | Line/area charts with time on X-axis |
+| Metric | Single value display |
+| Gauge | Circular gauge visualization |
+| Top N | Bar chart of top values |
+| Table | Tabular data display |
+| Markdown | Custom markdown with data variables |
+
+### Axis Configuration
+
+TSVB supports flexible axis configuration for time series visualizations:
+
+| Setting | Description | Options |
+|---------|-------------|---------|
+| `axis_position` | Position of the Y-axis | `left`, `right`, `hidden` |
+| `axis_scale` | Scale type for the axis | `normal`, `log` |
+| `axis_min` | Minimum axis value | Number or empty |
+| `axis_max` | Maximum axis value | Number or empty |
+| `separate_axis` | Enable per-series axis | `0` (no), `1` (yes) |
+
+#### Axis Position Constants
+
+```javascript
+export const AXIS_POSITION = {
+  LEFT: 'left',
+  RIGHT: 'right',
+  HIDDEN: 'hidden',
+};
+```
+
+### Aggregation Types
+
+TSVB supports various aggregation types for data analysis:
+
+| Aggregation | Description |
+|-------------|-------------|
+| Count | Document count |
+| Average | Mean value |
+| Sum | Total sum |
+| Min/Max | Minimum/Maximum values |
+| Cardinality | Unique value count |
+| Percentile | Percentile calculations |
+| Moving Average | Smoothed trend line |
+| Serial Diff | Difference between time periods |
+| Top Hit | Most recent document values |
+
+### Multi-Data Source Support
+
+Since v2.14, TSVB supports querying multiple data sources:
+
+```yaml
+# opensearch_dashboards.yml
+data_source.enabled: true
+vis_type_timeseries.enabled: true
+```
+
+### Usage Example
+
+```json
+{
+  "type": "timeseries",
+  "series": [
+    {
+      "id": "series-1",
+      "chart_type": "line",
+      "line_width": 1,
+      "point_size": 1,
+      "fill": 0.5,
+      "separate_axis": 1,
+      "axis_position": "right",
+      "axis_scale": "log",
+      "formatter": "number"
+    }
+  ],
+  "axis_scale": "normal",
+  "axis_position": "left"
+}
+```
+
+## Limitations
+
+- Axis scale setting requires "Separate Axis" to be enabled for per-series configuration
+- Hidden axis position only available for time series with separate axis
+- Some input fields use legacy HTML inputs due to type compatibility issues with EUI components
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#8504](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8504) | Allow hiding axis, per-axis scale, compressed input fields |
+| v2.14.0 | - | Multi-data source support introduced |
+
+## References
+
+- [TSVB Documentation](https://docs.opensearch.org/latest/dashboards/visualize/tsvb/): Official documentation
+- [Issue #1929](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1929): Axis scale override bug
+- [Visualizing data from multiple data sources](https://opensearch.org/blog/vega-tsvb-mds-visualizations/): Blog post on TSVB with MDS
+
+## Change History
+
+- **v2.18.0** (2024-10-29): Added hidden axis option, per-axis scale setting, compressed UI input fields ([#8504](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8504))
+- **v2.14.0**: Added multi-data source support for TSVB visualizations

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/tsvb-visualization-bugfixes.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/tsvb-visualization-bugfixes.md
@@ -1,0 +1,94 @@
+# TSVB Visualization
+
+## Summary
+
+This release improves the Time-Series Visual Builder (TSVB) in OpenSearch Dashboards with enhanced axis control options and UI consistency fixes. Users can now hide axes, set per-axis scale (normal/log), and benefit from compressed input fields that match the OUI design system.
+
+## Details
+
+### What's New in v2.18.0
+
+PR #8504 introduces three changes to TSVB time series visualizations:
+
+1. **Hide Axis Option**: New "Hidden" position option for the separate axis setting, allowing users to completely hide the Y-axis while maintaining data visualization
+2. **Per-Axis Scale Setting**: Each series with a separate axis can now have its own scale (Normal or Log), fixing a long-standing bug where enabling separate axis would override the global axis scale setting
+3. **Compressed Input Fields**: Non-OUI input fields now use `EuiFormControlLayout` with compressed styling for visual consistency
+
+### Technical Changes
+
+#### New Axis Position Option
+
+```javascript
+export const AXIS_POSITION = {
+  LEFT: 'left',
+  RIGHT: 'right',
+  HIDDEN: 'hidden',  // New in v2.18.0
+};
+```
+
+When axis position is set to "Hidden":
+- The axis is internally positioned to the left but rendered with `hide: true`
+- Data series continue to render normally
+- Useful for dashboard layouts where axis labels are not needed
+
+#### New Axis Scale Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `axis_scale` | Scale type for the series axis | `normal` |
+
+Available scale options:
+- `normal` - Linear scale
+- `log` - Logarithmic scale
+
+This fixes [Issue #1929](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1929) where enabling "Separate Axis" would force the scale to "Normal" regardless of the Panel Options setting.
+
+#### UI Component Updates
+
+Input fields in the following components now use compressed EUI styling:
+
+| Component | Field | Change |
+|-----------|-------|--------|
+| Moving Average Agg | Window | Wrapped with `EuiFormControlLayout` |
+| Serial Diff Agg | Lag | Wrapped with `EuiFormControlLayout` |
+| Top Hit Agg | Size | Wrapped with `EuiFormControlLayout` |
+| Gauge Panel | Max | Wrapped with `EuiFormControlLayout` |
+| Table Panel | Pivot Rows | Wrapped with `EuiFormControlLayout` |
+| Timeseries Config | Axis Min/Max | Wrapped with `EuiFormControlLayout` |
+
+The custom `.tvbAgg__input` CSS class was removed in favor of standard EUI classes.
+
+### Usage Example
+
+To configure a time series with a hidden axis and log scale:
+
+1. Navigate to **Visualize** → **Create Visualization** → **TSVB**
+2. Select **Time Series** visualization type
+3. Under **Data** tab, select a series and go to **Options**
+4. Set **Separate Axis** to **Yes**
+5. Set **Axis Position** to **Hidden** (new option)
+6. Set **Axis Scale** to **Log** (new option)
+
+### Migration Notes
+
+No migration required. Existing TSVB visualizations will continue to work. The new axis scale setting defaults to "normal" for backward compatibility.
+
+## Limitations
+
+- The "Hidden" axis position is only available for time series visualizations with separate axis enabled
+- Axis scale setting is per-series, not global (this is intentional to allow mixed scales)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8504](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8504) | Allow hiding the TSVB axis for time series, compress non-OUI input fields, allow setting scale of each axis |
+
+## References
+
+- [Issue #1929](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1929): Bug report - Separate axis overrides axis scale setting
+- [TSVB Documentation](https://docs.opensearch.org/2.18/dashboards/visualize/tsvb/): Official TSVB documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/tsvb-visualization.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -15,4 +15,5 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [OUI Updates](features/opensearch-dashboards/oui-updates.md) - Updates to OpenSearch UI component library (1.13 → 1.15)
 - [Query Enhancements (2)](features/opensearch-dashboards/query-enhancements-2.md) - Async polling, error handling, language compatibility, saved query fixes
 - [Sample Data Bugfixes](features/opensearch-dashboards/sample-data-bugfixes.md) - Update OTEL sample data description with compatible OS version
+- [TSVB Visualization](features/opensearch-dashboards/tsvb-visualization-bugfixes.md) - Hidden axis option, per-axis scale setting, compressed input fields
 - [UI/UX Bugfixes (2)](features/opensearch-dashboards/ui-ux-bugfixes-2.md) - Responsive design fixes for home page, page header, recent menu, and getting started cards


### PR DESCRIPTION
## Summary

This PR adds documentation for TSVB (Time-Series Visual Builder) visualization improvements in OpenSearch Dashboards v2.18.0.

## Changes in v2.18.0

Based on [PR #8504](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8504):

1. **Hidden Axis Option**: New "Hidden" position for separate axis, allowing users to hide the Y-axis while keeping data visualization
2. **Per-Axis Scale Setting**: Each series with separate axis can now have its own scale (Normal/Log), fixing [Issue #1929](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1929)
3. **Compressed Input Fields**: Non-OUI input fields now use `EuiFormControlLayout` with compressed styling for UI consistency

## Files Added/Modified

- `docs/releases/v2.18.0/features/opensearch-dashboards/tsvb-visualization-bugfixes.md` (new)
- `docs/features/opensearch-dashboards/tsvb-visualization.md` (new)
- `docs/releases/v2.18.0/index.md` (updated)
- `docs/features/index.md` (updated)

## Related Issue

Closes #689