### PR TITLE
docs: add workspace bugfixes report for v2.18.0

### DIFF
--- a/docs/features/opensearch-dashboards/workspace.md
+++ b/docs/features/opensearch-dashboards/workspace.md
@@ -127,6 +127,19 @@ opensearch_security.multitenancy.enabled: false
 | v3.0.0 | [#9420](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9420) | Fix saved objects find returning all workspaces |
 | v3.0.0 | [#9346](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9346) | Filter out recent items with errors |
 | v3.0.0 | [#9478](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9478) | Add error handling page for stale workspace state |
+| v2.18.0 | [#8435](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8435) | Remove What's New card in workspace overview |
+| v2.18.0 | [#8445](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8445) | Fix use case hidden features not accessible |
+| v2.18.0 | [#8524](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8524) | Fix Analytics/Essential use case overview crash |
+| v2.18.0 | [#8541](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8541) | Fix workspace selector jump on hover/click |
+| v2.18.0 | [#8570](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8570) | Fix workspace update navigation modal issue |
+| v2.18.0 | [#8581](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8581) | Disable copy all button when no saved objects |
+| v2.18.0 | [#8592](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8592) | Fix workspace selector style alignment |
+| v2.18.0 | [#8606](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8606) | Fix duplicate visualizations in dashboard |
+| v2.18.0 | [#8648](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8648) | Fix assets page crash after permission revocation |
+| v2.18.0 | [#8649](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8649) | Finetune search bar and workspace selector style |
+| v2.18.0 | [#8675](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8675) | Fix non-workspace admin defaultIndex update |
+| v2.18.0 | [#8718](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8718) | Fix index pattern issues |
+| v2.18.0 | [#8719](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8719) | Generate short URL with workspace info |
 
 ## References
 
@@ -136,8 +149,9 @@ opensearch_security.multitenancy.enabled: false
 - [Manage Workspaces](https://docs.opensearch.org/3.0/dashboards/workspace/manage-workspace/): Workspace management guide
 - [Workspace ACLs](https://docs.opensearch.org/3.0/dashboards/workspace/workspace-acl/): Access control documentation
 - [Workspaces APIs](https://docs.opensearch.org/3.0/dashboards/workspace/apis/): API reference
+- [v2.18 Workspace Documentation](https://docs.opensearch.org/2.18/dashboards/workspace/workspace/): v2.18 workspace documentation
 
 ## Change History
 
 - **v3.0.0** (2025-05-06): Bug fixes for saved object isolation, recent items error filtering, and stale workspace error handling
-- **v2.18.0**: Initial workspace feature introduction
+- **v2.18.0** (2024-11-05): 13 bug fixes including UI/UX improvements (workspace selector styling, alignment), page crash fixes (overview pages, assets page), permission handling (non-admin defaultIndex, permission revocation), navigation fixes (short URLs, inspect button), and index pattern scope isolation

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/workspace-bugfixes.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/workspace-bugfixes.md
@@ -1,0 +1,109 @@
+# Workspace Bugfixes
+
+## Summary
+
+OpenSearch Dashboards v2.18.0 includes 13 bug fixes for the Workspace feature, addressing UI/UX issues, page crashes, permission handling, and navigation problems. These fixes improve the stability and usability of workspaces for multi-tenant environments.
+
+## Details
+
+### What's New in v2.18.0
+
+This release focuses on stabilizing the Workspace feature with fixes across several areas:
+
+1. **UI/UX Improvements**: Workspace selector styling, alignment, and hover behavior
+2. **Page Crash Fixes**: Resolved crashes in overview pages and assets page
+3. **Permission Handling**: Fixed issues with non-admin users and permission revocation
+4. **Navigation & URLs**: Fixed short URL generation and inspect button navigation
+5. **Index Pattern Handling**: Corrected default index pattern behavior in workspaces
+
+### Bug Fixes by Category
+
+#### UI/UX Fixes
+
+| PR | Issue | Fix |
+|----|-------|-----|
+| [#8435](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8435) | What's New card cluttering workspace overview | Removed What's New card from workspace overview page |
+| [#8541](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8541) | Workspace selector jumps on hover/click | Fixed CSS positioning to prevent visual jumping |
+| [#8592](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8592) | Workspace selector style inconsistency | Aligned workspace selector style with data source selector, added mobile support, sorted by recently visited |
+| [#8649](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8649) | Search bar and workspace selector misalignment | Adjusted workspace selector to align with left nav items, improved search bar popup behavior |
+
+#### Page Crash Fixes
+
+| PR | Issue | Fix |
+|----|-------|-----|
+| [#8524](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8524) | Analytics/Essential use case overview crashed | Removed unused `collaboratorTypes` service dependency that caused `this` context error |
+| [#8581](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8581) | Assets page crashed when clicking "Copy assets" with empty table | Disabled "Copy all" button when no saved objects exist |
+| [#8648](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8648) | Assets page crashed after permission revocation | Added error handling for copy operation when `library_write` permission is revoked |
+| [#8606](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8606) | Dashboard rendered with duplicate visualizations | Fixed content management to prevent duplicate visualization rendering |
+
+#### Permission & Access Fixes
+
+| PR | Issue | Fix |
+|----|-------|-----|
+| [#8445](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8445) | Hidden use case features not accessible | Restored access to hidden features (getting started, overview, custom features) after use case selector refactor |
+| [#8675](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8675) | Non-workspace admin triggered defaultIndex update error | Prevented non-admin users from updating default index setting |
+| [#8718](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8718) | Index pattern issues with global vs workspace scope | Fixed workspace default index pattern to not extend from global setting, hidden "Set as default" button for global index patterns |
+
+#### Navigation & Update Fixes
+
+| PR | Issue | Fix |
+|----|-------|-----|
+| [#8570](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8570) | Navigate away modal shown after successful update | Fixed state management to not show navigation warning after workspace detail/collaborator updates |
+| [#8719](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8719) | Short URLs missing workspace info | Fixed short URL generation to include workspace context for visualizations, dashboards, and index patterns |
+
+### Technical Changes
+
+#### Workspace Selector Improvements
+
+The workspace selector received multiple styling and behavior fixes:
+
+- Background color now uses `euiSideNavBackgroundColor` for consistency
+- Workspaces sorted by most recently visited, then alphabetically
+- Mobile display issues resolved
+- Hover/click jump behavior eliminated
+
+#### Index Pattern Scope Isolation
+
+```mermaid
+graph TB
+    subgraph "Before Fix"
+        GIP[Global Index Pattern] --> WIP1[Workspace Index Pattern]
+        GIP --> WIP2[Workspace Index Pattern]
+    end
+    
+    subgraph "After Fix"
+        GIP2[Global Index Pattern]
+        WIP3[Workspace Index Pattern]
+        WIP4[Workspace Index Pattern]
+    end
+```
+
+Workspace default index patterns no longer inherit from global settings, preventing permission errors when users lack access to global index patterns.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8435](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8435) | Remove What's New card in workspace overview |
+| [#8445](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8445) | Fix use case hidden features not accessible |
+| [#8524](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8524) | Fix Analytics/Essential use case overview crash |
+| [#8541](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8541) | Fix workspace selector jump on hover/click |
+| [#8570](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8570) | Fix workspace update navigation modal issue |
+| [#8581](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8581) | Disable copy all button when no saved objects |
+| [#8592](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8592) | Fix workspace selector style alignment |
+| [#8606](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8606) | Fix duplicate visualizations in dashboard |
+| [#8648](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8648) | Fix assets page crash after permission revocation |
+| [#8649](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8649) | Finetune search bar and workspace selector style |
+| [#8675](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8675) | Fix non-workspace admin defaultIndex update |
+| [#8718](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8718) | Fix index pattern issues |
+| [#8719](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8719) | Generate short URL with workspace info |
+
+## References
+
+- [Workspace Documentation](https://docs.opensearch.org/2.18/dashboards/workspace/workspace/): Official workspace feature documentation
+- [Getting Started with Workspaces](https://docs.opensearch.org/2.18/dashboards/workspace/index/): Introduction to workspaces in v2.18
+- [Workspaces APIs](https://docs.opensearch.org/2.18/dashboards/workspace/apis/): API reference for workspace operations
+
+## Related Feature Report
+
+- [Full Workspace documentation](../../../features/opensearch-dashboards/workspace.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -18,3 +18,4 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Sample Data Bugfixes](features/opensearch-dashboards/sample-data-bugfixes.md) - Update OTEL sample data description with compatible OS version
 - [TSVB Visualization](features/opensearch-dashboards/tsvb-visualization-bugfixes.md) - Hidden axis option, per-axis scale setting, compressed input fields
 - [UI/UX Bugfixes (2)](features/opensearch-dashboards/ui-ux-bugfixes-2.md) - Responsive design fixes for home page, page header, recent menu, and getting started cards
+- [Workspace Bugfixes](features/opensearch-dashboards/workspace-bugfixes.md) - 13 bug fixes for workspace UI/UX, page crashes, permissions, and navigation


### PR DESCRIPTION
## Summary

This PR adds documentation for the 13 workspace bug fixes included in OpenSearch Dashboards v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch-dashboards/workspace-bugfixes.md`
- Feature report updated: `docs/features/opensearch-dashboards/workspace.md`

### Key Changes in v2.18.0

**UI/UX Improvements:**
- Removed What's New card from workspace overview
- Fixed workspace selector jump on hover/click
- Aligned workspace selector style with data source selector
- Improved search bar and workspace selector alignment

**Page Crash Fixes:**
- Fixed Analytics/Essential use case overview crash
- Fixed assets page crash with empty table
- Fixed assets page crash after permission revocation
- Fixed duplicate visualizations in dashboard

**Permission & Access Fixes:**
- Fixed hidden use case features not accessible
- Fixed non-workspace admin defaultIndex update error
- Fixed index pattern scope isolation

**Navigation Fixes:**
- Fixed workspace update navigation modal issue
- Fixed short URL generation to include workspace info

### PRs Investigated
- #8435, #8445, #8524, #8541, #8570, #8581, #8592, #8606, #8648, #8649, #8675, #8718, #8719

Closes #687