### PR TITLE
docs: add SQL error handling report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -155,6 +155,7 @@
 - [Flint Index Operations](sql/flint-index-operations.md)
 - [Flint Query Scheduler](sql/flint-query-scheduler.md)
 - [Security Lake Data Source](sql/security-lake-data-source.md)
+- [SQL Error Handling](sql/sql-error-handling.md)
 - [SQL Pagination](sql/sql-pagination.md)
 - [SQL Plugin Maintenance](sql/sql-plugin-maintenance.md)
 - [SQL Query Fixes](sql/sql-query-fixes.md)

--- a/docs/features/sql/sql-error-handling.md
+++ b/docs/features/sql/sql-error-handling.md
@@ -1,0 +1,127 @@
+# SQL Error Handling
+
+## Summary
+
+The OpenSearch SQL plugin provides error handling mechanisms to return meaningful error messages and appropriate HTTP status codes when queries fail. This includes handling malformed cursors, invalid query syntax, and edge cases in query parsing.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "SQL Plugin Error Handling"
+        Request[SQL Request] --> Parser[Query Parser]
+        Parser --> Validator[Expression Validator]
+        Validator --> Executor[Query Executor]
+        
+        Parser -->|Parse Error| ErrorHandler[Error Handler]
+        Validator -->|Validation Error| ErrorHandler
+        Executor -->|Execution Error| ErrorHandler
+        
+        ErrorHandler --> ErrorFactory[ErrorMessageFactory]
+        ErrorFactory --> Response[HTTP Response]
+    end
+    
+    subgraph "Error Categories"
+        ClientError[Client Errors - 400]
+        ServerError[Server Errors - 500]
+    end
+    
+    ErrorHandler --> ClientError
+    ErrorHandler --> ServerError
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `CursorResultExecutor` | Handles pagination cursor parsing and validation |
+| `OpenSearchActionFactory` | Validates SQL expression types before execution |
+| `TermFieldRewriter` | Validates table aliases and index mappings |
+| `ErrorMessageFactory` | Creates standardized error response messages |
+
+### Error Types
+
+| Error Type | HTTP Status | Description |
+|------------|-------------|-------------|
+| `SqlParseException` | 400 | Invalid SQL syntax |
+| `IllegalArgumentException` | 400 | Malformed cursor or invalid arguments |
+| `IndexNotFoundException` | 404 | Referenced index does not exist |
+| `OpenSearchException` | 4xx/5xx | OpenSearch cluster errors |
+
+### Error Response Format
+
+```json
+{
+  "error": {
+    "type": "ExceptionType",
+    "reason": "Human-readable error message"
+  },
+  "status": 400
+}
+```
+
+### Usage Example
+
+Valid cursor pagination:
+```bash
+# Initial query with pagination
+POST /_plugins/_sql
+{
+  "query": "SELECT * FROM my_index",
+  "fetch_size": 10
+}
+
+# Response includes cursor
+{
+  "cursor": "d:eyJhIjp7fSwiYyI6...",
+  "datarows": [...],
+  ...
+}
+
+# Continue with cursor
+POST /_plugins/_sql
+{
+  "cursor": "d:eyJhIjp7fSwiYyI6..."
+}
+```
+
+Malformed cursor error:
+```bash
+POST /_plugins/_sql
+{
+  "cursor": "invalid_cursor_string"
+}
+
+# Response
+{
+  "error": {
+    "type": "IllegalArgumentException",
+    "reason": "Malformed cursor: unable to extract cursor information"
+  },
+  "status": 400
+}
+```
+
+## Limitations
+
+- Error messages are in English only
+- Some complex query failures may produce generic error messages
+- Wildcard indices are not permitted in SQL subqueries
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#3066](https://github.com/opensearch-project/sql/pull/3066) | Improve error handling for malformed query cursors |
+| v2.18.0 | [#3080](https://github.com/opensearch-project/sql/pull/3080) | Improve error handling for some more edge cases |
+
+## References
+
+- [SQL and PPL API Documentation](https://docs.opensearch.org/latest/search-plugins/sql/sql-ppl-api/)
+- [SQL Plugin Documentation](https://docs.opensearch.org/latest/search-plugins/sql/index/)
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Improved error handling for malformed cursors and edge cases in query parsing

--- a/docs/releases/v2.18.0/features/sql/sql-error-handling.md
+++ b/docs/releases/v2.18.0/features/sql/sql-error-handling.md
@@ -1,0 +1,100 @@
+# SQL Error Handling
+
+## Summary
+
+OpenSearch 2.18.0 improves error handling in the SQL plugin for malformed queries and cursors. Previously, certain invalid inputs would return HTTP 500 errors with raw exception messages. This release ensures proper HTTP 400 responses with clear, user-friendly error messages.
+
+## Details
+
+### What's New in v2.18.0
+
+Two categories of error handling improvements were introduced:
+
+1. **Malformed cursor handling**: Invalid pagination cursors now return HTTP 400 with a clear "Malformed cursor" message instead of HTTP 500 with stack traces.
+
+2. **Malformed query handling**: Several edge cases in query parsing now return proper error responses:
+   - JOIN queries with invalid ON conditions
+   - Subqueries with wildcard indices
+   - Non-query SQL expressions
+
+### Technical Changes
+
+#### Components Modified
+
+| Component | Description |
+|-----------|-------------|
+| `CursorResultExecutor` | Enhanced error handling for cursor parsing failures |
+| `OpenSearchActionFactory` | Added validation for SQL expression types |
+| `TermFieldRewriter` | Added null checks for table aliases and index mappings |
+
+#### Error Response Format
+
+Before v2.18.0:
+```json
+{
+  "error": {
+    "type": "IllegalArgumentException",
+    "reason": "java.lang.IllegalArgumentException: ..."
+  },
+  "status": 500
+}
+```
+
+After v2.18.0:
+```json
+{
+  "error": {
+    "type": "IllegalArgumentException",
+    "reason": "Malformed cursor: unable to extract cursor information"
+  },
+  "status": 400
+}
+```
+
+### Usage Example
+
+Malformed cursor request:
+```bash
+POST /_plugins/_sql
+{
+  "cursor": "d:a11b4db33f"
+}
+```
+
+Response (v2.18.0+):
+```json
+{
+  "error": {
+    "type": "IllegalArgumentException",
+    "reason": "Malformed cursor: unable to extract cursor information"
+  },
+  "status": 400
+}
+```
+
+### Migration Notes
+
+No migration required. These are backward-compatible improvements to error responses. Applications that rely on specific error status codes should update their error handling to expect HTTP 400 for client errors instead of HTTP 500.
+
+## Limitations
+
+- Error messages are in English only
+- Some complex malformed queries may still produce less descriptive error messages
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3066](https://github.com/opensearch-project/sql/pull/3066) | Improve error handling for malformed query cursors |
+| [#3080](https://github.com/opensearch-project/sql/pull/3080) | Improve error handling for some more edge cases |
+| [#3084](https://github.com/opensearch-project/sql/pull/3084) | Backport #3066 to 2.x |
+| [#3112](https://github.com/opensearch-project/sql/pull/3112) | Backport #3080 to 2.18 |
+
+## References
+
+- [SQL and PPL API Documentation](https://docs.opensearch.org/2.18/search-plugins/sql/sql-ppl-api/)
+- [SQL Plugin Documentation](https://docs.opensearch.org/2.18/search-plugins/sql/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/sql/sql-error-handling.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -98,6 +98,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### SQL
 
+- [SQL Error Handling](features/sql/sql-error-handling.md) - Improved error handling for malformed cursors and edge cases in query parsing
 - [SQL Pagination](features/sql/sql-pagination.md) - Bug fixes for SQL pagination with `pretty` parameter and PIT refactor issues
 - [SQL Plugin Maintenance](features/sql/sql-plugin-maintenance.md) - Security fix for CVE-2024-47554 (commons-io upgrade to 2.14.0) and test fixes for 2.18 branch
 - [SQL Query Fixes](features/sql/sql-query-fixes.md) - Fix alias resolution in legacy SQL with filters, correct regex character range in Grok compiler


### PR DESCRIPTION
## Summary

This PR adds documentation for SQL error handling improvements in OpenSearch v2.18.0.

### Changes in v2.18.0

- **Malformed cursor handling**: Invalid pagination cursors now return HTTP 400 with a clear "Malformed cursor" message instead of HTTP 500 with stack traces
- **Malformed query handling**: Several edge cases in query parsing now return proper error responses (JOIN with invalid ON, subqueries with wildcards, non-query expressions)

### Reports Created

- Release report: `docs/releases/v2.18.0/features/sql/sql-error-handling.md`
- Feature report: `docs/features/sql/sql-error-handling.md`

### Related PRs

- [opensearch-project/sql#3066](https://github.com/opensearch-project/sql/pull/3066): Improve error handling for malformed query cursors
- [opensearch-project/sql#3080](https://github.com/opensearch-project/sql/pull/3080): Improve error handling for some more edge cases

Closes #600