### PR TITLE
docs: add remote-store-metrics report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -48,6 +48,7 @@
 - [Phone Number Analyzer](opensearch/phone-analyzer.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)
 - [Replication](opensearch/replication.md)
+- [Remote Store Metrics](opensearch/remote-store-metrics.md)
 - [Search Backpressure](opensearch/search-backpressure.md)
 - [Search Request Stats](opensearch/search-request-stats.md)
 - [Secure Transport Settings](opensearch/secure-transport-settings.md)

--- a/docs/features/opensearch/remote-store-metrics.md
+++ b/docs/features/opensearch/remote-store-metrics.md
@@ -1,0 +1,126 @@
+# Remote Store Metrics
+
+## Summary
+
+Remote Store Metrics provides node-level statistics for remote-backed storage operations in OpenSearch. This feature exposes metrics through the Node Stats API, enabling operators to monitor the health and performance of remote store operations, including pinned timestamp synchronization. These metrics complement the existing shard-level Remote Store Stats API by providing cluster-wide visibility into remote store operations.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Monitoring APIs"
+        NSA[Node Stats API]
+        RSSA[Remote Store Stats API]
+    end
+    
+    subgraph "Node Stats"
+        NS[NodeStats]
+        RSN[RemoteStoreNodeStats]
+    end
+    
+    subgraph "Remote Store Services"
+        RSPTS[RemoteStorePinnedTimestampService]
+        RSS[RemoteStoreService]
+    end
+    
+    subgraph "Remote Storage"
+        S3[S3 / Remote Store]
+    end
+    
+    NSA --> NS
+    NS --> RSN
+    RSN --> RSPTS
+    RSPTS --> S3
+    
+    RSSA --> RSS
+    RSS --> S3
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[RemoteStorePinnedTimestampService] -->|Periodic Fetch| B[Remote Store]
+    B -->|Pinned Timestamps| A
+    A -->|Update Timestamp| C[Static Cache]
+    D[Node Stats Request] -->|Query| E[RemoteStoreNodeStats]
+    E -->|Read| C
+    E -->|Return| F[API Response]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `RemoteStoreNodeStats` | Holds node-level remote store statistics, implements `Writeable` and `ToXContentFragment` |
+| `RemoteStorePinnedTimestampService` | Service that periodically fetches pinned timestamps from remote store |
+| `NodesStatsRequest.Metric.REMOTE_STORE` | Metric enum for requesting remote store statistics |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.remote_store.pinned_timestamps.enabled` | Enable pinned timestamps feature | `false` |
+| `cluster.remote_store.pinned_timestamps.scheduler_interval` | Interval for fetching pinned timestamps | `3m` |
+
+### Usage Example
+
+Query remote store metrics:
+
+```bash
+# Get remote store metrics for all nodes
+GET _nodes/stats/remote_store
+
+# Get remote store metrics for specific node
+GET _nodes/<node_id>/stats/remote_store
+
+# Combine with other metrics
+GET _nodes/stats/remote_store,indices,jvm
+```
+
+Example response:
+
+```json
+{
+  "_nodes": {
+    "total": 3,
+    "successful": 3,
+    "failed": 0
+  },
+  "cluster_name": "my-cluster",
+  "nodes": {
+    "node-1": {
+      "name": "data-node-1",
+      "remote_store": {
+        "last_successful_fetch_of_pinned_timestamps": 1694171633644
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Currently limited to pinned timestamp fetch metrics
+- Only meaningful for clusters with remote-backed storage enabled
+- Requires `cluster.remote_store.pinned_timestamps.enabled` to be `true` for meaningful data
+- Does not include shard-level metrics (use Remote Store Stats API for shard-level data)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#15611](https://github.com/opensearch-project/OpenSearch/pull/15611) | Add new metric REMOTE_STORE to NodeStats API response |
+
+## References
+
+- [Issue #15896](https://github.com/opensearch-project/OpenSearch/issues/15896): Original feature request
+- [Remote Store Stats API](https://docs.opensearch.org/2.18/tuning-your-cluster/availability-and-recovery/remote-store/remote-store-stats-api/): Shard-level remote store statistics
+- [Remote-backed Storage](https://docs.opensearch.org/2.18/tuning-your-cluster/availability-and-recovery/remote-store/index/): Remote store documentation
+- [Nodes Stats API](https://docs.opensearch.org/2.18/api-reference/nodes-apis/nodes-stats/): Node statistics API
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Initial implementation - added `last_successful_fetch_of_pinned_timestamps` metric to Node Stats API

--- a/docs/releases/v2.18.0/features/opensearch/remote-store-metrics.md
+++ b/docs/releases/v2.18.0/features/opensearch/remote-store-metrics.md
@@ -1,0 +1,109 @@
+# Remote Store Metrics
+
+## Summary
+
+OpenSearch 2.18.0 introduces a new `REMOTE_STORE` metric in the Node Stats API response. This enhancement adds node-level remote store statistics, starting with the timestamp of the last successful fetch of pinned timestamps from the `RemoteStorePinnedTimestampService`. This metric helps operators monitor and identify any lags in the pinned timestamp fetching process for remote-backed storage clusters.
+
+## Details
+
+### What's New in v2.18.0
+
+This release adds a new metric category `remote_store` to the Node Stats API, providing visibility into remote store operations at the node level.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Node Stats API"
+        NS[NodeStats]
+        RSN[RemoteStoreNodeStats]
+    end
+    
+    subgraph "Remote Store Service"
+        RSPTS[RemoteStorePinnedTimestampService]
+        PT[Pinned Timestamps]
+    end
+    
+    NS --> RSN
+    RSN --> RSPTS
+    RSPTS --> PT
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `RemoteStoreNodeStats` | New class that holds node-level remote store statistics |
+| `REMOTE_STORE` metric | New metric enum value in `NodesStatsRequest.Metric` |
+
+#### New Configuration
+
+The `remote_store` metric is available through the Node Stats API:
+
+```bash
+GET _nodes/stats/remote_store
+```
+
+#### API Response
+
+The new `remote_store` section in the Node Stats API response:
+
+```json
+{
+  "nodes": {
+    "<node_id>": {
+      "remote_store": {
+        "last_successful_fetch_of_pinned_timestamps": 1694171633644
+      }
+    }
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `last_successful_fetch_of_pinned_timestamps` | Unix timestamp (milliseconds) of the last successful fetch of pinned timestamps by the `RemoteStorePinnedTimestampService` |
+
+### Usage Example
+
+Query remote store metrics for all nodes:
+
+```bash
+GET _nodes/stats/remote_store
+```
+
+Query remote store metrics along with other metrics:
+
+```bash
+GET _nodes/stats/remote_store,indices
+```
+
+### Migration Notes
+
+- This is a new additive feature with no breaking changes
+- The metric is only populated when `cluster.remote_store.pinned_timestamps.enabled` is set to `true`
+- Backward compatibility is ensured through version checks
+
+## Limitations
+
+- Currently only includes the `last_successful_fetch_of_pinned_timestamps` metric
+- The metric is only meaningful for remote-backed storage clusters with pinned timestamps enabled
+- Additional remote store metrics may be added in future releases
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#15611](https://github.com/opensearch-project/OpenSearch/pull/15611) | Add new metric REMOTE_STORE to NodeStats API response |
+
+## References
+
+- [Issue #15896](https://github.com/opensearch-project/OpenSearch/issues/15896): Feature request for adding pinned timestamps to node stats
+- [Remote Store Stats API](https://docs.opensearch.org/2.18/tuning-your-cluster/availability-and-recovery/remote-store/remote-store-stats-api/): Shard-level remote store statistics
+- [Nodes Stats API](https://docs.opensearch.org/2.18/api-reference/nodes-apis/nodes-stats/): Node statistics API documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/remote-store-metrics.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -33,6 +33,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Identity Feature Flag Removal](features/opensearch/identity-feature-flag-removal.md) - Remove experimental identity feature flag, move authentication to plugins
 - [Docker Compose v2 Support](features/opensearch/docker-compose-v2-support.md) - Add support for Docker Compose v2 in TestFixturesPlugin for modern Docker installations
 - [Snapshot Restore Enhancements](features/opensearch/snapshot-restore-enhancements.md) - Alias renaming during restore and clone operation optimization for doc-rep clusters
+- [Remote Store Metrics](features/opensearch/remote-store-metrics.md) - New REMOTE_STORE metric in Node Stats API for monitoring pinned timestamp fetch operations
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

Add documentation for the Remote Store Metrics feature introduced in OpenSearch v2.18.0.

### Changes
- **Release report**: `docs/releases/v2.18.0/features/opensearch/remote-store-metrics.md`
- **Feature report**: `docs/features/opensearch/remote-store-metrics.md`
- Updated release index and features index

### Feature Overview
This release adds a new `REMOTE_STORE` metric to the Node Stats API, providing visibility into remote store operations at the node level. The initial metric tracks the timestamp of the last successful fetch of pinned timestamps from the `RemoteStorePinnedTimestampService`.

### Related
- Resolves #633
- OpenSearch PR: [#15611](https://github.com/opensearch-project/OpenSearch/pull/15611)
- OpenSearch Issue: [#15896](https://github.com/opensearch-project/OpenSearch/issues/15896)