### PR TITLE
docs: add test-fixes report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -37,6 +37,7 @@
 - [Segment Warmer](opensearch/segment-warmer.md)
 - [Star Tree Index](opensearch/star-tree-index.md)
 - [Stream Input/Output](opensearch/stream-inputoutput.md)
+- [Test Fixes](opensearch/test-fixes.md)
 - [Thread Context Permissions](opensearch/thread-context-permissions.md)
 - [Tiered Caching](opensearch/tiered-caching.md)
 - [Transport Nodes Action Optimization](opensearch/transport-nodes-action-optimization.md)

--- a/docs/features/opensearch/test-fixes.md
+++ b/docs/features/opensearch/test-fixes.md
@@ -1,0 +1,89 @@
+# Test Fixes
+
+## Summary
+
+This feature tracks fixes for flaky tests in OpenSearch's test suite, particularly focusing on tests that fail intermittently due to timing issues, race conditions, or incorrect assumptions about underlying library behavior. Stable tests are critical for maintaining CI/CD reliability and developer productivity.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Test Execution"
+        Test[Test Method]
+        Lucene[Lucene IndexSearcher]
+        Assertion[Assertion Logic]
+    end
+    
+    subgraph "TotalHits Handling"
+        Exact[EQUAL_TO Relation]
+        LowerBound[GREATER_THAN_OR_EQUAL_TO Relation]
+    end
+    
+    Test --> Lucene
+    Lucene --> Exact
+    Lucene --> LowerBound
+    Exact --> Assertion
+    LowerBound --> Assertion
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ApproximatePointRangeQueryTests` | Test class for approximate range queries on point fields |
+| `TotalHits.Relation` | Lucene enum indicating whether hit count is exact or a lower bound |
+| `IndexSearcher` | Lucene component that executes searches and returns hit counts |
+
+### Key Concepts
+
+#### Lucene TotalHits Behavior
+
+Lucene's `IndexSearcher.search()` method returns a `TotalHits` object containing:
+- `value`: The hit count (exact or lower bound)
+- `relation`: Either `EQUAL_TO` (exact) or `GREATER_THAN_OR_EQUAL_TO` (lower bound)
+
+For performance reasons, Lucene may return a lower bound estimate when:
+- The number of hits exceeds the default threshold (1000)
+- Early termination is triggered for efficiency
+
+#### Test Assertion Strategy
+
+Tests should handle both relations:
+
+```java
+if (topDocs.totalHits.relation == Relation.EQUAL_TO) {
+    // Exact count - assert equality
+    assertEquals(expectedCount, topDocs.totalHits.value);
+} else {
+    // Lower bound - assert within expected range
+    assertTrue(expectedCount <= topDocs.totalHits.value);
+    assertTrue(maxPossibleHits >= topDocs.totalHits.value);
+}
+```
+
+### Configuration
+
+No configuration changes required. This is an internal test improvement.
+
+## Limitations
+
+- Flaky test fixes are reactive - new flaky tests may emerge as code evolves
+- Some flaky tests may require more complex fixes involving test isolation or mocking
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#16434](https://github.com/opensearch-project/OpenSearch/pull/16434) | Fix flaky test in testApproximateRangeWithSizeOverDefault |
+
+## References
+
+- [Issue #15807](https://github.com/opensearch-project/OpenSearch/issues/15807): AUTOCUT Gradle Check Flaky Test Report for ApproximatePointRangeQueryTests
+- [Lucene IndexSearcher Documentation](https://lucene.apache.org/core/9_11_0/core/org/apache/lucene/search/IndexSearcher.html): TotalHits behavior documentation
+- [OpenSearch Gradle Check Metrics Dashboard](https://metrics.opensearch.org/_dashboards/app/dashboards#/view/e5e64d40-ed31-11ee-be99-69d1dbc75083): Flaky test tracking
+
+## Change History
+
+- **v2.18.0** (2024-10-23): Fix flaky test in `testApproximateRangeWithSizeOverDefault` by adjusting totalHits assertion logic

--- a/docs/releases/v2.18.0/features/opensearch/test-fixes.md
+++ b/docs/releases/v2.18.0/features/opensearch/test-fixes.md
@@ -1,0 +1,70 @@
+# Test Fixes
+
+## Summary
+
+This release item fixes a flaky test in `ApproximatePointRangeQueryTests.testApproximateRangeWithSizeOverDefault` that was causing intermittent CI failures. The fix adjusts the totalHits assertion logic to properly handle Lucene's behavior when returning hit counts beyond the default threshold.
+
+## Details
+
+### What's New in v2.18.0
+
+The `testApproximateRangeWithSizeOverDefault` test was failing intermittently due to how Lucene's `IndexSearcher` handles total hit counts. By default, Lucene provides an accurate count for up to 1000 hits. Beyond this threshold, Lucene may return a lower bound using `GREATER_THAN_OR_EQUAL_TO` for performance optimization.
+
+### Technical Changes
+
+#### Root Cause
+
+The test searches for documents in a range that includes 12,001 documents with a requested size of 11,000. When Lucene's `search()` method returns results:
+- Sometimes it returns `TotalHits.Relation.EQUAL_TO` with an exact count
+- Sometimes it returns `TotalHits.Relation.GREATER_THAN_OR_EQUAL_TO` with a lower bound estimate
+
+The original test only checked for exact equality, causing failures when Lucene used the lower bound relation.
+
+#### Fix Implementation
+
+The fix modifies the assertion logic to handle both cases:
+
+```java
+if (topDocs.totalHits.relation == Relation.EQUAL_TO) {
+    assertEquals(topDocs.totalHits.value, 11000);
+} else {
+    assertTrue(11000 <= topDocs.totalHits.value);
+    assertTrue(maxHits >= topDocs.totalHits.value);
+}
+```
+
+This approach:
+- Checks for exact count (11000) when relation is `EQUAL_TO`
+- Validates the count is within expected bounds (11000 to 12001) when relation is `GREATER_THAN_OR_EQUAL_TO`
+
+#### Code Cleanup
+
+The PR also includes minor code cleanup:
+- Removed redundant semicolons
+- Removed unnecessary blank lines
+- Added import for `TotalHits.Relation`
+
+### Usage Example
+
+No user-facing changes. This is an internal test fix.
+
+## Limitations
+
+- This fix addresses only the `testApproximateRangeWithSizeOverDefault` test
+- Other flaky tests in `ApproximatePointRangeQueryTests` may require similar fixes
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16434](https://github.com/opensearch-project/OpenSearch/pull/16434) | Fix flaky test by adjusting totalHits assertion logic |
+
+## References
+
+- [Issue #15807](https://github.com/opensearch-project/OpenSearch/issues/15807): AUTOCUT Gradle Check Flaky Test Report for ApproximatePointRangeQueryTests
+- [Lucene IndexSearcher Documentation](https://lucene.apache.org/core/9_11_0/core/org/apache/lucene/search/IndexSearcher.html): Explains totalHits behavior
+- [PR #4270](https://github.com/opensearch-project/OpenSearch/pull/4270): Similar fix for related flaky test issue
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/test-fixes.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -6,6 +6,10 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ## Features by Repository
 
+### OpenSearch
+
+- [Test Fixes](features/opensearch/test-fixes.md) - Fix flaky test in ApproximatePointRangeQueryTests by adjusting totalHits assertion logic
+
 ### OpenSearch Dashboards
 
 - [Dev Tools Modal](features/opensearch-dashboards/dev-tools.md) - Dev Tools console rendered as a modal overlay for improved workflow


### PR DESCRIPTION
## Summary

This PR adds documentation for the Test Fixes release item in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/test-fixes.md`
- Feature report: `docs/features/opensearch/test-fixes.md`

### Key Changes in v2.18.0
- Fix flaky test in `ApproximatePointRangeQueryTests.testApproximateRangeWithSizeOverDefault`
- Adjusted totalHits assertion logic to handle Lucene's `GREATER_THAN_OR_EQUAL_TO` relation

### Resources Used
- PR: [#16434](https://github.com/opensearch-project/OpenSearch/pull/16434)
- Issue: [#15807](https://github.com/opensearch-project/OpenSearch/issues/15807)

Closes #660