### PR TITLE
docs: add dashboards-maintenance report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -49,6 +49,7 @@
 - [Dashboards CI/CD & Documentation](opensearch-dashboards/dashboards-ci-cd-documentation.md)
 - [Dashboards Cypress Testing](opensearch-dashboards/dashboards-cypress-testing.md)
 - [Dashboards Frontend Cleanup](opensearch-dashboards/dashboards-frontend-cleanup.md)
+- [Dashboards Maintenance](opensearch-dashboards/dashboards-maintenance.md)
 - [Dashboards UI Updates (OUI)](opensearch-dashboards/dashboards-ui-updates.md)
 - [Dashboards UI/UX Fixes](opensearch-dashboards/dashboards-ui-ux-fixes.md)
 - [Data Connections](opensearch-dashboards/data-connections.md)

--- a/docs/features/opensearch-dashboards/dashboards-maintenance.md
+++ b/docs/features/opensearch-dashboards/dashboards-maintenance.md
@@ -1,0 +1,79 @@
+# Dashboards Maintenance
+
+## Summary
+
+Dashboards Maintenance encompasses routine maintenance tasks for OpenSearch Dashboards, including version bumps after releases, code cleanup, removal of deprecated APIs, and general housekeeping to keep the codebase clean and maintainable.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        subgraph "Query Enhancements Plugin"
+            API[Server Routes]
+            S3[S3 Type Config]
+        end
+        subgraph "Data Plugin"
+            Constants[Constants]
+            SearchParams[Search Params]
+        end
+    end
+    
+    API --> |"API calls"| OpenSearch[(OpenSearch)]
+    S3 --> API
+    SearchParams --> API
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Version Management | Package.json version updates after releases |
+| API Routes | Server-side route definitions for data source connections |
+| Search Parameters | Configuration for search request parameters |
+| UI Constants | Display text and default values |
+
+### Maintenance Activities
+
+#### Version Bumps
+After each release, the version in `package.json` is incremented to the next development version. This ensures proper version tracking during development cycles.
+
+#### API Cleanup
+Periodic cleanup of deprecated or unused APIs to reduce code complexity and maintenance burden:
+- Removal of unused service classes
+- Consolidation of API endpoints
+- Simplification of request/response handling
+
+#### Error Handling Improvements
+Enhanced error handling for edge cases:
+- Graceful handling of 404/400 responses
+- Proper abort controller usage for cancellable requests
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `DEFAULT_DATA.SET_TYPES.LOCAL_DATASOURCE.title` | Display name for local cluster | "Default Cluster" |
+
+## Limitations
+
+- Maintenance changes are typically internal and don't add user-facing features
+- API path changes may require updates to custom integrations
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#8225](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8225) | Post 2.17 version bump |
+| v2.18.0 | [#8226](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8226) | Clean up enhanced search API |
+
+## References
+
+- [PR #8225](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8225): Version bump post 2.17 release
+- [PR #8226](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8226): Enhanced search API cleanup
+
+## Change History
+
+- **v2.18.0** (2024-10-22): Version bump to 2.18.0, enhanced search API cleanup (removed ConnectionsService, deprecated routes, improved error handling)

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/dashboards-maintenance.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/dashboards-maintenance.md
@@ -1,0 +1,78 @@
+# Dashboards Maintenance
+
+## Summary
+
+This release includes routine maintenance updates for OpenSearch Dashboards: a version bump from 2.17.0 to 2.18.0 following the 2.17 release, and cleanup of the enhanced search API including removal of unused services and improved error handling.
+
+## Details
+
+### What's New in v2.18.0
+
+#### Version Bump Post 2.17 Release
+- Updated `package.json` version from `2.17.0` to `2.18.0`
+- Standard post-release version increment on the 2.x branch
+
+#### Enhanced Search API Cleanup
+The Discover plugin's enhanced search functionality received significant cleanup:
+
+1. **Deleted ConnectionsService**: Removed the unused `connections_service.ts` that was no longer needed
+2. **Removed dataframe from requests**: Eliminated the `df` (dataframe) object being passed into search requests
+3. **Deleted unused APIs**: Removed deprecated server routes:
+   - Removed `GET /api/enhancements/datasource/external` endpoint
+   - Removed `GET /api/enhancements/{queryId}` and `GET /api/enhancements/{queryId}/{dataSourceId}` routes
+4. **Improved error handling**: Added proper error handling for 404/400 responses when fetching data connections
+5. **API path consolidation**: Simplified API paths:
+   - `datasource/jobs` → `jobs`
+   - `datasource/connections` → `connections`
+
+#### UI Text Updates
+- Changed "Local Cluster" to "Default Cluster" for local data source display
+- Changed column header from "Cluster" to "Clusters" for data source selection
+
+### Technical Changes
+
+#### Removed Components
+| Component | Description |
+|-----------|-------------|
+| `ConnectionsService` | Unused service for managing data source connections |
+| `ConnectionsServiceDeps` | Type definition for ConnectionsService dependencies |
+| `df` parameter | Dataframe object in search request body |
+
+#### API Changes
+| Old Path | New Path | Change |
+|----------|----------|--------|
+| `/api/enhancements/datasource/external` | Removed | Endpoint deleted |
+| `/api/enhancements/datasource/jobs` | `/api/enhancements/jobs` | Path simplified |
+| `/api/enhancements/datasource/connections` | `/api/enhancements/connections/{id?}` | Path simplified, optional ID |
+
+#### Modified Files
+| File | Change |
+|------|--------|
+| `package.json` | Version 2.17.0 → 2.18.0 |
+| `src/plugins/data/common/constants.ts` | "Local Cluster" → "Default Cluster" |
+| `src/plugins/data/public/query/query_string/dataset_service/lib/index_type.ts` | "Cluster" → "Clusters" |
+| `src/plugins/query_enhancements/common/constants.ts` | API path updates |
+| `src/plugins/query_enhancements/public/datasets/s3_type.ts` | Updated fetch calls, added abort controllers |
+| `src/plugins/query_enhancements/server/routes/data_source_connection/routes.ts` | Consolidated routes, added error handling |
+| `src/plugins/query_enhancements/server/routes/index.ts` | Removed deprecated routes |
+
+## Limitations
+
+- These are internal maintenance changes with no user-facing feature impact
+- The API path changes may affect custom integrations using the old endpoints
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8225](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8225) | Post 2.17 version bump to 2.18.0 |
+| [#8226](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8226) | Clean up enhanced search API |
+
+## References
+
+- [PR #8225](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8225): Version bump
+- [PR #8226](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8226): API cleanup
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/dashboards-maintenance.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -20,3 +20,4 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [TSVB Visualization](features/opensearch-dashboards/tsvb-visualization-bugfixes.md) - Hidden axis option, per-axis scale setting, compressed input fields
 - [UI/UX Bugfixes (2)](features/opensearch-dashboards/ui-ux-bugfixes-2.md) - Responsive design fixes for home page, page header, recent menu, and getting started cards
 - [Workspace Bugfixes](features/opensearch-dashboards/workspace-bugfixes.md) - 13 bug fixes for workspace UI/UX, page crashes, permissions, and navigation
+- [Dashboards Maintenance](features/opensearch-dashboards/dashboards-maintenance.md) - Version bump post 2.17, enhanced search API cleanup


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dashboards Maintenance release item in v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch-dashboards/dashboards-maintenance.md`
- Feature report: `docs/features/opensearch-dashboards/dashboards-maintenance.md`

### Key Changes in v2.18.0
- Version bump from 2.17.0 to 2.18.0 post-release
- Enhanced search API cleanup:
  - Deleted unused ConnectionsService
  - Removed deprecated API routes
  - Improved error handling for data connections
  - Simplified API paths

### Related PRs
- [#8225](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8225): Post 2.17 version bump
- [#8226](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8226): Clean up enhanced search API

Closes #685