### PR TITLE
docs: add snapshot-restore-enhancements report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -48,6 +48,7 @@
 - [Search Backpressure](opensearch/search-backpressure.md)
 - [Search Request Stats](opensearch/search-request-stats.md)
 - [Segment Warmer](opensearch/segment-warmer.md)
+- [Snapshot Restore Enhancements](opensearch/snapshot-restore-enhancements.md)
 - [Star Tree Index](opensearch/star-tree-index.md)
 - [Streaming Indexing](opensearch/streaming-indexing.md)
 - [Stream Input/Output](opensearch/stream-inputoutput.md)

--- a/docs/features/opensearch/snapshot-restore-enhancements.md
+++ b/docs/features/opensearch/snapshot-restore-enhancements.md
@@ -1,0 +1,137 @@
+# Snapshot Restore Enhancements
+
+## Summary
+
+OpenSearch's snapshot restore functionality allows users to restore indexes and their associated aliases from snapshots. This feature provides alias renaming capabilities during restore operations and optimized clone operations for incremental snapshots, enabling flexible disaster recovery, cluster migration, and debugging workflows.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph "Snapshot Restore Flow"
+        A[Restore Request] --> B[RestoreService]
+        B --> C{Include Aliases?}
+        C -->|Yes| D{Rename Aliases?}
+        C -->|No| E[Remove Aliases]
+        D -->|Yes| F[Apply Alias Rename Pattern]
+        D -->|No| G[Keep Original Aliases]
+        F --> H[Build Index Metadata]
+        G --> H
+        E --> H
+        H --> I[Restore Index]
+    end
+    
+    subgraph "Clone Operation Flow"
+        J[Clone Request] --> K{Remote Store Enabled?}
+        K -->|No| L[Direct Clone]
+        K -->|Yes| M[Fetch Repository Data]
+        M --> N{Index Remote Store?}
+        N -->|Yes| O[Clone Remote Store Snapshot]
+        N -->|No| L
+        L --> P[Clone Shard Snapshot]
+        O --> Q[Clone Complete]
+        P --> Q
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `RestoreSnapshotRequest` | Request object containing restore parameters including alias rename patterns |
+| `RestoreService` | Service that orchestrates the restore operation and applies alias transformations |
+| `SnapshotsService` | Service handling snapshot clone operations with optimized path for doc-rep clusters |
+| `AliasMetadata` | Metadata class for alias information, supports creating renamed copies |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `rename_pattern` | Regex pattern to match index names for renaming | None |
+| `rename_replacement` | Replacement string for matched index names | None |
+| `rename_alias_pattern` | Regex pattern to match alias names for renaming | None |
+| `rename_alias_replacement` | Replacement string for matched alias names | None |
+| `include_aliases` | Whether to restore aliases with indexes | `true` |
+
+### Usage Examples
+
+#### Basic Restore with Alias Renaming
+
+```json
+POST /_snapshot/my_repo/my_snapshot/_restore
+{
+  "indices": "logs-*",
+  "rename_pattern": "logs-(.+)",
+  "rename_replacement": "restored-logs-$1",
+  "rename_alias_pattern": "(.+)",
+  "rename_alias_replacement": "restored-$1",
+  "include_aliases": true
+}
+```
+
+#### Restore for Debugging (Isolated Copy)
+
+```json
+POST /_snapshot/production_repo/daily_snapshot/_restore
+{
+  "indices": "orders",
+  "rename_pattern": "(.+)",
+  "rename_replacement": "debug_$1",
+  "rename_alias_pattern": "(.+)",
+  "rename_alias_replacement": "debug_$1",
+  "include_aliases": true,
+  "index_settings": {
+    "index.number_of_replicas": 0
+  }
+}
+```
+
+This creates `debug_orders` index with all aliases prefixed with `debug_`, completely isolated from production.
+
+### API Reference
+
+#### Restore Snapshot API
+
+```
+POST /_snapshot/{repository}/{snapshot}/_restore
+```
+
+**Request Body Parameters:**
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `indices` | String/Array | Indexes to restore (supports wildcards) |
+| `rename_pattern` | String | Regex pattern for index renaming |
+| `rename_replacement` | String | Replacement for index names |
+| `rename_alias_pattern` | String | Regex pattern for alias renaming |
+| `rename_alias_replacement` | String | Replacement for alias names |
+| `include_aliases` | Boolean | Include aliases in restore (default: true) |
+| `include_global_state` | Boolean | Restore cluster state (default: false) |
+| `partial` | Boolean | Allow partial restore (default: false) |
+
+## Limitations
+
+- Alias renaming uses Java regex; complex patterns may impact performance
+- Cannot rename aliases to names that conflict with existing indexes
+- Clone optimization only benefits document replication clusters
+- Repository data fetch still required for remote store enabled clusters during clone
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#16292](https://github.com/opensearch-project/OpenSearch/pull/16292) | Add support for renaming aliases during snapshot restore |
+| v2.18.0 | [#16296](https://github.com/opensearch-project/OpenSearch/pull/16296) | Optimise clone operation for incremental full cluster snapshots |
+
+## References
+
+- [Issue #15632](https://github.com/opensearch-project/OpenSearch/issues/15632): Original feature request for alias renaming
+- [Issue #16295](https://github.com/opensearch-project/OpenSearch/issues/16295): Clone optimization request
+- [Snapshot Restore Documentation](https://docs.opensearch.org/2.18/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/): Official documentation
+- [Restore Snapshot API](https://docs.opensearch.org/2.18/api-reference/snapshots/restore-snapshot/): API reference
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Added alias renaming support during snapshot restore; optimized clone operations for doc-rep clusters

--- a/docs/releases/v2.18.0/features/opensearch/snapshot-restore-enhancements.md
+++ b/docs/releases/v2.18.0/features/opensearch/snapshot-restore-enhancements.md
@@ -1,0 +1,98 @@
+# Snapshot Restore Enhancements
+
+## Summary
+
+OpenSearch v2.18.0 introduces two significant enhancements to snapshot operations: the ability to rename aliases during snapshot restore and performance optimizations for clone operations on incremental full cluster snapshots. These improvements provide greater flexibility when restoring snapshots to the same cluster and improve clone performance for document replication clusters.
+
+## Details
+
+### What's New in v2.18.0
+
+#### 1. Alias Renaming During Snapshot Restore
+
+A new pair of parameters has been added to the snapshot restore API that allows renaming aliases during restore, similar to the existing index renaming capability:
+
+| Parameter | Description |
+|-----------|-------------|
+| `rename_alias_pattern` | Regular expression to match aliases for renaming. Use capture groups `()` to reuse portions of the alias name. |
+| `rename_alias_replacement` | Replacement pattern for matched aliases. Use `$0` for entire match or `$1`, `$2`, etc. for capture groups. |
+
+This feature enables restoring snapshots into the same cluster as temporary separate indexes for research and debugging without alias conflicts.
+
+#### 2. Clone Operation Optimization
+
+The snapshot clone operation has been optimized for document replication (doc-rep) clusters. Previously, the clone operation required fetching repository data (index-N file) for each shard, which caused performance degradation when the index-N file exceeded 512KB. The optimization skips this unnecessary repository data fetch for doc-rep clusters since they only support full cluster incremental snapshots.
+
+### Technical Changes
+
+#### New API Parameters
+
+The `RestoreSnapshotRequest` class now includes:
+
+```java
+private String renameAliasPattern;
+private String renameAliasReplacement;
+```
+
+#### Usage Example
+
+```json
+POST /_snapshot/my_repository/my_snapshot/_restore
+{
+  "indices": "my_index",
+  "rename_pattern": "(.+)",
+  "rename_replacement": "restored_$1",
+  "rename_alias_pattern": "(.+)",
+  "rename_alias_replacement": "restored_alias_$1",
+  "include_aliases": true
+}
+```
+
+This restores `my_index` as `restored_my_index` and renames all its aliases with the `restored_alias_` prefix.
+
+#### Clone Optimization Logic
+
+```mermaid
+flowchart TB
+    A[Clone Operation Start] --> B{Remote Store Enabled?}
+    B -->|No| C[Skip Repository Data Fetch]
+    B -->|Yes| D[Fetch Repository Data]
+    C --> E[Execute Clone Directly]
+    D --> F{Index Remote Store Enabled?}
+    F -->|Yes| G[Clone Remote Store Snapshot]
+    F -->|No| E
+    E --> H[Clone Shard Snapshot]
+    G --> I[Clone Complete]
+    H --> I
+```
+
+### Migration Notes
+
+- The new alias renaming parameters are optional and backward compatible
+- Existing restore operations continue to work without modification
+- Clone operations automatically benefit from the optimization without configuration changes
+
+## Limitations
+
+- Alias renaming uses Java regex pattern matching; complex patterns may have performance implications
+- If two or more aliases are renamed to the same name, they will be merged
+- Clone optimization only applies to document replication clusters (not remote store enabled clusters)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16292](https://github.com/opensearch-project/OpenSearch/pull/16292) | Add support for renaming aliases during snapshot restore |
+| [#16296](https://github.com/opensearch-project/OpenSearch/pull/16296) | Optimise clone operation for incremental full cluster snapshots |
+
+## References
+
+- [Issue #15632](https://github.com/opensearch-project/OpenSearch/issues/15632): Feature request for alias renaming
+- [Issue #16295](https://github.com/opensearch-project/OpenSearch/issues/16295): Clone operation optimization request
+- [Documentation](https://docs.opensearch.org/2.18/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/): Snapshot restore API reference
+- [API Spec PR #615](https://github.com/opensearch-project/opensearch-api-specification/pull/615): API specification update
+- [Documentation PR #8544](https://github.com/opensearch-project/documentation-website/pull/8544): Documentation update
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/snapshot-restore-enhancements.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -26,6 +26,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Search Request Stats](features/opensearch/search-request-stats.md) - Enable coordinator search.request_stats_enabled by default
 - [Identity Feature Flag Removal](features/opensearch/identity-feature-flag-removal.md) - Remove experimental identity feature flag, move authentication to plugins
 - [Docker Compose v2 Support](features/opensearch/docker-compose-v2-support.md) - Add support for Docker Compose v2 in TestFixturesPlugin for modern Docker installations
+- [Snapshot Restore Enhancements](features/opensearch/snapshot-restore-enhancements.md) - Alias renaming during restore and clone operation optimization for doc-rep clusters
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Snapshot Restore Enhancements feature in OpenSearch v2.18.0.

### Changes in v2.18.0

1. **Alias Renaming During Snapshot Restore** (PR #16292)
   - New `rename_alias_pattern` and `rename_alias_replacement` parameters
   - Enables restoring snapshots to the same cluster with renamed aliases
   - Useful for debugging and research workflows

2. **Clone Operation Optimization** (PR #16296)
   - Optimized clone operations for document replication clusters
   - Skips unnecessary repository data fetch for doc-rep clusters
   - Improves performance when index-N file exceeds 512KB

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/snapshot-restore-enhancements.md`
- Feature report: `docs/features/opensearch/snapshot-restore-enhancements.md`

### References
- [PR #16292](https://github.com/opensearch-project/OpenSearch/pull/16292): Add support for renaming aliases during snapshot restore
- [PR #16296](https://github.com/opensearch-project/OpenSearch/pull/16296): Optimise clone operation for incremental full cluster snapshots
- [Issue #15632](https://github.com/opensearch-project/OpenSearch/issues/15632): Feature request
- [Issue #16295](https://github.com/opensearch-project/OpenSearch/issues/16295): Clone optimization request

Closes #640