### PR TITLE
docs: add neural-search-bugfixes report for v2.18.0

### DIFF
--- a/docs/features/neural-search/hybrid-query.md
+++ b/docs/features/neural-search/hybrid-query.md
@@ -182,6 +182,7 @@ GET /_plugins/_neural/stats/text_embedding_executions
 | v3.0.0 | [#1191](https://github.com/opensearch-project/neural-search/pull/1191) | Optimize embedding generation in Text Embedding Processor |
 | v3.0.0 | [#1246](https://github.com/opensearch-project/neural-search/pull/1246) | Optimize embedding generation in Sparse Encoding Processor |
 | v3.0.0 | [#1249](https://github.com/opensearch-project/neural-search/pull/1249) | Optimize embedding generation in Text/Image Embedding Processor |
+| v2.18.0 | [#956](https://github.com/opensearch-project/neural-search/pull/956) | Fixed incorrect document order for nested aggregations in hybrid query |
 | v2.17.0 | [#867](https://github.com/opensearch-project/neural-search/pull/867) | Removed misleading pagination code, added clear error |
 | v2.17.0 | [#877](https://github.com/opensearch-project/neural-search/pull/877) | Fixed merge logic for empty shard results |
 | v2.11.0 | - | Initial implementation of hybrid search |
@@ -204,5 +205,6 @@ GET /_plugins/_neural/stats/text_embedding_executions
 ## Change History
 
 - **v3.0.0** (2025-05-13): Z-Score normalization, lower bounds for min-max, filter support, inner hits, Stats API, semantic highlighter, analyzer-based neural sparse query, optimized embedding generation
+- **v2.18.0** (2024-11-05): Fixed incorrect document order for nested aggregations in hybrid query
 - **v2.17.0** (2024-09-17): Fixed pagination error handling and multi-shard merge logic
 - **v2.11.0** (2023-10-16): Initial implementation of hybrid search

--- a/docs/releases/v2.18.0/features/neural-search/neural-search-bugfixes.md
+++ b/docs/releases/v2.18.0/features/neural-search/neural-search-bugfixes.md
@@ -1,0 +1,113 @@
+# Neural Search Bugfixes
+
+## Summary
+
+This release fixes a bug in hybrid query where nested aggregations returned incorrect document order. The issue affected hybrid queries combined with deeply nested aggregations since v2.15, causing aggregation results to not correspond to the provided aggregation rules.
+
+## Details
+
+### What's New in v2.18.0
+
+Fixed incorrect document order for nested aggregations in hybrid query. The bug was caused by the `HybridQueryScorer` getting document IDs and scorers from a pre-sorted collection of doc iterators, which did not work correctly for deeply nested aggregations because the order could change dynamically.
+
+### Technical Changes
+
+#### Root Cause
+
+The `HybridQueryScorer.score()` method was iterating over `subScorersPQ` (a priority queue) directly, which maintained a pre-sorted order. However, for nested aggregations, the document order can change dynamically during aggregation processing, causing incorrect results.
+
+#### Fix Implementation
+
+The fix modifies the `score()` method in `HybridQueryScorer` to use `getSubMatches()` which returns the correct list of matching scorers for the current document:
+
+```java
+@Override
+public float score() throws IOException {
+    return score(getSubMatches());
+}
+
+private float score(DisiWrapper topList) throws IOException {
+    float totalScore = 0.0f;
+    for (DisiWrapper disiWrapper = topList; disiWrapper != null; disiWrapper = disiWrapper.next) {
+        // check if this doc has match in the subQuery. If not, add score as 0.0 and continue
+        if (disiWrapper.scorer.docID() == DocIdSetIterator.NO_MORE_DOCS) {
+            continue;
+        }
+        // ... score calculation
+    }
+    return totalScore;
+}
+```
+
+#### Changed Files
+
+| File | Change |
+|------|--------|
+| `HybridQueryScorer.java` | Modified `score()` to use `getSubMatches()` for correct document ordering |
+| `HybridQueryAggregationsIT.java` | Added integration tests for nested aggregations with hybrid query |
+| `BaseNeuralSearchIT.java` | Added `bulkIngest()` helper and extended `buildIndexConfiguration()` |
+| `TestUtils.java` | Added overloaded `assertHitResultsFromQuery()` for total count validation |
+| `ingest_bulk.json` | Test data for nested aggregation scenarios |
+
+### Usage Example
+
+Hybrid query with nested aggregations now returns correct results:
+
+```json
+GET /my-nlp-index/_search?search_pipeline=nlp-search-pipeline
+{
+  "aggs": {
+    "unique_names": {
+      "terms": {
+        "field": "actor",
+        "size": 10,
+        "order": { "max_score": "desc" }
+      },
+      "aggs": {
+        "top_doc": {
+          "top_hits": {
+            "size": 1,
+            "sort": [{ "_score": { "order": "desc" } }]
+          }
+        },
+        "max_score": {
+          "max": { "script": { "source": "_score" } }
+        }
+      }
+    }
+  },
+  "query": {
+    "hybrid": {
+      "queries": [
+        { "match": { "actor": "anil" } },
+        { "range": { "imdb": { "gte": 1.0, "lte": 10.0 } } }
+      ]
+    }
+  }
+}
+```
+
+### Migration Notes
+
+No migration required. This is a bug fix that restores correct behavior for hybrid queries with nested aggregations.
+
+## Limitations
+
+- Aggregation scores in the response are not normalized (expected behavior)
+- The fix applies to all nested aggregation scenarios with hybrid query
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#956](https://github.com/opensearch-project/neural-search/pull/956) | Fixed incorrect document order for nested aggregations in hybrid query |
+
+## References
+
+- [Issue #955](https://github.com/opensearch-project/neural-search/issues/955): Bug report for incorrect nested aggregation results
+- [Hybrid Search Documentation](https://docs.opensearch.org/2.18/search-plugins/hybrid-search/)
+- [Nested Aggregations](https://docs.opensearch.org/2.18/aggregations/bucket/nested/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/neural-search/hybrid-query.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -109,6 +109,10 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [k-NN Documentation](features/k-nn/k-nn-documentation.md) - JavaDoc cleanup for RescoreContext class
 - [k-NN Maintenance](features/k-nn/k-nn-maintenance.md) - Lucene 9.12 codec compatibility, force merge performance optimization, benchmark folder removal, code refactoring
 
+### Neural Search
+
+- [Neural Search Bugfixes](features/neural-search/neural-search-bugfixes.md) - Fixed incorrect document order for nested aggregations in hybrid query
+
 ### ML Commons
 
 - [ML Commons Configuration](features/ml-commons/ml-commons-configuration.md) - Change `.plugins-ml-config` index to use `auto_expand_replicas: 0-all` for maximum availability


### PR DESCRIPTION
## Summary

This PR adds the release report for Neural Search Bugfixes in v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/neural-search/neural-search-bugfixes.md`
- Feature report updated: `docs/features/neural-search/hybrid-query.md`

### Key Changes in v2.18.0
- Fixed incorrect document order for nested aggregations in hybrid query
- The bug was caused by `HybridQueryScorer` using pre-sorted doc iterators that didn't work correctly for deeply nested aggregations

### Resources Used
- PR: [#956](https://github.com/opensearch-project/neural-search/pull/956)
- Issue: [#955](https://github.com/opensearch-project/neural-search/issues/955)
- Docs: [Hybrid Search](https://docs.opensearch.org/2.18/search-plugins/hybrid-search/)

Closes #590