### PR TITLE
docs: add dynamic-config report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -57,6 +57,7 @@
 - [Dependency Updates](opensearch-dashboards/dependency-updates.md)
 - [Discover](opensearch-dashboards/discover.md)
 - [DOMPurify Sanitization](opensearch-dashboards/dompurify-sanitization.md)
+- [Dynamic Config](opensearch-dashboards/dynamic-config.md)
 - [i18n & Localization](opensearch-dashboards/i18n-localization.md)
 - [OSD Optimizer Cache](opensearch-dashboards/osd-optimizer-cache.md)
 - [Monaco Editor](opensearch-dashboards/monaco-editor.md)

--- a/docs/features/opensearch-dashboards/dynamic-config.md
+++ b/docs/features/opensearch-dashboards/dynamic-config.md
@@ -1,0 +1,107 @@
+# Dynamic Config
+
+## Summary
+
+Dynamic Config is a feature in OpenSearch Dashboards that enables runtime configuration management through a dedicated OpenSearch index. It allows the system to store and retrieve configuration settings dynamically without requiring server restarts, supporting features like advanced settings upgrades and workspace-aware configuration.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        OSD[OSD Server]
+        CSC[ConfigStoreClient]
+        WW[Workspace Wrapper]
+    end
+    
+    subgraph "OpenSearch"
+        IDX[".opensearch_dashboards_dynamic_config_N"]
+        ALIAS[".opensearch_dashboards_dynamic_config alias"]
+    end
+    
+    OSD --> CSC
+    CSC --> ALIAS
+    ALIAS --> IDX
+    WW --> CSC
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Server Startup] --> B{Alias Exists?}
+    B -->|No| C{Index Exists?}
+    C -->|No| D[Create Index + Alias]
+    C -->|Yes| E[Add Alias to Index]
+    B -->|Yes| F{Valid Setup?}
+    F -->|Yes| G[Continue]
+    F -->|No| H[Throw Error]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `OpenSearchConfigStoreClient` | Client for managing dynamic config index operations |
+| `WorkspaceIdConsumerWrapper` | Wrapper that handles workspace-aware saved object operations |
+| `WorkspaceSavedObjectsClientWrapper` | Filters config objects based on workspace context |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Index Name | Dynamic config index pattern | `.opensearch_dashboards_dynamic_config_N` |
+| Alias Name | Alias pointing to active index | `.opensearch_dashboards_dynamic_config` |
+
+### Index Naming Convention
+
+The dynamic config system uses versioned indices with an alias:
+
+```
+.opensearch_dashboards_dynamic_config_1  (index)
+.opensearch_dashboards_dynamic_config    (alias) -> points to active index
+```
+
+### Usage Example
+
+The dynamic config system operates transparently. Configuration is stored as documents in the index:
+
+```json
+{
+  "config_name": "advanced_settings",
+  "config_blob": {
+    "buildNum": 12345,
+    "defaultIndex": "my-index-pattern"
+  }
+}
+```
+
+### Workspace Integration
+
+Config saved objects are treated specially in workspace contexts:
+- Global configs (with `buildNum` attribute) are accessible across all workspaces
+- User-specific configs are filtered based on workspace membership
+- Config creation bypasses automatic workspace ID injection
+
+## Limitations
+
+- The alias must point to exactly one valid dynamic config index
+- Invalid alias configurations require manual cleanup before server restart
+- Index names must follow the pattern `.opensearch_dashboards_dynamic_config_N` where N is a positive integer
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#8160](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8160) | Fix config related issues and dedup category |
+| v2.18.0 | [#8184](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8184) | Fix bug when dynamic config index and alias are checked |
+
+## References
+
+- [Dynamic configuration in OpenSearch Dashboards](https://docs.opensearch.org/2.18/security/multi-tenancy/dynamic-config/): Official documentation
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Fixed config saved objects workspace handling, global config discovery during upgrades, and dynamic config index/alias validation

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/dynamic-config.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/dynamic-config.md
@@ -1,0 +1,86 @@
+# Dynamic Config Bugfixes
+
+## Summary
+
+This release fixes several bugs related to dynamic configuration management in OpenSearch Dashboards, particularly around workspace integration and index/alias handling during startup.
+
+## Details
+
+### What's New in v2.18.0
+
+Three key bugfixes were introduced to improve the reliability of dynamic configuration:
+
+1. **Config saved objects no longer auto-append workspaces** - When creating config saved objects, the system no longer automatically appends workspace IDs, ensuring global configs remain accessible across all workspaces.
+
+2. **Global config discovery during upgrades** - The advanced settings config upgrade process now correctly finds global configs by using the `sortField: 'buildNum'` parameter.
+
+3. **Dynamic config index/alias validation** - Fixed a bug where the system could fail if the `.opensearch_dashboards_dynamic_config` alias existed but pointed to an invalid or missing index.
+
+### Technical Changes
+
+#### Index and Alias Handling
+
+The `OpenSearchConfigStoreClient` now properly handles various edge cases during startup:
+
+| Scenario | Alias Present? | Index State | Behavior |
+|----------|---------------|-------------|----------|
+| Fresh install | No | No index | Create new index with alias |
+| Orphaned index | No | Index exists | Update index with alias |
+| Valid setup | Yes | Valid index | Do nothing |
+| Invalid alias | Yes | Multiple/wrong indices | Throw error |
+
+#### New Utility Functions
+
+| Function | Description |
+|----------|-------------|
+| `isDynamicConfigIndex()` | Validates if an index name matches the dynamic config pattern |
+| `extractVersionFromDynamicConfigIndex()` | Extracts version number from index name |
+| `searchLatestConfigIndex()` | Finds the most recent dynamic config index |
+
+#### Workspace Integration Fix
+
+The `WorkspaceIdConsumerWrapper` was updated to:
+- Skip workspace ID injection for `config` type saved objects
+- Allow global config discovery when searching with `sortField: 'buildNum'`
+
+```typescript
+// Config type objects bypass workspace filtering
+if (this.isConfigType(type)) {
+  return options; // Don't append workspace ID
+}
+```
+
+### Usage Example
+
+The fixes are transparent to users. The dynamic config system now correctly handles:
+
+```bash
+# Valid index patterns
+.opensearch_dashboards_dynamic_config_1
+.opensearch_dashboards_dynamic_config_4
+
+# Invalid patterns (will be ignored)
+.opensearch_dashboards_dynamic_config_foo
+.opensearch_dashboards_dynamic_config_
+```
+
+## Limitations
+
+- If the alias points to multiple indices or a non-dynamic-config index, the server will fail to start with an error message instructing the user to remove the invalid alias.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8160](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8160) | Fix config related issues and dedup category in landing page |
+| [#8184](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8184) | Fix bug when dynamic config index and alias are checked |
+
+## References
+
+- [PR #8160](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8160): Config related issues fix
+- [PR #8184](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8184): Dynamic config index/alias validation fix
+- [Dynamic configuration in OpenSearch Dashboards](https://docs.opensearch.org/2.18/security/multi-tenancy/dynamic-config/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/dynamic-config.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -9,6 +9,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### OpenSearch Dashboards
 
 - [CI/CD & Build Improvements](features/opensearch-dashboards/cicd-build-dashboards.md) - Switch OSD Optimizer to content-based hashing for CI compatibility
+- [Dynamic Config](features/opensearch-dashboards/dynamic-config.md) - Bugfixes for config saved objects, global config discovery, and index/alias validation
 - [i18n & Localization](features/opensearch-dashboards/i18n-localization.md) - i18n validation workflows, precommit hook, translation fixes, language selection fix
 - [Data Connections Bugfixes](features/opensearch-dashboards/data-connections-bugfixes.md) - MDS endpoint unification, tabs navigation, type display, auto-complete MDS support
 - [Dependency Updates](features/opensearch-dashboards/dependency-updates-dashboards.md) - JSON11 upgrade for UTF-8 safety, chokidar bump


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dynamic Config bugfixes in OpenSearch Dashboards v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch-dashboards/dynamic-config.md`
- Feature report: `docs/features/opensearch-dashboards/dynamic-config.md`

### Key Changes in v2.18.0
- Config saved objects no longer auto-append workspaces
- Global config discovery during upgrades fixed
- Dynamic config index/alias validation improved

### Related PRs
- [#8160](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8160): Fix config related issues and dedup category
- [#8184](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8184): Fix bug when dynamic config index and alias are checked

Closes #682