### PR TITLE
docs: add identity-feature-flag-removal report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -31,6 +31,7 @@
 - [Cryptography & Security Libraries](opensearch/cryptography-security-libraries.md)
 - [Gradle Build System](opensearch/gradle-build-system.md)
 - [HTTP Client](opensearch/http-client.md)
+- [Identity Feature Flag Removal](opensearch/identity-feature-flag-removal.md)
 - [Java Runtime & JPMS](opensearch/java-runtime-and-jpms.md)
 - [Lucene 10 Upgrade](opensearch/lucene-10-upgrade.md)
 - [Lucene Similarity](opensearch/lucene-similarity.md)

--- a/docs/features/opensearch/identity-feature-flag-removal.md
+++ b/docs/features/opensearch/identity-feature-flag-removal.md
@@ -1,0 +1,128 @@
+# Identity Feature Flag Removal
+
+## Summary
+
+The Identity Feature Flag Removal is a code cleanup change that removes the experimental `opensearch.experimental.feature.identity.enabled` feature flag from OpenSearch. This change makes the Identity plugin architecture always available without requiring explicit enablement, simplifying the codebase and enabling plugins to adopt the new authentication mechanism.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Core"
+        Node[Node] --> IS[IdentityService]
+        IS --> IP[IdentityPlugin Interface]
+        Node --> RC[RestController]
+        RC --> RHW[RestHandler Wrapper]
+    end
+    
+    subgraph "Identity Plugin"
+        IP --> SIP[ShiroIdentityPlugin]
+        SIP --> SM[ShiroSecurityManager]
+        SIP --> STE[ShiroTokenExtractor]
+        SIP --> ARH[AuthcRestHandler]
+        RHW --> ARH
+    end
+    
+    subgraph "Authentication Flow"
+        REQ[REST Request] --> ARH
+        ARH --> STE
+        STE --> Token[AuthToken]
+        Token --> SS[ShiroSubject]
+        SS --> Auth[Authenticate]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[REST Request] --> B[RestController]
+    B --> C[Plugin RestHandler Wrapper]
+    C --> D{Token Present?}
+    D -->|Yes| E[Extract Token]
+    E --> F[Authenticate Subject]
+    F --> G[Execute Handler]
+    D -->|No| G
+    G --> H[Response]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `IdentityService` | Core service that manages identity plugins and provides current subject |
+| `IdentityPlugin` | Interface for identity provider plugins |
+| `ShiroIdentityPlugin` | Apache Shiro-based identity plugin implementation |
+| `ShiroTokenExtractor` | Extracts authentication tokens from REST request headers |
+| `AuthcRestHandler` | REST handler wrapper that performs authentication |
+| `ShiroSubject` | Subject implementation backed by Apache Shiro |
+| `ShiroTokenManager` | Manages authentication tokens |
+
+### Configuration
+
+The feature flag has been removed. No configuration is required to enable identity functionality.
+
+| Setting | Status | Description |
+|---------|--------|-------------|
+| `opensearch.experimental.feature.identity.enabled` | **Removed** | Previously gated identity functionality |
+
+### Usage Example
+
+Identity plugins implement authentication via the `ActionPlugin.getRestHandlerWrapper` extension point:
+
+```java
+public class CustomIdentityPlugin extends Plugin implements IdentityPlugin, ActionPlugin {
+    
+    @Override
+    public Subject getCurrentSubject() {
+        return new CustomSubject();
+    }
+    
+    @Override
+    public TokenManager getTokenManager() {
+        return new CustomTokenManager();
+    }
+    
+    @Override
+    public UnaryOperator<RestHandler> getRestHandlerWrapper(ThreadContext threadContext) {
+        return handler -> new RestHandler.Wrapper(handler) {
+            @Override
+            public void handleRequest(RestRequest request, RestChannel channel, NodeClient client) 
+                    throws Exception {
+                // Custom authentication logic
+                AuthToken token = extractToken(request);
+                if (token != null) {
+                    authenticate(token);
+                }
+                super.handleRequest(request, channel, client);
+            }
+        };
+    }
+}
+```
+
+## Limitations
+
+- The `IdentityService` is marked as `@InternalApi` and may change in future versions
+- Only one identity plugin can be active at a time
+- The identity-shiro plugin only supports Basic authentication via the Authorization header
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#15430](https://github.com/opensearch-project/OpenSearch/pull/15430) | Remove identity-related feature flagged code from the RestController |
+| v2.18.0 | [#16024](https://github.com/opensearch-project/OpenSearch/pull/16024) | Remove Identity FeatureFlag |
+
+## References
+
+- [Issue #4439](https://github.com/opensearch-project/security/issues/4439): Remove Identity feature flag
+- [Issue #238](https://github.com/opensearch-project/opensearch-plugins/issues/238): Plugin adoption of new system index mechanism
+- [Blog: Introducing identity and access control for OpenSearch](https://opensearch.org/blog/introducing-identity/)
+- [Experimental feature flags documentation](https://docs.opensearch.org/2.18/install-and-configure/configuring-opensearch/experimental/)
+
+## Change History
+
+- **v2.18.0** (2024-10-22): Removed Identity feature flag, moved authentication logic to identity plugins

--- a/docs/releases/v2.18.0/features/opensearch/identity-feature-flag-removal.md
+++ b/docs/releases/v2.18.0/features/opensearch/identity-feature-flag-removal.md
@@ -1,0 +1,116 @@
+# Identity Feature Flag Removal
+
+## Summary
+
+This release removes the experimental `opensearch.experimental.feature.identity.enabled` feature flag from OpenSearch, making the Identity plugin architecture always available without requiring explicit enablement. The change simplifies the codebase by removing feature-flagged code paths and moves authentication logic from the core RestController to the identity-shiro plugin.
+
+## Details
+
+### What's New in v2.18.0
+
+The Identity feature flag removal consists of two main changes:
+
+1. **RestController Cleanup (PR #15430)**: Removed identity-related feature-flagged code from the RestController, delegating authentication to identity plugins via `ActionPlugin.getRestHandlerWrapper`.
+
+2. **Feature Flag Removal (PR #16024)**: Completely removed the `IDENTITY` feature flag from `FeatureFlags.java` and related settings.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v2.18.0"
+        RC1[RestController] -->|Feature Flag Check| Auth1[Built-in Auth Logic]
+        Auth1 --> Handler1[RestHandler]
+    end
+    
+    subgraph "After v2.18.0"
+        RC2[RestController] --> Wrapper[Plugin RestHandler Wrapper]
+        Wrapper --> Auth2[Plugin Auth Logic]
+        Auth2 --> Handler2[RestHandler]
+    end
+```
+
+#### Removed Components
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| `IDENTITY` constant | `FeatureFlags.java` | Feature flag string constant |
+| `IDENTITY_SETTING` | `FeatureFlags.java` | Boolean setting for the flag |
+| `handleAuthenticateUser()` | `RestController.java` | Built-in authentication method |
+| `RestTokenExtractor` | `server` module | Token extraction (moved to identity-shiro) |
+
+#### New Components
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| `ShiroTokenExtractor` | `identity-shiro` plugin | Token extraction from REST requests |
+| `AuthcRestHandler` | `ShiroIdentityPlugin` | REST handler wrapper for authentication |
+
+#### API Changes
+
+The `RestController` constructor no longer requires `IdentityService`:
+
+```java
+// Before
+new RestController(headers, wrapper, client, circuitBreaker, usageService, identityService);
+
+// After
+new RestController(headers, wrapper, client, circuitBreaker, usageService);
+```
+
+### Usage Example
+
+Identity plugins now implement authentication via `ActionPlugin.getRestHandlerWrapper`:
+
+```java
+public class ShiroIdentityPlugin extends Plugin implements IdentityPlugin, ActionPlugin {
+    
+    @Override
+    public UnaryOperator<RestHandler> getRestHandlerWrapper(ThreadContext threadContext) {
+        return AuthcRestHandler::new;
+    }
+    
+    class AuthcRestHandler extends RestHandler.Wrapper {
+        @Override
+        public void handleRequest(RestRequest request, RestChannel channel, NodeClient client) 
+                throws Exception {
+            AuthToken token = ShiroTokenExtractor.extractToken(request);
+            if (token != null) {
+                ShiroSubject subject = (ShiroSubject) getCurrentSubject();
+                subject.authenticate(token);
+            }
+            super.handleRequest(request, channel, client);
+        }
+    }
+}
+```
+
+### Migration Notes
+
+- **No user action required**: The feature flag removal is transparent to users
+- **Plugin developers**: Identity plugins should use `ActionPlugin.getRestHandlerWrapper` for authentication instead of relying on core RestController
+- **Configuration**: Remove any `opensearch.experimental.feature.identity.enabled` settings from `opensearch.yml` (no longer recognized)
+
+## Limitations
+
+- The `IdentityService` class is now marked as `@InternalApi` instead of `@ExperimentalApi`
+- Identity plugins are loaded unconditionally (no feature flag gating)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#15430](https://github.com/opensearch-project/OpenSearch/pull/15430) | Remove identity-related feature flagged code from the RestController |
+| [#16024](https://github.com/opensearch-project/OpenSearch/pull/16024) | Remove Identity FeatureFlag |
+
+## References
+
+- [Issue #4439](https://github.com/opensearch-project/security/issues/4439): Remove Identity feature flag
+- [Issue #238](https://github.com/opensearch-project/opensearch-plugins/issues/238): Plugin adoption of new system index mechanism
+- [Blog: Introducing identity and access control for OpenSearch](https://opensearch.org/blog/introducing-identity/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/identity-feature-flag-removal.md)

--- a/docs/releases/v2.18.0/features/opensearch/resthandler-improvements.md
+++ b/docs/releases/v2.18.0/features/opensearch/resthandler-improvements.md
@@ -1,0 +1,102 @@
+# RestHandler Improvements
+
+## Summary
+
+This release improves the `RestHandler.Wrapper` class to ensure complete delegation of all interface methods to the wrapped handler. Previously, when new methods were added to the `RestHandler` interface, the `Wrapper` class could miss delegating those methods, causing unexpected behavior. This fix adds missing delegation methods and introduces a reflection-based test to prevent future regressions.
+
+## Details
+
+### What's New in v2.18.0
+
+The `RestHandler.Wrapper` class now properly delegates two methods that were previously missing:
+
+- `isActionPaginated()` - Indicates whether the handler supports paginated responses
+- `supportsStreaming()` - Indicates whether the handler supports request/response streaming
+
+### Technical Changes
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph "RestHandler Interface"
+        RH[RestHandler]
+        RH --> handleRequest
+        RH --> canTripCircuitBreaker
+        RH --> supportsContentStream
+        RH --> supportsStreaming
+        RH --> allowsUnsafeBuffers
+        RH --> routes
+        RH --> deprecatedRoutes
+        RH --> replacedRoutes
+        RH --> allowSystemIndexAccessByDefault
+        RH --> isActionPaginated
+    end
+    
+    subgraph "Wrapper Implementation"
+        W[RestHandler.Wrapper]
+        W --> |delegates all methods| D[delegate: RestHandler]
+    end
+    
+    RH -.-> W
+```
+
+#### New Delegated Methods
+
+| Method | Description | Added in v2.18.0 |
+|--------|-------------|------------------|
+| `isActionPaginated()` | Returns whether the action supports pagination | ✓ |
+| `supportsStreaming()` | Returns whether streaming is supported | ✓ |
+
+#### Code Changes
+
+The `RestHandler.Wrapper` class was updated to include:
+
+```java
+@Override
+public boolean isActionPaginated() {
+    return delegate.isActionPaginated();
+}
+
+@Override
+public boolean supportsStreaming() {
+    return delegate.supportsStreaming();
+}
+```
+
+### Test Coverage
+
+A new reflection-based test was added to `BaseRestHandlerTests` that:
+
+1. Discovers all overridable methods in the `RestHandler` interface
+2. Invokes each method on a `RestHandler.Wrapper` instance
+3. Verifies that each method call is delegated to the wrapped handler
+4. Ensures no additional interactions occur
+
+This test will automatically fail if future changes to `RestHandler` add new methods without updating `Wrapper`.
+
+### Background
+
+This fix was prompted by [PR #14718](https://github.com/opensearch-project/OpenSearch/pull/14718) which added the `isActionPaginated()` method to support pagination for the `_cat/indices` API. That PR modified the `RestHandler` interface but did not update the `RestHandler.Wrapper` class, which could cause issues for plugins using the wrapper pattern.
+
+## Limitations
+
+- This is an internal API improvement; no user-facing changes
+- Plugins extending `RestHandler.Wrapper` should ensure they also delegate any custom methods
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16154](https://github.com/opensearch-project/OpenSearch/pull/16154) | Ensure RestHandler.Wrapper delegates all implementations |
+| [#14718](https://github.com/opensearch-project/OpenSearch/pull/14718) | Implementing pagination for _cat/indices API (caused the issue) |
+| [#1004](https://github.com/opensearch-project/OpenSearch/pull/1004) | Original introduction of RestHandler.Wrapper |
+
+## References
+
+- [PR #16154](https://github.com/opensearch-project/OpenSearch/pull/16154): Main implementation
+- [RestHandler.java](https://github.com/opensearch-project/OpenSearch/blob/2.18/server/src/main/java/org/opensearch/rest/RestHandler.java): Source code
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/resthandler-wrapper.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -24,6 +24,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Nested Aggregations](features/opensearch/nested-aggregations.md) - Fix infinite loop in nested aggregations with deep-level nested objects
 - [Code Cleanup](features/opensearch/code-cleanup.md) - Query approximation simplification, Stream API optimization, typo fix
 - [Search Request Stats](features/opensearch/search-request-stats.md) - Enable coordinator search.request_stats_enabled by default
+- [Identity Feature Flag Removal](features/opensearch/identity-feature-flag-removal.md) - Remove experimental identity feature flag, move authentication to plugins
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Identity Feature Flag Removal in OpenSearch v2.18.0.

### Changes
- **Release report**: `docs/releases/v2.18.0/features/opensearch/identity-feature-flag-removal.md`
- **Feature report**: `docs/features/opensearch/identity-feature-flag-removal.md`
- Updated release index and features index

### Key Changes in v2.18.0
- Removed `opensearch.experimental.feature.identity.enabled` feature flag
- Moved authentication logic from RestController to identity plugins
- Identity plugins now use `ActionPlugin.getRestHandlerWrapper` for authentication
- `IdentityService` marked as `@InternalApi` instead of `@ExperimentalApi`

### Related PRs
- [#15430](https://github.com/opensearch-project/OpenSearch/pull/15430): Remove identity-related feature flagged code from the RestController
- [#16024](https://github.com/opensearch-project/OpenSearch/pull/16024): Remove Identity FeatureFlag

Closes #642