### PR TITLE
docs: add replication report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -33,6 +33,7 @@
 - [Nodes Info API](opensearch/nodes-info-api.md)
 - [Node Roles Configuration](opensearch/node-roles-configuration.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)
+- [Replication](opensearch/replication.md)
 - [Search Backpressure](opensearch/search-backpressure.md)
 - [Segment Warmer](opensearch/segment-warmer.md)
 - [Star Tree Index](opensearch/star-tree-index.md)

--- a/docs/features/opensearch/replication.md
+++ b/docs/features/opensearch/replication.md
@@ -1,0 +1,93 @@
+# Replication
+
+## Summary
+
+Replication in OpenSearch ensures data durability and high availability by maintaining copies of data across multiple shards. The core replication infrastructure includes mechanisms for primary-replica synchronization, including the resync process that ensures replicas stay consistent with the primary shard after recovery or failover scenarios.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Primary Shard"
+        PS[Primary Shard]
+        TL[Translog]
+        PS --> TL
+    end
+    
+    subgraph "Resync Process"
+        RR[ResyncReplicationRequest]
+        RA[ResyncReplicationAction]
+    end
+    
+    subgraph "Replica Shards"
+        RS1[Replica 1]
+        RS2[Replica 2]
+    end
+    
+    TL --> |Batch Operations| RR
+    RR --> RA
+    RA --> RS1
+    RA --> RS2
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Primary Shard Recovery] --> B[Identify Missing Operations]
+    B --> C[Create ResyncReplicationRequest]
+    C --> D[Batch Translog Operations]
+    D --> E[Send to Replicas]
+    E --> F[Replicas Apply Operations]
+    F --> G[Sync Complete]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ResyncReplicationRequest` | Request class that batches translog operations for primary-replica resync |
+| `ResyncReplicationAction` | Transport action that handles resync requests |
+| `ReplicatedWriteRequest` | Base class for replicated write operations |
+| `Translog.Operation` | Individual translog operations (index, delete, etc.) |
+
+### Key Fields in ResyncReplicationRequest
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `trimAboveSeqNo` | `long` | Sequence number above which operations should be trimmed |
+| `maxSeenAutoIdTimestampOnPrimary` | `long` | Maximum auto-generated ID timestamp seen on primary |
+| `operations` | `Translog.Operation[]` | Array of translog operations to resync |
+
+### Usage Example
+
+The resync mechanism is internal to OpenSearch and triggered automatically during:
+
+```
+1. Replica shard recovery after node restart
+2. Shard relocation between nodes
+3. Primary shard failover and promotion
+```
+
+## Limitations
+
+- Resync operations are internal and not directly exposed via API
+- Large resync operations can impact cluster performance during recovery
+- Network bandwidth is consumed during resync between primary and replicas
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#16378](https://github.com/opensearch-project/OpenSearch/pull/16378) | Fix array hashCode calculation in ResyncReplicationRequest |
+
+## References
+
+- [Segment replication documentation](https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/segment-replication/index/): Alternative replication strategy
+- [Cross-cluster replication](https://docs.opensearch.org/latest/tuning-your-cluster/replication-plugin/index/): Replication across clusters
+
+## Change History
+
+- **v2.18.0** (2024-10-22): Fixed `hashCode()` calculation in `ResyncReplicationRequest` to properly handle array fields using `Arrays.hashCode()`

--- a/docs/releases/v2.18.0/features/opensearch/replication.md
+++ b/docs/releases/v2.18.0/features/opensearch/replication.md
@@ -1,0 +1,82 @@
+# Replication
+
+## Summary
+
+This release fixes a bug in the `ResyncReplicationRequest` class where the `hashCode()` method incorrectly calculated hash codes for array fields. The fix ensures proper contract compliance between `equals()` and `hashCode()` methods, which is essential for correct behavior when these objects are used in hash-based collections.
+
+## Details
+
+### What's New in v2.18.0
+
+The `ResyncReplicationRequest` class is used during primary-replica resync operations to batch translog operations from the primary shard to replica shards. The fix corrects the `hashCode()` implementation to properly handle the `operations` array field.
+
+### Technical Changes
+
+#### Bug Fix
+
+The issue was in the `hashCode()` method of `ResyncReplicationRequest`:
+
+**Before (incorrect):**
+```java
+@Override
+public int hashCode() {
+    return Objects.hash(trimAboveSeqNo, maxSeenAutoIdTimestampOnPrimary, operations);
+}
+```
+
+**After (correct):**
+```java
+@Override
+public int hashCode() {
+    return Objects.hash(trimAboveSeqNo, maxSeenAutoIdTimestampOnPrimary, Arrays.hashCode(operations));
+}
+```
+
+#### Problem Explanation
+
+When passing an array directly to `Objects.hash()`, Java uses the array's identity hash code (based on memory address) rather than the content-based hash code. This violates the contract between `equals()` and `hashCode()`:
+
+- `equals()` was correctly using `Arrays.equals(operations, that.operations)` to compare array contents
+- `hashCode()` was incorrectly using the array's identity hash code
+
+This mismatch means two `ResyncReplicationRequest` objects with identical content could have different hash codes, causing issues when used in hash-based collections like `HashMap` or `HashSet`.
+
+#### Components Affected
+
+| Component | Description |
+|-----------|-------------|
+| `ResyncReplicationRequest` | Request class for primary-replica resync operations |
+
+### Usage Example
+
+The fix ensures correct behavior in scenarios like:
+
+```java
+// Two requests with identical content
+ResyncReplicationRequest request1 = new ResyncReplicationRequest(shardId, 42L, 100, operations);
+ResyncReplicationRequest request2 = new ResyncReplicationRequest(shardId, 42L, 100, operations);
+
+// Contract: if equals() returns true, hashCode() must return same value
+assert request1.equals(request2);
+assert request1.hashCode() == request2.hashCode(); // Now works correctly
+```
+
+## Limitations
+
+- This is an internal bug fix with no user-facing API changes
+- No migration steps required
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16378](https://github.com/opensearch-project/OpenSearch/pull/16378) | Fix array hashCode calculation in ResyncReplicationRequest |
+| [#15383](https://github.com/opensearch-project/OpenSearch/pull/15383) | Previous attempt (closed without merge) |
+
+## References
+
+- [Segment replication documentation](https://docs.opensearch.org/2.18/tuning-your-cluster/availability-and-recovery/segment-replication/index/): Related replication concepts
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/replication.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -8,6 +8,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### OpenSearch
 
+- [Replication](features/opensearch/replication.md) - Fix array hashCode calculation in ResyncReplicationRequest
 - [Test Fixes](features/opensearch/test-fixes.md) - Fix flaky test in ApproximatePointRangeQueryTests by adjusting totalHits assertion logic
 
 ### OpenSearch Dashboards


### PR DESCRIPTION
## Summary

This PR adds documentation for the Replication feature fix in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/replication.md`
- Feature report: `docs/features/opensearch/replication.md`

### Key Changes in v2.18.0
- Fixed `hashCode()` calculation in `ResyncReplicationRequest` to properly handle array fields using `Arrays.hashCode()`
- This ensures correct contract compliance between `equals()` and `hashCode()` methods

### Related PR
- [opensearch-project/OpenSearch#16378](https://github.com/opensearch-project/OpenSearch/pull/16378): Fix array hashCode calculation in ResyncReplicationRequest

Closes #659