### PR TITLE
docs: add async-query report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -71,6 +71,7 @@
 - [Sample Data](opensearch-dashboards/sample-data.md)
 - [TSVB Visualization](opensearch-dashboards/tsvb-visualization.md)
 - [Workspace](opensearch-dashboards/workspace.md)
+- [Async Query](opensearch-dashboards/async-query.md)
 
 ## security
 

--- a/docs/features/opensearch-dashboards/async-query.md
+++ b/docs/features/opensearch-dashboards/async-query.md
@@ -1,0 +1,169 @@
+# Async Query
+
+## Summary
+
+Async Query is a feature in OpenSearch Dashboards that enables asynchronous execution of queries against external data sources like Amazon S3. It provides frontend polling mechanisms to handle long-running queries without timeout issues, supporting both SQL and PPL query languages for S3 datasets through Apache Spark integration.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        subgraph "Frontend"
+            Discover[Discover App]
+            SearchSource[SearchSource]
+            Interceptor[Search Interceptor]
+            Poller[Query Poller]
+        end
+        
+        subgraph "Backend"
+            Router[Search Router]
+            PPLAsync[PPL Async Strategy]
+            SQLAsync[SQL Async Strategy]
+            PPL[PPL Strategy]
+            SQL[SQL Strategy]
+        end
+    end
+    
+    subgraph "External"
+        Spark[Apache Spark / EMR]
+        S3[Amazon S3]
+    end
+    
+    Discover --> SearchSource
+    SearchSource --> Interceptor
+    Interceptor --> Poller
+    Interceptor --> Router
+    Router -->|S3 + PPL| PPLAsync
+    Router -->|S3 + SQL| SQLAsync
+    Router -->|Index + PPL| PPL
+    Router -->|Index + SQL| SQL
+    PPLAsync --> Spark
+    SQLAsync --> Spark
+    Spark --> S3
+```
+
+### Data Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Discover
+    participant SearchSource
+    participant Backend
+    participant Spark
+    participant S3
+    
+    User->>Discover: Submit PPL/SQL Query
+    Discover->>SearchSource: Execute search
+    SearchSource->>Backend: Start async query
+    Backend->>Spark: Submit query job
+    Spark-->>Backend: Job ID + Session ID
+    Backend-->>SearchSource: status: started, queryStatusConfig
+    
+    loop Every 5 seconds
+        SearchSource->>Backend: Poll status (queryId)
+        Backend->>Spark: Get job status
+        alt Job Running
+            Spark-->>Backend: status: running
+            Backend-->>SearchSource: status: running
+        else Job Complete
+            Spark->>S3: Fetch results
+            S3-->>Spark: Data
+            Spark-->>Backend: status: success, data
+            Backend-->>SearchSource: DataFrame results
+        else Job Failed
+            Spark-->>Backend: status: failed, error
+            Backend-->>SearchSource: Error response
+        end
+    end
+    
+    SearchSource-->>Discover: Display results
+    Discover-->>User: Show data
+```
+
+### Components
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| `SearchSource` | `src/plugins/data/common/search/search_source/` | Core search execution with polling support |
+| `handleQueryResults` | `src/plugins/data/common/utils/helpers.ts` | RxJS-based polling utility |
+| `PPLSearchInterceptor` | `src/plugins/query_enhancements/public/search/` | Routes PPL queries to appropriate strategy |
+| `SQLSearchInterceptor` | `src/plugins/query_enhancements/public/search/` | Routes SQL queries to appropriate strategy |
+| `pplAsyncSearchStrategyProvider` | `src/plugins/query_enhancements/server/search/` | Server-side PPL async execution |
+| `sqlAsyncSearchStrategyProvider` | `src/plugins/query_enhancements/server/search/` | Server-side SQL async execution |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.query.executionengine.async_query.enabled` | Enable async query execution | `true` |
+| `plugins.query.executionengine.async_query.external_scheduler.interval` | External scheduler check interval | `5 minutes` |
+
+### Search Strategies
+
+| Strategy | Identifier | Use Case |
+|----------|------------|----------|
+| PPL | `ppl` | Synchronous PPL for OpenSearch indexes |
+| PPL Async | `pplasync` | Asynchronous PPL for S3 datasets |
+| SQL | `sql` | Synchronous SQL for OpenSearch indexes |
+| SQL Async | `sqlasync` | Asynchronous SQL for S3 datasets |
+
+### Response Types
+
+```typescript
+// Polling response for async queries
+interface IDataFramePollingResponse {
+  type: DATA_FRAME_TYPES.POLLING;
+  status: 'started' | 'running' | 'success' | 'failed';
+  body?: IDataFrame | QueryStatusConfig | IDataFrameError;
+}
+
+// Query status configuration
+interface QueryStatusConfig {
+  queryId?: string;
+  sessionId?: string;
+}
+```
+
+### Usage Example
+
+PPL query for S3 data:
+```
+source = my_s3_table | head 10
+```
+
+SQL query for S3 data:
+```sql
+SELECT * FROM my_s3_table LIMIT 10
+```
+
+The system automatically detects the dataset type and routes to the appropriate async strategy.
+
+## Limitations
+
+- Fixed 5-second polling interval (not configurable per query)
+- Time filter support for async PPL is limited
+- Requires Apache Spark / EMR Serverless for query execution
+- S3 data source must be configured in OpenSearch Dashboards
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#8481](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8481) | Add logic to poll for async query result |
+| v2.18.0 | [#8706](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8706) | Add support for async PPL to Discover |
+
+## References
+
+- [Scheduled Query Acceleration](https://docs.opensearch.org/latest/dashboards/management/scheduled-query-acceleration/): SQA documentation
+- [Optimizing query performance using OpenSearch indexing](https://docs.opensearch.org/latest/dashboards/management/accelerate-external-data/): Index acceleration for external data
+- [SQL and PPL](https://docs.opensearch.org/latest/search-plugins/sql/index/): SQL/PPL plugin documentation
+- [Query Workbench](https://docs.opensearch.org/latest/dashboards/query-workbench/): Interactive query interface
+- [Connecting Amazon S3 to OpenSearch](https://docs.opensearch.org/latest/dashboards/management/S3-data-source/): S3 data source setup
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Initial implementation with frontend polling and async PPL support for S3 datasets

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/async-query.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/async-query.md
@@ -1,0 +1,151 @@
+# Async Query
+
+## Summary
+
+OpenSearch Dashboards v2.18.0 introduces async query support for Discover, enabling frontend polling for long-running queries against external data sources like Amazon S3. This enhancement prevents frontend timeouts during async search operations and adds PPL (Piped Processing Language) support for S3 datasets.
+
+## Details
+
+### What's New in v2.18.0
+
+This release adds two key capabilities:
+
+1. **Frontend Polling for Async Search**: Previously, async queries relied on the search strategy to poll for results, causing frontend timeouts for queries taking 1-2 minutes. The new implementation moves polling logic to the frontend, allowing queries to complete without timeout issues.
+
+2. **Async PPL Support for Discover**: S3 datasets now support PPL queries in addition to SQL, with a new `pplasync` search strategy that enables asynchronous PPL execution.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards Frontend"
+        UI[Discover UI]
+        SS[SearchSource]
+        SI[Search Interceptor]
+    end
+    
+    subgraph "Backend Search Strategies"
+        PPL[PPL Strategy]
+        SQL[SQL Strategy]
+        PPLA[PPL Async Strategy]
+        SQLA[SQL Async Strategy]
+    end
+    
+    subgraph "External Data Source"
+        S3[Amazon S3]
+        Spark[Apache Spark]
+    end
+    
+    UI --> SS
+    SS --> SI
+    SI -->|S3 Dataset + PPL| PPLA
+    SI -->|S3 Dataset + SQL| SQLA
+    SI -->|OpenSearch Index| PPL
+    SI -->|OpenSearch Index| SQL
+    PPLA --> Spark
+    SQLA --> Spark
+    Spark --> S3
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ppl_async_search_strategy.ts` | Server-side PPL async search strategy for S3 datasets |
+| `handleQueryResults` helper | Frontend utility for polling query status until completion |
+| `IDataFramePollingResponse` | New response type for polling-based async queries |
+| `QueryStatusConfig` | Configuration for tracking async query state |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `SEARCH_STRATEGY.PPL_ASYNC` | Search strategy identifier for async PPL | `pplasync` |
+| `API.PPL_ASYNC_SEARCH` | API endpoint for async PPL search | `/api/enhancements/search/pplasync` |
+
+#### Data Flow
+
+```mermaid
+sequenceDiagram
+    participant UI as Discover UI
+    participant SS as SearchSource
+    participant SI as Search Interceptor
+    participant BE as Backend Strategy
+    participant Spark as Apache Spark
+    
+    UI->>SS: Execute Query
+    SS->>SI: search(request)
+    SI->>BE: Start async query
+    BE->>Spark: Submit query
+    Spark-->>BE: queryId, sessionId
+    BE-->>SI: status: 'started', queryStatusConfig
+    
+    loop Poll until complete
+        SI->>BE: Poll with queryId
+        BE->>Spark: Check status
+        Spark-->>BE: status (running/success/failed)
+        BE-->>SI: Current status
+    end
+    
+    SI-->>SS: Final results
+    SS-->>UI: Display data
+```
+
+### Usage Example
+
+When querying S3 data with PPL in Discover, the default query format is now:
+
+```
+source = ${dataset.title} | head 10
+```
+
+The system automatically:
+1. Detects S3 dataset type
+2. Routes to `pplasync` search strategy
+3. Initiates query and receives `queryId`
+4. Polls for results at 5-second intervals
+5. Returns data when query completes
+
+### API Changes
+
+The search request body now supports polling parameters:
+
+```typescript
+interface PollQueryResultsParams {
+  queryId?: string;
+  sessionId?: string;
+}
+```
+
+Response types include new polling status:
+
+```typescript
+type IDataFramePollingResponse = {
+  type: DATA_FRAME_TYPES.POLLING;
+} & (FetchStatusResponse | QueryStartedResponse);
+```
+
+## Limitations
+
+- Polling interval is fixed at 5 seconds
+- Time filter support for async PPL queries is pending (noted as TODO)
+- Only S3 datasets use async strategies; OpenSearch indexes use synchronous strategies
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8481](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8481) | Add logic to poll for async query result |
+| [#8706](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8706) | Add support for async PPL to Discover |
+
+## References
+
+- [Scheduled Query Acceleration](https://docs.opensearch.org/2.18/dashboards/management/scheduled-query-acceleration/): SQA documentation
+- [SQL and PPL](https://docs.opensearch.org/2.18/search-plugins/sql/index/): SQL/PPL plugin documentation
+- [Query Workbench](https://docs.opensearch.org/2.18/dashboards/query-workbench/): Query Workbench documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/async-query.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -30,3 +30,4 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Workspace Bugfixes](features/opensearch-dashboards/workspace-bugfixes.md) - 13 bug fixes for workspace UI/UX, page crashes, permissions, and navigation
 - [Dashboards Maintenance](features/opensearch-dashboards/dashboards-maintenance.md) - Version bump post 2.17, enhanced search API cleanup
 - [Query Editor](features/opensearch-dashboards/query-editor.md) - Footer bar for single-line editor, extension ordering fix, PPL autocomplete improvements
+- [Async Query](features/opensearch-dashboards/async-query.md) - Frontend polling for async search, async PPL support for S3 datasets


### PR DESCRIPTION
## Summary

Add documentation for the Async Query feature introduced in OpenSearch Dashboards v2.18.0.

### Changes
- **Release report**: `docs/releases/v2.18.0/features/opensearch-dashboards/async-query.md`
- **Feature report**: `docs/features/opensearch-dashboards/async-query.md`
- Updated release and feature indexes

### Key Features Documented
- Frontend polling for async search to prevent timeout issues
- Async PPL support for S3 datasets via `pplasync` search strategy
- Architecture diagrams showing data flow and component interactions

### Related PRs
- opensearch-project/OpenSearch-Dashboards#8481: Add logic to poll for async query result
- opensearch-project/OpenSearch-Dashboards#8706: Add support for async PPL to Discover

Closes #674