### PR TITLE
docs: add security-analytics-findings report for v2.18.0

### DIFF
--- a/docs/features/security-analytics-dashboards/security-analytics-dashboards-plugin.md
+++ b/docs/features/security-analytics-dashboards/security-analytics-dashboards-plugin.md
@@ -91,6 +91,7 @@ The plugin integrates with OpenSearch Dashboards and requires the Security Analy
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.18.0 | [#1160](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1160) | Fix findings page crash and rule severity correctness |
 | v2.18.0 | [#1186](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1186) | Avoid showing unhelpful error toast when datasource is not yet selected |
 | v2.18.0 | [#1188](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1188) | Update getting started cards content and visual design |
 | v2.18.0 | [#1192](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1192) | Fix data source picker remount multiple times |
@@ -119,6 +120,6 @@ The plugin integrates with OpenSearch Dashboards and requires the Security Analy
 
 ## Change History
 
-- **v2.18.0** (2024-11-12): Data source handling bug fixes including picker remount optimization, error toast suppression, default data source selection, threat alerts card default, and getting started cards visual redesign
+- **v2.18.0** (2024-11-12): Findings page stability fixes including crash prevention when custom rules are deleted and correct severity display for multi-rule findings; Data source handling bug fixes including picker remount optimization, error toast suppression, default data source selection, threat alerts card default, and getting started cards visual redesign
 - **v2.17.0** (2024-09-17): UI enhancements including data source label updates, threat alerts card for Analytics workspace, URL data source ID handling, and comprehensive fit-and-finish styling updates
 - **v2.17.0** (2024-09-17): Multiple UI bugfixes including navigation, webpack errors, multi-data source support, and various UI/UX improvements

--- a/docs/releases/v2.18.0/features/security-analytics-dashboards/security-analytics-findings.md
+++ b/docs/releases/v2.18.0/features/security-analytics-dashboards/security-analytics-findings.md
@@ -1,0 +1,81 @@
+# Security Analytics Findings Bugfixes
+
+## Summary
+
+This release fixes two critical bugs in the Security Analytics Findings page in OpenSearch Dashboards: a page crash when custom rules are deleted after generating findings, and incorrect rule severity display in the findings table.
+
+## Details
+
+### What's New in v2.18.0
+
+This bugfix release addresses stability and correctness issues in the Security Analytics Findings page:
+
+1. **Findings Page Crash Fix**: Prevents the findings page from crashing when a custom rule that generated a finding is subsequently deleted
+2. **Rule Severity Correctness**: Ensures the findings table always displays the highest severity rule when multiple rules match a finding
+3. **Correlations Findings Table Fix**: Corrects the correlations findings flyout to show the rule with the highest severity
+
+### Technical Changes
+
+#### Problem Analysis
+
+The findings page was experiencing crashes due to:
+- Missing null checks when accessing rule data for deleted custom rules
+- Incorrect severity prioritization when multiple rules matched a single finding
+
+#### Code Changes
+
+**Findings.tsx** - Main findings page component:
+- Added null-safe access to rule data with fallback to `DEFAULT_EMPTY_DATA`
+- Implemented proper rule matching across all queries in a finding
+- Added severity-based sorting using `RuleSeverityPriority` to display highest severity rule
+
+**constants.ts** - Rule severity constants:
+- Added `RuleSeverityValue` enum for type-safe severity values
+- Added `RuleSeverityPriority` mapping for severity comparison
+
+**CorrelationsStore.ts** - Correlations data store:
+- Updated to match rules by severity priority
+- Ensures correlated findings display the most severe matching rule
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `RuleSeverityValue` | Enum defining severity levels: Critical, High, Medium, Low, Informational |
+| `RuleSeverityPriority` | Priority mapping for severity comparison (1=Critical, 5=Informational) |
+
+### Usage Example
+
+The fix is transparent to users. The findings table now correctly shows:
+
+```
+Finding ID | Rule Name      | Severity
+-----------+----------------+----------
+abc123     | Critical Rule  | critical   <- Highest severity shown
+def456     | High Rule      | high
+```
+
+When a finding matches multiple rules, the highest severity rule is displayed.
+
+### Migration Notes
+
+No migration required. The fix is automatically applied when upgrading to v2.18.0.
+
+## Limitations
+
+- Threat intel rules are currently excluded from severity prioritization in the correlations findings table
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1160](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1160) | Fix findings page crash and rule severity correctness |
+
+## References
+
+- [PR #1160](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1160): Main implementation
+- [Working with findings](https://docs.opensearch.org/2.18/security-analytics/usage/findings/): Official documentation
+
+## Related Feature Report
+
+- [Security Analytics Dashboards Plugin](../../../features/security-analytics-dashboards/security-analytics-dashboards-plugin.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -132,6 +132,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### Security Analytics Dashboards
 
 - [Security Analytics Data Source](features/security-analytics-dashboards/security-analytics-data-source.md) - Data source handling bug fixes including picker remount optimization, error toast suppression, default data source selection, and getting started cards visual redesign
+- [Security Analytics Findings](features/security-analytics-dashboards/security-analytics-findings.md) - Fix findings page crash when custom rules are deleted and correct rule severity display for multi-rule findings
 
 ### Security
 


### PR DESCRIPTION
## Summary

Add release report for Security Analytics Findings bugfixes in v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/security-analytics-dashboards/security-analytics-findings.md`
- Feature report: Updated `docs/features/security-analytics-dashboards/security-analytics-dashboards-plugin.md`

### Key Changes in v2.18.0
- Fix findings page crash when custom rules are deleted after generating findings
- Fix rule severity display to show highest severity when multiple rules match a finding
- Fix correlations findings table to show rule with highest severity

### Resources Used
- PR: opensearch-project/security-analytics-dashboards-plugin#1160
- Docs: https://docs.opensearch.org/2.18/security-analytics/usage/findings/

Closes #596