### PR TITLE
docs: add Flow Framework Bugfixes report for v2.18.0

### DIFF
--- a/docs/features/flow-framework/flow-framework.md
+++ b/docs/features/flow-framework/flow-framework.md
@@ -198,6 +198,7 @@ POST /_plugins/_flow_framework/workflow/<id>/_deprovision
 | v3.0.0 | [#1107](https://github.com/opensearch-project/flow-framework/pull/1107) | Fix bug handleReprovision missing wait_for_completion_timeout response |
 | v3.0.0 | [#1113](https://github.com/opensearch-project/flow-framework/pull/1113) | Add new attributes field to ToolStep |
 | v3.0.0 | [#936](https://github.com/opensearch-project/flow-framework/pull/936) | Add text to visualization agent template |
+| v2.18.0 | [#918](https://github.com/opensearch-project/flow-framework/pull/918) | Fixed template update location and improved logger statements in ReprovisionWorkflowTransportAction |
 | v2.18.0 | [#894](https://github.com/opensearch-project/flow-framework/pull/894) | Update workflow state without using painless script |
 | v2.17.0 | [#804](https://github.com/opensearch-project/flow-framework/pull/804) | Adds reprovision API to support updating search pipelines, ingest pipelines, index settings |
 
@@ -216,5 +217,5 @@ POST /_plugins/_flow_framework/workflow/<id>/_deprovision
 ## Change History
 
 - **v3.0.0** (2025-05-06): OpenSearch 3.0 compatibility fixes, per-tenant provisioning throttling, REST status code corrections, config parser fix for tenant_id, synchronous provisioning action listener fix, reprovision timeout response fix, ToolStep attributes field, text-to-visualization templates
-- **v2.18.0** (2024-11-05): Removed Painless scripts for workflow state updates, implemented optimistic locking with sequence numbers and primary terms for better concurrency control
+- **v2.18.0** (2024-11-05): Removed Painless scripts for workflow state updates, implemented optimistic locking with sequence numbers and primary terms for better concurrency control; Fixed template update location in ReprovisionWorkflowTransportAction to resolve flaky integration tests, improved logger statements for better debugging
 - **v2.17.0** (2024-10-01): Initial Reprovision API implementation supporting updates to search pipelines, ingest pipelines, and index settings

--- a/docs/releases/v2.18.0/features/flow-framework/flow-framework-bugfixes.md
+++ b/docs/releases/v2.18.0/features/flow-framework/flow-framework-bugfixes.md
@@ -1,0 +1,90 @@
+# Flow Framework Bugfixes
+
+## Summary
+
+This release fixes a bug in the reprovision workflow where the template update was occurring at the wrong location in the execution flow, causing flaky integration tests. The fix also improves logger statements for better debugging and clarity.
+
+## Details
+
+### What's New in v2.18.0
+
+Fixed the template update timing in `ReprovisionWorkflowTransportAction` to occur at the start of workflow execution rather than after completion. This resolves a race condition that caused the `testReprovisionWorkflow` integration test to fail intermittently across multiple platforms (Windows, Linux, macOS).
+
+### Technical Changes
+
+#### Bug Fix: Template Update Location
+
+The original implementation updated the template document after all workflow steps completed successfully. This created a race condition where the workflow state could be checked before the template was fully updated.
+
+**Before (v2.17.0):**
+```java
+// Template update happened AFTER workflow completion
+private void executeWorkflow(...) {
+    // Execute all workflow steps
+    // ...
+    // Then update template (race condition here)
+    flowFrameworkIndicesHandler.updateTemplateInGlobalContext(...);
+}
+```
+
+**After (v2.18.0):**
+```java
+// Template update now happens at START of execution
+private void executeWorkflowAsync(...) {
+    threadPool.executor(PROVISION_WORKFLOW_THREAD_POOL).execute(() -> {
+        updateTemplate(template, workflowId);  // Update first
+        executeWorkflow(template, workflowSequence, workflowId);
+    });
+}
+
+private void updateTemplate(Template template, String workflowId) {
+    flowFrameworkIndicesHandler.updateTemplateInGlobalContext(
+        workflowId, 
+        template, 
+        ActionListener.wrap(
+            templateResponse -> logger.info("Updated template for {}", workflowId),
+            exception -> logger.error("Failed to update use case template for {}", workflowId, exception)
+        ),
+        true  // ignores NOT_STARTED state for reprovision
+    );
+}
+```
+
+#### Improved Logger Statements
+
+Enhanced logging in the workflow execution to include the workflow step type for better debugging:
+
+```java
+// Before
+logger.info("Queueing process [{}].{}", processNode.id(), ...);
+
+// After  
+logger.info("Queueing Process [{} (type: {})].{}", 
+    processNode.id(), 
+    processNode.workflowStep().getName(), 
+    ...);
+```
+
+### Migration Notes
+
+No migration required. This is a bug fix that improves reliability without changing the API or behavior.
+
+## Limitations
+
+- The fix addresses the specific race condition in reprovision workflows
+- Template updates are now asynchronous at the start of execution
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#918](https://github.com/opensearch-project/flow-framework/pull/918) | Fixed Template Update Location and Improved Logger Statements in ReprovisionWorkflowTransportAction |
+
+## References
+
+- [Issue #870](https://github.com/opensearch-project/flow-framework/issues/870): Reprovision Workflow IT is flaky
+- [Create or Update Workflow API](https://docs.opensearch.org/2.18/automating-configurations/api/create-workflow/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/flow-framework/flow-framework.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -90,6 +90,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### Flow Framework
 
 - [Flow Framework Workflow State](features/flow-framework/flow-framework-workflow-state.md) - Remove Painless scripts for workflow state updates, implement optimistic locking
+- [Flow Framework Bugfixes](features/flow-framework/flow-framework-bugfixes.md) - Fix template update location in ReprovisionWorkflowTransportAction, improved logger statements
 - [Query Assist Data Summary Agent](features/flow-framework/query-assist.md) - Add sample template for Query Assist Data Summary Agent using Claude on Bedrock
 
 ### Alerting


### PR DESCRIPTION
## Summary

This PR adds documentation for the Flow Framework Bugfixes release item in v2.18.0.

### Changes

**Release Report Created:**
- `docs/releases/v2.18.0/features/flow-framework/flow-framework-bugfixes.md`

**Feature Report Updated:**
- `docs/features/flow-framework/flow-framework.md` - Added PR #918 to Related PRs and updated Change History

### Key Findings

This release fixes a bug in `ReprovisionWorkflowTransportAction` where the template update was occurring at the wrong location in the execution flow:

- **Problem**: Template was updated after workflow completion, causing a race condition
- **Solution**: Template update now happens at the start of workflow execution
- **Impact**: Resolves flaky `testReprovisionWorkflow` integration test across Windows, Linux, and macOS

### Resources Used
- PR: [opensearch-project/flow-framework#918](https://github.com/opensearch-project/flow-framework/pull/918)
- Issue: [opensearch-project/flow-framework#870](https://github.com/opensearch-project/flow-framework/issues/870)
- Docs: [Create or Update Workflow API](https://docs.opensearch.org/2.18/automating-configurations/api/create-workflow/)