### PR TITLE
docs: add flow-framework-workflow-state report for v2.18.0

### DIFF
--- a/docs/features/flow-framework/flow-framework.md
+++ b/docs/features/flow-framework/flow-framework.md
@@ -191,7 +191,6 @@ POST /_plugins/_flow_framework/workflow/<id>/_deprovision
 | Version | PR | Description |
 |---------|-----|-------------|
 | v3.0.0 | [#1026](https://github.com/opensearch-project/flow-framework/pull/1026) | Fix breaking changes for 3.0.0 release |
-| v2.17.0 | [#804](https://github.com/opensearch-project/flow-framework/pull/804) | Adds reprovision API to support updating search pipelines, ingest pipelines, index settings |
 | v3.0.0 | [#1074](https://github.com/opensearch-project/flow-framework/pull/1074) | Add per-tenant provisioning throttling |
 | v3.0.0 | [#1083](https://github.com/opensearch-project/flow-framework/pull/1083) | Change REST status codes for RBAC and provisioning |
 | v3.0.0 | [#1096](https://github.com/opensearch-project/flow-framework/pull/1096) | Fix Config parser does not handle tenant_id field |
@@ -199,6 +198,8 @@ POST /_plugins/_flow_framework/workflow/<id>/_deprovision
 | v3.0.0 | [#1107](https://github.com/opensearch-project/flow-framework/pull/1107) | Fix bug handleReprovision missing wait_for_completion_timeout response |
 | v3.0.0 | [#1113](https://github.com/opensearch-project/flow-framework/pull/1113) | Add new attributes field to ToolStep |
 | v3.0.0 | [#936](https://github.com/opensearch-project/flow-framework/pull/936) | Add text to visualization agent template |
+| v2.18.0 | [#894](https://github.com/opensearch-project/flow-framework/pull/894) | Update workflow state without using painless script |
+| v2.17.0 | [#804](https://github.com/opensearch-project/flow-framework/pull/804) | Adds reprovision API to support updating search pipelines, ingest pipelines, index settings |
 
 ## References
 
@@ -215,4 +216,5 @@ POST /_plugins/_flow_framework/workflow/<id>/_deprovision
 ## Change History
 
 - **v3.0.0** (2025-05-06): OpenSearch 3.0 compatibility fixes, per-tenant provisioning throttling, REST status code corrections, config parser fix for tenant_id, synchronous provisioning action listener fix, reprovision timeout response fix, ToolStep attributes field, text-to-visualization templates
+- **v2.18.0** (2024-11-05): Removed Painless scripts for workflow state updates, implemented optimistic locking with sequence numbers and primary terms for better concurrency control
 - **v2.17.0** (2024-10-01): Initial Reprovision API implementation supporting updates to search pipelines, ingest pipelines, and index settings

--- a/docs/releases/v2.18.0/features/flow-framework/flow-framework-workflow-state.md
+++ b/docs/releases/v2.18.0/features/flow-framework/flow-framework-workflow-state.md
@@ -1,0 +1,112 @@
+# Flow Framework Workflow State
+
+## Summary
+
+This bugfix removes the use of Painless scripts for workflow state updates in the Flow Framework plugin. The change improves portability, enables incremental resource tracking during deprovisioning, and provides better concurrency control using optimistic locking with sequence numbers and primary terms.
+
+## Details
+
+### What's New in v2.18.0
+
+The workflow state update mechanism has been refactored to eliminate Painless script dependencies:
+
+- **Removed Painless scripts**: The `updateFlowFrameworkSystemIndexDocWithScript()` method that used inline Painless scripts has been removed
+- **Optimistic locking**: Updates now use `ifSeqNo()` and `ifPrimaryTerm()` for strong consistency with automatic retries on version conflicts
+- **Full document updates**: Added new `updateFlowFrameworkSystemIndexDoc()` overload that accepts a complete `ToXContentObject` for full document replacement
+- **Improved error handling**: Better error messages and retry logic for concurrent update scenarios
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+flowchart TB
+    subgraph "Before v2.18.0"
+        A1[Add Resource] --> B1[Build Painless Script]
+        B1 --> C1[Execute Script Update]
+        C1 --> D1[Append to resources_created]
+    end
+    
+    subgraph "After v2.18.0"
+        A2[Add Resource] --> B2[Get Current State]
+        B2 --> C2[Modify State Object]
+        C2 --> D2[Update with SeqNo/PrimaryTerm]
+        D2 -->|Version Conflict| B2
+        D2 -->|Success| E2[Complete]
+    end
+```
+
+#### Key Code Changes
+
+| Component | Change |
+|-----------|--------|
+| `FlowFrameworkIndicesHandler` | Removed `updateFlowFrameworkSystemIndexDocWithScript()`, added optimistic locking |
+| `addResourceToStateIndex()` | Now uses get-modify-update pattern with retries |
+| `ReprovisionWorkflowTransportAction` | Uses `WorkflowState.builder()` instead of Painless script to clear error field |
+
+#### New Update Flow
+
+The new `getAndUpdateResourceInStateDocumentWithRetries()` method implements:
+
+1. **GET**: Fetch current workflow state document with sequence number and primary term
+2. **MODIFY**: Add new resource to the `resources_created` list
+3. **UPDATE**: Submit update with `setIfSeqNo()` and `setIfPrimaryTerm()` for optimistic locking
+4. **RETRY**: On `VersionConflictEngineException`, retry up to 5 times
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `RETRIES` | Maximum retry attempts on version conflicts | `5` |
+
+### Usage Example
+
+The change is transparent to API users. Workflow state updates continue to work the same way:
+
+```bash
+# Provision workflow - resources are tracked automatically
+POST /_plugins/_flow_framework/workflow/<id>/_provision
+
+# Check workflow status - resources_created list is maintained
+GET /_plugins/_flow_framework/workflow/<id>/_status
+```
+
+```json
+{
+  "workflow_id": "abc123",
+  "state": "COMPLETED",
+  "resources_created": [
+    {
+      "workflow_step_name": "create_connector",
+      "workflow_step_id": "step1",
+      "resource_type": "connector_id",
+      "resource_id": "conn_xyz"
+    }
+  ]
+}
+```
+
+### Migration Notes
+
+No migration required. This is an internal implementation change that maintains API compatibility.
+
+## Limitations
+
+- Maximum 5 retries on concurrent update conflicts (configurable via code constant)
+- Higher latency for concurrent updates due to get-modify-update pattern vs. atomic script updates
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#894](https://github.com/opensearch-project/flow-framework/pull/894) | Update workflow state without using painless script |
+
+## References
+
+- [Issue #779](https://github.com/opensearch-project/flow-framework/issues/779): [REFACTOR] Improve Workflow State Resource updates
+- [Issue #780](https://github.com/opensearch-project/flow-framework/issues/780): Related deprovisioning improvements
+- [Workflow State API](https://docs.opensearch.org/2.18/automating-configurations/api/search-workflow-state/): Search workflow state documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/flow-framework/flow-framework.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -80,3 +80,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### Multi-Plugin
 
 - [Search Autocomplete](features/multi-plugin/search-autocomplete.md) - Fix search_as_you_type multi-fields support and enhanced Dashboards autocomplete UX
+
+### Flow Framework
+
+- [Flow Framework Workflow State](features/flow-framework/flow-framework-workflow-state.md) - Remove Painless scripts for workflow state updates, implement optimistic locking


### PR DESCRIPTION
## Summary

This PR adds documentation for the Flow Framework Workflow State bugfix in v2.18.0.

### Changes

- **Release report**: `docs/releases/v2.18.0/features/flow-framework/flow-framework-workflow-state.md`
- **Feature report update**: Added v2.18.0 entry to `docs/features/flow-framework/flow-framework.md`
- **Release index update**: Added link to new report

### Key Changes in v2.18.0

- Removed Painless scripts for workflow state updates
- Implemented optimistic locking with sequence numbers and primary terms
- Added retry logic for concurrent update conflicts (up to 5 retries)
- Improved error handling and portability

### Related

- Closes #626
- PR: opensearch-project/flow-framework#894
- Issue: opensearch-project/flow-framework#779