### PR TITLE
docs: add search-request-stats report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -44,6 +44,7 @@
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)
 - [Replication](opensearch/replication.md)
 - [Search Backpressure](opensearch/search-backpressure.md)
+- [Search Request Stats](opensearch/search-request-stats.md)
 - [Segment Warmer](opensearch/segment-warmer.md)
 - [Star Tree Index](opensearch/star-tree-index.md)
 - [Streaming Indexing](opensearch/streaming-indexing.md)

--- a/docs/features/opensearch/search-request-stats.md
+++ b/docs/features/opensearch/search-request-stats.md
@@ -1,0 +1,176 @@
+# Search Request Stats
+
+## Summary
+
+Search Request Stats provides coordinator-level search latency metrics for OpenSearch clusters. This feature tracks the total time spent on search requests at the coordinator node, including detailed phase breakdowns (query, fetch, DFS, expand, can_match). It enables better observability and performance monitoring of search operations.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Coordinator Node"
+        SR[Search Request] --> SRS[SearchRequestStats]
+        SRS --> |onRequestStart| TookStats[Took Stats]
+        SRS --> |onPhaseStart/End| PhaseStats[Phase Stats]
+    end
+    
+    subgraph "Statistics Collection"
+        TookStats --> |time_in_millis| TotalTime[Total Time]
+        TookStats --> |current| CurrentRequests[Current Requests]
+        TookStats --> |total| TotalCount[Total Count]
+        PhaseStats --> QueryPhase[Query Phase]
+        PhaseStats --> FetchPhase[Fetch Phase]
+        PhaseStats --> DFSPhase[DFS Phases]
+        PhaseStats --> OtherPhases[Other Phases]
+    end
+    
+    subgraph "Nodes Stats API"
+        TotalTime --> API[/_nodes/stats/indices/search]
+        CurrentRequests --> API
+        TotalCount --> API
+        QueryPhase --> API
+        FetchPhase --> API
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SearchRequestStats` | Main class that extends `SearchRequestOperationsListener` to collect statistics |
+| `StatsHolder` | Inner class holding `current`, `total`, and `timing` metrics |
+| `SearchRequestOperationsListener` | Base listener interface for search request lifecycle events |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `search.request_stats_enabled` | Enable/disable coordinator search request statistics collection | `true` (since v2.18.0) |
+
+The setting is:
+- **Dynamic**: Can be changed at runtime via cluster settings API
+- **Node-scoped**: Applies to individual nodes
+
+### Statistics Breakdown
+
+The feature collects the following metrics:
+
+| Metric Category | Metrics | Description |
+|-----------------|---------|-------------|
+| `took` | `time_in_millis`, `current`, `total` | Overall search request statistics |
+| `dfs_pre_query` | `time_in_millis`, `current`, `total` | Distributed frequency search prequery phase |
+| `query` | `time_in_millis`, `current`, `total` | Query execution phase |
+| `fetch` | `time_in_millis`, `current`, `total` | Document fetch phase |
+| `dfs_query` | `time_in_millis`, `current`, `total` | DFS query phase |
+| `expand` | `time_in_millis`, `current`, `total` | Search expansion phase |
+| `can_match` | `time_in_millis`, `current`, `total` | Can match optimization phase |
+
+### Usage Example
+
+#### Enable/Disable Statistics
+
+```bash
+# Enable (default in v2.18.0+)
+PUT _cluster/settings
+{
+  "persistent": {
+    "search.request_stats_enabled": true
+  }
+}
+
+# Disable
+PUT _cluster/settings
+{
+  "persistent": {
+    "search.request_stats_enabled": false
+  }
+}
+```
+
+#### Retrieve Statistics
+
+```bash
+# Get search stats for all nodes
+GET _nodes/stats/indices/search
+
+# Get search stats for specific node
+GET _nodes/<node_id>/stats/indices/search
+```
+
+#### Example Response
+
+```json
+{
+  "nodes": {
+    "node_id": {
+      "indices": {
+        "search": {
+          "request": {
+            "took": {
+              "time_in_millis": 129,
+              "current": 0,
+              "total": 10
+            },
+            "dfs_pre_query": {
+              "time_in_millis": 0,
+              "current": 0,
+              "total": 0
+            },
+            "query": {
+              "time_in_millis": 98,
+              "current": 0,
+              "total": 10
+            },
+            "fetch": {
+              "time_in_millis": 6,
+              "current": 0,
+              "total": 10
+            },
+            "dfs_query": {
+              "time_in_millis": 0,
+              "current": 0,
+              "total": 0
+            },
+            "expand": {
+              "time_in_millis": 9,
+              "current": 0,
+              "total": 10
+            },
+            "can_match": {
+              "time_in_millis": 0,
+              "current": 0,
+              "total": 0
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Statistics are collected per-node and not aggregated across the cluster
+- Minimal performance overhead when enabled
+- Only tracks coordinator-level statistics (not shard-level)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.17.0 | [#15054](https://github.com/opensearch-project/OpenSearch/pull/15054) | Initial implementation - Add took time to request nodes stats |
+| v2.18.0 | [#16290](https://github.com/opensearch-project/OpenSearch/pull/16290) | Enable search.request_stats_enabled by default |
+| v2.18.0 | [#16320](https://github.com/opensearch-project/OpenSearch/pull/16320) | Backport to 2.x branch |
+
+## References
+
+- [Issue #10768](https://github.com/opensearch-project/OpenSearch/issues/10768): Original feature request - Search stats for coordinator node misses total search request time
+- [Nodes Stats API Documentation](https://docs.opensearch.org/latest/api-reference/nodes-apis/nodes-stats/): Official API documentation
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Enabled `search.request_stats_enabled` by default
+- **v2.17.0** (2024-09-17): Initial implementation with `took` statistics and phase breakdowns

--- a/docs/releases/v2.18.0/features/opensearch/search-request-stats.md
+++ b/docs/releases/v2.18.0/features/opensearch/search-request-stats.md
@@ -1,0 +1,118 @@
+# Search Request Stats
+
+## Summary
+
+In v2.18.0, the `search.request_stats_enabled` setting is now enabled by default. This change allows coordinator-level search request statistics to be collected automatically without requiring manual configuration, providing better out-of-the-box observability for search operations.
+
+## Details
+
+### What's New in v2.18.0
+
+The default value for `search.request_stats_enabled` has been changed from `false` to `true`. This means search request statistics are now collected by default on coordinator nodes.
+
+### Technical Changes
+
+#### Configuration Change
+
+| Setting | Previous Default | New Default |
+|---------|------------------|-------------|
+| `search.request_stats_enabled` | `false` | `true` |
+
+#### Code Change
+
+The change was made in `SearchRequestStats.java`:
+
+```java
+public static final Setting<Boolean> SEARCH_REQUEST_STATS_ENABLED = Setting.boolSetting(
+    SEARCH_REQUEST_STATS_ENABLED_KEY,
+    true,  // Changed from false
+    Setting.Property.Dynamic,
+    Setting.Property.NodeScope
+);
+```
+
+### Statistics Collected
+
+When enabled, the following coordinator-level statistics are collected and available via the Nodes Stats API:
+
+| Metric | Description |
+|--------|-------------|
+| `search.request.took` | Total search request time, count, and current |
+| `search.request.dfs_pre_query` | DFS prequery phase statistics |
+| `search.request.query` | Query phase statistics |
+| `search.request.fetch` | Fetch phase statistics |
+| `search.request.dfs_query` | DFS query phase statistics |
+| `search.request.expand` | Expand phase statistics |
+| `search.request.can_match` | Can match phase statistics |
+
+### Usage Example
+
+Statistics are available via the Nodes Stats API:
+
+```bash
+GET _nodes/stats/indices/search
+```
+
+Response includes:
+
+```json
+{
+  "indices": {
+    "search": {
+      "request": {
+        "took": {
+          "time_in_millis": 129,
+          "current": 0,
+          "total": 1
+        },
+        "query": {
+          "time_in_millis": 98,
+          "current": 0,
+          "total": 1
+        },
+        "fetch": {
+          "time_in_millis": 6,
+          "current": 0,
+          "total": 1
+        }
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- No action required for new clusters - statistics are collected automatically
+- Existing clusters upgrading to v2.18.0 will have statistics enabled by default
+- To disable (if needed for performance reasons), set:
+  ```bash
+  PUT _cluster/settings
+  {
+    "persistent": {
+      "search.request_stats_enabled": false
+    }
+  }
+  ```
+
+## Limitations
+
+- Statistics collection adds minimal overhead to search operations
+- Statistics are per-node and not aggregated across the cluster
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16290](https://github.com/opensearch-project/OpenSearch/pull/16290) | Enable coordinator search.request_stats_enabled by default |
+| [#16320](https://github.com/opensearch-project/OpenSearch/pull/16320) | Backport to 2.x branch |
+
+## References
+
+- [PR #15054](https://github.com/opensearch-project/OpenSearch/pull/15054): Original implementation adding took time to request nodes stats
+- [Issue #10768](https://github.com/opensearch-project/OpenSearch/issues/10768): Feature request for total search request time on coordinator node
+- [Nodes Stats API Documentation](https://docs.opensearch.org/2.18/api-reference/nodes-apis/nodes-stats/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/search-request-stats.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -23,6 +23,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Test Fixes](features/opensearch/test-fixes.md) - Fix flaky test in ApproximatePointRangeQueryTests by adjusting totalHits assertion logic
 - [Nested Aggregations](features/opensearch/nested-aggregations.md) - Fix infinite loop in nested aggregations with deep-level nested objects
 - [Code Cleanup](features/opensearch/code-cleanup.md) - Query approximation simplification, Stream API optimization, typo fix
+- [Search Request Stats](features/opensearch/search-request-stats.md) - Enable coordinator search.request_stats_enabled by default
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Search Request Stats feature in OpenSearch v2.18.0.

### Changes in v2.18.0
- The `search.request_stats_enabled` setting is now enabled by default (changed from `false` to `true`)
- This allows coordinator-level search request statistics to be collected automatically without manual configuration

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/search-request-stats.md`
- Feature report: `docs/features/opensearch/search-request-stats.md` (new)

### Key Information
- **PR**: [#16290](https://github.com/opensearch-project/OpenSearch/pull/16290)
- **Original Feature PR**: [#15054](https://github.com/opensearch-project/OpenSearch/pull/15054) (v2.17.0)
- **Issue**: [#10768](https://github.com/opensearch-project/OpenSearch/issues/10768)

### Feature Overview
Search Request Stats provides coordinator-level search latency metrics including:
- Total search request time (`took`)
- Phase breakdowns: query, fetch, DFS, expand, can_match

Closes #644