### PR TITLE
docs: add security-bugfixes report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -112,6 +112,7 @@
 - [Alerting Comments Security](security/alerting-comments-security.md)
 - [Correlation Alerts](security/correlation-alerts.md)
 - [Security Auth Enhancements](security/security-auth-enhancements.md)
+- [Security Bugfixes](security/security-bugfixes.md)
 - [Security Configuration](security/security-configuration.md)
 - [Security Plugin](security/security-plugin.md)
 

--- a/docs/features/security/security-bugfixes.md
+++ b/docs/features/security/security-bugfixes.md
@@ -1,0 +1,107 @@
+# Security Bugfixes
+
+## Summary
+
+This document tracks security-related bug fixes across OpenSearch Security plugin, Security Analytics plugin, and related components. These fixes address various issues including system index access control, authentication audit logging, configuration detection, SSL settings propagation, and stored field handling.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Security Plugin"
+        SIP[System Index Protection]
+        SAML[SAML Authenticator]
+        DEMO[Demo Config Detection]
+        SSL[SSL Dual Mode]
+        HASH[HashingStoredFieldVisitor]
+        MAP[Index Mappings]
+    end
+    
+    subgraph "Security Analytics"
+        SA[Security Analytics Plugin]
+        FORE[Forecasting Tests]
+    end
+    
+    subgraph "Alerting"
+        ALERT[Alerting Plugin]
+        ROLE[Role Permissions]
+    end
+    
+    SIP --> |Access Control| Core[OpenSearch Core]
+    SSL --> |Settings Propagation| Core
+    MAP --> |Index Operations| Core
+    HASH --> |Field Handling| Core
+```
+
+### Components
+
+| Component | Description | Repository |
+|-----------|-------------|------------|
+| System Index Protection | Prevents unauthorized access to security system indices | security |
+| SAML Authenticator | Handles SAML-based authentication and audit logging | security |
+| Demo Config Detection | Detects existing security configuration in YAML files | security |
+| SSL Dual Mode | Manages SSL/TLS dual mode settings propagation | security |
+| HashingStoredFieldVisitor | Handles stored fields in search operations | security |
+| Index Mappings | Manages index mapping operations for closed indices | security |
+| Role Permissions | Manages alerting role permissions | alerting |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security_config.ssl_dual_mode_enabled` | Enable SSL dual mode for mixed cluster configurations | `false` |
+| `plugins.security.ssl_only` | Run in SSL-only mode | `false` |
+
+### Usage Example
+
+**Dynamically changing SSL dual mode:**
+```bash
+curl -XPUT https://localhost:9200/_cluster/settings \
+  -k -H "Content-Type: application/json" \
+  -d '{"persistent": {"plugins.security_config.ssl_dual_mode_enabled": false}}'
+```
+
+**Using stored_fields in search:**
+```json
+GET /my-index/_search
+{
+  "stored_fields": ["title", "date"],
+  "query": {
+    "match": {
+      "content": "opensearch"
+    }
+  }
+}
+```
+
+## Limitations
+
+- SSL dual mode changes require companion OpenSearch core changes
+- Some fixes are backports and may have version-specific behavior
+- Demo configuration detection requires SnakeYaml library for nested YAML parsing
+
+## Related PRs
+
+| Version | PR | Repository | Description |
+|---------|-----|------------|-------------|
+| v2.18.0 | [#4775](https://github.com/opensearch-project/security/pull/4775) | security | Fix admin system index read |
+| v2.18.0 | [#4770](https://github.com/opensearch-project/security/pull/4770) | security | Remove SAML failed login audit |
+| v2.18.0 | [#4798](https://github.com/opensearch-project/security/pull/4798) | security | Handle non-flat YAML settings |
+| v2.18.0 | [#4830](https://github.com/opensearch-project/security/pull/4830) | security | SSL dual mode propagation |
+| v2.18.0 | [#4827](https://github.com/opensearch-project/security/pull/4827) | security | Fix HashingStoredFieldVisitor |
+| v2.18.0 | [#4777](https://github.com/opensearch-project/security/pull/4777) | security | Fix closed index mappings |
+| v2.18.0 | [#1303](https://github.com/opensearch-project/security-analytics/pull/1303) | security-analytics | Fix OS launch exception |
+
+## References
+
+- [Issue #4608](https://github.com/opensearch-project/security/issues/4608): SAML failed login audit issue
+- [Issue #4735](https://github.com/opensearch-project/security/issues/4735): Demo config nested YAML issue
+- [Issue #4755](https://github.com/opensearch-project/security/issues/4755): Admin system index read issue
+- [Issue #1273](https://github.com/opensearch-project/security-analytics/issues/1273): OS launch exception issue
+- [OpenSearch stored_fields documentation](https://opensearch.org/docs/latest/search-plugins/searching-data/retrieve-specific-fields/#searching-with-stored_fields)
+
+## Change History
+
+- **v2.18.0** (2024-10-29): Multiple security bug fixes including system index protection, SAML audit logging, demo config detection, SSL dual mode propagation, stored field handling, and closed index mappings

--- a/docs/releases/v2.18.0/features/security/security-bugfixes.md
+++ b/docs/releases/v2.18.0/features/security/security-bugfixes.md
@@ -1,0 +1,95 @@
+# Security Bugfixes
+
+## Summary
+
+OpenSearch v2.18.0 includes multiple security-related bug fixes across the Security plugin, Security Analytics plugin, and Alerting plugin. These fixes address issues with system index access control, SAML authentication audit logging, demo configuration detection, SSL dual mode settings propagation, stored field handling, closed index mappings, and alerting role permissions.
+
+## Details
+
+### What's New in v2.18.0
+
+This release addresses 9 bug fixes across security-related components:
+
+| Bug Fix | Repository | Description |
+|---------|------------|-------------|
+| Admin system index read | security | Prevent admin users from reading security system indices registered through core |
+| SAML failed login audit | security | Remove misleading failed login audit entries for SAML authenticator |
+| Demo config detection | security | Handle non-flat YAML settings for demo configuration detection |
+| SSL dual mode propagation | security | Ensure dual mode enabled flag from cluster settings propagates to core |
+| HashingStoredFieldVisitor | security | Fix stored fields handling in HashingStoredFieldVisitor |
+| Closed index mappings | security | Fix Get mappings request on closed indices |
+| Alerting role permissions | alerting | Fix comments permission for alerting_ack_alerts role |
+| OS launch exception | security-analytics | Remove redundant logic causing OpenSearch launch exception |
+| Forecasting security tests | security-analytics | Forward port flaky test fix and add forecasting security tests |
+
+### Technical Changes
+
+#### System Index Access Control Fix (PR #4774)
+
+Prevents unauthorized reads on security system indices registered through OpenSearch core. Previously, admin users could potentially read protected system index data.
+
+**Impact**: Enhanced security for system indices by enforcing proper access controls.
+
+#### SAML Authentication Audit Fix (PR #4762)
+
+Removes audit log entries for failed login attempts during SAML authentication. SAML authentication always re-requests authentication, causing misleading "failed login" audit entries.
+
+**Related Issue**: [#4608](https://github.com/opensearch-project/security/issues/4608)
+
+#### Demo Configuration Detection Fix (PR #4793)
+
+Fixes the demo configuration tool to correctly detect nested YAML settings for security configuration. Previously, the tool failed to recognize security settings in nested YAML format.
+
+**Related Issue**: [#4735](https://github.com/opensearch-project/security/issues/4735)
+
+**Technical Details**: Uses SnakeYaml library to properly parse and search for nested configuration cases.
+
+#### SSL Dual Mode Settings Propagation (PR #4820)
+
+Ensures the `plugins.security_config.ssl_dual_mode_enabled` cluster setting properly propagates to OpenSearch core. This fix enables dynamic changes to dual mode settings to take effect across the cluster.
+
+**Companion PR**: [OpenSearch#16387](https://github.com/opensearch-project/OpenSearch/pull/16387)
+
+**Configuration**:
+```yaml
+plugins.security_config.ssl_dual_mode_enabled: true
+plugins.security.ssl_only: true
+```
+
+#### HashingStoredFieldVisitor Fix (PR #4826)
+
+Fixes a bug in `HashingStoredFieldVisitor` to properly handle [stored_fields](https://opensearch.org/docs/latest/search-plugins/searching-data/retrieve-specific-fields/#searching-with-stored_fields) which are stored separately from `_source` in the backing index.
+
+#### Closed Index Mappings Fix (PR #4685)
+
+Fixes an issue filtering out fields on GET Mappings requests for closed indices. Updates the indices options used when getting concrete indices.
+
+#### Security Analytics Fixes
+
+- **PR #1303**: Removes redundant logic that caused OpenSearch launch exceptions and updates `actions/upload-artifact` to v3
+- **Related Issue**: [#1273](https://github.com/opensearch-project/security-analytics/issues/1273)
+
+## Limitations
+
+- The SSL dual mode fix requires the companion OpenSearch core PR to be present
+- Some fixes are backports from the main branch to the 2.x release branch
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#4775](https://github.com/opensearch-project/security/pull/4775) | security | Fix bug where admin can read system index (backport) |
+| [#4770](https://github.com/opensearch-project/security/pull/4770) | security | Remove failed login attempt for SAML authenticator (backport) |
+| [#4798](https://github.com/opensearch-project/security/pull/4798) | security | Handle non-flat YAML settings for demo config detection (backport) |
+| [#4830](https://github.com/opensearch-project/security/pull/4830) | security | Ensure dual mode enabled flag propagates to core (backport) |
+| [#4827](https://github.com/opensearch-project/security/pull/4827) | security | Fix HashingStoredFieldVisitor with stored fields (backport) |
+| [#4777](https://github.com/opensearch-project/security/pull/4777) | security | Fix Get mappings on closed index (backport) |
+| [#1303](https://github.com/opensearch-project/security-analytics/pull/1303) | security-analytics | Remove redundant logic to fix OS launch exception |
+
+## References
+
+- [Issue #4608](https://github.com/opensearch-project/security/issues/4608): SAML failed login audit issue
+- [Issue #4735](https://github.com/opensearch-project/security/issues/4735): Demo config nested YAML issue
+- [Issue #4755](https://github.com/opensearch-project/security/issues/4755): Admin system index read issue
+- [Issue #1273](https://github.com/opensearch-project/security-analytics/issues/1273): OS launch exception issue
+- [OpenSearch stored_fields documentation](https://opensearch.org/docs/latest/search-plugins/searching-data/retrieve-specific-fields/#searching-with-stored_fields)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -138,6 +138,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### Security
 
+- [Security Bugfixes](features/security/security-bugfixes.md) - Multiple bug fixes including system index access control, SAML audit logging, demo config detection, SSL dual mode propagation, stored field handling, and closed index mappings
 - [Security Plugin Maintenance](features/security/security-plugin-maintenance.md) - Cache endpoint deprecation warning, securityadmin script undeprecation, ASN1 refactoring for FIPS, CVE-2024-47554 fix, BWC test fixes
 
 ### Skills


### PR DESCRIPTION
## Summary

This PR adds documentation for security-related bug fixes in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/security/security-bugfixes.md`
- Feature report: `docs/features/security/security-bugfixes.md`

### Bug Fixes Documented

| Bug Fix | Repository | Description |
|---------|------------|-------------|
| Admin system index read | security | Prevent admin users from reading security system indices |
| SAML failed login audit | security | Remove misleading failed login audit entries for SAML authenticator |
| Demo config detection | security | Handle non-flat YAML settings for demo configuration detection |
| SSL dual mode propagation | security | Ensure dual mode enabled flag from cluster settings propagates to core |
| HashingStoredFieldVisitor | security | Fix stored fields handling in HashingStoredFieldVisitor |
| Closed index mappings | security | Fix Get mappings request on closed indices |
| OS launch exception | security-analytics | Remove redundant logic causing OpenSearch launch exception |

### Related PRs
- security#4775, #4770, #4798, #4830, #4827, #4777
- security-analytics#1303

Closes #593