### PR TITLE
docs: add Security Plugin Maintenance report for v2.18.0

### DIFF
--- a/docs/features/security/security-plugin.md
+++ b/docs/features/security/security-plugin.md
@@ -198,6 +198,13 @@ config:
 | v3.0.0 | [#1467](https://github.com/opensearch-project/security/pull/1467) | Refactored flaky test |
 | v3.0.0 | [#1498](https://github.com/opensearch-project/security/pull/1498) | Remove overrides of preserveIndicesUponCompletion |
 | v3.0.0 | [#1503](https://github.com/opensearch-project/security/pull/1503) | Remove usage of deprecated batchSize() method |
+| v2.18.0 | [#4776](https://github.com/opensearch-project/security/pull/4776) | Add deprecation warning for GET/POST/PUT cache |
+| v2.18.0 | [#4768](https://github.com/opensearch-project/security/pull/4768) | Undeprecate securityadmin script |
+| v2.18.0 | [#4765](https://github.com/opensearch-project/security/pull/4765) | Add isActionPaginated to DelegatingRestHandler |
+| v2.18.0 | [#4740](https://github.com/opensearch-project/security/pull/4740) | Refactor ASN1 call for FIPS compatibility |
+| v2.18.0 | [#4792](https://github.com/opensearch-project/security/pull/4792) | Fix CVE-2024-47554 (commons-io upgrade) |
+| v2.18.0 | [#4831](https://github.com/opensearch-project/security/pull/4831) | Fix bulk index requests in BWC tests |
+| v2.18.0 | [#4815](https://github.com/opensearch-project/security/pull/4815) | Fix integTest not called during release |
 | v2.17.0 | [#4603](https://github.com/opensearch-project/security/pull/4603) | Fix demo certificate hash validation |
 | v2.17.0 | [#4631](https://github.com/opensearch-project/security/pull/4631) | Fix authtoken endpoint |
 | v2.17.0 | [#4664](https://github.com/opensearch-project/security/pull/4664) | Handle null audit config |
@@ -209,6 +216,8 @@ config:
 
 ## References
 
+- [Issue #4728](https://github.com/opensearch-project/security/issues/4728): ASN1 refactoring for FIPS support (v2.18.0)
+- [Issue #4790](https://github.com/opensearch-project/security/issues/4790): CVE-2024-47554 tracking (v2.18.0)
 - [Issue #4274](https://github.com/opensearch-project/security/issues/4274): Blake2b hash issue
 - [Issue #3870](https://github.com/opensearch-project/security/issues/3870): Optimized privilege evaluation
 - [Issue #4927](https://github.com/opensearch-project/security/issues/4927): CIDR range support
@@ -227,5 +236,5 @@ config:
 ## Change History
 
 - **v3.0.0** (2025-05-06): Breaking changes - Blake2b hash fix, OpenSSL removal, whitelist→allowlist; Enhancements - optimized privilege evaluation, CIDR support in ignore_hosts, password validation improvements
-- **v2.18.0** (2024-11-05): Auto-convert security config models from v6 to v7
+- **v2.18.0** (2024-11-05): Maintenance - cache endpoint deprecation warning, undeprecate securityadmin script, ASN1 refactoring for FIPS compatibility, CVE-2024-47554 fix, pagination support, BWC test fixes
 - **v2.17.0** (2024-09-17): Bugfixes - demo certificate validation, auth token endpoint, audit config null handling, certificate SAN ordering, TermsAggregationEvaluator permissions; Refactoring - security provider instantiation for FIPS support, Log4j utility removal

--- a/docs/releases/v2.18.0/features/security/security-plugin-maintenance.md
+++ b/docs/releases/v2.18.0/features/security/security-plugin-maintenance.md
@@ -1,0 +1,105 @@
+# Security Plugin Maintenance
+
+## Summary
+
+OpenSearch v2.18.0 includes maintenance updates for the Security plugin, including maintainer changes, API deprecation warnings, code refactoring for FIPS compatibility, security vulnerability fixes, and test improvements.
+
+## Details
+
+### What's New in v2.18.0
+
+This release focuses on project maintenance, security fixes, and preparation for future changes:
+
+1. **Maintainer Updates**: Project governance changes with maintainer transitions
+2. **API Deprecation Warning**: Added deprecation warning for cache endpoint methods being removed in v3.0.0
+3. **Securityadmin Script**: Removed deprecation warning as no replacement is planned
+4. **FIPS Compatibility**: Refactored ASN1 calls to support multiple security providers
+5. **CVE Fix**: Addressed CVE-2024-47554 by upgrading commons-io
+6. **Test Improvements**: Fixed BWC tests and release workflow issues
+
+### Technical Changes
+
+#### API Deprecation
+
+The following cache endpoint methods are deprecated and will be removed in v3.0.0:
+
+| Method | Endpoint | Status |
+|--------|----------|--------|
+| GET | `/_plugins/_security/api/cache` | Deprecated |
+| POST | `/_plugins/_security/api/cache` | Deprecated |
+| PUT | `/_plugins/_security/api/cache` | Deprecated |
+
+Users should migrate to alternative approaches before upgrading to v3.0.0.
+
+#### Securityadmin Script
+
+The `securityadmin.sh` script deprecation warning has been removed. The script remains the recommended tool for security configuration management with no planned replacement.
+
+#### FIPS Compatibility
+
+Refactored `DefaultSecurityKeyStore` to use ASN1 methods compatible with both standard Bouncy Castle and FIPS-compliant Bouncy Castle libraries:
+
+```java
+// Before: Direct getObject() call
+ASN1Primitive obj = asn1TaggedObject.getObject();
+
+// After: Compatible with BC 2.x FIPS
+ASN1Primitive obj = ASN1TaggedObject.getInstance(asn1TaggedObject).getBaseObject();
+```
+
+#### Pagination Support
+
+Added `isActionPaginated` method to `DelegatingRestHandler` to support paginated REST actions in the security plugin.
+
+#### Security Vulnerability Fix
+
+| CVE | Severity | Fix |
+|-----|----------|-----|
+| CVE-2024-47554 | Medium | Upgraded commons-io from 2.11.0 to 2.17.0 |
+
+CVE-2024-47554 is a vulnerability in Apache Commons IO that could allow denial of service through malicious input.
+
+### Test Improvements
+
+#### BWC Test Fixes
+
+Fixed `SecurityBackwardsCompatibilityIT.testDataIngestionAndSearchBackwardsCompatibility()`:
+
+- Fixed bulk request serialization (was double-encoding JSON)
+- Added assertions to verify bulk items are actually indexed
+- Fixed DLS rules to match test documents
+- Added assertions for DLS/FLS rule application
+
+#### Release Workflow Fix
+
+Fixed `integTest` not being called during release test workflows.
+
+## Limitations
+
+- Cache endpoint deprecation warnings will appear in logs when using deprecated methods
+- FIPS compatibility requires Bouncy Castle 2.x FIPS libraries
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4667](https://github.com/opensearch-project/security/pull/4667) | Move @cliu123 to emeritus status |
+| [#4796](https://github.com/opensearch-project/security/pull/4796) | Add Derek Ho as maintainer |
+| [#4804](https://github.com/opensearch-project/security/pull/4804) | Move Stephen to emeritus |
+| [#4776](https://github.com/opensearch-project/security/pull/4776) | Add deprecation warning for GET/POST/PUT cache |
+| [#4768](https://github.com/opensearch-project/security/pull/4768) | Undeprecate securityadmin script |
+| [#4765](https://github.com/opensearch-project/security/pull/4765) | Add isActionPaginated to DelegatingRestHandler |
+| [#4740](https://github.com/opensearch-project/security/pull/4740) | Refactor ASN1 call for FIPS compatibility |
+| [#4815](https://github.com/opensearch-project/security/pull/4815) | Fix integTest not called during release |
+| [#4831](https://github.com/opensearch-project/security/pull/4831) | Fix bulk index requests in BWC tests |
+| [#4792](https://github.com/opensearch-project/security/pull/4792) | Fix CVE-2024-47554 |
+
+## References
+
+- [Issue #4728](https://github.com/opensearch-project/security/issues/4728): ASN1 refactoring for FIPS support
+- [Issue #4790](https://github.com/opensearch-project/security/issues/4790): CVE-2024-47554 tracking
+- [CVE-2024-47554](https://nvd.nist.gov/vuln/detail/CVE-2024-47554): Apache Commons IO vulnerability
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/security-plugin.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -101,6 +101,10 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 - [Security Analytics System Indices](features/security-analytics/security-analytics-system-indices.md) - Standardized system index settings (1 primary shard, 1-20 replicas), dedicated query indices option, correlation alert refresh policy fix
 
+### Security
+
+- [Security Plugin Maintenance](features/security/security-plugin-maintenance.md) - Cache endpoint deprecation warning, securityadmin script undeprecation, ASN1 refactoring for FIPS, CVE-2024-47554 fix, BWC test fixes
+
 ### Skills
 
 - [Skills Plugin Dependencies](features/skills/skills-plugin-dependencies.md) - Dependency updates (Mockito 5.14.2, JUnit5 5.11.2, ByteBuddy 1.15.4, Gradle 8.10.2) and test fix for AnomalyDetector API changes


### PR DESCRIPTION
## Summary

Add release report for Security Plugin Maintenance in OpenSearch v2.18.0.

## Changes

### Release Report
- `docs/releases/v2.18.0/features/security/security-plugin-maintenance.md`

### Feature Report Update
- `docs/features/security/security-plugin.md` - Added v2.18.0 PRs and updated change history

### Release Index Update
- `docs/releases/v2.18.0/index.md` - Added link to security plugin maintenance report

## Key Changes in v2.18.0

- **API Deprecation**: Added deprecation warning for GET/POST/PUT cache endpoints (removed in v3.0.0)
- **Securityadmin Script**: Removed deprecation warning as no replacement is planned
- **FIPS Compatibility**: Refactored ASN1 calls to support Bouncy Castle FIPS libraries
- **CVE Fix**: CVE-2024-47554 fixed by upgrading commons-io to 2.17.0
- **Pagination Support**: Added isActionPaginated to DelegatingRestHandler
- **Test Improvements**: Fixed BWC tests and release workflow issues

## Related Issue
Closes #620