### PR TITLE
docs: add k-NN maintenance report for v2.18.0

### DIFF
--- a/docs/features/k-nn/vector-search-k-nn.md
+++ b/docs/features/k-nn/vector-search-k-nn.md
@@ -213,6 +213,10 @@ PUT /_cluster/settings
 | Version | PR | Description |
 |---------|-----|-------------|
 | v3.0.0 | [#2564](https://github.com/opensearch-project/k-NN/pull/2564) | Breaking changes - remove deprecated settings |
+| v2.18.0 | [#2195](https://github.com/opensearch-project/k-NN/pull/2195) | Fix lucene codec after lucene version bumped to 9.12 |
+| v2.18.0 | [#2133](https://github.com/opensearch-project/k-NN/pull/2133) | Optimize KNNVectorValues creation for non-quantization cases |
+| v2.18.0 | [#2127](https://github.com/opensearch-project/k-NN/pull/2127) | Remove benchmarks folder from k-NN repo |
+| v2.18.0 | [#2167](https://github.com/opensearch-project/k-NN/pull/2167) | Minor refactoring and refactored some unit test |
 | v3.0.0 | [#2509](https://github.com/opensearch-project/k-NN/pull/2509) | Node-level circuit breakers |
 | v3.0.0 | [#2599](https://github.com/opensearch-project/k-NN/pull/2599) | Filter function in KNNQueryBuilder |
 | v3.0.0 | [#2345](https://github.com/opensearch-project/k-NN/pull/2345) | Concurrency optimizations for graph loading |
@@ -243,9 +247,12 @@ PUT /_cluster/settings
 - [Issue #1859](https://github.com/opensearch-project/k-NN/issues/1859): Space in field name prevents snapshots
 - [Issue #1878](https://github.com/opensearch-project/k-NN/issues/1878): script_fields painless script limitation
 - [Issue #1582](https://github.com/opensearch-project/k-NN/issues/1582): Native memory circuit breaker rearchitecture
+- [Issue #2193](https://github.com/opensearch-project/k-NN/issues/2193): Fix k-NN build due to lucene upgrade
+- [Issue #2134](https://github.com/opensearch-project/k-NN/issues/2134): Regression in cohere-10m force merge latency
 - [OpenSearch 3.0 Blog](https://opensearch.org/blog/opensearch-3-0-what-to-expect/): Release overview
 
 ## Change History
 
 - **v3.0.0** (2025-05-06): Breaking changes removing deprecated index settings; node-level circuit breakers; filter function in KNNQueryBuilder; concurrency optimizations for graph loading; Remote Native Index Build foundation
+- **v2.18.0** (2024-11-05): Lucene 9.12 codec compatibility (KNN9120Codec); force merge performance optimization for non-quantization cases (~20% improvement); removed deprecated benchmarks folder; code refactoring improvements
 - **v2.17.0** (2024-09-17): Memory overflow fix for cache behavior; improved filter handling for non-existent fields; script_fields context support; field name validation for snapshots; graph merge stats fix; binary vector IVF training fix; Windows build improvements

--- a/docs/releases/v2.18.0/features/k-nn/k-nn-maintenance.md
+++ b/docs/releases/v2.18.0/features/k-nn/k-nn-maintenance.md
@@ -1,0 +1,78 @@
+# k-NN Maintenance
+
+## Summary
+
+This release includes maintenance updates for the k-NN plugin: Lucene 9.12 codec compatibility, force merge performance optimization, benchmark folder removal, and code refactoring improvements.
+
+## Details
+
+### What's New in v2.18.0
+
+Four maintenance changes improve the k-NN plugin's compatibility, performance, and code quality.
+
+### Technical Changes
+
+#### Lucene 9.12 Codec Update
+
+When Lucene releases new versions, codec imports move to the `backward_codec` package path. This PR updates the k-NN plugin to work with Lucene 9.12:
+
+| Change | Description |
+|--------|-------------|
+| New `KNN9120Codec` class | Supports Lucene 9.12 vector formats |
+| `NativeEngineFieldVectorsWriter` update | Passes `FlatFieldVectorsWriter` to comply with Lucene 9.12 API changes |
+| Scalar quantization compress flag | Set to `false` for SQ bits > 4 per Lucene 9.12 requirements |
+
+The Lucene 9.12 API change requires `VectorFieldWriters` using `FlatFieldVectorsWriter` to call the `addValue` function explicitly.
+
+#### Force Merge Performance Optimization
+
+Addressed a ~20% regression in force merge latency for large datasets (cohere-10m) after switching to `NativeEngines990KnnVectorsWriter`.
+
+| Metric | Before (2.17) | After (2.18) |
+|--------|---------------|--------------|
+| Index segments | 75 | 92 |
+| Force merge time | 15.68 min | 12.51 min |
+| Force merge segments | 3 | 3 |
+
+The optimization skips unnecessary `KNNVectorValues` recreation when quantization is not needed.
+
+#### Benchmark Folder Removal
+
+Removed the deprecated `benchmarks` folder from the k-NN repository:
+
+- Workloads migrated to [opensearch-benchmark-workloads/vectorsearch](https://github.com/opensearch-project/opensearch-benchmark-workloads/tree/main/vectorsearch)
+- Eliminates CVE risks from outdated Python dependencies
+- Reduces maintenance burden for unused tooling
+
+#### Code Refactoring
+
+Minor improvements to code quality:
+
+- Updated unit tests to include empty field in multi-field scenarios
+- Replaced `IntStream` with collection stream for iterators (index not used)
+- Reduced if/else nesting through refactoring
+
+## Limitations
+
+- Lucene codec changes require index rebuild for existing indices to use new codec features
+- Force merge optimization only applies to non-quantization scenarios
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2195](https://github.com/opensearch-project/k-NN/pull/2195) | Fix lucene codec after lucene version bumped to 9.12 |
+| [#2133](https://github.com/opensearch-project/k-NN/pull/2133) | Optimize KNNVectorValues creation for non-quantization cases |
+| [#2127](https://github.com/opensearch-project/k-NN/pull/2127) | Remove benchmarks folder from k-NN repo |
+| [#2167](https://github.com/opensearch-project/k-NN/pull/2167) | Minor refactoring and refactored some unit test |
+
+## References
+
+- [Issue #2193](https://github.com/opensearch-project/k-NN/issues/2193): Fix k-NN build due to lucene upgrade
+- [Issue #2134](https://github.com/opensearch-project/k-NN/issues/2134): Regression in cohere-10m force merge latency
+- [Lucene PR #13538](https://github.com/apache/lucene/pull/13538): FlatFieldVectorsWriter API change
+- [k-NN Documentation](https://docs.opensearch.org/2.18/search-plugins/knn/index/): Official k-NN plugin docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/k-nn/vector-search-k-nn.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -92,3 +92,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### SQL
 
 - [SQL Plugin Maintenance](features/sql/sql-plugin-maintenance.md) - Security fix for CVE-2024-47554 (commons-io upgrade to 2.14.0) and test fixes for 2.18 branch
+
+### k-NN
+
+- [k-NN Maintenance](features/k-nn/k-nn-maintenance.md) - Lucene 9.12 codec compatibility, force merge performance optimization, benchmark folder removal, code refactoring


### PR DESCRIPTION
## Summary

This PR adds documentation for k-NN plugin maintenance changes in OpenSearch v2.18.0.

## Changes

### Release Report
- Created `docs/releases/v2.18.0/features/k-nn/k-nn-maintenance.md`

### Feature Report
- Updated `docs/features/k-nn/vector-search-k-nn.md` with v2.18.0 changes

### Release Index
- Added k-NN maintenance entry to `docs/releases/v2.18.0/index.md`

## Key Changes in v2.18.0

1. **Lucene 9.12 Codec Update** - New KNN9120Codec class for Lucene 9.12 compatibility
2. **Force Merge Performance** - ~20% improvement by optimizing KNNVectorValues creation
3. **Benchmark Folder Removal** - Removed deprecated benchmarks (migrated to opensearch-benchmark-workloads)
4. **Code Refactoring** - Unit test improvements and code cleanup

## Related PRs
- [#2195](https://github.com/opensearch-project/k-NN/pull/2195) - Lucene codec fix
- [#2133](https://github.com/opensearch-project/k-NN/pull/2133) - Force merge optimization
- [#2127](https://github.com/opensearch-project/k-NN/pull/2127) - Benchmark removal
- [#2167](https://github.com/opensearch-project/k-NN/pull/2167) - Code refactoring

Closes #623