### PR TITLE
docs: add i18n-localization report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -56,6 +56,7 @@
 - [Dependency Updates](opensearch-dashboards/dependency-updates.md)
 - [Discover](opensearch-dashboards/discover.md)
 - [DOMPurify Sanitization](opensearch-dashboards/dompurify-sanitization.md)
+- [i18n & Localization](opensearch-dashboards/i18n-localization.md)
 - [OSD Optimizer Cache](opensearch-dashboards/osd-optimizer-cache.md)
 - [Monaco Editor](opensearch-dashboards/monaco-editor.md)
 - [OpenSearch UI (OUI)](opensearch-dashboards/oui.md)

--- a/docs/features/opensearch-dashboards/i18n-localization.md
+++ b/docs/features/opensearch-dashboards/i18n-localization.md
@@ -1,0 +1,149 @@
+# i18n & Localization
+
+## Summary
+
+OpenSearch Dashboards provides internationalization (i18n) support enabling the UI to be displayed in multiple languages. The i18n framework includes translation file management, ICU message format support, and developer tooling for maintaining translation quality.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Source Code"
+        A[React Components] --> B[i18n.translate]
+        C[TypeScript Files] --> B
+    end
+    subgraph "i18n Framework"
+        B --> D[Message Extraction]
+        D --> E[Default Messages Map]
+        F[Locale Files] --> G[Translation Loader]
+        G --> H[Runtime i18n Service]
+    end
+    subgraph "Validation"
+        I[Precommit Hook] --> J[i18n Check]
+        K[CI Workflow] --> J
+        J --> L{Valid?}
+        L -->|Yes| M[Pass]
+        L -->|No| N[Fail with Errors]
+    end
+    E --> H
+    H --> O[Rendered UI]
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Developer writes i18n.translate] --> B[Extract messages]
+    B --> C[Generate default messages]
+    C --> D[Translators update locale files]
+    D --> E[i18n:check validates]
+    E --> F[Build includes translations]
+    F --> G[User selects language]
+    G --> H[Load locale file]
+    H --> I[Display translated UI]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `@osd/i18n` | Core i18n package providing translation functions |
+| `i18n.translate()` | Function to mark strings for translation |
+| `FormattedMessage` | React component for translated strings |
+| `i18n:check` | CLI tool to validate i18n usage |
+| `i18n:extract` | CLI tool to extract messages from source |
+| Precommit Hook | Git hook for local i18n validation |
+| CI Workflow | GitHub Actions job for PR validation |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `i18n.locale` | Default locale for the application | `en` |
+| `--ignore-incompatible` | Ignore mismatched keys in translations | `false` |
+| `--ignore-malformed` | Ignore malformed ICU format | `false` |
+| `--ignore-missing` | Ignore missing translations | `false` |
+| `--ignore-unused` | Ignore unused translations | `false` |
+| `--ignore-missing-formats` | Ignore missing formats object | `true` |
+
+### Supported Locales
+
+| Locale Code | Language |
+|-------------|----------|
+| `en` | English (default) |
+| `de-DE` | German |
+| `es-ES` | Spanish |
+| `fr-FR` | French |
+| `ko-KR` | Korean |
+| `tr-TR` | Turkish |
+| `zh-CN` | Chinese (Simplified) |
+
+### Usage Example
+
+Using i18n in React components:
+
+```typescript
+import { i18n } from '@osd/i18n';
+import { FormattedMessage } from '@osd/i18n/react';
+
+// Using i18n.translate
+const title = i18n.translate('myPlugin.title', {
+  defaultMessage: 'My Plugin Title',
+});
+
+// Using FormattedMessage component
+<FormattedMessage
+  id="myPlugin.description"
+  defaultMessage="Welcome to {name}"
+  values={{ name: 'OpenSearch' }}
+/>
+```
+
+Running validation:
+
+```bash
+# Validate all i18n usage
+yarn i18n:check
+
+# Extract messages for translation
+yarn i18n:extract
+```
+
+### i18n Key Naming Convention
+
+Keys must be prefixed with the plugin name:
+
+```typescript
+// Correct
+i18n.translate('workspace.title', { defaultMessage: 'Workspace' });
+
+// Incorrect - will fail validation
+i18n.translate('title', { defaultMessage: 'Workspace' });
+```
+
+## Limitations
+
+- Translation files must include a `formats` object (can be ignored with `--ignore-missing-formats`)
+- Dynamic i18n key construction is not supported and will fail validation
+- ICU message format variables must use consistent casing between source and translations
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#8411](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8411) | Add i18n checks to PR workflows |
+| v2.18.0 | [#8412](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8412) | Fix unprefixed i18n identifiers in examples |
+| v2.18.0 | [#8423](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8423) | Add precommit hook to validate i18n |
+| v2.18.0 | [#8483](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8483) | Fix inconsistent i18n key names |
+| v2.18.0 | [#8399](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8399) | Fix dynamic i18n in visBuilder plugin |
+| v2.18.0 | [#8674](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8674) | Fix unsupported language from localStorage |
+
+## References
+
+- [OpenSearch Dashboards Repository](https://github.com/opensearch-project/OpenSearch-Dashboards)
+
+## Change History
+
+- **v2.18.0** (2024-10-22): Added i18n validation to CI/CD workflows, precommit hook, fixed malformed translations, fixed language selection bug

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/i18n-localization.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/i18n-localization.md
@@ -1,0 +1,135 @@
+# i18n & Localization Bugfixes
+
+## Summary
+
+OpenSearch Dashboards v2.18.0 includes significant improvements to the internationalization (i18n) infrastructure, fixing malformed translations, adding automated validation workflows, and resolving a language selection bug that caused incorrect query language persistence.
+
+## Details
+
+### What's New in v2.18.0
+
+This release addresses multiple i18n-related issues:
+
+1. **Fixed malformed translations** across multiple locale files (de-DE, es-ES, fr-FR, ko-KR, tr-TR, zh-CN)
+2. **Added i18n validation to CI/CD workflows** to prevent future translation issues
+3. **Added precommit hook** for local i18n validation during development
+4. **Fixed unprefixed i18n identifiers** in examples and plugins
+5. **Fixed inconsistent i18n key names** in workspace and examples
+6. **Fixed unsupported language selection** from localStorage
+
+### Technical Changes
+
+#### i18n Validation Infrastructure
+
+```mermaid
+graph TB
+    subgraph "Development"
+        A[Developer Commits] --> B[Precommit Hook]
+        B --> C{i18n Check}
+        C -->|Pass| D[Commit Allowed]
+        C -->|Fail| E[Commit Blocked]
+    end
+    subgraph "CI/CD"
+        F[Pull Request] --> G[GitHub Actions]
+        G --> H[yarn i18n:check]
+        H -->|Pass| I[PR Checks Pass]
+        H -->|Fail| J[PR Checks Fail]
+    end
+```
+
+#### New npm Scripts
+
+| Script | Description |
+|--------|-------------|
+| `yarn i18n:check` | Validates i18n usage in code and translation files |
+| `yarn i18n:extract` | Extracts i18n messages from source code |
+
+#### i18n Check Options
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--ignore-incompatible` | Ignore mismatched keys in values and tokens | false |
+| `--ignore-malformed` | Ignore malformed ICU format usages | false |
+| `--ignore-missing` | Ignore missing translations in locale files | false |
+| `--ignore-unused` | Ignore unused translations in locale files | false |
+| `--ignore-untracked` | Ignore untracked files with i18n labels | false |
+| `--ignore-missing-formats` | Ignore missing 'formats' key in locale files | true |
+
+#### Translation Fixes
+
+Fixed ICU message format variable casing issues in translation files:
+
+| Locale | Fixed Keys |
+|--------|------------|
+| de-DE | `labelWarningInfo`, `newToOpenSearchDashboardsDescription` |
+| es-ES | `newToOpenSearchDashboardsDescription` |
+| fr-FR | `labelErrorInfo`, `savedObjectAddedToContainerSuccessMessageTitle`, `attributeService.saveToLibraryError`, `dashboardWasNotSavedDangerMessage`, `newToOpenSearchDashboardsDescription`, `dashboardExistsDescription` |
+| ko-KR | `fieldNotFound`, `labelErrorInfo` |
+| tr-TR | `newToOpenSearchDashboardsDescription`, `dashboardExistsDescription` |
+| zh-CN | `dashboardWasNotSavedDangerMessage` |
+
+#### Language Selection Fix
+
+Fixed a bug where unsupported query languages cached in localStorage would be incorrectly applied when navigating between applications:
+
+```typescript
+// Before: Always used cached language
+private getDefaultLanguage() {
+  return this.storage.get('userQueryLanguage') || 
+    this.uiSettings.get(UI_SETTINGS.SEARCH_QUERY_LANGUAGE);
+}
+
+// After: Validates language support before using cached value
+private getDefaultLanguage() {
+  const lastUsedLanguage = this.storage.get('userQueryLanguage');
+  if (lastUsedLanguage && this.isLanguageSupported(lastUsedLanguage)) {
+    return lastUsedLanguage;
+  }
+  return this.uiSettings.get(UI_SETTINGS.SEARCH_QUERY_LANGUAGE);
+}
+```
+
+### Usage Example
+
+Running i18n validation locally:
+
+```bash
+# Check all i18n usage
+yarn i18n:check
+
+# Check with specific options
+yarn i18n:check --ignore-missing --ignore-unused
+
+# Extract messages for translation
+yarn i18n:extract
+```
+
+### Migration Notes
+
+- Developers should run `yarn osd bootstrap` to install the precommit hook
+- Existing translation files may need updates if they contain malformed ICU message formats
+- The i18n check is now part of the CI workflow and will fail PRs with invalid translations
+
+## Limitations
+
+- The `--ignore-missing-formats` flag defaults to `true` to maintain backward compatibility with locale files missing the `formats` object
+- Precommit hook only validates staged files, not the entire codebase
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8411](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8411) | Add i18n checks to PR workflows, fix malformed translations |
+| [#8412](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8412) | Fix unprefixed i18n identifiers in examples |
+| [#8423](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8423) | Add precommit hook to validate i18n |
+| [#8483](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8483) | Fix inconsistent i18n key names in workspace and examples |
+| [#8399](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8399) | Fix dynamic uses of i18n in visBuilder plugin |
+| [#8674](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8674) | Fix unsupported language selection from localStorage |
+
+## References
+
+- [OpenSearch Dashboards Repository](https://github.com/opensearch-project/OpenSearch-Dashboards)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/i18n-localization.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -9,6 +9,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### OpenSearch Dashboards
 
 - [CI/CD & Build Improvements](features/opensearch-dashboards/cicd-build-dashboards.md) - Switch OSD Optimizer to content-based hashing for CI compatibility
+- [i18n & Localization](features/opensearch-dashboards/i18n-localization.md) - i18n validation workflows, precommit hook, translation fixes, language selection fix
 - [Data Connections Bugfixes](features/opensearch-dashboards/data-connections-bugfixes.md) - MDS endpoint unification, tabs navigation, type display, auto-complete MDS support
 - [Dependency Updates](features/opensearch-dashboards/dependency-updates-dashboards.md) - JSON11 upgrade for UTF-8 safety, chokidar bump
 - [Discover Bugfixes (2)](features/opensearch-dashboards/discover-bugfixes-2.md) - S3 fields support, deleted index pattern handling, time field display, saved query loading


### PR DESCRIPTION
## Summary

This PR adds documentation for the i18n & Localization bugfixes in OpenSearch Dashboards v2.18.0.

## Changes

### Release Report
- `docs/releases/v2.18.0/features/opensearch-dashboards/i18n-localization.md`

### Feature Report
- `docs/features/opensearch-dashboards/i18n-localization.md`

## Key Changes in v2.18.0

- Added i18n validation to CI/CD workflows (#8411)
- Added precommit hook for local i18n validation (#8423)
- Fixed malformed translations in multiple locale files
- Fixed unprefixed i18n identifiers in examples (#8412)
- Fixed inconsistent i18n key names in workspace and examples (#8483)
- Fixed dynamic i18n usage in visBuilder plugin (#8399)
- Fixed unsupported language selection from localStorage (#8674)

## Related Issue
Closes #686