### PR TITLE
docs: add phone-analyzer report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -45,6 +45,7 @@
 - [Nodes Info API](opensearch/nodes-info-api.md)
 - [Node Roles Configuration](opensearch/node-roles-configuration.md)
 - [OpenSearch Core Dependencies](opensearch/opensearch-core-dependencies.md)
+- [Phone Number Analyzer](opensearch/phone-analyzer.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)
 - [Replication](opensearch/replication.md)
 - [Search Backpressure](opensearch/search-backpressure.md)

--- a/docs/features/opensearch/phone-analyzer.md
+++ b/docs/features/opensearch/phone-analyzer.md
@@ -1,0 +1,177 @@
+# Phone Number Analyzer
+
+## Summary
+
+The Phone Number Analyzer is an OpenSearch plugin (`analysis-phonenumber`) that provides specialized analyzers and tokenizers for indexing and searching phone numbers. It handles the complexity of international phone number formats using Google's `libphonenumber` library, enabling flexible search across various phone number representations (with/without country codes, different separators, national prefixes, etc.).
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "analysis-phonenumber Plugin"
+        Plugin[PhoneNumberAnalysisPlugin]
+        
+        subgraph "Analyzers"
+            PA[phone analyzer<br/>Index time - with n-grams]
+            PSA[phone-search analyzer<br/>Search time - no n-grams]
+        end
+        
+        subgraph "Tokenizers"
+            PT[phone tokenizer]
+            PST[phone-search tokenizer]
+        end
+        
+        Plugin --> PA
+        Plugin --> PSA
+        Plugin --> PT
+        Plugin --> PST
+    end
+    
+    subgraph "Internal Components"
+        Analyzer[PhoneNumberAnalyzer]
+        Provider[PhoneNumberAnalyzerProvider]
+        Tokenizer[PhoneNumberTermTokenizer]
+        Factory[PhoneNumberTermTokenizerFactory]
+        
+        PA --> Provider --> Analyzer
+        PSA --> Provider
+        Analyzer --> Tokenizer
+        PT --> Factory --> Tokenizer
+        PST --> Factory
+    end
+    
+    subgraph "External"
+        LibPhone[Google libphonenumber]
+        Tokenizer --> LibPhone
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Input
+        Raw[Raw Phone Number<br/>+41 60 555 12 34]
+    end
+    
+    subgraph Processing
+        Parse[Parse with libphonenumber]
+        Extract[Extract Components]
+        NGram[Generate N-grams<br/>phone analyzer only]
+    end
+    
+    subgraph Output
+        Tokens[Tokens for Index/Search]
+    end
+    
+    Raw --> Parse --> Extract --> NGram --> Tokens
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `PhoneNumberAnalysisPlugin` | Main plugin class that registers analyzers and tokenizers with OpenSearch |
+| `PhoneNumberAnalyzer` | Analyzer implementation that wraps the tokenizer |
+| `PhoneNumberAnalyzerProvider` | Provider for creating analyzer instances with configuration |
+| `PhoneNumberTermTokenizer` | Core tokenizer that parses phone numbers using libphonenumber |
+| `PhoneNumberTermTokenizerFactory` | Factory for creating tokenizer instances |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `phone-region` | ISO 3166 country code for parsing local phone numbers without international prefix | `ZZ` (unknown region) |
+
+### Analyzer Types
+
+#### phone (Index Analyzer)
+
+Generates n-grams from the phone number for flexible partial matching during search:
+
+```
+Input: "+41 60 555 12 34"
+Output tokens: ["+41 60 555 12 34", "6055512", "41605551", "416055512", 
+                "6055", "41605551234", "605551234", "41", ...]
+```
+
+#### phone-search (Search Analyzer)
+
+Generates only basic tokens without n-grams for efficient search:
+
+```
+Input: "+41 60 555 12 34"
+Output tokens: ["+41 60 555 12 34", "41 60 555 12 34", "41605551234", "605551234", "41"]
+```
+
+### Usage Example
+
+```json
+PUT /contacts
+{
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "phone-ch": {
+          "type": "phone",
+          "phone-region": "CH"
+        },
+        "phone-search-ch": {
+          "type": "phone-search",
+          "phone-region": "CH"
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "phone_number": {
+        "type": "text",
+        "analyzer": "phone-ch",
+        "search_analyzer": "phone-search-ch"
+      }
+    }
+  }
+}
+```
+
+### Regional Phone Number Support
+
+When specifying a region, the analyzer can parse local phone numbers:
+
+```json
+// With phone-region: "CH" (Switzerland)
+// Input: "058 316 10 10" (local format)
+// Correctly parsed as Swiss number: +41 58 316 10 10
+```
+
+Without a region, only numbers with international prefix (`+`) are fully parsed.
+
+## Limitations
+
+- Not designed for finding phone numbers within large text documents
+- Should be used on fields containing only phone numbers
+- Collects entire field content into memory (unsuitable for large field values)
+- `phone-email` analyzer from the original elasticsearch-phone is not included
+- Alphabetic phone representations (e.g., `1-800-MICROSOFT`) are not fully supported
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#15915](https://github.com/opensearch-project/OpenSearch/pull/15915) | Initial implementation of phone number analyzer |
+
+## References
+
+- [Issue #11326](https://github.com/opensearch-project/OpenSearch/issues/11326): Original RFC for phone number analyzer
+- [Documentation](https://docs.opensearch.org/2.18/analyzers/supported-analyzers/phone-analyzers/): Official phone analyzer documentation
+- [libphonenumber](https://github.com/google/libphonenumber): Google's phone number parsing library
+- [elasticsearch-phone](https://github.com/purecloudlabs/elasticsearch-phone): Original Elasticsearch plugin this is based on
+- [Falsehoods about phone numbers](https://github.com/google/libphonenumber/blob/master/FALSEHOODS.md): Why phone number parsing is complex
+- [Documentation Issue #8389](https://github.com/opensearch-project/documentation-website/issues/8389): Documentation PR
+
+## Change History
+
+- **v2.18.0** (2024-10-22): Initial implementation with `phone` and `phone-search` analyzers/tokenizers

--- a/docs/releases/v2.18.0/features/opensearch/phone-analyzer.md
+++ b/docs/releases/v2.18.0/features/opensearch/phone-analyzer.md
@@ -1,0 +1,136 @@
+# Phone Analyzer
+
+## Summary
+
+OpenSearch 2.18.0 introduces a new `analysis-phonenumber` plugin that provides dedicated analyzers and tokenizers for parsing and searching phone numbers. The plugin uses Google's `libphonenumber` library to handle the complex task of phone number parsing across different international formats.
+
+## Details
+
+### What's New in v2.18.0
+
+This release adds a new plugin (`analysis-phonenumber`) with two analyzers and two tokenizers specifically designed for phone number fields:
+
+- **`phone` analyzer**: Index analyzer that generates n-grams for flexible matching
+- **`phone-search` analyzer**: Search analyzer that produces basic tokens without n-grams
+- **`phone` tokenizer**: Tokenizer for indexing with n-gram generation
+- **`phone-search` tokenizer**: Tokenizer for search without n-gram generation
+
+### Technical Changes
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph "analysis-phonenumber Plugin"
+        Plugin[PhoneNumberAnalysisPlugin]
+        Plugin --> PA[phone analyzer]
+        Plugin --> PSA[phone-search analyzer]
+        Plugin --> PT[phone tokenizer]
+        Plugin --> PST[phone-search tokenizer]
+    end
+    
+    subgraph "Core Components"
+        PA --> Analyzer[PhoneNumberAnalyzer]
+        PSA --> Analyzer
+        PT --> Tokenizer[PhoneNumberTermTokenizer]
+        PST --> Tokenizer
+        Analyzer --> Tokenizer
+    end
+    
+    subgraph "External Library"
+        Tokenizer --> LibPhone[libphonenumber]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `PhoneNumberAnalysisPlugin` | Main plugin class registering analyzers and tokenizers |
+| `PhoneNumberAnalyzer` | Analyzer wrapping the tokenizer |
+| `PhoneNumberAnalyzerProvider` | Provider for the analyzer |
+| `PhoneNumberTermTokenizer` | Core tokenizer using libphonenumber |
+| `PhoneNumberTermTokenizerFactory` | Factory for creating tokenizers |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `phone-region` | ISO 3166 country code for parsing local numbers | `ZZ` (unknown) |
+
+### Usage Example
+
+```json
+PUT /contacts
+{
+  "settings": {
+    "analysis": {
+      "analyzer": {
+        "phone-ch": {
+          "type": "phone",
+          "phone-region": "CH"
+        },
+        "phone-search-ch": {
+          "type": "phone-search",
+          "phone-region": "CH"
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "phone_number": {
+        "type": "text",
+        "analyzer": "phone-ch",
+        "search_analyzer": "phone-search-ch"
+      }
+    }
+  }
+}
+```
+
+### Token Generation
+
+The `phone` analyzer generates n-grams for flexible partial matching:
+
+```
+Input: "+41 60 555 12 34"
+Tokens: ["+41 60 555 12 34", "6055512", "41605551", "416055512", "6055", "41605551234", ...]
+```
+
+The `phone-search` analyzer generates only basic tokens:
+
+```
+Input: "+41 60 555 12 34"
+Tokens: ["+41 60 555 12 34", "41 60 555 12 34", "41605551234", "605551234", "41"]
+```
+
+### Installation
+
+```bash
+./bin/opensearch-plugin install analysis-phonenumber
+```
+
+## Limitations
+
+- Not designed for finding phone numbers in large text documents
+- Should be used on fields containing only phone numbers
+- Collects entire field content into memory (unsuitable for large field values)
+- `phone-email` analyzer from elasticsearch-phone is not ported (can be added if needed)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#15915](https://github.com/opensearch-project/OpenSearch/pull/15915) | Implement phone number analyzer |
+
+## References
+
+- [Issue #11326](https://github.com/opensearch-project/OpenSearch/issues/11326): RFC for new plugin with normalizer & analyzer for phone numbers
+- [Documentation](https://docs.opensearch.org/2.18/analyzers/supported-analyzers/phone-analyzers/): Phone number analyzers
+- [libphonenumber](https://github.com/google/libphonenumber): Google's phone number parsing library
+- [Falsehoods about phone numbers](https://github.com/google/libphonenumber/blob/master/FALSEHOODS.md): Why phone number parsing is complex
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/phone-analyzer.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -26,6 +26,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Task Management](features/opensearch/task-management.md) - Fix missing fields in task index mapping for proper task result storage
 - [Test Fixes](features/opensearch/test-fixes.md) - Fix flaky test in ApproximatePointRangeQueryTests by adjusting totalHits assertion logic
 - [Nested Aggregations](features/opensearch/nested-aggregations.md) - Fix infinite loop in nested aggregations with deep-level nested objects
+- [Phone Analyzer](features/opensearch/phone-analyzer.md) - New `phone` and `phone-search` analyzers for phone number indexing and search
 - [Code Cleanup](features/opensearch/code-cleanup.md) - Query approximation simplification, Stream API optimization, typo fix
 - [Search Request Stats](features/opensearch/search-request-stats.md) - Enable coordinator search.request_stats_enabled by default
 - [Secure Transport Settings](features/opensearch/secure-transport-settings.md) - Add dynamic SecureTransportParameters to fix SSL dual mode regression


### PR DESCRIPTION
## Summary

Add documentation for the Phone Number Analyzer feature introduced in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/phone-analyzer.md`
- Feature report: `docs/features/opensearch/phone-analyzer.md`

### Key Changes in v2.18.0
- New `analysis-phonenumber` plugin
- `phone` analyzer for indexing (with n-gram generation)
- `phone-search` analyzer for search (without n-grams)
- `phone-region` configuration for local number parsing
- Uses Google's libphonenumber library

### Resources Used
- PR: [#15915](https://github.com/opensearch-project/OpenSearch/pull/15915)
- Issue: [#11326](https://github.com/opensearch-project/OpenSearch/issues/11326)
- Docs: https://docs.opensearch.org/2.18/analyzers/supported-analyzers/phone-analyzers/

Closes #634