### PR TITLE
docs: add nested-aggregations report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -32,6 +32,7 @@
 - [Lucene Similarity](opensearch/lucene-similarity.md)
 - [Merge & Segment Settings](opensearch/merge-segment-settings.md)
 - [Multi-Search API](opensearch/multi-search-api.md)
+- [Nested Aggregations](opensearch/nested-aggregations.md)
 - [Node Join/Leave](opensearch/node-join-leave.md)
 - [Nodes Info API](opensearch/nodes-info-api.md)
 - [Node Roles Configuration](opensearch/node-roles-configuration.md)

--- a/docs/features/opensearch/nested-aggregations.md
+++ b/docs/features/opensearch/nested-aggregations.md
@@ -1,0 +1,151 @@
+# Nested Aggregations
+
+## Summary
+
+Nested aggregations allow you to aggregate on fields inside nested objects. The `nested` type is a specialized version of the object data type that allows arrays of objects to be indexed in a way that they can be queried independently of each other.
+
+Unlike the `object` type where all data is stored in the same document (allowing cross-object matches), nested objects are stored as separate hidden documents, enabling precise aggregations on specific nested object instances.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Nested Aggregation Processing"
+        Query[Search Query] --> NA[NestedAggregator]
+        NA --> PF[Parent Filter]
+        NA --> CF[Child Filter]
+        PF --> BitSet[BitSet Producer]
+        CF --> Scorer[Child Docs Scorer]
+        BitSet --> Collector[Leaf Bucket Collector]
+        Scorer --> Collector
+        Collector --> Results[Aggregation Results]
+    end
+    
+    subgraph "Object Mapper"
+        OM[ObjectMapper] --> Nested[Nested Type]
+        Nested --> isParent[isParent Method]
+        isParent --> |validates| NA
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Document with Nested Objects] --> B[Index as Separate Lucene Docs]
+    B --> C[Search Request with Nested Agg]
+    C --> D[NestedAggregator]
+    D --> E{Determine Parent-Child Relationship}
+    E --> F[Collect Child Documents]
+    F --> G[Build Aggregation Buckets]
+    G --> H[Return Results]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `NestedAggregator` | Main aggregator class that handles nested document collection |
+| `ObjectMapper.Nested` | Contains nested type configuration and utility methods |
+| `BitSetProducer` | Produces bit sets for identifying parent documents |
+| `LeafBucketCollector` | Collects documents into aggregation buckets |
+| `BufferingNestedLeafBucketCollector` | Buffers child documents for multi-bucket scenarios |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `path` | The nested object path to aggregate on | Required |
+
+### Usage Example
+
+**Index Mapping:**
+```json
+PUT logs
+{
+  "mappings": {
+    "properties": {
+      "pages": {
+        "type": "nested",
+        "properties": {
+          "page": { "type": "text" },
+          "load_time": { "type": "double" }
+        }
+      }
+    }
+  }
+}
+```
+
+**Nested Aggregation Query:**
+```json
+GET logs/_search
+{
+  "query": {
+    "match": { "response": "200" }
+  },
+  "aggs": {
+    "pages": {
+      "nested": {
+        "path": "pages"
+      },
+      "aggs": {
+        "min_load_time": { 
+          "min": { "field": "pages.load_time" } 
+        }
+      }
+    }
+  }
+}
+```
+
+**Multi-level Nested Aggregation:**
+```json
+POST index/_search
+{
+  "aggregations": {
+    "level1": {
+      "nested": { "path": "a" },
+      "aggregations": {
+        "terms_agg": {
+          "terms": { "field": "a.b1" },
+          "aggregations": {
+            "level2": {
+              "nested": { "path": "a.b2.c" },
+              "aggregations": {
+                "inner_terms": {
+                  "terms": { "field": "a.b2.c.d" }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Nested objects increase index size as each nested object is stored as a separate Lucene document
+- Deep nesting (many levels) can impact query performance
+- The `nested` aggregation must specify a path relative to the parent document
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#15931](https://github.com/opensearch-project/OpenSearch/pull/15931) | Fix infinite loop in nested agg |
+
+## References
+
+- [Issue #15914](https://github.com/opensearch-project/OpenSearch/issues/15914): Bug report for infinite loop in deep nested aggregations
+- [Nested Aggregations Documentation](https://docs.opensearch.org/2.18/aggregations/bucket/nested/): Official documentation
+- [Nested Field Type](https://docs.opensearch.org/2.18/field-types/supported-field-types/nested/): Nested field type documentation
+
+## Change History
+
+- **v2.18.0** (2024-10-22): Fixed infinite loop bug in deeply nested aggregations ([#15931](https://github.com/opensearch-project/OpenSearch/pull/15931))

--- a/docs/releases/v2.18.0/features/opensearch/nested-aggregations.md
+++ b/docs/releases/v2.18.0/features/opensearch/nested-aggregations.md
@@ -1,0 +1,134 @@
+# Nested Aggregations
+
+## Summary
+
+This release fixes a critical bug that caused infinite loops when executing nested aggregations with deep-level nested objects. The bug was introduced in v2.16.0 and caused queries with multi-level nested aggregations to hang indefinitely.
+
+## Details
+
+### What's New in v2.18.0
+
+Fixed an infinite loop bug in the `NestedAggregator` class that occurred when performing aggregations on deeply nested objects (3+ levels of nesting).
+
+### Technical Changes
+
+#### Bug Description
+
+The issue occurred when executing nested aggregations that traverse multiple levels of nested objects. The `isParent` method in `NestedAggregator` had a logic error where the `childObjectMapper` variable was not being updated during parent traversal, causing an infinite loop.
+
+**Before (buggy code):**
+```java
+private boolean isParent(ObjectMapper parentObjectMapper, ObjectMapper childObjectMapper, MapperService mapperService) {
+    if (parentObjectMapper == null) {
+        return false;
+    }
+    ObjectMapper parent;
+    do {
+        parent = childObjectMapper.getParentObjectMapper(mapperService);
+        // Bug: childObjectMapper never updated, causing infinite loop
+    } while (parent != null && parent != parentObjectMapper);
+    return parentObjectMapper == parent;
+}
+```
+
+**After (fixed code):**
+```java
+public static boolean isParent(ObjectMapper parentObjectMapper, ObjectMapper childObjectMapper, MapperService mapperService) {
+    if (parentObjectMapper == null || childObjectMapper == null) {
+        return false;
+    }
+
+    ObjectMapper parent = childObjectMapper.getParentObjectMapper(mapperService);
+    while (parent != null && parent != parentObjectMapper) {
+        childObjectMapper = parent;  // Fix: update childObjectMapper
+        parent = childObjectMapper.getParentObjectMapper(mapperService);
+    }
+    return parentObjectMapper == parent;
+}
+```
+
+#### Architecture Changes
+
+The `isParent` method was moved from `NestedAggregator` to `ObjectMapper.Nested` as a static utility method, making it reusable and easier to test.
+
+```mermaid
+graph TB
+    subgraph Before
+        NA1[NestedAggregator] --> |contains| IP1[isParent method]
+    end
+    subgraph After
+        NA2[NestedAggregator] --> |uses| OMN[ObjectMapper.Nested]
+        OMN --> |contains| IP2[isParent method]
+    end
+```
+
+#### Changed Files
+
+| File | Change |
+|------|--------|
+| `ObjectMapper.java` | Added static `isParent` method to `Nested` inner class |
+| `NestedAggregator.java` | Removed local `isParent` method, now imports from `ObjectMapper.Nested` |
+| `ObjectMapperTests.java` | Added unit tests for `isParent` method |
+| `410_nested_aggs.yml` | Added REST API integration test |
+
+### Usage Example
+
+The following query now works correctly without hanging:
+
+```json
+POST supplier/_search
+{
+  "aggregations": {
+    "reference_aggregation": {
+      "nested": {
+        "path": "references"
+      },
+      "aggregations": {
+        "references.key": {
+          "terms": {
+            "field": "references.key"
+          },
+          "aggregations": {
+            "referenceValueProperties": {
+              "nested": {
+                "path": "references.value.referenceValueProperties"
+              },
+              "aggregations": {
+                "propertyName": {
+                  "terms": {
+                    "field": "references.value.referenceValueProperties.propertyName"
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+No migration required. This is a bug fix that restores expected behavior for nested aggregations.
+
+## Limitations
+
+- This fix addresses the infinite loop issue but does not change the fundamental behavior of nested aggregations
+- Performance of deeply nested aggregations depends on the data structure and cardinality
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#15931](https://github.com/opensearch-project/OpenSearch/pull/15931) | Fix infinite loop in nested agg |
+
+## References
+
+- [Issue #15914](https://github.com/opensearch-project/OpenSearch/issues/15914): Original bug report - Deep level aggregations query hang the request
+- [Nested Aggregations Documentation](https://docs.opensearch.org/2.18/aggregations/bucket/nested/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/nested-aggregations.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -15,6 +15,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Replication](features/opensearch/replication.md) - Fix array hashCode calculation in ResyncReplicationRequest
 - [Task Management](features/opensearch/task-management.md) - Fix missing fields in task index mapping for proper task result storage
 - [Test Fixes](features/opensearch/test-fixes.md) - Fix flaky test in ApproximatePointRangeQueryTests by adjusting totalHits assertion logic
+- [Nested Aggregations](features/opensearch/nested-aggregations.md) - Fix infinite loop in nested aggregations with deep-level nested objects
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the nested aggregations bug fix in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/nested-aggregations.md`
- Feature report: `docs/features/opensearch/nested-aggregations.md`

### Key Changes in v2.18.0
- Fixed infinite loop bug in `NestedAggregator` when processing deeply nested aggregations (3+ levels)
- Moved `isParent` method from `NestedAggregator` to `ObjectMapper.Nested` as a static utility
- Fixed the loop logic to properly update `childObjectMapper` during parent traversal

### Related
- Closes #653
- OpenSearch PR: [#15931](https://github.com/opensearch-project/OpenSearch/pull/15931)
- OpenSearch Issue: [#15914](https://github.com/opensearch-project/OpenSearch/issues/15914)