### PR TITLE
docs: add node-join-leave report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -31,6 +31,7 @@
 - [Lucene Similarity](opensearch/lucene-similarity.md)
 - [Merge & Segment Settings](opensearch/merge-segment-settings.md)
 - [Multi-Search API](opensearch/multi-search-api.md)
+- [Node Join/Leave](opensearch/node-join-leave.md)
 - [Nodes Info API](opensearch/nodes-info-api.md)
 - [Node Roles Configuration](opensearch/node-roles-configuration.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)

--- a/docs/features/opensearch/node-join-leave.md
+++ b/docs/features/opensearch/node-join-leave.md
@@ -1,0 +1,124 @@
+# Node Join/Leave
+
+## Summary
+
+Node Join/Leave refers to the cluster coordination mechanism that handles nodes joining and leaving an OpenSearch cluster. The cluster manager is responsible for processing node-join and node-left tasks, maintaining cluster state, and ensuring proper connection management between nodes. This feature ensures cluster stability during node membership changes.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Cluster Manager Node"
+        Coord[Coordinator]
+        MS[MasterService]
+        CAS[ClusterApplierService]
+        NCS[NodeConnectionsService]
+        CCM[ClusterConnectionManager]
+        FC[FollowersChecker]
+        LC[LeaderChecker]
+    end
+    
+    subgraph "Data Node"
+        DN[Data Node]
+        PF[PeerFinder]
+        TS[TransportService]
+    end
+    
+    DN -->|Join Request| Coord
+    Coord -->|Validate| Coord
+    Coord -->|Queue Task| MS
+    MS -->|Publish State| CAS
+    CAS -->|Connect/Disconnect| NCS
+    NCS -->|Manage Connections| CCM
+    Coord -->|Monitor| FC
+    DN -->|Health Check| LC
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Node Join Flow"
+        A1[Node sends join request] --> A2[Coordinator validates]
+        A2 --> A3[Queue node-join task]
+        A3 --> A4[Compute new cluster state]
+        A4 --> A5[Publish to all nodes]
+        A5 --> A6[Wait for acknowledgments]
+        A6 --> A7[Commit cluster state]
+        A7 --> A8[FollowersChecker monitors node]
+    end
+    
+    subgraph "Node Left Flow"
+        B1[FollowersChecker detects failure] --> B2[Queue node-left task]
+        B2 --> B3[Mark pending disconnect]
+        B3 --> B4[Compute new cluster state]
+        B4 --> B5[Publish to remaining nodes]
+        B5 --> B6[Commit cluster state]
+        B6 --> B7[Disconnect from node]
+        B7 --> B8[Clear pending disconnect]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `Coordinator` | Main coordination component handling cluster state changes and node membership |
+| `MasterService` | Single-threaded executor for cluster state update tasks |
+| `ClusterApplierService` | Applies cluster state changes and manages node connections |
+| `NodeConnectionsService` | Abstraction for managing connections to cluster nodes |
+| `ClusterConnectionManager` | Low-level connection management with pending disconnection tracking |
+| `FollowersChecker` | Monitors follower nodes from the cluster manager |
+| `LeaderChecker` | Monitors the cluster manager from follower nodes |
+| `PeerFinder` | Discovers and connects to cluster peers |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.fault_detection.follower_check.timeout` | Timeout for follower health checks | 30s |
+| `cluster.fault_detection.follower_check.interval` | Interval between follower checks | 1s |
+| `cluster.fault_detection.follower_check.retry_count` | Retries before marking node as failed | 3 |
+| `cluster.publish.timeout` | Timeout for cluster state publication | 30s |
+| `discovery.find_peers_interval` | Interval for peer discovery/join retries | 1s |
+| `cluster.node_reconnect_interval` | Interval for reconnection attempts | 10s |
+
+### Usage Example
+
+Node join/leave is handled automatically by the cluster. Relevant log messages:
+
+```
+# Node joining
+[INFO ][o.o.c.s.MasterService] node-join[{node-id} join existing leader]
+
+# Node leaving
+[INFO ][o.o.c.s.MasterService] node-left[{node-id} reason: disconnected]
+
+# Cluster state applied
+[INFO ][o.o.c.s.ClusterApplierService] added {{node-id}...}
+[INFO ][o.o.c.s.ClusterApplierService] removed {{node-id}...}
+```
+
+## Limitations
+
+- Cluster manager is single-threaded for state updates, which can cause delays under heavy load
+- Node-join requests are rejected if the node has a pending disconnect to prevent race conditions
+- The `pendingDisconnections` tracking is only maintained on the active cluster manager
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#15521](https://github.com/opensearch-project/OpenSearch/pull/15521) | Fix race condition in node-join/node-left loop |
+
+## References
+
+- [Issue #4874](https://github.com/opensearch-project/OpenSearch/issues/4874): Race in node-left and node-join can prevent node from joining the cluster indefinitely
+- [Cluster Settings Documentation](https://docs.opensearch.org/2.18/install-and-configure/configuring-opensearch/cluster-settings/): Cluster configuration options
+- [Creating a Cluster](https://docs.opensearch.org/2.18/tuning-your-cluster/): Cluster tuning guide
+
+## Change History
+
+- **v2.18.0** (2024-10-22): Fixed race condition in node-join/node-left loop by introducing pending disconnection tracking

--- a/docs/releases/v2.18.0/features/opensearch/node-join-leave.md
+++ b/docs/releases/v2.18.0/features/opensearch/node-join-leave.md
@@ -1,0 +1,103 @@
+# Node Join/Leave Race Condition Fix
+
+## Summary
+
+This release fixes a critical race condition in the node-join and node-left processing loop that could prevent nodes from rejoining the cluster indefinitely. The fix introduces a pending disconnection tracking mechanism that rejects join requests from nodes that have an ongoing node-left task, ensuring clean state transitions.
+
+## Details
+
+### What's New in v2.18.0
+
+A race condition existed where a node could send a join request to the cluster manager while a node-left task was still being processed. This caused an infinite loop of node-join and node-left tasks, preventing the node from ever successfully joining the cluster.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Cluster Manager"
+        CM[Coordinator]
+        NCS[NodeConnectionsService]
+        CCM[ClusterConnectionManager]
+        FC[FollowersChecker]
+    end
+    
+    subgraph "Data Node"
+        DN[Data Node]
+        PF[PeerFinder]
+    end
+    
+    DN -->|1. Disconnect| CM
+    CM -->|2. Queue node-left task| CM
+    CM -->|3. Mark pending disconnect| CCM
+    DN -->|4. Join request| CM
+    CCM -->|5. Reject - pending disconnect| DN
+    CM -->|6. Complete node-left| CM
+    CCM -->|7. Clear pending disconnect| CCM
+    DN -->|8. Retry join request| CM
+    CM -->|9. Accept join| FC
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `pendingDisconnections` | Set in `ClusterConnectionManager` tracking nodes with ongoing node-left tasks |
+| `setPendingDisconnection()` | Method to mark a node as pending disconnect before cluster state publish |
+| `clearPendingDisconnections()` | Method to clear pending disconnections after commit or on cluster manager failover |
+
+#### Key Code Changes
+
+| Class | Change |
+|-------|--------|
+| `ClusterConnectionManager` | Added `pendingDisconnections` set and methods to manage it |
+| `Coordinator` | Marks nodes as pending disconnect before publish, clears on failover |
+| `NodeConnectionsService` | Exposes methods to set/clear pending disconnections |
+| `TransportService` | Delegates pending disconnection management to connection manager |
+| `Discovery` | Added `setNodeConnectionsService()` interface method |
+
+### Usage Example
+
+The fix is automatic and requires no configuration changes. The race condition is now handled internally:
+
+```
+Timeline (Before Fix):
+1. Node disconnects → node-left task queued
+2. Node sends join request → accepted (connection reused)
+3. node-left task wipes connection
+4. node-join task fails (NodeNotConnectedException)
+5. Loop repeats indefinitely
+
+Timeline (After Fix):
+1. Node disconnects → node-left task queued
+2. Node marked as pending disconnect
+3. Node sends join request → REJECTED (pending disconnect)
+4. node-left task completes, clears pending disconnect
+5. Node retries join request → accepted
+6. Node successfully joins cluster
+```
+
+### Migration Notes
+
+No migration required. This is a bug fix that improves cluster stability automatically.
+
+## Limitations
+
+- The `pendingDisconnections` set is only maintained on the active cluster manager node
+- If a disconnect is initiated while a connect is in progress, callers must ensure proper sequencing
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#15521](https://github.com/opensearch-project/OpenSearch/pull/15521) | Fix for race condition in node-join/node-left loop |
+
+## References
+
+- [Issue #4874](https://github.com/opensearch-project/OpenSearch/issues/4874): Original bug report - Race in node-left and node-join can prevent node from joining the cluster indefinitely
+- [Cluster Settings Documentation](https://docs.opensearch.org/2.18/install-and-configure/configuring-opensearch/cluster-settings/): Cluster manager timeout settings
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/node-join-leave.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -9,6 +9,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### OpenSearch
 
 - [Multi-Search API](features/opensearch/multi-search-api.md) - Fix multi-search with template doesn't return status code
+- [Node Join/Leave](features/opensearch/node-join-leave.md) - Fix race condition in node-join and node-left loop
 - [Streaming Indexing](features/opensearch/streaming-indexing.md) - Bug fixes for streaming bulk request hangs and newline termination errors
 - [Replication](features/opensearch/replication.md) - Fix array hashCode calculation in ResyncReplicationRequest
 - [Task Management](features/opensearch/task-management.md) - Fix missing fields in task index mapping for proper task result storage


### PR DESCRIPTION
## Summary

This PR adds documentation for the Node Join/Leave race condition fix in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/node-join-leave.md`
- Feature report: `docs/features/opensearch/node-join-leave.md`

### Key Changes in v2.18.0
- Fixed race condition in node-join/node-left loop that could prevent nodes from rejoining the cluster indefinitely
- Introduced pending disconnection tracking mechanism in `ClusterConnectionManager`
- Join requests from nodes with ongoing node-left tasks are now rejected until the task completes

### Resources Used
- PR: [#15521](https://github.com/opensearch-project/OpenSearch/pull/15521)
- Issue: [#4874](https://github.com/opensearch-project/OpenSearch/issues/4874)

Closes #655