### PR TITLE
docs: add SQL Plugin Maintenance report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -152,6 +152,7 @@
 - [Flint Index Operations](sql/flint-index-operations.md)
 - [Flint Query Scheduler](sql/flint-query-scheduler.md)
 - [Security Lake Data Source](sql/security-lake-data-source.md)
+- [SQL Plugin Maintenance](sql/sql-plugin-maintenance.md)
 - [SQL/PPL Engine](sql/sql-ppl-engine.md)
 - [SQL/PPL Breaking Changes](sql/sql-ppl-breaking-changes.md)
 

--- a/docs/features/sql/sql-plugin-maintenance.md
+++ b/docs/features/sql/sql-plugin-maintenance.md
@@ -1,0 +1,80 @@
+# SQL Plugin Maintenance
+
+## Summary
+
+The SQL plugin maintenance track covers ongoing dependency updates, security fixes, and test maintenance for the OpenSearch SQL plugin. This includes addressing security vulnerabilities in third-party libraries and ensuring test stability across release branches.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "SQL Plugin"
+        SQL[SQL Engine]
+        PPL[PPL Engine]
+        Async[Async Query]
+        DS[Datasources]
+        Spark[Spark Integration]
+    end
+    
+    subgraph "Dependencies"
+        CommonsIO[commons-io]
+        JSON[json]
+        AWS[AWS SDK]
+    end
+    
+    SQL --> CommonsIO
+    Async --> CommonsIO
+    DS --> CommonsIO
+    Spark --> CommonsIO
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| async-query | Asynchronous query execution module |
+| datasources | External data source connectors |
+| spark | Apache Spark integration for analytics |
+
+### Configuration
+
+No specific configuration required for maintenance updates.
+
+### Usage Example
+
+The SQL plugin continues to work as documented. No changes to SQL or PPL query syntax.
+
+```sql
+-- SQL queries work unchanged
+SELECT * FROM my_index WHERE field = 'value'
+```
+
+```ppl
+-- PPL queries work unchanged
+source=my_index | where field = 'value'
+```
+
+## Limitations
+
+- Maintenance updates are typically transparent to users
+- Security fixes may require cluster restart to take effect
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#3091](https://github.com/opensearch-project/sql/pull/3091) | Bump commons-io to 2.14.0 (backport) |
+| v2.18.0 | [#3113](https://github.com/opensearch-project/sql/pull/3113) | Fix tests on 2.18 branch |
+| v2.18.0 | [#3083](https://github.com/opensearch-project/sql/pull/3083) | Bump commons-io to 2.14.0 (main) |
+
+## References
+
+- [Issue #3055](https://github.com/opensearch-project/sql/issues/3055): CVE-2024-47554 vulnerability report
+- [CVE-2024-47554](https://www.mend.io/vulnerability-database/CVE-2024-47554): Apache Commons IO vulnerability
+- [SQL Plugin Documentation](https://docs.opensearch.org/2.18/search-plugins/sql/sql/index/): Official SQL documentation
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Bumped commons-io to 2.14.0 to fix CVE-2024-47554, fixed test failures on 2.18 branch

--- a/docs/releases/v2.18.0/features/sql/sql-plugin-maintenance.md
+++ b/docs/releases/v2.18.0/features/sql/sql-plugin-maintenance.md
@@ -1,0 +1,76 @@
+# SQL Plugin Maintenance
+
+## Summary
+
+This release includes maintenance updates for the SQL plugin, addressing a high-severity security vulnerability (CVE-2024-47554) in the commons-io library and fixing test failures on the 2.18 branch. These changes improve the security posture and stability of the SQL plugin without introducing functional changes.
+
+## Details
+
+### What's New in v2.18.0
+
+#### Security Fix: CVE-2024-47554
+
+The commons-io library was upgraded from version 2.8.0 to 2.14.0 to address CVE-2024-47554, a high-severity vulnerability (CVSS 7.5) that could cause uncontrolled resource consumption.
+
+**Vulnerability Details:**
+- The `org.apache.commons.io.input.XmlStreamReader` class could excessively consume CPU resources when processing maliciously crafted input
+- Attack Vector: Network
+- Attack Complexity: Low
+- Privileges Required: None
+- Impact: Availability (High)
+
+**Affected Components:**
+| Module | Previous Version | Updated Version |
+|--------|-----------------|-----------------|
+| async-query | 2.8.0 | 2.14.0 |
+| datasources | 2.8.0 | 2.14.0 |
+| spark | 2.8.0 | 2.14.0 |
+
+#### Test Fixes
+
+Fixed test failures on the 2.18 branch caused by rushed last-minute merging:
+- Updated documentation test output formatting (table column widths)
+- Fixed import issues in `MalformedCursorIT` due to missing Apache HTTP library in 2.18 branch
+- Incorporated fixes from PR #3087
+
+### Technical Changes
+
+#### Dependency Updates
+
+```gradle
+// Before
+implementation group: 'commons-io', name: 'commons-io', version: '2.8.0'
+
+// After
+implementation group: 'commons-io', name: 'commons-io', version: '2.14.0'
+```
+
+#### Test Documentation Updates
+
+Multiple RST documentation files were updated to fix table formatting in test output examples. The changes normalize column widths in output tables across various SQL and PPL documentation files.
+
+### Migration Notes
+
+No migration steps required. This is a transparent dependency upgrade and test fix with no API or configuration changes.
+
+## Limitations
+
+None specific to this release.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3091](https://github.com/opensearch-project/sql/pull/3091) | Backport commons-io bump to 2.x branch |
+| [#3113](https://github.com/opensearch-project/sql/pull/3113) | Fix tests on 2.18 branch |
+| [#3083](https://github.com/opensearch-project/sql/pull/3083) | Original commons-io bump (main branch) |
+
+## References
+
+- [Issue #3055](https://github.com/opensearch-project/sql/issues/3055): CVE-2024-47554 security vulnerability report
+- [CVE-2024-47554](https://www.mend.io/vulnerability-database/CVE-2024-47554): Vulnerability details
+- [Apache Commons IO Security Advisory](https://lists.apache.org/thread/6ozr91rr9cj5lm0zyhv30bsp317hk5z1): Official fix announcement
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/sql/sql-plugin-maintenance.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -88,3 +88,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### Alerting
 
 - [Alerting Doc-Level Monitor](features/alerting/alerting-doc-level-monitor.md) - Doc-level monitor improvements including comments system indices, remote monitor logging, separate query indices for external monitors, and query index lifecycle optimization
+
+### SQL
+
+- [SQL Plugin Maintenance](features/sql/sql-plugin-maintenance.md) - Security fix for CVE-2024-47554 (commons-io upgrade to 2.14.0) and test fixes for 2.18 branch


### PR DESCRIPTION
## Summary

This PR adds documentation for the SQL Plugin Maintenance release item in v2.18.0.

### Changes in v2.18.0

1. **Security Fix (CVE-2024-47554)**: Upgraded commons-io from 2.8.0 to 2.14.0 to address a high-severity vulnerability (CVSS 7.5) that could cause uncontrolled resource consumption via maliciously crafted input to `XmlStreamReader`.

2. **Test Fixes**: Fixed test failures on the 2.18 branch caused by rushed last-minute merging, including documentation table formatting and import issues.

### Reports Created

- Release report: `docs/releases/v2.18.0/features/sql/sql-plugin-maintenance.md`
- Feature report: `docs/features/sql/sql-plugin-maintenance.md`

### Related PRs

- [opensearch-project/sql#3091](https://github.com/opensearch-project/sql/pull/3091): Backport commons-io bump to 2.x
- [opensearch-project/sql#3113](https://github.com/opensearch-project/sql/pull/3113): Fix tests on 2.18 branch
- [opensearch-project/sql#3083](https://github.com/opensearch-project/sql/pull/3083): Original commons-io bump

Closes #624