### PR TITLE
docs: add flat-object-field report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -15,6 +15,7 @@
 - [Bulk API](opensearch/bulk-api.md)
 - [Deprecated Code Cleanup](opensearch/deprecated-code-cleanup.md)
 - [Cluster Permissions](opensearch/cluster-permissions.md)
+- [Flat Object Field](opensearch/flat-object-field.md)
 - [gRPC Transport & Services](opensearch/grpc-transport--services.md)
 - [Index Settings](opensearch/index-settings.md)
 - [Mapping Transformer](opensearch/mapping-transformer.md)

--- a/docs/features/opensearch/flat-object-field.md
+++ b/docs/features/opensearch/flat-object-field.md
@@ -1,0 +1,163 @@
+# Flat Object Field Type
+
+## Summary
+
+The `flat_object` field type is a specialized object field type introduced in OpenSearch 2.7 that treats an entire JSON object as a string. Unlike regular object fields that dynamically map all subfields, `flat_object` stores the JSON structure without creating separate field mappings for each nested key. This prevents "mapping explosion" when ingesting documents with many dynamic or unknown fields, such as logs with varying structures.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Document Ingestion"
+        DOC[JSON Document] --> PARSER[JsonToStringXContentParser]
+        PARSER --> VALIDATE{Valid Object?}
+        VALIDATE -->|Yes| FLATTEN[Flatten to String Fields]
+        VALIDATE -->|No| ERROR[ParsingException]
+        FLATTEN --> INDEX[Index as Keywords]
+    end
+    
+    subgraph "Indexed Fields"
+        INDEX --> KEYS[field._keys]
+        INDEX --> VALUES[field._values]
+        INDEX --> PATHS[field._paths]
+    end
+    
+    subgraph "Query Processing"
+        QUERY[Search Query] --> TERM[Term/Match Query]
+        TERM --> KEYS
+        TERM --> VALUES
+        TERM --> PATHS
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[JSON Object] --> B[Parse Object]
+    B --> C[Extract Keys]
+    B --> D[Extract Values]
+    B --> E[Build Paths]
+    C --> F[Store as Keywords]
+    D --> F
+    E --> F
+    F --> G[Lucene Index]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `FlatObjectFieldMapper` | Main mapper class that handles flat_object field indexing |
+| `JsonToStringXContentParser` | Parser that transforms JSON objects into string fields |
+| `FlatObjectFieldType` | Field type definition with query support |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `type` | Field type, must be `flat_object` | Required |
+
+### Supported Queries
+
+| Query Type | Description |
+|------------|-------------|
+| `term` | Exact match on leaf values |
+| `terms` | Match any of multiple values |
+| `terms_set` | Match a minimum number of terms |
+| `prefix` | Prefix matching on values |
+| `range` | Range queries on string values |
+| `match` | Full-text match (analyzed as keyword) |
+| `multi_match` | Match across multiple fields |
+| `query_string` | Query string syntax |
+| `simple_query_string` | Simplified query string |
+| `exists` | Check if field exists |
+| `wildcard` | Wildcard pattern matching |
+
+### Usage Example
+
+```json
+// Create index with flat_object field
+PUT /products
+{
+  "mappings": {
+    "properties": {
+      "metadata": {
+        "type": "flat_object"
+      }
+    }
+  }
+}
+
+// Index document with nested JSON
+PUT /products/_doc/1
+{
+  "metadata": {
+    "category": "electronics",
+    "specs": {
+      "weight": "1.5kg",
+      "dimensions": {
+        "width": "30cm",
+        "height": "20cm"
+      }
+    },
+    "tags": {
+      "color": "black",
+      "brand": "acme"
+    }
+  }
+}
+
+// Search by leaf value (finds document)
+GET /products/_search
+{
+  "query": {
+    "match": {
+      "metadata": "black"
+    }
+  }
+}
+
+// Search with dot notation path
+GET /products/_search
+{
+  "query": {
+    "term": {
+      "metadata.tags.color": "black"
+    }
+  }
+}
+```
+
+## Limitations
+
+- Only accepts JSON objects as values (not arrays, strings, or numbers directly)
+- No type-specific parsing (all values stored as strings)
+- No numerical operations (comparison, sorting by numeric value)
+- No text analysis (values stored as keywords)
+- No highlighting support
+- No aggregations on subfields using dot notation
+- No filtering by subfields
+- Painless scripting not supported for retrieving subfield values
+- Wildcard queries not supported for retrieving subfield values
+- Maximum field value length in dot notation is 2²⁴ − 1
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#15985](https://github.com/opensearch-project/OpenSearch/pull/15985) | Fix infinite loop when parsing invalid token types |
+| v2.7.0 | - | Initial implementation of flat_object field type |
+
+## References
+
+- [Issue #15982](https://github.com/opensearch-project/OpenSearch/issues/15982): Bug report for infinite loop with invalid tokens
+- [Flat object documentation](https://docs.opensearch.org/latest/field-types/supported-field-types/flat-object/): Official documentation
+- [Object field types](https://docs.opensearch.org/latest/field-types/supported-field-types/object-fields/): Overview of object field types
+
+## Change History
+
+- **v2.18.0** (2024-10-22): Fixed infinite loop bug when flat_object field receives invalid token types (arrays, strings, numbers). Now throws ParsingException with clear error message.
+- **v2.7.0** (2023-04-18): Initial implementation of flat_object field type.

--- a/docs/releases/v2.18.0/features/opensearch/flat-object-field.md
+++ b/docs/releases/v2.18.0/features/opensearch/flat-object-field.md
@@ -1,0 +1,104 @@
+# Flat Object Field
+
+## Summary
+
+This release fixes a critical bug in the `flat_object` field type that caused an infinite loop when parsing invalid token types. Prior to v2.18.0, providing an array of strings, a plain string, or a number for a `flat_object` field would cause write threads to loop indefinitely, potentially hanging the cluster. The fix adds proper validation and throws a `ParsingException` for unsupported value types.
+
+## Details
+
+### What's New in v2.18.0
+
+The `flat_object` field type now properly validates input and rejects invalid token types with clear error messages instead of entering an infinite loop.
+
+### Technical Changes
+
+#### Bug Root Cause
+
+The infinite loop occurred due to two issues in the parsing logic:
+
+1. `FlatObjectFieldMapper.parseCreateField()` attempted to parse flat object fields that were not objects or null
+2. `JsonToStringXContentParser.parseToken()` would encounter an `END_ARRAY` token, ignore it, and not advance the parser
+
+Combined, this created a scenario where passing an array of strings for a `flat_object` would parse the string values, then loop infinitely on the `END_ARRAY` token.
+
+#### Code Changes
+
+| Component | Change |
+|-----------|--------|
+| `FlatObjectFieldMapper` | Added validation to check for `START_OBJECT` token before parsing |
+| `JsonToStringXContentParser` | Simplified `parseToken()` method, removed unused `processNoNestedValue()` method |
+| `JsonToStringXContentParser` | Changed exception type from `IOException` to `ParsingException` for invalid tokens |
+
+#### Error Handling
+
+Invalid input now throws a `ParsingException` with a descriptive message:
+
+```
+[field_name] unexpected token [TOKEN_TYPE] in flat_object field value
+```
+
+Or for unexpected value tokens:
+
+```
+Unexpected value token type [TOKEN_TYPE]
+```
+
+### Usage Example
+
+```json
+// Valid: flat_object expects a JSON object
+PUT /test-index/_doc/1
+{
+  "catalog": {
+    "category": "books",
+    "price": 29.99
+  }
+}
+
+// Invalid: These now throw ParsingException instead of infinite loop
+// Array of strings
+PUT /test-index/_doc/2
+{
+  "catalog": ["Arrays in Action"]
+}
+
+// Plain string
+PUT /test-index/_doc/3
+{
+  "catalog": "Strings in Action"
+}
+
+// Number
+PUT /test-index/_doc/4
+{
+  "catalog": 12345
+}
+```
+
+### Migration Notes
+
+- No migration required
+- Existing valid documents are unaffected
+- Documents that previously caused infinite loops will now fail with a clear error message
+- Applications should ensure `flat_object` fields receive JSON objects, not arrays, strings, or numbers
+
+## Limitations
+
+- `flat_object` fields only accept JSON objects as values
+- Arrays, strings, numbers, and other primitive types are not supported as direct values
+- This is by design, as `flat_object` is intended to store complex nested JSON structures
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#15985](https://github.com/opensearch-project/OpenSearch/pull/15985) | Avoid infinite loop in flat_object parsing |
+
+## References
+
+- [Issue #15982](https://github.com/opensearch-project/OpenSearch/issues/15982): Bug report for unbounded execution
+- [Flat object documentation](https://docs.opensearch.org/2.18/field-types/supported-field-types/flat-object/): Official docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/flat-object-field.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -8,6 +8,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### OpenSearch
 
+- [Flat Object Field](features/opensearch/flat-object-field.md) - Fix infinite loop when flat_object field contains invalid token types
 - [Index Settings](features/opensearch/index-settings.md) - Fix default value handling when setting index.number_of_replicas and index.number_of_routing_shards to null
 - [Multi-Search API](features/opensearch/multi-search-api.md) - Fix multi-search with template doesn't return status code
 - [Node Join/Leave](features/opensearch/node-join-leave.md) - Fix race condition in node-join and node-left loop


### PR DESCRIPTION
## Summary

This PR adds documentation for the Flat Object Field bug fix in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/flat-object-field.md`
- Feature report: `docs/features/opensearch/flat-object-field.md`

### Key Changes in v2.18.0
- Fixed infinite loop bug when `flat_object` field receives invalid token types (arrays, strings, numbers)
- Now throws `ParsingException` with clear error message instead of hanging

### Related
- PR: [#15985](https://github.com/opensearch-project/OpenSearch/pull/15985)
- Issue: [#15982](https://github.com/opensearch-project/OpenSearch/issues/15982)