### PR TITLE
docs: add Data Connections bugfixes report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -51,6 +51,7 @@
 - [Dashboards Frontend Cleanup](opensearch-dashboards/dashboards-frontend-cleanup.md)
 - [Dashboards UI Updates (OUI)](opensearch-dashboards/dashboards-ui-updates.md)
 - [Dashboards UI/UX Fixes](opensearch-dashboards/dashboards-ui-ux-fixes.md)
+- [Data Connections](opensearch-dashboards/data-connections.md)
 - [Data Importer](opensearch-dashboards/data-importer.md)
 - [Dependency Updates](opensearch-dashboards/dependency-updates.md)
 - [Discover](opensearch-dashboards/discover.md)

--- a/docs/features/opensearch-dashboards/data-connections.md
+++ b/docs/features/opensearch-dashboards/data-connections.md
@@ -1,0 +1,139 @@
+# Data Connections
+
+## Summary
+
+Data Connections in OpenSearch Dashboards provides a unified interface for managing connections to various data sources, including OpenSearch clusters and direct query data sources like Amazon S3 and Prometheus. The feature supports Multi-Data Source (MDS) environments, enabling users to query and visualize data from multiple sources within a single Dashboards instance.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        UI[Data Connections UI]
+        DSM[Data Source Management Plugin]
+        API[Data Connections API]
+    end
+    
+    subgraph "Connection Types"
+        OSC[OpenSearch Connections]
+        DQC[Direct Query Connections]
+    end
+    
+    subgraph "Direct Query Sources"
+        S3[Amazon S3]
+        PROM[Prometheus]
+    end
+    
+    subgraph "OpenSearch Cluster"
+        LOCAL[Local Cluster]
+        REMOTE[Remote Clusters]
+    end
+    
+    UI --> DSM
+    DSM --> API
+    API --> OSC
+    API --> DQC
+    OSC --> LOCAL
+    OSC --> REMOTE
+    DQC --> S3
+    DQC --> PROM
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "User Actions"
+        SELECT[Select Data Source]
+        QUERY[Query Data]
+        REDIRECT[Navigate to Discover]
+    end
+    
+    subgraph "API Layer"
+        MDS_EP[MDS Endpoint]
+        NON_MDS_EP[Non-MDS Endpoint]
+    end
+    
+    subgraph "Data Sources"
+        FLINT[Flint Index]
+        INDEX[Associated Index]
+    end
+    
+    SELECT --> MDS_EP
+    SELECT -.->|Deprecated| NON_MDS_EP
+    QUERY --> MDS_EP
+    REDIRECT --> FLINT
+    REDIRECT --> INDEX
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Data Source Management Plugin | Core plugin for managing data source connections |
+| Data Connections UI | Tabbed interface for OpenSearch and Direct Query connections |
+| Data Connections API | REST API for CRUD operations on data connections |
+| Value Suggestion API | Auto-complete API with MDS support |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `data_source.enabled` | Enable Multi-Data Source feature | `false` |
+| `data_source.hideLocalCluster` | Hide local cluster from data source selection | `false` |
+| `query:enhancements:enabled` | Enable query enhancements for redirection | `true` |
+
+### API Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `/api/directquery/dataconnections/dataSourceMDSId={id}` | MDS-aware data connections endpoint |
+| `/api/directquery/dataconnections` | Legacy non-MDS endpoint (deprecated when MDS enabled) |
+
+### Usage Example
+
+Accessing data connections in OpenSearch Dashboards:
+
+1. Navigate to **Management > Dashboards Management > Data sources**
+2. Use tabs to switch between:
+   - **OpenSearch Connections**: Manage OpenSearch cluster connections
+   - **Direct Query Connections**: Manage S3 and Prometheus connections
+
+```yaml
+# Example: Enabling MDS in opensearch_dashboards.yml
+data_source:
+  enabled: true
+  hideLocalCluster: false
+```
+
+## Limitations
+
+- When `query:enhancements:enabled` is disabled, redirection from data connections to Discover is disabled
+- Direct query connections require the Observability plugin for full functionality
+- The "Query data" card redirects to Discover without pre-selecting the datasource
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#8460](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8460) | Replace segmented button with tabs |
+| v2.18.0 | [#8492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8492) | Add DataSource type display and Discover redirection |
+| v2.18.0 | [#8503](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8503) | Fix hide local cluster flag in sample data page |
+| v2.18.0 | [#8537](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8537) | Mute non-MDS endpoints when MDS enabled |
+| v2.18.0 | [#8544](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8544) | Direct query connections fit and finish fixes |
+| v2.18.0 | [#8713](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8713) | Add MDS support to auto-complete API |
+| v2.16.0 | [#7143](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7143) | Initial migration of direct query data source to data source management |
+
+## References
+
+- [Issue #8256](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8256): Redirection issue for direct query datasource
+- [Issue #8536](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8536): Deprecate non-MDS data connection endpoint
+- [Data Sources Documentation](https://docs.opensearch.org/2.18/dashboards/management/data-sources/): Official documentation
+- [Multi-Data Sources Documentation](https://docs.opensearch.org/2.18/dashboards/management/multi-data-sources/): Configuring multiple data sources
+
+## Change History
+
+- **v2.18.0** (2024-10-22): UI improvements (tabs navigation, type display), MDS endpoint unification, auto-complete MDS support, fit and finish fixes
+- **v2.16.0**: Initial migration of direct query data source to data source management plugin

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/data-connections-bugfixes.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/data-connections-bugfixes.md
@@ -1,0 +1,89 @@
+# Data Connections Bugfixes
+
+## Summary
+
+OpenSearch Dashboards v2.18.0 includes several bug fixes for the Data Connections feature, improving Multi-Data Source (MDS) compatibility, UI consistency, and navigation flows. These fixes address issues with direct query data connections, including endpoint unification, UI component updates, and proper handling of the hide local cluster flag.
+
+## Details
+
+### What's New in v2.18.0
+
+This release focuses on improving the Data Connections management experience in OpenSearch Dashboards, particularly for environments using Multi-Data Source (MDS) functionality.
+
+### Technical Changes
+
+#### UI Component Updates
+
+| Change | Description |
+|--------|-------------|
+| Tabs Navigation | Replaced segmented button with tabs for switching between OpenSearch connections and Direct query connections |
+| Empty Description Display | Updated en-dash (-) to em-dash (—) for empty descriptions |
+| Data Source View Menu | Added datasource-view menu for direct query connections details page |
+| Data Source Type Display | Added data source type column (S3, Prometheus) to the data sources page |
+
+#### MDS Endpoint Improvements
+
+| Change | Description |
+|--------|-------------|
+| Non-MDS Endpoint Muting | Muted non-MDS endpoints for direct query data connections when MDS is enabled |
+| Unified Endpoint Usage | Use MDS data connection endpoint for fetching local cluster direct query content |
+| Hide Local Cluster Flag | Fixed passing of `hideLocalCluster` flag to data source menu in sample data page |
+
+#### Redirection Fixes
+
+| Scenario | Behavior |
+|----------|----------|
+| Tables and Skipping Indices | Redirect to 'flint' datasource with datasource, database, and table name |
+| Covering Indices and Materialized Views | Redirect to the associated index name |
+| MDS Enabled | Redirect to Discover instead of Log Explorer |
+| MDS Disabled | Redirect to Log Explorer |
+| Query Enhancements Disabled | All redirection points are disabled |
+
+#### Auto-Complete API Enhancement
+
+Added MDS support to the value suggestion API, enabling auto-complete functionality to work correctly with external data sources.
+
+### Usage Example
+
+The Data Connections page now displays connection types:
+
+```
+Data Sources
+├── OpenSearch Connections (Tab)
+│   └── [List of OpenSearch cluster connections]
+└── Direct Query Connections (Tab)
+    ├── S3 Connection (Type: S3)
+    └── Prometheus Connection (Type: Prometheus)
+```
+
+### Migration Notes
+
+- If using MDS, the non-MDS endpoints (`/api/directquery/dataconnections`) are now muted
+- Use MDS endpoints (`/api/directquery/dataconnections/dataSourceMDSId={dataSourceMDSId?}`) for all data connection operations
+- Pass empty string `''` as cluster ID for local cluster calls when using MDS endpoints
+
+## Limitations
+
+- When `query:enhancements:enabled` is disabled, all redirection points from data connections are disabled
+- The "Query data in Observability Logs" card redirects to Discover without the datasource pre-selected (limitation of current Discover implementation)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8460](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8460) | Replace segmented button with tabs for OpenSearch connections and Direct query connections |
+| [#8492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8492) | Updated DataSource Management to redirect to Discover and display DataSource type |
+| [#8503](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8503) | Pass hide local cluster flag to data source menu in sample data page |
+| [#8537](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8537) | Mute non-MDS endpoints for direct query data connections |
+| [#8544](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8544) | Direct query connections fit and finish fixes |
+| [#8713](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8713) | Update auto-complete API with MDS support |
+
+## References
+
+- [Issue #8256](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8256): Redirection issue for direct query datasource in dashboards management
+- [Issue #8536](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8536): Deprecate non-MDS data connection endpoint for direct query data source
+- [Data Sources Documentation](https://docs.opensearch.org/2.18/dashboards/management/data-sources/): Official docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/data-connections.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -9,6 +9,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### OpenSearch Dashboards
 
 - [CI/CD & Build Improvements](features/opensearch-dashboards/cicd-build-dashboards.md) - Switch OSD Optimizer to content-based hashing for CI compatibility
+- [Data Connections Bugfixes](features/opensearch-dashboards/data-connections-bugfixes.md) - MDS endpoint unification, tabs navigation, type display, auto-complete MDS support
 - [Dependency Updates](features/opensearch-dashboards/dependency-updates-dashboards.md) - JSON11 upgrade for UTF-8 safety, chokidar bump
 - [Discover Bugfixes (2)](features/opensearch-dashboards/discover-bugfixes-2.md) - S3 fields support, deleted index pattern handling, time field display, saved query loading
 - [Maintainers](features/opensearch-dashboards/maintainers.md) - Add Hailong-am as maintainer


### PR DESCRIPTION
## Summary

This PR adds documentation for Data Connections bugfixes in OpenSearch Dashboards v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch-dashboards/data-connections-bugfixes.md`
- Feature report: `docs/features/opensearch-dashboards/data-connections.md` (new)

### Key Changes in v2.18.0
- Replaced segmented button with tabs for OpenSearch/Direct Query connections navigation
- Added data source type display (S3, Prometheus) to the data sources page
- Muted non-MDS endpoints for direct query data connections when MDS is enabled
- Fixed hide local cluster flag passing to data source menu in sample data page
- Added MDS support to auto-complete API
- UI fit and finish fixes (em-dash for empty descriptions, datasource-view menu)

### PRs Investigated
- #8460: Replace segmented button with tabs
- #8492: DataSource type display and Discover redirection
- #8503: Fix hide local cluster flag
- #8537: Mute non-MDS endpoints
- #8544: Fit and finish fixes
- #8713: Auto-complete API MDS support

Closes #688