### PR TITLE
docs: add Security Analytics System Indices report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -305,6 +305,7 @@
 ## security-analytics
 
 - [Security Analytics Detectors](security-analytics/security-analytics-detectors.md)
+- [Security Analytics System Indices](security-analytics/security-analytics-system-indices.md)
 - [Threat Intelligence](security-analytics/threat-intelligence.md)
 
 ## security-analytics-dashboards

--- a/docs/features/security-analytics/security-analytics-system-indices.md
+++ b/docs/features/security-analytics/security-analytics-system-indices.md
@@ -1,0 +1,110 @@
+# Security Analytics System Indices
+
+## Summary
+
+Security Analytics uses system indices to store configurations, detectors, rules, alerts, findings, and correlation data. These indices are protected and cannot be modified through the REST API or OpenSearch Dashboards interface. This feature provides standardized index settings for reliability and scalability, with configurable replica settings and optional dedicated query indices per detector.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Security Analytics Plugin"
+        DM[Detector Manager]
+        RM[Rule Manager]
+        AM[Alert Manager]
+        CM[Correlation Manager]
+    end
+    
+    subgraph "System Indices"
+        DI[".opensearch-sap-detectors-config"]
+        RI[".opensearch-sap-*-rules"]
+        QI[".opensearch-sap-*-detectors-queries-*"]
+        AI[".opensearch-sap-*-alerts"]
+        FI[".opensearch-sap-*-findings"]
+        CI["Correlation Indices"]
+        LI["Log Type Index"]
+        IOC["IOC Feed Indices"]
+    end
+    
+    DM --> DI
+    DM --> QI
+    RM --> RI
+    AM --> AI
+    AM --> FI
+    CM --> CI
+    DM --> LI
+    DM --> IOC
+```
+
+### Components
+
+| Component | Index Pattern | Description |
+|-----------|---------------|-------------|
+| Detector Config | `.opensearch-sap-detectors-config` | Stores detector configurations |
+| Query Indices | `.opensearch-sap-{log_type}-detectors-queries-*` | Doc-level monitor queries |
+| Alert Indices | `.opensearch-sap-{log_type}-alerts` | Security alerts |
+| Findings Indices | `.opensearch-sap-{log_type}-findings` | Detection findings |
+| Rule Indices | `.opensearch-sap-{log_type}-rules` | Detection rules |
+| Correlation History | `.opensearch-sap-correlation-history-*` | Correlation events |
+| Correlation Metadata | `.opensearch-sap-correlation-metadata` | Correlation metadata |
+| Correlation Rules | `.opensearch-sap-correlation-rules` | Correlation rule definitions |
+| Correlation Alerts | `.opensearch-sap-correlation-alerts` | Correlation alerts |
+| Log Type Config | `.opensearch-sap-log-types-config` | Log type configurations |
+| Custom Log Types | `.opensearch-sap-custom-log-types` | Custom log type definitions |
+| IOC Feeds | `.opensearch-sap-iocs-*` | Threat intelligence IOC data |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.hidden` | Hide system indices from normal index operations | `true` |
+| `index.number_of_shards` | Number of primary shards | `1` |
+| `index.auto_expand_replicas` | Auto-expand replica range | `1-20` |
+| `plugins.security_analytics.enable_detectors_with_dedicated_query_indices` | Enable dedicated query indices per detector | `false` |
+
+### Usage Example
+
+#### Enable Dedicated Query Indices
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "plugins.security_analytics.enable_detectors_with_dedicated_query_indices": true
+  }
+}
+```
+
+#### View System Index Settings
+
+```bash
+GET .opensearch-sap-*/_settings?flat_settings=true
+```
+
+## Limitations
+
+- System indices can only be accessed by users with TLS admin certificates
+- Changing dedicated query index setting requires detector recreation for existing detectors
+- System indices are not included in regular snapshot operations by default
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#1358](https://github.com/opensearch-project/security-analytics/pull/1358) | Update replicas to 1-20 and primary shards to 1 |
+| v2.18.0 | [#1364](https://github.com/opensearch-project/security-analytics/pull/1364) | Update min replicas to 0 |
+| v2.18.0 | [#1365](https://github.com/opensearch-project/security-analytics/pull/1365) | Enable dedicated query index settings |
+| v2.18.0 | [#1324](https://github.com/opensearch-project/security-analytics/pull/1324) | Separate doc-level monitor query indices |
+| v2.18.0 | [#1382](https://github.com/opensearch-project/security-analytics/pull/1382) | Set refresh policy to IMMEDIATE for correlation alerts |
+
+## References
+
+- [Security Analytics Documentation](https://docs.opensearch.org/latest/security-analytics/)
+- [Security Analytics System Indexes](https://docs.opensearch.org/latest/security-analytics/security/)
+- [System Indexes Configuration](https://docs.opensearch.org/latest/security/configuration/system-indices/)
+
+## Change History
+
+- **v2.18.0** (2024-10-29): Standardized system index settings (1 primary shard, 1-20 replicas), added dedicated query indices option, fixed correlation alert refresh policy

--- a/docs/releases/v2.18.0/features/security-analytics/security-analytics-system-indices.md
+++ b/docs/releases/v2.18.0/features/security-analytics/security-analytics-system-indices.md
@@ -1,0 +1,96 @@
+# Security Analytics System Indices
+
+## Summary
+
+This release includes several bugfixes for Security Analytics system indices in v2.18.0. The changes improve index configuration by standardizing replica settings, adding dedicated query indices for detectors, and fixing correlation alert refresh policies. These improvements enhance reliability and scalability of Security Analytics system indices.
+
+## Details
+
+### What's New in v2.18.0
+
+#### System Index Configuration Standardization
+
+All Security Analytics system indices now use consistent settings:
+- Primary shards: 1 (optimized for small system indices)
+- Auto-expand replicas: 1-20 (changed from 0-all)
+- Minimum replicas: 0 (updated from 1)
+
+#### Dedicated Query Indices for Detectors
+
+A new setting `plugins.security_analytics.enable_detectors_with_dedicated_query_indices` allows detectors to use dedicated query indices instead of shared ones. When enabled:
+- Each detector gets its own query index with UUID suffix
+- Improves isolation between detectors
+- Reduces contention on shared query indices
+
+#### Correlation Alert Refresh Policy Fix
+
+The refresh policy for correlation alert updates is now set to `IMMEDIATE`, ensuring alerts are visible immediately after acknowledgment.
+
+### Technical Changes
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security_analytics.enable_detectors_with_dedicated_query_indices` | Enable dedicated query indices per detector | `false` |
+| `minSystemIndexReplicas` | Minimum replicas for system indices | `1` |
+| `maxSystemIndexReplicas` | Maximum replicas for system indices | `20` |
+
+#### Affected System Indices
+
+| Index Pattern | Description |
+|---------------|-------------|
+| `.opensearch-sap-*-detectors-queries-*` | Detector query indices |
+| `.opensearch-sap-iocs-*` | IOC feed indices |
+| `.opensearch-sap-*-alerts` | Alert indices |
+| `.opensearch-sap-*-findings` | Findings indices |
+| Correlation indices | Correlation history and metadata |
+| Log type config index | Log type configuration |
+| Custom log type index | Custom log types |
+| Detector index | Detector configurations |
+| Rule indices | Detection rules |
+
+### Usage Example
+
+Enable dedicated query indices:
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "plugins.security_analytics.enable_detectors_with_dedicated_query_indices": true
+  }
+}
+```
+
+After enabling, new detectors will create dedicated query indices with pattern:
+`.opensearch-sap-{log_type}-detectors-queries-optimized-{uuid}`
+
+### Migration Notes
+
+- Existing detectors continue using shared query indices
+- To use dedicated indices for existing detectors, delete and recreate them after enabling the setting
+- Disabling the setting after enabling requires detector recreation
+
+## Limitations
+
+- Dedicated query indices increase the total number of indices in the cluster
+- Changing the setting does not automatically migrate existing detectors
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1358](https://github.com/opensearch-project/security-analytics/pull/1358) | Update replicas to 1-20 and primary shards to 1 |
+| [#1364](https://github.com/opensearch-project/security-analytics/pull/1364) | Update min replicas to 0 |
+| [#1365](https://github.com/opensearch-project/security-analytics/pull/1365) | Enable dedicated query index settings |
+| [#1324](https://github.com/opensearch-project/security-analytics/pull/1324) | Separate doc-level monitor query indices |
+| [#1382](https://github.com/opensearch-project/security-analytics/pull/1382) | Set refresh policy to IMMEDIATE for correlation alerts |
+
+## References
+
+- [Security Analytics Documentation](https://docs.opensearch.org/2.18/security-analytics/)
+- [Security Analytics System Indexes](https://docs.opensearch.org/2.18/security-analytics/security/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/security-analytics/security-analytics-system-indices.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -97,6 +97,10 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 - [k-NN Maintenance](features/k-nn/k-nn-maintenance.md) - Lucene 9.12 codec compatibility, force merge performance optimization, benchmark folder removal, code refactoring
 
+### Security Analytics
+
+- [Security Analytics System Indices](features/security-analytics/security-analytics-system-indices.md) - Standardized system index settings (1 primary shard, 1-20 replicas), dedicated query indices option, correlation alert refresh policy fix
+
 ### Skills
 
 - [Skills Plugin Dependencies](features/skills/skills-plugin-dependencies.md) - Dependency updates (Mockito 5.14.2, JUnit5 5.11.2, ByteBuddy 1.15.4, Gradle 8.10.2) and test fix for AnomalyDetector API changes


### PR DESCRIPTION
## Summary

This PR adds documentation for Security Analytics System Indices bugfixes in v2.18.0.

### Key Changes in v2.18.0

- **System Index Configuration Standardization**: All Security Analytics system indices now use 1 primary shard and 1-20 auto-expand replicas
- **Dedicated Query Indices**: New setting `plugins.security_analytics.enable_detectors_with_dedicated_query_indices` allows detectors to use dedicated query indices
- **Correlation Alert Fix**: Set refresh policy to IMMEDIATE for correlation alert updates

### Reports Created

- Release report: `docs/releases/v2.18.0/features/security-analytics/security-analytics-system-indices.md`
- Feature report: `docs/features/security-analytics/security-analytics-system-indices.md`

### Related PRs

| PR | Description |
|----|-------------|
| [#1358](https://github.com/opensearch-project/security-analytics/pull/1358) | Update replicas to 1-20 and primary shards to 1 |
| [#1364](https://github.com/opensearch-project/security-analytics/pull/1364) | Update min replicas to 0 |
| [#1365](https://github.com/opensearch-project/security-analytics/pull/1365) | Enable dedicated query index settings |
| [#1324](https://github.com/opensearch-project/security-analytics/pull/1324) | Separate doc-level monitor query indices |
| [#1382](https://github.com/opensearch-project/security-analytics/pull/1382) | Set refresh policy to IMMEDIATE for correlation alerts |

Closes #621