### PR TITLE
docs: add dynamic-settings report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -14,6 +14,7 @@
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
 - [Bulk API](opensearch/bulk-api.md)
 - [Deprecated Code Cleanup](opensearch/deprecated-code-cleanup.md)
+- [Dynamic Settings](opensearch/dynamic-settings.md)
 - [Cluster Permissions](opensearch/cluster-permissions.md)
 - [Flat Object Field](opensearch/flat-object-field.md)
 - [gRPC Transport & Services](opensearch/grpc-transport--services.md)

--- a/docs/features/opensearch/dynamic-settings.md
+++ b/docs/features/opensearch/dynamic-settings.md
@@ -1,0 +1,104 @@
+# Dynamic Settings
+
+## Summary
+
+OpenSearch provides dynamic cluster settings that can be updated at runtime without restarting nodes. This feature allows operators to tune cluster behavior for different workloads and cluster sizes, particularly useful for larger clusters where default values may not be optimal.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Settings Update Flow"
+        API[Cluster Settings API] --> CS[ClusterSettings]
+        CS --> |Validate| Val[Setting Validators]
+        Val --> |Update| Consumers[Settings Consumers]
+    end
+    
+    subgraph "Dynamic Settings Consumers"
+        Consumers --> Coord[Coordinator]
+        Consumers --> FC[FollowersChecker]
+        Consumers --> LC[LeaderChecker]
+        Consumers --> LD[LagDetector]
+        Consumers --> SBA[ShardsBatchGatewayAllocator]
+    end
+    
+    subgraph "Runtime Behavior"
+        Coord --> |publishTimeout| Pub[Cluster State Publication]
+        FC --> |followerCheckInterval/Timeout| FD[Fault Detection]
+        LC --> |leaderCheckTimeout| FD
+        LD --> |lagTimeout| NodeRemoval[Lagging Node Removal]
+        SBA --> |batchSize| Alloc[Shard Allocation]
+    end
+```
+
+### Dynamic Cluster Coordination Settings
+
+| Setting | Description | Default | Min | Max |
+|---------|-------------|---------|-----|-----|
+| `cluster.fault_detection.follower_check.interval` | Interval between follower health checks | 1000ms | 100ms | - |
+| `cluster.fault_detection.follower_check.timeout` | Timeout for follower check response | 10000ms | 1ms | 150000ms |
+| `cluster.fault_detection.leader_check.timeout` | Timeout for leader check response | 10000ms | 1ms | 60000ms |
+| `cluster.publish.timeout` | Timeout for cluster state publication | 30000ms | 1ms | - |
+| `cluster.follower_lag.timeout` | Timeout before removing lagging nodes | 90000ms | 1ms | - |
+
+### Dynamic Shard Allocation Settings
+
+| Setting | Description | Default | Min | Max |
+|---------|-------------|---------|-----|-----|
+| `cluster.allocator.gateway.batch_size` | Batch size for shard metadata fetch | 2000 | 1 | 10000 |
+
+### Usage Example
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.fault_detection.follower_check.interval": "2s",
+    "cluster.fault_detection.follower_check.timeout": "30s",
+    "cluster.publish.timeout": "60s",
+    "cluster.follower_lag.timeout": "120s",
+    "cluster.allocator.gateway.batch_size": 3000
+  }
+}
+```
+
+### Tuning for Large Clusters
+
+For clusters with many nodes or high network latency:
+
+1. **Increase timeouts** to prevent false-positive node failures
+2. **Increase batch size** to reduce allocation overhead
+3. **Adjust check intervals** based on cluster stability requirements
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.fault_detection.follower_check.timeout": "60s",
+    "cluster.publish.timeout": "90s",
+    "cluster.follower_lag.timeout": "180s"
+  }
+}
+```
+
+## Limitations
+
+- Very low timeout values can cause cluster instability
+- Settings changes take effect immediately but may not affect in-progress operations
+- Some settings have maximum value constraints for safety
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#16347](https://github.com/opensearch-project/OpenSearch/pull/16347) | Make multiple settings dynamic for tuning on larger clusters |
+
+## References
+
+- [Cluster Settings Documentation](https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/cluster-settings/): Official cluster settings reference
+
+## Change History
+
+- **v2.18.0** (2024-10-22): Made `cluster.fault_detection.follower_check.interval`, `cluster.publish.timeout`, `cluster.follower_lag.timeout`, and `cluster.allocator.gateway.batch_size` dynamic; increased `follower_check.timeout` max from 60s to 150s

--- a/docs/releases/v2.18.0/features/opensearch/dynamic-settings.md
+++ b/docs/releases/v2.18.0/features/opensearch/dynamic-settings.md
@@ -1,0 +1,104 @@
+# Dynamic Settings
+
+## Summary
+
+This release makes multiple cluster-level settings dynamic, allowing operators to tune them at runtime without restarting nodes. This is particularly useful for larger clusters where default values may not be optimal.
+
+## Details
+
+### What's New in v2.18.0
+
+Four cluster settings that were previously static (node-scope only) are now dynamic:
+
+| Setting | Description | Default | Min |
+|---------|-------------|---------|-----|
+| `cluster.fault_detection.follower_check.interval` | Interval between follower health checks from cluster manager | 1000ms | 100ms |
+| `cluster.publish.timeout` | Timeout for cluster state publication | 30000ms | 1ms |
+| `cluster.follower_lag.timeout` | Timeout before removing lagging nodes | 90000ms | 1ms |
+| `cluster.allocator.gateway.batch_size` | Batch size for shard allocation | 2000 | 1 |
+
+Additionally, the maximum value for `cluster.fault_detection.follower_check.timeout` was increased from 60s to 150s.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Cluster Settings Update Flow"
+        API[Cluster Settings API] --> CS[ClusterSettings]
+        CS --> |addSettingsUpdateConsumer| Coord[Coordinator]
+        CS --> |addSettingsUpdateConsumer| FC[FollowersChecker]
+        CS --> |addSettingsUpdateConsumer| LD[LagDetector]
+        CS --> |addSettingsUpdateConsumer| SBA[ShardsBatchGatewayAllocator]
+    end
+    
+    subgraph "Components Updated"
+        Coord --> |setPublishTimeout| PT[publishTimeout]
+        FC --> |setFollowerCheckInterval| FCI[followerCheckInterval]
+        LD --> |setFollowerLagTimeout| FLT[clusterStateApplicationTimeout]
+        SBA --> |setMaxBatchSize| MBS[maxBatchSize]
+    end
+```
+
+#### Modified Components
+
+| Component | Change |
+|-----------|--------|
+| `Coordinator` | Added `setPublishTimeout()` method and settings consumer |
+| `FollowersChecker` | Added `setFollowerCheckInterval()` method and settings consumer |
+| `LagDetector` | Added `setFollowerLagTimeout()` method, accepts `ClusterSettings` in constructor |
+| `ShardsBatchGatewayAllocator` | Added `setMaxBatchSize()` method and settings consumer |
+
+#### Setting Property Changes
+
+Each setting was updated to include `Setting.Property.Dynamic`:
+
+```java
+// Before
+Setting.Property.NodeScope
+
+// After
+Setting.Property.NodeScope,
+Setting.Property.Dynamic
+```
+
+### Usage Example
+
+Update settings dynamically via the Cluster Settings API:
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.fault_detection.follower_check.interval": "2s",
+    "cluster.publish.timeout": "60s",
+    "cluster.follower_lag.timeout": "120s",
+    "cluster.allocator.gateway.batch_size": 3000
+  }
+}
+```
+
+### Migration Notes
+
+No migration required. Existing clusters will continue using default values. Settings can be tuned at runtime as needed for larger clusters.
+
+## Limitations
+
+- Settings changes take effect immediately but may not affect in-progress operations
+- Very low values for timeout settings can cause cluster instability
+- The `follower_check.timeout` maximum is now 150s (increased from 60s)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16347](https://github.com/opensearch-project/OpenSearch/pull/16347) | Make multiple settings dynamic for tuning on larger clusters |
+
+## References
+
+- [Cluster Settings Documentation](https://docs.opensearch.org/2.18/install-and-configure/configuring-opensearch/cluster-settings/): Official cluster settings reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/dynamic-settings.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -8,6 +8,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### OpenSearch
 
+- [Dynamic Settings](features/opensearch/dynamic-settings.md) - Make multiple cluster settings dynamic for tuning on larger clusters
 - [Wildcard Query Fixes](features/opensearch/wildcard-query-fixes.md) - Fix escaped wildcard character handling and case-insensitive query on wildcard field
 - [Flat Object Field](features/opensearch/flat-object-field.md) - Fix infinite loop when flat_object field contains invalid token types
 - [Index Settings](features/opensearch/index-settings.md) - Fix default value handling when setting index.number_of_replicas and index.number_of_routing_shards to null


### PR DESCRIPTION
## Summary

Add documentation for the Dynamic Settings feature in OpenSearch v2.18.0.

### Changes

PR #16347 makes multiple cluster-level settings dynamic, allowing operators to tune them at runtime without restarting nodes:

- `cluster.fault_detection.follower_check.interval`
- `cluster.publish.timeout`
- `cluster.follower_lag.timeout`
- `cluster.allocator.gateway.batch_size`

Additionally, the maximum value for `cluster.fault_detection.follower_check.timeout` was increased from 60s to 150s.

### Reports Created

- Release report: `docs/releases/v2.18.0/features/opensearch/dynamic-settings.md`
- Feature report: `docs/features/opensearch/dynamic-settings.md`

### Related Issue

Closes #648