### PR TITLE
docs: add query-editor report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -66,6 +66,7 @@
 - [Monaco Editor](opensearch-dashboards/monaco-editor.md)
 - [OpenSearch UI (OUI)](opensearch-dashboards/oui.md)
 - [Query Enhancements](opensearch-dashboards/query-enhancements.md)
+- [Query Editor](opensearch-dashboards/query-editor.md)
 - [Sample Data](opensearch-dashboards/sample-data.md)
 - [TSVB Visualization](opensearch-dashboards/tsvb-visualization.md)
 - [Workspace](opensearch-dashboards/workspace.md)

--- a/docs/features/opensearch-dashboards/query-editor.md
+++ b/docs/features/opensearch-dashboards/query-editor.md
@@ -1,0 +1,142 @@
+# Query Editor
+
+## Summary
+
+The Query Editor is a core component of OpenSearch Dashboards that provides an interface for writing and executing queries in various query languages including DQL (Dashboards Query Language), PPL (Piped Processing Language), and SQL. It supports both single-line and multi-line editing modes with features like autocomplete, syntax highlighting, query history, and extensibility through plugins.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph QueryEditor["Query Editor"]
+        SingleLine[Single Line Editor]
+        MultiLine[Multi Line Editor]
+        Extensions[Query Editor Extensions]
+        Footer[Footer Bar]
+    end
+    
+    subgraph Languages["Language Support"]
+        DQL[DQL]
+        PPL[PPL]
+        SQL[SQL]
+    end
+    
+    subgraph Features["Features"]
+        Autocomplete[Autocomplete]
+        History[Query History]
+        Results[Query Results]
+    end
+    
+    SingleLine --> Languages
+    MultiLine --> Languages
+    Languages --> Autocomplete
+    QueryEditor --> Features
+    Extensions --> QueryEditor
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    User[User Input] --> Editor[Query Editor]
+    Editor --> Parser[Language Parser]
+    Parser --> Autocomplete[Autocomplete Engine]
+    Autocomplete --> Suggestions[Suggestions]
+    Editor --> Execute[Execute Query]
+    Execute --> Results[Query Results]
+    Results --> Footer[Footer Status]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `QueryEditorUI` | Main query editor React component |
+| `SingleLineInput` | Single-line Monaco editor wrapper |
+| `CodeEditor` | Multi-line Monaco editor wrapper |
+| `QueryEditorExtensions` | Extension point for plugins |
+| `QueryResult` | Query execution status display |
+| `RecentQueriesTable` | Query history panel |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `query.language` | Default query language | `DQL` |
+| `query.dataset` | Associated dataset/index pattern | - |
+| `query.dataset.timeFieldName` | Time field for the dataset | - |
+
+### Query Languages
+
+#### DQL (Dashboards Query Language)
+Simple text-based query language for filtering data:
+```
+status:200 AND response_time:>100
+```
+
+#### PPL (Piped Processing Language)
+Pipe-based query language for data exploration:
+```
+source = logs | where status = 200 | stats count() by host
+```
+
+#### SQL
+Standard SQL syntax for querying:
+```sql
+SELECT * FROM logs WHERE status = 200
+```
+
+### Autocomplete System
+
+The autocomplete system provides context-aware suggestions:
+
+- **Keywords**: Language-specific keywords (source, where, stats, etc.)
+- **Fields**: Index field names from the selected dataset
+- **Functions**: Aggregate and scalar functions
+- **Tables**: Available index patterns/data sources
+
+### Query Editor Extensions
+
+Plugins can extend the query editor through the extension API:
+
+```typescript
+queryEditorExtensions.register({
+  id: 'my-extension',
+  order: 100,
+  isEnabled: async () => true,
+  getComponent: () => MyExtensionComponent,
+});
+```
+
+### Footer Bar
+
+The footer bar displays:
+- Line count
+- Timestamp field name
+- Query execution status (loading/success/error)
+- Recent queries button
+
+## Limitations
+
+- Single-line editor footer only visible when focused
+- PPL and SQL require additional plugins for full functionality
+- Autocomplete suggestions depend on index pattern field mappings
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#8565](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8565) | Adds editor footer to single line editor on focus |
+| v2.18.0 | [#8045](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8045) | Fix order of query editor extensions not working |
+| v2.18.0 | [#8087](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8087) | PPL Autocomplete functions, fields, & table suggestion |
+
+## References
+
+- [Dashboards Query Language (DQL)](https://docs.opensearch.org/2.18/dashboards/dql/): Official DQL documentation
+- [Query Workbench](https://docs.opensearch.org/2.18/dashboards/query-workbench/): Query Workbench documentation
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Added footer bar to single-line editor, fixed query editor extension ordering, improved PPL autocomplete

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/query-editor.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/query-editor.md
@@ -1,0 +1,129 @@
+# Query Editor
+
+## Summary
+
+This release item improves the Query Editor in OpenSearch Dashboards with a new footer bar for single-line editors, fixes for query editor extension ordering, and PPL autocomplete improvements. These changes enhance the user experience when writing queries in Discover and other query-enabled interfaces.
+
+## Details
+
+### What's New in v2.18.0
+
+#### Single Line Editor Footer Bar
+
+A new footer bar has been added to the single-line query editor that appears when the editor is focused. This footer provides:
+
+- Line count display
+- Timestamp field name from the dataset
+- Query result status (loading, success, error)
+- Recent queries access button
+
+The footer improves visibility of query execution status and provides quick access to recent queries without switching to the multi-line editor.
+
+#### Query Editor Extensions Ordering Fix
+
+Fixed an issue where query editor extensions were not rendering in the correct order. When React portals were created asynchronously within the same container, the order could not be guaranteed. The fix creates separate pre-ordered containers for each extension.
+
+#### PPL Autocomplete Improvements
+
+Fixed various issues with PPL (Piped Processing Language) autocomplete:
+
+- Improved function suggestions with aggregate functions (avg, count, sum, min, max, var_samp, var_pop, stddev_samp, stddev_pop)
+- Fixed field and table name suggestions
+- Added proper sorting for keyword suggestions (pipe, comma, operators)
+- Keywords now display in lowercase for better readability
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `queryEditor__footer` | Footer container for single-line editor |
+| `queryEditor__footerItem` | Individual footer item styling |
+| `queryEditor__footerSpacer` | Flexible spacer between footer items |
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph SingleLineEditor
+        Editor[Monaco Editor]
+        Footer[Footer Bar]
+    end
+    
+    subgraph FooterItems
+        LineCount[Line Count]
+        Timestamp[Timestamp Field]
+        QueryResult[Query Result Status]
+        RecentQueries[Recent Queries]
+    end
+    
+    Editor --> Footer
+    Footer --> LineCount
+    Footer --> Timestamp
+    Footer --> QueryResult
+    Footer --> RecentQueries
+```
+
+#### Query Editor Extensions Flow
+
+```mermaid
+flowchart TB
+    subgraph Before["Before Fix"]
+        Container1[Single Container]
+        Ext1A[Extension A]
+        Ext2A[Extension B]
+        Container1 --> Ext1A
+        Container1 --> Ext2A
+    end
+    
+    subgraph After["After Fix"]
+        Container2[Parent Container]
+        ExtContainer1[Extension A Container]
+        ExtContainer2[Extension B Container]
+        Container2 --> ExtContainer1
+        Container2 --> ExtContainer2
+    end
+```
+
+### Usage Example
+
+The footer bar automatically appears when focusing on the single-line query editor:
+
+```
+┌─────────────────────────────────────────────────────────┐
+│ source = logs | where status = 200                      │
+├─────────────────────────────────────────────────────────┤
+│ 1 line  @timestamp  ✓ Completed in 0.5s  Recent queries │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Error Handling Improvements
+
+The query result component now properly surfaces errors from async search strategies:
+
+- Error messages are displayed with proper formatting
+- Status codes are correctly parsed from error responses
+- Loading state shows elapsed time during query execution
+
+## Limitations
+
+- Footer bar only appears when the editor is focused (disappears after 500ms blur timeout)
+- PPL autocomplete improvements are specific to the PPL language; DQL uses different autocomplete logic
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8565](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8565) | Adds editor footer to single line editor on focus |
+| [#8045](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8045) | Fix order of query editor extensions not working |
+| [#8087](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8087) | PPL Autocomplete functions, fields, & table suggestion |
+
+## References
+
+- [Dashboards Query Language (DQL)](https://docs.opensearch.org/2.18/dashboards/dql/): Official DQL documentation
+- [Query Workbench](https://docs.opensearch.org/2.18/dashboards/query-workbench/): Query Workbench documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/query-editor.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -28,3 +28,4 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [UI/UX Bugfixes (2)](features/opensearch-dashboards/ui-ux-bugfixes-2.md) - Responsive design fixes for home page, page header, recent menu, and getting started cards
 - [Workspace Bugfixes](features/opensearch-dashboards/workspace-bugfixes.md) - 13 bug fixes for workspace UI/UX, page crashes, permissions, and navigation
 - [Dashboards Maintenance](features/opensearch-dashboards/dashboards-maintenance.md) - Version bump post 2.17, enhanced search API cleanup
+- [Query Editor](features/opensearch-dashboards/query-editor.md) - Footer bar for single-line editor, extension ordering fix, PPL autocomplete improvements


### PR DESCRIPTION
## Summary

This PR adds documentation for the Query Editor feature in OpenSearch Dashboards v2.18.0.

## Changes in v2.18.0

- **Footer bar for single-line editor**: Adds a footer bar that appears when the editor is focused, showing line count, timestamp field, query status, and recent queries access
- **Query editor extension ordering fix**: Fixed issue where extensions were not rendering in correct order due to async React portal creation
- **PPL autocomplete improvements**: Fixed function, field, and table suggestions; improved keyword sorting and display

## Reports Created

- Release report: `docs/releases/v2.18.0/features/opensearch-dashboards/query-editor.md`
- Feature report: `docs/features/opensearch-dashboards/query-editor.md`

## Related PRs

- [#8565](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8565) - Adds editor footer to single line editor on focus
- [#8045](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8045) - Fix order of query editor extensions not working
- [#8087](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8087) - PPL Autocomplete functions, fields, & table suggestion

Closes #677