### PR TITLE
docs: add Cluster Stats API report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -13,6 +13,7 @@
 
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
 - [Bulk API](opensearch/bulk-api.md)
+- [Cluster Stats API](opensearch/cluster-stats-api.md)
 - [Code Cleanup](opensearch/code-cleanup.md)
 - [Deprecated Code Cleanup](opensearch/deprecated-code-cleanup.md)
 - [Dynamic Settings](opensearch/dynamic-settings.md)

--- a/docs/features/opensearch/cluster-stats-api.md
+++ b/docs/features/opensearch/cluster-stats-api.md
@@ -1,0 +1,164 @@
+# Cluster Stats API
+
+## Summary
+
+The Cluster Stats API returns comprehensive statistics about an OpenSearch cluster, including node-level metrics (OS, JVM, process, filesystem) and index-level metrics (shards, documents, storage, caches). Starting from v2.18.0, the API supports URI path filtering to request specific metrics, improving performance for monitoring and observability use cases.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "REST Layer"
+        A[RestClusterStatsAction] --> B[Parse Request Parameters]
+        B --> C[Build ClusterStatsRequest]
+    end
+    
+    subgraph "Transport Layer"
+        C --> D[TransportClusterStatsAction]
+        D --> E[Broadcast to Nodes]
+        E --> F[ClusterStatsNodeRequest]
+    end
+    
+    subgraph "Node Processing"
+        F --> G[Collect NodeInfo]
+        F --> H[Collect NodeStats]
+        F --> I[Collect ShardStats]
+        G --> J[ClusterStatsNodeResponse]
+        H --> J
+        I --> J
+    end
+    
+    subgraph "Response Aggregation"
+        J --> K[Aggregate Node Responses]
+        K --> L[ClusterStatsNodes]
+        K --> M[ClusterStatsIndices]
+        L --> N[ClusterStatsResponse]
+        M --> N
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Input
+        A[Client Request]
+    end
+    
+    subgraph Processing
+        A --> B[REST Handler]
+        B --> C[Transport Action]
+        C --> D[Node Collection]
+        D --> E[Stats Aggregation]
+    end
+    
+    subgraph Output
+        E --> F[JSON Response]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `RestClusterStatsAction` | REST handler that parses URI parameters and builds requests |
+| `ClusterStatsRequest` | Request object containing metric filters and node filters |
+| `ClusterStatsRequest.Metric` | Enum for node-level metrics (os, jvm, fs, process, etc.) |
+| `ClusterStatsRequest.IndexMetric` | Enum for index-level metrics (shards, docs, store, etc.) |
+| `TransportClusterStatsAction` | Transport action that coordinates node-level stats collection |
+| `ClusterStatsNodeResponse` | Per-node response containing NodeInfo, NodeStats, and ShardStats |
+| `ClusterStatsNodes` | Aggregated node statistics across the cluster |
+| `ClusterStatsIndices` | Aggregated index statistics across the cluster |
+| `ClusterStatsResponse` | Final response containing all aggregated statistics |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `timeout` | Request timeout for cluster stats operation | 30s |
+
+### API Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /_cluster/stats` | Get all cluster statistics |
+| `GET /_cluster/stats/nodes/{nodeId}` | Get stats for specific nodes |
+| `GET /_cluster/stats/{metric}/nodes/{nodeId}` | Get filtered node metrics |
+| `GET /_cluster/stats/{metric}/{index_metric}/nodes/{nodeId}` | Get filtered node and index metrics |
+
+### Supported Metrics
+
+**Node Metrics:**
+- `os` - Operating system statistics
+- `process` - Process statistics
+- `jvm` - JVM statistics
+- `fs` - Filesystem statistics
+- `plugins` - Plugin information
+- `ingest` - Ingest pipeline statistics
+- `network_types` - Network type information
+- `discovery_types` - Discovery method information
+- `packaging_types` - Distribution information
+- `indices` - Index statistics (gateway to index metrics)
+
+**Index Metrics:**
+- `shards` - Shard distribution statistics
+- `docs` - Document counts
+- `store` - Storage statistics
+- `fielddata` - Field data cache statistics
+- `query_cache` - Query cache statistics
+- `completion` - Completion suggester statistics
+- `segments` - Lucene segment statistics
+- `mappings` - Field type mapping statistics
+- `analysis` - Analyzer configuration statistics
+
+### Usage Example
+
+**Get all cluster stats:**
+```bash
+GET /_cluster/stats
+```
+
+**Get stats for specific nodes:**
+```bash
+GET /_cluster/stats/nodes/node1,node2
+```
+
+**Get only OS and JVM metrics:**
+```bash
+GET /_cluster/stats/os,jvm/nodes/_all
+```
+
+**Get index docs and segments only:**
+```bash
+GET /_cluster/stats/indices/docs,segments/nodes/_all
+```
+
+**Combined filtering:**
+```bash
+GET /_cluster/stats/os,indices/shards,docs/nodes/_all
+```
+
+## Limitations
+
+- Metric filtering requires OpenSearch 2.18.0+ (or 3.0.0+)
+- The `_all` keyword cannot be combined with individual metrics
+- Index metrics require the `indices` metric to be included in the request
+- During rolling upgrades, filtered requests may fail if sent to older nodes
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#15938](https://github.com/opensearch-project/OpenSearch/pull/15938) | URI path filtering support in cluster stats API |
+
+## References
+
+- [Cluster Stats API Documentation](https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-stats/)
+- [PR #14447](https://github.com/opensearch-project/OpenSearch/pull/14447): Original motivation for performance improvements
+
+## Change History
+
+- **v2.18.0** (2024-10-22): Added URI path filtering support for selective metric retrieval
+- **v1.0.0**: Initial cluster stats API implementation

--- a/docs/releases/v2.18.0/features/opensearch/cluster-stats-api.md
+++ b/docs/releases/v2.18.0/features/opensearch/cluster-stats-api.md
@@ -1,0 +1,155 @@
+# Cluster Stats API - URI Path Filtering
+
+## Summary
+
+OpenSearch v2.18.0 introduces URI path filtering support for the Cluster Stats API, allowing clients to request specific metrics without fetching the entire stats response. This improves API performance by reducing response payload size and server-side computation.
+
+## Details
+
+### What's New in v2.18.0
+
+The Cluster Stats API now supports filtering metrics through URI path parameters. Previously, the API returned all cluster statistics regardless of what information was needed. With this enhancement, clients can specify exactly which node-level and index-level metrics they want to retrieve.
+
+### Technical Changes
+
+#### New API Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `/_cluster/stats/{metric}/nodes/{nodeId}` | Filter by node metrics |
+| `/_cluster/stats/{metric}/{index_metric}/nodes/{nodeId}` | Filter by both node and index metrics |
+
+#### Supported Metrics
+
+**Node Metrics:**
+
+| Metric | Description |
+|--------|-------------|
+| `os` | Operating system statistics (load, memory) |
+| `process` | Process statistics (open file descriptors, CPU usage) |
+| `jvm` | JVM statistics (heap usage, threads) |
+| `fs` | File system usage statistics |
+| `plugins` | OpenSearch plugins information |
+| `ingest` | Ingest pipeline statistics |
+| `network_types` | Transport and HTTP network types |
+| `discovery_types` | Node discovery methods |
+| `packaging_types` | OpenSearch distribution information |
+| `indices` | Index statistics (requires index_metric for filtering) |
+
+**Index Metrics (when `indices` metric is requested):**
+
+| Metric | Description |
+|--------|-------------|
+| `shards` | Shard count and distribution |
+| `docs` | Document count and deleted documents |
+| `store` | Storage size information |
+| `fielddata` | Field data cache statistics |
+| `query_cache` | Query cache statistics |
+| `completion` | Completion suggester statistics |
+| `segments` | Lucene segment statistics |
+| `mappings` | Field type mappings information |
+| `analysis` | Analyzer configuration statistics |
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Client Request"
+        A[REST Request] --> B{Has Metric Filter?}
+    end
+    
+    subgraph "RestClusterStatsAction"
+        B -->|Yes| C[Parse Metrics]
+        B -->|No| D[Default: All Metrics]
+        C --> E[Build ClusterStatsRequest]
+        D --> E
+    end
+    
+    subgraph "TransportClusterStatsAction"
+        E --> F{computeAllMetrics?}
+        F -->|true| G[Collect All Stats]
+        F -->|false| H[Collect Filtered Stats]
+        G --> I[Build Response]
+        H --> I
+    end
+    
+    subgraph "Response"
+        I --> J[ClusterStatsResponse]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ClusterStatsRequest.Metric` | Enum defining available node-level metrics |
+| `ClusterStatsRequest.IndexMetric` | Enum defining available index-level metrics |
+| `computeAllMetrics` flag | Controls whether to compute all metrics or filter |
+
+### Usage Example
+
+**Request specific node stats only:**
+```bash
+GET /_cluster/stats/os,jvm/nodes/_all
+```
+
+**Request specific index stats:**
+```bash
+GET /_cluster/stats/indices/docs,segments/nodes/_all
+```
+
+**Request both node and index stats with filtering:**
+```bash
+GET /_cluster/stats/indices,os,jvm/shards/nodes/_all
+```
+
+**Response for filtered request:**
+```json
+{
+  "_nodes": {"total": 1, "successful": 1, "failed": 0},
+  "cluster_name": "opensearch-cluster",
+  "cluster_uuid": "abc123",
+  "timestamp": 1728897551016,
+  "status": "green",
+  "nodes": {
+    "count": {"total": 1, "cluster_manager": 1, "data": 1},
+    "versions": ["2.18.0"],
+    "os": {
+      "available_processors": 12,
+      "allocated_processors": 12,
+      "mem": {"total_in_bytes": 17179869184, "free_percent": 23}
+    },
+    "jvm": {
+      "max_uptime_in_millis": 495233,
+      "mem": {"heap_used_in_bytes": 106676736, "heap_max_in_bytes": 536870912}
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- Existing API calls without metric filters continue to work unchanged
+- The `_all` keyword can be used to request all metrics within a category
+- Invalid metric names result in a 400 Bad Request with descriptive error message
+
+## Limitations
+
+- Metric filtering is only available in OpenSearch 2.18.0 and later (3.0.0+)
+- Rolling upgrades require all nodes to be on compatible versions before using filtered endpoints
+- The `_all` keyword cannot be combined with individual metrics in the same request
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#15938](https://github.com/opensearch-project/OpenSearch/pull/15938) | URI path filtering support in cluster stats API |
+
+## References
+
+- [Cluster Stats API Documentation](https://docs.opensearch.org/2.18/api-reference/cluster-api/cluster-stats/)
+- [PR #14447](https://github.com/opensearch-project/OpenSearch/pull/14447): Original motivation for performance improvements
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/cluster-stats-api.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -8,6 +8,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### OpenSearch
 
+- [Cluster Stats API](features/opensearch/cluster-stats-api.md) - URI path filtering support for selective metric retrieval
 - [OpenSearch Core Dependencies](features/opensearch/opensearch-core-dependencies.md) - 26 dependency updates including Lucene 9.12.0, Netty 4.1.114, gRPC 1.68.0, Protobuf 3.25.5
 - [Cluster State Management](features/opensearch/cluster-state-management.md) - Fix voting configuration mismatch by updating lastSeenClusterState in commit phase
 - [Dynamic Settings](features/opensearch/dynamic-settings.md) - Make multiple cluster settings dynamic for tuning on larger clusters


### PR DESCRIPTION
## Summary

Add documentation for the Cluster Stats API URI path filtering feature introduced in OpenSearch v2.18.0.

## Changes

- **Release report**: `docs/releases/v2.18.0/features/opensearch/cluster-stats-api.md`
- **Feature report**: `docs/features/opensearch/cluster-stats-api.md`
- Updated release index and features index

## Feature Overview

PR #15938 introduces URI path filtering support for the Cluster Stats API, allowing clients to request specific metrics without fetching the entire stats response. This improves API performance by reducing response payload size and server-side computation.

### New Endpoints
- `/_cluster/stats/{metric}/nodes/{nodeId}`
- `/_cluster/stats/{metric}/{index_metric}/nodes/{nodeId}`

### Supported Metrics
- **Node metrics**: os, process, jvm, fs, plugins, ingest, network_types, discovery_types, packaging_types, indices
- **Index metrics**: shards, docs, store, fielddata, query_cache, completion, segments, mappings, analysis

## Related Issue

Closes #639