### PR TITLE
docs: add ml-commons-configuration report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -189,6 +189,7 @@
 
 - [Batch Ingestion](ml-commons/batch-ingestion.md)
 - [ML Commons CI/CD](ml-commons/ml-commons-ci-cd.md)
+- [ML Commons Configuration](ml-commons/ml-commons-configuration.md)
 - [ML Commons Connector](ml-commons/ml-commons-connector.md)
 - [ML Commons Connector Blueprints](ml-commons/ml-commons-blueprints.md)
 - [ML Commons MCP (Model Context Protocol)](ml-commons/ml-commons-mcp.md)

--- a/docs/features/ml-commons/ml-commons-configuration.md
+++ b/docs/features/ml-commons/ml-commons-configuration.md
@@ -1,0 +1,94 @@
+# ML Commons Configuration
+
+## Summary
+
+The ML Commons plugin uses several system indices to store configuration, models, tasks, and other metadata. The `.plugins-ml-config` index stores critical ML configuration data and is designed for maximum availability across the cluster.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "ML Commons System Indices"
+        CONFIG[".plugins-ml-config<br/>ML Configuration"]
+        MODEL[".plugins-ml-model"]
+        TASK[".plugins-ml-task"]
+        CONNECTOR[".plugins-ml-connector"]
+        CONTROLLER[".plugins-ml-controller"]
+        MEMORY[".plugins-ml-memory-*"]
+    end
+    
+    subgraph "Index Settings"
+        DEFAULT["DEFAULT_INDEX_SETTINGS<br/>auto_expand_replicas: 0-1"]
+        ALLNODES["ALL_NODES_REPLICA_INDEX_SETTINGS<br/>auto_expand_replicas: 0-all"]
+    end
+    
+    CONFIG --> ALLNODES
+    MODEL --> DEFAULT
+    TASK --> DEFAULT
+    CONNECTOR --> DEFAULT
+    CONTROLLER --> DEFAULT
+    MEMORY --> DEFAULT
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `IndexUtils` | Utility class providing index settings constants |
+| `MLIndicesHandler` | Handles ML index creation and updates |
+| `MLIndex.CONFIG` | Enum representing the `.plugins-ml-config` index |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.number_of_shards` | Number of primary shards | `1` |
+| `index.auto_expand_replicas` | Auto-expand replica range | `0-all` (config), `0-1` (others) |
+
+### Index Settings Constants
+
+| Constant | Use Case | Settings |
+|----------|----------|----------|
+| `DEFAULT_INDEX_SETTINGS` | Standard ML indices | `shards: 1`, `replicas: 0-1` |
+| `ALL_NODES_REPLICA_INDEX_SETTINGS` | Critical config index | `shards: 1`, `replicas: 0-all` |
+| `UPDATED_DEFAULT_INDEX_SETTINGS` | Dynamic update (standard) | `replicas: 0-1` |
+| `UPDATED_ALL_NODES_REPLICA_INDEX_SETTINGS` | Dynamic update (all-nodes) | `replicas: 0-all` |
+
+### Usage Example
+
+The ML Commons plugin automatically applies the appropriate settings when creating indices:
+
+```java
+// For .plugins-ml-config index
+CreateIndexRequest request = new CreateIndexRequest(indexName)
+    .mapping(mapping, XContentType.JSON)
+    .settings(ALL_NODES_REPLICA_INDEX_SETTINGS);
+
+// For other ML indices
+CreateIndexRequest request = new CreateIndexRequest(indexName)
+    .mapping(mapping, XContentType.JSON)
+    .settings(DEFAULT_INDEX_SETTINGS);
+```
+
+## Limitations
+
+- `0-all` replication increases storage requirements proportionally to cluster size
+- Only suitable for small, critical indices
+- Higher indexing load due to replication to all nodes
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#3017](https://github.com/opensearch-project/ml-commons/pull/3017) | Support index.auto_expand_replicas 0-all for .plugins-ml-config |
+
+## References
+
+- [Issue #3002](https://github.com/opensearch-project/ml-commons/issues/3002): Original feature request
+- [ML Commons cluster settings](https://docs.opensearch.org/2.18/ml-commons-plugin/cluster-settings/): Official documentation
+
+## Change History
+
+- **v2.18.0** (2024-10-22): Changed `.plugins-ml-config` index to use `auto_expand_replicas: 0-all` for maximum availability

--- a/docs/releases/v2.18.0/features/ml-commons/ml-commons-configuration.md
+++ b/docs/releases/v2.18.0/features/ml-commons/ml-commons-configuration.md
@@ -1,0 +1,68 @@
+# ML Commons Configuration
+
+## Summary
+
+This bugfix improves the availability of the `.plugins-ml-config` index by changing its `index.auto_expand_replicas` setting from `0-1` to `0-all`. This ensures the ML configuration index has a replica on every node in the cluster, maximizing availability for this small but critical index.
+
+## Details
+
+### What's New in v2.18.0
+
+The `.plugins-ml-config` index now uses `index.auto_expand_replicas: 0-all` instead of `0-1`, ensuring replicas exist on all nodes in the cluster.
+
+### Technical Changes
+
+#### Index Settings Changes
+
+| Setting | Before | After |
+|---------|--------|-------|
+| `index.auto_expand_replicas` for `.plugins-ml-config` | `0-1` | `0-all` |
+
+#### New Index Utility Constants
+
+The `IndexUtils` class was refactored to support different replication strategies:
+
+| Constant | Description | Settings |
+|----------|-------------|----------|
+| `DEFAULT_INDEX_SETTINGS` | Standard index settings | `shards: 1`, `auto_expand_replicas: 0-1` |
+| `ALL_NODES_REPLICA_INDEX_SETTINGS` | Maximum availability settings | `shards: 1`, `auto_expand_replicas: 0-all` |
+| `UPDATED_DEFAULT_INDEX_SETTINGS` | Dynamic update for standard | `auto_expand_replicas: 0-1` |
+| `UPDATED_ALL_NODES_REPLICA_INDEX_SETTINGS` | Dynamic update for all-nodes | `auto_expand_replicas: 0-all` |
+
+#### Schema Version Update
+
+The ML config index schema version was incremented from 3 to 4 to trigger the settings update on existing clusters.
+
+### Affected Components
+
+| Component | Change |
+|-----------|--------|
+| `MLIndicesHandler` | Uses `ALL_NODES_REPLICA_INDEX_SETTINGS` for config index |
+| `ConversationMetaIndex` | Uses `DEFAULT_INDEX_SETTINGS` (unchanged behavior) |
+| `InteractionsIndex` | Uses `DEFAULT_INDEX_SETTINGS` (unchanged behavior) |
+
+### Migration Notes
+
+- Existing clusters will automatically update the `.plugins-ml-config` index settings when the schema version check detects the change
+- No manual intervention required
+- The change increases storage requirements proportionally to cluster size
+
+## Limitations
+
+- Using `0-all` can significantly increase storage requirements and indexing load on large clusters
+- This setting is only suitable for small, critical indices like the ML config index
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3017](https://github.com/opensearch-project/ml-commons/pull/3017) | Support index.auto_expand_replicas 0-all for .plugins-ml-config |
+
+## References
+
+- [Issue #3002](https://github.com/opensearch-project/ml-commons/issues/3002): Feature request for 0-all support
+- [ML Commons cluster settings](https://docs.opensearch.org/2.18/ml-commons-plugin/cluster-settings/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/ml-commons-configuration.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -106,6 +106,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### ML Commons
 
+- [ML Commons Configuration](features/ml-commons/ml-commons-configuration.md) - Change `.plugins-ml-config` index to use `auto_expand_replicas: 0-all` for maximum availability
 - [ML Commons Connectors & Blueprints](features/ml-commons/ml-commons-connectors-blueprints.md) - Bedrock Converse blueprint, cross-account model invocation tutorial, role temporary credential support, Titan Embedding V2 blueprint
 - [ML Commons CI/CD](features/ml-commons/ml-commons-ci-cd.md) - Workflow approval system for external contributors, artifact actions upgrade to v4, developer guide updates
 


### PR DESCRIPTION
## Summary

Add release and feature reports for ML Commons Configuration bugfix in v2.18.0.

### Changes

This bugfix improves the availability of the `.plugins-ml-config` index by changing its `index.auto_expand_replicas` setting from `0-1` to `0-all`. This ensures the ML configuration index has a replica on every node in the cluster, maximizing availability for this small but critical index.

### Reports Created

- Release report: `docs/releases/v2.18.0/features/ml-commons/ml-commons-configuration.md`
- Feature report: `docs/features/ml-commons/ml-commons-configuration.md`

### Related

- Closes #605
- PR: [opensearch-project/ml-commons#3017](https://github.com/opensearch-project/ml-commons/pull/3017)
- Issue: [opensearch-project/ml-commons#3002](https://github.com/opensearch-project/ml-commons/issues/3002)