### PR TITLE
docs: add Security Analytics Correlation bug fixes report for v2.18.0

### DIFF
--- a/docs/features/security-analytics/threat-intelligence.md
+++ b/docs/features/security-analytics/threat-intelligence.md
@@ -181,6 +181,9 @@ POST _plugins/_security_analytics/threat_intel/sources/
 |---------|-----|-------------|
 | v3.0.0 | [#1493](https://github.com/opensearch-project/security-analytics/pull/1493) | Custom format IOC upload support |
 | v3.0.0 | [#1455](https://github.com/opensearch-project/security-analytics/pull/1455) | Custom format implementation (2.x backport) |
+| v2.18.0 | [#1180](https://github.com/opensearch-project/security-analytics/pull/1180) | Backport of alias resolution and enum fixes |
+| v2.18.0 | [#1173](https://github.com/opensearch-project/security-analytics/pull/1173) | Fix alias resolution in threat intel monitor |
+| v2.18.0 | [#1178](https://github.com/opensearch-project/security-analytics/pull/1178) | Fix enum state query for REFRESHING state |
 | v2.17.0 | [#1207](https://github.com/opensearch-project/security-analytics/pull/1207) | User validation for threat intel transport layer |
 | v2.17.0 | [#1234](https://github.com/opensearch-project/security-analytics/pull/1234) | Make threat intel run with standard detectors |
 | v2.17.0 | [#1254](https://github.com/opensearch-project/security-analytics/pull/1254) | Event-driven lock release for source config |
@@ -200,5 +203,6 @@ POST _plugins/_security_analytics/threat_intel/sources/
 ## Change History
 
 - **v3.0.0** (2025-05-13): Added custom JSON format support with JSONPath schema, relaxed IOC type validation to support custom types
+- **v2.18.0** (2024-11-05): Bug fixes - threat intel monitors now correctly resolve index aliases to concrete indices; fixed REFRESHING state enum query
 - **v2.17.0** (2024-09-17): Bug fixes for security (user validation, context stashing), stability (multi-node race conditions, event-driven lock release), and integration with standard detectors
 - **v2.15.0**: Initial threat intelligence feature with S3, IOC_UPLOAD, and URL_DOWNLOAD source types

--- a/docs/releases/v2.18.0/features/security-analytics/security-analytics-correlation.md
+++ b/docs/releases/v2.18.0/features/security-analytics/security-analytics-correlation.md
@@ -1,0 +1,117 @@
+# Security Analytics Correlation Bug Fixes
+
+## Summary
+
+This release fixes two bugs in the Security Analytics threat intelligence monitor functionality:
+
+1. **Alias Resolution Fix**: Threat intel monitors now correctly work with index aliases by resolving them to concrete indices before scanning for IOCs
+2. **Enum State Query Fix**: Fixed a query issue where the REFRESHING state was incorrectly used as an enum instead of its string value
+
+## Details
+
+### What's New in v2.18.0
+
+These bug fixes address issues that prevented threat intelligence monitors from functioning correctly in certain scenarios.
+
+### Technical Changes
+
+#### Alias Resolution Fix (PR #1173)
+
+The threat intel monitor's `per_ioc_type_scan_input_list` field contains a map of index to fields. When users specify an alias as the index input, the monitor needs to resolve it to concrete indices during execution.
+
+**Problem**: When the monitor executed and processed documents from concrete indices, it couldn't find the field mappings because the mapping was stored under the alias name, not the concrete index name.
+
+**Solution**: Added a new mapping (`concreteIndexToMonitorInputIndicesMap`) that resolves monitor input indices (which may be aliases) to their concrete indices. This allows the IOC scan service to correctly look up field mappings.
+
+```mermaid
+flowchart TB
+    A[Monitor Input: alias1] --> B[IndexNameExpressionResolver]
+    B --> C[Concrete Index: index-001]
+    C --> D[Lookup Fields from alias1 mapping]
+    D --> E[Extract IOC values]
+    E --> F[Scan against IOC store]
+```
+
+**Changed Components**:
+
+| Component | Change |
+|-----------|--------|
+| `IocScanContext` | Added `concreteIndexToMonitorInputIndicesMap` field |
+| `IoCScanService` | Updated to use concrete-to-alias mapping for field lookup |
+| `TransportThreatIntelMonitorFanOutAction` | Injects `IndexNameExpressionResolver` and builds the mapping |
+| `IndexUtils` | Added `getConcreteindexToMonitorInputIndicesMap()` utility method |
+
+#### Enum State Query Fix (PR #1178)
+
+**Problem**: When querying for threat intel source configs in REFRESHING state, the code was using the enum directly instead of its string value, causing the match query to fail.
+
+**Solution**: Changed `REFRESHING` to `REFRESHING.toString()` in the query builder.
+
+```java
+// Before (incorrect)
+stateQueryBuilder.should(QueryBuilders.matchQuery(stateFieldName, REFRESHING));
+
+// After (correct)
+stateQueryBuilder.should(QueryBuilders.matchQuery(stateFieldName, REFRESHING.toString()));
+```
+
+### Usage Example
+
+Threat intel monitors now work correctly with aliases:
+
+```json
+POST _plugins/_security_analytics/threat_intel/monitors
+{
+    "name": "Threat intel monitor with alias",
+    "schedule": {
+        "period": {
+            "interval": 1,
+            "unit": "MINUTES"
+        }
+    },
+    "enabled": true,
+    "indices": [
+        "my-logs-alias"  // Now correctly resolves to concrete indices
+    ],
+    "per_ioc_type_scan_input_list": [
+        {
+            "ioc_type": "ipv4-addr",
+            "index_to_fields_map": {
+                "my-logs-alias": ["src_ip", "dst_ip"]
+            }
+        }
+    ],
+    "triggers": [
+        {
+            "data_sources": ["my-logs-alias"],
+            "name": "malicious-ip-trigger",
+            "severity": "high"
+        }
+    ]
+}
+```
+
+### Migration Notes
+
+No migration required. These are bug fixes that improve existing functionality.
+
+## Limitations
+
+- When a concrete index resolves to multiple monitor input indices (aliases), the system picks one of them to get the field mappings
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1180](https://github.com/opensearch-project/security-analytics/pull/1180) | Backport of #1173 and #1178 to 2.x |
+| [#1173](https://github.com/opensearch-project/security-analytics/pull/1173) | Fix alias resolution in threat intel monitor |
+| [#1178](https://github.com/opensearch-project/security-analytics/pull/1178) | Fix enum state query for REFRESHING state |
+
+## References
+
+- [Threat Intelligence Documentation](https://docs.opensearch.org/2.18/security-analytics/threat-intelligence/index/): Official docs
+- [Monitor API](https://docs.opensearch.org/2.18/security-analytics/threat-intelligence/api/monitor/): API reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security-analytics/threat-intelligence.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -127,6 +127,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### Security Analytics
 
 - [Security Analytics System Indices](features/security-analytics/security-analytics-system-indices.md) - Standardized system index settings (1 primary shard, 1-20 replicas), dedicated query indices option, correlation alert refresh policy fix
+- [Security Analytics Correlation](features/security-analytics/security-analytics-correlation.md) - Bug fixes for threat intel monitor alias resolution and REFRESHING state enum query
 
 ### Security Analytics Dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security Analytics Correlation bug fixes in v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/security-analytics/security-analytics-correlation.md`
- Feature report updated: `docs/features/security-analytics/threat-intelligence.md`

### Key Changes in v2.18.0

1. **Alias Resolution Fix (PR #1173)**: Threat intel monitors now correctly work with index aliases by resolving them to concrete indices before scanning for IOCs

2. **Enum State Query Fix (PR #1178)**: Fixed a query issue where the REFRESHING state was incorrectly used as an enum instead of its string value

### Related Issue
Closes #597