### PR TITLE
docs: add ML Commons Connectors & Blueprints report for v2.18.0

### DIFF
--- a/docs/features/ml-commons/ml-commons-blueprints.md
+++ b/docs/features/ml-commons/ml-commons-blueprints.md
@@ -62,6 +62,7 @@ OpenSearch provides two types of connector blueprints:
 - Titan Multimodal Embedding
 - Cohere Embed English/Multilingual v3
 - Claude 3.5, 3.7 (standard and extended thinking modes)
+- Converse API (Claude 3 Sonnet and other chat models)
 
 #### OpenAI
 - text-embedding-ada-002
@@ -143,6 +144,20 @@ POST /_plugins/_ml/connectors/_create
 | v3.0.0 | [#3612](https://github.com/opensearch-project/ml-commons/pull/3612) | Fix template query link |
 | v3.0.0 | [#2975](https://github.com/opensearch-project/ml-commons/pull/2975) | Add tutorial for RAG of OpenAI and Bedrock |
 
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#3659](https://github.com/opensearch-project/ml-commons/pull/3659) | Add standard blueprint for vector search |
+| v3.0.0 | [#3584](https://github.com/opensearch-project/ml-commons/pull/3584) | Add blueprint for Claude 3.7 on Bedrock |
+| v3.0.0 | [#3725](https://github.com/opensearch-project/ml-commons/pull/3725) | Add standard blueprint for Azure embedding ada2 |
+| v3.0.0 | [#3612](https://github.com/opensearch-project/ml-commons/pull/3612) | Fix template query link |
+| v3.0.0 | [#2975](https://github.com/opensearch-project/ml-commons/pull/2975) | Add tutorial for RAG of OpenAI and Bedrock |
+| v2.18.0 | [#2960](https://github.com/opensearch-project/ml-commons/pull/2960) | Connector blueprint for Amazon Bedrock Converse |
+| v2.18.0 | [#3058](https://github.com/opensearch-project/ml-commons/pull/3058) | Support role temporary credential in connector tutorial |
+| v2.18.0 | [#3064](https://github.com/opensearch-project/ml-commons/pull/3064) | Add tutorial for cross-account model invocation |
+| v2.18.0 | [#3094](https://github.com/opensearch-project/ml-commons/pull/3094) | Tune Titan embedding model blueprint for V2 |
+
 ## References
 
 - [Connector Blueprints Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/blueprints/)
@@ -150,9 +165,12 @@ POST /_plugins/_ml/connectors/_create
 - [Connectors Overview](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/connectors/)
 - [ML Commons Cluster Settings](https://docs.opensearch.org/3.0/ml-commons-plugin/cluster-settings/)
 - [Issue #3619](https://github.com/opensearch-project/ml-commons/issues/3619): Standard blueprints feature request
+- [Amazon Bedrock Converse API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html)
+- [Bedrock Titan Embedding Models](https://docs.aws.amazon.com/bedrock/latest/userguide/titan-embedding-models.html)
 
 ## Change History
 
 - **v3.0.0** (2025-05-06): Added standard blueprints for vector search, Claude 3.7 blueprint, Azure OpenAI blueprint, RAG tutorials
+- **v2.18.0** (2024-11-12): Added Bedrock Converse blueprint, cross-account model invocation tutorial, role temporary credential support, Titan Embedding V2 blueprint
 - **v2.14.0** (2024-05-14): Introduced ML inference processor support for standard blueprints
 - **v2.9.0** (2023-07-24): Initial connector blueprints feature

--- a/docs/releases/v2.18.0/features/ml-commons/ml-commons-connectors-blueprints.md
+++ b/docs/releases/v2.18.0/features/ml-commons/ml-commons-connectors-blueprints.md
@@ -1,0 +1,129 @@
+# ML Commons Connectors & Blueprints
+
+## Summary
+
+This release adds new connector blueprints and tutorials for ML Commons, including support for Amazon Bedrock Converse API, cross-account model invocation, role-based temporary credentials, and Titan Embedding V2 model configuration.
+
+## Details
+
+### What's New in v2.18.0
+
+Four documentation and blueprint improvements were added to ML Commons:
+
+1. **Amazon Bedrock Converse Blueprint** - New connector blueprint for the Amazon Bedrock Converse API
+2. **Cross-Account Model Invocation Tutorial** - Guide for invoking Bedrock models from a different AWS account
+3. **Role Temporary Credential Support** - Enhanced AIConnectorHelper to support IAM role-based authentication
+4. **Titan Embedding V2 Blueprint** - Updated blueprint with V2-specific parameters
+
+### Technical Changes
+
+#### New Connector Blueprint: Bedrock Converse
+
+A new blueprint was added for Amazon Bedrock's Converse API, enabling chat-style interactions with models like Claude 3 Sonnet:
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+    "name": "Amazon Bedrock Converse",
+    "description": "Connector for Amazon Bedrock Converse",
+    "version": 1,
+    "protocol": "aws_sigv4",
+    "credential": {
+        "roleArn": "<YOUR_ROLE_ARN>"
+    },
+    "parameters": {
+        "region": "<AWS_REGION>",
+        "service_name": "bedrock",
+        "response_filter": "$.output.message.content[0].text",
+        "model": "anthropic.claude-3-sonnet-20240229-v1:0"
+    },
+    "actions": [
+        {
+            "action_type": "predict",
+            "method": "POST",
+            "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/converse",
+            "request_body": "{\"messages\":[{\"role\":\"user\",\"content\":[{\"type\":\"text\",\"text\":\"${parameters.inputs}\"}]}]}"
+        }
+    ]
+}
+```
+
+#### Cross-Account Model Invocation
+
+New tutorial for invoking Bedrock models across AWS accounts using:
+
+| Credential | Description |
+|------------|-------------|
+| `roleArn` | IAM role in Account A to assume external role |
+| `externalAccountRoleArn` | IAM role in Account B with Bedrock permissions |
+
+This feature enables organizations to centralize ML model access while maintaining separate OpenSearch clusters.
+
+#### AIConnectorHelper Enhancements
+
+The `AIConnectorHelper` Python class was updated to support:
+
+- IAM role-based authentication (in addition to IAM user)
+- Flexible trust policy generation for both users and roles
+- Session token support for temporary credentials
+
+```python
+helper = AIConnectorHelper(
+    region,
+    opensearch_domain_name,
+    opensearch_domain_username,
+    opensearch_domain_password,
+    aws_user_name,      # Optional: IAM user name
+    aws_role_name       # Optional: IAM role name
+)
+```
+
+#### Titan Embedding V2 Configuration
+
+Updated blueprint for Titan Embedding V2 with new parameters:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `model` | Model identifier | `amazon.titan-embed-text-v2:0` |
+| `dimensions` | Embedding dimensions | 1024 |
+| `normalize` | Normalize embeddings | true |
+| `embeddingTypes` | Output type | `["float"]` |
+
+### Usage Example
+
+Cross-account connector configuration:
+
+```json
+{
+  "credential": {
+    "roleArn": "arn:aws:iam::<account_A>:role/my_cross_account_role",
+    "externalAccountRoleArn": "arn:aws:iam::<account_B>:role/my_invoke_bedrock_role"
+  }
+}
+```
+
+## Limitations
+
+- Cross-account model invocation requires OpenSearch 2.15+
+- `binary` embedding type not supported in built-in post-process function for Titan V2
+- Neural search plugin only supports one embedding per document
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2960](https://github.com/opensearch-project/ml-commons/pull/2960) | Connector blueprint for Amazon Bedrock Converse |
+| [#3058](https://github.com/opensearch-project/ml-commons/pull/3058) | Support role temporary credential in connector tutorial |
+| [#3064](https://github.com/opensearch-project/ml-commons/pull/3064) | Add tutorial for cross-account model invocation |
+| [#3094](https://github.com/opensearch-project/ml-commons/pull/3094) | Tune Titan embedding model blueprint for V2 |
+
+## References
+
+- [Connector Blueprints Documentation](https://docs.opensearch.org/2.18/ml-commons-plugin/remote-models/blueprints/)
+- [Connectors Overview](https://docs.opensearch.org/2.18/ml-commons-plugin/remote-models/connectors/)
+- [Amazon Bedrock Converse API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html)
+- [Bedrock Titan Embedding Models](https://docs.aws.amazon.com/bedrock/latest/userguide/titan-embedding-models.html)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/ml-commons-blueprints.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -102,6 +102,10 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 - [k-NN Maintenance](features/k-nn/k-nn-maintenance.md) - Lucene 9.12 codec compatibility, force merge performance optimization, benchmark folder removal, code refactoring
 
+### ML Commons
+
+- [ML Commons Connectors & Blueprints](features/ml-commons/ml-commons-connectors-blueprints.md) - Bedrock Converse blueprint, cross-account model invocation tutorial, role temporary credential support, Titan Embedding V2 blueprint
+
 ### Query Insights
 
 - [Query Insights Settings](features/query-insights/query-insights-settings.md) - Change default values for grouping attribute settings (field_name, field_type) from false to true


### PR DESCRIPTION
## Summary

This PR adds documentation for ML Commons Connectors & Blueprints improvements in v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/ml-commons/ml-commons-connectors-blueprints.md`
- Feature report: `docs/features/ml-commons/ml-commons-blueprints.md` (updated)

### Key Changes in v2.18.0
- Added Amazon Bedrock Converse API connector blueprint
- Added cross-account model invocation tutorial for AWS managed OpenSearch
- Enhanced AIConnectorHelper to support IAM role-based temporary credentials
- Updated Titan Embedding blueprint with V2-specific parameters (dimensions, normalize, embeddingTypes)

### Related PRs
- [#2960](https://github.com/opensearch-project/ml-commons/pull/2960) - Connector blueprint for Amazon Bedrock Converse
- [#3058](https://github.com/opensearch-project/ml-commons/pull/3058) - Support role temporary credential in connector tutorial
- [#3064](https://github.com/opensearch-project/ml-commons/pull/3064) - Add tutorial for cross-account model invocation
- [#3094](https://github.com/opensearch-project/ml-commons/pull/3094) - Tune Titan embedding model blueprint for V2

Closes #610