### PR TITLE
docs: add content-management report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -45,6 +45,7 @@
 ## opensearch-dashboards
 
 - [CI/CD & Build Fixes](opensearch-dashboards/ci-cd-build-fixes.md)
+- [Content Management](opensearch-dashboards/content-management.md)
 - [Cross-Cluster Search](opensearch-dashboards/cross-cluster-search.md)
 - [Dashboards CI/CD & Documentation](opensearch-dashboards/dashboards-ci-cd-documentation.md)
 - [Dashboards Cypress Testing](opensearch-dashboards/dashboards-cypress-testing.md)

--- a/docs/features/opensearch-dashboards/content-management.md
+++ b/docs/features/opensearch-dashboards/content-management.md
@@ -1,0 +1,186 @@
+# Content Management
+
+## Summary
+
+The Content Management plugin is a core OpenSearch Dashboards plugin that provides a framework for dynamically rendering pages with customizable sections. It enables plugins to register content providers and create flexible, composable page layouts using sections that can contain dashboards, cards, or custom content. The plugin is particularly useful for building overview pages and workspace-specific landing pages.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Content Management Plugin"
+        CMS[ContentManagementService]
+        Page[Page Class]
+        Section[Section]
+        Content[Content]
+    end
+    
+    subgraph "Plugin Lifecycle"
+        Setup["Setup Phase"]
+        Start["Start Phase"]
+    end
+    
+    subgraph "External Plugins"
+        Provider[Content Provider]
+        Consumer[Page Consumer]
+    end
+    
+    Setup -->|"registerPage()"| CMS
+    Start -->|"registerContentProvider()"| CMS
+    Start -->|"getPage() / renderPage()"| Consumer
+    
+    CMS --> Page
+    Page --> Section
+    Section --> Content
+    Provider -->|"provides content"| Content
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph Registration
+        RP[Register Page] --> PS[Page Store]
+        RCP[Register Content Provider] --> CP[Content Providers]
+    end
+    
+    subgraph Rendering
+        GP[getPage/renderPage] --> Page
+        Page --> Sections$[Sections Observable]
+        Sections$ --> SR[Section Renderer]
+        SR --> ER[Embeddable Renderer]
+    end
+    
+    CP --> Page
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ContentManagementService` | Core service managing pages and content providers |
+| `Page` | Represents a renderable page with sections |
+| `Section` | A container for content (dashboard, card, or custom) |
+| `Content` | Individual content items within sections |
+| `PageRender` | React component for rendering pages |
+| `SectionRender` | React component for rendering sections |
+
+### Section Types
+
+| Type | Description | Use Case |
+|------|-------------|----------|
+| `dashboard` | Embeds a saved dashboard | Overview pages with visualizations |
+| `card` | Displays card-based content | Quick links, summaries |
+| `custom` | Custom React component | Specialized UI elements |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `section.id` | Unique identifier for the section | Required |
+| `section.kind` | Type of section (dashboard/card/custom) | Required |
+| `section.order` | Display order (lower = higher priority) | Required |
+| `section.title` | Optional section title | `undefined` |
+| `section.input` | Section-specific configuration | Varies by kind |
+
+### API Reference
+
+#### Setup Phase
+
+```typescript
+interface ContentManagementPluginSetup {
+  registerPage: (pageConfig: PageConfig) => void;
+}
+```
+
+#### Start Phase
+
+```typescript
+interface ContentManagementPluginStart {
+  registerContentProvider: (provider: ContentProvider) => void;
+  updatePageSection: (
+    targetArea: string,
+    callback: (section: Section | null, err?: Error) => Section | null
+  ) => void;
+  getPage: (id: string) => Page | undefined;  // Added in v2.18.0
+  renderPage: (id: string, options?: RenderOptions) => React.ReactNode;
+}
+```
+
+#### Page Class Methods
+
+```typescript
+class Page {
+  createSection(section: Section): void;
+  removeSection(id: string): void;  // Added in v2.18.0
+  getSections(): Section[];
+  getSections$(): BehaviorSubject<Section[]>;
+  updateSectionInput(sectionId: string, callback: Function): void;
+  addContent(sectionId: string, content: Content): void;
+  getContents(sectionId: string): Content[];
+  getContents$(sectionId: string): BehaviorSubject<Content[]>;
+}
+```
+
+### Usage Example
+
+```typescript
+// Setup phase: Register a page
+class MyPlugin {
+  setup(core, { contentManagement }) {
+    contentManagement.registerPage({ id: 'my-overview' });
+  }
+
+  start(core, { contentManagement }) {
+    // Register a content provider
+    contentManagement.registerContentProvider({
+      id: 'my-provider',
+      getContent: () => ({
+        id: 'my-content',
+        kind: 'card',
+        order: 100,
+        title: 'Quick Actions',
+        // ... card configuration
+      }),
+      getTargetArea: () => 'my-overview/section1',
+    });
+
+    // Get page and manipulate sections
+    const page = contentManagement.getPage('my-overview');
+    if (page) {
+      page.removeSection('unwanted-section');
+    }
+
+    // Render the page
+    return contentManagement.renderPage('my-overview');
+  }
+}
+```
+
+## Limitations
+
+- The `getPage` API is marked as experimental and may change in future releases
+- Dashboard sections are exclusive - one section can only hold one dashboard
+- Content providers must be registered during the start phase
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#8624](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8624) | Add Page API to allow remove section |
+| v2.17.0 | [#7651](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7651) | Allow updating section input after page rendered |
+| v2.17.0 | [#7633](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7633) | Fix content provider ID exception handling |
+| v2.16.0 | [#7201](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7201) | Initial implementation - new core plugin for dynamic content rendering |
+
+## References
+
+- [PR #7228](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7228): RFC for Content Management plugin
+- [Source Code](https://github.com/opensearch-project/OpenSearch-Dashboards/tree/main/src/plugins/content_management): Plugin implementation
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Added `getPage` API and `removeSection` method; UI fix for card section spacing
+- **v2.17.0** (2024-09-17): Added `updatePageSection` API for dynamic section input updates
+- **v2.16.0** (2024-08-06): Initial implementation with page registration, content providers, and section rendering

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/content-management.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/content-management.md
@@ -1,0 +1,114 @@
+# Content Management
+
+## Summary
+
+This release adds a new Page API to the Content Management plugin that allows programmatic removal of sections from dynamically rendered pages. Additionally, it includes a UI fix that removes unnecessary spacing when card section titles are not displayed.
+
+## Details
+
+### What's New in v2.18.0
+
+The Content Management plugin receives two enhancements:
+
+1. **New `getPage` API**: Exposes the Page object to allow plugins to access and manipulate page sections directly
+2. **New `removeSection` method**: Enables removal of sections from a page by section ID
+3. **UI improvement**: Removes unnecessary `<EuiSpacer />` component when card section title is not shown
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Content Management Plugin"
+        CMS[ContentManagementService]
+        Page[Page Class]
+        Section[Section]
+    end
+    
+    subgraph "Plugin API (Start)"
+        getPage["getPage(id)"]
+        renderPage["renderPage(id)"]
+        updatePageSection["updatePageSection()"]
+        registerContentProvider["registerContentProvider()"]
+    end
+    
+    CMS --> Page
+    Page --> Section
+    getPage --> Page
+    Page -->|"removeSection(id)"| Section
+```
+
+#### New API Methods
+
+| Method | Description | Return Type |
+|--------|-------------|-------------|
+| `getPage(id: string)` | Retrieves a Page object by ID | `Page \| undefined` |
+| `page.removeSection(id: string)` | Removes a section from the page | `void` |
+
+#### API Changes
+
+The `ContentManagementPluginStart` interface now exposes a new `getPage` method:
+
+```typescript
+export interface ContentManagementPluginStart {
+  /**
+   * @experimental this API is experimental and might change in future releases
+   */
+  getPage: (id: string) => Page | undefined;
+  // ... existing methods
+}
+```
+
+The `Page` class adds a new `removeSection` method:
+
+```typescript
+class Page {
+  removeSection(id: string) {
+    this.sections.delete(id);
+    this.sections$.next(this.getSections());
+  }
+}
+```
+
+### Usage Example
+
+```typescript
+// Get the content management plugin start contract
+const contentManagement = core.getStartServices().then(([, plugins]) => {
+  return plugins.contentManagement;
+});
+
+// Get a page and remove a section
+const page = contentManagement.getPage('homepage');
+if (page) {
+  // Remove a specific section by ID
+  page.removeSection('unwanted-section-id');
+}
+```
+
+### Migration Notes
+
+This is an additive change with no breaking changes. Existing code continues to work without modification.
+
+## Limitations
+
+- The `getPage` API is marked as experimental and may change in future releases
+- Section removal is immediate and triggers a re-render via RxJS BehaviorSubject
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8624](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8624) | Add Page API to allow remove section |
+| [#8631](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8631) | Backport to 2.x branch |
+
+## References
+
+- [PR #8624](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8624): Main implementation
+- [PR #7201](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7201): Original Content Management plugin introduction (v2.16.0)
+- [PR #7651](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7651): Update section input API (v2.17.0)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/content-management.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -8,6 +8,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### OpenSearch Dashboards
 
+- [Content Management](features/opensearch-dashboards/content-management.md) - Add Page API to allow remove section
 - [Discover](features/opensearch-dashboards/discover.md) - Data summary panel, updated appearance, cache management, and bug fixes
 - [CI/CD & Build Improvements](features/opensearch-dashboards/cicd-build-dashboards.md) - Switch OSD Optimizer to content-based hashing for CI compatibility
 - [Input Control Visualization](features/opensearch-dashboards/input-control-visualization.md) - Fix disabled ValidatedDualRange component sizing


### PR DESCRIPTION
## Summary

This PR adds documentation for the Content Management plugin enhancement in OpenSearch Dashboards v2.18.0.

### Changes in v2.18.0
- New `getPage` API to retrieve Page objects by ID
- New `removeSection` method on Page class to programmatically remove sections
- UI fix: Removed unnecessary spacing when card section title is not shown

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch-dashboards/content-management.md`
- Feature report: `docs/features/opensearch-dashboards/content-management.md` (new)

### Related PR
- [opensearch-project/OpenSearch-Dashboards#8624](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8624)