### PR TITLE
docs: add streaming-indexing report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -38,6 +38,7 @@
 - [Search Backpressure](opensearch/search-backpressure.md)
 - [Segment Warmer](opensearch/segment-warmer.md)
 - [Star Tree Index](opensearch/star-tree-index.md)
+- [Streaming Indexing](opensearch/streaming-indexing.md)
 - [Stream Input/Output](opensearch/stream-inputoutput.md)
 - [Task Management](opensearch/task-management.md)
 - [Test Fixes](opensearch/test-fixes.md)

--- a/docs/features/opensearch/streaming-indexing.md
+++ b/docs/features/opensearch/streaming-indexing.md
@@ -1,0 +1,142 @@
+# Streaming Indexing
+
+## Summary
+
+Streaming Indexing is an experimental feature that provides a streaming variant of the Bulk API (`/_bulk/stream`). It enables continuous document ingestion with immediate per-document responses, eliminating the need to estimate optimal batch sizes and naturally applying backpressure between clients and the cluster.
+
+The feature was introduced in OpenSearch 2.17.0 and requires the `transport-reactor-netty4` HTTP transport plugin.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph Client
+        A[HTTP Client] -->|HTTP/2 or HTTP/1.1 Chunked| B[/_bulk/stream Endpoint]
+    end
+    subgraph "OpenSearch Server"
+        B --> C[ReactorNetty4HttpServerTransport]
+        C --> D[RestController]
+        D --> E[RestBulkStreamingAction]
+        E --> F[BulkStreamingRestHandler]
+    end
+    subgraph "Document Processing"
+        F --> G[Request Parser]
+        G --> H[Batch Accumulator]
+        H --> I[Index/Update/Delete Operations]
+        I --> J[Streaming Response Writer]
+    end
+    J -->|Per-batch Response| A
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Input
+        A[Document 1] --> B[Document 2]
+        B --> C[Document N]
+    end
+    subgraph Batching
+        C --> D{Batch Ready?}
+        D -->|batch_size reached| E[Send to Shards]
+        D -->|batch_interval elapsed| E
+    end
+    subgraph Output
+        E --> F[Response 1]
+        F --> G[Response 2]
+        G --> H[Response N]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `transport-reactor-netty4` | HTTP transport plugin providing reactive streaming support |
+| `RestBulkStreamingAction` | REST handler for the `/_bulk/stream` endpoint |
+| `BulkStreamingRestHandler` | Processes streaming requests and produces streaming responses |
+| `ReactorNetty4HttpServerTransport` | Netty-based HTTP server with streaming capabilities |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `http.type` | Must be set to `reactor-netty4` to enable streaming | `netty4` |
+| `batch_interval` | Time to accumulate operations before sending to data nodes | - |
+| `batch_size` | Number of operations to accumulate before sending | `1` |
+
+### API Endpoints
+
+```
+POST /_bulk/stream
+POST /<index>/_bulk/stream
+```
+
+### Query Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `pipeline` | String | Pipeline ID for preprocessing documents |
+| `refresh` | Enum | Whether to refresh affected shards (`true`, `false`, `wait_for`) |
+| `require_alias` | Boolean | Require all actions target an index alias |
+| `routing` | String | Route request to specified shard |
+| `timeout` | Time | Request timeout (default: `1m`) |
+| `batch_interval` | Time | Batch accumulation interval |
+| `batch_size` | Integer | Batch size threshold |
+
+### Usage Example
+
+```bash
+# Enable reactor-netty4 transport in opensearch.yml
+# http.type: reactor-netty4
+
+# Stream bulk operations
+curl -X POST "http://localhost:9200/_bulk/stream" \
+  -H "Transfer-Encoding: chunked" \
+  -H "Content-Type: application/json" -d'
+{ "index": { "_index": "movies", "_id": "1" } }
+{ "title": "The Matrix", "year": 1999 }
+{ "index": { "_index": "movies", "_id": "2" } }
+{ "title": "Inception", "year": 2010 }
+'
+```
+
+### Response Format
+
+Each batch returns a separate JSON response:
+
+```json
+{"took": 11, "errors": false, "items": [{"index": {"_index": "movies", "_id": "1", "_version": 1, "result": "created", "status": 201}}]}
+{"took": 5, "errors": false, "items": [{"index": {"_index": "movies", "_id": "2", "_version": 1, "result": "created", "status": 201}}]}
+```
+
+## Limitations
+
+- Requires `transport-reactor-netty4` plugin installation
+- Experimental feature - not recommended for production use
+- Requires HTTP/2 or HTTP/1.1 with chunked transfer encoding
+- Default HTTP transport (`netty4`) does not support streaming
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.15.0 | [#13772](https://github.com/opensearch-project/OpenSearch/pull/13772) | Enhance RestAction with request/response streaming support |
+| v2.17.0 | [#15381](https://github.com/opensearch-project/OpenSearch/pull/15381) | Introduce bulk HTTP API streaming flavor |
+| v2.18.0 | [#16158](https://github.com/opensearch-project/OpenSearch/pull/16158) | Fix streaming bulk request hangs |
+| v2.18.0 | [#16337](https://github.com/opensearch-project/OpenSearch/pull/16337) | Fix intermittent newline termination failures |
+
+## References
+
+- [Issue #9065](https://github.com/opensearch-project/OpenSearch/issues/9065): Streaming Bulk API tracking issue
+- [Issue #9070](https://github.com/opensearch-project/OpenSearch/issues/9070): Bulk HTTP API streaming flavor
+- [Issue #9071](https://github.com/opensearch-project/OpenSearch/issues/9071): RestAction streaming support
+- [Streaming Bulk API Documentation](https://docs.opensearch.org/latest/api-reference/document-apis/bulk-streaming/)
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Bug fixes for request hangs and newline termination errors
+- **v2.17.0** (2024-09-17): Initial release of Streaming Bulk API
+- **v2.15.0** (2024-06-25): RestAction streaming support foundation

--- a/docs/releases/v2.18.0/features/opensearch/streaming-indexing.md
+++ b/docs/releases/v2.18.0/features/opensearch/streaming-indexing.md
@@ -1,0 +1,96 @@
+# Streaming Indexing
+
+## Summary
+
+This release includes bug fixes for the Streaming Bulk API (`/_bulk/stream`) that resolve issues with request hangs and intermittent newline termination errors when indexing large documents. These fixes improve the reliability of streaming bulk operations, particularly for documents exceeding 8KB in size.
+
+## Details
+
+### What's New in v2.18.0
+
+Two critical bug fixes were backported to v2.18.0 to address stability issues in the Streaming Bulk API:
+
+1. **Request Hang Fix** ([#16158](https://github.com/opensearch-project/OpenSearch/pull/16158)): Fixed an issue where streaming bulk requests would hang indefinitely when processing certain document patterns, particularly when combining scripted requests with larger documents.
+
+2. **Newline Termination Error Fix** ([#16337](https://github.com/opensearch-project/OpenSearch/pull/16337)): Fixed intermittent "The bulk request must be terminated by a newline [\n]" failures that occurred when bulk indexing documents larger than 1KB.
+
+### Technical Changes
+
+#### Root Cause Analysis
+
+The issues stemmed from how Netty handles HTTP chunked transfer encoding:
+
+- Netty could emit chunks partially, causing incomplete document parsing
+- The Reactor Netty library lacked configuration options to control this behavior
+- Documents exceeding the default 8KB chunk size were particularly affected
+
+#### Fixes Applied
+
+| Component | Change | PR |
+|-----------|--------|-----|
+| RestController | Changed `Mono.ignoreElements(this).then()` to `Mono.from(this).ignoreElement().then()` for proper stream handling | [#16158](https://github.com/opensearch-project/OpenSearch/pull/16158) |
+| ReactorNetty4HttpServerTransport | Added `.allowPartialChunks(false)` configuration to prevent partial chunk emission | [#16337](https://github.com/opensearch-project/OpenSearch/pull/16337) |
+| Reactor Netty | Upgraded from 1.1.22 to 1.1.23 which includes the fix for partial chunk handling | [#16337](https://github.com/opensearch-project/OpenSearch/pull/16337) |
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph Client
+        A[HTTP Client] -->|Chunked Transfer| B[/_bulk/stream]
+    end
+    subgraph "OpenSearch (transport-reactor-netty4)"
+        B --> C[ReactorNetty4HttpServerTransport]
+        C -->|allowPartialChunks=false| D[HTTP Decoder]
+        D --> E[RestController]
+        E -->|Mono.from.ignoreElement| F[BulkStreamingRestHandler]
+    end
+    subgraph Processing
+        F --> G[Document Parser]
+        G --> H[Index Operations]
+        H --> I[Streaming Response]
+    end
+```
+
+### Usage Example
+
+The Streaming Bulk API allows continuous document ingestion with immediate responses:
+
+```bash
+curl -X POST "http://localhost:9200/_bulk/stream" \
+  -H "Transfer-Encoding: chunked" \
+  -H "Content-Type: application/json" -d'
+{ "index": { "_index": "test", "_id": "1" } }
+{ "field": "value with large content..." }
+'
+```
+
+After these fixes, documents of any size (including those exceeding 8KB) are processed reliably without hanging or newline errors.
+
+### Migration Notes
+
+No migration required. These are bug fixes that improve existing functionality. Users experiencing intermittent failures with the Streaming Bulk API should upgrade to v2.18.0 or later.
+
+## Limitations
+
+- The Streaming Bulk API requires the `transport-reactor-netty4` plugin to be installed
+- The feature remains experimental and is not recommended for production use
+- HTTP/2 or HTTP/1.1 with chunked transfer encoding is required
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16158](https://github.com/opensearch-project/OpenSearch/pull/16158) | Fix streaming bulk request hangs |
+| [#16337](https://github.com/opensearch-project/OpenSearch/pull/16337) | Fix intermittent newline termination failures |
+
+## References
+
+- [Issue #16035](https://github.com/opensearch-project/OpenSearch/issues/16035): Streaming bulk request hangs
+- [Issue #16214](https://github.com/opensearch-project/OpenSearch/issues/16214): Intermittent newline termination failures
+- [Streaming Bulk API Documentation](https://docs.opensearch.org/2.18/api-reference/document-apis/bulk-streaming/)
+- [Reactor Netty Issue #3452](https://github.com/reactor/reactor-netty/issues/3452): Partial chunk handling
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/streaming-indexing.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -9,6 +9,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### OpenSearch
 
 - [Multi-Search API](features/opensearch/multi-search-api.md) - Fix multi-search with template doesn't return status code
+- [Streaming Indexing](features/opensearch/streaming-indexing.md) - Bug fixes for streaming bulk request hangs and newline termination errors
 - [Replication](features/opensearch/replication.md) - Fix array hashCode calculation in ResyncReplicationRequest
 - [Task Management](features/opensearch/task-management.md) - Fix missing fields in task index mapping for proper task result storage
 - [Test Fixes](features/opensearch/test-fixes.md) - Fix flaky test in ApproximatePointRangeQueryTests by adjusting totalHits assertion logic


### PR DESCRIPTION
## Summary

This PR adds documentation for the Streaming Indexing feature bug fixes in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/streaming-indexing.md`
- Feature report: `docs/features/opensearch/streaming-indexing.md` (new)

### Key Changes in v2.18.0
- Fixed streaming bulk request hangs ([#16158](https://github.com/opensearch-project/OpenSearch/pull/16158))
- Fixed intermittent "The bulk request must be terminated by a newline [\n]" failures ([#16337](https://github.com/opensearch-project/OpenSearch/pull/16337))
- Upgraded Reactor Netty from 1.1.22 to 1.1.23

### Resources Used
- PR: #16158, #16337
- Issues: #16035, #16214
- Docs: https://docs.opensearch.org/2.18/api-reference/document-apis/bulk-streaming/

Closes #656