### PR TITLE
docs: add query-assist report for v2.18.0

### DIFF
--- a/docs/features/ml-commons/query-assist.md
+++ b/docs/features/ml-commons/query-assist.md
@@ -145,6 +145,7 @@ Query Assist provides clear feedback for different error scenarios:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.18.0 | [#875](https://github.com/opensearch-project/flow-framework/pull/875) | Add query assist data summary agent template |
 | v2.17.0 | [#7998](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7998) | Agent error badge, ml-commons response schema update |
 | v2.16.0 | [#7212](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7212) | Add query enhancements plugin as core plugin |
 | v2.13.0 | - | Initial Query Assist implementation |
@@ -152,13 +153,16 @@ Query Assist provides clear feedback for different error scenarios:
 ## References
 
 - [OpenSearch Assistant Documentation](https://docs.opensearch.org/latest/dashboards/dashboards-assistant/index/)
+- [Data Summary Documentation](https://docs.opensearch.org/latest/dashboards/dashboards-assistant/data-summary/)
 - [PPL Tool Documentation](https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/tools/ppl-tool/)
 - [Event Analytics - Query Assist](https://docs.opensearch.org/latest/observing-your-data/event-analytics/)
 - [OpenSearch Assistant Toolkit](https://docs.opensearch.org/latest/ml-commons-plugin/opensearch-assistant/)
+- [Flow Framework Sample Templates](https://github.com/opensearch-project/flow-framework/tree/2.x/sample-templates)
 - [dashboards-assistant Getting Started Guide](https://github.com/opensearch-project/dashboards-assistant/blob/main/GETTING_STARTED_GUIDE.md)
 
 ## Change History
 
+- **v2.18.0** (2024-11-12): Added Query Assist Data Summary Agent sample template to Flow Framework
 - **v2.17.0** (2024-10-08): Enhanced error handling with agent error badge, updated ml-commons response schema processing, improved index pattern support
 - **v2.16.0** (2024-08-06): Query enhancements plugin added as core plugin with Query Assist feature
 - **v2.13.0** (2024-02-20): Initial introduction of Query Assist in OpenSearch Dashboards

--- a/docs/releases/v2.18.0/features/flow-framework/query-assist.md
+++ b/docs/releases/v2.18.0/features/flow-framework/query-assist.md
@@ -1,0 +1,121 @@
+# Query Assist Data Summary Agent Template
+
+## Summary
+
+This bugfix adds a sample template for the Query Assist Data Summary Agent to the Flow Framework plugin. The template provides a ready-to-use workflow for deploying a data summarization agent that works with the Query Assist feature in OpenSearch Dashboards, enabling users to get AI-generated summaries of their query results.
+
+## Details
+
+### What's New in v2.18.0
+
+A new sample template has been added to help users quickly set up the Query Assist Data Summary Agent. This agent summarizes data returned from PPL queries and provides insights based on user questions.
+
+### Technical Changes
+
+#### New Sample Templates
+
+Two new template files were added to the `sample-templates/` directory:
+
+| File | Format | Description |
+|------|--------|-------------|
+| `query-assist-data-summary-agent-claude-tested.json` | JSON | Data summary agent template using Claude on Bedrock |
+| `query-assist-data-summary-agent-claude-tested.yml` | YAML | Same template in YAML format |
+
+#### Template Workflow
+
+The template creates a complete workflow with four nodes:
+
+```mermaid
+graph TB
+    A[create_claude_connector] --> B[register_claude_model]
+    B --> C[create_query_assist_data_summary_ml_model_tool]
+    C --> D[create_query_assist_data_summary_agent]
+```
+
+| Node | Type | Description |
+|------|------|-------------|
+| `create_claude_connector` | create_connector | Creates AWS Bedrock connector for Claude model |
+| `register_claude_model` | register_remote_model | Registers and deploys the Claude model |
+| `create_query_assist_data_summary_ml_model_tool` | create_tool | Creates MLModelTool with summarization prompt |
+| `create_query_assist_data_summary_agent` | register_agent | Registers the flow agent |
+
+#### Agent Prompt
+
+The agent uses a specialized prompt for data summarization:
+
+```
+Human: You are an assistant that helps to summarize the data and provide data insights.
+The data are queried from OpenSearch index through user's question which was translated into PPL query.
+Here is a sample PPL query: `source=<index> | where <field> = <value>`.
+Now you are given ${parameters.sample_count} sample data out of ${parameters.total_count} total data.
+The user's question is `${parameters.question}`, the translated PPL query is `${parameters.ppl}` and sample data are:
+```
+${parameters.sample_data}
+```
+Could you help provide a summary of the sample data and provide some useful insights with precise wording and in plain text format, do not use markdown format.
+You don't need to echo my requirements in response.
+
+Assistant:
+```
+
+#### Connector Configuration
+
+The template configures a Bedrock connector with:
+
+| Parameter | Value | Description |
+|-----------|-------|-------------|
+| `protocol` | `aws_sigv4` | AWS Signature V4 authentication |
+| `model` | `anthropic.claude-instant-v1` | Claude Instant model on Bedrock |
+| `region` | `us-west-2` | AWS region (configurable) |
+| `max_tokens_to_sample` | `8000` | Maximum response tokens |
+| `temperature` | `0.0001` | Low temperature for consistent outputs |
+
+### Usage Example
+
+Deploy the template using the Flow Framework API:
+
+```bash
+POST /_plugins/_flow_framework/workflow?provision=true
+# Use contents from query-assist-data-summary-agent-claude-tested.json
+# Replace credential placeholders with actual AWS credentials
+```
+
+After deployment, configure the root agent:
+
+```bash
+POST /.plugins-ml-config/_doc/os_data2summary
+{
+  "type": "os_root_agent",
+  "configuration": {
+    "agent_id": "<DATA_SUMMARY_AGENT_ID>"
+  }
+}
+```
+
+### Version Compatibility
+
+The template specifies compatibility with:
+- OpenSearch 2.17.0
+- OpenSearch 3.0.0
+
+## Limitations
+
+- Requires AWS credentials with Bedrock access
+- Template uses Claude Instant model; users may need to modify for other models
+- Credentials must be manually replaced in the template before use
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#875](https://github.com/opensearch-project/flow-framework/pull/875) | Add query assist data summary agent template |
+
+## References
+
+- [Data Summary Documentation](https://docs.opensearch.org/2.18/dashboards/dashboards-assistant/data-summary/)
+- [Flow Framework Sample Templates](https://github.com/opensearch-project/flow-framework/tree/2.x/sample-templates)
+- [OpenSearch Assistant Toolkit](https://docs.opensearch.org/2.18/ml-commons-plugin/opensearch-assistant/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/ml-commons/query-assist.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -89,6 +89,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### Flow Framework
 
 - [Flow Framework Workflow State](features/flow-framework/flow-framework-workflow-state.md) - Remove Painless scripts for workflow state updates, implement optimistic locking
+- [Query Assist Data Summary Agent](features/flow-framework/query-assist.md) - Add sample template for Query Assist Data Summary Agent using Claude on Bedrock
 
 ### Alerting
 


### PR DESCRIPTION
## Summary

Add documentation for Query Assist Data Summary Agent template added in v2.18.0.

## Changes

### Release Report
- Created `docs/releases/v2.18.0/features/flow-framework/query-assist.md`
- Documents the new sample template for Query Assist Data Summary Agent using Claude on Bedrock

### Feature Report Update
- Updated `docs/features/ml-commons/query-assist.md`
- Added v2.18.0 entry to Related PRs table
- Added v2.18.0 entry to Change History
- Added Data Summary Documentation and Flow Framework Sample Templates to References

### Release Index Update
- Updated `docs/releases/v2.18.0/index.md` to include the new report

## Related Issue
Closes #609