### PR TITLE
docs: add task-management report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -38,6 +38,7 @@
 - [Segment Warmer](opensearch/segment-warmer.md)
 - [Star Tree Index](opensearch/star-tree-index.md)
 - [Stream Input/Output](opensearch/stream-inputoutput.md)
+- [Task Management](opensearch/task-management.md)
 - [Test Fixes](opensearch/test-fixes.md)
 - [Thread Context Permissions](opensearch/thread-context-permissions.md)
 - [Tiered Caching](opensearch/tiered-caching.md)

--- a/docs/features/opensearch/task-management.md
+++ b/docs/features/opensearch/task-management.md
@@ -1,0 +1,165 @@
+# Task Management
+
+## Summary
+
+OpenSearch's Task Management system tracks and manages long-running operations within the cluster. Tasks are stored in the `.tasks` system index, which uses strict dynamic mapping to ensure data integrity. The system provides APIs to list, monitor, and cancel running tasks.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Task Management System"
+        TM[TaskManager]
+        TRS[TaskResultsService]
+        TI[.tasks Index]
+    end
+    
+    subgraph "Operations"
+        OP[Long-running Operations]
+        CCR[Cross-Cluster Replication]
+        REINDEX[Reindex]
+        SEARCH[Async Search]
+    end
+    
+    OP --> TM
+    CCR --> TM
+    REINDEX --> TM
+    SEARCH --> TM
+    
+    TM --> TRS
+    TRS --> TI
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Operation Started] --> B[Task Created]
+    B --> C[TaskManager Tracks]
+    C --> D{Task Completed?}
+    D -->|Yes| E[Store Result]
+    D -->|Cancelled| F[Store with Cancellation Time]
+    E --> G[TaskResultsService]
+    F --> G
+    G --> H[.tasks Index]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `TaskManager` | Central component that tracks all running tasks in the cluster |
+| `TaskResultsService` | Service responsible for storing task results to the `.tasks` index |
+| `TaskInfo` | Data structure containing task metadata and status |
+| `TaskResult` | Wrapper containing task info and response/error |
+| `.tasks` Index | System index storing completed task results |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `task_result_index.mapping.version` | Internal mapping version for `.tasks` index | 5 |
+| `dynamic` | Mapping mode for `.tasks` index | `strict` |
+
+### Task Index Mapping
+
+The `.tasks` index stores task results with the following key fields:
+
+```json
+{
+  "_doc": {
+    "_meta": {
+      "version": 5
+    },
+    "dynamic": "strict",
+    "properties": {
+      "completed": { "type": "boolean" },
+      "task": {
+        "properties": {
+          "action": { "type": "keyword" },
+          "cancellable": { "type": "boolean" },
+          "cancelled": { "type": "boolean" },
+          "id": { "type": "long" },
+          "node": { "type": "keyword" },
+          "parent_task_id": { "type": "keyword" },
+          "running_time_in_nanos": { "type": "long" },
+          "start_time_in_millis": { "type": "long" },
+          "cancellation_time_millis": { "type": "long" },
+          "type": { "type": "keyword" },
+          "status": { "type": "object", "enabled": false },
+          "description": { "type": "text" },
+          "headers": { "type": "object", "enabled": false },
+          "resource_stats": { "type": "object", "enabled": false }
+        }
+      },
+      "response": { "type": "object", "enabled": false },
+      "error": { "type": "object", "enabled": false }
+    }
+  }
+}
+```
+
+### Usage Example
+
+```bash
+# List all running tasks
+GET _tasks
+
+# Get task by ID
+GET _tasks/<task_id>
+
+# Cancel a task
+POST _tasks/<task_id>/_cancel
+
+# List tasks with details
+GET _tasks?detailed=true
+
+# Filter tasks by action
+GET _tasks?actions=*search&detailed=true
+
+# View stored task results
+GET .tasks/_search
+{
+  "query": {
+    "match_all": {}
+  }
+}
+```
+
+### Resource Stats
+
+The `resource_stats` object tracks resource usage for tasks that support resource tracking:
+
+| Field | Description |
+|-------|-------------|
+| `average` | Average resource usage across thread executions |
+| `total` | Sum of resource usages across thread executions |
+| `min` | Minimum resource usage |
+| `max` | Maximum resource usage |
+| `thread_info.active_threads` | Number of threads currently working on the task |
+| `thread_info.thread_executions` | Number of threads scheduled to work on the task |
+
+## Limitations
+
+- Not all tasks are cancellable (check `cancellable` field)
+- `resource_stats` is stored as disabled object (not searchable)
+- Task results are only stored for completed/cancelled tasks
+- The `.tasks` index uses strict mapping - all fields must be predefined
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#16201](https://github.com/opensearch-project/OpenSearch/pull/16201) | Fix missing fields in task index mapping |
+
+## References
+
+- [Issue #16060](https://github.com/opensearch-project/OpenSearch/issues/16060): Bug report for missing mapping fields
+- [Tasks API Documentation](https://docs.opensearch.org/2.18/api-reference/tasks/): Official Tasks API docs
+- [task-index-mapping.json](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/resources/org/opensearch/tasks/task-index-mapping.json): Source mapping file
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Fixed missing `cancellation_time_millis` and `resource_stats` fields in task index mapping

--- a/docs/releases/v2.18.0/features/opensearch/task-management.md
+++ b/docs/releases/v2.18.0/features/opensearch/task-management.md
@@ -1,0 +1,98 @@
+# Task Management
+
+## Summary
+
+This release fixes a critical bug in the `.tasks` index mapping that caused `StrictDynamicMappingException` when storing task results for cancelled tasks. The fix adds missing fields (`cancellation_time_millis` and `resource_stats`) to the task index mapping, ensuring proper task result storage across all OpenSearch operations.
+
+## Details
+
+### What's New in v2.18.0
+
+The `.tasks` index uses strict dynamic mapping, which means all fields must be explicitly defined in the mapping before they can be indexed. Two fields were missing from the mapping:
+
+- `cancellation_time_millis`: Records when a task was cancelled
+- `resource_stats`: Contains resource usage statistics for the task
+
+Without these fields, any operation that cancelled a task (such as deleting an auto-follow rule in Cross-Cluster Replication) would fail to update the `.tasks` index.
+
+### Technical Changes
+
+#### Mapping Version Update
+
+The task index mapping version was incremented from 4 to 5 to trigger mapping updates on existing clusters.
+
+#### New Fields Added
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `cancellation_time_millis` | `long` | Timestamp when the task was cancelled |
+| `resource_stats` | `object` (disabled) | Resource usage statistics for the task |
+
+#### Updated Mapping Structure
+
+```json
+{
+  "_doc": {
+    "_meta": {
+      "version": 5
+    },
+    "dynamic": "strict",
+    "properties": {
+      "task": {
+        "properties": {
+          "cancellation_time_millis": {
+            "type": "long"
+          },
+          "resource_stats": {
+            "type": "object",
+            "enabled": false
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Usage Example
+
+After this fix, task cancellation operations work correctly:
+
+```bash
+# Cancel a task - now properly stores result in .tasks index
+POST _tasks/<task_id>/_cancel
+
+# View stored task results
+GET .tasks/_search
+{
+  "query": {
+    "match_all": {}
+  }
+}
+```
+
+### Migration Notes
+
+- No manual migration required
+- The mapping version increment ensures automatic updates
+- Existing `.tasks` indexes will be updated when OpenSearch starts
+
+## Limitations
+
+- The `resource_stats` field is stored as a disabled object (not indexed/searchable)
+- This fix is specifically for the internal `.tasks` system index
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16201](https://github.com/opensearch-project/OpenSearch/pull/16201) | Fix missing fields in task index mapping |
+
+## References
+
+- [Issue #16060](https://github.com/opensearch-project/OpenSearch/issues/16060): Original bug report
+- [Tasks API Documentation](https://docs.opensearch.org/2.18/api-reference/tasks/): Official Tasks API docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/task-management.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -9,6 +9,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### OpenSearch
 
 - [Replication](features/opensearch/replication.md) - Fix array hashCode calculation in ResyncReplicationRequest
+- [Task Management](features/opensearch/task-management.md) - Fix missing fields in task index mapping for proper task result storage
 - [Test Fixes](features/opensearch/test-fixes.md) - Fix flaky test in ApproximatePointRangeQueryTests by adjusting totalHits assertion logic
 
 ### OpenSearch Dashboards


### PR DESCRIPTION
## Summary

This PR adds documentation for the Task Management feature fix in OpenSearch v2.18.0.

### Changes
- **Release report**: `docs/releases/v2.18.0/features/opensearch/task-management.md`
- **Feature report**: `docs/features/opensearch/task-management.md`
- Updated release and feature indexes

### Key Findings

The `.tasks` index uses strict dynamic mapping, which caused `StrictDynamicMappingException` when storing task results for cancelled tasks. PR #16201 fixed this by adding two missing fields to the task index mapping:

- `cancellation_time_millis`: Records when a task was cancelled
- `resource_stats`: Contains resource usage statistics for the task

This fix is particularly important for Cross-Cluster Replication (CCR) plugin users who experienced errors when deleting auto-follow rules.

### Related
- OpenSearch PR: [#16201](https://github.com/opensearch-project/OpenSearch/pull/16201)
- OpenSearch Issue: [#16060](https://github.com/opensearch-project/OpenSearch/issues/16060)
- Investigation Issue: #658