### PR TITLE
docs: add data connections dataset picker report for v2.18.0

### DIFF
--- a/docs/features/opensearch-dashboards/data-connections.md
+++ b/docs/features/opensearch-dashboards/data-connections.md
@@ -118,12 +118,14 @@ data_source:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.18.0 | [#8255](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8255) | Support data connections and multi-select table in dataset picker |
 | v2.18.0 | [#8460](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8460) | Replace segmented button with tabs |
 | v2.18.0 | [#8492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8492) | Add DataSource type display and Discover redirection |
 | v2.18.0 | [#8503](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8503) | Fix hide local cluster flag in sample data page |
 | v2.18.0 | [#8537](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8537) | Mute non-MDS endpoints when MDS enabled |
 | v2.18.0 | [#8544](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8544) | Direct query connections fit and finish fixes |
 | v2.18.0 | [#8713](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8713) | Add MDS support to auto-complete API |
+| v2.17.0 | [#7925](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7925) | Add data-connection saved object type for external connections |
 | v2.16.0 | [#7143](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7143) | Initial migration of direct query data source to data source management |
 
 ## References
@@ -135,5 +137,6 @@ data_source:
 
 ## Change History
 
-- **v2.18.0** (2024-10-22): UI improvements (tabs navigation, type display), MDS endpoint unification, auto-complete MDS support, fit and finish fixes
+- **v2.18.0** (2024-10-22): Dataset picker data connections support (multi-select table, pagination, search), UI improvements (tabs navigation, type display), MDS endpoint unification, auto-complete MDS support, fit and finish fixes
+- **v2.17.0** (2024-09-17): Added data-connection saved object type for external connections (CloudWatch, Security Lake)
 - **v2.16.0**: Initial migration of direct query data source to data source management plugin

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/data-connections.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/data-connections.md
@@ -1,0 +1,138 @@
+# Data Connections - Dataset Picker Support
+
+## Summary
+
+This release adds support for data connections and multi-select table functionality in the Discover dataset picker. The feature establishes a framework for using external connections (like CloudWatch Logs or Security Lake) in the dataset selector, building on the data-connection saved object type introduced in v2.17.0.
+
+## Details
+
+### What's New in v2.18.0
+
+- **Data Connections Framework**: Sets up the infrastructure for external data connections in the Discover dataset selector
+- **Multi-Select Dataset Table**: New `DatasetTable` component enabling selection of multiple datasets simultaneously
+- **Pagination Support**: Added pagination token support for large dataset lists
+- **Search Functionality**: Integrated search capability within the dataset table
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Dataset Picker"
+        DE[Dataset Explorer]
+        DT[DatasetTable Component]
+        DS[DatasetService]
+    end
+    
+    subgraph "Data Structures"
+        DST[DataStructure]
+        DFO[DataStructureFetchOptions]
+    end
+    
+    subgraph "Connection Types"
+        IDX[Index/Index Pattern]
+        DC[Data Connections]
+    end
+    
+    DE --> DT
+    DE --> DS
+    DT --> DST
+    DS --> DFO
+    DST --> IDX
+    DST --> DC
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `DatasetTable` | Multi-select table component for dataset selection with search and pagination |
+| `DataStructureFetchOptions` | Interface for fetch options including search and pagination token |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `paginationToken` | Token for paginated results in DataStructure | `undefined` |
+| `multiSelect` | Enable multi-select mode in DataStructure | `false` |
+
+#### API Changes
+
+The `DatasetTypeConfig.fetch` method signature was extended:
+
+```typescript
+// Before
+fetch: (services: IDataPluginServices, path: DataStructure[]) => Promise<DataStructure>;
+
+// After
+fetch: (
+  services: IDataPluginServices,
+  path: DataStructure[],
+  options?: DataStructureFetchOptions
+) => Promise<DataStructure>;
+```
+
+New `DataStructureFetchOptions` interface:
+
+```typescript
+interface DataStructureFetchOptions {
+  search?: string;        // Search string to filter results
+  paginationToken?: string; // Token for paginated results
+}
+```
+
+### Usage Example
+
+The dataset picker now supports multi-select mode when `multiSelect` is enabled on a DataStructure:
+
+```typescript
+// DataStructure with multi-select enabled
+const dataStructure: DataStructure = {
+  id: 'connections',
+  title: 'Data Connections',
+  type: 'data-connection',
+  multiSelect: true,
+  paginationToken: 'next-page-token',
+  children: [
+    { id: 'conn1', title: 'CloudWatch Logs', type: 'cloudwatch' },
+    { id: 'conn2', title: 'Security Lake', type: 'security-lake' }
+  ]
+};
+```
+
+When multi-select is enabled, selecting datasets concatenates their IDs with commas:
+
+```typescript
+// Selected: conn1, conn2
+// Result: { id: 'conn1,conn2', title: 'CloudWatch Logs,Security Lake', type: 'cloudwatch' }
+```
+
+### Migration Notes
+
+- This PR establishes the framework only; specific connection types (CloudWatch, Security Lake) are not included
+- Existing dataset picker functionality remains unchanged for single-select scenarios
+- The `data-connection` saved object type from PR #7925 is a prerequisite
+
+## Limitations
+
+- No specific external connection types are implemented in this PR (framework only)
+- UX is not finalized (as noted in the PR description)
+- Multi-select requires all selected items to be of the same type
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8255](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8255) | Support data connections and multi-select table in dataset picker |
+| [#7925](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7925) | Add data-connection saved object type for external connections |
+
+## References
+
+- [PR #8255](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8255): Main implementation
+- [PR #7925](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7925): Data-connection saved object type (prerequisite)
+- [Data Sources Documentation](https://docs.opensearch.org/2.18/dashboards/management/data-sources/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/data-connections.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -16,6 +16,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Data Source Permissions](features/opensearch-dashboards/data-source-permissions.md) - Fix missing functions in data source permission saved object wrapper
 - [Dynamic Config](features/opensearch-dashboards/dynamic-config.md) - Bugfixes for config saved objects, global config discovery, and index/alias validation
 - [i18n & Localization](features/opensearch-dashboards/i18n-localization.md) - i18n validation workflows, precommit hook, translation fixes, language selection fix
+- [Data Connections](features/opensearch-dashboards/data-connections.md) - Dataset picker support for data connections with multi-select table, pagination, and search
 - [Data Connections Bugfixes](features/opensearch-dashboards/data-connections-bugfixes.md) - MDS endpoint unification, tabs navigation, type display, auto-complete MDS support
 - [Dependency Updates](features/opensearch-dashboards/dependency-updates-dashboards.md) - JSON11 upgrade for UTF-8 safety, chokidar bump
 - [Discover Bugfixes (2)](features/opensearch-dashboards/discover-bugfixes-2.md) - S3 fields support, deleted index pattern handling, time field display, saved query loading


### PR DESCRIPTION
## Summary

This PR adds documentation for the Data Connections dataset picker support feature in OpenSearch Dashboards v2.18.0.

### Changes

**Release Report** (`docs/releases/v2.18.0/features/opensearch-dashboards/data-connections.md`):
- Documents PR #8255 which adds data connections and multi-select table support in the dataset picker
- Covers the framework for external connections (CloudWatch, Security Lake)
- Includes architecture diagram, new components, API changes, and usage examples

**Feature Report Update** (`docs/features/opensearch-dashboards/data-connections.md`):
- Added PR #8255 and #7925 to Related PRs table
- Updated Change History with v2.17.0 entry for data-connection saved object type
- Enhanced v2.18.0 entry to include dataset picker support

**Release Index Update** (`docs/releases/v2.18.0/index.md`):
- Added link to new data connections release report

### Key Features Documented

- Multi-select dataset table component (`DatasetTable`)
- Pagination support via `paginationToken`
- Search functionality within dataset table
- `DataStructureFetchOptions` interface for fetch options
- Extended `DatasetTypeConfig.fetch` method signature

### Related Issue

Closes #669