### PR TITLE
docs: add UI/UX Bugfixes report for v2.18.0

### DIFF
--- a/docs/features/opensearch-dashboards/dashboards-ui-ux-fixes.md
+++ b/docs/features/opensearch-dashboards/dashboards-ui-ux-fixes.md
@@ -114,6 +114,14 @@ graph TB
 | v3.0.0 | [#9484](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9484) | Replace @elastic/filesaver |
 | v3.0.0 | [#9488](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9488) | Replace formatNumWithCommas |
 | v3.0.0 | [#9057](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9057) | Update data source details buttons |
+| v2.18.0 | [#8216](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8216) | Add tooltips for sidebar icon buttons |
+| v2.18.0 | [#8217](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8217) | Fix initial page UI issues |
+| v2.18.0 | [#8218](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8218) | Remove nav group for dev tools |
+| v2.18.0 | [#8223](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8223) | Fix overlay offsets on pages with feature header |
+| v2.18.0 | [#8232](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8232) | Use @osd/std to prettify objects for display |
+| v2.18.0 | [#8274](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8274) | Temporary fix for Chrome 129 mask-image bug |
+| v2.18.0 | [#8320](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8320) | Update OSD to respect new OUI breakpoints |
+| v2.18.0 | [#8335](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8335) | Fix HeaderControl not rendered if not mount in initial rendering |
 | v2.18.0 | [#8529](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8529) | Update the title of header recent menu |
 | v2.18.0 | [#8554](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8554) | Fix new home page small screen display issues |
 | v2.18.0 | [#8600](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8600) | Fix padding and responsive behavior of page header |
@@ -121,12 +129,16 @@ graph TB
 
 ## References
 
+- [Issue #8211](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8211): Pretty string display issue
+- [Issue #8250](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8250): Chrome 129 mask-image rendering
+- [Issue #8313](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8313): HeaderControl rendering issue
 - [Issue #9474](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9474): Dataset selector flashing
 - [Issue #9673](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9673): Essential property copy
 - [Issue #9679](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9679): Query params signer error
 - [Issue #9341](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9341): Remove @elastic/filesaver
+- [OUI PR #1414](https://github.com/opensearch-project/oui/pull/1414): Chrome 129 fix in OUI
 
 ## Change History
 
 - **v3.0.0** (2025-05-06): Initial collection of UI/UX fixes including navigation, query editor, data source, and Discover improvements
-- **v2.18.0** (2024-11-05): Responsive design fixes for home page, page header, recent menu, and getting started cards
+- **v2.18.0** (2024-11-05): Sidebar tooltips, initial page fixes, dev tools nav group removal, overlay positioning, Chrome 129 workaround, OUI breakpoints, HeaderControl rendering, responsive design fixes

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/ui-ux-bugfixes.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/ui-ux-bugfixes.md
@@ -1,0 +1,112 @@
+# UI/UX Bugfixes
+
+## Summary
+
+OpenSearch Dashboards v2.18.0 includes 8 UI/UX bug fixes addressing sidebar tooltips, initial page layout, navigation grouping, overlay positioning, object display formatting, Chrome 129 compatibility, OUI breakpoint handling, and HeaderControl rendering issues.
+
+## Details
+
+### What's New in v2.18.0
+
+This release addresses various UI/UX issues across the Dashboards interface:
+
+1. **Sidebar Icon Tooltips**: Added tooltips for sidebar icon buttons to improve accessibility and discoverability
+2. **Initial Page UI**: Fixed layout issues including vertical centering, spacing, and external link icons
+3. **Dev Tools Navigation**: Removed dev tools from the data administration nav group (standalone application)
+4. **Overlay Positioning**: Fixed tooltip and dropdown positioning on pages with feature headers
+5. **Object Display**: Switched to `@osd/std` for consistent object prettification
+6. **Chrome 129 Fix**: Temporary workaround for Chrome's mask-image rendering bug
+7. **OUI Breakpoints**: Updated OSD to respect new OUI breakpoints (xxl, xxxl)
+8. **HeaderControl Rendering**: Fixed HeaderControl not rendering when not mounted in initial render
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "UI Components"
+        SB[Sidebar Icons]
+        IP[Initial Page]
+        DT[Dev Tools]
+        OV[Overlays]
+    end
+    
+    subgraph "Rendering"
+        HC[HeaderControl]
+        BP[Breakpoints]
+        MI[Mask Image]
+    end
+    
+    subgraph "Utilities"
+        PS[Pretty String]
+        TT[Tooltips]
+    end
+    
+    SB --> TT
+    IP --> BP
+    OV --> MI
+    HC --> BP
+    PS --> OV
+```
+
+#### Key Fixes
+
+| Fix | Component | Description |
+|-----|-----------|-------------|
+| Sidebar Tooltips | CollapsibleNavGroupEnabled | Added `EuiToolTip` wrapper for icon buttons |
+| Initial Page | Home Plugin | Removed vertical centering, added top padding, fixed spacing |
+| Dev Tools Nav | Console Plugin | Removed nav group registration for dev tools |
+| Overlay Offsets | Feature Header | Changed margin to padding to fix absolute positioning |
+| Pretty String | @osd/std | Use standard library for object display |
+| Chrome 129 | CSS | Added `contain: paint` for mask-image elements |
+| OUI Breakpoints | Core | Handle xxl/xxxl breakpoints as xl equivalent |
+| HeaderControl | Application | Added `useObservableValue` hook for reactive updates |
+
+### Usage Example
+
+The HeaderControl fix introduces a new pattern for subscribing to observable updates:
+
+```typescript
+// Before: Controls not re-rendered after initial mount
+const controls = application.currentRightControls$;
+
+// After: Using useObservableValue for reactive updates
+import { useObservableValue } from '@osd/std';
+
+const controls = useObservableValue(application.currentRightControls$);
+// Component now re-renders when controls change
+```
+
+### Migration Notes
+
+No migration required. These are bug fixes that improve existing functionality.
+
+## Limitations
+
+- Chrome 129 fix is temporary; may be removed when Chrome fixes the underlying issue
+- OUI breakpoint handling treats xxl/xxxl as xl (no distinct behavior for larger screens)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8216](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8216) | Add tooltips for sidebar icon buttons |
+| [#8217](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8217) | Fix initial page UI issues |
+| [#8218](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8218) | Remove nav group for dev tools |
+| [#8223](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8223) | Fix overlay offsets on pages with feature header |
+| [#8232](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8232) | Use @osd/std to prettify objects for display |
+| [#8274](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8274) | Temporary fix for Chrome 129 mask-image bug |
+| [#8320](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8320) | Update OSD to respect new OUI breakpoints |
+| [#8335](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8335) | Fix HeaderControl not rendered if not mount in initial rendering |
+
+## References
+
+- [Issue #8211](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8211): Pretty string display issue
+- [Issue #8250](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8250): Chrome 129 mask-image rendering
+- [Issue #8313](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8313): HeaderControl rendering issue
+- [OUI PR #1414](https://github.com/opensearch-project/oui/pull/1414): Chrome 129 fix in OUI
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/dashboards-ui-ux-fixes.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -18,6 +18,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Query Enhancements (2)](features/opensearch-dashboards/query-enhancements-2.md) - Async polling, error handling, language compatibility, saved query fixes
 - [Sample Data Bugfixes](features/opensearch-dashboards/sample-data-bugfixes.md) - Update OTEL sample data description with compatible OS version
 - [TSVB Visualization](features/opensearch-dashboards/tsvb-visualization-bugfixes.md) - Hidden axis option, per-axis scale setting, compressed input fields
+- [UI/UX Bugfixes](features/opensearch-dashboards/ui-ux-bugfixes.md) - Sidebar tooltips, initial page fixes, overlay positioning, Chrome 129 workaround, OUI breakpoints, HeaderControl rendering
 - [UI/UX Bugfixes (2)](features/opensearch-dashboards/ui-ux-bugfixes-2.md) - Responsive design fixes for home page, page header, recent menu, and getting started cards
 - [Workspace Bugfixes](features/opensearch-dashboards/workspace-bugfixes.md) - 13 bug fixes for workspace UI/UX, page crashes, permissions, and navigation
 - [Dashboards Maintenance](features/opensearch-dashboards/dashboards-maintenance.md) - Version bump post 2.17, enhanced search API cleanup


### PR DESCRIPTION
## Summary

This PR adds documentation for UI/UX Bugfixes in OpenSearch Dashboards v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch-dashboards/ui-ux-bugfixes.md`
- Feature report: `docs/features/opensearch-dashboards/dashboards-ui-ux-fixes.md` (updated)

### Key Changes in v2.18.0
- Sidebar icon tooltips for improved accessibility
- Initial page UI fixes (layout, spacing, external link icons)
- Dev tools removed from data administration nav group
- Overlay positioning fixes for pages with feature headers
- Object display prettification using @osd/std
- Chrome 129 mask-image rendering workaround
- OUI breakpoint handling (xxl, xxxl)
- HeaderControl reactive rendering fix

### PRs Investigated
- #8216: Add tooltips for sidebar icon buttons
- #8217: Fix initial page UI issues
- #8218: Remove nav group for dev tools
- #8223: Fix overlay offsets on pages with feature header
- #8232: Use @osd/std to prettify objects for display
- #8274: Temporary fix for Chrome 129 mask-image bug
- #8320: Update OSD to respect new OUI breakpoints
- #8335: Fix HeaderControl not rendered if not mount in initial rendering

Closes #684