### PR TITLE
docs: add remote-cluster-state report for v2.18.0

### DIFF
--- a/docs/features/opensearch/cluster-state-management.md
+++ b/docs/features/opensearch/cluster-state-management.md
@@ -74,6 +74,8 @@ sequenceDiagram
 | `PublicationTransportHandler` | Handles transport-level publication of cluster state to follower nodes |
 | `lastSeenClusterState` | Reference to the last cluster state seen by a node, used as base for applying diffs |
 | `ApplyCommitRequest` | Request sent during commit phase to finalize cluster state changes |
+| `preCommitState` | Reference to the cluster state that has been published but not yet applied locally (v2.18.0+) |
+| `RemoteClusterStateCache` | In-memory cache for remote cluster state based on term-version (v2.18.0+) |
 
 ### Configuration
 
@@ -83,6 +85,7 @@ sequenceDiagram
 | `cluster.remote_store.publication.enabled` | Enable remote cluster state publication | `false` |
 | `cluster.publish.timeout` | Timeout for cluster state publication | `30s` |
 | `cluster.publish.info_timeout` | Timeout before logging slow publication info | `10s` |
+| `opensearch.experimental.optimization.termversion.precommit.enabled` | Enable pre-commit state usage for term-version checks (v2.18.0+) | `false` |
 
 ### Voting Configuration
 
@@ -117,12 +120,15 @@ node.attr.remote_store.repository.my-remote-state-repo.settings.region: us-east-
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.18.0 | [#15424](https://github.com/opensearch-project/OpenSearch/pull/15424) | Fallback to remote cluster-state on term-version check mismatch |
 | v2.18.0 | [#16215](https://github.com/opensearch-project/OpenSearch/pull/16215) | Fix: Update last seen cluster state in commit phase |
 
 ## References
 
+- [Issue #15414](https://github.com/opensearch-project/OpenSearch/issues/15414): Feature request for leveraging ClusterState from Publish phase
 - [Remote Cluster State Documentation](https://docs.opensearch.org/2.18/tuning-your-cluster/availability-and-recovery/remote-store/remote-cluster-state/)
 
 ## Change History
 
+- **v2.18.0** (2024-10-29): Added fallback mechanism to use pre-commit state or remote cluster state on term-version mismatch, reducing unnecessary cluster state transfers in large clusters
 - **v2.18.0** (2024-10-29): Fixed voting configuration mismatch by updating lastSeenClusterState in commit phase

--- a/docs/releases/v2.18.0/features/opensearch/remote-cluster-state.md
+++ b/docs/releases/v2.18.0/features/opensearch/remote-cluster-state.md
@@ -1,0 +1,121 @@
+# Remote Cluster State Fallback
+
+## Summary
+
+This release adds a fallback mechanism for cluster state retrieval when there's a term-version mismatch between nodes. When a node's locally applied cluster state doesn't match the cluster manager's committed state, the node can now fall back to either the locally cached pre-commit state or download the cluster state from remote storage, reducing unnecessary full cluster state transfers from the cluster manager.
+
+## Details
+
+### What's New in v2.18.0
+
+This enhancement addresses a performance issue in large clusters where cluster state appliers may take significant time (up to ~18 seconds in 1000-node clusters) to commit the cluster state. During this period, read requests on nodes would fetch the entire cluster state from the cluster manager due to term-version mismatches.
+
+The new fallback mechanism provides three sources for cluster state retrieval:
+
+1. **Applied State**: The locally committed cluster state (existing behavior)
+2. **Pre-commit State**: The cluster state that has been published but not yet applied locally
+3. **Remote Cluster State**: Download from remote storage when remote publication is enabled
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Read Request Flow"
+        REQ[Admin Read Request]
+        TV[GetTermVersion]
+        CM[Cluster Manager]
+    end
+    
+    subgraph "Local Node State Sources"
+        AS[Applied State]
+        PCS[Pre-commit State]
+    end
+    
+    subgraph "Remote Store"
+        RCS[Remote Cluster State]
+        CACHE[RemoteClusterStateCache]
+    end
+    
+    REQ --> TV
+    TV --> CM
+    CM -->|Term-Version| REQ
+    REQ -->|Match?| AS
+    REQ -->|Fallback 1| PCS
+    REQ -->|Fallback 2| RCS
+    RCS --> CACHE
+    CACHE -->|Cached| REQ
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `RemoteClusterStateCache` | In-memory cache for remote cluster state based on term-version, avoiding redundant downloads |
+| `preCommitState` | New atomic reference in `ClusterApplierService` storing the published but uncommitted cluster state |
+| `isStatePresentInRemote` | New field in `GetTermVersionResponse` indicating if state can be downloaded from remote |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `opensearch.experimental.optimization.termversion.precommit.enabled` | Feature flag to enable pre-commit state usage for term-version checks | `false` |
+
+### State Retrieval Logic
+
+The new `getStateFromLocalNode` method in `TransportClusterManagerNodeAction` implements the fallback chain:
+
+```java
+// 1. Check applied state
+if (termVersion.equals(new ClusterStateTermVersion(appliedState))) {
+    return appliedState;
+}
+
+// 2. Check pre-commit state
+if (preCommitState != null && termVersion.equals(new ClusterStateTermVersion(preCommitState))) {
+    return preCommitState;
+}
+
+// 3. Fallback to remote cluster state (if enabled)
+if (remoteClusterStateService != null && termVersionResponse.isStatePresentInRemote()) {
+    ClusterState clusterStateFromRemote = remoteClusterStateService.getClusterStateForManifest(...);
+    return clusterStateFromRemote;
+}
+```
+
+### Usage Example
+
+Enable the feature flag and remote cluster state:
+
+```yaml
+# opensearch.yml
+opensearch.experimental.optimization.termversion.precommit.enabled: true
+cluster.remote_store.state.enabled: true
+cluster.remote_store.publication.enabled: true
+```
+
+### Migration Notes
+
+This is a backward-compatible enhancement. No migration is required. The feature is gated behind an experimental feature flag and only activates when remote cluster state publication is enabled.
+
+## Limitations
+
+- The pre-commit state feature is experimental and requires explicit feature flag enablement
+- Remote cluster state fallback only works when remote publication is enabled on all nodes
+- The cache stores only the most recent cluster state by term-version
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#15424](https://github.com/opensearch-project/OpenSearch/pull/15424) | Fallback on Term-Version check mismatch - Remote cluster-state |
+
+## References
+
+- [Issue #15414](https://github.com/opensearch-project/OpenSearch/issues/15414): Feature request for leveraging ClusterState from Publish phase
+- [Remote Cluster State Documentation](https://docs.opensearch.org/2.18/tuning-your-cluster/availability-and-recovery/remote-store/remote-cluster-state/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/cluster-state-management.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -12,6 +12,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Cluster Stats API](features/opensearch/cluster-stats-api.md) - URI path filtering support for selective metric retrieval
 - [OpenSearch Core Dependencies](features/opensearch/opensearch-core-dependencies.md) - 26 dependency updates including Lucene 9.12.0, Netty 4.1.114, gRPC 1.68.0, Protobuf 3.25.5
 - [Cluster State Management](features/opensearch/cluster-state-management.md) - Fix voting configuration mismatch by updating lastSeenClusterState in commit phase
+- [Remote Cluster State](features/opensearch/remote-cluster-state.md) - Fallback to remote cluster state on term-version check mismatch for improved performance in large clusters
 - [Dynamic Settings](features/opensearch/dynamic-settings.md) - Make multiple cluster settings dynamic for tuning on larger clusters
 - [Wildcard Query Fixes](features/opensearch/wildcard-query-fixes.md) - Fix escaped wildcard character handling and case-insensitive query on wildcard field
 - [Flat Object Field](features/opensearch/flat-object-field.md) - Fix infinite loop when flat_object field contains invalid token types


### PR DESCRIPTION
## Summary

This PR adds documentation for the Remote Cluster State fallback feature introduced in v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/remote-cluster-state.md`
- Feature report: `docs/features/opensearch/cluster-state-management.md` (updated)

### Key Changes in v2.18.0
- Added fallback mechanism to use pre-commit state or remote cluster state on term-version mismatch
- New `RemoteClusterStateCache` component for caching downloaded cluster state
- New `preCommitState` reference in `ClusterApplierService`
- New feature flag `opensearch.experimental.optimization.termversion.precommit.enabled`

### Resources Used
- PR: #15424
- Issue: #15414
- Docs: https://docs.opensearch.org/2.18/tuning-your-cluster/availability-and-recovery/remote-store/remote-cluster-state/

Closes #627