### PR TITLE
docs: add SQL Query Fixes report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -157,6 +157,7 @@
 - [Security Lake Data Source](sql/security-lake-data-source.md)
 - [SQL Pagination](sql/sql-pagination.md)
 - [SQL Plugin Maintenance](sql/sql-plugin-maintenance.md)
+- [SQL Query Fixes](sql/sql-query-fixes.md)
 - [SQL/PPL Engine](sql/sql-ppl-engine.md)
 - [SQL/PPL Breaking Changes](sql/sql-ppl-breaking-changes.md)
 

--- a/docs/features/sql/sql-query-fixes.md
+++ b/docs/features/sql/sql-query-fixes.md
@@ -1,0 +1,142 @@
+# SQL Query Fixes
+
+## Summary
+
+This feature documents bug fixes for the OpenSearch SQL plugin that improve query reliability. Key fixes include resolving alias issues in legacy SQL queries with filters and correcting overly permissive regular expression patterns in the Grok compiler.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "SQL Query Processing"
+        A[SQL Query] --> B[SQL Parser]
+        B --> C{Query Type}
+        C -->|Legacy SQL| D[Legacy Engine]
+        C -->|New SQL| E[New Engine]
+    end
+    
+    subgraph "Legacy SQL with Alias Fix"
+        D --> F[SelectResultSet]
+        F --> G[loadFromEsState]
+        G --> H{Is Alias?}
+        H -->|Yes| I[GetAliasesRequest]
+        I --> J[Resolve to Index]
+        J --> K[Load Field Mappings]
+        H -->|No| K
+    end
+    
+    subgraph "Grok Pattern Matching"
+        L[Grok Pattern] --> M[GrokCompiler]
+        M --> N[Pattern Validation]
+        N --> O[Character Class Check]
+        O --> P[Compile Pattern]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SelectResultSet` | Handles result set formatting for legacy SQL queries |
+| `GrokCompiler` | Compiles Grok patterns for log parsing |
+| `GrokUtils` | Utility functions for Grok pattern processing |
+
+### Bug Fixes
+
+#### 1. Alias Resolution in Legacy SQL
+
+When using legacy SQL queries with index aliases and filters, the query would fail because the alias name was used directly for field mapping lookups instead of the actual index name.
+
+**Before (Error)**:
+```json
+{
+  "error": {
+    "reason": "There was internal problem at backend",
+    "details": "Index type [my-alias] does not exist",
+    "type": "IllegalArgumentException"
+  },
+  "status": 500
+}
+```
+
+**After (Success)**:
+```json
+{
+  "schema": [
+    { "name": "field1", "type": "text" },
+    { "name": "field2", "type": "keyword" }
+  ],
+  "total": 1,
+  "datarows": [["value1", "value2"]],
+  "size": 1,
+  "status": 200
+}
+```
+
+#### 2. Regex Character Range Fix
+
+The regular expression `[A-z]` was corrected to `[a-zA-Z_]` to prevent matching unintended special characters (`[ \ ] ^ _ \``).
+
+### Usage Example
+
+```bash
+# Create index with data
+PUT /products
+{
+  "mappings": {
+    "properties": {
+      "name": { "type": "text" },
+      "category": { "type": "keyword" },
+      "price": { "type": "float" }
+    }
+  }
+}
+
+# Create alias
+POST /_aliases
+{
+  "actions": [
+    { "add": { "index": "products", "alias": "product-alias" } }
+  ]
+}
+
+# Query using alias with filter (works after fix)
+POST /_plugins/_sql
+{
+  "query": "SELECT * FROM product-alias",
+  "fetch_size": 10,
+  "filter": {
+    "term": {
+      "category": "electronics"
+    }
+  }
+}
+```
+
+## Limitations
+
+- Alias resolution fix applies only to legacy SQL engine queries
+- When an alias points to multiple indices, the first index is used for field mapping resolution
+- The regex fix affects Grok pattern compilation; existing patterns using `[A-z]` may need review
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#3109](https://github.com/opensearch-project/sql/pull/3109) | Backport: Resolve Alias Issues in Legacy SQL with Filters |
+| v2.18.0 | [#3107](https://github.com/opensearch-project/sql/pull/3107) | Backport: Correct regular expression range |
+| main | [#2960](https://github.com/opensearch-project/sql/pull/2960) | Original: Resolve Alias Issues in Legacy SQL with Filters |
+| main | [#2836](https://github.com/opensearch-project/sql/pull/2836) | Original: Correct regular expression range |
+
+## References
+
+- [Issue #2912](https://github.com/opensearch-project/sql/issues/2912): Pagination of index aliases is not supported - Re-opened
+- [Issue #1398](https://github.com/opensearch-project/sql/issues/1398): Original alias pagination bug report
+- [SQL Documentation](https://docs.opensearch.org/2.18/search-plugins/sql/sql/index/): OpenSearch SQL plugin documentation
+- [SQL and PPL API](https://docs.opensearch.org/2.18/search-plugins/sql/sql-ppl-api/): SQL API reference
+
+## Change History
+
+- **v2.18.0** (2024-10-29): Fixed alias resolution in legacy SQL with filters, corrected regex character range in Grok compiler

--- a/docs/releases/v2.18.0/features/sql/sql-query-fixes.md
+++ b/docs/releases/v2.18.0/features/sql/sql-query-fixes.md
@@ -1,0 +1,109 @@
+# SQL Query Fixes
+
+## Summary
+
+This release includes two bug fixes for the SQL plugin: resolving alias issues in legacy SQL queries with filters, and correcting an overly permissive regular expression range in the Grok pattern compiler.
+
+## Details
+
+### What's New in v2.18.0
+
+Two critical bug fixes improve SQL query reliability:
+
+1. **Alias Resolution with Filters**: Legacy SQL queries using index aliases with filters now work correctly
+2. **Regex Range Correction**: Fixed overly permissive character range `[A-z]` in Grok pattern matching
+
+### Technical Changes
+
+#### Fix 1: Alias Issues in Legacy SQL with Filters
+
+**Problem**: When executing legacy SQL queries against an index alias with a filter parameter, the query failed with "Index type [alias-name] does not exist" error.
+
+**Root Cause**: The `SelectResultSet.loadFromEsState()` method used the alias name directly for field mapping lookups, but OpenSearch requires the actual index name.
+
+**Solution**: Added alias-to-index resolution using `GetAliasesRequest` before loading field mappings.
+
+```java
+// Before: Used alias name directly
+String indexName = fetchIndexName(query);
+
+// After: Resolve alias to actual index name
+GetAliasesResponse getAliasesResponse =
+    client.admin().indices().getAliases(new GetAliasesRequest(indexName)).actionGet();
+if (getAliasesResponse != null && !getAliasesResponse.getAliases().isEmpty()) {
+    indexName = getAliasesResponse.getAliases().keySet().iterator().next();
+}
+```
+
+**Affected File**: `legacy/src/main/java/org/opensearch/sql/legacy/executor/format/SelectResultSet.java`
+
+#### Fix 2: Regular Expression Range Correction
+
+**Problem**: The regex pattern `[A-z]` in Grok compiler matched unintended characters: `[ \ ] ^ _ \``
+
+**Root Cause**: In ASCII, characters between 'Z' (90) and 'a' (97) include special characters that were inadvertently matched.
+
+**Solution**: Changed `[A-z]` to `[a-zA-Z_]` for explicit character class definition.
+
+```java
+// Before: Overly permissive range
+private static final Pattern patternLinePattern = Pattern.compile("^([A-z0-9_]+)\\s+(.*)$");
+
+// After: Explicit character classes
+private static final Pattern patternLinePattern = Pattern.compile("^([a-zA-Z0-9_]+)\\s+(.*)$");
+```
+
+**Affected Files**:
+- `common/src/main/java/org/opensearch/sql/common/grok/GrokCompiler.java`
+- `common/src/main/java/org/opensearch/sql/common/grok/GrokUtils.java`
+
+### Usage Example
+
+After the fix, alias queries with filters work correctly:
+
+```bash
+# Create an index and alias
+PUT /my-index
+POST /_aliases
+{
+  "actions": [
+    { "add": { "index": "my-index", "alias": "my-alias" } }
+  ]
+}
+
+# Query using alias with filter - now works in v2.18.0
+POST /_plugins/_sql
+{
+  "query": "SELECT * FROM my-alias",
+  "fetch_size": 10,
+  "filter": {
+    "term": {
+      "field_name": "value"
+    }
+  }
+}
+```
+
+## Limitations
+
+- The alias resolution fix applies only to legacy SQL queries (not the new SQL engine)
+- When an alias points to multiple indices, the first index in the response is used for field mapping resolution
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3109](https://github.com/opensearch-project/sql/pull/3109) | Backport: Resolve Alias Issues in Legacy SQL with Filters |
+| [#3107](https://github.com/opensearch-project/sql/pull/3107) | Backport: Correct regular expression range |
+| [#2960](https://github.com/opensearch-project/sql/pull/2960) | Original: Resolve Alias Issues in Legacy SQL with Filters |
+| [#2836](https://github.com/opensearch-project/sql/pull/2836) | Original: Correct regular expression range |
+
+## References
+
+- [Issue #2912](https://github.com/opensearch-project/sql/issues/2912): Pagination of index aliases is not supported - Re-opened
+- [Issue #1398](https://github.com/opensearch-project/sql/issues/1398): Original alias pagination bug report
+- [SQL Documentation](https://docs.opensearch.org/2.18/search-plugins/sql/sql/index/): OpenSearch SQL plugin documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/sql/sql-query-fixes.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -100,6 +100,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 - [SQL Pagination](features/sql/sql-pagination.md) - Bug fixes for SQL pagination with `pretty` parameter and PIT refactor issues
 - [SQL Plugin Maintenance](features/sql/sql-plugin-maintenance.md) - Security fix for CVE-2024-47554 (commons-io upgrade to 2.14.0) and test fixes for 2.18 branch
+- [SQL Query Fixes](features/sql/sql-query-fixes.md) - Fix alias resolution in legacy SQL with filters, correct regex character range in Grok compiler
 - [SQL Scheduler](features/sql/sql-scheduler.md) - Bugfix to remove scheduler index from SystemIndexDescriptor to prevent conflicts with Job Scheduler plugin
 
 ### k-NN


### PR DESCRIPTION
## Summary

Add documentation for SQL Query Fixes in v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/sql/sql-query-fixes.md`
- Feature report: `docs/features/sql/sql-query-fixes.md`

### Key Changes in v2.18.0
- Fixed alias resolution in legacy SQL queries with filters (PR #3109, #2960)
- Corrected overly permissive regex character range `[A-z]` to `[a-zA-Z_]` in Grok compiler (PR #3107, #2836)

### Resources Used
- PR: #3109, #3107, #2960, #2836
- Issue: #2912, #1398
- Docs: https://docs.opensearch.org/2.18/search-plugins/sql/sql/index/

Closes #601