### PR TITLE
docs: add Dev Tools modal report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -59,6 +59,7 @@
 - [Data Importer](opensearch-dashboards/data-importer.md)
 - [Data Source Permissions](opensearch-dashboards/data-source-permissions.md)
 - [Dependency Updates](opensearch-dashboards/dependency-updates.md)
+- [Dev Tools](opensearch-dashboards/dev-tools.md)
 - [Discover](opensearch-dashboards/discover.md)
 - [DOMPurify Sanitization](opensearch-dashboards/dompurify-sanitization.md)
 - [Dynamic Config](opensearch-dashboards/dynamic-config.md)

--- a/docs/features/opensearch-dashboards/dev-tools.md
+++ b/docs/features/opensearch-dashboards/dev-tools.md
@@ -1,0 +1,124 @@
+# Dev Tools
+
+## Summary
+
+Dev Tools is a development environment in OpenSearch Dashboards that provides an interactive console for running queries, exploring data, and debugging problems. It allows developers and administrators to interact directly with OpenSearch APIs, test queries, and manage cluster configurations without leaving the Dashboards interface.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        subgraph "Dev Tools Plugin"
+            DT[DevToolsIcon] --> Modal[Modal Overlay]
+            Modal --> MainApp[MainApp Component]
+            MainApp --> Router[Router]
+        end
+        
+        subgraph "Console Plugin"
+            Router --> Console[Console Application]
+            Console --> Editor[Query Editor]
+            Console --> Output[Response Output]
+            Console --> TopNav[Top Nav Menu]
+        end
+        
+        subgraph "Services"
+            Console --> HTTP[HTTP Service]
+            Console --> Storage[Local Storage]
+            Console --> DS[Data Source Service]
+        end
+    end
+    
+    HTTP --> OS[OpenSearch Cluster]
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    User -->|Write Query| Editor[Query Editor]
+    Editor -->|Execute| HTTP[HTTP Service]
+    HTTP -->|Request| OS[OpenSearch]
+    OS -->|Response| HTTP
+    HTTP -->|Display| Output[Response Panel]
+    Output -->|View| User
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `DevToolsIcon` | Header icon that opens Dev Tools modal |
+| `MainApp` | Main application wrapper with routing |
+| `DevToolsWrapper` | Container for dev tool applications |
+| `TopNavMenu` | Navigation menu with History, Settings, Help, Export, Import |
+| `Editor` | Split-panel editor with request/response views |
+| `NetworkRequestStatusBar` | Displays request status and timing |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `console:autocomplete` | Enable autocomplete suggestions | `true` |
+| `console:fontSize` | Editor font size | `14` |
+| `console:history` | Enable query history | `true` |
+| `home:useNewHomePage` | Enable modal-based Dev Tools | `false` |
+
+### Usage Example
+
+Access Dev Tools from the OpenSearch Dashboards menu:
+
+**Management > Dev Tools**
+
+Or click the console icon in the header (when new UX is enabled).
+
+```json
+// Example: Search all indices
+GET _search
+{
+  "query": {
+    "match_all": {}
+  }
+}
+
+// Example: Check cluster health
+GET _cluster/health
+
+// Example: List all indices
+GET _cat/indices?v
+```
+
+### Features
+
+- **Query Console**: Interactive editor for running OpenSearch queries
+- **Autocomplete**: Context-aware suggestions for APIs and fields
+- **History**: Access previously executed queries
+- **Import/Export**: Save and load query collections
+- **Multi-line Support**: Write complex queries with proper formatting
+- **Response Formatting**: Pretty-printed JSON responses
+- **Request Timing**: View execution time for queries
+- **Multiple Data Sources**: Connect to different OpenSearch clusters (when MDS enabled)
+
+## Limitations
+
+- Query history is stored in browser local storage
+- Large responses may impact browser performance
+- Modal mode uses in-memory routing (no browser history)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#7938](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7938) | Change dev tools to a modal |
+
+## References
+
+- [Dev Tools Documentation](https://docs.opensearch.org/latest/dashboards/dev-tools/index-dev/): Official documentation
+- [Running queries in the Dev Tools console](https://docs.opensearch.org/latest/dashboards/dev-tools/run-queries/): Query guide
+- [Top 3 scenarios for managing multiple clusters](https://opensearch.org/blog/top-3-scenarios-where-managing-multiple-clusters-with-one-opensearch-dashboards-is-a-life-saver/): Blog post on Dev Tools with MDS
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Changed Dev Tools to render inside a modal overlay for improved UX

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/dev-tools.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/dev-tools.md
@@ -1,0 +1,102 @@
+# Dev Tools Modal
+
+## Summary
+
+In v2.18.0, the Dev Tools console has been transformed from a full-page application to a modal overlay. This change allows users to access the Dev Tools console from anywhere in OpenSearch Dashboards without navigating away from their current context, improving workflow efficiency for developers and administrators.
+
+## Details
+
+### What's New in v2.18.0
+
+The Dev Tools console now renders inside a full-page modal overlay instead of requiring navigation to a separate page. Users can open the console by clicking the Dev Tools icon in the header, work with queries, and close the modal to return to their previous location.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v2.18.0"
+        A1[Header Icon] -->|Navigate| B1[Dev Tools Page]
+        B1 --> C1[Console Plugin]
+    end
+    
+    subgraph "v2.18.0+"
+        A2[Header Icon] -->|Open Modal| B2[EuiOverlayMask]
+        B2 --> C2[Dev Tools Modal Content]
+        C2 --> D2[Console Plugin]
+        C2 --> E2[Data Source Selector]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `DevToolsIcon` | Updated to render modal overlay instead of navigating to app |
+| `MainApp` | Extracted from `renderApp` for reuse in modal context |
+| `EuiOverlayMask` | Full-page modal container with close button |
+| `MemoryRouter` | In-memory routing for modal context |
+
+#### UI Changes
+
+| Element | Change |
+|---------|--------|
+| Top Nav Menu | New layout with `useUpdatedUX` flag for modal context |
+| Menu Items | Repositioned with left/right positioning support |
+| Network Status Bar | Integrated into top nav for updated UX |
+| Close Button | Added at bottom of modal for easy dismissal |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `useUpdatedUX` | Enables modal-optimized UI layout | `true` in modal |
+| `MenuItemPosition.LEFT` | Position menu items on left side | - |
+| `MenuItemPosition.RIGHT` | Position menu items on right side | - |
+
+### Usage Example
+
+The Dev Tools modal is accessed via the header icon:
+
+1. Click the Dev Tools icon (console icon) in the OpenSearch Dashboards header
+2. The modal opens as a full-page overlay
+3. Use the console to run queries against OpenSearch
+4. Click "Close" button or the X icon to dismiss the modal
+
+```typescript
+// Modal is triggered by clicking the DevToolsIcon component
+<DevToolsIcon
+  core={core}
+  devTools={devTools}
+  deps={deps}
+  title="Dev Tools"
+/>
+```
+
+### Migration Notes
+
+- No migration required - the feature is automatically enabled with the new navigation UX
+- The traditional full-page Dev Tools application remains available for direct navigation
+- Modal behavior is controlled by the `home:useNewHomePage` UI setting
+
+## Limitations
+
+- Modal context uses `MemoryRouter`, so browser back/forward navigation doesn't work within the modal
+- The modal covers the entire viewport, hiding the underlying page content
+- When multiple overlay masks exist, closing the Dev Tools modal may affect scroll behavior
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#7938](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7938) | Change dev tools to a modal |
+
+## References
+
+- [Dev Tools Documentation](https://docs.opensearch.org/2.18/dashboards/dev-tools/index-dev/): Official documentation
+- [Running queries in the Dev Tools console](https://docs.opensearch.org/2.18/dashboards/dev-tools/run-queries/): Query guide
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/dev-tools.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -8,6 +8,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### OpenSearch Dashboards
 
+- [Dev Tools Modal](features/opensearch-dashboards/dev-tools.md) - Dev Tools console rendered as a modal overlay for improved workflow
 - [Navigation Updates](features/opensearch-dashboards/navigation-updates.md) - Flattened navigation, persistent state, small screen support, border style updates
 - [Content Management](features/opensearch-dashboards/content-management.md) - Add Page API to allow remove section
 - [Discover](features/opensearch-dashboards/discover.md) - Data summary panel, updated appearance, cache management, and bug fixes


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dev Tools modal feature introduced in OpenSearch Dashboards v2.18.0.

### Changes

- **Release Report**: `docs/releases/v2.18.0/features/opensearch-dashboards/dev-tools.md`
  - Documents the change from full-page to modal-based Dev Tools
  - Includes architecture diagrams, component details, and usage examples

- **Feature Report**: `docs/features/opensearch-dashboards/dev-tools.md`
  - Comprehensive documentation of the Dev Tools feature
  - Covers architecture, data flow, configuration, and usage

### Related Issue

Closes #662

### Key Changes in v2.18.0

- Dev Tools now renders inside a full-page modal overlay
- Users can access the console from anywhere without navigating away
- New `useUpdatedUX` flag for modal-optimized UI layout
- Menu items repositioned with left/right positioning support