### PR TITLE
docs: add SQL Scheduler bugfix report for v2.18.0

### DIFF
--- a/docs/features/sql/flint-query-scheduler.md
+++ b/docs/features/sql/flint-query-scheduler.md
@@ -181,6 +181,7 @@ GET /.async-query-scheduler/_search
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.18.0 | [#3097](https://github.com/opensearch-project/sql/pull/3097) | Remove scheduler index from SystemIndexDescriptor |
 | v2.17.0 | [#2834](https://github.com/opensearch-project/sql/pull/2834) | Flint query scheduler part 1 - integrate job scheduler plugin |
 | v2.17.0 | [#2961](https://github.com/opensearch-project/sql/pull/2961) | Flint query scheduler part 2 - scheduler service and Flint integration |
 | v2.17.0 | [#2973](https://github.com/opensearch-project/sql/pull/2973) | Add feature flag for async query scheduler |
@@ -190,9 +191,10 @@ GET /.async-query-scheduler/_search
 - [Issue #2832](https://github.com/opensearch-project/sql/issues/2832): Integrate job scheduler plugin
 - [Issue #2833](https://github.com/opensearch-project/sql/issues/2833): Introduce scheduling service
 - [RFC #416](https://github.com/opensearch-project/opensearch-spark/issues/416): Direct Query External Query Scheduler
-- [Documentation](https://docs.opensearch.org/2.17/dashboards/management/scheduled-query-acceleration/): Scheduled Query Acceleration
+- [Documentation](https://docs.opensearch.org/2.18/dashboards/management/scheduled-query-acceleration/): Scheduled Query Acceleration
 - [Flint Index Reference](https://github.com/opensearch-project/opensearch-spark/blob/main/docs/index.md): OpenSearch Spark documentation
 
 ## Change History
 
+- **v2.18.0** (2024-10-23): Bugfix - Remove scheduler index from SystemIndexDescriptor to prevent conflicts with Job Scheduler plugin
 - **v2.17.0** (2024-09-17): Initial implementation with Job Scheduler integration, scheduler service, and feature flag support

--- a/docs/releases/v2.18.0/features/sql/sql-scheduler.md
+++ b/docs/releases/v2.18.0/features/sql/sql-scheduler.md
@@ -1,0 +1,84 @@
+# SQL Scheduler
+
+## Summary
+
+This bugfix removes the SQL scheduler index (`.async-query-scheduler`) from the `SystemIndexDescriptor` registration in the SQL plugin. The scheduler index was incorrectly registered as a system index, which caused issues because the Job Scheduler plugin already manages this index. This change corrects the system index configuration to prevent conflicts.
+
+## Details
+
+### What's New in v2.18.0
+
+The SQL plugin previously registered the `.async-query-scheduler` index as a system index in the `getSystemIndexDescriptors()` method. This was incorrect because:
+
+1. The Job Scheduler plugin already manages the scheduler index lifecycle
+2. Duplicate system index registration can cause conflicts during index operations
+3. The scheduler index should be managed by the Job Scheduler plugin, not the SQL plugin
+
+### Technical Changes
+
+#### Code Changes
+
+The fix removes the scheduler index registration from `SQLPlugin.java`:
+
+```java
+// Before (v2.17.0)
+@Override
+public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
+    List<SystemIndexDescriptor> systemIndexDescriptors = new ArrayList<>();
+    systemIndexDescriptors.add(
+        new SystemIndexDescriptor(
+            OpenSearchDataSourceMetadataStorage.DATASOURCE_INDEX_NAME, "SQL DataSources index"));
+    systemIndexDescriptors.add(
+        new SystemIndexDescriptor(
+            SPARK_REQUEST_BUFFER_INDEX_NAME + "*", "SQL Spark Request Buffer index pattern"));
+    systemIndexDescriptors.add(
+        new SystemIndexDescriptor(
+            OpenSearchAsyncQueryScheduler.SCHEDULER_INDEX_NAME, "SQL Scheduler job index"));
+    return systemIndexDescriptors;
+}
+
+// After (v2.18.0)
+@Override
+public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
+    List<SystemIndexDescriptor> systemIndexDescriptors = new ArrayList<>();
+    systemIndexDescriptors.add(
+        new SystemIndexDescriptor(
+            OpenSearchDataSourceMetadataStorage.DATASOURCE_INDEX_NAME, "SQL DataSources index"));
+    systemIndexDescriptors.add(
+        new SystemIndexDescriptor(
+            SPARK_REQUEST_BUFFER_INDEX_NAME + "*", "SQL Spark Request Buffer index pattern"));
+    return systemIndexDescriptors;
+}
+```
+
+#### System Index Registration (After Fix)
+
+| Index | Description | Registered By |
+|-------|-------------|---------------|
+| `.ql-datasources` | SQL DataSources index | SQL Plugin |
+| `.spark-request-buffer*` | SQL Spark Request Buffer index pattern | SQL Plugin |
+| `.async-query-scheduler` | Scheduler job index | Job Scheduler Plugin |
+
+### Migration Notes
+
+No migration is required. The fix is transparent to users and does not affect existing scheduler jobs or index data.
+
+## Limitations
+
+None specific to this bugfix.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3092](https://github.com/opensearch-project/sql/pull/3092) | Remove scheduler index from SystemIndexDescriptor (main) |
+| [#3097](https://github.com/opensearch-project/sql/pull/3097) | Backport to 2.x branch |
+
+## References
+
+- [PR #3092](https://github.com/opensearch-project/sql/pull/3092): Original implementation
+- [Documentation](https://docs.opensearch.org/2.18/dashboards/management/scheduled-query-acceleration/): Scheduled Query Acceleration
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/sql/flint-query-scheduler.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -99,6 +99,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### SQL
 
 - [SQL Plugin Maintenance](features/sql/sql-plugin-maintenance.md) - Security fix for CVE-2024-47554 (commons-io upgrade to 2.14.0) and test fixes for 2.18 branch
+- [SQL Scheduler](features/sql/sql-scheduler.md) - Bugfix to remove scheduler index from SystemIndexDescriptor to prevent conflicts with Job Scheduler plugin
 
 ### k-NN
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the SQL Scheduler bugfix in v2.18.0.

### Changes
- **Release report**: `docs/releases/v2.18.0/features/sql/sql-scheduler.md`
  - Documents the removal of scheduler index from SystemIndexDescriptor
  - Explains the technical changes and rationale
- **Feature report update**: `docs/features/sql/flint-query-scheduler.md`
  - Added v2.18.0 entry to Related PRs table
  - Added v2.18.0 entry to Change History
- **Release index update**: Added link to new report

### Related Issue
Closes #603

### Key Changes in v2.18.0
- Removed `.async-query-scheduler` index from SQL plugin's SystemIndexDescriptor registration
- Prevents conflicts with Job Scheduler plugin which already manages this index