### PR TITLE
docs: add k-NN documentation report for v2.18.0

### DIFF
--- a/docs/features/k-nn/k-nn-query-rescore.md
+++ b/docs/features/k-nn/k-nn-query-rescore.md
@@ -150,6 +150,7 @@ GET my-knn-index/_search
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.18.0 | [#2190](https://github.com/opensearch-project/k-NN/pull/2190) | JavaDoc cleanup for RescoreContext |
 | v2.17.0 | [#1984](https://github.com/opensearch-project/k-NN/pull/1984) | k-NN query rescore support for native engines |
 
 ## References
@@ -160,4 +161,5 @@ GET my-knn-index/_search
 
 ## Change History
 
+- **v2.18.0** (2024-10-22): JavaDoc cleanup for RescoreContext class
 - **v2.17.0** (2024-09-17): Initial implementation of k-NN query rescore support for native engines

--- a/docs/releases/v2.18.0/features/k-nn/k-nn-documentation.md
+++ b/docs/releases/v2.18.0/features/k-nn/k-nn-documentation.md
@@ -1,0 +1,66 @@
+# k-NN Documentation
+
+## Summary
+
+This release includes a JavaDoc cleanup fix for the k-NN plugin that removes redundant documentation comments from the `RescoreContext` class. The fix addresses a documentation issue that affected JavaDoc generation on Linux machines.
+
+## Details
+
+### What's New in v2.18.0
+
+The `userProvided` field in `RescoreContext.java` had excessive inline documentation that was redundant with the existing brief comment. This PR removes 24 lines of verbose documentation while preserving the essential explanation.
+
+### Technical Changes
+
+#### Code Cleanup
+
+The `RescoreContext` class is used for k-NN query rescoring operations. The `userProvided` flag tracks whether the oversample factor was explicitly set by the user or uses a default value.
+
+**Before (verbose):**
+```java
+/**
+ * Flag to track whether the oversample factor is user-provided or default. The Reason to introduce
+ * this is to set default when Shard Level rescoring is false,
+ * else we end up overriding user provided value in NativeEngineKnnVectorQuery
+ *
+ * This flag is crucial to differentiate between user-defined oversample factors...
+ * [24 additional lines of documentation]
+ */
+@Builder.Default
+private boolean userProvided = true;
+```
+
+**After (concise):**
+```java
+/**
+ * Flag to track whether the oversample factor is user-provided or default. The Reason to introduce
+ * this is to set default when Shard Level rescoring is false,
+ * else we end up overriding user provided value in NativeEngineKnnVectorQuery
+ */
+@Builder.Default
+private boolean userProvided = true;
+```
+
+### Impact
+
+- Cleaner JavaDoc generation on Linux machines
+- Reduced code verbosity without losing essential information
+- No functional changes to the k-NN plugin behavior
+
+## Limitations
+
+None. This is a documentation-only change with no impact on functionality.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2190](https://github.com/opensearch-project/k-NN/pull/2190) | Java Docs Fix For 2.x |
+
+## References
+
+- [PR #2190](https://github.com/opensearch-project/k-NN/pull/2190): Java Docs Fix for 2.x in Linux Machine
+
+## Related Feature Report
+
+- [k-NN Query Rescore](../../../features/k-nn/k-nn-query-rescore.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -106,6 +106,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### k-NN
 
+- [k-NN Documentation](features/k-nn/k-nn-documentation.md) - JavaDoc cleanup for RescoreContext class
 - [k-NN Maintenance](features/k-nn/k-nn-maintenance.md) - Lucene 9.12 codec compatibility, force merge performance optimization, benchmark folder removal, code refactoring
 
 ### ML Commons


### PR DESCRIPTION
## Summary

Adds release report for k-NN documentation fix in v2.18.0.

### Changes
- Created release report: `docs/releases/v2.18.0/features/k-nn/k-nn-documentation.md`
- Updated feature report: `docs/features/k-nn/k-nn-query-rescore.md` (added v2.18.0 change history)
- Updated release index: `docs/releases/v2.18.0/index.md`

### PR Investigated
- [opensearch-project/k-NN#2190](https://github.com/opensearch-project/k-NN/pull/2190): Java Docs Fix For 2.x

Closes #599