### PR TITLE
docs: add UI/UX Improvements report for v2.18.0

### DIFF
--- a/docs/features/opensearch-dashboards/dashboards-ui-ux-fixes.md
+++ b/docs/features/opensearch-dashboards/dashboards-ui-ux-fixes.md
@@ -101,6 +101,7 @@ graph TB
 | Version | PR | Description |
 |---------|-----|-------------|
 | v3.0.0 | [#9514](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9514) | Make nav icon style compatible with sidecar |
+| v2.18.0 | [#8227](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8227) | Change page title to h1 with xs size for accessibility |
 | v3.0.0 | [#9516](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9516) | Fix data frame null or undefined object conversion error |
 | v3.0.0 | [#9665](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9665) | Fix workspace disabled navigation |
 | v3.0.0 | [#9666](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9666) | Close suggestions after query submission |
@@ -141,4 +142,4 @@ graph TB
 ## Change History
 
 - **v3.0.0** (2025-05-06): Initial collection of UI/UX fixes including navigation, query editor, data source, and Discover improvements
-- **v2.18.0** (2024-11-05): Sidebar tooltips, initial page fixes, dev tools nav group removal, overlay positioning, Chrome 129 workaround, OUI breakpoints, HeaderControl rendering, responsive design fixes
+- **v2.18.0** (2024-11-05): Sidebar tooltips, initial page fixes, dev tools nav group removal, overlay positioning, Chrome 129 workaround, OUI breakpoints, HeaderControl rendering, responsive design fixes, page title semantic improvements (h1 + xs size)

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/ui-ux-improvements.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/ui-ux-improvements.md
@@ -1,0 +1,71 @@
+# UI/UX Improvements
+
+## Summary
+
+This release improves the semantic structure and accessibility of page titles in OpenSearch Dashboards application headers. Page titles are now rendered as proper `<h1>` heading elements with appropriate sizing, enhancing screen reader compatibility and HTML semantics.
+
+## Details
+
+### What's New in v2.18.0
+
+The page title in application headers has been changed from a generic text element to a semantic heading element:
+
+- Changed from `<EuiText size="s">` to `<EuiTitle size="xs"><h1>...</h1></EuiTitle>`
+- Provides proper document structure with `<h1>` as the main page heading
+- Uses extra-small (`xs`) title size to maintain visual consistency
+- Improves accessibility for screen readers and assistive technologies
+
+### Technical Changes
+
+#### Component Changes
+
+| Before | After |
+|--------|-------|
+| `<EuiText size="s">{screenTitle}</EuiText>` | `<EuiTitle size="xs"><h1>{screenTitle}</h1></EuiTitle>` |
+
+#### CSS Updates
+
+The SCSS selector was updated to match the new component:
+
+```scss
+.osdTopNavMenuScreenTitle {
+  // Changed from .euiText to .euiTitle
+  .euiTitle {
+    line-height: $euiFormControlCompressedHeight;
+    white-space: nowrap;
+    overflow: hidden;
+  }
+}
+```
+
+#### Files Changed
+
+| File | Change |
+|------|--------|
+| `src/plugins/navigation/public/top_nav_menu/top_nav_menu.tsx` | Replace EuiText with EuiTitle + h1 |
+| `src/plugins/navigation/public/top_nav_menu/_index.scss` | Update CSS selector |
+
+### Visual Comparison
+
+The change maintains visual consistency across all theme versions (v7, vNext, v9) while improving semantic structure. The page title appearance remains similar but now uses proper heading semantics.
+
+## Limitations
+
+- The change is purely semantic/accessibility focused
+- No visual changes are expected in most cases
+- Custom CSS targeting `.euiText` within page titles may need updates
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8227](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8227) | Change page title of application headers to h1 and xs |
+
+## References
+
+- [PR #8227](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8227): Main implementation
+- [EUI Title Component](https://oui.opensearch.org/1.6/#/display/title): OpenSearch UI title component documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/dashboards-ui-ux-fixes.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -30,6 +30,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [TSVB Visualization](features/opensearch-dashboards/tsvb-visualization-bugfixes.md) - Hidden axis option, per-axis scale setting, compressed input fields
 - [UI/UX Bugfixes](features/opensearch-dashboards/ui-ux-bugfixes.md) - Sidebar tooltips, initial page fixes, overlay positioning, Chrome 129 workaround, OUI breakpoints, HeaderControl rendering
 - [UI/UX Bugfixes (2)](features/opensearch-dashboards/ui-ux-bugfixes-2.md) - Responsive design fixes for home page, page header, recent menu, and getting started cards
+- [UI/UX Improvements](features/opensearch-dashboards/ui-ux-improvements.md) - Page title semantic improvements (h1 + xs size) for accessibility
 - [Workspace](features/opensearch-dashboards/workspace.md) - Workspace-level UI settings, collaborator management, data connection integration, global search bar, ACL auditor
 - [Workspace Bugfixes](features/opensearch-dashboards/workspace-bugfixes.md) - 13 bug fixes for workspace UI/UX, page crashes, permissions, and navigation
 - [Dashboards Maintenance](features/opensearch-dashboards/dashboards-maintenance.md) - Version bump post 2.17, enhanced search API cleanup


### PR DESCRIPTION
## Summary

Add release report for UI/UX Improvements in OpenSearch Dashboards v2.18.0.

### Changes
- Created release report: `docs/releases/v2.18.0/features/opensearch-dashboards/ui-ux-improvements.md`
- Updated feature report: `docs/features/opensearch-dashboards/dashboards-ui-ux-fixes.md`
- Updated release index: `docs/releases/v2.18.0/index.md`

### Key Changes in v2.18.0
- Page titles in application headers changed from `<EuiText>` to `<EuiTitle size="xs"><h1>...</h1></EuiTitle>`
- Improves semantic HTML structure and accessibility for screen readers

### Related PR
- [opensearch-project/OpenSearch-Dashboards#8227](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8227)