### PR TITLE
docs: add navigation-updates report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -62,6 +62,7 @@
 - [Dynamic Config](opensearch-dashboards/dynamic-config.md)
 - [i18n & Localization](opensearch-dashboards/i18n-localization.md)
 - [Input Control Visualization](opensearch-dashboards/input-control-visualization.md)
+- [Navigation](opensearch-dashboards/navigation.md)
 - [OSD Optimizer Cache](opensearch-dashboards/osd-optimizer-cache.md)
 - [Monaco Editor](opensearch-dashboards/monaco-editor.md)
 - [OpenSearch UI (OUI)](opensearch-dashboards/oui.md)

--- a/docs/features/opensearch-dashboards/navigation.md
+++ b/docs/features/opensearch-dashboards/navigation.md
@@ -1,0 +1,138 @@
+# Navigation
+
+## Summary
+
+OpenSearch Dashboards provides a configurable left navigation system that allows users to access various applications and features. The navigation supports multiple use cases (Analytics, Observability, Security Analytics, Search, Essentials) with customizable menu structures. Key features include collapsible navigation, persistent state, responsive design for different screen sizes, and docking/undocking capabilities.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Core Navigation System"
+        Chrome[Chrome Service]
+        NavGroup[Nav Group Manager]
+        LeftNav[Left Navigation Component]
+        StateStore[Navigation State Storage]
+    end
+    
+    subgraph "Navigation Groups"
+        All[Analytics All]
+        Obs[Observability]
+        SecAnalytics[Security Analytics]
+        Search[Search]
+        Essentials[Essentials]
+    end
+    
+    subgraph "Plugin Integration"
+        PluginA[Plugin A]
+        PluginB[Plugin B]
+        PluginC[Plugin C]
+    end
+    
+    Chrome --> NavGroup
+    NavGroup --> LeftNav
+    LeftNav --> StateStore
+    
+    All --> NavGroup
+    Obs --> NavGroup
+    SecAnalytics --> NavGroup
+    Search --> NavGroup
+    Essentials --> NavGroup
+    
+    PluginA --> NavGroup
+    PluginB --> NavGroup
+    PluginC --> NavGroup
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    User[User Action] --> NavComponent[Navigation Component]
+    NavComponent --> StateCheck{Check State}
+    StateCheck -->|Expand| Expand[Expand Navigation]
+    StateCheck -->|Collapse| Collapse[Collapse Navigation]
+    Expand --> SaveState[Save to Storage]
+    Collapse --> SaveState
+    SaveState --> LocalStorage[Browser Local Storage]
+    
+    PageLoad[Page Load] --> LoadState[Load Saved State]
+    LoadState --> LocalStorage
+    LoadState --> ApplyState[Apply Navigation State]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Chrome Service | Core service managing browser chrome including navigation |
+| Nav Group Manager | Manages navigation groups and their associated links |
+| Left Navigation Component | UI component rendering the collapsible left navigation |
+| Navigation State Storage | Persists navigation expand/collapse state |
+| Responsive Handler | Manages navigation behavior across screen sizes |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `navGroupEnabled` | Enable the new navigation group system | `false` |
+| `showInAllNavGroup` | Show link in Analytics(all) nav group | `false` |
+| Navigation dock state | Docked or undocked navigation | Docked |
+
+### Usage Example
+
+#### Docking/Undocking Navigation
+
+Users can dock or undock the navigation menu:
+1. Select the menu icon on the upper-left toolbar
+2. Select "Dock navigation" or "Undock navigation" at the bottom of the menu
+
+#### Plugin Navigation Registration
+
+```typescript
+// Register navigation links for a plugin
+public setup(core: CoreSetup) {
+  core.chrome.navGroup.addNavLinksToGroup(
+    DEFAULT_NAV_GROUPS.all,
+    [{
+      id: 'myPlugin',
+      title: 'My Plugin',
+      category: AppCategory.detect,
+      showInAllNavGroup: true,
+      order: 100
+    }]
+  );
+}
+```
+
+#### Responsive Navigation
+
+The navigation automatically adapts to screen size:
+- **Large screens**: Full navigation with expand/collapse
+- **Small screens**: Collapsed by default, overlay when expanded
+
+## Limitations
+
+- Navigation state is stored in browser local storage (not synced across devices)
+- Custom navigation configurations require plugin code changes
+- Some legacy plugins may not fully support the new navigation system
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#8332](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8332) | Flatten left nav in Analytics(all) use case |
+| v2.18.0 | [#8286](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8286) | Remember state when expand/collapse left nav |
+| v2.18.0 | [#8489](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8489) | Update border style when new left nav expanded |
+| v2.18.0 | [#8076](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8076) | Add sample data menu back |
+| v2.18.0 | [#7962](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7962) | Make left nav compatible with small screen |
+
+## References
+
+- [OpenSearch Dashboards Quickstart Guide](https://docs.opensearch.org/2.18/dashboards/quickstart/): Official documentation on navigation
+
+## Change History
+
+- **v2.18.0** (2024-10-22): Flattened navigation in Analytics(all) use case, persistent expand/collapse state, small screen compatibility, border style updates, sample data menu restored

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/navigation-updates.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/navigation-updates.md
@@ -1,0 +1,125 @@
+# Navigation Updates
+
+## Summary
+
+OpenSearch Dashboards v2.18.0 introduces significant improvements to the left navigation menu, including flattened menu structure in the Analytics(all) use case, persistent expand/collapse state, improved small screen compatibility, and visual refinements. These changes enhance usability by reducing navigation depth and improving the overall user experience across different screen sizes.
+
+## Details
+
+### What's New in v2.18.0
+
+This release focuses on navigation UX improvements across OpenSearch Dashboards and multiple plugins:
+
+1. **Flattened Navigation in Analytics(all) Use Case**: Multi-level navigation menus are flattened to reduce context switching and confusion
+2. **Persistent Navigation State**: The left nav remembers its expanded/collapsed state across sessions
+3. **Small Screen Compatibility**: Improved responsive behavior for mobile devices and smaller screens
+4. **Visual Refinements**: Updated border styling when the navigation is expanded (shadow replaced with border)
+5. **Sample Data Menu**: Re-added the sample data menu item for easier access to sample datasets
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Navigation System"
+        NavGroup[Nav Group Manager]
+        LeftNav[Left Navigation Component]
+        StateStore[Navigation State Storage]
+    end
+    
+    subgraph "Use Cases"
+        Analytics[Analytics All]
+        Observability[Observability]
+        Security[Security Analytics]
+        Search[Search]
+        Essentials[Essentials]
+    end
+    
+    subgraph "Plugins"
+        Alerting[Alerting Plugin]
+        AD[Anomaly Detection Plugin]
+        Maps[Maps Plugin]
+        Obs[Observability Plugin]
+    end
+    
+    NavGroup --> LeftNav
+    LeftNav --> StateStore
+    Analytics --> NavGroup
+    Observability --> NavGroup
+    Security --> NavGroup
+    Search --> NavGroup
+    Essentials --> NavGroup
+    
+    Alerting --> Analytics
+    AD --> Analytics
+    Maps --> Analytics
+    Obs --> Analytics
+```
+
+#### Key Components
+
+| Component | Description |
+|-----------|-------------|
+| `CollapsibleNavGroupEnabled` | Controls the new collapsible navigation behavior |
+| `showInAllNavGroup` | Property to show links within nav group category for backward compatibility |
+| Navigation State Storage | Persists expand/collapse state using browser storage |
+| Responsive Nav Handler | Manages navigation behavior on different screen sizes |
+
+#### UI Changes
+
+| Change | Before | After |
+|--------|--------|-------|
+| Menu Structure | Multi-level nested menus | Flattened single-level menus |
+| Expand State | Not persisted | Persisted across sessions |
+| Border Style | Shadow effect | Clean border line |
+| Small Screen | Limited support | Full responsive support |
+
+### Usage Example
+
+The navigation changes are automatic when `navGroupEnabled` is set. Plugins register their navigation items with the appropriate category:
+
+```typescript
+// Plugin registration with flattened category
+core.chrome.navGroup.addNavLinksToGroup(
+  DEFAULT_NAV_GROUPS.all,
+  [{
+    id: 'myPlugin',
+    category: AppCategory.detect, // Flattened in Analytics(all)
+    showInAllNavGroup: true
+  }]
+);
+```
+
+### Migration Notes
+
+- Plugin developers should update their navigation category registrations to align with the flattened structure
+- The `showInAllNavGroup` property ensures backward compatibility for existing plugins
+- No user action required - changes apply automatically
+
+## Limitations
+
+- Navigation state persistence uses browser local storage, so state is not synced across devices
+- Some plugins may need updates to fully support the flattened navigation structure
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#8332](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8332) | OpenSearch-Dashboards | Flatten left nav in Analytics(all) use case |
+| [#8286](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8286) | OpenSearch-Dashboards | Remember state when expand/collapse left nav |
+| [#8489](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8489) | OpenSearch-Dashboards | Update border style when new left nav expanded |
+| [#8076](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8076) | OpenSearch-Dashboards | Add sample data menu back |
+| [#7962](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7962) | OpenSearch-Dashboards | Make left nav compatible with small screen |
+| [#674](https://github.com/opensearch-project/dashboards-maps/pull/674) | dashboards-maps | Update category to flatten menus |
+| [#883](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/883) | anomaly-detection-dashboards-plugin | Update category to flatten menus |
+| [#2182](https://github.com/opensearch-project/dashboards-observability/pull/2182) | dashboards-observability | Update category to flatten menus |
+| [#1114](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1114) | alerting-dashboards-plugin | Update category to flatten menus |
+
+## References
+
+- [OpenSearch Dashboards Quickstart Guide](https://docs.opensearch.org/2.18/dashboards/quickstart/): Documentation on docking/undocking navigation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/navigation.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -8,6 +8,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### OpenSearch Dashboards
 
+- [Navigation Updates](features/opensearch-dashboards/navigation-updates.md) - Flattened navigation, persistent state, small screen support, border style updates
 - [Content Management](features/opensearch-dashboards/content-management.md) - Add Page API to allow remove section
 - [Discover](features/opensearch-dashboards/discover.md) - Data summary panel, updated appearance, cache management, and bug fixes
 - [CI/CD & Build Improvements](features/opensearch-dashboards/cicd-build-dashboards.md) - Switch OSD Optimizer to content-based hashing for CI compatibility


### PR DESCRIPTION
## Summary

This PR adds documentation for the Navigation Updates feature in OpenSearch Dashboards v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch-dashboards/navigation-updates.md`
- Feature report: `docs/features/opensearch-dashboards/navigation.md` (new)

### Key Changes in v2.18.0
- Flattened navigation in Analytics(all) use case to reduce context switching
- Persistent expand/collapse state across sessions
- Small screen compatibility improvements
- Updated border styling (shadow replaced with border)
- Sample data menu restored

### PRs Investigated
- OpenSearch-Dashboards: #8332, #8286, #8489, #8076, #7962
- dashboards-maps: #674
- anomaly-detection-dashboards-plugin: #883
- dashboards-observability: #2182
- alerting-dashboards-plugin: #1114

Closes #675