### PR TITLE
docs: add ml-commons-bugfixes report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -192,6 +192,7 @@
 ## ml-commons
 
 - [Batch Ingestion](ml-commons/batch-ingestion.md)
+- [ML Commons Bugfixes](ml-commons/ml-commons-bugfixes.md)
 - [ML Commons CI/CD](ml-commons/ml-commons-ci-cd.md)
 - [ML Commons Configuration](ml-commons/ml-commons-configuration.md)
 - [ML Commons Connector](ml-commons/ml-commons-connector.md)

--- a/docs/features/ml-commons/ml-commons-bugfixes.md
+++ b/docs/features/ml-commons/ml-commons-bugfixes.md
@@ -1,0 +1,100 @@
+# ML Commons Bugfixes
+
+## Summary
+
+This document tracks bugfixes and stability improvements for the ML Commons plugin across OpenSearch releases. ML Commons provides machine learning capabilities including model deployment, inference processors, RAG pipelines, connectors for external ML services, and agent execution.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "ML Commons Components"
+        RAG[RAG Pipeline]
+        INF[ML Inference Processor]
+        CONN[Connector Manager]
+        MODEL[Model Manager]
+        AGENT[Agent Executor]
+    end
+    
+    subgraph "External Services"
+        BEDROCK[Amazon Bedrock]
+        OPENAI[OpenAI]
+        OTHER[Other ML Services]
+    end
+    
+    RAG --> INF
+    INF --> CONN
+    CONN --> BEDROCK
+    CONN --> OPENAI
+    CONN --> OTHER
+    MODEL --> CONN
+    AGENT --> MODEL
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| RAG Pipeline | Retrieval-Augmented Generation pipeline for combining search with LLM responses |
+| ML Inference Processor | Ingest and search processors for ML model inference |
+| Connector Manager | Manages connections to external ML services with credential encryption |
+| Model Manager | Handles model deployment, state management, and auto-redeployment |
+| Agent Executor | Executes ML agents (flow, conversational, etc.) |
+
+### Key Bug Categories
+
+#### RAG Pipeline Stability
+- Null pointer exception handling for missing parameters
+- Graceful error handling for required configuration
+
+#### ML Inference Processor
+- JsonPath return format consistency between ingest and search processors
+- Parameter serialization fixes
+
+#### Connector Management
+- Time field population (created_time, last_updated_time)
+- Master key race condition during credential encryption/decryption
+- Backward compatibility for API changes
+
+#### Model Deployment
+- State recovery after node crashes or cluster restarts
+- Remote model auto-redeployment optimization
+
+#### Agent Execution
+- Correct error logging for different agent types
+
+## Limitations
+
+- Legacy connectors created before time field fixes will have null `created_time`
+- JsonPath behavior changes may require pipeline updates for existing configurations
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#3100](https://github.com/opensearch-project/ml-commons/pull/3100) | Gracefully handle error when generative_qa_parameters is not provided |
+| v2.18.0 | [#3057](https://github.com/opensearch-project/ml-commons/pull/3057) | Fix RAG processor NPE when optional parameters not provided |
+| v2.18.0 | [#2985](https://github.com/opensearch-project/ml-commons/pull/2985) | Fix ML inference ingest processor JsonPath return format |
+| v2.18.0 | [#2922](https://github.com/opensearch-project/ml-commons/pull/2922) | Populate time fields for connectors on return |
+| v2.18.0 | [#3137](https://github.com/opensearch-project/ml-commons/pull/3137) | Fix model stuck in deploying state during node crash/cluster restart |
+| v2.18.0 | [#2976](https://github.com/opensearch-project/ml-commons/pull/2976) | Filter out remote model auto-redeployment |
+| v2.18.0 | [#3151](https://github.com/opensearch-project/ml-commons/pull/3151) | Increase wait timeout to fetch master key |
+| v2.18.0 | [#3173](https://github.com/opensearch-project/ml-commons/pull/3173) | Handle BWC for Bedrock Converse API |
+| v2.18.0 | [#2809](https://github.com/opensearch-project/ml-commons/pull/2809) | Fix error log to show correct agent type |
+| v2.18.0 | [#3073](https://github.com/opensearch-project/ml-commons/pull/3073) | Add Bedrock multimodal built-in function usage example |
+
+## References
+
+- [Issue #3092](https://github.com/opensearch-project/ml-commons/issues/3092): RAG pipeline error handling
+- [Issue #2983](https://github.com/opensearch-project/ml-commons/issues/2983): RAG processor NPE
+- [Issue #2974](https://github.com/opensearch-project/ml-commons/issues/2974): ML inference processor JsonPath issue
+- [Issue #2890](https://github.com/opensearch-project/ml-commons/issues/2890): Connector time fields not implemented
+- [Issue #2970](https://github.com/opensearch-project/ml-commons/issues/2970): Model stuck in deploying state
+- [Issue #3126](https://github.com/opensearch-project/ml-commons/issues/3126): Bedrock Converse API BWC
+- [Issue #3060](https://github.com/opensearch-project/ml-commons/issues/3060): Bedrock multimodal documentation
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Multiple bugfixes for RAG pipelines, ML inference processors, connector time fields, model deployment stability, master key race condition, Bedrock BWC, and agent logging

--- a/docs/releases/v2.18.0/features/ml-commons/ml-commons-bugfixes.md
+++ b/docs/releases/v2.18.0/features/ml-commons/ml-commons-bugfixes.md
@@ -1,0 +1,115 @@
+# ML Commons Bugfixes
+
+## Summary
+
+OpenSearch v2.18.0 includes 11 bugfixes for the ML Commons plugin, addressing issues across RAG pipelines, ML inference processors, connector management, model deployment, and agent execution. These fixes improve stability and reliability for machine learning workloads.
+
+## Details
+
+### What's New in v2.18.0
+
+This release focuses on stability improvements and bug fixes across multiple ML Commons components.
+
+### Technical Changes
+
+#### RAG Pipeline Fixes
+
+Two critical fixes address null pointer exceptions (NPE) in RAG pipelines:
+
+1. **Missing generative_qa_parameters handling** ([#3100](https://github.com/opensearch-project/ml-commons/pull/3100)): Gracefully handles errors when required `generative_qa_parameters` is not provided for a RAG pipeline, preventing crashes and providing meaningful error messages.
+
+2. **Optional parameters NPE fix** ([#3057](https://github.com/opensearch-project/ml-commons/pull/3057)): Explicitly checks if parameters are null before serializing field names and values in the RAG processor.
+
+#### ML Inference Processor Fix
+
+**JsonPath return format consistency** ([#2985](https://github.com/opensearch-project/ml-commons/pull/2985)): Fixed inconsistent behavior where the ML inference ingest processor always returned lists when using JsonPath in `input_maps`. The fix standardizes the JsonPath configuration across ML inference search processors and ingest processors, returning the original format of the object instead of always wrapping in a list.
+
+Before fix:
+```json
+{
+  "input": ["red shoes"]  // Always returned as list
+}
+```
+
+After fix:
+```json
+{
+  "input": "red shoes"  // Returns original string format
+}
+```
+
+#### Connector Time Fields
+
+**Populate time fields for connectors** ([#2922](https://github.com/opensearch-project/ml-commons/pull/2922)): Fixed an issue where `created_time` and `last_updated_time` fields were always null for connectors. Now these fields are properly populated when creating and updating connectors via the API.
+
+| Operation | created_time | last_updated_time |
+|-----------|--------------|-------------------|
+| Create connector | ✅ Set | ✅ Set |
+| Update connector | ✅ Preserved | ✅ Updated |
+
+#### Model Deployment Stability
+
+1. **Model stuck in deploying state** ([#3137](https://github.com/opensearch-project/ml-commons/pull/3137)): Fixed an issue where models could get stuck in "deploying" state during node crashes or cluster restarts. The fix ensures proper state cleanup and recovery.
+
+2. **Remote model auto-redeployment filter** ([#2976](https://github.com/opensearch-project/ml-commons/pull/2976)): Filters out remote model auto-redeployment in `MLModelAutoRedeployer` since remote models support auto-deployment on first prediction request.
+
+#### Master Key Race Condition
+
+**Increased wait timeout for master key** ([#3151](https://github.com/opensearch-project/ml-commons/pull/3151)): Fixed a race condition during master key initialization when encrypting/decrypting credentials in connectors. The encrypt/decrypt thread could previously get a null key even if the key was successfully fetched from the config index in another thread.
+
+#### Bedrock Integration
+
+**BWC for Bedrock Converse API** ([#3173](https://github.com/opensearch-project/ml-commons/pull/3173)): Handles backward compatibility for serialization and deserialization of newly added fields for the Bedrock Converse API.
+
+#### Agent Logging
+
+**Correct agent type in error logs** ([#2809](https://github.com/opensearch-project/ml-commons/pull/2809)): Fixed error logging in `MLAgentExecutor` to show the correct agent type instead of always showing "flow agent".
+
+Before:
+```
+[ERROR] Failed to run flow agent
+```
+
+After:
+```
+[ERROR] Failed to run conversational agent
+```
+
+#### Documentation
+
+**Bedrock multimodal documentation** ([#3073](https://github.com/opensearch-project/ml-commons/pull/3073)): Added usage examples for Bedrock multimodal built-in functions in documentation.
+
+## Limitations
+
+- Connectors created before v2.18.0 will not have `created_time` populated (remains null), but `last_updated_time` will be set on next update
+- The JsonPath fix may require updates to existing pipelines that relied on the previous list-wrapping behavior
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3100](https://github.com/opensearch-project/ml-commons/pull/3100) | Gracefully handle error when generative_qa_parameters is not provided |
+| [#3057](https://github.com/opensearch-project/ml-commons/pull/3057) | Fix RAG processor NPE when optional parameters not provided |
+| [#2985](https://github.com/opensearch-project/ml-commons/pull/2985) | Fix ML inference ingest processor JsonPath return format |
+| [#2922](https://github.com/opensearch-project/ml-commons/pull/2922) | Populate time fields for connectors on return |
+| [#3137](https://github.com/opensearch-project/ml-commons/pull/3137) | Fix model stuck in deploying state during node crash/cluster restart |
+| [#2976](https://github.com/opensearch-project/ml-commons/pull/2976) | Filter out remote model auto-redeployment |
+| [#3151](https://github.com/opensearch-project/ml-commons/pull/3151) | Increase wait timeout to fetch master key |
+| [#3173](https://github.com/opensearch-project/ml-commons/pull/3173) | Handle BWC for Bedrock Converse API |
+| [#2809](https://github.com/opensearch-project/ml-commons/pull/2809) | Fix error log to show correct agent type |
+| [#3073](https://github.com/opensearch-project/ml-commons/pull/3073) | Add Bedrock multimodal built-in function usage example |
+| [#369](https://github.com/opensearch-project/ml-commons/pull/369) | Fix category order and description in data administration |
+
+## References
+
+- [Issue #3092](https://github.com/opensearch-project/ml-commons/issues/3092): RAG pipeline error handling
+- [Issue #2983](https://github.com/opensearch-project/ml-commons/issues/2983): RAG processor NPE
+- [Issue #2974](https://github.com/opensearch-project/ml-commons/issues/2974): ML inference processor JsonPath issue
+- [Issue #2890](https://github.com/opensearch-project/ml-commons/issues/2890): Connector time fields not implemented
+- [Issue #2970](https://github.com/opensearch-project/ml-commons/issues/2970): Model stuck in deploying state
+- [Issue #3126](https://github.com/opensearch-project/ml-commons/issues/3126): Bedrock Converse API BWC
+- [Issue #3060](https://github.com/opensearch-project/ml-commons/issues/3060): Bedrock multimodal documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/ml-commons-bugfixes.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -115,6 +115,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### ML Commons
 
+- [ML Commons Bugfixes](features/ml-commons/ml-commons-bugfixes.md) - 11 bug fixes for RAG pipelines, ML inference processors, connector time fields, model deployment stability, master key race condition, Bedrock BWC, and agent logging
 - [ML Commons Configuration](features/ml-commons/ml-commons-configuration.md) - Change `.plugins-ml-config` index to use `auto_expand_replicas: 0-all` for maximum availability
 - [ML Commons Connectors & Blueprints](features/ml-commons/ml-commons-connectors-blueprints.md) - Bedrock Converse blueprint, cross-account model invocation tutorial, role temporary credential support, Titan Embedding V2 blueprint
 - [ML Commons CI/CD](features/ml-commons/ml-commons-ci-cd.md) - Workflow approval system for external contributors, artifact actions upgrade to v4, developer guide updates


### PR DESCRIPTION
## Summary

This PR adds documentation for ML Commons bugfixes in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/ml-commons/ml-commons-bugfixes.md`
- Feature report: `docs/features/ml-commons/ml-commons-bugfixes.md`

### Key Changes in v2.18.0
- RAG pipeline NPE fixes for missing parameters
- ML inference processor JsonPath return format consistency
- Connector time fields (created_time, last_updated_time) population
- Model deployment stability during node crashes/cluster restarts
- Master key race condition fix
- Bedrock Converse API backward compatibility
- Agent executor error logging fix

### PRs Covered
- #3100: Gracefully handle error when generative_qa_parameters is not provided
- #3057: Fix RAG processor NPE when optional parameters not provided
- #2985: Fix ML inference ingest processor JsonPath return format
- #2922: Populate time fields for connectors on return
- #3137: Fix model stuck in deploying state during node crash/cluster restart
- #2976: Filter out remote model auto-redeployment
- #3151: Increase wait timeout to fetch master key
- #3173: Handle BWC for Bedrock Converse API
- #2809: Fix error log to show correct agent type
- #3073: Add Bedrock multimodal built-in function usage example

Closes #589