### PR TITLE
docs: add index-settings report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -16,6 +16,7 @@
 - [Deprecated Code Cleanup](opensearch/deprecated-code-cleanup.md)
 - [Cluster Permissions](opensearch/cluster-permissions.md)
 - [gRPC Transport & Services](opensearch/grpc-transport--services.md)
+- [Index Settings](opensearch/index-settings.md)
 - [Mapping Transformer](opensearch/mapping-transformer.md)
 - [Cluster Manager Task Throttling](opensearch/cluster-manager-throttling.md)
 - [Dependency Management](opensearch/dependency-management.md)

--- a/docs/features/opensearch/index-settings.md
+++ b/docs/features/opensearch/index-settings.md
@@ -1,0 +1,112 @@
+# Index Settings
+
+## Summary
+
+Index settings control the behavior and configuration of OpenSearch indexes. Settings can be specified at index creation time and some can be updated dynamically. This feature covers the proper handling of default values when settings are explicitly set to `null`, ensuring consistency with cluster-level defaults.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Index Settings Flow"
+        API[Index/Settings API]
+        MCS[MetadataCreateIndexService]
+        MUS[MetadataUpdateSettingsService]
+        CS[ClusterSettings]
+        IM[IndexMetadata]
+    end
+    
+    API -->|Create Index| MCS
+    API -->|Update Settings| MUS
+    MCS -->|Read Defaults| CS
+    MUS -->|Read Defaults| CS
+    MCS -->|Apply Settings| IM
+    MUS -->|Apply Settings| IM
+```
+
+### Key Settings
+
+| Setting | Type | Scope | Description |
+|---------|------|-------|-------------|
+| `index.number_of_replicas` | Integer | Dynamic | Number of replica shards per primary shard |
+| `index.number_of_routing_shards` | Integer | Static | Number of routing shards for index splitting |
+| `cluster.default_number_of_replicas` | Integer | Cluster | Default replica count when not specified |
+
+### Default Value Resolution
+
+When an index setting is set to `null`, OpenSearch resolves the default value using the following priority:
+
+1. **Cluster-level setting** (e.g., `cluster.default_number_of_replicas`)
+2. **Calculated optimal value** (e.g., routing shards based on number of shards)
+3. **Hardcoded default** (e.g., `1` for replicas)
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.default_number_of_replicas` | Cluster-wide default for replica count | `1` |
+| `index.number_of_replicas` | Per-index replica count | Uses cluster default |
+| `index.number_of_routing_shards` | Routing shards for split operations | Calculated based on shards |
+
+### Usage Example
+
+```bash
+# Configure cluster default
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.default_number_of_replicas": 2
+  }
+}
+
+# Create index (uses cluster default of 2 replicas)
+PUT my-index
+{
+  "settings": {
+    "number_of_shards": 3
+  }
+}
+
+# Override replica count
+PUT my-index/_settings
+{
+  "index": {
+    "number_of_replicas": 5
+  }
+}
+
+# Reset to cluster default
+PUT my-index/_settings
+{
+  "index": {
+    "number_of_replicas": null
+  }
+}
+
+# Verify settings
+GET my-index/_settings
+```
+
+## Limitations
+
+- `index.number_of_routing_shards` is a static setting and cannot be changed after index creation
+- Setting values to `null` requires explicit API calls; omitting a setting in a partial update does not reset it
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#14948](https://github.com/opensearch-project/OpenSearch/pull/14948) | Fix update settings with null replica not honoring cluster setting |
+| v2.18.0 | [#16331](https://github.com/opensearch-project/OpenSearch/pull/16331) | Fix wrong default value when setting routing shards to null |
+
+## References
+
+- [Issue #14810](https://github.com/opensearch-project/OpenSearch/issues/14810): Original bug report for replica count
+- [Issue #16327](https://github.com/opensearch-project/OpenSearch/issues/16327): Original bug report for routing shards
+- [Index Settings Documentation](https://docs.opensearch.org/2.18/install-and-configure/configuring-opensearch/index-settings/): Official documentation
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Fixed default value handling when `index.number_of_replicas` and `index.number_of_routing_shards` are set to `null`

--- a/docs/releases/v2.18.0/features/opensearch/index-settings.md
+++ b/docs/releases/v2.18.0/features/opensearch/index-settings.md
@@ -1,0 +1,122 @@
+# Index Settings
+
+## Summary
+
+This release fixes two bugs related to index settings default value handling when settings are explicitly set to `null`. Previously, setting `index.number_of_replicas` or `index.number_of_routing_shards` to `null` did not properly honor cluster-level defaults or calculate correct values.
+
+## Details
+
+### What's New in v2.18.0
+
+Two bug fixes improve the consistency of index settings behavior when users explicitly set values to `null`:
+
+1. **Replica count default handling**: When updating `index.number_of_replicas` to `null`, the system now correctly uses the `cluster.default_number_of_replicas` setting instead of always defaulting to `1`.
+
+2. **Routing shards default handling**: When creating an index with `index.number_of_routing_shards` set to `null`, the system now calculates the correct default value (same as when the setting is omitted) instead of incorrectly using `number_of_shards`.
+
+### Technical Changes
+
+#### Fix 1: Replica Count Default (PR #14948)
+
+**Problem**: When calling the Update Settings API with `index.number_of_replicas: null`, the replica count always reset to `1`, ignoring the `cluster.default_number_of_replicas` cluster setting.
+
+**Solution**: Modified `MetadataUpdateSettingsService` to read the cluster's default replica count setting and use it as the fallback value.
+
+```java
+// Before: Always used hardcoded default of 1
+indexSettings.put(
+    IndexMetadata.SETTING_NUMBER_OF_REPLICAS,
+    IndexMetadata.INDEX_NUMBER_OF_REPLICAS_SETTING.get(Settings.EMPTY)
+);
+
+// After: Uses cluster setting as default
+final int defaultReplicaCount = clusterService.getClusterSettings()
+    .get(Metadata.DEFAULT_REPLICA_COUNT_SETTING);
+indexSettings.put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, defaultReplicaCount);
+```
+
+#### Fix 2: Routing Shards Default (PR #16331)
+
+**Problem**: When creating an index with `index.number_of_routing_shards: null`, the value incorrectly defaulted to `number_of_shards` instead of the calculated optimal value for index splitting.
+
+**Solution**: Modified `MetadataCreateIndexService.getIndexNumberOfRoutingShards()` to check if the setting value is actually `null` rather than just checking if the setting exists.
+
+```java
+// Before: Checked if setting exists (true even for null value)
+if (IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING.exists(indexSettings)) {
+    routingNumShards = IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING.get(indexSettings);
+}
+
+// After: Checks if actual value is non-null
+if (indexSettings.get(IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING.getKey()) != null) {
+    routingNumShards = IndexMetadata.INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING.get(indexSettings);
+}
+```
+
+### Usage Example
+
+#### Setting Replica Count to Null
+
+```bash
+# Set cluster default
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.default_number_of_replicas": 3
+  }
+}
+
+# Create index with custom replica count
+PUT my-index
+{
+  "settings": {
+    "number_of_replicas": 2
+  }
+}
+
+# Reset to cluster default (now correctly uses 3, not 1)
+PUT my-index/_settings
+{
+  "index": {
+    "number_of_replicas": null
+  }
+}
+```
+
+#### Setting Routing Shards to Null
+
+```bash
+# Create index with null routing shards (now correctly calculates optimal value)
+PUT my-index
+{
+  "settings": {
+    "number_of_routing_shards": null,
+    "number_of_shards": 2
+  }
+}
+
+# Verify routing_num_shards is calculated (e.g., 1024), not equal to number_of_shards (2)
+GET _cluster/state/metadata/my-index
+```
+
+## Limitations
+
+- These fixes only affect new operations after upgrading to v2.18.0
+- Existing indexes with incorrect settings are not automatically corrected
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#14948](https://github.com/opensearch-project/OpenSearch/pull/14948) | Fix update settings with null replica not honoring cluster setting |
+| [#16331](https://github.com/opensearch-project/OpenSearch/pull/16331) | Fix wrong default value when setting `index.number_of_routing_shards` to null |
+
+## References
+
+- [Issue #14810](https://github.com/opensearch-project/OpenSearch/issues/14810): Bug report for replica count default
+- [Issue #16327](https://github.com/opensearch-project/OpenSearch/issues/16327): Bug report for routing shards default
+- [Index Settings Documentation](https://docs.opensearch.org/2.18/install-and-configure/configuring-opensearch/index-settings/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/index-settings.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -8,6 +8,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### OpenSearch
 
+- [Index Settings](features/opensearch/index-settings.md) - Fix default value handling when setting index.number_of_replicas and index.number_of_routing_shards to null
 - [Multi-Search API](features/opensearch/multi-search-api.md) - Fix multi-search with template doesn't return status code
 - [Node Join/Leave](features/opensearch/node-join-leave.md) - Fix race condition in node-join and node-left loop
 - [Streaming Indexing](features/opensearch/streaming-indexing.md) - Bug fixes for streaming bulk request hangs and newline termination errors


### PR DESCRIPTION
## Summary

This PR adds documentation for the Index Settings bug fixes in OpenSearch v2.18.0.

### Changes
- **Release report**: `docs/releases/v2.18.0/features/opensearch/index-settings.md`
- **Feature report**: `docs/features/opensearch/index-settings.md`
- Updated release index and features index

### Key Fixes Documented
1. **PR #14948**: Fix update settings with null replica not honoring `cluster.default_number_of_replicas` setting
2. **PR #16331**: Fix wrong default value when setting `index.number_of_routing_shards` to null on index creation

### Related Issue
Closes #654