### PR TITLE
docs: add SQL Pagination bug fixes report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -155,6 +155,7 @@
 - [Flint Index Operations](sql/flint-index-operations.md)
 - [Flint Query Scheduler](sql/flint-query-scheduler.md)
 - [Security Lake Data Source](sql/security-lake-data-source.md)
+- [SQL Pagination](sql/sql-pagination.md)
 - [SQL Plugin Maintenance](sql/sql-plugin-maintenance.md)
 - [SQL/PPL Engine](sql/sql-ppl-engine.md)
 - [SQL/PPL Breaking Changes](sql/sql-ppl-breaking-changes.md)

--- a/docs/features/sql/sql-pagination.md
+++ b/docs/features/sql/sql-pagination.md
@@ -1,0 +1,143 @@
+# SQL Pagination
+
+## Summary
+
+SQL Pagination enables paginated responses for SQL queries in OpenSearch, allowing clients to retrieve large result sets in manageable chunks. The feature uses Point in Time (PIT) internally to maintain consistent results across pagination requests, replacing the previous scroll-based implementation.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph Client
+        REQ[SQL Request with fetch_size]
+        CURSOR[Cursor Request]
+    end
+    
+    subgraph "SQL Plugin"
+        API[REST SQL API]
+        VALID[Request Validator]
+        V2[V2 Engine]
+        V1[V1 Legacy Engine]
+    end
+    
+    subgraph "OpenSearch Core"
+        PIT[Point in Time]
+        SEARCH[Search API]
+    end
+    
+    REQ --> API
+    CURSOR --> API
+    API --> VALID
+    VALID -->|Supported| V2
+    VALID -->|Unsupported params| V1
+    V2 --> PIT
+    PIT --> SEARCH
+    V1 --> SEARCH
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Initial Query with fetch_size] --> B{Validate Request}
+    B -->|Valid| C[Create PIT Context]
+    B -->|Invalid| D[Return Error]
+    C --> E[Execute Search]
+    E --> F{More Results?}
+    F -->|Yes| G[Return Results + Cursor]
+    F -->|No| H[Return Results Only]
+    G --> I[Client sends Cursor]
+    I --> J[Resume from PIT]
+    J --> E
+    H --> K[Auto-close PIT]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SQLQueryRequest` | Validates request parameters and determines engine routing |
+| `PrettyFormatRestExecutor` | Handles response formatting and cursor generation |
+| `OpenSearchRequestBuilder` | Builds search requests with PIT support |
+| `ElasticJoinExecutor` | Handles join queries with proper error handling |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.sql.pagination.api` | Enable/disable pagination API | `true` |
+| `plugins.sql.pagination.api.search_after` | Use PIT-based pagination (vs scroll) | `true` |
+
+### Supported Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `fetch_size` | Integer | Number of results per page (default: 1000, 0 = no pagination) |
+| `format` | String | Response format: `jdbc`, `csv`, `raw`, `json` |
+| `pretty` | Boolean | Pretty-print JSON response |
+
+### Usage Example
+
+```bash
+# Initial paginated query
+POST _plugins/_sql
+{
+  "query": "SELECT firstname, lastname FROM accounts WHERE age > 20 ORDER BY state ASC",
+  "fetch_size": 5
+}
+
+# Response with cursor
+{
+  "schema": [
+    {"name": "firstname", "type": "text"},
+    {"name": "lastname", "type": "text"}
+  ],
+  "cursor": "d:eyJhIjp7fSwicyI6IkRYRjFaWEo1UVc1a1JtVjBZMmdCQUFBQUFBQUFBQU1...",
+  "total": 956,
+  "datarows": [["Cherry", "Carey"], ...],
+  "size": 5,
+  "status": 200
+}
+
+# Fetch next page using cursor
+POST _plugins/_sql
+{
+  "cursor": "d:eyJhIjp7fSwicyI6IkRYRjFaWEo1UVc1a1JtVjBZMmdCQUFBQUFBQUFBQU1..."
+}
+
+# Close cursor explicitly (optional - auto-closes on last page)
+POST _plugins/_sql/close
+{
+  "cursor": "d:eyJhIjp7fSwicyI6IkRYRjFaWEo1UVc1a1JtVjBZMmdCQUFBQUFBQUFBQU1..."
+}
+```
+
+## Limitations
+
+- Pagination only supports basic queries
+- Not supported with aggregations, nested queries, or complex joins
+- Only works with `jdbc` response format
+- `fetch_size` of 0 disables pagination
+- Cursor context has a timeout (configurable via PIT settings)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#3106](https://github.com/opensearch-project/sql/pull/3106) | Fix: SQL pagination with `pretty` parameter |
+| v2.18.0 | [#3108](https://github.com/opensearch-project/sql/pull/3108) | Fix: PIT refactor minor issues |
+| v2.18.0 | [#2759](https://github.com/opensearch-project/sql/pull/2759) | Original: Pretty parameter support |
+| v2.18.0 | [#3045](https://github.com/opensearch-project/sql/pull/3045) | Original: PIT refactor bug fixes |
+
+## References
+
+- [Issue #2460](https://github.com/opensearch-project/sql/issues/2460): SQL pagination doesn't work in Dev tools
+- [SQL and PPL API Documentation](https://docs.opensearch.org/2.18/search-plugins/sql/sql-ppl-api/): Official API documentation
+- [Point in Time Documentation](https://docs.opensearch.org/2.18/search-plugins/searching-data/point-in-time/): PIT in SQL
+- [Pagination Limitations](https://docs.opensearch.org/2.18/search-plugins/sql/limitation/): SQL pagination limitations
+
+## Change History
+
+- **v2.18.0** (2024-10-29): Fixed pagination with `pretty` parameter; Fixed PIT refactor issues (join query NPE, incorrect cursor generation)

--- a/docs/releases/v2.18.0/features/sql/sql-pagination.md
+++ b/docs/releases/v2.18.0/features/sql/sql-pagination.md
@@ -1,0 +1,113 @@
+# SQL Pagination Bug Fixes
+
+## Summary
+
+This release fixes two bugs related to SQL pagination functionality. The first fix allows SQL pagination to work correctly with the `pretty` URL parameter, which is commonly used in OpenSearch Dashboards Dev Tools. The second fix addresses several minor issues with the SQL PIT (Point in Time) refactor, including NullPointerException errors in join queries and incorrect cursor generation.
+
+## Details
+
+### What's New in v2.18.0
+
+Two bug fixes improve the reliability of SQL pagination:
+
+1. **Pretty Parameter Support**: SQL pagination now works correctly when the `pretty` URL parameter is included in requests, fixing a regression that broke pagination in Dev Tools.
+
+2. **PIT Refactor Bug Fixes**: Several issues discovered during E2E testing of the SQL PIT refactor have been resolved.
+
+### Technical Changes
+
+#### Bug Fix 1: Pretty Parameter Support (PR #2759)
+
+The V2 pagination implementation previously restricted URL parameters, causing requests with the `pretty` parameter to fall back to the V1 engine. This resulted in cursor encoding mismatches and NullPointerException errors.
+
+**Root Cause**: The `isSupported()` method in `SQLQueryRequest.java` only allowed the `format` parameter, rejecting requests with `pretty`.
+
+**Fix**: Updated the parameter validation to accept both `format` and `pretty` as supported parameters:
+
+```java
+// Before: Only format was supported
+var noUnsupportedParams = params.isEmpty() || 
+    (params.size() == 1 && params.containsKey(QUERY_PARAMS_FORMAT));
+
+// After: Both format and pretty are supported
+Predicate<String> supportedParams = Set.of(QUERY_PARAMS_FORMAT, QUERY_PARAMS_PRETTY)::contains;
+boolean hasUnsupportedParams = (!params.isEmpty()) && 
+    params.keySet().stream().dropWhile(supportedParams).findAny().isPresent();
+```
+
+#### Bug Fix 2: PIT Refactor Issues (PR #3045)
+
+| Issue | Description | Fix |
+|-------|-------------|-----|
+| Join query NPE | Join queries failing with NullPointerException when internal errors occur | Added proper exception handling with meaningful error message |
+| Incorrect cursor | Cursor returned when not needed (e.g., `SELECT a.* FROM index a`) | Fixed `isDefaultCursor()` to check `fetchSize != 0` before generating cursor |
+| Invalid size parameter | Using `size` instead of `fetch_size` generated unusable cursor | Fixed cursor generation logic to only create cursor when `fetch_size` is properly specified |
+
+**Key Code Change in `PrettyFormatRestExecutor.java`**:
+
+```java
+protected boolean isDefaultCursor(SearchResponse searchResponse, DefaultQueryAction queryAction) {
+    if (LocalClusterState.state().getSettingValue(SQL_PAGINATION_API_SEARCH_AFTER)) {
+        // Fixed: Check fetchSize is not 0 before generating cursor
+        return queryAction.getSqlRequest().fetchSize() != 0
+            && Objects.requireNonNull(searchResponse.getHits().getTotalHits()).value
+                >= queryAction.getSqlRequest().fetchSize();
+    } else {
+        return !Strings.isNullOrEmpty(searchResponse.getScrollId());
+    }
+}
+```
+
+### Usage Example
+
+SQL pagination now works correctly in Dev Tools with the `pretty` parameter:
+
+```bash
+# Initial query with fetch_size
+POST _plugins/_sql?pretty
+{
+  "query": "SELECT * FROM accounts",
+  "fetch_size": 5
+}
+
+# Response includes cursor for pagination
+{
+  "schema": [...],
+  "cursor": "n:1f8b08000000000000ff...",
+  "total": 100,
+  "datarows": [...],
+  "size": 5,
+  "status": 200
+}
+
+# Subsequent request with cursor (pretty parameter now works)
+POST _plugins/_sql?pretty
+{
+  "cursor": "n:1f8b08000000000000ff..."
+}
+```
+
+## Limitations
+
+- Pagination only supports basic queries (no aggregations, nested queries, etc.)
+- The `fetch_size` parameter is only supported for the `jdbc` response format
+- A value of 0 for `fetch_size` falls back to non-paginated response
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3106](https://github.com/opensearch-project/sql/pull/3106) | Backport: SQL pagination should work with the `pretty` parameter |
+| [#3108](https://github.com/opensearch-project/sql/pull/3108) | Backport: Bug Fixes for minor issues with SQL PIT refactor |
+| [#2759](https://github.com/opensearch-project/sql/pull/2759) | Original: SQL pagination should work with the `pretty` parameter |
+| [#3045](https://github.com/opensearch-project/sql/pull/3045) | Original: Bug Fixes for minor issues with SQL PIT refactor |
+
+## References
+
+- [Issue #2460](https://github.com/opensearch-project/sql/issues/2460): SQL pagination doesn't work in Dev tools
+- [SQL and PPL API Documentation](https://docs.opensearch.org/2.18/search-plugins/sql/sql-ppl-api/): Official API documentation
+- [Point in Time Documentation](https://docs.opensearch.org/2.18/search-plugins/searching-data/point-in-time/): PIT in SQL
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/sql/sql-pagination.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -98,6 +98,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### SQL
 
+- [SQL Pagination](features/sql/sql-pagination.md) - Bug fixes for SQL pagination with `pretty` parameter and PIT refactor issues
 - [SQL Plugin Maintenance](features/sql/sql-plugin-maintenance.md) - Security fix for CVE-2024-47554 (commons-io upgrade to 2.14.0) and test fixes for 2.18 branch
 - [SQL Scheduler](features/sql/sql-scheduler.md) - Bugfix to remove scheduler index from SystemIndexDescriptor to prevent conflicts with Job Scheduler plugin
 


### PR DESCRIPTION
## Summary

This PR adds documentation for SQL Pagination bug fixes in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/sql/sql-pagination.md`
- Feature report: `docs/features/sql/sql-pagination.md`

### Key Changes in v2.18.0
- Fixed SQL pagination to work with the `pretty` URL parameter (commonly used in Dev Tools)
- Fixed PIT refactor issues including:
  - NullPointerException in join queries
  - Incorrect cursor generation when `fetchSize` is 0
  - Invalid cursor with unsupported `size` parameter

### Related PRs
- [#3106](https://github.com/opensearch-project/sql/pull/3106): Backport - SQL pagination with `pretty` parameter
- [#3108](https://github.com/opensearch-project/sql/pull/3108): Backport - PIT refactor bug fixes
- [#2759](https://github.com/opensearch-project/sql/pull/2759): Original - Pretty parameter support
- [#3045](https://github.com/opensearch-project/sql/pull/3045): Original - PIT refactor bug fixes

Closes #602