### PR TITLE
docs: add query-ci-cd report for v2.18.0

### DIFF
--- a/docs/features/ci/cd-build-improvements.md
+++ b/docs/features/ci/cd-build-improvements.md
@@ -95,6 +95,7 @@ CI/CD improvements typically involve changes to:
 | v2.18.0 | [#965](https://github.com/opensearch-project/notifications/pull/965) | notifications | Fix CI workflows for Node 20 |
 | v2.18.0 | [#2138](https://github.com/opensearch-project/observability/pull/2138) | observability | CVE fix for lint-staged |
 | v2.18.0 | [#2187](https://github.com/opensearch-project/observability/pull/2187) | observability | Add compile step before Cypress |
+| v2.18.0 | [#117](https://github.com/opensearch-project/query-insights/pull/117) | query-insights | Upgrade deprecated actions/upload-artifact to v3 |
 
 ## References
 
@@ -102,4 +103,4 @@ CI/CD improvements typically involve changes to:
 
 ## Change History
 
-- **v2.18.0** (2024-11-05): JDK-21 baseline for index-management, CI workflow fixes for notifications and observability, test security improvements for ml-commons, backport process improvements
+- **v2.18.0** (2024-11-05): JDK-21 baseline for index-management, CI workflow fixes for notifications, observability, and query-insights, test security improvements for ml-commons, backport process improvements

--- a/docs/releases/v2.18.0/features/query-insights/query-ci-cd.md
+++ b/docs/releases/v2.18.0/features/query-insights/query-ci-cd.md
@@ -1,0 +1,54 @@
+# Query CI/CD
+
+## Summary
+
+This bugfix upgrades deprecated `actions/upload-artifact` GitHub Actions from v1/v2 to v3 in the query-insights plugin CI workflows. This resolves CI failures caused by GitHub deprecating older versions of the artifact upload action.
+
+## Details
+
+### What's New in v2.18.0
+
+GitHub deprecated `actions/upload-artifact` v1 and v2 in February 2024, causing CI workflows to fail with automatic errors. This change updates all artifact upload actions to v3 across the query-insights CI workflows.
+
+### Technical Changes
+
+#### Files Modified
+
+| File | Changes |
+|------|---------|
+| `.github/workflows/ci.yml` | Updated 5 `actions/upload-artifact` references from v1/v2 to v3 |
+| `.github/workflows/integ-tests-with-security.yml` | Updated 2 `actions/upload-artifact` references from v2 to v3 |
+
+#### Before/After
+
+```yaml
+# Before
+- uses: actions/upload-artifact@v1
+- uses: actions/upload-artifact@v2
+
+# After
+- uses: actions/upload-artifact@v3
+```
+
+### Migration Notes
+
+No migration required. This is a CI infrastructure change that does not affect plugin functionality.
+
+## Limitations
+
+- `actions/upload-artifact@v3` has different retention and artifact handling compared to v1/v2
+- Future upgrades to v4 may be needed as GitHub continues to deprecate older versions
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#117](https://github.com/opensearch-project/query-insights/pull/117) | Upgrade deprecated actions/upload-artifact versions to v3 |
+
+## References
+
+- [GitHub Blog: Deprecation notice for v1 and v2 of artifact actions](https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/): Official deprecation announcement
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ci/cd-build-improvements.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -111,6 +111,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### Query Insights
 
 - [Query Insights Settings](features/query-insights/query-insights-settings.md) - Change default values for grouping attribute settings (field_name, field_type) from false to true
+- [Query CI/CD](features/query-insights/query-ci-cd.md) - Upgrade deprecated actions/upload-artifact from v1/v2 to v3
 
 ### Security Analytics
 


### PR DESCRIPTION
## Summary

Add release report for Query CI/CD bugfix in v2.18.0.

### Changes
- Created release report: `docs/releases/v2.18.0/features/query-insights/query-ci-cd.md`
- Updated feature report: `docs/features/ci/cd-build-improvements.md`
- Updated release index: `docs/releases/v2.18.0/index.md`

### PR Investigated
- [opensearch-project/query-insights#117](https://github.com/opensearch-project/query-insights/pull/117): Upgrade deprecated actions/upload-artifact versions to v3

Closes #607