### PR TITLE
docs: add cluster-state-management report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -21,6 +21,7 @@
 - [Index Settings](opensearch/index-settings.md)
 - [Mapping Transformer](opensearch/mapping-transformer.md)
 - [Cluster Manager Task Throttling](opensearch/cluster-manager-throttling.md)
+- [Cluster State Management](opensearch/cluster-state-management.md)
 - [Dependency Management](opensearch/dependency-management.md)
 - [Locale Provider](opensearch/locale-provider.md)
 - [HTTP API](opensearch/http-api.md)

--- a/docs/features/opensearch/cluster-state-management.md
+++ b/docs/features/opensearch/cluster-state-management.md
@@ -1,0 +1,128 @@
+# Cluster State Management
+
+## Summary
+
+Cluster state management in OpenSearch handles the coordination and distribution of cluster metadata across all nodes. The cluster state contains critical information including index settings, mappings, shard allocation, cluster-level settings, and voting configurations. Proper management ensures cluster consistency and enables features like remote cluster state publication for improved durability.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Cluster Manager Node"
+        CM[Coordinator]
+        CS[CoordinationState]
+        PTH[PublicationTransportHandler]
+    end
+    
+    subgraph "Follower Nodes"
+        F1[Follower 1]
+        F2[Follower 2]
+        F3[Follower N]
+    end
+    
+    subgraph "Remote Store"
+        RS[Remote Cluster State]
+    end
+    
+    CM --> CS
+    CS --> PTH
+    PTH -->|Publish| F1
+    PTH -->|Publish| F2
+    PTH -->|Publish| F3
+    PTH -->|Commit| F1
+    PTH -->|Commit| F2
+    PTH -->|Commit| F3
+    CM -.->|Remote Publication| RS
+    RS -.->|Download| F1
+    RS -.->|Download| F2
+    RS -.->|Download| F3
+```
+
+### Cluster State Publication Flow
+
+```mermaid
+sequenceDiagram
+    participant CM as Cluster Manager
+    participant PTH as PublicationTransportHandler
+    participant F as Follower Node
+    participant RS as Remote Store
+    
+    CM->>PTH: Publish Request
+    PTH->>F: Send Cluster State (full/diff)
+    F->>F: Apply on lastSeenClusterState
+    F-->>PTH: Publish Response
+    
+    CM->>PTH: Commit Request
+    PTH->>F: Apply Commit
+    F->>F: Set committed config
+    F->>F: Update lastSeenClusterState
+    F-->>PTH: Commit Response
+    
+    Note over RS: Remote Publication Path
+    CM->>RS: Upload Cluster State
+    F->>RS: Download Cluster State
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `Coordinator` | Main lifecycle coordinator managing cluster state transitions between CANDIDATE, LEADER, and FOLLOWER modes |
+| `CoordinationState` | Maintains the coordination state including current term, last accepted state, and voting configurations |
+| `PublicationTransportHandler` | Handles transport-level publication of cluster state to follower nodes |
+| `lastSeenClusterState` | Reference to the last cluster state seen by a node, used as base for applying diffs |
+| `ApplyCommitRequest` | Request sent during commit phase to finalize cluster state changes |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.remote_store.state.enabled` | Enable remote cluster state storage | `false` |
+| `cluster.remote_store.publication.enabled` | Enable remote cluster state publication | `false` |
+| `cluster.publish.timeout` | Timeout for cluster state publication | `30s` |
+| `cluster.publish.info_timeout` | Timeout before logging slow publication info | `10s` |
+
+### Voting Configuration
+
+The cluster state contains coordination metadata with two voting configurations:
+
+- **Accepted Voting Configuration**: The configuration accepted during the publish phase
+- **Committed Voting Configuration**: The configuration committed after successful publication
+
+These configurations determine which nodes can participate in cluster manager elections and must remain consistent across all nodes.
+
+### Usage Example
+
+```yaml
+# Enable remote cluster state in opensearch.yml
+cluster.remote_store.state.enabled: true
+cluster.remote_store.publication.enabled: true
+
+# Remote state repository settings
+node.attr.remote_store.state.repository: my-remote-state-repo
+node.attr.remote_store.repository.my-remote-state-repo.type: s3
+node.attr.remote_store.repository.my-remote-state-repo.settings.bucket: my-bucket
+node.attr.remote_store.repository.my-remote-state-repo.settings.region: us-east-1
+```
+
+## Limitations
+
+- Remote cluster state publication requires all nodes to have remote publication enabled
+- Unsafe bootstrap scripts cannot be run when remote cluster state is enabled
+- When majority of cluster manager nodes are lost, nodes must be replaced and reseeded to bootstrap a new cluster
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#16215](https://github.com/opensearch-project/OpenSearch/pull/16215) | Fix: Update last seen cluster state in commit phase |
+
+## References
+
+- [Remote Cluster State Documentation](https://docs.opensearch.org/2.18/tuning-your-cluster/availability-and-recovery/remote-store/remote-cluster-state/)
+
+## Change History
+
+- **v2.18.0** (2024-10-29): Fixed voting configuration mismatch by updating lastSeenClusterState in commit phase

--- a/docs/releases/v2.18.0/features/opensearch/cluster-state-management.md
+++ b/docs/releases/v2.18.0/features/opensearch/cluster-state-management.md
@@ -1,0 +1,113 @@
+# Cluster State Management
+
+## Summary
+
+This release fixes a bug in cluster state management where the committed voting configuration could become stale during remote cluster state publication. The fix updates the `lastSeenClusterState` in the commit phase to ensure voting configuration consistency across cluster state updates.
+
+## Details
+
+### What's New in v2.18.0
+
+The change addresses a coordination metadata mismatch issue that occurs during remote cluster state publication when voting configuration changes.
+
+### Technical Changes
+
+#### Problem Background
+
+Coordination metadata contains two voting configurations:
+- **Accepted voting configuration**: Sent during the publish phase when voting configuration changes
+- **Committed voting configuration**: Set by each node using the accepted voting configuration during the commit phase
+
+When a voting configuration change occurs:
+1. The changed accepted voting configuration is sent in the publish phase
+2. Follower nodes apply this cluster state on the `lastSeenClusterState` in `PublicationTransportHandler`
+3. In the commit phase, each node sets the committed voting configuration using the accepted voting configuration
+
+The issue arises when the next cluster state is published without any voting configuration diff. This update uses `lastSeenClusterState` again to apply the diff, causing the committed voting configuration to retain an older value.
+
+#### Solution
+
+```mermaid
+graph TB
+    subgraph "Before Fix"
+        A1[Publish Phase] --> B1[Apply on lastSeenClusterState]
+        B1 --> C1[Commit Phase]
+        C1 --> D1[Set committed config]
+        D1 --> E1[Next Publish]
+        E1 --> F1[Apply diff on stale lastSeenClusterState]
+        F1 --> G1[Committed config mismatch]
+    end
+    
+    subgraph "After Fix"
+        A2[Publish Phase] --> B2[Apply on lastSeenClusterState]
+        B2 --> C2[Commit Phase]
+        C2 --> D2[Set committed config]
+        D2 --> E2[Update lastSeenClusterState]
+        E2 --> F2[Next Publish]
+        F2 --> G2[Apply diff on updated lastSeenClusterState]
+        G2 --> H2[Committed config consistent]
+    end
+```
+
+The fix updates `lastSeenClusterState` in the commit phase, ensuring subsequent cluster state updates apply diffs on the correct base state.
+
+#### Code Changes
+
+| Component | Change |
+|-----------|--------|
+| `Coordinator.handleApplyCommit()` | Added `Consumer<ClusterState> updateLastSeen` parameter to update lastSeenClusterState after commit |
+| `PublicationTransportHandler` | Changed handler signature from `BiConsumer` to `TriConsumer` to pass `updateLastSeen` callback |
+| `PublicationTransportHandler.updateLastSeen()` | New private method to update `lastSeenClusterState` |
+
+#### Key Implementation
+
+In `Coordinator.java`:
+```java
+private void handleApplyCommit(
+    ApplyCommitRequest applyCommitRequest,
+    Consumer<ClusterState> updateLastSeen,
+    ActionListener<Void> applyListener
+) {
+    synchronized (mutex) {
+        coordinationState.get().handleCommit(applyCommitRequest);
+        final ClusterState committedState = hideStateIfNotRecovered(
+            coordinationState.get().getLastAcceptedState());
+        applierState = mode == Mode.CANDIDATE 
+            ? clusterStateWithNoClusterManagerBlock(committedState) 
+            : committedState;
+        clusterApplier.setPreCommitState(applierState);
+        updateLastSeen.accept(coordinationState.get().getLastAcceptedState());
+        // ... rest of method
+    }
+}
+```
+
+In `PublicationTransportHandler.java`:
+```java
+private void updateLastSeen(final ClusterState clusterState) {
+    lastSeenClusterState.set(clusterState);
+}
+```
+
+### Impact
+
+This fix is particularly important for clusters using remote cluster state publication, where coordination metadata is not sent in every diff (unlike local publication). Without this fix, clusters could experience voting configuration inconsistencies after voting configuration changes.
+
+## Limitations
+
+- This is a bug fix with no new configuration options
+- Only affects clusters using remote cluster state publication
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16215](https://github.com/opensearch-project/OpenSearch/pull/16215) | Update last seen cluster state in commit phase |
+
+## References
+
+- [Remote Cluster State Documentation](https://docs.opensearch.org/2.18/tuning-your-cluster/availability-and-recovery/remote-store/remote-cluster-state/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/cluster-state-management.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -8,6 +8,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### OpenSearch
 
+- [Cluster State Management](features/opensearch/cluster-state-management.md) - Fix voting configuration mismatch by updating lastSeenClusterState in commit phase
 - [Dynamic Settings](features/opensearch/dynamic-settings.md) - Make multiple cluster settings dynamic for tuning on larger clusters
 - [Wildcard Query Fixes](features/opensearch/wildcard-query-fixes.md) - Fix escaped wildcard character handling and case-insensitive query on wildcard field
 - [Flat Object Field](features/opensearch/flat-object-field.md) - Fix infinite loop when flat_object field contains invalid token types


### PR DESCRIPTION
## Summary

This PR adds documentation for the Cluster State Management fix in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/cluster-state-management.md`
- Feature report: `docs/features/opensearch/cluster-state-management.md`

### Key Changes in v2.18.0
- Fixed voting configuration mismatch during remote cluster state publication
- Updated `lastSeenClusterState` in commit phase to ensure consistency
- Changed `PublicationTransportHandler` to use `TriConsumer` for passing update callback

### Related Issue
Closes #647

### Source PR
- [opensearch-project/OpenSearch#16215](https://github.com/opensearch-project/OpenSearch/pull/16215)