### PR TITLE
docs: add Index Management Bugfixes report for v2.18.0

### DIFF
--- a/docs/features/index-management/index-management.md
+++ b/docs/features/index-management/index-management.md
@@ -183,6 +183,9 @@ PUT _plugins/_rollup/jobs/sample_rollup
 | v3.0.0 | [#1377](https://github.com/opensearch-project/index-management/pull/1377) | Target Index Settings for rollup |
 | v3.0.0 | [#1388](https://github.com/opensearch-project/index-management/pull/1388) | CVE fix: logback-core upgrade |
 | v3.0.0 | [#1404](https://github.com/opensearch-project/index-management/pull/1404) | Java Agent migration build fix |
+| v2.18.0 | [#1257](https://github.com/opensearch-project/index-management/pull/1257) | Fixing snapshot bug - partial snapshot detection |
+| v2.18.0 | [#1187](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1187) | Create snapshot policy button reload fix |
+| v2.18.0 | [#1189](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1189) | Data source initialization fix |
 | v2.17.0 | [#1219](https://github.com/opensearch-project/index-management/pull/1219) | Skip execution optimization using cluster service |
 | v2.17.0 | [#1222](https://github.com/opensearch-project/index-management/pull/1222) | Security integration test fixes |
 
@@ -198,4 +201,5 @@ PUT _plugins/_rollup/jobs/sample_rollup
 ## Change History
 
 - **v3.0.0** (2025-05-06): Added ISM unfollow action for CCR, rollup target index settings, CVE fixes, Java Agent migration
+- **v2.18.0** (2024-11-05): Fixed snapshot status detection (partial snapshots now correctly detected as failures), fixed snapshot policy button causing dashboard reload, fixed data source initialization in multi-data-source environments
 - **v2.17.0** (2024-09-17): Performance optimization for skip execution check using cluster service instead of NodesInfoRequest, security integration test fixes

--- a/docs/releases/v2.18.0/features/index-management/index-management-bugfixes.md
+++ b/docs/releases/v2.18.0/features/index-management/index-management-bugfixes.md
@@ -1,0 +1,127 @@
+# Index Management Bugfixes
+
+## Summary
+
+This release includes three important bugfixes for the Index Management plugin and its Dashboards component. The fixes address issues with snapshot status detection, snapshot policy UI navigation, and data source initialization in multi-data-source environments.
+
+## Details
+
+### What's New in v2.18.0
+
+Three bugfixes were merged to improve the reliability and user experience of Index Management:
+
+1. **Snapshot Status Detection Fix** - Fixed incorrect detection of partial snapshots as successful
+2. **Snapshot Policy Button Fix** - Fixed dashboard reload issue when clicking "Create snapshot policy"
+3. **Data Source Initialization Fix** - Fixed initial data source being incorrectly set to local cluster
+
+### Technical Changes
+
+#### Snapshot Status Detection (Backend)
+
+The `WaitForSnapshotStep` was updated to use `GetSnapshotsRequest` instead of `SnapshotsStatusRequest` for checking snapshot completion status.
+
+**Problem**: The previous implementation using `GetSnapshotStatus` API could incorrectly report partial snapshots as successful, leading to data integrity issues.
+
+**Solution**: Replaced with `GetSnapshots` API which provides accurate `SnapshotState` information including:
+- `IN_PROGRESS` - Snapshot is still running
+- `SUCCESS` - Snapshot completed successfully
+- `FAILED` - Snapshot failed
+- `PARTIAL` - Snapshot is partial (now correctly detected as failure)
+- `INCOMPATIBLE` - Snapshot is incompatible
+
+```kotlin
+// Before: Using SnapshotsStatusRequest
+val request = SnapshotsStatusRequest()
+    .snapshots(arrayOf(snapshotName))
+    .repository(repository)
+val response: SnapshotsStatusResponse = client.admin().cluster()
+    .suspendUntil { snapshotsStatus(request, it) }
+
+// After: Using GetSnapshotsRequest
+val newRequest = GetSnapshotsRequest()
+    .snapshots(arrayOf(snapshotName))
+    .repository(repository)
+val response: GetSnapshotsResponse = client.admin().cluster()
+    .suspendUntil { getSnapshots(newRequest, it) }
+```
+
+#### Snapshot Policy Button Fix (Frontend)
+
+Changed the "Create Policy" button behavior from using `href` navigation to using the `run` callback method.
+
+```typescript
+// Before: href causes full page reload
+{
+  label: "Create policy",
+  iconType: "plus",
+  fill: true,
+  href: `${PLUGIN_NAME}#${ROUTES.CREATE_SNAPSHOT_POLICY}`,
+  ...
+}
+
+// After: run callback for SPA navigation
+{
+  label: "Create policy",
+  iconType: "plus",
+  fill: true,
+  run: this.onClickCreate,
+  ...
+}
+```
+
+#### Data Source Initialization Fix (Frontend)
+
+Fixed the initial data source selection logic to properly handle the "Local" cluster identifier.
+
+```typescript
+// Before: Only checked for undefined
+dataSourceLoading: dataSourceId === undefined 
+    ? props.multiDataSourceEnabled : false
+
+// After: Also checks for "Local" identifier
+dataSourceLoading: dataSourceId === undefined || dataSourceId === "Local" 
+    ? props.multiDataSourceEnabled : false
+```
+
+Also added validation to prevent empty data source selection:
+```typescript
+onSelectedDataSources = (dataSources: DataSourceOption[]) => {
+  if (dataSources.length == 0) {
+    return; // No datasource selected, skip update
+  }
+  // ... rest of the handler
+}
+```
+
+### Files Changed
+
+| File | Changes |
+|------|---------|
+| `WaitForSnapshotStep.kt` | Replaced SnapshotsStatusRequest with GetSnapshotsRequest |
+| `WaitForSnapshotStepTests.kt` | Updated tests for new API |
+| `TestUtils.kt` | Added mockSnapshotInfo helper function |
+| `SnapshotPolicies.tsx` | Changed button from href to run callback |
+| `Main.tsx` | Fixed data source initialization logic |
+
+## Limitations
+
+- The snapshot status fix only affects new snapshot operations; existing snapshots with incorrect status are not retroactively corrected
+- The data source fix requires the multi-data-source feature to be enabled
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#1257](https://github.com/opensearch-project/index-management/pull/1257) | index-management | Fixing snapshot bug |
+| [#1187](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1187) | index-management-dashboards-plugin | Create snapshot policy button reloads the dashboard |
+| [#1189](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1189) | index-management-dashboards-plugin | Fixing a bug with initial data source being set to local cluster |
+
+## References
+
+- [Snapshot Management Documentation](https://docs.opensearch.org/2.18/dashboards/sm-dashboards/)
+- [Snapshot Management API](https://docs.opensearch.org/2.18/tuning-your-cluster/availability-and-recovery/snapshots/sm-api/)
+- [Index State Management](https://docs.opensearch.org/2.18/im-plugin/ism/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/index-management/index-management.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -149,6 +149,10 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 - [Job Scheduler](features/job-scheduler/job-scheduler.md) - Return LockService from createComponents for Guice injection
 
+### Index Management
+
+- [Index Management Bugfixes](features/index-management/index-management-bugfixes.md) - Snapshot status detection fix, snapshot policy button reload fix, data source initialization fix
+
 ### Observability
 
 - [Observability Bugfixes](features/observability/observability-bugfixes.md) - Multiple bug fixes including navigation fixes, workspace compatibility, MDS support improvements, and UI/UX enhancements


### PR DESCRIPTION
## Summary

This PR adds documentation for Index Management bugfixes in v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/index-management/index-management-bugfixes.md`
- Feature report: `docs/features/index-management/index-management.md` (updated)

### Key Changes in v2.18.0
- **Snapshot Status Detection Fix** - Fixed incorrect detection of partial snapshots as successful by replacing GetSnapshotStatus API with GetSnapshots API
- **Snapshot Policy Button Fix** - Fixed dashboard reload issue when clicking \"Create snapshot policy\" button
- **Data Source Initialization Fix** - Fixed initial data source being incorrectly set to local cluster in multi-data-source environments

### Related PRs
- [opensearch-project/index-management#1257](https://github.com/opensearch-project/index-management/pull/1257) - Fixing snapshot bug
- [opensearch-project/index-management-dashboards-plugin#1187](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1187) - Create snapshot policy button reloads the dashboard
- [opensearch-project/index-management-dashboards-plugin#1189](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1189) - Fixing a bug with initial data source being set to local cluster

Closes #587"