### PR TITLE
docs: add skills-plugin-dependencies report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -300,6 +300,7 @@
 ## skills
 
 - [Skills / Tools](skills/skills-tools.md)
+- [Skills Plugin Dependencies](skills/skills-plugin-dependencies.md)
 
 ## security-analytics
 

--- a/docs/features/skills/skills-plugin-dependencies.md
+++ b/docs/features/skills/skills-plugin-dependencies.md
@@ -1,0 +1,86 @@
+# Skills Plugin Dependencies
+
+## Summary
+The Skills plugin is part of the OpenSearch ML ecosystem, providing agent-based capabilities for AI/ML workflows. This document tracks dependency management and maintenance updates for the Skills plugin, ensuring compatibility with the broader OpenSearch ecosystem.
+
+## Details
+
+### Architecture
+```mermaid
+graph TB
+    subgraph "Skills Plugin"
+        Skills[Skills Plugin]
+        Tests[Test Suite]
+        Build[Build System]
+    end
+    
+    subgraph "Dependencies"
+        Mockito[Mockito]
+        JUnit[JUnit5]
+        ByteBuddy[ByteBuddy]
+        Gradle[Gradle]
+        Lombok[Lombok]
+    end
+    
+    subgraph "OpenSearch Ecosystem"
+        AD[Anomaly Detection]
+        ML[ML Commons]
+        Core[OpenSearch Core]
+    end
+    
+    Skills --> AD
+    Skills --> ML
+    Skills --> Core
+    Tests --> Mockito
+    Tests --> JUnit
+    Mockito --> ByteBuddy
+    Build --> Gradle
+    Build --> Lombok
+```
+
+### Components
+| Component | Description |
+|-----------|-------------|
+| Skills Plugin | Agent-based AI/ML capabilities for OpenSearch |
+| Test Suite | Unit and integration tests using Mockito and JUnit5 |
+| Build System | Gradle-based build with Lombok annotation processing |
+
+### Key Dependencies
+| Dependency | Purpose | Current Version |
+|------------|---------|-----------------|
+| Mockito | Mocking framework for unit tests | 5.14.2 |
+| JUnit5 | Testing framework | 5.11.2 |
+| ByteBuddy | Runtime code generation (used by Mockito) | 1.15.4 |
+| Gradle | Build automation | 8.10.2 |
+| io.freefair.lombok | Lombok Gradle plugin | 8.10.2 |
+
+### Dependency Update Strategy
+The Skills plugin follows automated dependency management using Mend (formerly WhiteSource) Renovate:
+- Automated PRs for dependency updates
+- Monorepo updates grouped together (e.g., Mockito core + junit-jupiter)
+- Backport labels for 2.x branch compatibility
+
+## Limitations
+- Dependency updates may require coordination with upstream OpenSearch plugins
+- ByteBuddy version must be compatible with Mockito version
+- Test fixes may be needed when dependent plugins change their APIs
+
+## Related PRs
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#427](https://github.com/opensearch-project/skills/pull/427) | Fix test failure due to external change |
+| v2.18.0 | [#437](https://github.com/opensearch-project/skills/pull/437) | Update mockito monorepo to v5.14.2 |
+| v2.18.0 | [#363](https://github.com/opensearch-project/skills/pull/363) | Update junit5 monorepo to v5.11.2 |
+| v2.18.0 | [#43](https://github.com/opensearch-project/skills/pull/43) | Update byte-buddy to v1.15.4 |
+| v2.18.0 | [#279](https://github.com/opensearch-project/skills/pull/279) | Update byte-buddy-agent to v1.15.4 |
+| v2.18.0 | [#432](https://github.com/opensearch-project/skills/pull/432) | Update Gradle to v8.10.2 |
+| v2.18.0 | [#434](https://github.com/opensearch-project/skills/pull/434) | Update io.freefair.lombok to v8.10.2 |
+
+## References
+- [Skills Plugin Repository](https://github.com/opensearch-project/skills)
+- [Mockito Documentation](https://site.mockito.org/)
+- [JUnit5 User Guide](https://junit.org/junit5/docs/current/user-guide/)
+- [Gradle Documentation](https://docs.gradle.org/)
+
+## Change History
+- **v2.18.0** (2024-10-29): Updated Mockito to 5.14.2, JUnit5 to 5.11.2, ByteBuddy to 1.15.4, Gradle to 8.10.2, Lombok plugin to 8.10.2; Fixed test failures from AnomalyDetector API changes

--- a/docs/releases/v2.18.0/features/skills/skills-plugin-dependencies.md
+++ b/docs/releases/v2.18.0/features/skills/skills-plugin-dependencies.md
@@ -1,0 +1,65 @@
+# Skills Plugin Dependencies
+
+## Summary
+This release includes dependency updates and a test fix for the Skills plugin in OpenSearch v2.18.0. The changes update testing frameworks (Mockito, JUnit5), build tools (Gradle, Lombok plugin), and runtime libraries (ByteBuddy) to their latest versions, along with a fix for test failures caused by external API changes.
+
+## Details
+
+### What's New in v2.18.0
+
+#### Dependency Updates
+The following dependencies were updated to improve stability, security, and compatibility:
+
+| Dependency | Previous Version | New Version | Type |
+|------------|-----------------|-------------|------|
+| Mockito (core + junit-jupiter) | 5.13.0 | 5.14.2 | Testing |
+| JUnit5 (jupiter-api + engine) | 5.10.2 | 5.11.2 | Testing |
+| ByteBuddy | 1.14.9 | 1.15.4 | Runtime |
+| ByteBuddy Agent | 1.14.12 | 1.15.4 | Runtime |
+| Gradle | 8.10 | 8.10.2 | Build |
+| io.freefair.lombok | 8.10 | 8.10.2 | Build Plugin |
+
+#### Test Fix
+Fixed test failures in the 2.x branch caused by changes to the `AnomalyDetector` constructor in the anomaly-detection plugin. The tests were updated to accommodate the new constructor signature.
+
+### Technical Changes
+
+#### Mockito 5.14.2 Improvements
+- Improved Java agent installation within Mockito jar
+- Fixed gradle mockitoAgent configuration transitivity
+- Better error messages when accessing mocks after `clearInlineMocks`
+
+#### JUnit5 5.11.2 Updates
+- Updated test framework with latest bug fixes and improvements
+- Better compatibility with modern Java versions
+
+#### Gradle 8.10.2 Fixes
+- Fixed dependency resolution performance issues from 8.10
+- Fixed `LifecycleAwareProject` equals() contract
+- Disabled isolated projects validation when feature is disabled
+
+### Migration Notes
+No migration steps required. These are internal dependency updates that maintain backward compatibility.
+
+## Limitations
+- ByteBuddy updates may require Java agent configuration adjustments in some environments
+
+## Related PRs
+| PR | Description |
+|----|-------------|
+| [#427](https://github.com/opensearch-project/skills/pull/427) | Fix test failure due to external change |
+| [#437](https://github.com/opensearch-project/skills/pull/437) | Update mockito monorepo to v5.14.2 |
+| [#363](https://github.com/opensearch-project/skills/pull/363) | Update junit5 monorepo to v5.11.2 |
+| [#43](https://github.com/opensearch-project/skills/pull/43) | Update byte-buddy to v1.15.4 |
+| [#279](https://github.com/opensearch-project/skills/pull/279) | Update byte-buddy-agent to v1.15.4 |
+| [#432](https://github.com/opensearch-project/skills/pull/432) | Update Gradle to v8.10.2 |
+| [#434](https://github.com/opensearch-project/skills/pull/434) | Update io.freefair.lombok to v8.10.2 |
+
+## References
+- [Mockito 5.14.2 Release Notes](https://github.com/mockito/mockito/releases/tag/v5.14.2)
+- [JUnit5 5.11.2 Release Notes](https://github.com/junit-team/junit5/releases/tag/r5.11.2)
+- [Gradle 8.10.2 Release Notes](https://docs.gradle.org/8.10.2/release-notes.html)
+- [ByteBuddy Project](https://bytebuddy.net)
+
+## Related Feature Report
+- [Full feature documentation](../../../features/skills/skills-plugin-dependencies.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -96,3 +96,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### k-NN
 
 - [k-NN Maintenance](features/k-nn/k-nn-maintenance.md) - Lucene 9.12 codec compatibility, force merge performance optimization, benchmark folder removal, code refactoring
+
+### Skills
+
+- [Skills Plugin Dependencies](features/skills/skills-plugin-dependencies.md) - Dependency updates (Mockito 5.14.2, JUnit5 5.11.2, ByteBuddy 1.15.4, Gradle 8.10.2) and test fix for AnomalyDetector API changes


### PR DESCRIPTION
## Summary
This PR adds documentation for Skills Plugin Dependencies in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/skills/skills-plugin-dependencies.md`
- Feature report: `docs/features/skills/skills-plugin-dependencies.md`

### Key Changes in v2.18.0
- Updated Mockito to 5.14.2
- Updated JUnit5 to 5.11.2
- Updated ByteBuddy to 1.15.4
- Updated Gradle to 8.10.2
- Updated io.freefair.lombok plugin to 8.10.2
- Fixed test failures caused by AnomalyDetector API changes

### Related PRs
- [#427](https://github.com/opensearch-project/skills/pull/427) - Fix test failure due to external change
- [#437](https://github.com/opensearch-project/skills/pull/437) - Update mockito monorepo to v5.14.2
- [#363](https://github.com/opensearch-project/skills/pull/363) - Update junit5 monorepo to v5.11.2
- [#43](https://github.com/opensearch-project/skills/pull/43) - Update byte-buddy to v1.15.4
- [#279](https://github.com/opensearch-project/skills/pull/279) - Update byte-buddy-agent to v1.15.4
- [#432](https://github.com/opensearch-project/skills/pull/432) - Update Gradle to v8.10.2
- [#434](https://github.com/opensearch-project/skills/pull/434) - Update io.freefair.lombok to v8.10.2

Closes #622