### PR TITLE
docs: add dashboards-improvements report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -51,6 +51,7 @@
 - [Dashboards CI/CD & Documentation](opensearch-dashboards/dashboards-ci-cd-documentation.md)
 - [Dashboards Cypress Testing](opensearch-dashboards/dashboards-cypress-testing.md)
 - [Dashboards Frontend Cleanup](opensearch-dashboards/dashboards-frontend-cleanup.md)
+- [Dashboards Improvements](opensearch-dashboards/dashboards-improvements.md)
 - [Dashboards Maintenance](opensearch-dashboards/dashboards-maintenance.md)
 - [Dashboards UI Updates (OUI)](opensearch-dashboards/dashboards-ui-updates.md)
 - [Dashboards UI/UX Fixes](opensearch-dashboards/dashboards-ui-ux-fixes.md)

--- a/docs/features/opensearch-dashboards/dashboards-improvements.md
+++ b/docs/features/opensearch-dashboards/dashboards-improvements.md
@@ -1,0 +1,95 @@
+# Dashboards Improvements
+
+## Summary
+
+The Dashboards Improvements feature enhances the query execution experience in OpenSearch Dashboards by providing visual feedback during long-running queries. Users see a loading indicator with elapsed time counter when queries take longer than 3 seconds, and completion time is displayed when queries finish.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "QueryResult Component"
+        A[Query Submitted] --> B[Start Timer]
+        B --> C{Status Check}
+        C -->|LOADING| D{Elapsed > 3s?}
+        D -->|No| E[Hidden]
+        D -->|Yes| F[Show Spinner + Time]
+        C -->|READY| G[Show Completion Time]
+        C -->|ERROR| H[Show Error Button]
+        H --> I[Error Popover]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[useSearch Hook] --> B[BehaviorSubject data$]
+    B --> C[QueryResult Component]
+    C --> D{Check Status}
+    D -->|LOADING| E[useEffect Timer]
+    E --> F[setElapsedTime]
+    F --> G[Render Loading UI]
+    D -->|READY| H[Render Completion]
+    D -->|ERROR| I[Render Error Popover]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `QueryResult` | React component displaying query execution status |
+| `ResultStatus` | Enum defining query states (UNINITIALIZED, LOADING, READY, NO_RESULTS, ERROR) |
+| `QueryStatus` | Interface for query status with timing information |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `BUFFER_TIME` | Milliseconds before showing loading indicator | 3000 |
+
+### Usage Example
+
+```typescript
+import { QueryResult, QueryStatus, ResultStatus } from './query_result';
+
+// Example usage in a component
+const queryStatus: QueryStatus = {
+  status: ResultStatus.LOADING,
+  startTime: Date.now(),
+};
+
+<QueryResult queryStatus={queryStatus} />
+```
+
+### Display States
+
+| State | Condition | Display |
+|-------|-----------|---------|
+| Hidden | Loading < 3s | Nothing shown |
+| Loading | Loading ≥ 3s | Spinner + "Loading X s" |
+| Complete (fast) | Finished < 1s | Check icon + "Completed in X ms" |
+| Complete (slow) | Finished ≥ 1s | Check icon + "Completed in X.X s" |
+| Error | Query failed | Alert icon + "Error" (clickable for details) |
+
+## Limitations
+
+- Loading indicator has a 3-second buffer before appearing
+- Timer updates at 1-second intervals
+- Only available in query-enabled views (Discover, Query Workbench)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#8212](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8212) | Add loading indicator and counter to query result |
+
+## References
+
+- [PR #8212](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8212): Initial implementation
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Added loading indicator with time counter for query results

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/dashboards-improvements.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/dashboards-improvements.md
@@ -1,0 +1,106 @@
+# Dashboards Improvements
+
+## Summary
+
+This release adds a loading indicator with time counter to query results in OpenSearch Dashboards. When queries take longer than 3 seconds, users see a visual loading spinner with elapsed time, improving the user experience during long-running queries.
+
+## Details
+
+### What's New in v2.18.0
+
+The `QueryResult` component now displays query execution status with intelligent timing:
+
+- **Loading indicator**: Appears after 3 seconds of query execution with elapsed time counter
+- **Completion time display**: Shows execution time in milliseconds (< 1s) or seconds (≥ 1s)
+- **Error handling**: Displays error details in a popover when queries fail
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Query Execution Flow"
+        A[User Submits Query] --> B[Query Starts]
+        B --> C{Elapsed > 3s?}
+        C -->|No| D[No Indicator]
+        C -->|Yes| E[Show Loading + Timer]
+        E --> F{Query Complete?}
+        D --> F
+        F -->|Success| G[Show Completion Time]
+        F -->|Error| H[Show Error Popover]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `QueryResult` | Enhanced component with loading state and time tracking |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `BUFFER_TIME` | Delay before showing loading indicator | 3000 ms |
+
+#### State Management
+
+The component uses React hooks for state management:
+
+- `useState` for popover visibility and elapsed time tracking
+- `useEffect` for interval-based time updates (1 second intervals)
+- `startTime` property added to `QueryStatus` interface for tracking query start
+
+### Usage Example
+
+The loading indicator automatically appears in the Discover application when running queries:
+
+```typescript
+// QueryStatus interface
+interface QueryStatus {
+  status: ResultStatus;
+  body?: { error?: { ... } };
+  elapsedMs?: number;
+  startTime?: number;  // New in v2.18.0
+}
+
+// Status values
+enum ResultStatus {
+  UNINITIALIZED = 'uninitialized',
+  LOADING = 'loading',
+  READY = 'ready',
+  NO_RESULTS = 'none',
+  ERROR = 'error',
+}
+```
+
+### Display Behavior
+
+| Query Duration | Display |
+|----------------|---------|
+| < 3 seconds | No loading indicator |
+| ≥ 3 seconds | "Loading X s" with spinner |
+| Completed < 1s | "Completed in X ms" |
+| Completed ≥ 1s | "Completed in X.X s" |
+| Error | "Error" button with details popover |
+
+## Limitations
+
+- Loading indicator only appears after 3 second buffer time
+- Time counter updates every 1 second (not real-time)
+- Only applies to Discover and query-enabled views
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8212](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8212) | Add loading indicator and counter to query result |
+
+## References
+
+- [PR #8212](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8212): Implementation PR
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/dashboards-improvements.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -36,3 +36,4 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Dashboards Maintenance](features/opensearch-dashboards/dashboards-maintenance.md) - Version bump post 2.17, enhanced search API cleanup
 - [Query Editor](features/opensearch-dashboards/query-editor.md) - Footer bar for single-line editor, extension ordering fix, PPL autocomplete improvements
 - [Async Query](features/opensearch-dashboards/async-query.md) - Frontend polling for async search, async PPL support for S3 datasets
+- [Dashboards Improvements](features/opensearch-dashboards/dashboards-improvements.md) - Loading indicator with time counter for query results


### PR DESCRIPTION
## Summary

Adds documentation for the Dashboards Improvements feature in OpenSearch v2.18.0.

### Changes
- Release report: `docs/releases/v2.18.0/features/opensearch-dashboards/dashboards-improvements.md`
- Feature report: `docs/features/opensearch-dashboards/dashboards-improvements.md`
- Updated release index and features index

### Feature Overview
This release adds a loading indicator with time counter to query results in OpenSearch Dashboards:
- Loading indicator appears after 3 seconds with elapsed time counter
- Completion time displayed in milliseconds (< 1s) or seconds (≥ 1s)
- Error handling with details popover

### Related
- PR: opensearch-project/OpenSearch-Dashboards#8212
- Issue: #667