### PR TITLE
docs: add anomaly-detection-dependencies report for v2.18.0

### DIFF
--- a/docs/features/anomaly-detection/anomaly-detection-dependencies.md
+++ b/docs/features/anomaly-detection/anomaly-detection-dependencies.md
@@ -1,0 +1,89 @@
+# Anomaly Detection Dependencies
+
+## Summary
+
+The Anomaly Detection plugin maintains various dependencies for core functionality, serialization, and testing. Regular dependency updates ensure security, compatibility with the OpenSearch core, and access to the latest features and bug fixes.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Anomaly Detection Plugin"
+        AD[Anomaly Detection Core]
+        RCF[Random Cut Forest]
+    end
+    
+    subgraph "Serialization"
+        Jackson[Jackson Core/Databind/Annotations]
+        Protostuff[Protostuff]
+    end
+    
+    subgraph "Testing"
+        JUnit[JUnit Jupiter]
+        Mockito[Mockito]
+        ByteBuddy[Byte Buddy]
+    end
+    
+    subgraph "Build Tools"
+        Gradle[Gradle Plugins]
+        GHA[GitHub Actions]
+    end
+    
+    AD --> Jackson
+    AD --> Protostuff
+    RCF --> Jackson
+    AD -.-> JUnit
+    AD -.-> Mockito
+    Mockito --> ByteBuddy
+
+```
+
+### Key Dependencies
+
+| Category | Dependency | Purpose |
+|----------|------------|---------|
+| Serialization | Jackson | JSON serialization/deserialization |
+| Serialization | Protostuff | RCF model serialization |
+| ML | Random Cut Forest | Anomaly detection algorithm |
+| Math | Apache Commons Math3 | Statistical computations |
+| Utilities | Guava | Collections and utilities |
+| Testing | JUnit Jupiter | Unit testing framework |
+| Testing | Mockito | Mocking framework |
+| Testing | Byte Buddy | Runtime code generation for mocks |
+
+### Configuration
+
+Dependencies are managed in `build.gradle` with version variables for consistency:
+
+```groovy
+ext {
+    jacksonVersion = "2.18.0"
+}
+
+dependencies {
+    implementation("com.fasterxml.jackson.core:jackson-databind:${jacksonVersion}")
+    implementation("com.fasterxml.jackson.core:jackson-annotations:${jacksonVersion}")
+}
+```
+
+## Limitations
+
+- Jackson version must be compatible with OpenSearch core's jackson-core
+- Test dependencies should align with OpenSearch test framework versions
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#1337](https://github.com/opensearch-project/anomaly-detection/pull/1337) | Updating several dependencies |
+
+## References
+
+- [Anomaly Detection Repository](https://github.com/opensearch-project/anomaly-detection)
+- [Anomaly Detection Documentation](https://docs.opensearch.org/latest/observing-your-data/ad/index/)
+
+## Change History
+
+- **v2.18.0** (2024-10-29): Updated Jackson to 2.18.0, JUnit Jupiter to 5.11.2, Mockito to 5.14.1; removed unused javassist dependency

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -211,6 +211,7 @@
 - [Anomaly Detection Missing Data Handling](anomaly-detection/anomaly-detection-missing-data-handling.md)
 - [Dual Cluster Development Environment](anomaly-detection/dual-cluster-development.md)
 - [Remote/Multi-Index Support](anomaly-detection/remote-multi-index-support.md)
+- [Anomaly Detection Dependencies](anomaly-detection/anomaly-detection-dependencies.md)
 
 ## observability
 

--- a/docs/releases/v2.18.0/features/anomaly-detection/anomaly-detection-dependencies.md
+++ b/docs/releases/v2.18.0/features/anomaly-detection/anomaly-detection-dependencies.md
@@ -1,0 +1,57 @@
+# Anomaly Detection Dependencies
+
+## Summary
+
+This release updates several dependencies in the Anomaly Detection plugin to address security vulnerabilities and improve compatibility. The update also removes the unused `javassist` dependency to reduce the plugin's footprint.
+
+## Details
+
+### What's New in v2.18.0
+
+Consolidated dependency updates that were previously tracked in separate dependabot PRs, making maintenance and rebasing easier.
+
+### Technical Changes
+
+#### Dependency Updates
+
+| Dependency | Previous Version | New Version | Notes |
+|------------|------------------|-------------|-------|
+| jackson-databind | 2.16.1 | 2.18.0 | Core serialization |
+| jackson-annotations | 2.16.1 | 2.18.0 | Core serialization |
+| jackson-core | 2.16.0 | 2.18.0 | Core serialization (forced) |
+| mockito-core | 5.9.0 | 5.14.1 | Test framework |
+| junit-jupiter-api | 5.10.0 | 5.11.2 | Test framework |
+| junit-jupiter-params | 5.10.0 | 5.11.2 | Test framework |
+| junit-jupiter-engine | 5.10.0 | 5.11.2 | Test framework |
+| junit-platform-launcher | 1.10.0 | 1.11.2 | Test framework |
+| org.gradle.test-retry | 1.5.7 | 1.6.0 | Gradle plugin |
+| release-drafter | v5 | v6 | GitHub Actions |
+| actions/setup-java | v4 | v3 | GitHub Actions (downgrade) |
+
+#### Removed Dependencies
+
+| Dependency | Version | Reason |
+|------------|---------|--------|
+| javassist | 3.28.0-GA | Unused - all tests pass without it |
+
+### Migration Notes
+
+No migration required. This is a transparent dependency update with no API changes.
+
+## Limitations
+
+None identified.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1337](https://github.com/opensearch-project/anomaly-detection/pull/1337) | Updating several dependencies |
+
+## References
+
+- [Anomaly Detection Documentation](https://docs.opensearch.org/2.18/observing-your-data/ad/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/anomaly-detection/anomaly-detection-dependencies.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -115,6 +115,10 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Query Insights Settings](features/query-insights/query-insights-settings.md) - Change default values for grouping attribute settings (field_name, field_type) from false to true
 - [Query CI/CD](features/query-insights/query-ci-cd.md) - Upgrade deprecated actions/upload-artifact from v1/v2 to v3
 
+### Anomaly Detection
+
+- [Anomaly Detection Dependencies](features/anomaly-detection/anomaly-detection-dependencies.md) - Dependency updates (Jackson 2.18.0, JUnit Jupiter 5.11.2, Mockito 5.14.1) and removal of unused javassist dependency
+
 ### Security Analytics
 
 - [Security Analytics System Indices](features/security-analytics/security-analytics-system-indices.md) - Standardized system index settings (1 primary shard, 1-20 replicas), dedicated query indices option, correlation alert refresh policy fix


### PR DESCRIPTION
## Summary

Adds documentation for the Anomaly Detection Dependencies bugfix in OpenSearch v2.18.0.

## Changes

- **Release Report**: `docs/releases/v2.18.0/features/anomaly-detection/anomaly-detection-dependencies.md`
- **Feature Report**: `docs/features/anomaly-detection/anomaly-detection-dependencies.md`
- Updated release index and features index

## Key Findings

PR #1337 in anomaly-detection repository updates several dependencies:
- Jackson: 2.16.1 → 2.18.0
- Mockito: 5.9.0 → 5.14.1
- JUnit Jupiter: 5.10.0 → 5.11.2
- Removed unused `javassist` dependency

Closes #604