### PR TITLE
docs: add alerting doc-level monitor report for v2.18.0

### DIFF
--- a/docs/features/alerting/alerting.md
+++ b/docs/features/alerting/alerting.md
@@ -150,6 +150,11 @@ POST _plugins/_alerting/monitors
 | Version | PR | Description |
 |---------|-----|-------------|
 | v3.0.0 | [#1780](https://github.com/opensearch-project/alerting/pull/1780) | Fix bucket selector aggregation writeable name |
+| v2.18.0 | [#1659](https://github.com/opensearch-project/alerting/pull/1659) | Adding Alerting Comments system indices and Security ITs |
+| v2.18.0 | [#1663](https://github.com/opensearch-project/alerting/pull/1663) | Add logging for remote monitor execution flows |
+| v2.18.0 | [#1664](https://github.com/opensearch-project/alerting/pull/1664) | Separate doc-level monitor query indices for externally defined monitors |
+| v2.18.0 | [#1668](https://github.com/opensearch-project/alerting/pull/1668) | Move deletion of query index before its creation |
+| v2.18.0 | [#1674](https://github.com/opensearch-project/alerting/pull/1674) | Create query index at the time of monitor creation |
 | v3.0.0 | [#1823](https://github.com/opensearch-project/alerting/pull/1823) | Fix build due to phasing off SecurityManager |
 | v3.0.0 | [#1824](https://github.com/opensearch-project/alerting/pull/1824) | Use java-agent Gradle plugin |
 | v3.0.0 | [#1831](https://github.com/opensearch-project/alerting/pull/1831) | Correct release notes filename |
@@ -176,4 +181,5 @@ POST _plugins/_alerting/monitors
 ## Change History
 
 - **v3.0.0** (2025): Bug fixes for bucket selector aggregation, Java Agent migration, and dashboard subfield selection
+- **v2.18.0** (2024-11-05): Doc-level monitor improvements - alerting comments system indices, remote monitor logging, separate query indices for external monitors, query index lifecycle optimization
 - **v2.17.0** (2024-09-17): Monitor lock renewal fix, distribution build fixes, workspace navigation fix, trigger name validation fix, alerts card rendering fix, cypress and unit test fixes

--- a/docs/releases/v2.18.0/features/alerting/alerting-doc-level-monitor.md
+++ b/docs/releases/v2.18.0/features/alerting/alerting-doc-level-monitor.md
@@ -1,0 +1,133 @@
+# Alerting Doc-Level Monitor Bugfixes
+
+## Summary
+
+This release includes several bug fixes and improvements for doc-level monitors in the Alerting plugin. Key changes include adding Alerting Comments system indices with security integration tests, improved logging for remote monitor execution, separate query indices for externally defined monitors, and optimized query index lifecycle management.
+
+## Details
+
+### What's New in v2.18.0
+
+This release addresses multiple issues related to doc-level monitor query index management and adds infrastructure for alerting comments.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Doc-Level Monitor"
+        Monitor[Monitor]
+        QueryIndex[Query Index]
+        Metadata[Monitor Metadata]
+    end
+    
+    subgraph "Query Index Lifecycle"
+        Create[Create at Monitor Creation]
+        Delete[Delete Before Creation]
+        Cleanup[Cleanup on Monitor Delete]
+    end
+    
+    subgraph "External Monitors"
+        ExtMonitor[External Monitor]
+        SeparateIndex[Separate Query Index]
+        DeleteEveryRun[Delete Index Every Run]
+    end
+    
+    Monitor --> QueryIndex
+    Monitor --> Metadata
+    
+    Create --> QueryIndex
+    Delete --> Create
+    Cleanup --> QueryIndex
+    
+    ExtMonitor --> SeparateIndex
+    SeparateIndex --> DeleteEveryRun
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `CommentsIndices` | System indices for alerting comments with security integration |
+| `deleteQueryIndexInEveryRun` | Boolean flag to control query index deletion behavior for external monitors |
+| `deleteDocLevelQueryIndex` | New method to delete doc-level query index |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `delete_query_index_in_every_run` | Controls whether query index is deleted on every monitor run | `false` |
+
+### Usage Example
+
+Creating a doc-level monitor with external query index management:
+
+```json
+POST _plugins/_alerting/monitors
+{
+  "type": "monitor",
+  "name": "external-doc-level-monitor",
+  "monitor_type": "doc_level_monitor",
+  "enabled": true,
+  "owner": "sample-remote-monitor-plugin",
+  "schedule": {
+    "period": {
+      "interval": 1,
+      "unit": "MINUTES"
+    }
+  },
+  "inputs": [{
+    "doc_level_input": {
+      "indices": ["logs-*"],
+      "queries": [{
+        "id": "query1",
+        "name": "error-query",
+        "query": "level:ERROR"
+      }]
+    }
+  }],
+  "triggers": [{
+    "name": "error-trigger",
+    "severity": "1",
+    "condition": {
+      "script": {
+        "source": "return true",
+        "lang": "painless"
+      }
+    }
+  }]
+}
+```
+
+### Migration Notes
+
+- Monitors with `deleteQueryIndexInEveryRun=true` (typically externally defined monitors) will have their query indices deleted after each run
+- Query indices are now created at monitor creation time rather than at first execution
+- The deletion of query index now happens before its creation to prevent stale data issues
+
+## Limitations
+
+- External monitors with `deleteQueryIndexInEveryRun=true` may have slightly higher overhead due to index recreation
+- Comments system indices require security plugin integration for proper access control
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1659](https://github.com/opensearch-project/alerting/pull/1659) | Adding Alerting Comments system indices and Security ITs |
+| [#1663](https://github.com/opensearch-project/alerting/pull/1663) | Add logging for remote monitor execution flows |
+| [#1664](https://github.com/opensearch-project/alerting/pull/1664) | Separate doc-level monitor query indices for externally defined monitors |
+| [#1668](https://github.com/opensearch-project/alerting/pull/1668) | Move deletion of query index before its creation |
+| [#1674](https://github.com/opensearch-project/alerting/pull/1674) | Create query index at the time of monitor creation |
+
+## References
+
+- [Per Document Monitors Documentation](https://docs.opensearch.org/2.18/observing-your-data/alerting/per-document-monitors/): Official documentation for per-document monitors
+- [Alerting Documentation](https://docs.opensearch.org/2.18/observing-your-data/alerting/index/): Main alerting documentation
+- [PR #1655](https://github.com/opensearch-project/alerting/pull/1655): Related PR for alerting comments feature
+- [PR #1673](https://github.com/opensearch-project/alerting/pull/1673): Related PR for query index creation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/alerting/alerting.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -84,3 +84,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### Flow Framework
 
 - [Flow Framework Workflow State](features/flow-framework/flow-framework-workflow-state.md) - Remove Painless scripts for workflow state updates, implement optimistic locking
+
+### Alerting
+
+- [Alerting Doc-Level Monitor](features/alerting/alerting-doc-level-monitor.md) - Doc-level monitor improvements including comments system indices, remote monitor logging, separate query indices for external monitors, and query index lifecycle optimization


### PR DESCRIPTION
## Summary

This PR adds documentation for the Alerting Doc-Level Monitor bugfixes in v2.18.0.

### Changes

- Created release report: `docs/releases/v2.18.0/features/alerting/alerting-doc-level-monitor.md`
- Updated feature report: `docs/features/alerting/alerting.md`
- Updated release index: `docs/releases/v2.18.0/index.md`

### Key Changes in v2.18.0

- **Alerting Comments System Indices** (PR #1659): Added system indices for alerting comments with security integration tests
- **Remote Monitor Logging** (PR #1663): Added logging for remote monitor execution flows
- **Separate Query Indices** (PR #1664): Separate doc-level monitor query indices for externally defined monitors with `deleteQueryIndexInEveryRun` flag
- **Query Index Lifecycle** (PR #1668, #1674): Optimized query index lifecycle - deletion before creation and creation at monitor creation time

### Related Issue

Closes #625