### PR TITLE
docs: add release notes report for v2.18.0

### DIFF
--- a/docs/features/multi-plugin/version-bumps-release-notes.md
+++ b/docs/features/multi-plugin/version-bumps-release-notes.md
@@ -66,6 +66,11 @@ release-notes/
 | v3.0.0 | [#1843](https://github.com/opensearch-project/alerting/pull/1843) | alerting | Added 3.0 release notes |
 | v3.0.0 | [#775](https://github.com/opensearch-project/common-utils/pull/775) | common-utils | Update shadow plugin and bump to 3.0.0.0-alpha1 |
 | v3.0.0 | [#1384](https://github.com/opensearch-project/index-management/pull/1384) | index-management | Bump Version to 3.0.0-alpha1 |
+| v2.18.0 | [#1718](https://github.com/opensearch-project/alerting/pull/1718) | alerting | Added 2.18.0 release notes |
+| v2.18.0 | [#750](https://github.com/opensearch-project/common-utils/pull/750) | common-utils | Added 2.18.0.0 release notes |
+| v2.18.0 | [#980](https://github.com/opensearch-project/notifications/pull/980) | notifications | Added 2.18.0 release notes |
+| v2.18.0 | [#148](https://github.com/opensearch-project/query-insights/pull/148) | query-insights | Add release notes for 2.18 |
+| v2.18.0 | [#1399](https://github.com/opensearch-project/security/pull/1399) | security | Added 2.18.0 release notes |
 | v2.17.0 | [#1650](https://github.com/opensearch-project/alerting/pull/1650) | alerting | Added 2.17 release notes |
 | v2.17.0 | [#1635](https://github.com/opensearch-project/alerting/pull/1635) | alerting | Increment version to 2.17.0-SNAPSHOT |
 | v2.17.0 | [#727](https://github.com/opensearch-project/common-utils/pull/727) | common-utils | Added 2.17.0.0 release notes |
@@ -82,4 +87,5 @@ release-notes/
 ## Change History
 
 - **v3.0.0** (2025-05-06): Version bumps and release notes across 9 repositories (alerting, common-utils, index-management, notifications, security, sql, and dashboard plugins)
+- **v2.18.0** (2024-11-05): Release notes across 5 repositories (alerting, common-utils, notifications, query-insights, security)
 - **v2.17.0** (2024-09-17): Version bumps and release notes across 12 repositories (alerting, anomaly-detection, asynchronous-search, common-utils, dashboards-notifications, index-management, job-scheduler, ml-commons, notifications, query-insights, security, sql)

--- a/docs/releases/v2.18.0/features/multi-plugin/release-notes.md
+++ b/docs/releases/v2.18.0/features/multi-plugin/release-notes.md
@@ -1,0 +1,62 @@
+# Release Notes
+
+## Summary
+
+This release item covers the addition of v2.18.0 release notes across multiple OpenSearch plugin repositories. These PRs document the changes, enhancements, bug fixes, and maintenance updates included in the v2.18.0 release for each plugin.
+
+## Details
+
+### What's New in v2.18.0
+
+Release notes were added to 5 plugin repositories documenting the changes included in OpenSearch v2.18.0:
+
+| Repository | Release Notes File |
+|------------|-------------------|
+| alerting | `opensearch-alerting.release-notes-2.18.0.0.md` |
+| common-utils | `opensearch-common-utils.release-notes-2.18.0.0.md` |
+| notifications | `opensearch-notifications.release-notes-2.18.0.0.md` |
+| query-insights | `opensearch-query-insights.release-notes-2.18.0.0.md` |
+| security | `opensearch-security.release-notes-2.18.0.0.md` |
+
+### Release Notes Content Summary
+
+#### Alerting (v2.18.0.0)
+- **Refactoring**: Alerting Comments system indices, remote monitor logging, separate doc-level monitor query indices
+- **Bug Fixes**: Query index deletion timing, bucket level monitor optimization, query index shard configuration
+
+#### Common Utils (v2.18.0.0)
+- **Maintenance**: Version bump to 2.18.0-SNAPSHOT, Gradle 8.10.2 update
+- **Enhancements**: Dynamic deletion support for doc-level monitor query indices
+
+#### Notifications (v2.18.0.0)
+- **Maintenance**: Version bump to 2.18.0-SNAPSHOT, CI workflow fixes
+
+#### Query Insights (v2.18.0.0)
+- **Enhancements**: Time range parameter for historical top N queries, health_stats API, OpenTelemetry error metrics, query field name/type grouping settings
+- **Bug Fixes**: Measurement parsing logic refactor
+- **Maintenance**: Security-based integration tests, default settings updates
+
+#### Security (v2.18.0.0)
+- **Enhancements**: Improved certificate error messages, datastreams as AuditLog sink, V6→V7 config auto-conversion, circuit breaker override, AD index permissions, PBKDF2 password hashing fix
+- **Bug Fixes**: Non-flat YAML settings handling, system index read protection, dual mode flag propagation, SAML login fix, stored fields hashing, closed index mappings
+- **Maintenance**: Multiple dependency bumps, maintainer updates, CVE-2024-47554 fix
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#1718](https://github.com/opensearch-project/alerting/pull/1718) | alerting | Added 2.18.0 release notes |
+| [#750](https://github.com/opensearch-project/common-utils/pull/750) | common-utils | Added 2.18.0.0 release notes |
+| [#980](https://github.com/opensearch-project/notifications/pull/980) | notifications | Added 2.18.0 release notes |
+| [#148](https://github.com/opensearch-project/query-insights/pull/148) | query-insights | Add release notes for 2.18 |
+| [#1399](https://github.com/opensearch-project/security/pull/1399) | security | Added 2.18.0 release notes |
+
+## References
+
+- [Issue #1654](https://github.com/opensearch-project/alerting/issues/1654): Alerting release notes tracking
+- [Issue #730](https://github.com/opensearch-project/common-utils/issues/730): Common-utils release notes tracking
+- [Issue #958](https://github.com/opensearch-project/notifications/issues/958): Notifications release notes tracking
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/multi-plugin/version-bumps-release-notes.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -85,6 +85,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 - [Dependency Updates](features/multi-plugin/dependency-updates.md) - 19 dependency updates including CVE-2024-7254 fix, Gradle 8.10.2, upload-artifact v4
 - [Search Autocomplete](features/multi-plugin/search-autocomplete.md) - Fix search_as_you_type multi-fields support and enhanced Dashboards autocomplete UX
+- [Release Notes](features/multi-plugin/release-notes.md) - v2.18.0 release notes added across alerting, common-utils, notifications, query-insights, and security repositories
 
 ### Flow Framework
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the v2.18.0 release notes PRs across multiple OpenSearch plugin repositories.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/multi-plugin/release-notes.md`
- Feature report updated: `docs/features/multi-plugin/version-bumps-release-notes.md`

### Repositories Covered
- alerting (#1718)
- common-utils (#750)
- notifications (#980)
- query-insights (#148)
- security (#1399)

### Key Changes in v2.18.0
- Alerting: Comments system indices, remote monitor logging, doc-level monitor query index improvements
- Common Utils: Dynamic deletion support for doc-level monitor query indices
- Notifications: CI workflow fixes
- Query Insights: Health stats API, OpenTelemetry metrics, query grouping settings
- Security: Datastreams audit log sink, V6→V7 config conversion, multiple bug fixes

Closes #608