### PR TITLE
docs: add Observability Bugfixes report for v2.18.0

### DIFF
--- a/docs/features/dashboards-observability/observability-multi-data-source-support.md
+++ b/docs/features/dashboards-observability/observability-multi-data-source-support.md
@@ -204,6 +204,9 @@ When MDS is enabled, integration instances include a `references` field:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.18.0 | [#2213](https://github.com/opensearch-project/dashboards-observability/pull/2213) | Fix missing else condition for MDS remote cluster calls |
+| v2.18.0 | [#2222](https://github.com/opensearch-project/dashboards-observability/pull/2222) | MDS plugin de-registration and error code changes |
+| v2.18.0 | [#2225](https://github.com/opensearch-project/dashboards-observability/pull/2225) | Fixes span to logs redirection, updates MDS label when undefined |
 | v2.17.0 | [#2048](https://github.com/opensearch-project/dashboards-observability/pull/2048) | Multi-data Source Support for Getting Started |
 | v2.17.0 | [#2051](https://github.com/opensearch-project/dashboards-observability/pull/2051) | MDS support in Integrations |
 | v2.17.0 | [#2097](https://github.com/opensearch-project/dashboards-observability/pull/2097) | Deregister plugins in MDS mode |
@@ -217,4 +220,5 @@ When MDS is enabled, integration instances include a `references` field:
 
 ## Change History
 
+- **v2.18.0** (2024-10-22): Bug fixes for MDS including plugin de-registration improvements, error code handling, remote cluster call fixes, and MDS label handling
 - **v2.17.0** (2024-09-17): Initial MDS support for Getting Started, Integrations, and plugin deregistration

--- a/docs/features/dashboards-observability/observability-ui.md
+++ b/docs/features/dashboards-observability/observability-ui.md
@@ -98,6 +98,14 @@ The Observability plugin uses OpenSearch Dashboards saved objects for persistenc
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.18.0 | [#2146](https://github.com/opensearch-project/dashboards-observability/pull/2146) | Fix getting started cards re-direction to integrations |
+| v2.18.0 | [#2201](https://github.com/opensearch-project/dashboards-observability/pull/2201) | Update traces span redirection to Discover |
+| v2.18.0 | [#2209](https://github.com/opensearch-project/dashboards-observability/pull/2209) | Update getting started cards content and visual design |
+| v2.18.0 | [#2210](https://github.com/opensearch-project/dashboards-observability/pull/2210) | Observability Overview page rework |
+| v2.18.0 | [#2211](https://github.com/opensearch-project/dashboards-observability/pull/2211) | Rotate x-Axis labels by 45 degrees |
+| v2.18.0 | [#2217](https://github.com/opensearch-project/dashboards-observability/pull/2217) | Metrics fixes - disable expand button |
+| v2.18.0 | [#2219](https://github.com/opensearch-project/dashboards-observability/pull/2219) | Re-direction fix for associated logs from traces |
+| v2.18.0 | [#2225](https://github.com/opensearch-project/dashboards-observability/pull/2225) | Fixes span to logs redirection, updates MDS label |
 | v2.17.0 | [#2078](https://github.com/opensearch-project/dashboards-observability/pull/2078) | Traces/Services UI update |
 | v2.17.0 | [#2090](https://github.com/opensearch-project/dashboards-observability/pull/2090) | Observability dashboards UI update |
 | v2.17.0 | [#2092](https://github.com/opensearch-project/dashboards-observability/pull/2092) | Logs UI update |
@@ -111,4 +119,5 @@ The Observability plugin uses OpenSearch Dashboards saved objects for persistenc
 
 ## Change History
 
+- **v2.18.0** (2024-10-22): Multiple bug fixes including navigation fixes, overview page rework, getting started cards redesign, x-axis label rotation, and trace-to-logs redirection improvements
 - **v2.17.0** (2024-09-17): UI updates for Traces, Services, Logs, and Dashboards views to align with new header design patterns

--- a/docs/features/dashboards-observability/observability-workspace-integration.md
+++ b/docs/features/dashboards-observability/observability-workspace-integration.md
@@ -155,11 +155,13 @@ class ObsDashboardStateManager {
 - State management uses RxJS BehaviorSubjects as a temporary solution; planned migration to Redux or React Context
 - Workspace ID prefixing only applies to newly created assets, not existing ones
 - The embedded dashboard inherits the time range from the Overview page controls, not from the dashboard's saved time range
+- The `observability:defaultDashboard` setting can only be updated by workspace owners or OSD admins when workspaces are enabled (v2.18.0+)
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.18.0 | [#2223](https://github.com/opensearch-project/dashboards-observability/pull/2223) | Fix non-workspace admin update observability:defaultDashboard |
 | v2.17.0 | [#2101](https://github.com/opensearch-project/dashboards-observability/pull/2101) | Make createAssets API compatible with workspace |
 | v2.17.0 | [#2077](https://github.com/opensearch-project/dashboards-observability/pull/2077) | OverviewPage made with Content Management |
 | v2.16.0 | [#7201](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7201) | Content Management plugin introduction (dependency) |
@@ -171,4 +173,5 @@ class ObsDashboardStateManager {
 
 ## Change History
 
+- **v2.18.0** (2024-10-22): Fixed permission issue where non-workspace admins could update `observability:defaultDashboard` setting
 - **v2.17.0** (2024-10-15): Initial implementation - workspace-compatible createAssets API and Content Management-based Overview page

--- a/docs/releases/v2.18.0/features/observability/observability-bugfixes.md
+++ b/docs/releases/v2.18.0/features/observability/observability-bugfixes.md
@@ -1,0 +1,90 @@
+# Observability Bugfixes
+
+## Summary
+
+OpenSearch Dashboards Observability plugin received multiple bug fixes in v2.18.0, addressing navigation issues, workspace compatibility, Multi-Data Source (MDS) support, and UI improvements. These fixes improve the overall stability and user experience of the Observability features.
+
+## Details
+
+### What's New in v2.18.0
+
+This release includes 12 bug fixes across several areas:
+
+1. **Navigation and Redirection Fixes**: Fixed multiple issues with navigation between Observability components
+2. **Workspace Compatibility**: Improved integration with the Workspaces feature
+3. **Multi-Data Source (MDS) Support**: Fixed issues with MDS plugin registration and error handling
+4. **UI/UX Improvements**: Enhanced visual design and fixed display issues
+
+### Technical Changes
+
+#### Navigation Fixes
+
+| Issue | Fix | PR |
+|-------|-----|-----|
+| Getting started cards using `href` instead of `navigateToApp` | Replaced `href` with `navigateToApp` from core for proper workspace URL scoping | [#2146](https://github.com/opensearch-project/dashboards-observability/pull/2146) |
+| Span to logs redirection broken | Fixed redirection from traces span flyout to Discover | [#2201](https://github.com/opensearch-project/dashboards-observability/pull/2201), [#2219](https://github.com/opensearch-project/dashboards-observability/pull/2219) |
+| MDS label undefined during redirection | Updated MDS label handling when undefined | [#2225](https://github.com/opensearch-project/dashboards-observability/pull/2225) |
+
+#### Workspace Integration Fixes
+
+| Issue | Fix | PR |
+|-------|-----|-----|
+| Non-workspace admin updating `observability:defaultDashboard` shows error | Restricted `observability:defaultDashboard` updates to workspace owner/OSD admin only | [#2223](https://github.com/opensearch-project/dashboards-observability/pull/2223) |
+
+#### Multi-Data Source (MDS) Fixes
+
+| Issue | Fix | PR |
+|-------|-----|-----|
+| APIs returning 500 errors | Fixed error code handling for MDS-related APIs | [#2222](https://github.com/opensearch-project/dashboards-observability/pull/2222) |
+| Plugins not in MDS causing issues | Added de-registration for plugins not onboarded to MDS | [#2222](https://github.com/opensearch-project/dashboards-observability/pull/2222) |
+| Missing else condition in remote cluster calls | Added missing else condition for remote cluster handling | [#2213](https://github.com/opensearch-project/dashboards-observability/pull/2213) |
+
+#### UI/UX Improvements
+
+| Change | Description | PR |
+|--------|-------------|-----|
+| Overview page rework | Moved page options to header, added UI setting to persist card visibility, updated empty states | [#2210](https://github.com/opensearch-project/dashboards-observability/pull/2210) |
+| Getting started cards redesign | Updated content and visual design of getting started cards | [#2209](https://github.com/opensearch-project/dashboards-observability/pull/2209) |
+| X-axis label rotation | Rotated x-axis labels by 45 degrees counter-clockwise to prevent overlapping | [#2211](https://github.com/opensearch-project/dashboards-observability/pull/2211) |
+| Metrics panel expand button | Disabled and hid expand button for metrics panel | [#2217](https://github.com/opensearch-project/dashboards-observability/pull/2217) |
+
+#### Integration Fixes
+
+| Issue | Fix | PR |
+|-------|-----|-----|
+| VPC integration MV creation query broken | Fixed the VPC integration's Materialized View creation query | [#2179](https://github.com/opensearch-project/dashboards-observability/pull/2179) |
+
+### Migration Notes
+
+No migration steps required. These are bug fixes that improve existing functionality.
+
+## Limitations
+
+- The `observability:defaultDashboard` setting can now only be updated by workspace owners or OSD admins when workspaces are enabled
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2146](https://github.com/opensearch-project/dashboards-observability/pull/2146) | Fix getting started cards re-direction to integrations |
+| [#2179](https://github.com/opensearch-project/dashboards-observability/pull/2179) | Fix the VPC integration's MV creation query |
+| [#2201](https://github.com/opensearch-project/dashboards-observability/pull/2201) | Update traces span redirection |
+| [#2209](https://github.com/opensearch-project/dashboards-observability/pull/2209) | Update getting started cards content and visual design |
+| [#2210](https://github.com/opensearch-project/dashboards-observability/pull/2210) | Observability Overview page rework |
+| [#2211](https://github.com/opensearch-project/dashboards-observability/pull/2211) | Rotate x-Axis labels by 45 degrees |
+| [#2213](https://github.com/opensearch-project/dashboards-observability/pull/2213) | Fix missing else condition for MDS remote cluster calls |
+| [#2217](https://github.com/opensearch-project/dashboards-observability/pull/2217) | Metrics fixes - disable expand button |
+| [#2219](https://github.com/opensearch-project/dashboards-observability/pull/2219) | Re-direction fix for associated logs from traces |
+| [#2222](https://github.com/opensearch-project/dashboards-observability/pull/2222) | MDS plugin de-registration and error code changes |
+| [#2223](https://github.com/opensearch-project/dashboards-observability/pull/2223) | Fix non-workspace admin update observability:defaultDashboard |
+| [#2225](https://github.com/opensearch-project/dashboards-observability/pull/2225) | Fixes span to logs redirection, updates MDS label when undefined |
+
+## References
+
+- [opensearch-catalog#195](https://github.com/opensearch-project/opensearch-catalog/issues/195): VPC integration MV creation issue
+
+## Related Feature Report
+
+- [Observability UI](../../../features/dashboards-observability/observability-ui.md)
+- [Observability Multi-Data Source Support](../../../features/dashboards-observability/observability-multi-data-source-support.md)
+- [Observability Workspace Integration](../../../features/dashboards-observability/observability-workspace-integration.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -140,6 +140,10 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 - [Query Workbench Bugfixes](features/dashboards-query-workbench/query-workbench-bugfixes.md) - Bug fixes for modal mounting support and MDS error handling
 
+### Observability
+
+- [Observability Bugfixes](features/observability/observability-bugfixes.md) - Multiple bug fixes including navigation fixes, workspace compatibility, MDS support improvements, and UI/UX enhancements
+
 ### Security
 
 - [Security Bugfixes](features/security/security-bugfixes.md) - Multiple bug fixes including system index access control, SAML audit logging, demo config detection, SSL dual mode propagation, stored field handling, and closed index mappings


### PR DESCRIPTION
## Summary

This PR adds documentation for Observability plugin bug fixes in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/observability/observability-bugfixes.md`
- Updated feature reports:
  - `docs/features/dashboards-observability/observability-ui.md`
  - `docs/features/dashboards-observability/observability-multi-data-source-support.md`
  - `docs/features/dashboards-observability/observability-workspace-integration.md`

### Key Changes in v2.18.0

**Navigation Fixes:**
- Fixed getting started cards using `href` instead of `navigateToApp` for workspace compatibility
- Fixed span to logs redirection from traces
- Fixed MDS label handling when undefined

**Workspace Integration:**
- Fixed non-workspace admin updating `observability:defaultDashboard` showing error

**Multi-Data Source (MDS) Fixes:**
- Fixed APIs returning 500 errors
- Added de-registration for plugins not onboarded to MDS
- Fixed missing else condition in remote cluster calls

**UI/UX Improvements:**
- Overview page rework with header options and card visibility settings
- Getting started cards redesign
- X-axis label rotation to prevent overlapping
- Metrics panel expand button disabled

**Integration Fixes:**
- Fixed VPC integration MV creation query

### PRs Investigated
- #2146, #2179, #2201, #2209, #2210, #2211, #2213, #2217, #2219, #2222, #2223, #2225

Closes #591