### PR TITLE
docs: add experimental-features report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -62,6 +62,7 @@
 - [Discover](opensearch-dashboards/discover.md)
 - [DOMPurify Sanitization](opensearch-dashboards/dompurify-sanitization.md)
 - [Dynamic Config](opensearch-dashboards/dynamic-config.md)
+- [Experimental Features](opensearch-dashboards/experimental-features.md)
 - [i18n & Localization](opensearch-dashboards/i18n-localization.md)
 - [Input Control Visualization](opensearch-dashboards/input-control-visualization.md)
 - [Monaco Editor](opensearch-dashboards/monaco-editor.md)

--- a/docs/features/opensearch-dashboards/experimental-features.md
+++ b/docs/features/opensearch-dashboards/experimental-features.md
@@ -1,0 +1,173 @@
+# Experimental Features - User Personal Settings
+
+## Summary
+
+User Personal Settings is an experimental feature in OpenSearch Dashboards that enables individual users to customize their dashboard preferences independently from global settings. This feature introduces a scoped settings architecture where settings can be defined as `global`, `user`, or both, allowing for personalized user experiences while maintaining system-wide defaults.
+
+Key benefits:
+- Users can customize preferences without affecting other users
+- Settings are persisted per user identity
+- Seamless integration with existing uiSettings infrastructure
+- Optional permission control via ACL
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Frontend"
+        USP[User Settings Page]
+        ASP[Advanced Settings Page]
+        USC_FE[UiSettings Client]
+    end
+    
+    subgraph "Backend"
+        Routes[Settings Routes]
+        USC_BE[UiSettingsClient]
+        Wrapper[UserUISettingsClientWrapper]
+        SOC[SavedObjectsClient]
+    end
+    
+    subgraph "Storage"
+        GlobalSO[Global Config<br/>type: config<br/>id: version]
+        UserSO[User Config<br/>type: config<br/>id: username]
+    end
+    
+    USP --> USC_FE
+    ASP --> USC_FE
+    USC_FE --> Routes
+    Routes --> USC_BE
+    USC_BE --> Wrapper
+    Wrapper --> SOC
+    SOC --> GlobalSO
+    SOC --> UserSO
+    
+    style USP fill:#e1f5fe
+    style UserSO fill:#e8f5e9
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Read Flow"
+        R1[Get Setting] --> R2{Has Scope?}
+        R2 -->|Yes| R3[Read from specified scope]
+        R2 -->|No| R4[Read from all scopes]
+        R4 --> R5[Merge: User overrides Global]
+        R3 --> R6[Return value]
+        R5 --> R6
+    end
+    
+    subgraph "Write Flow"
+        W1[Set Setting] --> W2{Has Scope?}
+        W2 -->|Yes| W3[Write to specified scope]
+        W2 -->|No| W4[Group by setting definition]
+        W4 --> W5[Write global settings]
+        W4 --> W6[Write user settings]
+    end
+```
+
+### Components
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| `UiSettingScope` | `src/core/types/ui_settings.ts` | Enum defining GLOBAL and USER scopes |
+| `UserSettingsApp` | `src/plugins/advanced_settings/public/management_app/user_settings.tsx` | React component for user settings page |
+| `UserUISettingsClientWrapper` | `src/plugins/advanced_settings/server/saved_objects/` | Translates user ID placeholders to actual usernames |
+| `CURRENT_USER_PLACEHOLDER` | `src/core/server/ui_settings/utils.ts` | Constant `<current_user>` used as placeholder |
+
+### Configuration
+
+| Setting | Type | Description | Default |
+|---------|------|-------------|---------|
+| `scope` | `UiSettingScope \| UiSettingScope[]` | Defines where the setting is stored | `UiSettingScope.GLOBAL` |
+| `userSettings.enabled` | `boolean` | Capability flag indicating if user settings are available | `false` |
+
+### Usage Example
+
+#### Registering a User-Scoped Setting
+
+```typescript
+import { UiSettingScope } from 'opensearch-dashboards/public';
+
+core.uiSettings.register({
+  'theme:darkMode': {
+    name: 'Dark Mode',
+    value: false,
+    description: 'Enable dark mode for the interface',
+    scope: [UiSettingScope.GLOBAL, UiSettingScope.USER],
+    schema: schema.boolean(),
+  },
+  defaultWorkspace: {
+    name: 'Default Workspace',
+    value: '',
+    description: 'Your default workspace',
+    scope: UiSettingScope.USER,
+    schema: schema.string(),
+  },
+});
+```
+
+#### Reading Settings
+
+```typescript
+// Get merged value (user overrides global)
+const darkMode = await uiSettings.get('theme:darkMode');
+
+// Get specifically from user scope
+const userDarkMode = await uiSettings.get('theme:darkMode', UiSettingScope.USER);
+
+// Get specifically from global scope
+const globalDarkMode = await uiSettings.get('theme:darkMode', UiSettingScope.GLOBAL);
+```
+
+#### Writing Settings
+
+```typescript
+// Write to appropriate scope based on setting definition
+await uiSettings.set('defaultWorkspace', 'workspace-123');
+
+// Explicitly write to user scope
+await uiSettings.set('theme:darkMode', true, UiSettingScope.USER);
+```
+
+#### REST API
+
+```bash
+# Get user settings
+curl -X GET 'http://localhost:5601/api/opensearch-dashboards/settings?scope=user' \
+  -H 'Authorization: Basic <credentials>'
+
+# Set user settings
+curl -X POST 'http://localhost:5601/api/opensearch-dashboards/settings?scope=user' \
+  -H 'Authorization: Basic <credentials>' \
+  -H 'Content-Type: application/json' \
+  -H 'osd-xsrf: osd-fetch' \
+  -d '{"changes": {"defaultWorkspace": "my-workspace"}}'
+```
+
+## Limitations
+
+- **Authentication Required**: User-level settings only work when authentication is enabled
+- **Experimental Status**: Feature is marked experimental and may change in future releases
+- **Nav Groups Required**: User Settings page visibility requires nav groups to be enabled
+- **No Version Migration**: User settings do not automatically migrate between OSD versions (unlike global settings)
+- **Single User Storage**: Settings are stored per username, not supporting multiple profiles per user
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#7953](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7953) | Initial implementation of user level settings |
+
+## References
+
+- [Issue #7821](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7821): RFC - User level settings
+- [Issue #7909](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7909): User setting page feature request
+- [Workspace Documentation](https://docs.opensearch.org/2.18/dashboards/workspace/workspace/): OpenSearch Dashboards Workspace
+
+## Change History
+
+- **v2.18.0** (2024-10-22): Initial implementation with user settings page, scoped uiSettings, and UserUISettingsClientWrapper

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/experimental-features.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/experimental-features.md
@@ -1,0 +1,144 @@
+# Experimental Features - User Personal Settings
+
+## Summary
+
+OpenSearch Dashboards v2.18.0 introduces experimental support for user-level personal settings. This feature allows individual users to customize their dashboard preferences without affecting other users' configurations. The implementation includes a new User Settings page, modifications to the uiSettings client to support scoped settings, and a `UserUISettingsClientWrapper` to translate user ID placeholders to actual user identities.
+
+## Details
+
+### What's New in v2.18.0
+
+This release adds the foundation for user-level settings in OpenSearch Dashboards:
+
+1. **User Settings Page**: A new dedicated page for users to configure personal preferences
+2. **Scoped UI Settings**: Settings can now be defined with `scope: 'user'` to indicate user-level storage
+3. **User ID Translation**: A saved objects client wrapper that translates `<current_user>` placeholders to actual usernames
+4. **Permission Control**: When ACL is enabled, user settings are protected with user-specific permissions
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Client Layer"
+        UI[User Settings Page]
+        API[Settings API]
+    end
+    
+    subgraph "Server Layer"
+        USC[UiSettingsClient]
+        Wrapper[UserUISettingsClientWrapper]
+        SOC[SavedObjectsClient]
+    end
+    
+    subgraph "Storage Layer"
+        Global[Global Config<br/>config:version]
+        User[User Config<br/>config:username]
+    end
+    
+    UI --> API
+    API --> USC
+    USC --> Wrapper
+    Wrapper --> SOC
+    SOC --> Global
+    SOC --> User
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `UserSettingsApp` | React component for the User Settings page |
+| `UserUISettingsClientWrapper` | Saved objects client wrapper for user ID translation |
+| `UiSettingScope` | Enum defining `GLOBAL` and `USER` scopes |
+| `setupUserSettingsPage` | Function to register the user settings page with content management |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `scope` | UiSettings parameter to define setting scope | `UiSettingScope.GLOBAL` |
+| `userSettings.enabled` | Capability flag for user settings feature | `false` (enabled when authenticated) |
+
+#### API Changes
+
+The uiSettings client methods now accept an optional `scope` parameter:
+
+```typescript
+// Get user-scoped setting
+await uiSettings.get(key, UiSettingScope.USER);
+
+// Set user-scoped setting
+await uiSettings.set(key, value, UiSettingScope.USER);
+
+// Get all settings (merges global and user)
+await uiSettings.getAll();
+```
+
+REST API endpoints also support scope via query parameter:
+
+```
+GET /api/opensearch-dashboards/settings?scope=user
+POST /api/opensearch-dashboards/settings?scope=user
+```
+
+### Usage Example
+
+Registering a user-scoped setting:
+
+```typescript
+uiSettings.register({
+  defaultWorkspace: {
+    name: 'Default Workspace',
+    value: '',
+    description: 'The default workspace to load on login',
+    scope: UiSettingScope.USER,
+    schema: schema.string(),
+  },
+});
+```
+
+Setting a user preference via API:
+
+```bash
+curl -X POST http://localhost:5601/api/opensearch-dashboards/settings \
+  -H 'Authorization: Basic <credentials>' \
+  -H 'Content-Type: application/json' \
+  -H 'osd-xsrf: osd-fetch' \
+  -d '{
+    "changes": {
+      "defaultWorkspace": "my-workspace-id"
+    }
+  }'
+```
+
+### Migration Notes
+
+- This feature requires authentication to be enabled for user-level settings to work
+- When security is not enabled, user-scoped settings fall back to global settings
+- Existing global settings are not affected by this change
+- The feature is marked as experimental and may change in future releases
+
+## Limitations
+
+- User settings require OSD authentication to be enabled
+- The User Settings page is only visible when nav groups are enabled
+- User settings are stored per username, not per session
+- No migration path for existing user preferences from other storage mechanisms
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#7953](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7953) | [Workspace] Add User level setting |
+
+## References
+
+- [Issue #7821](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7821): RFC - User level settings
+- [Issue #7909](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7909): User setting page feature request
+- [Workspace Documentation](https://docs.opensearch.org/2.18/dashboards/workspace/workspace/): OpenSearch Dashboards Workspace docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/experimental-features.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -38,3 +38,4 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Async Query](features/opensearch-dashboards/async-query.md) - Frontend polling for async search, async PPL support for S3 datasets
 - [Dashboards Improvements](features/opensearch-dashboards/dashboards-improvements.md) - Loading indicator with time counter for query results
 - [MDS Integration Support](features/opensearch-dashboards/mds-integration-support.md) - Multi Data Source support for Integration feature
+- [Experimental Features](features/opensearch-dashboards/experimental-features.md) - User personal settings with scoped uiSettings and User Settings page


### PR DESCRIPTION
## Summary

This PR adds documentation for the Experimental Features (User Personal Settings) release item in OpenSearch Dashboards v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch-dashboards/experimental-features.md`
- Feature report: `docs/features/opensearch-dashboards/experimental-features.md`

### Key Changes in v2.18.0
- User Settings Page for personal preferences
- Scoped UI Settings (`UiSettingScope.GLOBAL` and `UiSettingScope.USER`)
- `UserUISettingsClientWrapper` for user ID translation
- Permission control via ACL for user settings

### Resources Used
- PR: [#7953](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7953)
- Issue: [#7821](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7821) (RFC)
- Issue: [#7909](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7909) (Feature request)

Closes #663