### PR TITLE
docs: add security-cve-fixes-dashboards report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -74,6 +74,7 @@
 - [Query Enhancements](opensearch-dashboards/query-enhancements.md)
 - [Sample Data](opensearch-dashboards/sample-data.md)
 - [Saved Query UX](opensearch-dashboards/saved-query-ux.md)
+- [Security CVE Fixes](opensearch-dashboards/security-cve-fixes.md)
 - [TSVB Visualization](opensearch-dashboards/tsvb-visualization.md)
 - [Workspace](opensearch-dashboards/workspace.md)
 

--- a/docs/features/opensearch-dashboards/security-cve-fixes.md
+++ b/docs/features/opensearch-dashboards/security-cve-fixes.md
@@ -1,0 +1,93 @@
+# Security CVE Fixes (Dashboards)
+
+## Summary
+
+OpenSearch Dashboards maintains security by regularly updating npm dependencies to address known CVEs (Common Vulnerabilities and Exposures). This ongoing effort ensures that the dashboard application remains protected against security vulnerabilities in third-party libraries.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        OSD[OSD Application]
+        subgraph "Security-Critical Dependencies"
+            AXIOS[axios<br/>HTTP Client]
+            DOMPURIFY[dompurify<br/>HTML Sanitizer]
+            ELLIPTIC[elliptic<br/>Cryptography]
+            PTR[path-to-regexp<br/>URL Routing]
+            MM[micromatch<br/>Glob Matching]
+            DNS[dns-sync<br/>DNS Resolution]
+        end
+    end
+    OSD --> AXIOS
+    OSD --> DOMPURIFY
+    OSD --> ELLIPTIC
+    OSD --> PTR
+    OSD --> MM
+    OSD --> DNS
+```
+
+### Components
+
+| Component | Purpose | Security Concern |
+|-----------|---------|------------------|
+| axios | HTTP client for API requests | SSRF vulnerabilities |
+| dompurify | HTML sanitization to prevent XSS | XSS bypass vulnerabilities |
+| elliptic | Elliptic curve cryptography | Signature malleability |
+| path-to-regexp | URL path matching for routing | ReDoS vulnerabilities |
+| micromatch | Glob pattern matching | ReDoS vulnerabilities |
+| dns-sync | Synchronous DNS resolution | Command injection |
+
+### CVE Summary
+
+| CVE | Package | Description | Severity |
+|-----|---------|-------------|----------|
+| CVE-2017-16100 | dns-sync | Command injection via DNS lookup | Critical |
+| CVE-2024-39338 | axios | Server-Side Request Forgery | High |
+| CVE-2024-45296 | path-to-regexp | Regular Expression DoS | High |
+| CVE-2024-45801 | dompurify | XSS sanitization bypass | High |
+| CVE-2024-48948 | elliptic | ECDSA signature malleability | Low |
+| CVE-2024-42459 | elliptic | Signature verification issue | Medium |
+| CVE-2024-42460 | elliptic | Signature verification issue | Medium |
+| CVE-2024-42461 | elliptic | Signature verification issue | Medium |
+
+### Security Update Process
+
+The OpenSearch Dashboards team follows a proactive security update process:
+
+1. **Monitoring**: Automated tools (Dependabot, Mend) scan for CVEs
+2. **Assessment**: Security team evaluates impact and urgency
+3. **Patching**: Dependencies are updated to fixed versions
+4. **Testing**: Comprehensive testing ensures no regressions
+5. **Release**: Updates are included in the next release
+
+## Limitations
+
+- Some upstream packages may not receive timely updates, requiring forked/patched versions
+- Transitive dependencies may require multiple version updates across the dependency tree
+- Low-severity CVEs may still cause administrative overhead (e.g., security scanner alerts)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#7811](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7811) | [CVE-2017-16100] dns-sync patched version |
+| v2.18.0 | [#8026](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8026) | micromatch 4.0.7 → 4.0.8 |
+| v2.18.0 | [#8197](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8197) | [CVE-2024-45296] path-to-regexp updates |
+| v2.18.0 | [#8346](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8346) | [CVE-2024-45801] dompurify 3.0.11 → 3.1.6 |
+| v2.18.0 | [#8490](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8490) | [CVE-2024-39338] axios 1.7.2 → 1.7.7 |
+| v2.18.0 | [#8742](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8742) | [CVE-2024-48948] elliptic 6.5.7 → 6.6.0 |
+
+## References
+
+- [CVE-2017-16100](https://nvd.nist.gov/vuln/detail/CVE-2017-16100): dns-sync command injection
+- [CVE-2024-39338](https://nvd.nist.gov/vuln/detail/CVE-2024-39338): axios SSRF vulnerability
+- [CVE-2024-45296](https://nvd.nist.gov/vuln/detail/CVE-2024-45296): path-to-regexp ReDoS
+- [CVE-2024-45801](https://nvd.nist.gov/vuln/detail/CVE-2024-45801): dompurify XSS bypass
+- [CVE-2024-48948](https://nvd.nist.gov/vuln/detail/CVE-2024-48948): elliptic signature malleability
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Fixed CVE-2017-16100, CVE-2024-39338, CVE-2024-45296, CVE-2024-45801, CVE-2024-48948; bumped micromatch

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/security-cve-fixes.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/security-cve-fixes.md
@@ -1,0 +1,77 @@
+# Security CVE Fixes (Dashboards)
+
+## Summary
+
+OpenSearch Dashboards v2.18.0 addresses multiple security vulnerabilities by updating several npm dependencies to patched versions. These updates fix CVEs ranging from command injection to ReDoS (Regular Expression Denial of Service) vulnerabilities in commonly used JavaScript libraries.
+
+## Details
+
+### What's New in v2.18.0
+
+This release includes security patches for 6 npm dependencies that had known CVEs:
+
+| CVE | Package | Old Version | New Version | Severity |
+|-----|---------|-------------|-------------|----------|
+| CVE-2017-16100 | dns-sync | vulnerable | patched fork | Critical |
+| CVE-2024-39338 | axios | 1.7.2 | 1.7.7 | High |
+| CVE-2024-45296 | path-to-regexp | various | 1.9.0, 3.3.0, 6.3.0 | High |
+| CVE-2024-45801 | dompurify | 3.0.11 | 3.1.6 | High |
+| CVE-2024-48948 | elliptic | 6.5.7 | 6.6.0 | Low |
+| N/A | micromatch | 4.0.7 | 4.0.8 | Medium |
+
+### Technical Changes
+
+#### CVE-2017-16100: dns-sync Command Injection
+
+The `dns-sync` library had a critical command injection vulnerability. Since the upstream package hasn't been updated, a patched fork is used until the official package is fixed.
+
+#### CVE-2024-39338: axios SSRF
+
+The axios HTTP client had a Server-Side Request Forgery vulnerability that could allow attackers to bypass security controls. Updated from 1.7.2 to 1.7.7.
+
+#### CVE-2024-45296: path-to-regexp ReDoS
+
+The `path-to-regexp` library used for URL routing had a Regular Expression Denial of Service vulnerability. Multiple versions were updated across the dependency tree (1.9.0, 3.3.0, 6.3.0).
+
+#### CVE-2024-45801: dompurify XSS Bypass
+
+DOMPurify, used for HTML sanitization, had a vulnerability that could allow XSS attacks to bypass sanitization. Updated from 3.0.11 to 3.1.6.
+
+#### CVE-2024-48948: elliptic Signature Malleability
+
+The `elliptic` cryptographic library had a signature malleability issue. While categorized as low severity, it could cause administrative annoyance. Updated from 6.5.7 to 6.6.0.
+
+#### micromatch Security Update
+
+The `micromatch` glob matching library was updated from 4.0.7 to 4.0.8 to address security concerns.
+
+### Migration Notes
+
+No migration steps required. These are dependency updates that are transparent to users and administrators.
+
+## Limitations
+
+- The `dns-sync` fix uses a patched fork rather than the official package, pending upstream updates.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#7811](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7811) | [CVE-2017-16100] Use a patched version for the `dns-sync` dependency |
+| [#8026](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8026) | Bump `micromatch` from 4.0.7 to 4.0.8 |
+| [#8197](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8197) | [CVE-2024-45296] Bump `path-to-regexp` to 1.9.0, 3.3.0, and 6.3.0 |
+| [#8346](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8346) | [CVE-2024-45801] Bump `dompurify` from 3.0.11 to 3.1.6 |
+| [#8490](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8490) | [CVE-2024-39338] Bump axios from 1.7.2 to 1.7.7 |
+| [#8742](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8742) | [CVE-2024-48948] Bump `elliptic` from 6.5.7 to 6.6.0 |
+
+## References
+
+- [CVE-2017-16100](https://nvd.nist.gov/vuln/detail/CVE-2017-16100): dns-sync command injection
+- [CVE-2024-39338](https://nvd.nist.gov/vuln/detail/CVE-2024-39338): axios SSRF vulnerability
+- [CVE-2024-45296](https://nvd.nist.gov/vuln/detail/CVE-2024-45296): path-to-regexp ReDoS
+- [CVE-2024-45801](https://nvd.nist.gov/vuln/detail/CVE-2024-45801): dompurify XSS bypass
+- [CVE-2024-48948](https://nvd.nist.gov/vuln/detail/CVE-2024-48948): elliptic signature malleability
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/security-cve-fixes.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -40,3 +40,4 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Dashboards Improvements](features/opensearch-dashboards/dashboards-improvements.md) - Loading indicator with time counter for query results
 - [MDS Integration Support](features/opensearch-dashboards/mds-integration-support.md) - Multi Data Source support for Integration feature
 - [Experimental Features](features/opensearch-dashboards/experimental-features.md) - User personal settings with scoped uiSettings and User Settings page
+- [Security CVE Fixes](features/opensearch-dashboards/security-cve-fixes.md) - Security updates for dns-sync, axios, path-to-regexp, dompurify, elliptic, micromatch


### PR DESCRIPTION
## Summary

This PR adds documentation for Security CVE Fixes in OpenSearch Dashboards v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch-dashboards/security-cve-fixes.md`
- Feature report: `docs/features/opensearch-dashboards/security-cve-fixes.md`

### CVEs Addressed
| CVE | Package | Description |
|-----|---------|-------------|
| CVE-2017-16100 | dns-sync | Command injection |
| CVE-2024-39338 | axios | SSRF vulnerability |
| CVE-2024-45296 | path-to-regexp | ReDoS |
| CVE-2024-45801 | dompurify | XSS bypass |
| CVE-2024-48948 | elliptic | Signature malleability |

### Related PRs
- #7811, #8026, #8197, #8346, #8490, #8742

Closes #661