### PR TITLE
docs: add sample-data report for v2.18.0

### DIFF
--- a/docs/features/opensearch-dashboards/sample-data.md
+++ b/docs/features/opensearch-dashboards/sample-data.md
@@ -39,6 +39,25 @@ graph TB
     SD --> Patterns
 ```
 
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Installation"
+        User[User] --> Install[Install Sample Data]
+        Install --> CreateIndex[Create Indices]
+        CreateIndex --> LoadData[Load JSON Data]
+        LoadData --> CreateSO[Create Saved Objects]
+    end
+    
+    subgraph "Usage"
+        CreateSO --> Dashboard[View Dashboard]
+        CreateSO --> AppLinks[App Links]
+        AppLinks --> Traces[Trace Analytics]
+        AppLinks --> Services[Service Map]
+    end
+```
+
 ### Components
 
 | Component | Description |
@@ -49,6 +68,8 @@ graph TB
 | Sample E-commerce | E-commerce transaction data |
 | Sample Web Logs | Web server access logs |
 | Sample OTEL Data | OpenTelemetry traces, metrics, logs, and service maps |
+| MountPointPortal | Portal component for rendering DataSourceMenu in header (v2.18.0+) |
+| HeaderControl | Navigation UI component for page description (v2.18.0+) |
 
 ### OTEL Sample Data
 
@@ -56,22 +77,26 @@ The OTEL sample data provides correlated observability signals for an e-commerce
 
 | Index | Description | Time Fields |
 |-------|-------------|-------------|
-| `otel-v1-apm-span-sample` | Trace spans | startTime, endTime |
+| `otel-v1-apm-span-sample` | Trace spans | startTime, endTime, traceGroupFields.endTime |
 | `otel-v1-apm-service-map-sample` | Service dependency map | - |
-| `ss4o_metrics-otel-sample` | Metrics data | @timestamp, startTime, time |
+| `ss4o_metrics-otel-sample` | Metrics data | @timestamp, exemplar.time, startTime, time, observedTimestamp |
 | `ss4o_logs-otel-sample` | Log data | time, observedTime |
 
 ### Configuration
 
 | Setting | Description | Default |
 |---------|-------------|---------|
+| `home:useNewHomePage` | Enable updated UX for sample data page | false |
 | `home.sampleData.otelSpecTitle` | OTEL sample data title | "Sample Observability Logs, Traces, and Metrics" |
 | `home.sampleData.otelSpecDescription` | OTEL sample data description | Includes compatibility note |
+| `indexName` (DataIndexSchema) | Optional custom index name for sample data | - |
+| `newPath` (AppLinkSchema) | Alternative app path for new navigation | - |
+| `appendDatasourceToPath` (AppLinkSchema) | Append datasource ID to navigation path | false |
 
 ### Usage
 
 1. Navigate to OpenSearch Dashboards Home page
-2. Click "Add sample data"
+2. Click "Add sample data" (or "Sample data" with updated UX)
 3. Select the desired sample dataset
 4. Click "Add data" to install
 
@@ -79,26 +104,53 @@ The OTEL sample data provides correlated observability signals for an e-commerce
 
 The OTEL sample data provides quick links to:
 
-- **View traces**: Navigate to `observability-traces#/traces`
-- **View services**: Navigate to `observability-traces#/services`
+- **View traces**: Navigate to `observability-traces#/traces` (or `observability-traces-nav#/traces` with new nav)
+- **View services**: Navigate to `observability-traces#/services` (or `observability-services-nav#/services` with new nav)
+
+### Usage Example
+
+```typescript
+// OTEL sample data app links configuration
+const appLinks: AppLinkSchema[] = [
+  {
+    path: 'observability-traces#/traces',
+    icon: 'apmTrace',
+    label: 'View traces',
+    newPath: 'observability-traces-nav#/traces',
+    appendDatasourceToPath: true,
+  },
+  {
+    path: 'observability-traces#/services',
+    icon: 'graphApp',
+    label: 'View services',
+    newPath: 'observability-services-nav#/services',
+    appendDatasourceToPath: true,
+  },
+];
+```
 
 ## Limitations
 
 - OTEL sample data is compatible only with OpenSearch 2.13+ domains
 - Sample data is for demonstration and learning purposes only
 - Data is static and does not update in real-time
+- OTEL sample data has no associated dashboard; users navigate directly to Trace Analytics
+- Updated UI only visible when `useUpdatedUX` flag is enabled
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.18.0 | [#8291](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8291) | Update sample data page UI when useUpdatedUX enabled |
+| v2.18.0 | [#8587](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8587) | Add support for OTEL sample data - logs, traces and metrics |
 | v2.18.0 | [#8693](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8693) | Update OTEL sample data description with compatible OS version |
 
 ## References
 
+- [Issue #8312](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8312): Update Sample Data Page UI for New Updated UX
 - [OpenSearch Dashboards Quickstart Guide](https://docs.opensearch.org/latest/dashboards/quickstart/): Official documentation on adding sample data
 - [Trace Analytics Getting Started](https://docs.opensearch.org/latest/observing-your-data/trace/getting-started/): Using OTEL data with trace analytics
 
 ## Change History
 
-- **v2.18.0** (2024-11-12): Added compatibility warning to OTEL sample data description (OpenSearch 2.13+ required)
+- **v2.18.0** (2024-11-12): Updated sample data page UI with new UX; Added OTEL sample data for traces, metrics, logs, and service maps; Added compatibility warning to OTEL sample data description (OpenSearch 2.13+ required)

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/sample-data.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/sample-data.md
@@ -1,0 +1,132 @@
+# Sample Data
+
+## Summary
+
+OpenSearch Dashboards v2.18.0 introduces two significant enhancements to the Sample Data feature: an updated UI for the sample data page when the new UX is enabled, and support for OpenTelemetry (OTEL) sample data including logs, traces, and metrics. These changes improve the user experience and provide observability-focused sample datasets for exploring OpenSearch's trace analytics capabilities.
+
+## Details
+
+### What's New in v2.18.0
+
+1. **Updated Sample Data Page UI** (PR #8291)
+   - Data source selector moved to top right corner for consistency with other pages
+   - Removed duplicate "Sample Data" title
+   - Improved layout with `EuiPanel` wrapper when `useUpdatedUX` is enabled
+   - Updated breadcrumbs to show "Sample data" instead of "Add data"
+
+2. **OTEL Sample Data Support** (PR #8587)
+   - New sample dataset with correlated observability signals
+   - Includes traces, metrics, logs, and service maps in OpenTelemetry format
+   - Direct navigation links to Trace Analytics and Services views
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Sample Data Page - Updated UX"
+        Header[HeaderControl]
+        DSM[DataSourceMenu]
+        Portal[MountPointPortal]
+    end
+    
+    subgraph "OTEL Sample Data"
+        OTEL[otelSpecProvider]
+        Traces[Trace Spans Index]
+        Services[Service Map Index]
+        Metrics[Metrics Index]
+        Logs[Logs Index]
+    end
+    
+    subgraph "Navigation"
+        TracesNav[observability-traces-nav]
+        ServicesNav[observability-services-nav]
+    end
+    
+    Header --> Portal
+    Portal --> DSM
+    
+    OTEL --> Traces
+    OTEL --> Services
+    OTEL --> Metrics
+    OTEL --> Logs
+    
+    OTEL --> TracesNav
+    OTEL --> ServicesNav
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `otelSpecProvider` | Provider function for OTEL sample dataset registration |
+| `MountPointPortal` | Portal component for rendering DataSourceMenu in header |
+| `HeaderControl` | Navigation UI component for page description |
+
+#### New OTEL Data Indices
+
+| Index Name | Description | Time Fields |
+|------------|-------------|-------------|
+| `otel-v1-apm-span-sample` | Trace span data | startTime, endTime, traceGroupFields.endTime |
+| `otel-v1-apm-service-map-sample` | Service dependency map | - |
+| `ss4o_metrics-otel-sample` | Metrics data | @timestamp, exemplar.time, startTime, time, observedTimestamp |
+| `ss4o_logs-otel-sample` | Log data | time, observedTime |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `home:useNewHomePage` | Enable updated UX for sample data page | false |
+| `indexName` (DataIndexSchema) | Optional custom index name for sample data | - |
+| `newPath` (AppLinkSchema) | Alternative app path for new navigation | - |
+| `appendDatasourceToPath` (AppLinkSchema) | Append datasource ID to navigation path | false |
+
+### Usage Example
+
+```typescript
+// OTEL sample data app links configuration
+const appLinks: AppLinkSchema[] = [
+  {
+    path: 'observability-traces#/traces',
+    icon: 'apmTrace',
+    label: 'View traces',
+    newPath: 'observability-traces-nav#/traces',
+    appendDatasourceToPath: true,
+  },
+  {
+    path: 'observability-traces#/services',
+    icon: 'graphApp',
+    label: 'View services',
+    newPath: 'observability-services-nav#/services',
+    appendDatasourceToPath: true,
+  },
+];
+```
+
+### Migration Notes
+
+- Enable `home:useNewHomePage` in UI settings to use the updated sample data page UI
+- OTEL sample data does not include a default dashboard; users navigate directly to Trace Analytics
+
+## Limitations
+
+- Updated UI only visible when `useUpdatedUX` flag is enabled
+- OTEL sample data has no associated dashboard (overviewDashboard is empty)
+- OTEL data requires Observability plugin for full functionality
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8291](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8291) | Update sample data page UI when useUpdatedUX enabled |
+| [#8587](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8587) | Add support for OTEL sample data - logs, traces and metrics |
+
+## References
+
+- [Issue #8312](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8312): Update Sample Data Page UI for New Updated UX
+- [OpenSearch Dashboards Quickstart](https://docs.opensearch.org/2.18/dashboards/quickstart/): Adding sample data
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/sample-data.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -23,6 +23,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [OUI Updates](features/opensearch-dashboards/oui-updates.md) - Updates to OpenSearch UI component library (1.13 → 1.15)
 - [Query Enhancements (2)](features/opensearch-dashboards/query-enhancements-2.md) - Async polling, error handling, language compatibility, saved query fixes
 - [Query Enhancements Bugfixes](features/opensearch-dashboards/query-enhancements-bugfixes.md) - Search strategy extensibility, recent query fix, module exports, keyboard shortcuts
+- [Sample Data](features/opensearch-dashboards/sample-data.md) - Updated UI for new UX, OTEL sample data support for traces, metrics, and logs
 - [Sample Data Bugfixes](features/opensearch-dashboards/sample-data-bugfixes.md) - Update OTEL sample data description with compatible OS version
 - [Saved Query UX](features/opensearch-dashboards/saved-query-ux.md) - New flyout-based UI for saved queries, sample queries on no results page
 - [TSVB Visualization](features/opensearch-dashboards/tsvb-visualization-bugfixes.md) - Hidden axis option, per-axis scale setting, compressed input fields


### PR DESCRIPTION
## Summary

Add release and feature reports for Sample Data feature in OpenSearch Dashboards v2.18.0.

## Changes

### Release Report
- `docs/releases/v2.18.0/features/opensearch-dashboards/sample-data.md`

### Feature Report (Updated)
- `docs/features/opensearch-dashboards/sample-data.md`

## Key Changes in v2.18.0

1. **Updated Sample Data Page UI** (PR #8291)
   - Data source selector moved to top right corner
   - Removed duplicate title
   - Improved layout with EuiPanel wrapper when useUpdatedUX enabled

2. **OTEL Sample Data Support** (PR #8587)
   - New sample dataset with OpenTelemetry traces, metrics, logs, and service maps
   - Direct navigation links to Trace Analytics and Services views
   - Custom index names for OTEL data indices

## Related Issue
Closes #670