### PR TITLE
docs: add query-enhancements-bugfixes report for v2.18.0

### DIFF
--- a/docs/features/opensearch-dashboards/query-enhancements.md
+++ b/docs/features/opensearch-dashboards/query-enhancements.md
@@ -117,6 +117,10 @@ source = logs-* | where status >= 400 | head 100
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.18.0 | [#8245](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8245) | Expose method to register search strategy routes |
+| v2.18.0 | [#8252](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8252) | Fix running recent query button |
+| v2.18.0 | [#8299](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8299) | Expose datasets and data_frames directories for imports |
+| v2.18.0 | [#8322](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8322) | Add keyboard shortcut for running queries |
 | v2.18.0 | [#8555](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8555) | Refactored polling logic to poll for results once current request completes |
 | v2.18.0 | [#8650](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8650) | Fix random big number when loading in query result |
 | v2.18.0 | [#8724](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8724) | Polling for PPL results; Saved dataset to saved queries |
@@ -131,4 +135,4 @@ source = logs-* | where status >= 400 | head 100
 
 ## Change History
 
-- **v2.18.0** (2024-11-05): Bug fixes for async polling, error handling, language compatibility, and saved query persistence
+- **v2.18.0** (2024-11-05): Bug fixes for async polling, error handling, language compatibility, saved query persistence; Added extensibility for custom search strategies via `defineSearchStrategyRoute`; Added keyboard shortcut (Cmd/Ctrl+Enter) for query execution; Exposed datasets and data_frames modules for external plugin imports

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/query-enhancements-bugfixes.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/query-enhancements-bugfixes.md
@@ -1,0 +1,110 @@
+# Query Enhancements Bugfixes
+
+## Summary
+
+This release includes bug fixes and improvements for the Query Enhancements plugin in OpenSearch Dashboards v2.18.0. The changes focus on extensibility for custom search strategies, fixing the recent query button behavior, improving module imports for external plugins, and adding keyboard shortcuts for query execution.
+
+## Details
+
+### What's New in v2.18.0
+
+#### Extensibility for Custom Search Strategies
+
+The Query Enhancements plugin now exposes a method to register search strategy routes, enabling external plugins to define custom search strategies with their own API endpoints.
+
+```mermaid
+graph TB
+    subgraph "External Plugin"
+        CS[Custom Search Strategy]
+    end
+    subgraph "Query Enhancements Plugin"
+        DSR[defineSearchStrategyRoute]
+        Router[Router]
+    end
+    subgraph "Search Interceptor"
+        SI[Search Interceptor]
+    end
+    
+    CS --> DSR
+    DSR --> Router
+    Router --> SI
+```
+
+#### Technical Changes
+
+##### New API: defineSearchStrategyRoute
+
+| Component | Description |
+|-----------|-------------|
+| `defineSearchStrategyRoute` | New method exposed in plugin setup to register custom search strategy routes |
+| `defineSearchStrategyRouteProvider` | Factory function that encapsulates logger and router for route registration |
+
+##### Module Export Improvements
+
+| Change | Description |
+|--------|-------------|
+| `datasets` directory | Now exposed for specific imports from data plugin |
+| `data_frames` directory | Now exposed for specific imports from data plugin |
+
+This allows external plugins to import specific modules without pulling in the entire common code:
+
+```typescript
+// Before: Required importing complete common code
+import { Dataset } from '@opensearch-project/opensearch-dashboards/data/common';
+
+// After: Can import from specific subdirectories
+import { Dataset } from '@opensearch-project/opensearch-dashboards/data/common/datasets';
+```
+
+##### Recent Query Button Fix
+
+Fixed a bug where clicking the "Run Recent Query" button would incorrectly switch to a different query language instead of preserving the original language context.
+
+##### Keyboard Shortcut for Query Execution
+
+Added `Cmd+Enter` (Mac) / `Ctrl+Enter` (Windows/Linux) keyboard shortcut to execute queries directly from the query editor, improving user productivity.
+
+| Shortcut | Platform | Action |
+|----------|----------|--------|
+| `Cmd+Enter` | macOS | Execute current query |
+| `Ctrl+Enter` | Windows/Linux | Execute current query |
+
+### Usage Example
+
+```typescript
+// Registering a custom search strategy route
+class MyPlugin {
+  setup(core, { queryEnhancements }) {
+    const mySearchStrategy = {
+      search: async (context, request, options) => {
+        // Custom search implementation
+        return { body: results };
+      }
+    };
+    
+    queryEnhancements.defineSearchStrategyRoute('my-strategy', mySearchStrategy);
+  }
+}
+```
+
+## Limitations
+
+- Custom search strategies must implement the `ISearchStrategy` interface
+- The keyboard shortcut only works when the query editor has focus
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8245](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8245) | Expose method to register search strategy routes in query enhancement |
+| [#8252](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8252) | Fix running recent query button to work properly |
+| [#8299](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8299) | Expose datasets and data_frames directories for specific imports |
+| [#8322](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8322) | Add keyboard shortcut for running queries |
+
+## References
+
+- [Query Workbench Documentation](https://docs.opensearch.org/2.18/dashboards/query-workbench/): Official query interface documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/query-enhancements.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -16,6 +16,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Maintainers](features/opensearch-dashboards/maintainers.md) - Add Hailong-am as maintainer
 - [OUI Updates](features/opensearch-dashboards/oui-updates.md) - Updates to OpenSearch UI component library (1.13 → 1.15)
 - [Query Enhancements (2)](features/opensearch-dashboards/query-enhancements-2.md) - Async polling, error handling, language compatibility, saved query fixes
+- [Query Enhancements Bugfixes](features/opensearch-dashboards/query-enhancements-bugfixes.md) - Search strategy extensibility, recent query fix, module exports, keyboard shortcuts
 - [Sample Data Bugfixes](features/opensearch-dashboards/sample-data-bugfixes.md) - Update OTEL sample data description with compatible OS version
 - [TSVB Visualization](features/opensearch-dashboards/tsvb-visualization-bugfixes.md) - Hidden axis option, per-axis scale setting, compressed input fields
 - [UI/UX Bugfixes](features/opensearch-dashboards/ui-ux-bugfixes.md) - Sidebar tooltips, initial page fixes, overlay positioning, Chrome 129 workaround, OUI breakpoints, HeaderControl rendering


### PR DESCRIPTION
## Summary

Adds release report for Query Enhancements bugfixes in OpenSearch Dashboards v2.18.0.

## Changes

### Release Report
- `docs/releases/v2.18.0/features/opensearch-dashboards/query-enhancements-bugfixes.md`

### Feature Report Update
- Updated `docs/features/opensearch-dashboards/query-enhancements.md` with new PRs and change history

### PRs Covered
- #8245: Expose method to register search strategy routes
- #8252: Fix running recent query button
- #8299: Expose datasets and data_frames directories for imports
- #8322: Add keyboard shortcut for running queries

Closes #683