### PR TITLE
docs: add dynamic-threadpool-resize report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -27,6 +27,7 @@
 - [Cluster State Management](opensearch/cluster-state-management.md)
 - [Dependency Management](opensearch/dependency-management.md)
 - [Docker Compose v2 Support](opensearch/docker-compose-v2-support.md)
+- [Dynamic Threadpool Resize](opensearch/dynamic-threadpool-resize.md)
 - [Locale Provider](opensearch/locale-provider.md)
 - [HTTP API](opensearch/http-api.md)
 - [Jackson & Query Limits](opensearch/jackson--query-limits.md)

--- a/docs/features/opensearch/dynamic-threadpool-resize.md
+++ b/docs/features/opensearch/dynamic-threadpool-resize.md
@@ -1,0 +1,177 @@
+# Dynamic Threadpool Resize
+
+## Summary
+
+Dynamic Threadpool Resize enables operators to modify thread pool sizes at runtime through the cluster settings API, eliminating the need for node restarts when tuning thread pool configurations. This feature supports both scaling and fixed thread pool types, allowing fine-grained control over thread allocation based on workload requirements.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Configuration Flow"
+        API[Cluster Settings API]
+        CS[ClusterSettings]
+        TP[ThreadPool]
+        VAL[Validation]
+        APPLY[Apply Changes]
+    end
+    
+    subgraph "Thread Pool Types"
+        SCALING[Scaling ThreadPool<br/>core, max]
+        FIXED[Fixed ThreadPool<br/>size]
+        AUTO[Fixed Auto Queue<br/>size]
+    end
+    
+    subgraph "Executors"
+        EX1[OpenSearchThreadPoolExecutor]
+        EX2[OpenSearchThreadPoolExecutor]
+        EX3[OpenSearchThreadPoolExecutor]
+    end
+    
+    API -->|PUT _cluster/settings| CS
+    CS --> VAL
+    VAL -->|Valid| APPLY
+    APPLY --> TP
+    
+    TP --> SCALING
+    TP --> FIXED
+    TP --> AUTO
+    
+    SCALING --> EX1
+    FIXED --> EX2
+    AUTO --> EX3
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[User Request] --> B[Cluster Settings API]
+    B --> C{Validate Settings}
+    C -->|Invalid| D[Reject with Error]
+    C -->|Valid| E[Update ThreadPool]
+    E --> F{Pool Type?}
+    F -->|Scaling| G[Set core/max]
+    F -->|Fixed| H[Set size]
+    G --> I[Executor Updated]
+    H --> I
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ThreadPool` | Main class managing all thread pools, now with dynamic resize capability |
+| `ClusterSettings` | Handles cluster-wide settings including new thread pool settings |
+| `OpenSearchThreadPoolExecutor` | Underlying executor that supports runtime size changes |
+| `CLUSTER_THREAD_POOL_SIZE_SETTING` | New group setting for dynamic thread pool configuration |
+
+### Configuration
+
+| Setting | Description | Default | Pool Types |
+|---------|-------------|---------|------------|
+| `cluster.thread_pool.<name>.size` | Thread pool size for fixed pools | Pool-specific | Fixed, Fixed Auto Queue |
+| `cluster.thread_pool.<name>.core` | Minimum thread count | Pool-specific | Scaling |
+| `cluster.thread_pool.<name>.max` | Maximum thread count | Pool-specific | Scaling |
+
+### Thread Pool Types and Defaults
+
+**Scaling Thread Pools:**
+
+| Pool Name | Default Core | Default Max |
+|-----------|--------------|-------------|
+| `generic` | 4 | 128-512 (based on processors) |
+| `management` | 1 | 5 |
+| `flush` | 1 | halfProc (max 5) |
+| `refresh` | 1 | halfProc (max 10) |
+| `warmer` | 1 | halfProc (max 5) |
+| `snapshot` | 1 | halfProc (max 5) |
+| `snapshot_deletion` | 1 | 64-256 (based on processors) |
+| `fetch_shard_started` | 1 | 2 × processors |
+| `fetch_shard_store` | 1 | 2 × processors |
+
+**Fixed Thread Pools:**
+
+| Pool Name | Default Size |
+|-----------|--------------|
+| `get` | processors |
+| `write` | processors |
+| `analyze` | 1 |
+| `force_merge` | 1 |
+| `system_read` | halfProc (max 5) |
+| `system_write` | halfProc (max 5) |
+
+### Usage Example
+
+```json
+// Increase snapshot thread pool for faster snapshot operations
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.thread_pool.snapshot.core": "4",
+    "cluster.thread_pool.snapshot.max": "10"
+  }
+}
+
+// Increase write thread pool for high-throughput indexing
+PUT _cluster/settings
+{
+  "transient": {
+    "cluster.thread_pool.write.size": "16"
+  }
+}
+
+// Reset to defaults by setting to null
+PUT _cluster/settings
+{
+  "transient": {
+    "cluster.thread_pool.write.size": null
+  }
+}
+```
+
+### Validation Rules
+
+1. **Thread pool name validation**: Must be a valid core thread pool name
+2. **Scaling pool validation**:
+   - Only `core` and `max` settings allowed
+   - Both values must be positive (≥ 1)
+   - `core` must be ≤ `max`
+3. **Fixed pool validation**:
+   - Only `size` setting allowed
+   - Value must be positive (≥ 1)
+
+### Implementation Details
+
+The resize operation handles the order of operations carefully to avoid `IllegalArgumentException` from the underlying `ThreadPoolExecutor`:
+
+- When **decreasing** pool size: core is decreased first, then max
+- When **increasing** pool size: max is increased first, then core
+
+This ensures `core ≤ max` invariant is maintained during the transition.
+
+## Limitations
+
+- Only core thread pools can be resized; plugin-defined pools are not supported
+- Queue sizes cannot be modified dynamically
+- The `same` (direct executor) thread pool cannot be resized
+- Changes apply to the current node; cluster settings propagate to all nodes
+- No automatic rollback if resize causes issues
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#16236](https://github.com/opensearch-project/OpenSearch/pull/16236) | Add support to dynamically resize threadpools size |
+
+## References
+
+- [PR #16236](https://github.com/opensearch-project/OpenSearch/pull/16236): Original implementation
+- [CAT Thread Pool API](https://docs.opensearch.org/2.18/api-reference/cat/cat-thread-pool/): Monitor thread pool status
+- [Nodes Info API](https://docs.opensearch.org/2.18/api-reference/nodes-apis/nodes-info/): View thread pool configuration
+
+## Change History
+
+- **v2.18.0** (2024-10-29): Initial implementation - dynamic thread pool resize capability

--- a/docs/releases/v2.18.0/features/opensearch/dynamic-threadpool-resize.md
+++ b/docs/releases/v2.18.0/features/opensearch/dynamic-threadpool-resize.md
@@ -1,0 +1,112 @@
+# Dynamic Threadpool Resize
+
+## Summary
+
+OpenSearch v2.18.0 introduces the ability to dynamically resize thread pool sizes at runtime without requiring a node restart. This feature allows operators to adjust thread pool configurations through cluster settings API, enabling real-time tuning of thread pools based on workload demands.
+
+## Details
+
+### What's New in v2.18.0
+
+This release adds a new cluster setting `cluster.thread_pool.<pool_name>.<setting>` that allows dynamic modification of thread pool sizes for all core thread pools.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Cluster Settings Update"
+        API[Cluster Settings API]
+        CS[ClusterSettings]
+        TP[ThreadPool]
+    end
+    
+    subgraph "Thread Pool Types"
+        SCALING[Scaling ThreadPool]
+        FIXED[Fixed ThreadPool]
+    end
+    
+    API -->|PUT _cluster/settings| CS
+    CS -->|validateSetting| TP
+    CS -->|setThreadPool| TP
+    TP --> SCALING
+    TP --> FIXED
+    
+    SCALING -->|core, max| Executor1[OpenSearchThreadPoolExecutor]
+    FIXED -->|size| Executor2[OpenSearchThreadPoolExecutor]
+```
+
+#### New Configuration
+
+| Setting | Description | Applicable Pool Types |
+|---------|-------------|----------------------|
+| `cluster.thread_pool.<name>.size` | Thread pool size | Fixed, Fixed Auto Queue |
+| `cluster.thread_pool.<name>.core` | Core pool size | Scaling |
+| `cluster.thread_pool.<name>.max` | Maximum pool size | Scaling |
+
+#### Supported Thread Pools
+
+**Scaling Thread Pools** (configurable via `core` and `max`):
+- `generic`, `management`, `flush`, `refresh`, `warmer`, `snapshot`, `snapshot_deletion`
+- `fetch_shard_started`, `fetch_shard_store`, `translog_transfer`, `remote_purge`
+- `remote_refresh_retry`, `remote_recovery`, `remote_state_read`
+
+**Fixed Thread Pools** (configurable via `size`):
+- `get`, `analyze`, `write`, `listener`, `force_merge`, `system_read`, `system_write`
+- `translog_sync`, `remote_state_checksum`
+
+### Usage Example
+
+```json
+// Resize scaling thread pool (snapshot)
+PUT _cluster/settings
+{
+  "transient": {
+    "cluster.thread_pool.snapshot.core": "2",
+    "cluster.thread_pool.snapshot.max": "5"
+  }
+}
+
+// Resize fixed thread pool (get)
+PUT _cluster/settings
+{
+  "transient": {
+    "cluster.thread_pool.get.size": "10"
+  }
+}
+```
+
+### Validation Rules
+
+- Thread pool name must be a valid core thread pool
+- For scaling pools: `core` must be ≤ `max`, both must be positive
+- For fixed pools: `size` must be positive
+- Invalid configurations are rejected with `IllegalArgumentException`
+
+### Migration Notes
+
+No migration required. This is a new capability that can be used immediately after upgrading to v2.18.0. Existing static configurations in `opensearch.yml` continue to work as before.
+
+## Limitations
+
+- Only core thread pools defined in OpenSearch can be resized
+- Plugin-defined thread pools are not supported
+- Queue sizes cannot be modified dynamically (only thread counts)
+- Changes are applied per-node; cluster-wide settings propagate to all nodes
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16236](https://github.com/opensearch-project/OpenSearch/pull/16236) | Add support to dynamically resize threadpools size |
+
+## References
+
+- [PR #16236](https://github.com/opensearch-project/OpenSearch/pull/16236): Main implementation
+- [CAT Thread Pool API](https://docs.opensearch.org/2.18/api-reference/cat/cat-thread-pool/): Monitor thread pool status
+- [Nodes Info API](https://docs.opensearch.org/2.18/api-reference/nodes-apis/nodes-info/): View thread pool configuration
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/dynamic-threadpool-resize.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -35,6 +35,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Snapshot Restore Enhancements](features/opensearch/snapshot-restore-enhancements.md) - Alias renaming during restore and clone operation optimization for doc-rep clusters
 - [Remote Store Metrics](features/opensearch/remote-store-metrics.md) - New REMOTE_STORE metric in Node Stats API for monitoring pinned timestamp fetch operations
 - [S3 Repository](features/opensearch/s3-repository.md) - Standard retry mode for S3 clients and SLF4J warning fix
+- [Dynamic Threadpool Resize](features/opensearch/dynamic-threadpool-resize.md) - Runtime thread pool size adjustment via cluster settings API
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dynamic Threadpool Resize feature introduced in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/dynamic-threadpool-resize.md`
- Feature report: `docs/features/opensearch/dynamic-threadpool-resize.md`

### Feature Overview
OpenSearch v2.18.0 introduces the ability to dynamically resize thread pool sizes at runtime without requiring a node restart. This feature allows operators to adjust thread pool configurations through the cluster settings API.

### Key Changes in v2.18.0
- New `cluster.thread_pool.<pool_name>.<setting>` cluster setting
- Support for scaling thread pools (core/max) and fixed thread pools (size)
- Runtime validation of thread pool configurations
- Proper handling of resize order to maintain invariants

### Resources Used
- PR: #16236
- Docs: OpenSearch thread pool documentation