### PR TITLE
docs: add wildcard query fixes report for v2.18.0

### DIFF
--- a/docs/features/opensearch/wildcard-field.md
+++ b/docs/features/opensearch/wildcard-field.md
@@ -143,15 +143,20 @@ GET logs/_search
 | Version | PR | Description |
 |---------|-----|-------------|
 | v3.0.0 | [#17349](https://github.com/opensearch-project/OpenSearch/pull/17349) | Optimize to 3-gram only indexing |
+| v2.18.0 | [#15737](https://github.com/opensearch-project/OpenSearch/pull/15737) | Fix wildcard query containing escaped character |
+| v2.18.0 | [#15882](https://github.com/opensearch-project/OpenSearch/pull/15882) | Fix case-insensitive query on wildcard field |
 | v2.15.0 | Initial | Wildcard field type introduction |
 
 ## References
 
 - [Wildcard Field Documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/wildcard/): Official documentation
 - [Issue #17099](https://github.com/opensearch-project/OpenSearch/issues/17099): 3-gram optimization feature request with benchmarks
+- [Issue #15555](https://github.com/opensearch-project/OpenSearch/issues/15555): Bug report for escaped wildcard character handling
+- [Issue #15855](https://github.com/opensearch-project/OpenSearch/issues/15855): Bug report for case-insensitive query issue
 - [OpenSearch 2.15 Blog](https://opensearch.org/blog/diving-into-opensearch-2-15/): Initial feature announcement
 
 ## Change History
 
 - **v3.0.0** (2025-05-06): Changed indexing strategy from 1-3 gram to 3-gram only, reducing index size by ~20% and improving write throughput by 5-30%
+- **v2.18.0** (2024-11-05): Fixed escaped wildcard character handling and case-insensitive query behavior
 - **v2.15.0** (2024-06-25): Initial introduction of wildcard field type with 1-3 gram indexing

--- a/docs/releases/v2.18.0/features/opensearch/wildcard-query-fixes.md
+++ b/docs/releases/v2.18.0/features/opensearch/wildcard-query-fixes.md
@@ -1,0 +1,151 @@
+# Wildcard Query Fixes
+
+## Summary
+
+OpenSearch v2.18.0 fixes two bugs in wildcard queries on wildcard field types: escaped wildcard characters (`\*`, `\?`) are now handled correctly, and case-insensitive queries return expected results. These fixes ensure wildcard fields behave consistently with keyword fields for pattern matching.
+
+## Details
+
+### What's New in v2.18.0
+
+Two critical bug fixes for the wildcard field type:
+
+1. **Escaped Character Handling** ([#15737](https://github.com/opensearch-project/OpenSearch/pull/15737)): Wildcard queries containing escaped `\*` or `\?` characters now work correctly on wildcard fields, matching the behavior of keyword fields.
+
+2. **Case-Insensitive Query Fix** ([#15882](https://github.com/opensearch-project/OpenSearch/pull/15882)): The `case_insensitive` parameter now properly returns all matching documents regardless of case.
+
+### Technical Changes
+
+#### Bug 1: Escaped Wildcard Characters
+
+**Problem**: When searching for literal `*` or `?` characters using escape sequences (`\*`, `\?`), wildcard fields returned no results while keyword fields worked correctly.
+
+**Root Cause**: The `WildcardFieldMapper.getRequiredNGrams()` method did not properly handle escape sequences when extracting n-grams for the index lookup phase.
+
+**Fix**: Added `performEscape()` method to properly process escape sequences:
+
+```java
+private static String performEscape(String str) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < str.length(); i++) {
+        if (str.charAt(i) == '\\' && (i + 1) < str.length()) {
+            char c = str.charAt(i + 1);
+            if (c == '*' || c == '?') {
+                i++;
+            }
+        }
+        sb.append(str.charAt(i));
+    }
+    return sb.toString();
+}
+```
+
+Also updated `getNonWildcardSequence()` to recognize escaped wildcards as literal characters.
+
+#### Bug 2: Case-Insensitive Queries
+
+**Problem**: Queries with `case_insensitive: true` only returned exact case matches instead of all case variations.
+
+**Root Cause**: The `matchAllTermsQuery()` method used case-sensitive `TermQuery` for the approximation phase, filtering out documents with different case before the verification phase could run.
+
+**Fix**: Updated `matchAllTermsQuery()` to use `AutomatonQueries.caseInsensitiveTermQuery()` when case-insensitive matching is requested:
+
+```java
+private static BooleanQuery matchAllTermsQuery(String fieldName, Set<String> terms, boolean caseInsensitive) {
+    BooleanQuery.Builder matchAllTermsBuilder = new BooleanQuery.Builder();
+    Query query;
+    for (String term : terms) {
+        if (caseInsensitive) {
+            query = AutomatonQueries.caseInsensitiveTermQuery(new Term(fieldName, term));
+        } else {
+            query = new TermQuery(new Term(fieldName, term));
+        }
+        matchAllTermsBuilder.add(query, BooleanClause.Occur.FILTER);
+    }
+    return matchAllTermsBuilder.build();
+}
+```
+
+### Usage Example
+
+**Escaped wildcard search** (searching for literal `*`):
+
+```json
+PUT escape_test
+{
+  "mappings": {
+    "properties": {
+      "content": { "type": "wildcard" }
+    }
+  }
+}
+
+POST escape_test/_doc
+{ "content": "* test *" }
+
+GET escape_test/_search
+{
+  "query": {
+    "wildcard": {
+      "content": {
+        "value": "\\**"
+      }
+    }
+  }
+}
+```
+
+**Case-insensitive search**:
+
+```json
+PUT case_test
+{
+  "mappings": {
+    "properties": {
+      "name": { "type": "wildcard" }
+    }
+  }
+}
+
+POST case_test/_bulk
+{"index": {}}
+{"name": "TtAa"}
+{"index": {}}
+{"name": "ttaa"}
+{"index": {}}
+{"name": "TTAA"}
+
+GET case_test/_search
+{
+  "query": {
+    "wildcard": {
+      "name": {
+        "value": "TtAa",
+        "case_insensitive": true
+      }
+    }
+  }
+}
+// Returns all 3 documents
+```
+
+## Limitations
+
+- These fixes apply only to the `wildcard` field type, not to wildcard queries on `keyword` or `text` fields (which already worked correctly)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#15737](https://github.com/opensearch-project/OpenSearch/pull/15737) | Fix wildcard query containing escaped character |
+| [#15882](https://github.com/opensearch-project/OpenSearch/pull/15882) | Fix case-insensitive query on wildcard field |
+
+## References
+
+- [Issue #15555](https://github.com/opensearch-project/OpenSearch/issues/15555): Bug report for escaped wildcard character handling
+- [Issue #15855](https://github.com/opensearch-project/OpenSearch/issues/15855): Bug report for case-insensitive query issue
+- [Wildcard Field Documentation](https://docs.opensearch.org/2.18/field-types/supported-field-types/wildcard/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/wildcard-field.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -8,6 +8,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### OpenSearch
 
+- [Wildcard Query Fixes](features/opensearch/wildcard-query-fixes.md) - Fix escaped wildcard character handling and case-insensitive query on wildcard field
 - [Flat Object Field](features/opensearch/flat-object-field.md) - Fix infinite loop when flat_object field contains invalid token types
 - [Index Settings](features/opensearch/index-settings.md) - Fix default value handling when setting index.number_of_replicas and index.number_of_routing_shards to null
 - [Multi-Search API](features/opensearch/multi-search-api.md) - Fix multi-search with template doesn't return status code


### PR DESCRIPTION
## Summary

This PR adds documentation for the wildcard query fixes in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/wildcard-query-fixes.md`
- Feature report: `docs/features/opensearch/wildcard-field.md` (updated)

### Key Changes in v2.18.0
- Fixed escaped wildcard character handling (`\*`, `\?`) in wildcard queries on wildcard fields
- Fixed case-insensitive query behavior to return all matching documents regardless of case

### Related PRs
- [#15737](https://github.com/opensearch-project/OpenSearch/pull/15737): Fix wildcard query containing escaped character
- [#15882](https://github.com/opensearch-project/OpenSearch/pull/15882): Fix case-insensitive query on wildcard field

Closes #649