### PR TITLE
docs: add Query Insights Settings report for v2.18.0

### DIFF
--- a/docs/features/query-insights/query-insights.md
+++ b/docs/features/query-insights/query-insights.md
@@ -97,6 +97,8 @@ flowchart TB
 | `search.insights.top_queries.memory.top_n_size` | Number of top queries to track | `10` |
 | `search.insights.top_queries.memory.window_size` | Time window for collection | `1m` |
 | `search.insights.top_queries.group_by` | Group queries by: `NONE`, `SIMILARITY` | `NONE` |
+| `search.insights.top_queries.grouping.attributes.field_name` | Include field names in query structure for grouping | `true` |
+| `search.insights.top_queries.grouping.attributes.field_type` | Include field types in query structure for grouping | `true` |
 | `search.insights.top_queries.exporter.type` | Exporter type: `none`, `local_index` | `none` |
 | `search.insights.top_queries.exporter.template_priority` | Index template priority | `1847` |
 
@@ -185,6 +187,7 @@ GET /_insights/live_queries?sort=latency&size=5
 | v3.0.0 | [#300](https://github.com/opensearch-project/query-insights/pull/300) | Top queries API verbose param |
 | v3.0.0 | [#298](https://github.com/opensearch-project/query-insights/pull/298) | Skip profile queries |
 | v3.0.0 | [#266](https://github.com/opensearch-project/query-insights/pull/266) | Strict hash check on top queries indices |
+| v2.18.0 | [#144](https://github.com/opensearch-project/query-insights/pull/144) | Set default true for field name and type setting |
 | v2.17.0 | [#74](https://github.com/opensearch-project/query-insights/pull/74) | Fix listener startup when query metrics enabled |
 | v2.17.0 | [#64](https://github.com/opensearch-project/query-insights/pull/64) | Add query shape hash method |
 | v2.17.0 | [#71](https://github.com/opensearch-project/query-insights/pull/71) | Add more integration tests |
@@ -209,5 +212,6 @@ GET /_insights/live_queries?sort=latency&size=5
 ## Change History
 
 - **v3.0.0**: Added Live Queries API, default index template, verbose parameter, profile query filtering, strict hash check
+- **v2.18.0**: Changed default values for grouping attribute settings (`field_name` and `field_type`) from `false` to `true` for more accurate query grouping
 - **v2.17.0**: Fixed listener startup when query metrics enabled; added query shape hash method; fixed CVE-2023-2976; improved integration test coverage for query grouping; added code hygiene checks (Spotless, Checkstyle); fixed snapshot publishing configuration
 - **v2.12.0**: Initial release with Top N queries feature

--- a/docs/releases/v2.18.0/features/query-insights/query-insights-settings.md
+++ b/docs/releases/v2.18.0/features/query-insights/query-insights-settings.md
@@ -1,0 +1,86 @@
+# Query Insights Settings
+
+## Summary
+
+This bugfix changes the default values for the Query Insights grouping attribute settings `field_name` and `field_type` from `false` to `true`. This ensures that when queries are grouped by similarity, the query structure includes field names and field data types by default, providing more accurate and useful query grouping out of the box.
+
+## Details
+
+### What's New in v2.18.0
+
+The Query Insights plugin's grouping feature allows similar queries to be grouped together based on their query structure. Prior to this change, the settings that control whether field names and field types are included in the query structure were disabled by default, which could result in overly broad query groupings.
+
+### Technical Changes
+
+#### Configuration Changes
+
+| Setting | Old Default | New Default |
+|---------|-------------|-------------|
+| `search.insights.top_queries.grouping.attributes.field_name` | `false` | `true` |
+| `search.insights.top_queries.grouping.attributes.field_type` | `false` | `true` |
+
+#### Impact on Query Grouping
+
+With these settings now enabled by default:
+
+**Before (field_name=false, field_type=false):**
+```
+bool
+  must
+    term
+  filter
+    match
+    range
+```
+
+**After (field_name=true, field_type=true):**
+```
+bool []
+  must:
+    term [field1, keyword]
+  filter:
+    match [field2, text]
+    range [field4, long]
+```
+
+This provides more granular query grouping, distinguishing between queries that operate on different fields even if they have the same structure.
+
+### Usage Example
+
+The settings can still be disabled if broader grouping is desired:
+
+```bash
+PUT _cluster/settings
+{
+  "persistent": {
+    "search.insights.top_queries.grouping.attributes.field_name": false,
+    "search.insights.top_queries.grouping.attributes.field_type": false
+  }
+}
+```
+
+### Migration Notes
+
+- Existing clusters upgrading to v2.18.0 will automatically use the new defaults
+- Query groups may become more granular after upgrade due to field name/type inclusion
+- No action required unless broader grouping behavior is preferred
+
+## Limitations
+
+- More granular grouping may result in more query groups being tracked
+- Consider adjusting `max_groups_excluding_topn` if tracking limits are reached
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#144](https://github.com/opensearch-project/query-insights/pull/144) | Set default true for field name and type setting |
+
+## References
+
+- [Grouping Top N Queries Documentation](https://docs.opensearch.org/2.18/observing-your-data/query-insights/grouping-top-n-queries/)
+- [Query Insights Documentation](https://docs.opensearch.org/2.18/observing-your-data/query-insights/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/query-insights/query-insights.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -101,6 +101,10 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 - [k-NN Maintenance](features/k-nn/k-nn-maintenance.md) - Lucene 9.12 codec compatibility, force merge performance optimization, benchmark folder removal, code refactoring
 
+### Query Insights
+
+- [Query Insights Settings](features/query-insights/query-insights-settings.md) - Change default values for grouping attribute settings (field_name, field_type) from false to true
+
 ### Security Analytics
 
 - [Security Analytics System Indices](features/security-analytics/security-analytics-system-indices.md) - Standardized system index settings (1 primary shard, 1-20 replicas), dedicated query indices option, correlation alert refresh policy fix


### PR DESCRIPTION
## Summary

This PR adds documentation for the Query Insights Settings bugfix in v2.18.0.

### Changes

- **Release Report**: `docs/releases/v2.18.0/features/query-insights/query-insights-settings.md`
  - Documents the change in default values for `field_name` and `field_type` grouping attributes from `false` to `true`
  
- **Feature Report Update**: `docs/features/query-insights/query-insights.md`
  - Added new configuration settings for grouping attributes
  - Added PR #144 to Related PRs table
  - Added v2.18.0 entry to Change History

- **Release Index Update**: `docs/releases/v2.18.0/index.md`
  - Added Query Insights section with link to the new report

### Related Issue

Closes #614

### Related PR

- [opensearch-project/query-insights#144](https://github.com/opensearch-project/query-insights/pull/144) - Set default true for field name and type setting