### PR TITLE
docs: add multi-search-api report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -30,6 +30,7 @@
 - [Lucene 10 Upgrade](opensearch/lucene-10-upgrade.md)
 - [Lucene Similarity](opensearch/lucene-similarity.md)
 - [Merge & Segment Settings](opensearch/merge-segment-settings.md)
+- [Multi-Search API](opensearch/multi-search-api.md)
 - [Nodes Info API](opensearch/nodes-info-api.md)
 - [Node Roles Configuration](opensearch/node-roles-configuration.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)

--- a/docs/features/opensearch/multi-search-api.md
+++ b/docs/features/opensearch/multi-search-api.md
@@ -1,0 +1,156 @@
+# Multi-Search API
+
+## Summary
+
+The Multi-Search API allows executing multiple search requests in a single API call, improving efficiency when running batch queries. OpenSearch provides two variants: the standard Multi-Search API (`_msearch`) and the Multi-Search Template API (`_msearch/template`) for parameterized searches using stored templates.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph Client
+        REQ[Multi-Search Request]
+    end
+    subgraph OpenSearch
+        COORD[Coordinating Node]
+        subgraph "Search Execution"
+            MS[Multi-Search Handler]
+            MST[Multi-Search Template Handler]
+            TE[Template Engine]
+        end
+        subgraph "Data Nodes"
+            S1[Shard 1]
+            S2[Shard 2]
+            S3[Shard N]
+        end
+    end
+    REQ --> COORD
+    COORD --> MS
+    COORD --> MST
+    MST --> TE
+    TE --> MS
+    MS --> S1
+    MS --> S2
+    MS --> S3
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Client Request] --> B{API Type}
+    B -->|_msearch| C[Parse Search Bodies]
+    B -->|_msearch/template| D[Render Templates]
+    D --> C
+    C --> E[Execute Searches in Parallel]
+    E --> F[Aggregate Results]
+    F --> G[Return Response with Status Codes]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `MultiSearchRequest` | Holds multiple search requests |
+| `MultiSearchResponse` | Contains array of search responses with status codes |
+| `MultiSearchTemplateRequest` | Holds multiple template-based search requests |
+| `MultiSearchTemplateResponse` | Contains array of template search responses with status codes |
+| `SearchTemplateResponse` | Individual template search response |
+
+### API Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET/POST /_msearch` | Execute multiple search requests |
+| `GET/POST /{index}/_msearch` | Execute multiple searches against specific index |
+| `GET/POST /_msearch/template` | Execute multiple search template requests |
+| `GET/POST /{index}/_msearch/template` | Execute multiple template searches against specific index |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `max_concurrent_searches` | Maximum concurrent searches per request | Node count dependent |
+| `max_concurrent_shard_requests` | Maximum concurrent shard requests per node | 5 |
+| `pre_filter_shard_size` | Pre-filter shard size threshold | 128 |
+| `rest_total_hits_as_int` | Return hits.total as integer | false |
+
+### Usage Example
+
+#### Multi-Search Request
+
+```json
+GET _msearch
+{"index":"logs-*"}
+{"query":{"match":{"message":"error"}}}
+{"index":"metrics-*"}
+{"query":{"range":{"@timestamp":{"gte":"now-1h"}}}}
+```
+
+#### Multi-Search Template Request
+
+```json
+GET _msearch/template
+{"index":"products"}
+{"id":"product_search","params":{"query":"laptop","size":10}}
+{"index":"products"}
+{"id":"product_search","params":{"query":"phone","size":5}}
+```
+
+#### Response Format
+
+```json
+{
+  "took": 15,
+  "responses": [
+    {
+      "took": 5,
+      "timed_out": false,
+      "_shards": {
+        "total": 5,
+        "successful": 5,
+        "skipped": 0,
+        "failed": 0
+      },
+      "hits": {
+        "total": {"value": 100, "relation": "eq"},
+        "max_score": 1.5,
+        "hits": [...]
+      },
+      "status": 200
+    },
+    {
+      "error": {
+        "type": "index_not_found_exception",
+        "reason": "no such index [unknown]"
+      },
+      "status": 404
+    }
+  ]
+}
+```
+
+## Limitations
+
+- Request body must use newline-delimited JSON format
+- Each search is independent; no cross-search dependencies
+- Large batch sizes may impact cluster performance
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#16265](https://github.com/opensearch-project/OpenSearch/pull/16265) | Fix multi-search with template doesn't return status code |
+
+## References
+
+- [Issue #11133](https://github.com/opensearch-project/OpenSearch/issues/11133): Bug report for missing status field
+- [Multi-Search API Documentation](https://docs.opensearch.org/latest/api-reference/multi-search/): Official multi-search docs
+- [Multi-Search Template Documentation](https://docs.opensearch.org/latest/api-reference/msearch-template/): Official template docs
+- [Search Templates Documentation](https://docs.opensearch.org/latest/api-reference/search-template/): Search template reference
+
+## Change History
+
+- **v2.18.0** (2024-10-22): Added `status` field to Multi-Search Template API responses for consistency with Multi-Search API

--- a/docs/releases/v2.18.0/features/opensearch/multi-search-api.md
+++ b/docs/releases/v2.18.0/features/opensearch/multi-search-api.md
@@ -1,0 +1,134 @@
+# Multi-Search API
+
+## Summary
+
+This release fixes a bug where the Multi-Search Template API (`_msearch/template`) did not return a `status` field in each search response, unlike the regular Multi-Search API (`_msearch`). This fix ensures response consistency between the two similar APIs, making it easier for clients to handle responses uniformly.
+
+## Details
+
+### What's New in v2.18.0
+
+The Multi-Search Template API now includes a `status` field in each response item, matching the behavior of the Multi-Search API. This applies to both successful responses and error responses.
+
+### Technical Changes
+
+#### Response Format Change
+
+Before v2.18.0, the `_msearch/template` response did not include status codes:
+
+```json
+{
+  "took": 5,
+  "responses": [
+    {
+      "took": 3,
+      "timed_out": false,
+      "_shards": { ... },
+      "hits": { ... }
+    }
+  ]
+}
+```
+
+After v2.18.0, each response includes a `status` field:
+
+```json
+{
+  "took": 5,
+  "responses": [
+    {
+      "took": 3,
+      "timed_out": false,
+      "_shards": { ... },
+      "hits": { ... },
+      "status": 200
+    }
+  ]
+}
+```
+
+#### Modified Components
+
+| Component | Description |
+|-----------|-------------|
+| `MultiSearchTemplateResponse.java` | Added `status` field to failure responses using `ExceptionsHelper.status()` |
+| `SearchTemplateResponse.java` | Added `status` field to successful responses using `response.status().getStatus()` |
+
+#### Status Codes
+
+The `status` field returns standard HTTP status codes:
+
+| Status | Meaning |
+|--------|---------|
+| 200 | Successful search |
+| 400 | Bad request (e.g., invalid query, malformed template) |
+| 404 | Index not found |
+
+### Usage Example
+
+```json
+GET _msearch/template
+{"index":"my-index"}
+{"id":"my_template","params":{"query_text":"search term"}}
+{"index":"unknown_index"}
+{"id":"my_template","params":{"query_text":"another term"}}
+```
+
+Response:
+
+```json
+{
+  "took": 10,
+  "responses": [
+    {
+      "took": 5,
+      "timed_out": false,
+      "_shards": {
+        "total": 1,
+        "successful": 1,
+        "skipped": 0,
+        "failed": 0
+      },
+      "hits": {
+        "total": { "value": 10, "relation": "eq" },
+        "max_score": 1.0,
+        "hits": [...]
+      },
+      "status": 200
+    },
+    {
+      "error": {
+        "type": "index_not_found_exception",
+        "reason": "no such index [unknown_index]",
+        "root_cause": [...]
+      },
+      "status": 404
+    }
+  ]
+}
+```
+
+### Migration Notes
+
+This is a backward-compatible change. Existing clients will continue to work, but can now optionally use the `status` field for more consistent error handling across `_msearch` and `_msearch/template` APIs.
+
+## Limitations
+
+- The fix only affects the Multi-Search Template API response format
+- No changes to request format or query behavior
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16265](https://github.com/opensearch-project/OpenSearch/pull/16265) | Fix multi-search with template doesn't return status code |
+
+## References
+
+- [Issue #11133](https://github.com/opensearch-project/OpenSearch/issues/11133): Bug report - MultiSearchTemplateResponse does not return a status field
+- [Issue #708](https://github.com/opensearch-project/opensearch-java/issues/708): Related Java client issue
+- [Multi-Search Template Documentation](https://docs.opensearch.org/2.18/api-reference/msearch-template/): Official API documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/multi-search-api.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -8,6 +8,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### OpenSearch
 
+- [Multi-Search API](features/opensearch/multi-search-api.md) - Fix multi-search with template doesn't return status code
 - [Replication](features/opensearch/replication.md) - Fix array hashCode calculation in ResyncReplicationRequest
 - [Task Management](features/opensearch/task-management.md) - Fix missing fields in task index mapping for proper task result storage
 - [Test Fixes](features/opensearch/test-fixes.md) - Fix flaky test in ApproximatePointRangeQueryTests by adjusting totalHits assertion logic


### PR DESCRIPTION
## Summary

This PR adds documentation for the Multi-Search API fix in OpenSearch v2.18.0.

### Changes
- **Release Report**: `docs/releases/v2.18.0/features/opensearch/multi-search-api.md`
- **Feature Report**: `docs/features/opensearch/multi-search-api.md`
- Updated release index and features index

### Key Changes in v2.18.0
- Fixed missing `status` field in Multi-Search Template API (`_msearch/template`) responses
- Now consistent with Multi-Search API (`_msearch`) response format
- Status codes (200, 400, 404) included in each response item

### Related
- Closes #657
- PR: opensearch-project/OpenSearch#16265
- Issue: opensearch-project/OpenSearch#11133