### PR TITLE
docs: add docker-compose-v2-support report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -24,6 +24,7 @@
 - [Cluster Manager Task Throttling](opensearch/cluster-manager-throttling.md)
 - [Cluster State Management](opensearch/cluster-state-management.md)
 - [Dependency Management](opensearch/dependency-management.md)
+- [Docker Compose v2 Support](opensearch/docker-compose-v2-support.md)
 - [Locale Provider](opensearch/locale-provider.md)
 - [HTTP API](opensearch/http-api.md)
 - [Jackson & Query Limits](opensearch/jackson--query-limits.md)

--- a/docs/features/opensearch/docker-compose-v2-support.md
+++ b/docs/features/opensearch/docker-compose-v2-support.md
@@ -1,0 +1,121 @@
+# Docker Compose v2 Support
+
+## Summary
+
+The TestFixturesPlugin in OpenSearch's build system supports Docker Compose for running integration tests that require external services (like GCS, S3, Azure storage emulators). This feature ensures compatibility with both Docker Compose v1 (`docker-compose`) and Docker Compose v2 (`docker compose`), allowing developers on modern systems to run these tests without issues.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Build System"
+        A[Gradle Build] --> B[TestFixturesPlugin]
+        B --> C[DockerSupportService]
+    end
+    
+    subgraph "Docker Detection"
+        C --> D{Docker Available?}
+        D -->|Yes| E{Check Compose v2}
+        E -->|Available| F[Use docker compose]
+        E -->|Not Available| G{Check Compose v1}
+        G -->|Available| H[Use docker-compose]
+        G -->|Not Available| I[Skip Docker Tasks]
+        D -->|No| I
+    end
+    
+    subgraph "Test Execution"
+        F --> J[ComposeUp Task]
+        H --> J
+        J --> K[Run Integration Tests]
+        K --> L[ComposeDown Task]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Test Task] --> B[preProcessFixture]
+    B --> C[composeUp]
+    C --> D[postProcessFixture]
+    D --> E[Test Execution]
+    E --> F[composeDown]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `DockerSupportService` | Service that detects Docker and Docker Compose availability |
+| `DockerAvailability` | Data class holding Docker availability status |
+| `TestFixturesPlugin` | Gradle plugin that manages Docker-based test fixtures |
+| `ComposeExtension` | Configuration for Docker Compose integration |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `useDockerComposeV2` | Whether to use Docker Compose v2 syntax | Auto-detected |
+| `executable` | Path to Docker/Docker Compose binary | Auto-detected |
+| `COMPOSE_HTTP_TIMEOUT` | HTTP timeout for Docker Compose operations | 120 seconds |
+
+### Detection Logic
+
+The system checks for Docker Compose availability in the following order:
+
+1. **Docker Compose v2**: Runs `docker compose version` to check if the compose plugin is available
+2. **Docker Compose v1**: Checks for `docker-compose` binary in standard locations:
+   - Unix: `/usr/local/bin/docker-compose`, `/usr/bin/docker-compose`
+   - Windows: `%PROGRAMFILES%\Docker\Docker\resources\bin\docker-compose.exe`
+
+### Usage Example
+
+```groovy
+// build.gradle - Using test fixtures
+plugins {
+    id 'opensearch.testfixtures'
+}
+
+testFixtures {
+    // Fixtures are automatically configured based on docker-compose.yml
+}
+
+// docker-compose.yml in project root
+version: '3'
+services:
+  gcs-fixture:
+    image: fake-gcs-server
+    ports:
+      - "4443:4443"
+```
+
+Running tests:
+```bash
+# Tests automatically use available Docker Compose version
+./gradlew :plugins:repository-gcs:test
+```
+
+## Limitations
+
+- Requires Docker to be installed and running on the system
+- Docker Compose v2 requires Docker CLI with the compose plugin installed
+- Test fixtures are skipped entirely if neither Docker Compose version is available
+- CI environments may need Docker Compose throttling to avoid parallel execution issues
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#16049](https://github.com/opensearch-project/OpenSearch/pull/16049) | Add support for docker compose v2 in TestFixturesPlugin |
+
+## References
+
+- [Issue #16050](https://github.com/opensearch-project/OpenSearch/issues/16050): Original bug report
+- [Docker Compose v2 Migration](https://docs.docker.com/compose/releases/migrate/): Official Docker documentation
+- [opensearch-api-specification#457](https://github.com/opensearch-project/opensearch-api-specification/issues/457): Similar update in API specification repo
+
+## Change History
+
+- **v2.18.0** (2024-10-22): Added Docker Compose v2 support alongside existing v1 support

--- a/docs/releases/v2.18.0/features/opensearch/docker-compose-v2-support.md
+++ b/docs/releases/v2.18.0/features/opensearch/docker-compose-v2-support.md
@@ -1,0 +1,93 @@
+# Docker Compose v2 Support
+
+## Summary
+
+This release adds support for Docker Compose v2 in the TestFixturesPlugin, enabling developers to run integration tests that depend on Docker containers on systems where only Docker Compose v2 (`docker compose` without hyphen) is available. Previously, tests would be skipped on systems without the legacy `docker-compose` binary.
+
+## Details
+
+### What's New in v2.18.0
+
+The TestFixturesPlugin now detects and supports both Docker Compose v1 (`docker-compose`) and Docker Compose v2 (`docker compose`). This change ensures that Gradle tasks relying on Docker test fixtures are no longer skipped on modern systems where only Docker Compose v2 is installed.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Docker Detection Flow"
+        A[DockerSupportService] --> B{Check docker-compose v1}
+        B -->|Found| C[isComposeAvailable = true]
+        B -->|Not Found| D{Check docker compose v2}
+        D -->|Found| E[isComposeV2Available = true]
+        D -->|Not Found| F[Both unavailable]
+    end
+    
+    subgraph "TestFixturesPlugin"
+        G[Configure ComposeExtension] --> H{isComposeV2Available?}
+        H -->|Yes| I[UseDockerComposeV2 = true]
+        H -->|No| J{isComposeAvailable?}
+        J -->|Yes| K[UseDockerComposeV2 = false]
+        J -->|No| L[Skip docker tasks]
+    end
+    
+    C --> G
+    E --> G
+    F --> L
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `isComposeV2Available` | New field in `DockerAvailability` class to track Docker Compose v2 availability |
+| Docker Compose v2 detection | Runs `docker compose version` to check for v2 support |
+
+#### Code Changes
+
+The `DockerSupportService.java` was updated to:
+1. Add `isComposeV2Available` field to `DockerAvailability` class
+2. Check for Docker Compose v2 by running `docker compose version`
+3. Report both v1 and v2 availability status
+
+The `TestFixturesPlugin.java` was updated to:
+1. Prefer Docker Compose v2 when available
+2. Fall back to Docker Compose v1 if v2 is not available
+3. Skip tasks only when neither version is available
+
+### Usage Example
+
+No configuration changes are required. The plugin automatically detects the available Docker Compose version:
+
+```bash
+# On systems with Docker Compose v2 only
+./gradlew :plugins:repository-gcs:test
+
+# Previously: Task would be skipped with "docker-compose unavailable"
+# Now: Task runs successfully using "docker compose" command
+```
+
+### Migration Notes
+
+No migration required. This is a backward-compatible change that adds support for Docker Compose v2 while maintaining support for v1.
+
+## Limitations
+
+- Requires Docker to be installed and running
+- Docker Compose v2 detection requires Docker CLI with compose plugin
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16049](https://github.com/opensearch-project/OpenSearch/pull/16049) | Add support for docker compose v2 in TestFixturesPlugin |
+
+## References
+
+- [Issue #16050](https://github.com/opensearch-project/OpenSearch/issues/16050): Bug report for docker-compose v1 dependency
+- [Docker Compose v2 Migration](https://docs.docker.com/compose/releases/migrate/): Official Docker documentation on v1 to v2 migration
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/docker-compose-v2-support.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -25,6 +25,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Code Cleanup](features/opensearch/code-cleanup.md) - Query approximation simplification, Stream API optimization, typo fix
 - [Search Request Stats](features/opensearch/search-request-stats.md) - Enable coordinator search.request_stats_enabled by default
 - [Identity Feature Flag Removal](features/opensearch/identity-feature-flag-removal.md) - Remove experimental identity feature flag, move authentication to plugins
+- [Docker Compose v2 Support](features/opensearch/docker-compose-v2-support.md) - Add support for Docker Compose v2 in TestFixturesPlugin for modern Docker installations
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

Add documentation for Docker Compose v2 Support feature in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/docker-compose-v2-support.md`
- Feature report: `docs/features/opensearch/docker-compose-v2-support.md`

### Key Changes in v2.18.0
- Added Docker Compose v2 detection in DockerSupportService
- TestFixturesPlugin now prefers Docker Compose v2 when available
- Backward compatible with Docker Compose v1

### Resources Used
- PR: #16049
- Issue: #16050

Closes #641