### PR TITLE
docs: add Input Control Visualization report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -60,6 +60,7 @@
 - [DOMPurify Sanitization](opensearch-dashboards/dompurify-sanitization.md)
 - [Dynamic Config](opensearch-dashboards/dynamic-config.md)
 - [i18n & Localization](opensearch-dashboards/i18n-localization.md)
+- [Input Control Visualization](opensearch-dashboards/input-control-visualization.md)
 - [OSD Optimizer Cache](opensearch-dashboards/osd-optimizer-cache.md)
 - [Monaco Editor](opensearch-dashboards/monaco-editor.md)
 - [OpenSearch UI (OUI)](opensearch-dashboards/oui.md)

--- a/docs/features/opensearch-dashboards/input-control-visualization.md
+++ b/docs/features/opensearch-dashboards/input-control-visualization.md
@@ -1,0 +1,93 @@
+# Input Control Visualization
+
+## Summary
+
+Input Control Visualization is a panel type in OpenSearch Dashboards that allows users to add interactive filter controls to dashboards. Unlike traditional visualizations, Controls provide interactive inputs that filter data across all visualizations in a dashboard. Users can create two types of controls: **Options list** (dropdown for terms aggregation filtering) and **Range slider** (for filtering within specified value ranges).
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph Dashboard
+        IC[Input Control Panel]
+        V1[Visualization 1]
+        V2[Visualization 2]
+        V3[Visualization 3]
+    end
+    
+    subgraph "Input Control Types"
+        OL[Options List]
+        RS[Range Slider]
+    end
+    
+    IC --> OL
+    IC --> RS
+    OL -->|Filter| V1
+    OL -->|Filter| V2
+    OL -->|Filter| V3
+    RS -->|Filter| V1
+    RS -->|Filter| V2
+    RS -->|Filter| V3
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `input_control_vis` plugin | Core plugin providing Input Control visualization type |
+| `RangeControl` | Component for range slider controls using `ValidatedDualRange` |
+| `ListControl` | Component for dropdown options list controls |
+| `FormRow` | Wrapper component for control layout and labels |
+| `ValidatedDualRange` | EUI-based dual range slider with validation |
+
+### Control Types
+
+| Type | Description | Use Case |
+|------|-------------|----------|
+| Options List | Dropdown selection from terms aggregation | Filter by categorical fields (e.g., `machine.os.keyword`) |
+| Range Slider | Dual-handle slider for numeric ranges | Filter by numeric fields (e.g., `hour_of_day`, `price`) |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `decimalPlaces` | Number of decimal places for range values | `0` |
+| `min` | Minimum value for range slider | Auto-detected from data |
+| `max` | Maximum value for range slider | Auto-detected from data |
+| `disabled` | Whether the control is disabled | `false` |
+
+### Usage Example
+
+To add an Input Control to a dashboard:
+
+1. Navigate to **Visualize** > **Create visualization**
+2. Select **Controls** as the visualization type
+3. Configure control options:
+   - Choose control type (Options list or Range slider)
+   - Select index pattern and field
+   - Configure additional options (label, parent control, etc.)
+4. Save and add to dashboard
+
+## Limitations
+
+- Controls filter data across all visualizations in the dashboard
+- Range slider requires numeric fields
+- Options list works best with keyword fields for exact matching
+- Parent-child control relationships require careful configuration
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#8108](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8108) | Fix disabled ValidatedDualRange component sizing |
+
+## References
+
+- [Building data visualizations](https://docs.opensearch.org/2.18/dashboards/visualize/viz-index/): OpenSearch Dashboards visualization documentation
+- [PR #8108](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8108): Disabled range control sizing fix
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Fixed sizing of disabled ValidatedDualRange components in range slider controls

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/input-control-visualization.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/input-control-visualization.md
@@ -1,0 +1,57 @@
+# Input Control Visualization Bugfix
+
+## Summary
+
+This release fixes a visual sizing issue with disabled `ValidatedDualRange` components in Input Control visualizations. When a range slider control was disabled, it displayed with incorrect dimensions, causing visual inconsistency in dashboards.
+
+## Details
+
+### What's New in v2.18.0
+
+The fix ensures that disabled range slider controls in Input Control visualizations maintain proper sizing by adding the `formRowDisplay="rowCompressed"` property to the disabled state rendering.
+
+### Technical Changes
+
+#### Component Fix
+
+The `RangeControl` component in the `input_control_vis` plugin was updated to include the `formRowDisplay` property when rendering disabled `ValidatedDualRange` components.
+
+| File | Change |
+|------|--------|
+| `src/plugins/input_control_vis/public/components/vis/range_control.tsx` | Added `formRowDisplay="rowCompressed"` to disabled state |
+
+#### Code Change
+
+Before:
+```tsx
+return <ValidatedDualRange disabled showInput />;
+```
+
+After:
+```tsx
+return <ValidatedDualRange disabled showInput formRowDisplay="rowCompressed" />;
+```
+
+### Visual Impact
+
+The fix corrects the height and spacing of disabled range slider controls to match the enabled state, ensuring consistent visual appearance across dashboard controls.
+
+## Limitations
+
+- This fix only affects the visual rendering of disabled range controls
+- No functional changes to the Input Control visualization behavior
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8108](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8108) | Correct the size of disabled ValidatedDualRange components in InputControl visualizations |
+
+## References
+
+- [PR #8108](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8108): Main implementation
+- [Building data visualizations](https://docs.opensearch.org/2.18/dashboards/visualize/viz-index/): OpenSearch Dashboards visualization documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/input-control-visualization.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -9,6 +9,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### OpenSearch Dashboards
 
 - [CI/CD & Build Improvements](features/opensearch-dashboards/cicd-build-dashboards.md) - Switch OSD Optimizer to content-based hashing for CI compatibility
+- [Input Control Visualization](features/opensearch-dashboards/input-control-visualization.md) - Fix disabled ValidatedDualRange component sizing
 - [Data Source Permissions](features/opensearch-dashboards/data-source-permissions.md) - Fix missing functions in data source permission saved object wrapper
 - [Dynamic Config](features/opensearch-dashboards/dynamic-config.md) - Bugfixes for config saved objects, global config discovery, and index/alias validation
 - [i18n & Localization](features/opensearch-dashboards/i18n-localization.md) - i18n validation workflows, precommit hook, translation fixes, language selection fix


### PR DESCRIPTION
## Summary

This PR adds documentation for the Input Control Visualization bugfix in OpenSearch Dashboards v2.18.0.

## Changes

### Release Report
- `docs/releases/v2.18.0/features/opensearch-dashboards/input-control-visualization.md`

### Feature Report
- `docs/features/opensearch-dashboards/input-control-visualization.md`

## Key Changes in v2.18.0

- Fixed sizing of disabled `ValidatedDualRange` components in Input Control visualizations
- Added `formRowDisplay="rowCompressed"` property to maintain consistent visual appearance

## Related Issue

Closes #680

## Related PR

- [opensearch-project/OpenSearch-Dashboards#8108](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8108)