### PR TITLE
docs: add S3 async deletion report for v2.18.0

### DIFF
--- a/docs/releases/v2.18.0/features/opensearch/s3-async-deletion.md
+++ b/docs/releases/v2.18.0/features/opensearch/s3-async-deletion.md
@@ -1,0 +1,104 @@
+# S3 Async Deletion
+
+## Summary
+
+This release introduces asynchronous deletion support for the S3 repository plugin (`repository-s3`). The feature uses the AWS S3 async client for delete operations during snapshot deletion, improving performance and reducing port exhaustion issues in high-load scenarios.
+
+## Details
+
+### What's New in v2.18.0
+
+- Added async deletion methods to `S3BlobContainer` using the S3 async client
+- Introduced a new cluster setting `cluster.snapshot.async-deletion.enable` to control async deletion behavior
+- Created `S3AsyncDeleteHelper` utility class for managing batched async delete operations
+- Extended `AsyncMultiStreamBlobContainer` interface with async delete methods
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Snapshot Deletion Flow"
+        BlobRepo[BlobStoreRepository]
+        Container[S3BlobContainer]
+        AsyncClient[S3 Async Client]
+        S3[Amazon S3]
+    end
+    
+    BlobRepo -->|deleteContainer| Container
+    Container -->|deleteAsync| AsyncClient
+    AsyncClient -->|DeleteObjectsRequest| S3
+    
+    subgraph "Batch Processing"
+        List[List Objects]
+        Batch[Create Batches]
+        Delete[Delete Batch]
+        List --> Batch
+        Batch --> Delete
+    end
+    
+    Container --> List
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `S3AsyncDeleteHelper` | Utility class for executing batched async delete operations |
+| `deleteAsync()` | New method in `S3BlobContainer` for async container deletion |
+| `deleteBlobsAsyncIgnoringIfNotExists()` | New method for async blob deletion ignoring missing blobs |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.snapshot.async-deletion.enable` | Enable/disable async deletion for S3 repositories | `true` |
+
+### Usage Example
+
+The async deletion is enabled by default. To disable it:
+
+```yaml
+# opensearch.yml
+cluster.snapshot.async-deletion.enable: false
+```
+
+Or dynamically via API:
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.snapshot.async-deletion.enable": false
+  }
+}
+```
+
+### Migration Notes
+
+- Async deletion is enabled by default in v2.18.0
+- Existing snapshot deletion workflows will automatically use async deletion when enabled
+- No changes required to existing repository configurations
+- The setting can be toggled dynamically without cluster restart
+
+## Limitations
+
+- Async deletion is only available for S3 repositories (not other repository types)
+- The feature requires the S3 async client to be properly configured
+- Batch size for deletions is controlled by the existing `bulk_deletes_size` setting
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#15621](https://github.com/opensearch-project/OpenSearch/pull/15621) | Add support for async deletion in S3BlobContainer |
+
+## References
+
+- [PR #15621](https://github.com/opensearch-project/OpenSearch/pull/15621): Main implementation PR
+- [Snapshot Management](https://docs.opensearch.org/2.18/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-management/): OpenSearch snapshot documentation
+
+## Related Feature Report
+
+- [S3 Repository](../../../features/opensearch/s3-repository.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -38,6 +38,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Snapshot Restore Enhancements](features/opensearch/snapshot-restore-enhancements.md) - Alias renaming during restore and clone operation optimization for doc-rep clusters
 - [Remote Store Metrics](features/opensearch/remote-store-metrics.md) - New REMOTE_STORE metric in Node Stats API for monitoring pinned timestamp fetch operations
 - [S3 Repository](features/opensearch/s3-repository.md) - Standard retry mode for S3 clients and SLF4J warning fix
+- [S3 Async Deletion](features/opensearch/s3-async-deletion.md) - Async deletion support for S3 repository using S3 async client
 - [Dynamic Threadpool Resize](features/opensearch/dynamic-threadpool-resize.md) - Runtime thread pool size adjustment via cluster settings API
 - [Async Shard Fetch Metrics](features/opensearch/async-shard-fetch-metrics.md) - OTel counter metrics for async shard fetch success and failure tracking
 - [Search API Enhancements](features/opensearch/search-api-enhancements.md) - WithFieldName interface for aggregation/sort builders and successfulSearchShardIndices in SearchRequestContext


### PR DESCRIPTION
## Summary

This PR adds documentation for the S3 Async Deletion feature introduced in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/s3-async-deletion.md`
- Feature report: Updated `docs/features/opensearch/s3-repository.md`

### Key Changes in v2.18.0
- Added async deletion methods to `S3BlobContainer` using the S3 async client
- Introduced `cluster.snapshot.async-deletion.enable` cluster setting (default: `true`)
- Created `S3AsyncDeleteHelper` utility class for batched async delete operations
- Extended `AsyncMultiStreamBlobContainer` interface with async delete methods

### Resources Used
- PR: #15621
- Docs: OpenSearch snapshot management documentation

Closes #617