### PR TITLE
docs: add code-cleanup report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -13,6 +13,7 @@
 
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
 - [Bulk API](opensearch/bulk-api.md)
+- [Code Cleanup](opensearch/code-cleanup.md)
 - [Deprecated Code Cleanup](opensearch/deprecated-code-cleanup.md)
 - [Dynamic Settings](opensearch/dynamic-settings.md)
 - [Cluster Permissions](opensearch/cluster-permissions.md)

--- a/docs/features/opensearch/code-cleanup.md
+++ b/docs/features/opensearch/code-cleanup.md
@@ -1,0 +1,91 @@
+# Code Cleanup
+
+## Summary
+
+Code cleanup encompasses various internal improvements to the OpenSearch codebase that enhance maintainability, fix bugs, and optimize performance without changing user-facing APIs. These changes include removing redundant code, fixing inefficient patterns, and correcting typos.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Query Approximation Framework"
+        ASQ[ApproximateScoreQuery]
+        APQ[ApproximatePointRangeQuery]
+        OQ[Original Query]
+        ASQ --> APQ
+        ASQ --> OQ
+    end
+    
+    subgraph "Date Range Query"
+        DFM[DateFieldMapper]
+        IODVQ[IndexOrDocValuesQuery]
+        DFM --> ASQ
+        IODVQ --> OQ
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ApproximateScoreQuery` | Entry-point wrapper for query approximation framework |
+| `ApproximatePointRangeQuery` | Approximate version of point range queries |
+| `DateFieldMapper` | Mapper for date fields, uses approximation for range queries |
+| `QueryAnalyzer` | Percolator query analysis with optimized extraction logic |
+| `RemoteStoreNodeAttribute` | Node attribute for remote store configuration |
+
+### Key Improvements
+
+#### Query Approximation Simplification
+
+The approximation framework was simplified by removing the specialized `ApproximateIndexOrDocValuesQuery` class. The generic `ApproximateScoreQuery` now handles all cases:
+
+- Wraps any original query (including `IndexOrDocValuesQuery`)
+- Pairs with an `ApproximateQuery` for potential optimization
+- Decides at runtime which query to execute based on context
+
+#### Stream API Best Practices
+
+Replaced inefficient Stream API patterns with traditional loops where appropriate:
+
+- Avoid multiple stream traversals over the same collection
+- Use boolean flags instead of `count()` for existence checks
+- Combine related operations into single passes
+
+### Configuration
+
+No configuration changes. These are internal code improvements.
+
+### Usage Example
+
+These changes are internal and don't affect user-facing APIs. The query approximation framework is controlled by a feature flag:
+
+```yaml
+# opensearch.yml
+opensearch.experimental.feature.approximate_point_range_query.enabled: true
+```
+
+## Limitations
+
+- Internal changes only; no user-facing API modifications
+- Query approximation requires feature flag to be enabled
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#16273](https://github.com/opensearch-project/OpenSearch/pull/16273) | Remove ApproximateIndexOrDocValuesQuery |
+| v2.18.0 | [#15386](https://github.com/opensearch-project/OpenSearch/pull/15386) | Fix inefficient Stream API call chains |
+| v2.18.0 | [#15362](https://github.com/opensearch-project/OpenSearch/pull/15362) | Fix typo in RemoteStoreNodeAttribute.toString() |
+
+## References
+
+- [PR #16273](https://github.com/opensearch-project/OpenSearch/pull/16273): Query approximation framework cleanup
+- [PR #15386](https://github.com/opensearch-project/OpenSearch/pull/15386): Stream API optimization in percolator
+- [PR #15362](https://github.com/opensearch-project/OpenSearch/pull/15362): RemoteStoreNodeAttribute typo fix
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Query approximation simplification, Stream API optimization, typo fix

--- a/docs/releases/v2.18.0/features/opensearch/code-cleanup.md
+++ b/docs/releases/v2.18.0/features/opensearch/code-cleanup.md
@@ -1,0 +1,118 @@
+# Code Cleanup
+
+## Summary
+
+OpenSearch v2.18.0 includes several code cleanup improvements that simplify the query approximation framework, fix inefficient Stream API usage patterns, and correct a typo in the RemoteStoreNodeAttribute class. These changes improve code maintainability and performance without changing user-facing behavior.
+
+## Details
+
+### What's New in v2.18.0
+
+This release consolidates three code cleanup improvements:
+
+1. **Query Approximation Framework Simplification**: Removed the redundant `ApproximateIndexOrDocValuesQuery` class by leveraging the existing `ApproximateScoreQuery` wrapper
+2. **Stream API Optimization**: Fixed inefficient Stream API call chains ending with `count()` in the percolator module
+3. **Typo Fix**: Corrected `super.toString()` to `sb.toString()` in `RemoteStoreNodeAttribute`
+
+### Technical Changes
+
+#### Query Approximation Refactoring
+
+The `ApproximateIndexOrDocValuesQuery` class was removed because `ApproximateScoreQuery` already provides the ability to choose between approximate and original queries. The refactoring:
+
+- Removes `ApproximateIndexOrDocValuesQuery.java` (62 lines)
+- Updates `DateFieldMapper` to use `ApproximateScoreQuery` directly with `IndexOrDocValuesQuery` as the original query
+- Simplifies the approximation check in `ApproximatePointRangeQuery.canApproximate()`
+- Makes `ApproximateScoreQuery` final and its `resolvedQuery` field package-private
+
+```java
+// Before: Specialized wrapper
+new ApproximateIndexOrDocValuesQuery(
+    pointRangeQuery,
+    approximateQuery,
+    dvQuery
+)
+
+// After: Generic wrapper with IndexOrDocValuesQuery
+new ApproximateScoreQuery(
+    new IndexOrDocValuesQuery(pointRangeQuery, dvQuery),
+    approximateQuery
+)
+```
+
+#### Stream API Optimization
+
+Fixed inefficient Stream API patterns in `QueryAnalyzer.minTermLength()`:
+
+```java
+// Before: Two separate stream operations
+if (extractions.stream().filter(q -> q.term != null).count() == 0
+    && extractions.stream().filter(q -> q.range != null).count() > 0) {
+    return Integer.MIN_VALUE;
+}
+
+// After: Single loop with boolean flags
+boolean hasTerm = false;
+boolean hasRange = false;
+for (QueryExtraction qt : extractions) {
+    if (qt.term != null) {
+        hasTerm = true;
+        min = Math.min(min, qt.bytes().length);
+    }
+    if (qt.range != null) {
+        hasRange = true;
+    }
+}
+if (!hasTerm && hasRange) {
+    return Integer.MIN_VALUE;
+}
+```
+
+#### RemoteStoreNodeAttribute Typo Fix
+
+```java
+// Before: Returns Object.toString() instead of built string
+public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append('{').append(this.repositoriesMetadata).append('}');
+    return super.toString();  // Bug: ignores sb
+}
+
+// After: Returns the constructed string
+public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append('{').append(this.repositoriesMetadata).append('}');
+    return sb.toString();  // Fixed
+}
+```
+
+### Files Changed
+
+| PR | Files Modified | Lines Changed |
+|----|----------------|---------------|
+| #16273 | 14 files | +117/-175 |
+| #15386 | 2 files | +14/-7 |
+| #15362 | 2 files | +2/-1 |
+
+## Limitations
+
+- These are internal code improvements with no user-facing API changes
+- The query approximation refactoring requires the `approximate_point_range_query` feature flag to be enabled
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16273](https://github.com/opensearch-project/OpenSearch/pull/16273) | Remove ApproximateIndexOrDocValuesQuery |
+| [#15386](https://github.com/opensearch-project/OpenSearch/pull/15386) | Fix inefficient Stream API call chains ending with count() |
+| [#15362](https://github.com/opensearch-project/OpenSearch/pull/15362) | Fix typo super->sb in method toString() of RemoteStoreNodeAttribute |
+
+## References
+
+- [PR #16273](https://github.com/opensearch-project/OpenSearch/pull/16273): Query approximation framework cleanup
+- [PR #15386](https://github.com/opensearch-project/OpenSearch/pull/15386): Stream API optimization
+- [PR #15362](https://github.com/opensearch-project/OpenSearch/pull/15362): RemoteStoreNodeAttribute typo fix
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/code-cleanup.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -21,6 +21,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Task Management](features/opensearch/task-management.md) - Fix missing fields in task index mapping for proper task result storage
 - [Test Fixes](features/opensearch/test-fixes.md) - Fix flaky test in ApproximatePointRangeQueryTests by adjusting totalHits assertion logic
 - [Nested Aggregations](features/opensearch/nested-aggregations.md) - Fix infinite loop in nested aggregations with deep-level nested objects
+- [Code Cleanup](features/opensearch/code-cleanup.md) - Query approximation simplification, Stream API optimization, typo fix
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Code Cleanup release item in OpenSearch v2.18.0.

## Changes

### Release Report
- `docs/releases/v2.18.0/features/opensearch/code-cleanup.md`

### Feature Report
- `docs/features/opensearch/code-cleanup.md`

## PRs Investigated

| PR | Description |
|----|-------------|
| [#16273](https://github.com/opensearch-project/OpenSearch/pull/16273) | Remove ApproximateIndexOrDocValuesQuery - simplifies query approximation framework |
| [#15386](https://github.com/opensearch-project/OpenSearch/pull/15386) | Fix inefficient Stream API call chains ending with count() |
| [#15362](https://github.com/opensearch-project/OpenSearch/pull/15362) | Fix typo super->sb in method toString() of RemoteStoreNodeAttribute |

## Key Findings

- Query approximation framework simplified by removing redundant `ApproximateIndexOrDocValuesQuery` class
- Stream API patterns optimized in percolator module's `QueryAnalyzer`
- Typo fix in `RemoteStoreNodeAttribute.toString()` method

Closes #646