### PR TITLE
docs: add Offline Nodes report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -46,6 +46,7 @@
 - [Node Join/Leave](opensearch/node-join-leave.md)
 - [Nodes Info API](opensearch/nodes-info-api.md)
 - [Node Roles Configuration](opensearch/node-roles-configuration.md)
+- [Offline Nodes (Background Tasks)](opensearch/offline-nodes.md)
 - [OpenSearch Core Dependencies](opensearch/opensearch-core-dependencies.md)
 - [Phone Number Analyzer](opensearch/phone-analyzer.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)

--- a/docs/features/opensearch/offline-nodes.md
+++ b/docs/features/opensearch/offline-nodes.md
@@ -1,0 +1,162 @@
+# Offline Nodes (Background Tasks)
+
+## Summary
+
+Offline Nodes is an OpenSearch feature that enables workload segregation by offloading resource-intensive background operations from data nodes to dedicated offline nodes. Background tasks like segment merges, force merges, snapshots, re-indexing, and remote garbage collection can consume significant resources, impacting the predictability of core indexing and search operations. By running these tasks on a separate fleet of offline nodes, users can achieve independent scalability and better resource utilization.
+
+This feature is particularly beneficial for Remote Store enabled clusters where data is stored remotely and can be efficiently accessed from dedicated offline nodes.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Online Fleet (Data Nodes)"
+        DN1[Data Node 1]
+        DN2[Data Node 2]
+        DN3[Data Node 3]
+        RS[(Remote Store)]
+    end
+    
+    subgraph "Task Management"
+        TQ[Task Queue/Store]
+        TC[TaskClient]
+    end
+    
+    subgraph "Offline Fleet"
+        ON1[Offline Node 1]
+        ON2[Offline Node 2]
+        BTS[BackgroundTaskService]
+    end
+    
+    DN1 -->|Upload Segments| RS
+    DN2 -->|Upload Segments| RS
+    DN3 -->|Upload Segments| RS
+    
+    DN1 -->|Submit Task| TQ
+    DN2 -->|Submit Task| TQ
+    DN3 -->|Submit Task| TQ
+    
+    ON1 -->|Poll Tasks| TQ
+    ON2 -->|Poll Tasks| TQ
+    
+    ON1 -->|Download/Upload| RS
+    ON2 -->|Download/Upload| RS
+    
+    BTS --> ON1
+    BTS --> ON2
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Task Lifecycle"
+        A[Task Created] --> B[Task Submitted to Queue]
+        B --> C[Task Assigned to Worker]
+        C --> D[Task Execution Started]
+        D --> E{Heartbeat}
+        E -->|Success| F[Task Completed]
+        E -->|Timeout| G[Task Abandoned]
+        G --> C
+        D --> H[Task Failed]
+        H --> I{Retry?}
+        I -->|Yes| C
+        I -->|No| J[Task Failed Permanently]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `Task` | Core entity representing a background task with status, parameters, and lifecycle timestamps |
+| `TaskId` | Unique identifier for each task |
+| `TaskParams` | Abstract base class for task-specific parameters (e.g., MergeTaskParams) |
+| `TaskStatus` | Task state: UNASSIGNED, ASSIGNED, ACTIVE, SUCCESS, FAILED, CANCELLED |
+| `TaskType` | Category of task: MERGE, SNAPSHOT (extensible) |
+| `TaskManagerClient` | Interface for task CRUD operations, listing, and assignment |
+| `TaskProducerClient` | Interface for submitting new tasks to the queue |
+| `TaskWorkerClient` | Interface for workers to retrieve assigned tasks and send heartbeats |
+| `TaskWorker` | Interface for executing tasks on offline nodes |
+| `WorkerNode` | Represents an offline node with id, name, and IP address |
+| `BackgroundTaskService` | Service running on offline nodes that coordinates task execution |
+| `TaskManagerClientPlugin` | Plugin interface for providing custom TaskManagerClient implementations |
+| `TaskWorkerPlugin` | Plugin interface for providing custom TaskWorker implementations |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `opensearch.experimental.feature.task.background.enabled` | Feature flag to enable background task execution | `false` |
+
+### Task Queue Implementations
+
+The framework supports multiple queue implementations:
+
+1. **System Index**: Use an OpenSearch system index as the task queue
+2. **Cluster State (PersistentTasksCustomMetadata)**: Leverage existing persistent tasks infrastructure
+3. **External Queue**: Integrate with Apache Kafka, Apache Cassandra, or cloud-native solutions
+
+### Usage Example
+
+```java
+// Task submission from Data Node
+TaskProducerClient producer = getTaskProducerClient();
+Task mergeTask = Task.Builder.builder(
+    new TaskId(UUID.randomUUID().toString()),
+    TaskStatus.UNASSIGNED,
+    new MergeTaskParams(shardId, segmentsToMerge),
+    TaskType.MERGE,
+    System.currentTimeMillis()
+).build();
+producer.submitTask(mergeTask);
+
+// Task execution on Offline Node
+public class MergeTaskWorker implements TaskWorker {
+    @Override
+    public void executeTask(Task task) {
+        MergeTaskParams params = (MergeTaskParams) task.getParams();
+        // Download segments from Remote Store
+        // Perform merge operation
+        // Upload merged segments to Remote Store
+        // Update task status
+    }
+}
+
+// Task assignment and heartbeat
+TaskManagerClient manager = getTaskManagerClient();
+boolean assigned = manager.assignTask(taskId, workerNode);
+if (assigned) {
+    // Execute task
+    workerClient.sendTaskHeartbeat(taskId, System.currentTimeMillis());
+}
+```
+
+## Limitations
+
+- **Experimental**: Feature is experimental and APIs may change in future releases
+- **Remote Store Required**: Designed for Remote Store enabled clusters where data is accessible from offline nodes
+- **Additional Cost**: Requires provisioning separate offline nodes and incurs additional data transfer costs
+- **Implementation Required**: Users must implement queue backend and task workers for their use cases
+- **Multiple Writers**: Requires handling multiple writers for single shard's Remote Segments Store
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#13574](https://github.com/opensearch-project/OpenSearch/pull/13574) | Adds offline-tasks library containing various interfaces for Offline Background Tasks |
+
+## References
+
+- [Issue #13575](https://github.com/opensearch-project/OpenSearch/issues/13575): Add a new library containing required abstractions to run Offline Background Tasks
+- [Issue #13554](https://github.com/opensearch-project/OpenSearch/issues/13554): Design Proposal - Offline Background Tasks
+- [Issue #12361](https://github.com/opensearch-project/OpenSearch/issues/12361): RFC - Offline Background Tasks
+- [Issue #12725](https://github.com/opensearch-project/OpenSearch/issues/12725): META - Phase #1 Offline Background Tasks
+- [Issue #12727](https://github.com/opensearch-project/OpenSearch/issues/12727): Feature Request - Background Tasks
+- [Issue #12726](https://github.com/opensearch-project/OpenSearch/issues/12726): Feature Request - Separation of Merges
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Initial implementation - Added offline-tasks library with core abstractions and interfaces

--- a/docs/releases/v2.18.0/features/opensearch/offline-nodes.md
+++ b/docs/releases/v2.18.0/features/opensearch/offline-nodes.md
@@ -1,0 +1,129 @@
+# Offline Nodes
+
+## Summary
+
+OpenSearch v2.18.0 introduces the foundational `offline-tasks` library, providing the core abstractions and interfaces needed to run background tasks on dedicated offline nodes. This feature enables workload segregation by offloading resource-intensive background operations (like segment merges, snapshots, and garbage collection) from data nodes to dedicated offline nodes, improving predictability and scalability of core indexing and search operations.
+
+## Details
+
+### What's New in v2.18.0
+
+This release adds the initial `offline-tasks` library (`libs/task-commons`) containing:
+
+- Core task management interfaces and abstractions
+- Task lifecycle management (creation, assignment, execution, completion)
+- Worker node abstractions for task execution
+- Plugin interfaces for extensibility
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Data Nodes"
+        DN[Data Node]
+        TP[TaskProducerClient]
+        DN --> TP
+    end
+    
+    subgraph "Task Store/Queue"
+        TQ[Task Queue]
+        TM[TaskManagerClient]
+    end
+    
+    subgraph "Offline Nodes"
+        ON[Offline Node]
+        TW[TaskWorker]
+        TWC[TaskWorkerClient]
+        ON --> TW
+        ON --> TWC
+    end
+    
+    TP -->|Submit Task| TQ
+    TM -->|Manage Tasks| TQ
+    TWC -->|Get Assigned Tasks| TQ
+    TWC -->|Send Heartbeat| TQ
+    TW -->|Execute| Task
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `Task` | Core task entity with lifecycle timestamps, status, and worker assignment |
+| `TaskId` | Unique identifier for tasks |
+| `TaskParams` | Base class for task-specific parameters |
+| `TaskStatus` | Enum: UNASSIGNED, ASSIGNED, ACTIVE, SUCCESS, FAILED, CANCELLED |
+| `TaskType` | Enum: MERGE, SNAPSHOT (extensible) |
+| `TaskManagerClient` | Interface for task CRUD operations and assignment |
+| `TaskProducerClient` | Interface for submitting new tasks |
+| `TaskWorkerClient` | Interface for workers to get assigned tasks and send heartbeats |
+| `TaskWorker` | Interface for task execution |
+| `WorkerNode` | Represents a worker node in the offline fleet |
+| `TaskManagerClientPlugin` | Plugin interface for custom TaskManagerClient implementations |
+| `TaskWorkerPlugin` | Plugin interface for custom TaskWorker implementations |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `opensearch.experimental.feature.task.background.enabled` | Feature flag to enable background task execution | `false` |
+
+### Usage Example
+
+The library provides abstractions that can be implemented for different queue backends:
+
+```java
+// Submit a task from a data node
+TaskProducerClient producer = getTaskProducerClient();
+Task task = Task.Builder.builder(
+    new TaskId("merge-123"),
+    TaskStatus.UNASSIGNED,
+    new MergeTaskParams(...),
+    TaskType.MERGE,
+    System.currentTimeMillis()
+).build();
+producer.submitTask(task);
+
+// Worker node picks up and executes tasks
+TaskWorkerClient workerClient = getTaskWorkerClient();
+List<Task> assignedTasks = workerClient.getAssignedTasks(new TaskListRequest());
+for (Task task : assignedTasks) {
+    taskWorker.executeTask(task);
+    workerClient.sendTaskHeartbeat(task.getTaskId(), System.currentTimeMillis());
+}
+```
+
+### Migration Notes
+
+This is an experimental feature gated behind a feature flag. To enable:
+
+1. Set `opensearch.experimental.feature.task.background.enabled=true` in `opensearch.yml`
+2. Implement `TaskManagerClientPlugin` to provide a task queue backend
+3. Implement `TaskWorkerPlugin` for specific task types (e.g., merge operations)
+
+## Limitations
+
+- **Experimental**: This feature is marked as experimental and APIs may change
+- **Foundation only**: v2.18.0 provides only the library abstractions; actual offline node functionality requires additional implementation
+- **No built-in queue**: Users must implement their own task queue backend (system index, Kafka, etc.)
+- **Remote Store required**: Offline nodes are designed for Remote Store enabled clusters
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#13574](https://github.com/opensearch-project/OpenSearch/pull/13574) | Adds offline-tasks library containing various interfaces for Offline Background Tasks |
+
+## References
+
+- [Issue #13575](https://github.com/opensearch-project/OpenSearch/issues/13575): Add a new library containing required abstractions to run Offline Background Tasks
+- [Issue #13554](https://github.com/opensearch-project/OpenSearch/issues/13554): Design Proposal - Offline Background Tasks
+- [Issue #12361](https://github.com/opensearch-project/OpenSearch/issues/12361): RFC - Offline Background Tasks
+- [Issue #12725](https://github.com/opensearch-project/OpenSearch/issues/12725): META - Phase #1 Offline Background Tasks
+- [Issue #12727](https://github.com/opensearch-project/OpenSearch/issues/12727): Feature Request - Background Tasks
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/offline-nodes.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -42,6 +42,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Dynamic Threadpool Resize](features/opensearch/dynamic-threadpool-resize.md) - Runtime thread pool size adjustment via cluster settings API
 - [Async Shard Fetch Metrics](features/opensearch/async-shard-fetch-metrics.md) - OTel counter metrics for async shard fetch success and failure tracking
 - [Search API Enhancements](features/opensearch/search-api-enhancements.md) - WithFieldName interface for aggregation/sort builders and successfulSearchShardIndices in SearchRequestContext
+- [Offline Nodes](features/opensearch/offline-nodes.md) - New offline-tasks library with core abstractions for running background tasks on dedicated offline nodes
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Offline Nodes feature introduced in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/offline-nodes.md`
- Feature report: `docs/features/opensearch/offline-nodes.md`

### Key Changes in v2.18.0
- New `offline-tasks` library (`libs/task-commons`) with core abstractions for background task execution
- Task lifecycle management interfaces (Task, TaskId, TaskParams, TaskStatus, TaskType)
- Client interfaces (TaskManagerClient, TaskProducerClient, TaskWorkerClient)
- Worker abstractions (TaskWorker, WorkerNode)
- Plugin interfaces (TaskManagerClientPlugin, TaskWorkerPlugin)
- Feature flag: `opensearch.experimental.feature.task.background.enabled`

### Resources Used
- PR: [#13574](https://github.com/opensearch-project/OpenSearch/pull/13574)
- Issue: [#13575](https://github.com/opensearch-project/OpenSearch/issues/13575)
- RFC: [#12361](https://github.com/opensearch-project/OpenSearch/issues/12361)
- Design Proposal: [#13554](https://github.com/opensearch-project/OpenSearch/issues/13554)

Closes #616