### PR TITLE
docs: add flat-object-query-optimization report for v2.18.0

### DIFF
--- a/docs/features/opensearch/flat-object-field.md
+++ b/docs/features/opensearch/flat-object-field.md
@@ -141,23 +141,26 @@ GET /products/_search
 - No aggregations on subfields using dot notation
 - No filtering by subfields
 - Painless scripting not supported for retrieving subfield values
-- Wildcard queries not supported for retrieving subfield values
 - Maximum field value length in dot notation is 2²⁴ − 1
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.18.0 | [#14383](https://github.com/opensearch-project/OpenSearch/pull/14383) | Use IndexOrDocValuesQuery to optimize query, delegate to KeywordFieldType |
 | v2.18.0 | [#15985](https://github.com/opensearch-project/OpenSearch/pull/15985) | Fix infinite loop when parsing invalid token types |
 | v2.7.0 | - | Initial implementation of flat_object field type |
 
 ## References
 
+- [Issue #11537](https://github.com/opensearch-project/OpenSearch/issues/11537): Feature request for IndexOrDocValuesQuery support
+- [Issue #11635](https://github.com/opensearch-project/OpenSearch/issues/11635): Bug report for code duplication in query generation
 - [Issue #15982](https://github.com/opensearch-project/OpenSearch/issues/15982): Bug report for infinite loop with invalid tokens
 - [Flat object documentation](https://docs.opensearch.org/latest/field-types/supported-field-types/flat-object/): Official documentation
 - [Object field types](https://docs.opensearch.org/latest/field-types/supported-field-types/object-fields/): Overview of object field types
+- [Use flat object in OpenSearch](https://opensearch.org/blog/flat-object/): Blog post
 
 ## Change History
 
-- **v2.18.0** (2024-10-22): Fixed infinite loop bug when flat_object field receives invalid token types (arrays, strings, numbers). Now throws ParsingException with clear error message.
+- **v2.18.0** (2024-10-22): Added IndexOrDocValuesQuery optimization for improved query performance. Delegated query generation to KeywordFieldType to reduce code duplication. Enabled wildcard query support. Fixed infinite loop bug when flat_object field receives invalid token types.
 - **v2.7.0** (2023-04-18): Initial implementation of flat_object field type.

--- a/docs/releases/v2.18.0/features/opensearch/flat-object-query-optimization.md
+++ b/docs/releases/v2.18.0/features/opensearch/flat-object-query-optimization.md
@@ -1,0 +1,139 @@
+# Flat Object Query Optimization
+
+## Summary
+
+This release optimizes query performance for `flat_object` fields by using `IndexOrDocValuesQuery` to dynamically choose between index-based and doc_values-based query execution. The implementation also delegates query generation to the underlying `KeywordFieldType`, reducing code duplication and ensuring flat object fields benefit from the same query optimizations as keyword fields.
+
+## Details
+
+### What's New in v2.18.0
+
+The `flat_object` field type now uses `IndexOrDocValuesQuery` for multiple query types, allowing OpenSearch to dynamically select the most efficient query execution path based on the data characteristics.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v2.18.0"
+        Q1[Query] --> FO1[FlatObjectFieldType]
+        FO1 --> TQ1[TermQuery/TermRangeQuery]
+        TQ1 --> IDX1[Index Only]
+    end
+    
+    subgraph "After v2.18.0"
+        Q2[Query] --> FO2[FlatObjectFieldType]
+        FO2 --> KW[KeywordFieldType Delegate]
+        KW --> IOD[IndexOrDocValuesQuery]
+        IOD --> IDX2[Index]
+        IOD --> DV[Doc Values]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `KeywordFieldType.rewriteForDocValue()` | New protected method to rewrite values for doc_values queries |
+| `FlatObjectFieldType.valueFieldType()` | Helper method to select appropriate keyword field type for queries |
+
+#### Query Delegation
+
+The `FlatObjectFieldType` now delegates query generation to its underlying `KeywordFieldType` subfields:
+
+| Query Type | Delegation Target |
+|------------|-------------------|
+| `termsQuery` | `valueFieldType().termsQuery()` |
+| `prefixQuery` | `valueFieldType().prefixQuery()` |
+| `regexpQuery` | `valueFieldType().regexpQuery()` |
+| `fuzzyQuery` | `valueFieldType().fuzzyQuery()` |
+| `rangeQuery` | `valueFieldType().rangeQuery()` |
+| `wildcardQuery` | `valueFieldType().wildcardQuery()` |
+
+#### Wildcard Query Support
+
+Previously, wildcard queries on `flat_object` fields threw a `QueryShardException`. This release enables wildcard query support by delegating to the keyword field type.
+
+### Usage Example
+
+```json
+// Create index with flat_object field
+PUT /test-index
+{
+  "mappings": {
+    "properties": {
+      "issue": {
+        "properties": {
+          "labels": {
+            "type": "flat_object"
+          }
+        }
+      }
+    }
+  }
+}
+
+// Index document
+PUT /test-index/_doc/1
+{
+  "issue": {
+    "labels": {
+      "number": 1,
+      "name": "abc0",
+      "status": 1
+    }
+  }
+}
+
+// Wildcard query (now supported)
+GET /test-index/_search
+{
+  "query": {
+    "wildcard": {
+      "issue.labels.name": "abc*"
+    }
+  }
+}
+
+// Range query (now optimized with IndexOrDocValuesQuery)
+GET /test-index/_search
+{
+  "query": {
+    "range": {
+      "issue.labels.status": {
+        "gte": 0,
+        "lte": 2
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- No migration required
+- Existing queries will automatically benefit from the optimization
+- Wildcard queries on flat_object fields are now supported (previously threw an exception)
+
+## Limitations
+
+- Query optimization depends on both index and doc_values being enabled
+- Performance improvement varies based on data distribution and query selectivity
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#14383](https://github.com/opensearch-project/OpenSearch/pull/14383) | Flat object field use IndexOrDocValuesQuery to optimize query |
+
+## References
+
+- [Issue #11537](https://github.com/opensearch-project/OpenSearch/issues/11537): Feature request for IndexOrDocValuesQuery support
+- [Issue #11635](https://github.com/opensearch-project/OpenSearch/issues/11635): Bug report for code duplication in query generation
+- [Flat object documentation](https://docs.opensearch.org/2.18/field-types/supported-field-types/flat-object/): Official docs
+- [Use flat object in OpenSearch](https://opensearch.org/blog/flat-object/): Blog post
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/flat-object-field.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -14,6 +14,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Dynamic Settings](features/opensearch/dynamic-settings.md) - Make multiple cluster settings dynamic for tuning on larger clusters
 - [Wildcard Query Fixes](features/opensearch/wildcard-query-fixes.md) - Fix escaped wildcard character handling and case-insensitive query on wildcard field
 - [Flat Object Field](features/opensearch/flat-object-field.md) - Fix infinite loop when flat_object field contains invalid token types
+- [Flat Object Query Optimization](features/opensearch/flat-object-query-optimization.md) - Use IndexOrDocValuesQuery to optimize query performance, enable wildcard queries
 - [Index Settings](features/opensearch/index-settings.md) - Fix default value handling when setting index.number_of_replicas and index.number_of_routing_shards to null
 - [Multi-Search API](features/opensearch/multi-search-api.md) - Fix multi-search with template doesn't return status code
 - [Node Join/Leave](features/opensearch/node-join-leave.md) - Fix race condition in node-join and node-left loop


### PR DESCRIPTION
## Summary

This PR adds documentation for the Flat Object Query Optimization feature in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/flat-object-query-optimization.md`
- Feature report: `docs/features/opensearch/flat-object-field.md` (updated)

### Key Changes in v2.18.0
- Added `IndexOrDocValuesQuery` optimization for improved query performance
- Delegated query generation to `KeywordFieldType` to reduce code duplication
- Enabled wildcard query support on flat_object fields (previously threw exception)

### Resources Used
- PR: [#14383](https://github.com/opensearch-project/OpenSearch/pull/14383)
- Issue: [#11537](https://github.com/opensearch-project/OpenSearch/issues/11537)
- Issue: [#11635](https://github.com/opensearch-project/OpenSearch/issues/11635)
- Docs: https://docs.opensearch.org/2.18/field-types/supported-field-types/flat-object/
- Blog: https://opensearch.org/blog/flat-object/

Closes #636