### PR TITLE
docs: add data-source-permissions report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -54,6 +54,7 @@
 - [Dashboards UI/UX Fixes](opensearch-dashboards/dashboards-ui-ux-fixes.md)
 - [Data Connections](opensearch-dashboards/data-connections.md)
 - [Data Importer](opensearch-dashboards/data-importer.md)
+- [Data Source Permissions](opensearch-dashboards/data-source-permissions.md)
 - [Dependency Updates](opensearch-dashboards/dependency-updates.md)
 - [Discover](opensearch-dashboards/discover.md)
 - [DOMPurify Sanitization](opensearch-dashboards/dompurify-sanitization.md)

--- a/docs/features/opensearch-dashboards/data-source-permissions.md
+++ b/docs/features/opensearch-dashboards/data-source-permissions.md
@@ -1,0 +1,109 @@
+# Data Source Permissions
+
+## Summary
+
+Data Source Permissions is a security feature in OpenSearch Dashboards that controls access to data source operations based on user roles. It uses a client wrapper pattern to intercept saved object operations and enforce permission checks, ensuring that only authorized users can create, update, or delete data sources.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        Request[HTTP Request]
+        Router[Router]
+        SOC[Saved Objects Client]
+        Wrapper[DataSourcePermissionClientWrapper]
+        DS[Data Source Saved Objects]
+    end
+    
+    Request --> Router
+    Router --> SOC
+    SOC --> Wrapper
+    Wrapper -->|Permission Check| DS
+    
+    subgraph "Permission Logic"
+        Admin[isDataSourceAdmin?]
+        ManageableBy[manageableBy Setting]
+        DashAdmin[isDashboardAdmin?]
+    end
+    
+    Wrapper --> Admin
+    Wrapper --> ManageableBy
+    Wrapper --> DashAdmin
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `DataSourcePermissionClientWrapper` | Wraps the saved objects client to enforce permission checks |
+| `manageableBy` setting | Controls who can manage data sources (`all`, `none`, `dashboard_admin`) |
+| `isDataSourceAdmin` | Flag indicating if user has data source admin privileges |
+| `isDashboardAdmin` | Flag indicating if user has dashboard admin privileges |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `manageableBy` | Controls data source management permissions | `all` |
+
+#### Permission Modes
+
+| Mode | Description |
+|------|-------------|
+| `all` | Any user can manage data sources |
+| `none` | No user can manage data sources (except data source admins) |
+| `dashboard_admin` | Only dashboard admins can manage data sources |
+
+### How It Works
+
+1. When a saved object operation is requested, the wrapper intercepts it
+2. If the user is a data source admin, all operations are allowed
+3. If `manageableBy` is `all`, all operations are allowed
+4. If `manageableBy` is `dashboard_admin`, only dashboard admins can perform operations
+5. If `manageableBy` is `none`, operations are blocked with a permission error
+6. For non-data-source saved objects, operations pass through unchanged
+
+### Usage Example
+
+```yaml
+# opensearch_dashboards.yml
+# Configure data source management permissions
+data_source.manageableBy: "dashboard_admin"
+```
+
+### Error Handling
+
+When a user lacks permission, the wrapper throws a forbidden error:
+
+```json
+{
+  "statusCode": 403,
+  "error": "Forbidden",
+  "message": "You have no permission to perform this operation"
+}
+```
+
+## Limitations
+
+- Permission checks only apply to data source saved objects
+- The wrapper must expose all saved object client functions to avoid runtime errors
+- Permission settings are cluster-wide, not per-data-source
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#8118](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8118) | Fix missing functions in client wrapper |
+
+## References
+
+- [Data Sources Documentation](https://docs.opensearch.org/2.18/dashboards/management/data-sources/): Official documentation
+- [Data Source Permissions](https://docs.opensearch.org/2.18/security/access-control/permissions/#data-source-permissions): Permission configuration
+- [Multiple Data Sources](https://docs.opensearch.org/2.18/dashboards/management/multi-data-sources/): Configuring multiple data sources
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Fixed missing saved object client functions in permission wrapper

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/data-source-permissions.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/data-source-permissions.md
@@ -1,0 +1,84 @@
+# Data Source Permissions Bugfix
+
+## Summary
+
+This bugfix resolves a critical issue where OpenSearch Dashboards would fail to start with an internal server error due to missing functions in the Data Source Permission saved object client wrapper. The error occurred because the wrapper did not properly expose all required saved object client functions.
+
+## Details
+
+### What's New in v2.18.0
+
+Fixed the `DataSourcePermissionClientWrapper` to include all necessary saved object client functions that were previously missing.
+
+### Technical Changes
+
+#### Root Cause
+
+The `DataSourcePermissionClientWrapper` class wraps the saved object client to enforce permission checks for data source operations. However, when returning the wrapped client, it only included custom implementations for `create`, `bulkCreate`, `delete`, `update`, and `bulkUpdate` methods, while omitting other essential client functions.
+
+This caused the following error when accessing OpenSearch Dashboards:
+
+```
+TypeError: this.savedObjectsClient.get is not a function
+    at UiSettingsClient.read
+```
+
+#### Fix Applied
+
+Added the missing saved object client functions to the wrapper return object:
+
+| Function | Description |
+|----------|-------------|
+| `get` | Retrieve a single saved object |
+| `checkConflicts` | Check for conflicts before operations |
+| `errors` | Access error utilities |
+| `addToNamespaces` | Add saved object to namespaces |
+| `deleteFromNamespaces` | Remove saved object from namespaces |
+| `find` | Search for saved objects |
+| `bulkGet` | Retrieve multiple saved objects |
+| `deleteByWorkspace` | Delete saved objects by workspace |
+
+#### Code Change
+
+```typescript
+return {
+  ...wrapperOptions.client,
+  create: createWithManageableBy,
+  bulkCreate: bulkCreateWithManageableBy,
+  delete: deleteWithManageableBy,
+  update: updateWithManageableBy,
+  bulkUpdate: bulkUpdateWithManageableBy,
+  // Added missing functions
+  get: wrapperOptions.client.get,
+  checkConflicts: wrapperOptions.client.checkConflicts,
+  errors: wrapperOptions.client.errors,
+  addToNamespaces: wrapperOptions.client.addToNamespaces,
+  deleteFromNamespaces: wrapperOptions.client.deleteFromNamespaces,
+  find: wrapperOptions.client.find,
+  bulkGet: wrapperOptions.client.bulkGet,
+  deleteByWorkspace: wrapperOptions.client.deleteByWorkspace,
+};
+```
+
+### Impact
+
+Without this fix, OpenSearch Dashboards would display an "Internal Server Error" and fail to load properly when the data source permission feature was enabled.
+
+## Limitations
+
+None specific to this fix.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8118](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8118) | Fix data source permission client wrapper error |
+
+## References
+
+- [Data Sources Documentation](https://docs.opensearch.org/2.18/dashboards/management/data-sources/): Official documentation for data sources
+- [Data Source Permissions](https://docs.opensearch.org/2.18/security/access-control/permissions/#data-source-permissions): Permission configuration
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/data-source-permissions.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -9,6 +9,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### OpenSearch Dashboards
 
 - [CI/CD & Build Improvements](features/opensearch-dashboards/cicd-build-dashboards.md) - Switch OSD Optimizer to content-based hashing for CI compatibility
+- [Data Source Permissions](features/opensearch-dashboards/data-source-permissions.md) - Fix missing functions in data source permission saved object wrapper
 - [Dynamic Config](features/opensearch-dashboards/dynamic-config.md) - Bugfixes for config saved objects, global config discovery, and index/alias validation
 - [i18n & Localization](features/opensearch-dashboards/i18n-localization.md) - i18n validation workflows, precommit hook, translation fixes, language selection fix
 - [Data Connections Bugfixes](features/opensearch-dashboards/data-connections-bugfixes.md) - MDS endpoint unification, tabs navigation, type display, auto-complete MDS support


### PR DESCRIPTION
## Summary

This PR adds documentation for the Data Source Permissions bugfix in OpenSearch Dashboards v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch-dashboards/data-source-permissions.md`
- Feature report: `docs/features/opensearch-dashboards/data-source-permissions.md`

### Key Changes in v2.18.0
- Fixed missing saved object client functions in `DataSourcePermissionClientWrapper`
- Added `get`, `checkConflicts`, `errors`, `addToNamespaces`, `deleteFromNamespaces`, `find`, `bulkGet`, and `deleteByWorkspace` functions
- Resolved "Internal Server Error" when opening OpenSearch Dashboards with data source permissions enabled

### Resources Used
- PR: [#8118](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8118)
- Docs: https://docs.opensearch.org/2.18/dashboards/management/data-sources/

Closes #681