### PR TITLE
docs: add async-shard-fetch-metrics report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -11,6 +11,7 @@
 
 ## opensearch
 
+- [Async Shard Fetch Metrics](opensearch/async-shard-fetch-metrics.md)
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
 - [Bulk API](opensearch/bulk-api.md)
 - [Cluster Stats API](opensearch/cluster-stats-api.md)

--- a/docs/features/opensearch/async-shard-fetch-metrics.md
+++ b/docs/features/opensearch/async-shard-fetch-metrics.md
@@ -1,0 +1,143 @@
+# Async Shard Fetch Metrics
+
+## Summary
+
+Async Shard Fetch Metrics provide OpenTelemetry-based observability into the cluster manager's shard allocation process. When nodes join or leave a cluster, the cluster manager performs async shard fetch operations to retrieve shard metadata from data nodes. These metrics track the success and failure rates of these operations, helping operators identify issues with shard allocation and cluster recovery.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Cluster Manager Node"
+        subgraph "Shard Allocation"
+            GA[GatewayAllocator]
+            SBGA[ShardsBatchGatewayAllocator]
+            PSA[PrimaryShardAllocator]
+            RSA[ReplicaShardAllocator]
+        end
+        
+        subgraph "Async Fetch Layer"
+            ASF[AsyncShardFetch]
+            ASBF[AsyncShardBatchFetch]
+            ASFC[AsyncShardFetchCache]
+        end
+        
+        subgraph "Metrics"
+            CMM[ClusterManagerMetrics]
+            SC[asyncFetchSuccessCounter]
+            FC[asyncFetchFailureCounter]
+        end
+    end
+    
+    subgraph "Data Nodes"
+        DN1[Data Node 1]
+        DN2[Data Node 2]
+        DN3[Data Node N]
+    end
+    
+    GA --> PSA
+    GA --> RSA
+    SBGA --> PSA
+    SBGA --> RSA
+    PSA --> ASF
+    RSA --> ASF
+    PSA --> ASBF
+    RSA --> ASBF
+    ASF --> ASFC
+    ASBF --> ASFC
+    ASFC --> CMM
+    CMM --> SC
+    CMM --> FC
+    
+    ASF -.->|fetch metadata| DN1
+    ASF -.->|fetch metadata| DN2
+    ASF -.->|fetch metadata| DN3
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Node Join/Leave Event] --> B[Reroute Triggered]
+    B --> C[GatewayAllocator]
+    C --> D{Batch Mode?}
+    D -->|Yes| E[ShardsBatchGatewayAllocator]
+    D -->|No| F[AsyncShardFetch]
+    E --> G[AsyncShardBatchFetch]
+    F --> H[AsyncShardFetchCache]
+    G --> H
+    H --> I{Fetch Result}
+    I -->|Success| J[processResponses]
+    I -->|Failure| K[processFailures]
+    J --> L[Increment Success Counter]
+    K --> M[Increment Failure Counter]
+    L --> N[Metrics Exported]
+    M --> N
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ClusterManagerMetrics` | Central class holding all cluster manager metrics including async fetch counters |
+| `AsyncShardFetchCache` | Cache layer that processes fetch responses and increments metrics |
+| `asyncFetchSuccessCounter` | OTel counter for successful async fetch operations |
+| `asyncFetchFailureCounter` | OTel counter for failed async fetch operations |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `opensearch.experimental.feature.telemetry.enabled` | Enable telemetry feature flag | `false` |
+| `telemetry.feature.metrics.enabled` | Enable metrics collection | `false` |
+| `telemetry.otel.metrics.publish.interval` | Metrics publish interval | `60s` |
+| `telemetry.otel.metrics.exporter.class` | Metrics exporter class | `LoggingMetricExporter` |
+
+### Metrics Reference
+
+| Metric Name | Type | Description |
+|-------------|------|-------------|
+| `async.fetch.success.count` | Counter | Number of successful async shard fetch responses processed |
+| `async.fetch.failure.count` | Counter | Number of failed async shard fetch responses processed |
+
+### Usage Example
+
+Enable the metrics framework in `opensearch.yml`:
+
+```yaml
+# Enable experimental telemetry feature
+opensearch.experimental.feature.telemetry.enabled: true
+
+# Enable metrics
+telemetry.feature.metrics.enabled: true
+
+# Optional: Configure exporter (default logs to file)
+telemetry.otel.metrics.exporter.class: io.opentelemetry.exporter.logging.LoggingMetricExporter
+```
+
+Metrics will be written to `logs/_otel_metrics.log` by default, or exported via gRPC if using `OtlpGrpcMetricExporter`.
+
+## Limitations
+
+- Requires experimental telemetry feature to be enabled
+- Metrics are aggregate counts without per-shard or per-node dimensions
+- No latency/histogram metrics for fetch duration
+- Counter values reset on node restart
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#15976](https://github.com/opensearch-project/OpenSearch/pull/15976) | Add success and failure count OTel metrics for async shard fetch |
+
+## References
+
+- [Issue #8098](https://github.com/opensearch-project/OpenSearch/issues/8098): META - Cluster Manager Async Shard Fetch Revamp
+- [Issue #5098](https://github.com/opensearch-project/OpenSearch/issues/5098): Async shard fetches taking up GBs of memory causing ClusterManager JVM to spike
+- [Metrics Framework Documentation](https://docs.opensearch.org/2.18/monitoring-your-cluster/metrics/getting-started/): Official OpenSearch metrics framework docs
+
+## Change History
+
+- **v2.18.0** (2024-10-22): Initial implementation - Added success and failure counter metrics for async shard fetch operations

--- a/docs/releases/v2.18.0/features/opensearch/async-shard-fetch-metrics.md
+++ b/docs/releases/v2.18.0/features/opensearch/async-shard-fetch-metrics.md
@@ -1,0 +1,106 @@
+# Async Shard Fetch Metrics
+
+## Summary
+
+This release adds OpenTelemetry (OTel) counter metrics for async shard fetch operations, enabling operators to monitor the success and failure rates of shard metadata fetching during cluster operations like node joins and restarts. These metrics provide visibility into the cluster manager's shard allocation process.
+
+## Details
+
+### What's New in v2.18.0
+
+Two new counter metrics have been added to the `ClusterManagerMetrics` class to track async shard fetch operations:
+
+- `async.fetch.success.count`: Counts successful async shard fetch operations
+- `async.fetch.failure.count`: Counts failed async shard fetch operations
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Cluster Manager"
+        CM[ClusterManagerMetrics]
+        ASF[AsyncShardFetch]
+        ASFC[AsyncShardFetchCache]
+        GA[GatewayAllocator]
+        SBGA[ShardsBatchGatewayAllocator]
+    end
+    
+    subgraph "Metrics"
+        SC[asyncFetchSuccessCounter]
+        FC[asyncFetchFailureCounter]
+    end
+    
+    GA --> ASF
+    SBGA --> ASF
+    ASF --> ASFC
+    ASFC --> CM
+    CM --> SC
+    CM --> FC
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `asyncFetchSuccessCounter` | Counter metric tracking successful async fetch operations |
+| `asyncFetchFailureCounter` | Counter metric tracking failed async fetch operations |
+
+#### New Metrics
+
+| Metric Name | Description | Unit |
+|-------------|-------------|------|
+| `async.fetch.success.count` | Number of successful async shard fetches | count |
+| `async.fetch.failure.count` | Number of failed async shard fetches | count |
+
+### Implementation Details
+
+The metrics are incremented in `AsyncShardFetchCache`:
+
+- **Success counter**: Incremented in `processResponses()` with the count of successful responses
+- **Failure counter**: Incremented in `processFailures()` with the count of failed node exceptions
+
+The `ClusterManagerMetrics` instance is now injected through the dependency chain:
+- `ClusterModule` binds `ClusterManagerMetrics` as a singleton
+- `GatewayAllocator` receives it via constructor injection
+- `ShardsBatchGatewayAllocator` receives it via constructor injection
+- `AsyncShardFetch` and `AsyncShardBatchFetch` pass it to their cache implementations
+
+### Usage Example
+
+To view these metrics, enable the OpenSearch metrics framework:
+
+```yaml
+# opensearch.yml
+opensearch.experimental.feature.telemetry.enabled: true
+telemetry.feature.metrics.enabled: true
+```
+
+The metrics will be exported via the configured telemetry exporter (e.g., `LoggingMetricExporter` or `OtlpGrpcMetricExporter`).
+
+### Migration Notes
+
+No migration required. The metrics are automatically available when the telemetry feature is enabled.
+
+## Limitations
+
+- Metrics require the experimental telemetry feature to be enabled
+- Metrics are aggregated counts and do not include per-shard or per-node breakdowns
+- No histogram or latency metrics are included in this change
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#15976](https://github.com/opensearch-project/OpenSearch/pull/15976) | Add success and failure count OTel metrics for async shard fetch |
+
+## References
+
+- [Issue #8098](https://github.com/opensearch-project/OpenSearch/issues/8098): META - Cluster Manager Async Shard Fetch Revamp
+- [Issue #5098](https://github.com/opensearch-project/OpenSearch/issues/5098): Async shard fetches taking up GBs of memory
+- [Metrics Framework Documentation](https://docs.opensearch.org/2.18/monitoring-your-cluster/metrics/getting-started/): Official docs for metrics framework
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/async-shard-fetch-metrics.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -36,6 +36,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Remote Store Metrics](features/opensearch/remote-store-metrics.md) - New REMOTE_STORE metric in Node Stats API for monitoring pinned timestamp fetch operations
 - [S3 Repository](features/opensearch/s3-repository.md) - Standard retry mode for S3 clients and SLF4J warning fix
 - [Dynamic Threadpool Resize](features/opensearch/dynamic-threadpool-resize.md) - Runtime thread pool size adjustment via cluster settings API
+- [Async Shard Fetch Metrics](features/opensearch/async-shard-fetch-metrics.md) - OTel counter metrics for async shard fetch success and failure tracking
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Async Shard Fetch Metrics feature introduced in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/async-shard-fetch-metrics.md`
- Feature report: `docs/features/opensearch/async-shard-fetch-metrics.md`

### Feature Overview
PR #15976 adds OpenTelemetry counter metrics for async shard fetch operations:
- `async.fetch.success.count`: Tracks successful async shard fetch operations
- `async.fetch.failure.count`: Tracks failed async shard fetch operations

These metrics provide visibility into the cluster manager's shard allocation process during node joins and restarts.

### Key Changes in v2.18.0
- Added two new counter metrics to `ClusterManagerMetrics`
- Integrated metrics into `AsyncShardFetchCache` for both single and batch fetch modes
- Metrics are exported via the OpenSearch metrics framework (requires telemetry feature enabled)

### Resources Used
- PR: [#15976](https://github.com/opensearch-project/OpenSearch/pull/15976)
- Issue: [#8098](https://github.com/opensearch-project/OpenSearch/issues/8098) - META Cluster Manager Async Shard Fetch Revamp
- Docs: [Metrics Framework](https://docs.opensearch.org/2.18/monitoring-your-cluster/metrics/getting-started/)