### PR TITLE
docs: add ml-commons-ci-cd report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -188,6 +188,7 @@
 ## ml-commons
 
 - [Batch Ingestion](ml-commons/batch-ingestion.md)
+- [ML Commons CI/CD](ml-commons/ml-commons-ci-cd.md)
 - [ML Commons Connector](ml-commons/ml-commons-connector.md)
 - [ML Commons Connector Blueprints](ml-commons/ml-commons-blueprints.md)
 - [ML Commons MCP (Model Context Protocol)](ml-commons/ml-commons-mcp.md)

--- a/docs/features/ml-commons/ml-commons-ci-cd.md
+++ b/docs/features/ml-commons/ml-commons-ci-cd.md
@@ -1,0 +1,144 @@
+# ML Commons CI/CD
+
+## Summary
+
+ML Commons CI/CD infrastructure provides automated build, test, and deployment workflows for the ML Commons plugin. The system includes security measures to protect CI resources from unauthorized use while maintaining a smooth contributor experience.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "GitHub Events"
+        PUSH[Push Event]
+        PR[Pull Request]
+    end
+    
+    subgraph "Approval Workflow"
+        RA[require-approval.yml]
+        CO[CODEOWNERS Check]
+    end
+    
+    subgraph "Environments"
+        ENV1[ml-commons-cicd-env<br/>No approval needed]
+        ENV2[ml-commons-cicd-env-require-approval<br/>Requires maintainer approval]
+    end
+    
+    subgraph "CI Pipeline"
+        IMG[Get-CI-Image-Tag]
+        BUILD_L[Build-ml-linux]
+        TEST_L[Test-ml-linux-docker]
+        BUILD_W[Build-ml-windows]
+    end
+    
+    subgraph "Artifacts"
+        UP[Upload Artifact v4]
+        DOWN[Download Artifact v4]
+    end
+    
+    PUSH --> RA
+    PR --> RA
+    RA --> CO
+    CO -->|Maintainer| ENV1
+    CO -->|External| ENV2
+    ENV1 --> IMG
+    ENV2 -->|After approval| IMG
+    IMG --> BUILD_L
+    BUILD_L --> UP
+    BUILD_L --> TEST_L
+    TEST_L --> DOWN
+    IMG --> BUILD_W
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `CI-workflow.yml` | Main CI workflow for build and test |
+| `require-approval.yml` | Reusable workflow for approval checks |
+| `ml-commons-cicd-env` | GitHub environment for trusted contributors |
+| `ml-commons-cicd-env-require-approval` | GitHub environment requiring maintainer approval |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Approval required | External contributors need approval | Yes |
+| Push bypass | Push events skip approval | Yes |
+| CODEOWNERS bypass | Maintainers skip approval | Yes |
+
+### Workflow Files
+
+#### require-approval.yml
+
+```yaml
+name: Check if the workflow require approval
+on:
+  workflow_call:
+    outputs:
+      is-require-approval:
+        value: ${{ jobs.Require-Approval.outputs.output-is-require-approval }}
+
+jobs:
+  Require-Approval:
+    runs-on: ubuntu-latest
+    outputs:
+      output-is-require-approval: ${{ steps.step-is-require-approval.outputs.is-require-approval }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Get CodeOwner List
+        id: step-is-require-approval
+        run: |
+          github_event=${{ github.event_name }}
+          if [[ "$github_event" = "push" ]]; then
+            echo "is-require-approval=ml-commons-cicd-env" >> $GITHUB_OUTPUT
+          else
+            approvers=$(cat .github/CODEOWNERS | grep @ | tr -d '* ' | sed 's/@/,/g' | sed 's/,//1')
+            author=${{ github.event.pull_request.user.login }}
+            if [[ "$approvers" =~ "$author" ]]; then
+              echo "is-require-approval=ml-commons-cicd-env" >> $GITHUB_OUTPUT
+            else
+              echo "is-require-approval=ml-commons-cicd-env-require-approval" >> $GITHUB_OUTPUT
+            fi
+          fi
+```
+
+### Usage Example
+
+For external contributors, the workflow waits for approval:
+
+```yaml
+jobs:
+  Get-Require-Approval:
+    uses: ./.github/workflows/require-approval.yml
+
+  Build-ml-linux:
+    needs: [Get-Require-Approval, Get-CI-Image-Tag]
+    environment: ${{ needs.Get-Require-Approval.outputs.is-require-approval }}
+```
+
+## Limitations
+
+- Approval is per-PR, not per-commit
+- External contributors may experience CI delays
+- CODEOWNERS file must be kept up-to-date
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#3005](https://github.com/opensearch-project/ml-commons/pull/3005) | Add Test Env Require Approval Action |
+| v2.18.0 | [#3162](https://github.com/opensearch-project/ml-commons/pull/3162) | Upgrading upload artifact to v4 |
+| v2.18.0 | [#2881](https://github.com/opensearch-project/ml-commons/pull/2881) | Bump actions/download-artifact from 3 to 4.1.7 |
+| v2.18.0 | [#3062](https://github.com/opensearch-project/ml-commons/pull/3062) | Updates dev guide to inform the workflow approval step |
+
+## References
+
+- [MAINTAINERS.md](https://github.com/opensearch-project/ml-commons/blob/main/MAINTAINERS.md): List of maintainers
+- [DEVELOPER_GUIDE.md](https://github.com/opensearch-project/ml-commons/blob/main/DEVELOPER_GUIDE.md): Developer guide with approval info
+- [GitHub Actions Environments](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment): GitHub documentation on environments
+
+## Change History
+
+- **v2.18.0** (2024-10-29): Added workflow approval system, upgraded artifact actions to v4, updated developer guide

--- a/docs/releases/v2.18.0/features/ml-commons/ml-commons-ci-cd.md
+++ b/docs/releases/v2.18.0/features/ml-commons/ml-commons-ci-cd.md
@@ -1,0 +1,112 @@
+# ML Commons CI/CD
+
+## Summary
+
+This release includes CI/CD infrastructure improvements for the ML Commons plugin, focusing on workflow security, artifact handling, and developer documentation updates.
+
+## Details
+
+### What's New in v2.18.0
+
+Four PRs improve the CI/CD pipeline:
+
+1. **Workflow Approval System** - New approval workflow for external contributors
+2. **Artifact Actions Upgrade** - Updated upload/download artifact actions to v4
+3. **Developer Guide Update** - Documentation for the new approval process
+
+### Technical Changes
+
+#### Workflow Architecture
+
+```mermaid
+graph TB
+    subgraph "PR Trigger"
+        PR[Pull Request Created]
+    end
+    
+    subgraph "Approval Check"
+        RA[require-approval.yml]
+        CO[Check CODEOWNERS]
+    end
+    
+    subgraph "Environment Selection"
+        ENV1[ml-commons-cicd-env]
+        ENV2[ml-commons-cicd-env-require-approval]
+    end
+    
+    subgraph "CI Jobs"
+        BUILD[Build-ml-linux]
+        TEST[Test-ml-linux-docker]
+        WIN[Build-ml-windows]
+    end
+    
+    PR --> RA
+    RA --> CO
+    CO -->|Author is maintainer| ENV1
+    CO -->|Author is external| ENV2
+    ENV1 --> BUILD
+    ENV2 -->|Requires approval| BUILD
+    BUILD --> TEST
+    BUILD --> WIN
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `require-approval.yml` | Reusable workflow to check if PR author is in CODEOWNERS |
+| `Get-Require-Approval` job | New job in CI-workflow.yml that determines environment |
+
+#### Workflow Logic
+
+The approval workflow checks:
+1. If event is `push` → No approval needed (uses `ml-commons-cicd-env`)
+2. If PR author is in `.github/CODEOWNERS` → No approval needed
+3. If PR author is external → Requires maintainer approval (uses `ml-commons-cicd-env-require-approval`)
+
+#### Artifact Actions Updates
+
+| Action | Old Version | New Version |
+|--------|-------------|-------------|
+| `actions/upload-artifact` | v3 | v4 |
+| `actions/download-artifact` | v3 | v4.1.7 |
+
+### Usage Example
+
+External contributors will see their CI workflow pending approval:
+
+```yaml
+# CI workflow waits for maintainer approval
+environment: ml-commons-cicd-env-require-approval
+```
+
+Maintainers can approve the workflow from the GitHub Actions UI.
+
+### Migration Notes
+
+- External contributors must wait for maintainer approval before CI runs
+- Maintainers listed in CODEOWNERS bypass the approval requirement
+- Push events (merges) do not require approval
+
+## Limitations
+
+- Approval is required per PR, not per commit
+- External contributors may experience delays waiting for approval
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3005](https://github.com/opensearch-project/ml-commons/pull/3005) | Add Test Env Require Approval Action |
+| [#3162](https://github.com/opensearch-project/ml-commons/pull/3162) | Upgrading upload artifact to v4 |
+| [#2881](https://github.com/opensearch-project/ml-commons/pull/2881) | Bump actions/download-artifact from 3 to 4.1.7 |
+| [#3062](https://github.com/opensearch-project/ml-commons/pull/3062) | Updates dev guide to inform the workflow approval step |
+
+## References
+
+- [MAINTAINERS.md](https://github.com/opensearch-project/ml-commons/blob/main/MAINTAINERS.md): List of maintainers
+- [DEVELOPER_GUIDE.md](https://github.com/opensearch-project/ml-commons/blob/main/DEVELOPER_GUIDE.md): Developer guide with approval info
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/ml-commons-ci-cd.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -107,6 +107,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### ML Commons
 
 - [ML Commons Connectors & Blueprints](features/ml-commons/ml-commons-connectors-blueprints.md) - Bedrock Converse blueprint, cross-account model invocation tutorial, role temporary credential support, Titan Embedding V2 blueprint
+- [ML Commons CI/CD](features/ml-commons/ml-commons-ci-cd.md) - Workflow approval system for external contributors, artifact actions upgrade to v4, developer guide updates
 
 ### Query Insights
 


### PR DESCRIPTION
## Summary

Add release and feature reports for ML Commons CI/CD improvements in v2.18.0.

## Changes

- Release report: `docs/releases/v2.18.0/features/ml-commons/ml-commons-ci-cd.md`
- Feature report: `docs/features/ml-commons/ml-commons-ci-cd.md`
- Updated release index
- Updated features index

## Key Changes in v2.18.0

- Workflow approval system for external contributors (PR #3005)
- Upgraded upload-artifact to v4 (PR #3162)
- Upgraded download-artifact to v4.1.7 (PR #2881)
- Updated developer guide with approval process documentation (PR #3062)

Closes #606