### PR TITLE
docs: add Job Scheduler report for v2.18.0

### DIFF
--- a/docs/features/job-scheduler/job-scheduler.md
+++ b/docs/features/job-scheduler/job-scheduler.md
@@ -167,6 +167,7 @@ Job Scheduler supports two schedule formats:
 | v3.0.0 | [#702](https://github.com/opensearch-project/job-scheduler/pull/702) | Enable custom start commands and options to resolve GHA issues |
 | v3.0.0 | [#730](https://github.com/opensearch-project/job-scheduler/pull/730) | Fix JS compile issues caused by OpenSearch JPMS Refactoring |
 | v3.0.0 | [#737](https://github.com/opensearch-project/job-scheduler/pull/737) | Only download demo certs when integTest run with -Dsecurity.enabled=true |
+| v2.18.0 | [#670](https://github.com/opensearch-project/job-scheduler/pull/670) | Return LockService from createComponents for Guice injection |
 | v2.17.0 | [#658](https://github.com/opensearch-project/job-scheduler/pull/658) | Fix system index compatibility with v1 templates |
 
 ## References
@@ -177,8 +178,10 @@ Job Scheduler supports two schedule formats:
 - [Issue #698](https://github.com/opensearch-project/job-scheduler/issues/698): GitHub Action Deprecation
 - [Issue #715](https://github.com/opensearch-project/job-scheduler/issues/715): Release 3.0 Breaking Changes
 - [Issue #14984](https://github.com/opensearch-project/OpenSearch/issues/14984): CreateIndexRequest.mapping() bug with v1 templates
+- [Issue #4439](https://github.com/opensearch-project/security/issues/4439): RFC - Strengthen System Index Protection in the Plugin Ecosystem
 
 ## Change History
 
 - **v3.0.0** (2025): CI/CD improvements, JPMS compatibility fixes, conditional demo certificate downloads
+- **v2.18.0** (2024-11-05): Return LockService from createComponents for Guice injection, enabling shared lock service across plugins
 - **v2.17.0** (2024-09-17): Fixed system index compatibility with v1 templates in LockService and JobDetailsService

--- a/docs/releases/v2.18.0/features/job-scheduler/job-scheduler.md
+++ b/docs/releases/v2.18.0/features/job-scheduler/job-scheduler.md
@@ -1,0 +1,102 @@
+# Job Scheduler
+
+## Summary
+
+This bugfix makes the `LockService` instance injectable via Guice by returning it from `JobSchedulerPlugin.createComponents()`. This enables plugins that depend on Job Scheduler's SPI to use dependency injection for the LockService instead of creating their own instances.
+
+## Details
+
+### What's New in v2.18.0
+
+The `LockService` is now returned as a component from `createComponents()`, making it available for Guice injection to dependent plugins.
+
+### Technical Changes
+
+#### Code Change
+
+The change is minimal but impactful - a single line modification in `JobSchedulerPlugin.java`:
+
+```java
+// Before
+return Collections.emptyList();
+
+// After
+return List.of(this.lockService);
+```
+
+#### Architecture Impact
+
+```mermaid
+graph TB
+    subgraph "Before v2.18.0"
+        JS1[Job Scheduler Plugin]
+        GEO1[Geospatial Plugin]
+        LK1[LockService Instance 1]
+        LK2[LockService Instance 2]
+        
+        JS1 --> LK1
+        GEO1 --> LK2
+    end
+    
+    subgraph "After v2.18.0"
+        JS2[Job Scheduler Plugin]
+        GEO2[Geospatial Plugin]
+        LK3[Shared LockService]
+        
+        JS2 --> LK3
+        GEO2 -.->|Guice Injection| LK3
+    end
+```
+
+### Why This Matters
+
+This change is part of a larger effort to strengthen system index protection in the OpenSearch plugin ecosystem ([security#4439](https://github.com/opensearch-project/security/issues/4439)). Key benefits:
+
+1. **Proper System Index Access**: Plugins like Geospatial can now use Job Scheduler's LockService (which has permission to Job Scheduler's system indices) instead of creating their own instance
+2. **Reduced ThreadContext Stashing**: Plugins no longer need to stash the ThreadContext to access lock-related system indices
+3. **Security Improvement**: Supports the initiative to restrict what plugins can do when ThreadContext is stashed
+
+### Migration Notes
+
+Plugins that currently instantiate their own `LockService` can now inject it via Guice:
+
+```java
+// Before: Creating own LockService instance
+public class MyPlugin implements Plugin {
+    @Override
+    public Collection<Object> createComponents(...) {
+        LockService lockService = new LockService(client, clusterService);
+        // ...
+    }
+}
+
+// After: Inject shared LockService from Job Scheduler
+public class MyPlugin implements Plugin, ClusterPlugin {
+    @Inject
+    public MyPlugin(LockService lockService) {
+        // Use injected lockService
+    }
+}
+```
+
+## Limitations
+
+- Plugins must be converted to `ClusterPlugin` to use Guice injection
+- Requires Job Scheduler plugin to be installed
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#670](https://github.com/opensearch-project/job-scheduler/pull/670) | Return instance of LockService from createComponents |
+
+## References
+
+- [Issue #4439](https://github.com/opensearch-project/security/issues/4439): RFC - Strengthen System Index Protection in the Plugin Ecosystem
+- [Issue #238](https://github.com/opensearch-project/opensearch-plugins/issues/238): Remove usages of ThreadContext.stashContext across plugins
+- [Geospatial PR #677](https://github.com/opensearch-project/geospatial/pull/677): Companion PR making Geospatial a ClusterPlugin
+- [Documentation](https://docs.opensearch.org/2.18/monitoring-your-cluster/job-scheduler/index/): Job Scheduler official docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/job-scheduler/job-scheduler.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -145,6 +145,10 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 - [Query Workbench Bugfixes](features/dashboards-query-workbench/query-workbench-bugfixes.md) - Bug fixes for modal mounting support and MDS error handling
 
+### Job Scheduler
+
+- [Job Scheduler](features/job-scheduler/job-scheduler.md) - Return LockService from createComponents for Guice injection
+
 ### Observability
 
 - [Observability Bugfixes](features/observability/observability-bugfixes.md) - Multiple bug fixes including navigation fixes, workspace compatibility, MDS support improvements, and UI/UX enhancements


### PR DESCRIPTION
## Summary

Add release report for Job Scheduler v2.18.0 bugfix (PR #670).

### Changes
- Created release report: `docs/releases/v2.18.0/features/job-scheduler/job-scheduler.md`
- Updated feature report: `docs/features/job-scheduler/job-scheduler.md`
- Updated release index: `docs/releases/v2.18.0/index.md`

### Key Finding

This bugfix makes the `LockService` instance injectable via Guice by returning it from `JobSchedulerPlugin.createComponents()`. This is part of a larger effort to strengthen system index protection in the OpenSearch plugin ecosystem (security#4439).

### Related Issue
Closes #588