### PR TITLE
docs: add search-autocomplete report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -157,6 +157,7 @@
 - [Look & Feel UI Improvements](multi-plugin/look-and-feel-ui-improvements.md)
 - [Maintainer Updates](multi-plugin/maintainer-updates.md)
 - [Multi-Data Source Support](multi-plugin/multi-data-source-support.md)
+- [Search Autocomplete](multi-plugin/search-autocomplete.md)
 - [Version Bumps & Release Notes](multi-plugin/version-bumps-release-notes.md)
 
 ## opensearch-remote-metadata-sdk

--- a/docs/features/multi-plugin/search-autocomplete.md
+++ b/docs/features/multi-plugin/search-autocomplete.md
@@ -1,0 +1,176 @@
+# Search Autocomplete
+
+## Summary
+
+Search Autocomplete in OpenSearch provides real-time search suggestions as users type, improving search experience and helping users find relevant content faster. This feature spans both OpenSearch core (via the `search_as_you_type` field type) and OpenSearch Dashboards (via the query editor autocomplete UI).
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Core"
+        SAYT[search_as_you_type Field]
+        SAYT --> ROOT[Root Field]
+        SAYT --> NGRAM2[_2gram Subfield]
+        SAYT --> NGRAM3[_3gram Subfield]
+        SAYT --> PREFIX[_index_prefix Subfield]
+        SAYT --> MULTI[Multi-Fields]
+    end
+    
+    subgraph "OpenSearch Dashboards"
+        QE[Query Editor]
+        QE --> AC[Autocomplete Provider]
+        AC --> DQL[DQL Suggestions]
+        AC --> PPL[PPL Suggestions]
+        AC --> SQL[SQL Suggestions]
+        QE --> SW[Suggestion Widget]
+        SW --> HINTS[User Hints]
+    end
+    
+    subgraph "Query Flow"
+        USER[User Input] --> QE
+        QE --> QUERY[Search Query]
+        QUERY --> SAYT
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Index Time"
+        DOC[Document] --> ANALYZE[Analyzer]
+        ANALYZE --> TOKENS[Tokens]
+        TOKENS --> NGRAMS[N-grams Generation]
+        NGRAMS --> EDGE[Edge N-grams]
+        EDGE --> INDEX[Lucene Index]
+    end
+    
+    subgraph "Query Time"
+        INPUT[User Input] --> SUGGEST[Suggestion Request]
+        SUGGEST --> MATCH[Prefix Matching]
+        MATCH --> INDEX
+        INDEX --> RESULTS[Suggestions]
+        RESULTS --> DISPLAY[Display to User]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `search_as_you_type` field | Specialized field type that creates n-gram and edge n-gram subfields for efficient prefix matching |
+| `_2gram` subfield | Stores 2-word shingles for phrase matching |
+| `_3gram` subfield | Stores 3-word shingles for longer phrase matching |
+| `_index_prefix` subfield | Stores edge n-grams for prefix completion |
+| Multi-fields | Custom subfields (e.g., keyword) for sorting or exact matching |
+| Query Editor | Dashboards component providing autocomplete UI |
+| Suggestion Widget | Monaco editor widget displaying autocomplete suggestions |
+| DQL Autocomplete | Provides field names, values, and operators for DQL queries |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `max_shingle_size` | Maximum n-gram size (2-4) | 3 |
+| `analyzer` | Analyzer for index and search time | standard |
+| `search_analyzer` | Override analyzer for search time | (uses analyzer) |
+| `index` | Whether field is searchable | true |
+| `store` | Whether to store field value separately | false |
+
+### Usage Example
+
+**Creating a search_as_you_type field with multi-fields**:
+
+```json
+PUT products
+{
+  "mappings": {
+    "properties": {
+      "name": {
+        "type": "search_as_you_type",
+        "max_shingle_size": 3,
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          },
+          "lowercase": {
+            "type": "keyword",
+            "normalizer": "lowercase"
+          }
+        }
+      }
+    }
+  },
+  "settings": {
+    "analysis": {
+      "normalizer": {
+        "lowercase": {
+          "type": "custom",
+          "filter": ["lowercase"]
+        }
+      }
+    }
+  }
+}
+```
+
+**Autocomplete query using bool_prefix**:
+
+```json
+GET products/_search
+{
+  "query": {
+    "multi_match": {
+      "query": "wire head",
+      "type": "bool_prefix",
+      "fields": [
+        "name",
+        "name._2gram",
+        "name._3gram"
+      ]
+    }
+  }
+}
+```
+
+**Phrase prefix query for ordered matching**:
+
+```json
+GET products/_search
+{
+  "query": {
+    "match_phrase_prefix": {
+      "name": "wireless head"
+    }
+  }
+}
+```
+
+## Limitations
+
+- `search_as_you_type` fields do not support `doc_values` (always false)
+- Maximum shingle size is limited to 4
+- Larger `max_shingle_size` values increase index size
+- Multi-fields support was added in v2.18.0 (previously silently ignored)
+- Dashboards autocomplete behavior may vary between DQL, PPL, and SQL query languages
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#15988](https://github.com/opensearch-project/OpenSearch/pull/15988) | Fix search_as_you_type not supporting multi-fields |
+| v2.18.0 | [#7991](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7991) | Keep Autocomplete suggestion window open and put user hints below the suggestion window |
+
+## References
+
+- [Issue #5035](https://github.com/opensearch-project/OpenSearch/issues/5035): Original bug report for search_as_you_type multi-fields
+- [search_as_you_type Documentation](https://docs.opensearch.org/latest/field-types/supported-field-types/search-as-you-type/): Official field type documentation
+- [Autocomplete Documentation](https://docs.opensearch.org/latest/search-plugins/searching-data/autocomplete/): Autocomplete functionality guide
+- [Elasticsearch PR #82430](https://github.com/elastic/elasticsearch/pull/82430): Original fix in Elasticsearch
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Fixed search_as_you_type multi-fields support; Enhanced Dashboards autocomplete UX with persistent suggestions and user hints

--- a/docs/releases/v2.18.0/features/multi-plugin/search-autocomplete.md
+++ b/docs/releases/v2.18.0/features/multi-plugin/search-autocomplete.md
@@ -1,0 +1,137 @@
+# Search Autocomplete
+
+## Summary
+
+OpenSearch v2.18.0 brings two improvements to search autocomplete functionality: a bug fix for `search_as_you_type` field type to support multi-fields in OpenSearch core, and enhanced autocomplete UX in OpenSearch Dashboards with persistent suggestion windows and user hints.
+
+## Details
+
+### What's New in v2.18.0
+
+This release includes improvements across both OpenSearch and OpenSearch Dashboards:
+
+1. **search_as_you_type Multi-Fields Support (OpenSearch)**: Fixed a bug where `search_as_you_type` fields silently ignored the `fields` parameter in mapping definitions. Now multi-fields (subfields) are properly created and indexed.
+
+2. **Autocomplete UX Improvements (Dashboards)**: Enhanced the query editor autocomplete experience with persistent suggestion windows, user hints, and improved operator styling.
+
+### Technical Changes
+
+#### OpenSearch: search_as_you_type Multi-Fields Fix
+
+The `SearchAsYouTypeFieldMapper` was not resolving the `fields` parameter, causing multi-fields to be silently ignored. The fix modifies the mapper to properly build and pass multi-fields to the parent constructor.
+
+**Before (Bug)**:
+```java
+return new SearchAsYouTypeFieldMapper(
+    name, ft, copyTo.build(), prefixFieldMapper, shingleFieldMappers, this);
+```
+
+**After (Fixed)**:
+```java
+return new SearchAsYouTypeFieldMapper(
+    name, ft, multiFieldsBuilder.build(this, context), copyTo.build(),
+    prefixFieldMapper, shingleFieldMappers, this);
+```
+
+#### New Mapping Capability
+
+You can now define multi-fields on `search_as_you_type` fields:
+
+```json
+PUT my_index
+{
+  "mappings": {
+    "properties": {
+      "title": {
+        "type": "search_as_you_type",
+        "fields": {
+          "sortable": {
+            "type": "keyword",
+            "normalizer": "lowercase_normalizer"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### OpenSearch Dashboards: Autocomplete UX Enhancements
+
+| Change | Description |
+|--------|-------------|
+| Persistent suggestion window | Suggestion window stays open when editor is focused, after typing space, and after selecting a suggestion |
+| User hints | Added "Tab to insert, ESC to close window" hint below suggestion window |
+| Operator styling | DQL operators (AND, OR, NOT) now display with distinct operator icon and styling |
+| Trigger on focus | Suggestions automatically appear when clicking into the query editor |
+
+**Key Implementation Details**:
+
+- Added `triggerSuggestOnFocus` prop to `CodeEditor` component
+- Added `triggerCharacters: [' ']` to trigger suggestions after space
+- Added command to trigger next suggestion after selection: `{ id: 'editor.action.triggerSuggest', title: 'Trigger Next Suggestion' }`
+- Added CSS pseudo-element for user hints via `.suggest-widget.visible::after`
+
+### Usage Example
+
+**Using search_as_you_type with multi-fields**:
+
+```json
+// Create index with search_as_you_type and keyword subfield
+PUT products
+{
+  "mappings": {
+    "properties": {
+      "name": {
+        "type": "search_as_you_type",
+        "fields": {
+          "keyword": {
+            "type": "keyword"
+          }
+        }
+      }
+    }
+  }
+}
+
+// Search with bool_prefix for autocomplete
+GET products/_search
+{
+  "query": {
+    "multi_match": {
+      "query": "lap",
+      "type": "bool_prefix",
+      "fields": ["name", "name._2gram", "name._3gram"]
+    }
+  }
+}
+
+// Use keyword subfield for exact match or sorting
+GET products/_search
+{
+  "query": { "term": { "name.keyword": "Laptop Pro" } },
+  "sort": [{ "name.keyword": "asc" }]
+}
+```
+
+## Limitations
+
+- The `search_as_you_type` multi-fields fix is available in v2.18.0+ and v3.0.0+
+- Dashboards autocomplete improvements apply to DQL queries; PPL and SQL may require additional modifications for optimal behavior
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#15988](https://github.com/opensearch-project/OpenSearch/pull/15988) | OpenSearch | Fix search_as_you_type not supporting multi-fields |
+| [#7991](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7991) | OpenSearch-Dashboards | Keep Autocomplete suggestion window open and put user hints below the suggestion window |
+
+## References
+
+- [Issue #5035](https://github.com/opensearch-project/OpenSearch/issues/5035): Original bug report for search_as_you_type multi-fields
+- [search_as_you_type Documentation](https://docs.opensearch.org/2.18/field-types/supported-field-types/search-as-you-type/): Official field type documentation
+- [Autocomplete Documentation](https://docs.opensearch.org/2.18/search-plugins/searching-data/autocomplete/): Autocomplete functionality guide
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/multi-plugin/search-autocomplete.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -53,3 +53,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [MDS Integration Support](features/opensearch-dashboards/mds-integration-support.md) - Multi Data Source support for Integration feature
 - [Experimental Features](features/opensearch-dashboards/experimental-features.md) - User personal settings with scoped uiSettings and User Settings page
 - [Security CVE Fixes](features/opensearch-dashboards/security-cve-fixes.md) - Security updates for dns-sync, axios, path-to-regexp, dompurify, elliptic, micromatch
+
+### Multi-Plugin
+
+- [Search Autocomplete](features/multi-plugin/search-autocomplete.md) - Fix search_as_you_type multi-fields support and enhanced Dashboards autocomplete UX


### PR DESCRIPTION
## Summary

This PR adds documentation for the Search Autocomplete feature improvements in OpenSearch v2.18.0.

## Changes

### Release Report
- `docs/releases/v2.18.0/features/multi-plugin/search-autocomplete.md`

### Feature Report
- `docs/features/multi-plugin/search-autocomplete.md`

## Key Changes in v2.18.0

1. **OpenSearch Core (PR #15988)**: Fixed `search_as_you_type` field type to properly support multi-fields (subfields). Previously, the `fields` parameter was silently ignored.

2. **OpenSearch Dashboards (PR #7991)**: Enhanced autocomplete UX with:
   - Persistent suggestion window (stays open on focus, after space, after selection)
   - User hints below suggestion window ("Tab to insert, ESC to close window")
   - Improved operator styling for DQL (AND, OR, NOT)

## Related Issue
Closes #651