### PR TITLE
docs: add Security Analytics IOC bug fixes report for v2.18.0

### DIFF
--- a/docs/features/security-analytics/threat-intelligence.md
+++ b/docs/features/security-analytics/threat-intelligence.md
@@ -181,6 +181,9 @@ POST _plugins/_security_analytics/threat_intel/sources/
 |---------|-----|-------------|
 | v3.0.0 | [#1493](https://github.com/opensearch-project/security-analytics/pull/1493) | Custom format IOC upload support |
 | v3.0.0 | [#1455](https://github.com/opensearch-project/security-analytics/pull/1455) | Custom format implementation (2.x backport) |
+| v2.18.0 | [#1335](https://github.com/opensearch-project/security-analytics/pull/1335) | Add null check for multi-indicator type scans |
+| v2.18.0 | [#1373](https://github.com/opensearch-project/security-analytics/pull/1373) | Fix ListIOCs API count limits (total IOCs and findings per IOC) |
+| v2.18.0 | [#1392](https://github.com/opensearch-project/security-analytics/pull/1392) | Add exists check for IOC index creation |
 | v2.18.0 | [#1356](https://github.com/opensearch-project/security-analytics/pull/1356) | Fix notifications listener leak in threat intel monitor |
 | v2.18.0 | [#1317](https://github.com/opensearch-project/security-analytics/pull/1317) | Threat intel monitor bug fixes (empty index sort, grouped listener) |
 | v2.18.0 | [#1383](https://github.com/opensearch-project/security-analytics/pull/1383) | Fix search monitor query in update threat intel alert status API |
@@ -196,6 +199,7 @@ POST _plugins/_security_analytics/threat_intel/sources/
 
 ## References
 
+- [Issue #1191](https://github.com/opensearch-project/security-analytics/issues/1191): ListIOCsAPI total hits and findings count per IOC are incorrect
 - [Issue #1421](https://github.com/opensearch-project/security-analytics/issues/1421): Custom JSON schema feature request
 - [Issue #1224](https://github.com/opensearch-project/security-analytics/issues/1224): Lock release issue
 - [Issue #1247](https://github.com/opensearch-project/security-analytics/issues/1247): Job mapping upgrade issue
@@ -209,6 +213,6 @@ POST _plugins/_security_analytics/threat_intel/sources/
 ## Change History
 
 - **v3.0.0** (2025-05-13): Added custom JSON format support with JSONPath schema, relaxed IOC type validation to support custom types
-- **v2.18.0** (2024-11-05): Bug fixes - notification listener leak fix, duplicate findings prevention, source config validation, improved error handling for partial failures
+- **v2.18.0** (2024-11-05): Bug fixes - IOC scan null check for multi-indicator types, ListIOCs API count limits removed (total IOCs and findings per IOC no longer capped at 10,000), IOC index exists check to prevent race conditions, notification listener leak fix, duplicate findings prevention, source config validation, improved error handling for partial failures
 - **v2.17.0** (2024-09-17): Bug fixes for security (user validation, context stashing), stability (multi-node race conditions, event-driven lock release), and integration with standard detectors
 - **v2.15.0**: Initial threat intelligence feature with S3, IOC_UPLOAD, and URL_DOWNLOAD source types

--- a/docs/releases/v2.18.0/features/security-analytics/security-analytics-ioc.md
+++ b/docs/releases/v2.18.0/features/security-analytics/security-analytics-ioc.md
@@ -1,0 +1,107 @@
+# Security Analytics IOC Bug Fixes
+
+## Summary
+
+This release includes three bug fixes for the Security Analytics IOC (Indicators of Compromise) functionality, addressing issues with null pointer exceptions during multi-indicator type scans, incorrect IOC and findings count limits in the ListIOCs API, and index creation race conditions when indexing large numbers of IOCs.
+
+## Details
+
+### What's New in v2.18.0
+
+Three critical bug fixes improve the stability and accuracy of IOC-related operations:
+
+1. **Null Check for Multi-Indicator Type Scans** - Prevents NullPointerException when threat intel monitors are configured with multiple indicator types
+2. **ListIOCs API Count Fixes** - Removes the 10,000 cap on total IOC count and findings per IOC
+3. **IOC Index Exists Check** - Prevents `resource_already_exists_exception` when indexing more than 10,000 IOCs
+
+### Technical Changes
+
+#### Bug Fix 1: Null Check in IoCScanService
+
+**Problem**: When a threat intel monitor was configured with multiple indicator types (e.g., IPv4, hashes, domain names), a `NullPointerException` occurred in `IoCScanService.extractIocsPerType()` because the `fields` variable could be null when iterating over indicator types.
+
+**Solution**: Added null check for `fieldsConfiguredInMonitorForCurrentIndex` before iterating:
+
+```java
+List<String> fieldsConfiguredInMonitorForCurrentIndex = 
+    iocTypeToIndexFieldMapping.getIndexToFieldsMap().get(index);
+if (fieldsConfiguredInMonitorForCurrentIndex != null && 
+    !fieldsConfiguredInMonitorForCurrentIndex.isEmpty()) {
+    // Process fields
+}
+```
+
+**Files Changed**:
+- `IoCScanService.java` - Added null check in `extractIocsPerType()` method
+
+#### Bug Fix 2: ListIOCs API Count Limits
+
+**Problem**: The ListIOCs API had two issues:
+1. Total IOC count was capped at 10,000 due to missing `trackTotalHits(true)`
+2. Number of findings per IOC was capped at 10,000 because it used the GetIocFindings API which had pagination limits
+
+**Solution**: 
+1. Added `.trackTotalHits(true)` to the search request to get accurate total counts
+2. Replaced the GetIocFindings API call with a direct aggregation query using terms aggregation to count findings per IOC
+
+```java
+SearchSourceBuilder findingsCountSourceBuilder = new SearchSourceBuilder()
+    .fetchSource(false)
+    .trackTotalHits(true)
+    .query(QueryBuilders.termsQuery(IOC_ID_KEYWORD_FIELD, iocIds))
+    .size(0)
+    .aggregation(
+        AggregationBuilders
+            .terms(IOC_COUNT_AGG_NAME)
+            .field(IOC_ID_KEYWORD_FIELD)
+            .size(iocIds.size())
+    );
+```
+
+**Files Changed**:
+- `TransportListIOCsAction.java` - Refactored findings count logic to use aggregations
+
+#### Bug Fix 3: IOC Index Exists Check
+
+**Problem**: When indexing more than 10,000 IOCs, a `ResourceAlreadyExistsException` could occur because the batch indexing process attempted to create the same index multiple times concurrently.
+
+**Solution**: Added exception handling in `STIX2IOCFeedStore.initFeedIndex()` to gracefully handle the case when the index already exists:
+
+```java
+if (e instanceof ResourceAlreadyExistsException || 
+    (e instanceof RemoteTransportException && 
+     e.getCause() instanceof ResourceAlreadyExistsException)) {
+    log.debug("index {} already exist", feedIndexName);
+    listener.onResponse(null);
+    return;
+}
+```
+
+**Files Changed**:
+- `STIX2IOCFeedStore.java` - Added exists check in `initFeedIndex()` method
+
+### Migration Notes
+
+No migration required. These are bug fixes that improve existing functionality without changing APIs or data formats.
+
+## Limitations
+
+- The aggregation-based findings count still has a practical limit based on the terms aggregation bucket size, but this is configurable and much higher than the previous 10,000 limit
+- Multi-indicator type monitors require proper field mappings for each indicator type in the monitored indices
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1335](https://github.com/opensearch-project/security-analytics/pull/1335) | Add null check while adding fetched IOCs into per-indicator-type map |
+| [#1373](https://github.com/opensearch-project/security-analytics/pull/1373) | Fixed ListIOCs number of findings cap |
+| [#1392](https://github.com/opensearch-project/security-analytics/pull/1392) | Add exists check for IOCs index |
+
+## References
+
+- [Issue #1191](https://github.com/opensearch-project/security-analytics/issues/1191): ListIOCsAPI total hits and findings count per IOC are incorrect
+- [Threat Intelligence Documentation](https://docs.opensearch.org/2.18/security-analytics/threat-intelligence/index/): Official documentation
+
+## Related Feature Report
+
+- [Threat Intelligence](../../../features/security-analytics/threat-intelligence.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -129,6 +129,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Security Analytics System Indices](features/security-analytics/security-analytics-system-indices.md) - Standardized system index settings (1 primary shard, 1-20 replicas), dedicated query indices option, correlation alert refresh policy fix
 - [Security Analytics Correlation](features/security-analytics/security-analytics-correlation.md) - Bug fixes for threat intel monitor alias resolution and REFRESHING state enum query
 - [Threat Intel Bug Fixes](features/security-analytics/threat-intel-bugfixes.md) - Notification listener leak fix, duplicate findings prevention, source config validation, improved error handling
+- [Security Analytics IOC](features/security-analytics/security-analytics-ioc.md) - IOC bug fixes: null check for multi-indicator scans, ListIOCs API count limits removed, index exists check for large IOC batches
 
 ### Security Analytics Dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for Security Analytics IOC bug fixes in v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/security-analytics/security-analytics-ioc.md`
- Feature report: Updated `docs/features/security-analytics/threat-intelligence.md`

### Key Changes in v2.18.0

1. **Null Check for Multi-Indicator Type Scans** (PR #1335)
   - Fixes NullPointerException when threat intel monitors are configured with multiple indicator types

2. **ListIOCs API Count Fixes** (PR #1373)
   - Removes the 10,000 cap on total IOC count
   - Removes the 10,000 cap on findings per IOC
   - Uses aggregation-based counting instead of GetIocFindings API

3. **IOC Index Exists Check** (PR #1392)
   - Prevents `resource_already_exists_exception` when indexing more than 10,000 IOCs

### Resources Used
- PR: #1335, #1373, #1392
- Issue: #1191
- Docs: https://docs.opensearch.org/2.18/security-analytics/threat-intelligence/index/