### PR TITLE
docs: add list-apis-paginated report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -21,6 +21,7 @@
 - [Flat Object Field](opensearch/flat-object-field.md)
 - [gRPC Transport & Services](opensearch/grpc-transport--services.md)
 - [Index Settings](opensearch/index-settings.md)
+- [List APIs (Paginated)](opensearch/list-apis-paginated.md)
 - [Mapping Transformer](opensearch/mapping-transformer.md)
 - [Cluster Manager Task Throttling](opensearch/cluster-manager-throttling.md)
 - [Cluster State Management](opensearch/cluster-state-management.md)

--- a/docs/features/opensearch/list-apis-paginated.md
+++ b/docs/features/opensearch/list-apis-paginated.md
@@ -1,0 +1,211 @@
+# List APIs (Paginated)
+
+## Summary
+
+List APIs provide paginated alternatives to OpenSearch's cat APIs for retrieving cluster metadata. As clusters grow to contain thousands of indices and shards, traditional cat API responses become too large, causing client timeouts and cluster stress. List APIs solve this by returning results in manageable pages using token-based pagination, allowing efficient iteration through large datasets without overwhelming the cluster or client.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Client"
+        C[Client Application]
+    end
+    
+    subgraph "REST Layer"
+        LI[RestListIndicesAction]
+        LS[RestListShardsAction]
+    end
+    
+    subgraph "Pagination Layer"
+        IPS[IndexPaginationStrategy]
+        SPS[ShardPaginationStrategy]
+        PT[PageToken Encoder/Decoder]
+    end
+    
+    subgraph "Cluster State"
+        CS[ClusterState]
+        IM[IndexMetadata]
+        SR[ShardRouting]
+    end
+    
+    C -->|"/_list/indices"| LI
+    C -->|"/_list/shards"| LS
+    
+    LI --> IPS
+    LS --> SPS
+    
+    IPS --> PT
+    SPS --> PT
+    
+    IPS --> CS
+    SPS --> CS
+    
+    CS --> IM
+    CS --> SR
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Request"
+        R1[Initial Request]
+        R2[Paginated Request]
+    end
+    
+    subgraph "Processing"
+        P1[Parse Parameters]
+        P2[Decode Token]
+        P3[Get Cluster State]
+        P4[Apply Pagination]
+        P5[Encode Next Token]
+    end
+    
+    subgraph "Response"
+        RESP[Paginated Response]
+    end
+    
+    R1 --> P1
+    R2 --> P2
+    P1 --> P3
+    P2 --> P3
+    P3 --> P4
+    P4 --> P5
+    P5 --> RESP
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `RestListIndicesAction` | REST handler for `/_list/indices` endpoint |
+| `RestListShardsAction` | REST handler for `/_list/shards` endpoint |
+| `IndexPaginationStrategy` | Pagination logic using index creation timestamps as sort keys |
+| `ShardPaginationStrategy` | Pagination logic for shards, maintaining shard ID integrity across pages |
+| `PageToken` | Encapsulates pagination state (last sort value, position) |
+| `RequestLimitSettings` | Dynamic cluster settings for cat API response limits |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cat.indices.response.limit.number_of_indices` | Max indices for `_cat/indices` before returning 429 | -1 (unlimited) |
+| `cat.shards.response.limit.number_of_shards` | Max shards for `_cat/shards` before returning 429 | -1 (unlimited) |
+| `cat.segments.response.limit.number_of_indices` | Max indices for `_cat/segments` before returning 429 | -1 (unlimited) |
+
+### API Reference
+
+#### List Indices API
+
+**Endpoints:**
+- `GET /_list/indices`
+- `GET /_list/indices/{indices}`
+
+**Query Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `next_token` | String | null | Token for fetching next page (Base64 encoded) |
+| `size` | Integer | 5000 | Maximum indices per page |
+| `sort` | String | asc | Sort order by creation time: `asc` or `desc` |
+
+#### List Shards API
+
+**Endpoints:**
+- `GET /_list/shards`
+- `GET /_list/shards/{indices}`
+
+**Query Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `next_token` | String | null | Token for fetching next page (Base64 encoded) |
+| `size` | Integer | 2000 | Maximum shards per page (minimum enforced) |
+| `sort` | String | asc | Sort order by index creation time: `asc` or `desc` |
+
+### Usage Example
+
+**Paginated index listing:**
+```bash
+# First page
+curl "localhost:9200/_list/indices?format=json&size=100"
+
+# Response
+{
+  "next_token": "eyJsYXN0X3NvcnRfdmFsdWUiOjE2OTcwMDAwMDAwMDB9",
+  "indices": [
+    {"index": "logs-2024-01", "health": "green", "status": "open", "pri": "5", "rep": "1"},
+    {"index": "logs-2024-02", "health": "green", "status": "open", "pri": "5", "rep": "1"}
+  ]
+}
+
+# Subsequent pages
+curl "localhost:9200/_list/indices?format=json&next_token=eyJsYXN0X3NvcnRfdmFsdWUiOjE2OTcwMDAwMDAwMDB9"
+```
+
+**Paginated shard listing:**
+```bash
+curl "localhost:9200/_list/shards?format=json&size=500"
+
+# Response
+{
+  "next_token": "MCQw",
+  "shards": [
+    {"index": "logs-2024-01", "shard": "0", "prirep": "p", "state": "STARTED", "docs": "1000", "store": "10mb", "ip": "10.0.0.1", "node": "node-1"},
+    {"index": "logs-2024-01", "shard": "0", "prirep": "r", "state": "STARTED", "docs": "1000", "store": "10mb", "ip": "10.0.0.2", "node": "node-2"}
+  ]
+}
+```
+
+**Plain text format (backward compatible):**
+```bash
+curl "localhost:9200/_list/shards"
+
+# Response
+logs-2024-01 0 p STARTED 1000 10mb 10.0.0.1 node-1
+logs-2024-01 0 r STARTED 1000 10mb 10.0.0.2 node-2
+next_token MCQw
+```
+
+**Configure cat API limits:**
+```bash
+curl -X PUT "localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d'
+{
+  "persistent": {
+    "cat.indices.response.limit.number_of_indices": 1000,
+    "cat.shards.response.limit.number_of_shards": 10000
+  }
+}'
+```
+
+## Limitations
+
+- Pagination uses index creation timestamps as sort keys; indices created during pagination may appear in unexpected positions
+- For `_list/shards`, all shards of a single shard ID must fit in one page (page size must exceed max replica count)
+- `next_token` is opaque and should not be modified by clients
+- Cat API limits return HTTP 429 when exceeded; clients must handle this response
+- Sorting is limited to index creation time; custom sort fields are not supported
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#14718](https://github.com/opensearch-project/OpenSearch/pull/14718) | Implementing pagination for `_cat/indices` API |
+| v2.18.0 | [#14641](https://github.com/opensearch-project/OpenSearch/pull/14641) | Implementing pagination for `_cat/shards` |
+| v2.18.0 | [#15986](https://github.com/opensearch-project/OpenSearch/pull/15986) | Add changes to block calls in cat shards, indices and segments based on dynamic limit settings |
+
+## References
+
+- [Issue #14258](https://github.com/opensearch-project/OpenSearch/issues/14258): Paginate `_cat/indices` API
+- [Issue #14257](https://github.com/opensearch-project/OpenSearch/issues/14257): Paginate `_cat/shards` API
+- [Issue #15954](https://github.com/opensearch-project/OpenSearch/issues/15954): Blocking non-paginated calls
+- [List API Documentation](https://docs.opensearch.org/2.18/api-reference/list/): Official docs
+- [List indices Documentation](https://docs.opensearch.org/2.18/api-reference/list/list-indices/): List indices API
+- [List shards Documentation](https://docs.opensearch.org/2.18/api-reference/list/list-shards/): List shards API
+
+## Change History
+
+- **v2.18.0** (2024-10-22): Initial implementation with `_list/indices`, `_list/shards` APIs and cat API response limits

--- a/docs/releases/v2.18.0/features/opensearch/list-apis-paginated.md
+++ b/docs/releases/v2.18.0/features/opensearch/list-apis-paginated.md
@@ -1,0 +1,185 @@
+# List APIs (Paginated)
+
+## Summary
+
+OpenSearch 2.18.0 introduces new paginated List APIs (`_list/indices` and `_list/shards`) as alternatives to the existing cat APIs. These APIs address scalability issues in large clusters where cat API responses can become too large, causing client timeouts and cluster stress. Additionally, dynamic cluster settings allow administrators to block non-paginated cat API calls when limits are exceeded.
+
+## Details
+
+### What's New in v2.18.0
+
+- New `/_list/indices` API with pagination support
+- New `/_list/shards` API with pagination support
+- Dynamic cluster settings to limit cat API responses
+- HTTP 429 response when limits are exceeded
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Client Request"
+        REQ[API Request]
+    end
+    
+    subgraph "New List APIs"
+        LI[/_list/indices]
+        LS[/_list/shards]
+    end
+    
+    subgraph "Legacy Cat APIs"
+        CI[/_cat/indices]
+        CS[/_cat/shards]
+        CSG[/_cat/segments]
+    end
+    
+    subgraph "Request Limit Settings"
+        RLS[RequestLimitSettings]
+        LIMIT{Limit Check}
+    end
+    
+    REQ --> LI
+    REQ --> LS
+    REQ --> CI
+    REQ --> CS
+    REQ --> CSG
+    
+    CI --> RLS
+    CS --> RLS
+    CSG --> RLS
+    RLS --> LIMIT
+    LIMIT -->|Exceeded| E429[HTTP 429]
+    LIMIT -->|OK| RESP[Response]
+    
+    LI --> PAGE[Paginated Response]
+    LS --> PAGE
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `RestListIndicesAction` | REST handler for `/_list/indices` endpoint |
+| `RestListShardsAction` | REST handler for `/_list/shards` endpoint |
+| `IndexPaginationStrategy` | Pagination logic using index creation timestamps |
+| `ShardPaginationStrategy` | Pagination logic for shards based on index order |
+| `RequestLimitSettings` | Dynamic settings for cat API response limits |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cat.indices.response.limit.number_of_indices` | Max indices for `_cat/indices` | -1 (unlimited) |
+| `cat.shards.response.limit.number_of_shards` | Max shards for `_cat/shards` | -1 (unlimited) |
+| `cat.segments.response.limit.number_of_indices` | Max indices for `_cat/segments` | -1 (unlimited) |
+
+#### API Changes
+
+**New Endpoints:**
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /_list/indices` | Paginated list of indices |
+| `GET /_list/indices/{indices}` | Paginated list of specific indices |
+| `GET /_list/shards` | Paginated list of shards |
+| `GET /_list/shards/{indices}` | Paginated list of shards for specific indices |
+
+**Query Parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `next_token` | String | null | Token for fetching next page |
+| `size` | Integer | 2000 (shards), 5000 (indices) | Max items per page |
+| `sort` | String | asc | Sort order: `asc` or `desc` |
+
+### Usage Example
+
+**List indices with pagination:**
+```bash
+# First page
+curl "localhost:9200/_list/indices?format=json&size=100"
+
+# Response
+{
+  "next_token": "eyJsYXN0X3NvcnRfdmFsdWUiOjE2...",
+  "indices": [
+    {"index": "logs-2024-01", "health": "green", ...},
+    {"index": "logs-2024-02", "health": "green", ...}
+  ]
+}
+
+# Next page using token
+curl "localhost:9200/_list/indices?format=json&next_token=eyJsYXN0X3NvcnRfdmFsdWUiOjE2..."
+```
+
+**List shards with pagination:**
+```bash
+curl "localhost:9200/_list/shards?format=json&size=500"
+
+# Response
+{
+  "next_token": "MCQw",
+  "shards": [
+    {"index": "test-ind", "shard": "0", "prirep": "p", "state": "STARTED", ...},
+    {"index": "test-ind", "shard": "0", "prirep": "r", "state": "STARTED", ...}
+  ]
+}
+```
+
+**Plain text format:**
+```bash
+curl "localhost:9200/_list/shards"
+
+# Response
+test-index 1 p STARTED 0 208b 127.0.0.1 data1
+test-index 1 r STARTED 0 208b 127.0.0.1 data5
+next_token MCQw
+```
+
+**Configure cat API limits:**
+```bash
+# Set limit to block large cat/indices requests
+curl -X PUT "localhost:9200/_cluster/settings" -H 'Content-Type: application/json' -d'
+{
+  "persistent": {
+    "cat.indices.response.limit.number_of_indices": 1000,
+    "cat.shards.response.limit.number_of_shards": 10000
+  }
+}'
+```
+
+### Migration Notes
+
+1. For clusters with many indices/shards, switch from `_cat/indices` to `_list/indices` and `_cat/shards` to `_list/shards`
+2. Update monitoring scripts to handle paginated responses with `next_token`
+3. Consider setting cat API limits to encourage migration to paginated APIs
+4. Both JSON and plain text formats are supported for backward compatibility
+
+## Limitations
+
+- Pagination uses index creation timestamps as sort keys; indices created during pagination may appear in unexpected positions depending on sort order
+- Shards for a single shard ID cannot span across pages (minimum page size must accommodate max replicas)
+- `next_token` is Base64 encoded and should be treated as opaque
+- Cat API limits return HTTP 429 when exceeded, requiring client handling
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#14718](https://github.com/opensearch-project/OpenSearch/pull/14718) | Implementing pagination for `_cat/indices` API |
+| [#14641](https://github.com/opensearch-project/OpenSearch/pull/14641) | Implementing pagination for `_cat/shards` |
+| [#15986](https://github.com/opensearch-project/OpenSearch/pull/15986) | Add changes to block calls in cat shards, indices and segments based on dynamic limit settings |
+
+## References
+
+- [Issue #14258](https://github.com/opensearch-project/OpenSearch/issues/14258): Paginate `_cat/indices` API
+- [Issue #14257](https://github.com/opensearch-project/OpenSearch/issues/14257): Paginate `_cat/shards` API
+- [Issue #15954](https://github.com/opensearch-project/OpenSearch/issues/15954): Blocking non-paginated calls
+- [List API Documentation](https://docs.opensearch.org/2.18/api-reference/list/): Official docs
+- [List indices Documentation](https://docs.opensearch.org/2.18/api-reference/list/list-indices/): List indices API
+- [List shards Documentation](https://docs.opensearch.org/2.18/api-reference/list/list-shards/): List shards API
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/list-apis-paginated.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -8,6 +8,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### OpenSearch
 
+- [List APIs (Paginated)](features/opensearch/list-apis-paginated.md) - New `_list/indices` and `_list/shards` APIs with pagination support, plus cat API response limits
 - [Cluster Stats API](features/opensearch/cluster-stats-api.md) - URI path filtering support for selective metric retrieval
 - [OpenSearch Core Dependencies](features/opensearch/opensearch-core-dependencies.md) - 26 dependency updates including Lucene 9.12.0, Netty 4.1.114, gRPC 1.68.0, Protobuf 3.25.5
 - [Cluster State Management](features/opensearch/cluster-state-management.md) - Fix voting configuration mismatch by updating lastSeenClusterState in commit phase


### PR DESCRIPTION
## Summary

Add documentation for List APIs (Paginated) feature introduced in OpenSearch v2.18.0.

## Changes

- **Release report**: `docs/releases/v2.18.0/features/opensearch/list-apis-paginated.md`
- **Feature report**: `docs/features/opensearch/list-apis-paginated.md`
- Updated release index and features index

## Feature Overview

OpenSearch 2.18.0 introduces paginated List APIs as alternatives to cat APIs:

- `/_list/indices` - Paginated alternative to `/_cat/indices`
- `/_list/shards` - Paginated alternative to `/_cat/shards`
- Dynamic cluster settings to limit cat API responses (returns HTTP 429 when exceeded)

## Related PRs

- opensearch-project/OpenSearch#14718 - Pagination for `_cat/indices`
- opensearch-project/OpenSearch#14641 - Pagination for `_cat/shards`
- opensearch-project/OpenSearch#15986 - Cat API response limits

Closes #635