### PR TITLE
docs: add threat intel bugfixes report for v2.18.0

### DIFF
--- a/docs/features/security-analytics/threat-intelligence.md
+++ b/docs/features/security-analytics/threat-intelligence.md
@@ -181,6 +181,10 @@ POST _plugins/_security_analytics/threat_intel/sources/
 |---------|-----|-------------|
 | v3.0.0 | [#1493](https://github.com/opensearch-project/security-analytics/pull/1493) | Custom format IOC upload support |
 | v3.0.0 | [#1455](https://github.com/opensearch-project/security-analytics/pull/1455) | Custom format implementation (2.x backport) |
+| v2.18.0 | [#1356](https://github.com/opensearch-project/security-analytics/pull/1356) | Fix notifications listener leak in threat intel monitor |
+| v2.18.0 | [#1317](https://github.com/opensearch-project/security-analytics/pull/1317) | Threat intel monitor bug fixes (empty index sort, grouped listener) |
+| v2.18.0 | [#1383](https://github.com/opensearch-project/security-analytics/pull/1383) | Fix search monitor query in update threat intel alert status API |
+| v2.18.0 | [#1393](https://github.com/opensearch-project/security-analytics/pull/1393) | Add validation for threat intel source config |
 | v2.18.0 | [#1180](https://github.com/opensearch-project/security-analytics/pull/1180) | Backport of alias resolution and enum fixes |
 | v2.18.0 | [#1173](https://github.com/opensearch-project/security-analytics/pull/1173) | Fix alias resolution in threat intel monitor |
 | v2.18.0 | [#1178](https://github.com/opensearch-project/security-analytics/pull/1178) | Fix enum state query for REFRESHING state |
@@ -195,6 +199,8 @@ POST _plugins/_security_analytics/threat_intel/sources/
 - [Issue #1421](https://github.com/opensearch-project/security-analytics/issues/1421): Custom JSON schema feature request
 - [Issue #1224](https://github.com/opensearch-project/security-analytics/issues/1224): Lock release issue
 - [Issue #1247](https://github.com/opensearch-project/security-analytics/issues/1247): Job mapping upgrade issue
+- [Issue #1319](https://github.com/opensearch-project/security-analytics/issues/1319): Threat intel monitor bug fixes tracking
+- [Issue #1366](https://github.com/opensearch-project/security-analytics/issues/1366): Source config validation issue
 - [Threat Intelligence Documentation](https://docs.opensearch.org/3.0/security-analytics/threat-intelligence/index/): Official documentation
 - [Source API](https://docs.opensearch.org/3.0/security-analytics/threat-intelligence/api/source/): API reference
 - [Monitor API](https://docs.opensearch.org/3.0/security-analytics/threat-intelligence/api/monitor/): Monitor API reference
@@ -203,6 +209,6 @@ POST _plugins/_security_analytics/threat_intel/sources/
 ## Change History
 
 - **v3.0.0** (2025-05-13): Added custom JSON format support with JSONPath schema, relaxed IOC type validation to support custom types
-- **v2.18.0** (2024-11-05): Bug fixes - threat intel monitors now correctly resolve index aliases to concrete indices; fixed REFRESHING state enum query
+- **v2.18.0** (2024-11-05): Bug fixes - notification listener leak fix, duplicate findings prevention, source config validation, improved error handling for partial failures
 - **v2.17.0** (2024-09-17): Bug fixes for security (user validation, context stashing), stability (multi-node race conditions, event-driven lock release), and integration with standard detectors
 - **v2.15.0**: Initial threat intelligence feature with S3, IOC_UPLOAD, and URL_DOWNLOAD source types

--- a/docs/releases/v2.18.0/features/security-analytics/threat-intel-bugfixes.md
+++ b/docs/releases/v2.18.0/features/security-analytics/threat-intel-bugfixes.md
@@ -1,0 +1,88 @@
+# Threat Intel Bug Fixes
+
+## Summary
+
+This release includes critical bug fixes for the Threat Intelligence feature in Security Analytics. The fixes address notification listener leaks, duplicate findings generation, and improved error handling in threat intel monitors. These improvements enhance the stability and reliability of threat intelligence monitoring.
+
+## Details
+
+### What's New in v2.18.0
+
+This release focuses on stability improvements for threat intel monitors:
+
+1. **Notification Listener Leak Fix**: Fixed a memory leak where notification listeners were not properly released after successful notification delivery
+2. **Duplicate Findings Prevention**: Monitor execution now marks as successful when findings are generated, even if alert creation or notification fails, preventing duplicate findings
+3. **Source Config Validation**: Added validation to prevent creation of source configs with missing required fields
+4. **Improved Error Handling**: Better handling of partial failures during monitor execution
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Monitor Execution Flow (Fixed)"
+        A[Threat Intel Monitor] --> B[Scan IOCs]
+        B --> C{Findings Generated?}
+        C -->|Yes| D[Create Findings]
+        D --> E{Alert Creation}
+        E -->|Success| F[Send Notification]
+        E -->|Failure| G[Mark Execution Success]
+        F -->|Success| H[Release Listener]
+        F -->|Failure| G
+        H --> I[Mark Execution Success]
+        G --> J[Prevent Duplicate Findings]
+        C -->|No| K[Continue Monitoring]
+    end
+```
+
+#### Bug Fixes
+
+| Issue | Fix | Impact |
+|-------|-----|--------|
+| Listener leak on notification success | Added `listener.onResponse(null)` call after successful notification | Prevents memory leaks in long-running monitors |
+| Duplicate findings on alert failure | Mark execution as succeeded when findings generated | Prevents repeated findings for same IOC matches |
+| Duplicate findings on notification failure | Mark execution as succeeded when alerts generated | Moves marker forward in monitor metadata |
+| Source config with null values | Added validation for required fields | Allows reading/deleting configs with null values |
+
+#### Changed Components
+
+| Component | Change |
+|-----------|--------|
+| `NotificationService` | Added listener callback on successful notification |
+| `IoCScanService` | Changed error handling to mark execution success on partial failures |
+| `SaIoCScanService` | Reordered alert save and notification send operations |
+| `BaseEntityCrudService` | Improved error logging and listener failure handling |
+| `SATIFSourceConfigDto` | Added validation for required fields (name, type, format, source, ioc_types) |
+
+### Usage Example
+
+No API changes are required. The fixes are internal improvements that automatically apply to existing threat intel monitors.
+
+### Migration Notes
+
+No migration required. Existing threat intel monitors will benefit from these fixes automatically after upgrading to v2.18.0.
+
+## Limitations
+
+- These fixes address stability issues but do not change the fundamental behavior of threat intel monitors
+- Source configs with null values created before this fix can still be read and deleted but cannot be updated
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1356](https://github.com/opensearch-project/security-analytics/pull/1356) | Fix notifications listener leak in threat intel monitor |
+| [#1317](https://github.com/opensearch-project/security-analytics/pull/1317) | Threat intel monitor bug fixes (empty index sort, grouped listener) |
+| [#1383](https://github.com/opensearch-project/security-analytics/pull/1383) | Fix search monitor query in update threat intel alert status API |
+| [#1393](https://github.com/opensearch-project/security-analytics/pull/1393) | Add validation for threat intel source config |
+
+## References
+
+- [Issue #1319](https://github.com/opensearch-project/security-analytics/issues/1319): Threat intel monitor bug fixes tracking
+- [Issue #1366](https://github.com/opensearch-project/security-analytics/issues/1366): Source config validation issue
+- [Threat Intelligence Documentation](https://docs.opensearch.org/2.18/security-analytics/threat-intelligence/index/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/security-analytics/threat-intelligence.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -128,6 +128,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 - [Security Analytics System Indices](features/security-analytics/security-analytics-system-indices.md) - Standardized system index settings (1 primary shard, 1-20 replicas), dedicated query indices option, correlation alert refresh policy fix
 - [Security Analytics Correlation](features/security-analytics/security-analytics-correlation.md) - Bug fixes for threat intel monitor alias resolution and REFRESHING state enum query
+- [Threat Intel Bug Fixes](features/security-analytics/threat-intel-bugfixes.md) - Notification listener leak fix, duplicate findings prevention, source config validation, improved error handling
 
 ### Security Analytics Dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for threat intel bug fixes in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/security-analytics/threat-intel-bugfixes.md`
- Feature report: `docs/features/security-analytics/threat-intelligence.md` (updated)

### Key Changes in v2.18.0
- **Notification Listener Leak Fix**: Fixed memory leak where notification listeners were not properly released after successful notification delivery
- **Duplicate Findings Prevention**: Monitor execution now marks as successful when findings are generated, even if alert creation or notification fails
- **Source Config Validation**: Added validation to prevent creation of source configs with missing required fields
- **Improved Error Handling**: Better handling of partial failures during monitor execution

### Related PRs
- [#1356](https://github.com/opensearch-project/security-analytics/pull/1356): Fix notifications listener leak in threat intel monitor
- [#1317](https://github.com/opensearch-project/security-analytics/pull/1317): Threat intel monitor bug fixes
- [#1383](https://github.com/opensearch-project/security-analytics/pull/1383): Fix search monitor query in update threat intel alert status API
- [#1393](https://github.com/opensearch-project/security-analytics/pull/1393): Add validation for threat intel source config

Closes #595