### PR TITLE
docs: add tiered-caching report for v2.18.0

### DIFF
--- a/docs/features/opensearch/tiered-caching.md
+++ b/docs/features/opensearch/tiered-caching.md
@@ -112,12 +112,14 @@ GET /_nodes/stats/caches/request_cache?level=tier
 | v3.0.0 | [#17513](https://github.com/opensearch-project/OpenSearch/pull/17513) | Single cache manager for all ehcache disk caches |
 | v3.0.0 | [#17190](https://github.com/opensearch-project/OpenSearch/pull/17190) | Took-time threshold guards heap tier as well as disk tier |
 | v2.19.0 | - | Disk cache partitioning for improved concurrency |
+| v2.18.0 | [#16047](https://github.com/opensearch-project/OpenSearch/pull/16047) | Segmented cache changes for improved concurrency |
 | v2.14.0 | - | Initial tiered caching support (experimental) |
 | v2.13.0 | - | cache-ehcache plugin introduced |
 
 ## References
 
 - [Issue #16162](https://github.com/opensearch-project/OpenSearch/issues/16162): RFC - Optimize caching policy for Request cache
+- [Issue #13989](https://github.com/opensearch-project/OpenSearch/issues/13989): Performance improvement for TieredCaching
 - [Issue #10024](https://github.com/opensearch-project/OpenSearch/issues/10024): Tiered caching tracking issue
 - [Tiered Cache Documentation](https://docs.opensearch.org/3.0/search-plugins/caching/tiered-cache/)
 - [Tiered Caching Blog](https://opensearch.org/blog/tiered-cache/)
@@ -127,5 +129,6 @@ GET /_nodes/stats/caches/request_cache?level=tier
 
 - **v3.0.0** (2025-05-06): Single cache manager for disk caches reduces CPU overhead; took-time policy extended to guard heap tier
 - **v2.19.0** (2025-02-11): Disk cache partitioning with read/write locks for improved concurrency
+- **v2.18.0** (2024-11-05): Segmented cache architecture with configurable segments; query recomputation moved outside write lock; new settings for segment count and per-tier sizes
 - **v2.14.0** (2024-05-14): Initial experimental tiered caching support for request cache
 - **v2.13.0** (2024-04-02): cache-ehcache plugin introduced for disk cache implementation

--- a/docs/releases/v2.18.0/features/opensearch/tiered-caching.md
+++ b/docs/releases/v2.18.0/features/opensearch/tiered-caching.md
@@ -1,0 +1,108 @@
+# Tiered Caching - Segmented Cache Changes
+
+## Summary
+
+This release introduces segmented cache architecture to the tiered spillover cache, significantly improving performance for concurrent read/write operations. Previously, the tiered cache used a single global read/write lock, which created a bottleneck. The new segmented approach distributes cache operations across multiple segments, each with its own lock, enabling higher throughput.
+
+## Details
+
+### What's New in v2.18.0
+
+The tiered spillover cache now supports segmentation, addressing critical performance issues identified in benchmarks:
+
+1. **Segmented Cache Architecture**: The cache is divided into multiple segments (default based on CPU cores), each with its own read/write lock
+2. **Improved Concurrency**: Multiple writers can operate simultaneously on different segments
+3. **Query Recomputation Outside Lock**: Cache miss handling no longer blocks other threads during query recomputation
+4. **New Configuration Settings**: Segment count and per-tier size settings for fine-tuning
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Tiered Spillover Cache (v2.18.0)"
+        Query[Incoming Query] --> Hash{Hash Key}
+        Hash --> S1[Segment 1]
+        Hash --> S2[Segment 2]
+        Hash --> SN[Segment N]
+        
+        subgraph "Each Segment"
+            direction TB
+            RWL[Read/Write Lock]
+            OH[On-Heap Cache]
+            DC[Disk Cache]
+            RWL --> OH
+            OH -->|Eviction| DC
+        end
+        
+        S1 --> RWL
+        S2 --> RWL
+        SN --> RWL
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `TieredSpilloverCacheSegment` | Individual cache segment with its own read/write lock for concurrency |
+| `tieredSpilloverCacheSegments[]` | Array of segments that distribute cache operations |
+| `CompletableFuture` map | Handles concurrent requests for the same key to ensure single load |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `indices.requests.cache.tiered_spillover.segments` | Number of cache segments | `2^(ceil(log2(CPU_CORES * 1.5)))` |
+| `indices.requests.cache.tiered_spillover.onheap.store.size` | On-heap cache size | 1% of heap |
+| `indices.requests.cache.tiered_spillover.disk.store.size` | Disk cache size | 1 GB |
+
+Valid segment count values: 1, 2, 4, 8, 16, 32, 64, 128, 256 (must be power of 2 up to 256)
+
+### Usage Example
+
+```yaml
+# opensearch.yml - Enable tiered caching with custom segments
+indices.requests.cache.store.name: tiered_spillover
+indices.requests.cache.tiered_spillover.onheap.store.name: opensearch_onheap
+indices.requests.cache.tiered_spillover.disk.store.name: ehcache_disk
+
+# Configure segment count (power of 2, up to 256)
+indices.requests.cache.tiered_spillover.segments: 16
+
+# Configure cache sizes
+indices.requests.cache.tiered_spillover.onheap.store.size: 2%
+indices.requests.cache.tiered_spillover.disk.store.size: 5gb
+```
+
+### Performance Improvements
+
+The segmented architecture addresses two key performance issues:
+
+1. **Single Lock Bottleneck**: Previously, only one thread could write to the cache at a time. Now, multiple threads can write to different segments concurrently.
+
+2. **Query Recomputation Blocking**: Previously, cache misses triggered query recomputation under the write lock, blocking all other operations. Now, a `CompletableFuture` map ensures only one thread loads a given key while others wait without holding locks.
+
+## Limitations
+
+- Segment count must be a power of 2 (1, 2, 4, 8, 16, 32, 64, 128, or 256)
+- Per-segment size must be greater than 0 bytes
+- Minimum disk cache size is 10 MB
+- Still experimental - not recommended for production use
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16047](https://github.com/opensearch-project/OpenSearch/pull/16047) | Segmented cache changes for tiered caching |
+
+## References
+
+- [Issue #13989](https://github.com/opensearch-project/OpenSearch/issues/13989): Performance improvement for TieredCaching
+- [Tiered Cache Documentation](https://docs.opensearch.org/2.18/search-plugins/caching/tiered-cache/)
+- [Tiered Caching Blog](https://opensearch.org/blog/tiered-cache/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/tiered-caching.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -22,6 +22,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Search Backpressure](features/opensearch/search-backpressure.md) - Add validation for cancellation settings to prevent cluster crashes
 - [Search Pipeline](features/opensearch/search-pipeline.md) - Add support for msearch API to pass search pipeline name
 - [Star Tree Index](features/opensearch/star-tree-index.md) - Initial experimental release with metric aggregations (sum, min, max, avg, value_count)
+- [Tiered Caching](features/opensearch/tiered-caching.md) - Segmented cache architecture for improved concurrency and performance
 - [Streaming Indexing](features/opensearch/streaming-indexing.md) - Bug fixes for streaming bulk request hangs and newline termination errors
 - [Replication](features/opensearch/replication.md) - Fix array hashCode calculation in ResyncReplicationRequest
 - [Task Management](features/opensearch/task-management.md) - Fix missing fields in task index mapping for proper task result storage


### PR DESCRIPTION
## Summary

This PR adds documentation for the Tiered Caching segmented cache changes introduced in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/tiered-caching.md`
- Feature report: `docs/features/opensearch/tiered-caching.md` (updated)

### Key Changes in v2.18.0
- Segmented cache architecture with configurable segments (power of 2, up to 256)
- Query recomputation moved outside write lock for better concurrency
- New settings: `tiered_spillover.segments`, `tiered_spillover.onheap.store.size`, `tiered_spillover.disk.store.size`
- CompletableFuture map for handling concurrent requests for the same key

### Resources Used
- PR: #16047
- Issue: #13989
- Docs: https://docs.opensearch.org/2.18/search-plugins/caching/tiered-cache/

Closes #628