### PR TITLE
docs: add Security Analytics Data Source report for v2.18.0

### DIFF
--- a/docs/features/security-analytics-dashboards/security-analytics-dashboards-plugin.md
+++ b/docs/features/security-analytics-dashboards/security-analytics-dashboards-plugin.md
@@ -91,6 +91,11 @@ The plugin integrates with OpenSearch Dashboards and requires the Security Analy
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.18.0 | [#1186](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1186) | Avoid showing unhelpful error toast when datasource is not yet selected |
+| v2.18.0 | [#1188](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1188) | Update getting started cards content and visual design |
+| v2.18.0 | [#1192](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1192) | Fix data source picker remount multiple times |
+| v2.18.0 | [#1199](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1199) | Switch to default datasource instead of local cluster on initial loading |
+| v2.18.0 | [#1200](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1200) | Make data source default cluster for threat alerts card |
 | v2.17.0 | [#1100](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1100) | Update data source selection label and help text |
 | v2.17.0 | [#1124](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1124) | Add threat alerts card for Analytics (All) workspace |
 | v2.17.0 | [#1125](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1125) | Update URL with data source ID; redirect on reload |
@@ -105,13 +110,15 @@ The plugin integrates with OpenSearch Dashboards and requires the Security Analy
 
 ## References
 
-- [About Security Analytics](https://docs.opensearch.org/2.17/security-analytics/): Overview of Security Analytics
-- [Setting up Security Analytics](https://docs.opensearch.org/2.17/security-analytics/sec-analytics-config/index/): Configuration guide
-- [Using Security Analytics](https://docs.opensearch.org/2.17/security-analytics/usage/index/): Usage documentation
-- [OpenSearch Security for Security Analytics](https://docs.opensearch.org/2.17/security-analytics/security/): Security configuration
+- [About Security Analytics](https://docs.opensearch.org/2.18/security-analytics/): Overview of Security Analytics
+- [Setting up Security Analytics](https://docs.opensearch.org/2.18/security-analytics/sec-analytics-config/index/): Configuration guide
+- [Using Security Analytics](https://docs.opensearch.org/2.18/security-analytics/usage/index/): Usage documentation
+- [OpenSearch Security for Security Analytics](https://docs.opensearch.org/2.18/security-analytics/security/): Security configuration
+- [Configuring and using multiple data sources](https://docs.opensearch.org/2.18/dashboards/management/multi-data-sources/): Multi-data source configuration
 - [security-analytics-dashboards-plugin](https://github.com/opensearch-project/security-analytics-dashboards-plugin): GitHub repository
 
 ## Change History
 
+- **v2.18.0** (2024-11-12): Data source handling bug fixes including picker remount optimization, error toast suppression, default data source selection, threat alerts card default, and getting started cards visual redesign
 - **v2.17.0** (2024-09-17): UI enhancements including data source label updates, threat alerts card for Analytics workspace, URL data source ID handling, and comprehensive fit-and-finish styling updates
 - **v2.17.0** (2024-09-17): Multiple UI bugfixes including navigation, webpack errors, multi-data source support, and various UI/UX improvements

--- a/docs/releases/v2.18.0/features/security-analytics-dashboards/security-analytics-data-source.md
+++ b/docs/releases/v2.18.0/features/security-analytics-dashboards/security-analytics-data-source.md
@@ -1,0 +1,111 @@
+# Security Analytics Data Source
+
+## Summary
+
+This release includes multiple bug fixes for data source handling in the Security Analytics Dashboards plugin. The fixes address issues with data source picker remounting, error toast notifications, default data source selection, and getting started cards visual design.
+
+## Details
+
+### What's New in v2.18.0
+
+Five bug fixes improve the data source selection experience in Security Analytics:
+
+1. **Data Source Picker Remount Fix**: Prevents the DataSourceSelector component from remounting on every render by using `useMemo`
+2. **Error Toast Suppression**: Avoids showing unhelpful error toasts when a data source is not yet selected
+3. **Default Data Source Selection**: Switches to the default data source instead of local cluster on initial loading
+4. **Threat Alerts Card Default**: Uses the configured data source as default for the threat alerts card instead of local cluster
+5. **Getting Started Cards Update**: Updates content and visual design of getting started cards on the overview page
+
+### Technical Changes
+
+#### Data Source Picker Optimization
+
+The `DataSourceSelector` component was being recreated on every render, causing React to unmount and remount the element repeatedly. This was fixed by wrapping the component creation in `useMemo`:
+
+```typescript
+const DataSourceSelector = useMemo(() => {
+  if (getDataSourceMenu) {
+    return getDataSourceMenu();
+  }
+  return null;
+}, [getDataSourceMenu]);
+```
+
+#### Default Data Source Handling
+
+The default data source observable was changed from using `LocalCluster` to an empty object, allowing proper handling when local cluster is disabled:
+
+```typescript
+// Before: Local cluster as default
+const LocalCluster: DataSourceOption = { label: 'Local cluster', id: '' };
+export const dataSourceObservable = new BehaviorSubject<DataSourceOption>(LocalCluster);
+
+// After: Empty object to allow data source picker to determine correct default
+export const dataSourceObservable = new BehaviorSubject<DataSourceOption>({});
+```
+
+#### Error Handling Improvements
+
+Added logic to suppress "no living connections" errors that occur during initial data source selection:
+
+```typescript
+if (errorMessage.toLowerCase().includes('no living connections')) {
+  return;
+}
+```
+
+#### Threat Alerts Card Data Source
+
+Changed the threat alerts card to use undefined as initial state instead of hardcoded local cluster:
+
+```typescript
+// Before
+const [dataSource, setDataSource] = useState<DataSourceOption>({
+  label: 'Local cluster',
+  id: '',
+});
+
+// After
+const [dataSource, setDataSource] = useState<DataSourceOption>();
+```
+
+### Getting Started Cards Visual Update
+
+The overview page getting started cards were redesigned with:
+
+- Icon-based visual design using EuiIcon components
+- Simplified card structure with direct onClick handlers
+- Updated descriptions and footer text
+- New CSS class `usecaseOverviewGettingStartedCard` for styling
+
+| Card | Icon | Description |
+|------|------|-------------|
+| Get Started | rocket | Configure Security Analytics tools and components |
+| Discover | compass | Explore data to uncover and discover insights |
+| Threat Detection | pulse | Identify security threats with detection rules |
+| Threat Intelligence | radar | Scan log data for malicious actors |
+
+## Limitations
+
+- These fixes are specific to the Security Analytics Dashboards plugin
+- Requires proper data source configuration in OpenSearch Dashboards
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1186](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1186) | Avoid showing unhelpful error toast when datasource is not yet selected |
+| [#1188](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1188) | Fix: Update getting started cards content and visual design |
+| [#1192](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1192) | Fix: data source picker remount multiple times |
+| [#1199](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1199) | Bug fix to switch to default datasource instead of local cluster when initial loading |
+| [#1200](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1200) | Make data source default cluster for threat alerts card |
+
+## References
+
+- [About Security Analytics](https://docs.opensearch.org/2.18/security-analytics/): Overview of Security Analytics
+- [Configuring and using multiple data sources](https://docs.opensearch.org/2.18/dashboards/management/multi-data-sources/): Multi-data source configuration guide
+- [security-analytics-dashboards-plugin](https://github.com/opensearch-project/security-analytics-dashboards-plugin): GitHub repository
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security-analytics-dashboards/security-analytics-dashboards-plugin.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -128,6 +128,10 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 - [Security Analytics System Indices](features/security-analytics/security-analytics-system-indices.md) - Standardized system index settings (1 primary shard, 1-20 replicas), dedicated query indices option, correlation alert refresh policy fix
 
+### Security Analytics Dashboards
+
+- [Security Analytics Data Source](features/security-analytics-dashboards/security-analytics-data-source.md) - Data source handling bug fixes including picker remount optimization, error toast suppression, default data source selection, and getting started cards visual redesign
+
 ### Security
 
 - [Security Plugin Maintenance](features/security/security-plugin-maintenance.md) - Cache endpoint deprecation warning, securityadmin script undeprecation, ASN1 refactoring for FIPS, CVE-2024-47554 fix, BWC test fixes


### PR DESCRIPTION
## Summary

This PR adds documentation for Security Analytics Data Source bug fixes in v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/security-analytics-dashboards/security-analytics-data-source.md`
- Feature report updated: `docs/features/security-analytics-dashboards/security-analytics-dashboards-plugin.md`

### Key Changes in v2.18.0
- Data source picker remount optimization using `useMemo`
- Error toast suppression for unselected data sources
- Default data source selection instead of local cluster
- Threat alerts card default data source fix
- Getting started cards visual redesign

### Related PRs
- #1186: Avoid showing unhelpful error toast when datasource is not yet selected
- #1188: Update getting started cards content and visual design
- #1192: Fix data source picker remount multiple times
- #1199: Switch to default datasource instead of local cluster on initial loading
- #1200: Make data source default cluster for threat alerts card

Closes #598