### PR TITLE
docs: add secure-transport-settings report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -48,6 +48,7 @@
 - [Replication](opensearch/replication.md)
 - [Search Backpressure](opensearch/search-backpressure.md)
 - [Search Request Stats](opensearch/search-request-stats.md)
+- [Secure Transport Settings](opensearch/secure-transport-settings.md)
 - [Segment Warmer](opensearch/segment-warmer.md)
 - [Snapshot Restore Enhancements](opensearch/snapshot-restore-enhancements.md)
 - [Star Tree Index](opensearch/star-tree-index.md)

--- a/docs/features/opensearch/secure-transport-settings.md
+++ b/docs/features/opensearch/secure-transport-settings.md
@@ -1,0 +1,136 @@
+# Secure Transport Settings
+
+## Summary
+
+The `SecureTransportSettingsProvider` interface provides security-related settings for OpenSearch transport layer communication. It allows security plugins to configure SSL/TLS settings, exception handlers, and dynamic transport parameters for secure node-to-node and client-to-node communication.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Core"
+        A[NetworkModule] --> B[SecureNetty4Transport]
+        B --> C[SSLServerChannelInitializer]
+        B --> D[SSLClientChannelInitializer]
+    end
+    
+    subgraph "Security Plugin"
+        E[OpenSearchSecurityPlugin] --> F[OpenSearchSecureSettingsFactory]
+        F --> G[SecureTransportSettingsProvider]
+        H[SSLConfig] --> G
+    end
+    
+    subgraph "Configuration Sources"
+        I[opensearch.yml] --> H
+        J[Cluster Settings API] --> H
+    end
+    
+    G --> B
+    C --> K[DualModeSslHandler]
+    D --> L[SSL Engine]
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Cluster Settings Update] --> B[SSLConfig Listener]
+    B --> C[Update dualModeEnabled]
+    C --> D[SecureTransportSettingsProvider.parameters]
+    D --> E[SecureNetty4Transport]
+    E --> F[Apply to new connections]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SecureTransportSettingsProvider` | Interface for providing security settings to transport layer |
+| `SecureTransportParameters` | Interface for dynamic transport parameters (e.g., dual mode) |
+| `DefaultSecureTransportParameters` | Default implementation reading from static settings |
+| `SecureNetty4Transport` | Netty-based secure transport implementation |
+| `DualModeSslHandler` | Handler for SSL dual mode (mixed SSL/non-SSL connections) |
+| `SSLConfig` | Security plugin class managing SSL configuration with cluster settings listener |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security_config.ssl_dual_mode_enabled` | Enable SSL dual mode for mixed SSL/non-SSL transport | `false` |
+| `plugins.security.ssl_only` | Run security plugin in SSL-only mode | `false` |
+
+### Interface Definition
+
+```java
+@ExperimentalApi
+public interface SecureTransportSettingsProvider {
+    
+    // Get transport adapter providers
+    default Collection<TransportAdapterProvider<Transport>> getTransportAdapterProviders(Settings settings) {
+        return Collections.emptyList();
+    }
+    
+    // Get dynamic transport parameters
+    default Optional<SecureTransportParameters> parameters(Settings settings) {
+        return Optional.of(new DefaultSecureTransportParameters(settings));
+    }
+    
+    // Build exception handler for transport errors
+    Optional<TransportExceptionHandler> buildServerTransportExceptionHandler(
+        Settings settings, Transport transport);
+    
+    // Build SSL engine for server transport
+    Optional<SSLEngine> buildSecureServerTransportEngine(
+        Settings settings, Transport transport) throws SSLException;
+    
+    // Build SSL engine for client transport
+    Optional<SSLEngine> buildSecureClientTransportEngine(
+        Settings settings, String hostname, int port) throws SSLException;
+    
+    @ExperimentalApi
+    interface SecureTransportParameters {
+        boolean dualModeEnabled();
+    }
+}
+```
+
+### Usage Example
+
+Dynamically toggle SSL dual mode via cluster settings:
+
+```bash
+# Enable dual mode (allow mixed SSL/non-SSL connections)
+curl -XPUT https://localhost:9200/_cluster/settings \
+  -k -H "Content-Type: application/json" \
+  -d '{"persistent": {"plugins.security_config.ssl_dual_mode_enabled": true}}'
+
+# Disable dual mode (require SSL for all connections)
+curl -XPUT https://localhost:9200/_cluster/settings \
+  -k -H "Content-Type: application/json" \
+  -d '{"persistent": {"plugins.security_config.ssl_dual_mode_enabled": false}}'
+```
+
+## Limitations
+
+- `SecureTransportParameters` interface is marked as `@ExperimentalApi` and may change
+- Currently only exposes `dualModeEnabled()` parameter
+- Dynamic updates only affect new connections; existing connections are not affected
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#16387](https://github.com/opensearch-project/OpenSearch/pull/16387) | Add method to return dynamic SecureTransportParameters |
+| v2.18.0 | [#4820](https://github.com/opensearch-project/security/pull/4820) | Security plugin: propagate dual mode from cluster settings |
+
+## References
+
+- [PR #16387](https://github.com/opensearch-project/OpenSearch/pull/16387): Core implementation
+- [Security PR #4820](https://github.com/opensearch-project/security/pull/4820): Security plugin implementation
+- [TLS Configuration](https://docs.opensearch.org/2.18/security/configuration/tls/): Official TLS documentation
+
+## Change History
+
+- **v2.18.0** (2024-10-29): Added `parameters()` method and `SecureTransportParameters` interface to support dynamic SSL dual mode settings

--- a/docs/releases/v2.18.0/features/opensearch/secure-transport-settings.md
+++ b/docs/releases/v2.18.0/features/opensearch/secure-transport-settings.md
@@ -1,0 +1,95 @@
+# Secure Transport Settings
+
+## Summary
+
+This release adds a new method to the `SecureTransportSettingsProvider` interface that allows plugins to provide dynamic `SecureTransportParameters`. This fixes a regression introduced in v2.14 where the SSL dual mode setting (`plugins.security_config.ssl_dual_mode_enabled`) was not being propagated dynamically from cluster settings to the transport layer.
+
+## Details
+
+### What's New in v2.18.0
+
+The `SecureTransportSettingsProvider` interface now includes a `parameters()` method that returns dynamic transport parameters. This enables security plugins to feed dynamically updated settings (like SSL dual mode) to the OpenSearch core, rather than relying solely on static node settings from `opensearch.yml`.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v2.18.0"
+        A1[opensearch.yml] --> B1[Static Settings]
+        B1 --> C1[SecureNetty4Transport]
+    end
+    
+    subgraph "After v2.18.0"
+        A2[opensearch.yml] --> B2[Static Settings]
+        D2[Cluster Settings API] --> E2[SSLConfig]
+        E2 --> F2[SecureTransportSettingsProvider]
+        B2 --> F2
+        F2 --> G2[SecureNetty4Transport]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `SecureTransportParameters` | New interface for dynamic transport parameters |
+| `DefaultSecureTransportParameters` | Default implementation reading from static settings |
+| `parameters()` method | New method in `SecureTransportSettingsProvider` interface |
+
+#### API Changes
+
+New method added to `SecureTransportSettingsProvider`:
+
+```java
+default Optional<SecureTransportParameters> parameters(Settings settings) {
+    return Optional.of(new DefaultSecureTransportParameters(settings));
+}
+
+@ExperimentalApi
+interface SecureTransportParameters {
+    boolean dualModeEnabled();
+}
+```
+
+### Usage Example
+
+Dynamically update SSL dual mode setting via cluster settings API:
+
+```bash
+curl -XPUT https://localhost:9200/_cluster/settings \
+  -k -H "Content-Type: application/json" \
+  -d '{"persistent": {"plugins.security_config.ssl_dual_mode_enabled": false}}'
+```
+
+With this fix, the setting change is now properly propagated to the transport layer, allowing new nodes to join the cluster with the updated SSL configuration.
+
+### Migration Notes
+
+- No migration required for users
+- Plugin developers implementing `SecureTransportSettingsProvider` can override the `parameters()` method to provide custom dynamic parameters
+- The default implementation maintains backward compatibility by reading from static node settings
+
+## Limitations
+
+- The `SecureTransportParameters` interface is marked as `@ExperimentalApi`
+- Currently only exposes `dualModeEnabled()` parameter
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16387](https://github.com/opensearch-project/OpenSearch/pull/16387) | Add method to return dynamic SecureTransportParameters from SecureTransportSettingsProvider interface |
+| [#4820](https://github.com/opensearch-project/security/pull/4820) | Companion PR: Ensure dual mode enabled flag from cluster settings can get propagated to core |
+
+## References
+
+- [PR #16387](https://github.com/opensearch-project/OpenSearch/pull/16387): Main implementation
+- [Security PR #4820](https://github.com/opensearch-project/security/pull/4820): Security plugin companion PR
+- [Security PR #4119](https://github.com/opensearch-project/security/pull/4119): Original change that introduced the regression
+- [TLS Configuration Documentation](https://docs.opensearch.org/2.18/security/configuration/tls/): Official TLS configuration guide
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/secure-transport-settings.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -26,6 +26,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Nested Aggregations](features/opensearch/nested-aggregations.md) - Fix infinite loop in nested aggregations with deep-level nested objects
 - [Code Cleanup](features/opensearch/code-cleanup.md) - Query approximation simplification, Stream API optimization, typo fix
 - [Search Request Stats](features/opensearch/search-request-stats.md) - Enable coordinator search.request_stats_enabled by default
+- [Secure Transport Settings](features/opensearch/secure-transport-settings.md) - Add dynamic SecureTransportParameters to fix SSL dual mode regression
 - [Identity Feature Flag Removal](features/opensearch/identity-feature-flag-removal.md) - Remove experimental identity feature flag, move authentication to plugins
 - [Docker Compose v2 Support](features/opensearch/docker-compose-v2-support.md) - Add support for Docker Compose v2 in TestFixturesPlugin for modern Docker installations
 - [Snapshot Restore Enhancements](features/opensearch/snapshot-restore-enhancements.md) - Alias renaming during restore and clone operation optimization for doc-rep clusters


### PR DESCRIPTION
## Summary

Add documentation for the Secure Transport Settings feature introduced in v2.18.0.

### Changes

This PR adds a new method to the `SecureTransportSettingsProvider` interface that allows plugins to provide dynamic `SecureTransportParameters`. This fixes a regression introduced in v2.14 where the SSL dual mode setting (`plugins.security_config.ssl_dual_mode_enabled`) was not being propagated dynamically from cluster settings to the transport layer.

### Reports Created

- Release report: `docs/releases/v2.18.0/features/opensearch/secure-transport-settings.md`
- Feature report: `docs/features/opensearch/secure-transport-settings.md`

### Key Changes in v2.18.0

- Added `parameters()` method to `SecureTransportSettingsProvider` interface
- Added `SecureTransportParameters` interface with `dualModeEnabled()` method
- Added `DefaultSecureTransportParameters` default implementation
- Updated `SecureNetty4Transport` to use dynamic parameters instead of static settings

### Related PRs

- [OpenSearch #16387](https://github.com/opensearch-project/OpenSearch/pull/16387): Core implementation
- [Security #4820](https://github.com/opensearch-project/security/pull/4820): Security plugin companion PR