### PR TITLE
docs: add search-backpressure report for v2.18.0

### DIFF
--- a/docs/features/opensearch/search-backpressure.md
+++ b/docs/features/opensearch/search-backpressure.md
@@ -124,12 +124,15 @@ PUT /_cluster/settings
 | Version | PR | Description |
 |---------|-----|-------------|
 | v3.0.0 | [#10028](https://github.com/opensearch-project/OpenSearch/pull/10028) | Add task completion count in search backpressure stats API |
+| v2.18.0 | [#15501](https://github.com/opensearch-project/OpenSearch/pull/15501) | Add validation for the search backpressure cancellation settings |
 
 ## References
 
 - [Issue #8698](https://github.com/opensearch-project/OpenSearch/issues/8698): Add total successful task count in nodeStats API
-- [Search Backpressure Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/search-backpressure/): Official documentation
+- [Issue #15495](https://github.com/opensearch-project/OpenSearch/issues/15495): [BUG] Updating some search backpressure settings crash the cluster
+- [Search Backpressure Documentation](https://docs.opensearch.org/2.18/tuning-your-cluster/availability-and-recovery/search-backpressure/): Official documentation
 
 ## Change History
 
 - **v3.0.0** (2025-05-06): Added `completion_count` field to stats API for calculating cancellation percentages
+- **v2.18.0** (2024-11-05): Added validation for `cancellation_rate`, `cancellation_ratio`, and `cancellation_burst` settings to prevent cluster crashes

--- a/docs/releases/v2.18.0/features/opensearch/search-backpressure.md
+++ b/docs/releases/v2.18.0/features/opensearch/search-backpressure.md
@@ -1,0 +1,88 @@
+# Search Backpressure Validation
+
+## Summary
+
+This release adds validation for search backpressure cancellation settings (`cancellation_rate`, `cancellation_ratio`, `cancellation_burst`) to prevent cluster crashes when updating these settings to invalid values. Previously, setting these values to 0 or updating `cancellation_burst` to a non-default value could crash the cluster.
+
+## Details
+
+### What's New in v2.18.0
+
+This release fixes a critical bug where updating certain search backpressure settings could crash the cluster:
+
+1. **Bug Fix**: Setting `cancellation_burst` to a non-default value caused cluster crash because `cancellationRate` was always 0 when passed to `SearchBackpressureState`
+2. **Validation Added**: `cancellation_rate` and `cancellation_ratio` now validate that values must be greater than 0
+3. **New Setting API**: Added `Setting.doubleSetting()` overloads that accept custom validators
+
+### Technical Changes
+
+#### Root Cause
+
+The `SearchBackpressureState` constructor was not receiving the `cancellationRate` value from cluster settings. When `cancellation_burst` was updated, the `TokenBucket` constructor threw an exception because `rate must be greater than zero`.
+
+#### Fix Implementation
+
+1. **SearchBackpressureState.java**: Added `cancellationRate` parameter to constructor and properly initialized the field
+2. **SearchBackpressureService.java**: Now passes `getCancellationRate()` to `SearchBackpressureState` constructor
+3. **Setting.java**: Added new `doubleSetting()` methods with `Validator<Double>` parameter support
+
+#### New Validation Rules
+
+| Setting | Validation |
+|---------|------------|
+| `search_backpressure.cancellation_rate` | Must be > 0 |
+| `search_backpressure.cancellation_ratio` | Must be > 0 and <= 1.0 |
+| `search_backpressure.search_task.cancellation_rate` | Must be > 0 |
+| `search_backpressure.search_task.cancellation_ratio` | Must be > 0 and <= 1.0 |
+| `search_backpressure.search_shard_task.cancellation_rate` | Must be > 0 |
+| `search_backpressure.search_shard_task.cancellation_ratio` | Must be > 0 and <= 1.0 |
+
+### Usage Example
+
+```bash
+# These settings now work correctly
+PUT _cluster/settings
+{
+  "transient": {
+    "search_backpressure.search_task.cancellation_burst": 11,
+    "search_backpressure.search_task.cancellation_rate": 0.1,
+    "search_backpressure.search_task.cancellation_ratio": 0.2
+  }
+}
+
+# Invalid values now return proper validation errors instead of crashing
+PUT _cluster/settings
+{
+  "transient": {
+    "search_backpressure.search_task.cancellation_rate": 0.0
+  }
+}
+# Returns: "search_backpressure.search_task.cancellation_rate must be > 0"
+```
+
+### Migration Notes
+
+- No migration required
+- Clusters that previously crashed due to invalid settings will now properly reject invalid values with clear error messages
+- Existing valid configurations are unaffected
+
+## Limitations
+
+- The fix is included in v2.18.0 and later versions
+- Clusters running earlier versions should avoid setting `cancellation_burst` to non-default values
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#15501](https://github.com/opensearch-project/OpenSearch/pull/15501) | Add validation for the search backpressure cancellation settings |
+
+## References
+
+- [Issue #15495](https://github.com/opensearch-project/OpenSearch/issues/15495): [BUG] Updating some search backpressure settings crash the cluster
+- [Forum Post](https://forum.opensearch.org/t/unable-to-start-opensearch-loop-failed-to-apply-settings-and-rate-must-be-greater-than-zero/20908): Original bug report
+- [Search Backpressure Documentation](https://docs.opensearch.org/2.18/tuning-your-cluster/availability-and-recovery/search-backpressure/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/search-backpressure.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -12,6 +12,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Index Settings](features/opensearch/index-settings.md) - Fix default value handling when setting index.number_of_replicas and index.number_of_routing_shards to null
 - [Multi-Search API](features/opensearch/multi-search-api.md) - Fix multi-search with template doesn't return status code
 - [Node Join/Leave](features/opensearch/node-join-leave.md) - Fix race condition in node-join and node-left loop
+- [Search Backpressure](features/opensearch/search-backpressure.md) - Add validation for cancellation settings to prevent cluster crashes
 - [Streaming Indexing](features/opensearch/streaming-indexing.md) - Bug fixes for streaming bulk request hangs and newline termination errors
 - [Replication](features/opensearch/replication.md) - Fix array hashCode calculation in ResyncReplicationRequest
 - [Task Management](features/opensearch/task-management.md) - Fix missing fields in task index mapping for proper task result storage


### PR DESCRIPTION
## Summary

Add documentation for Search Backpressure validation fix in v2.18.0.

### Changes
- Created release report: `docs/releases/v2.18.0/features/opensearch/search-backpressure.md`
- Updated feature report: `docs/features/opensearch/search-backpressure.md`
- Updated release index: `docs/releases/v2.18.0/index.md`

### Key Changes in v2.18.0
- Fixed critical bug where updating `cancellation_burst` to non-default value crashed the cluster
- Added validation for `cancellation_rate` and `cancellation_ratio` settings (must be > 0)
- Added new `Setting.doubleSetting()` overloads with custom validator support

### Related
- PR: opensearch-project/OpenSearch#15501
- Issue: opensearch-project/OpenSearch#15495
- Closes #650