### PR TITLE
docs: add reporting bugfixes report for v2.18.0

### DIFF
--- a/docs/features/dashboards-reporting/dashboards-reporting.md
+++ b/docs/features/dashboards-reporting/dashboards-reporting.md
@@ -119,6 +119,7 @@ opensearch-reporting-cli \
 | v3.0.0 | [#524](https://github.com/opensearch-project/dashboards-reporting/pull/524) | Support for date range in report generation |
 | v3.0.0 | [#554](https://github.com/opensearch-project/dashboards-reporting/pull/554) | Updated optional parameters for timeFrom and timeTo |
 | v3.0.0 | [#570](https://github.com/opensearch-project/dashboards-reporting/pull/570) | Reporting Popover UI fix |
+| v2.18.0 | [#464](https://github.com/opensearch-project/dashboards-reporting/pull/464) | Fix missing imports in report_settings |
 
 ## References
 
@@ -131,3 +132,4 @@ opensearch-reporting-cli \
 ## Change History
 
 - **v3.0.0** (2025-05-20): Fixed date range handling in report generation, made time parameters optional, fixed popover UI positioning
+- **v2.18.0** (2024-11-12): Fixed missing EUI component imports in report_settings component

--- a/docs/releases/v2.18.0/features/dashboards-reporting/reporting-bugfixes.md
+++ b/docs/releases/v2.18.0/features/dashboards-reporting/reporting-bugfixes.md
@@ -1,0 +1,72 @@
+# Reporting Bugfixes
+
+## Summary
+
+This release fixes a bug in the OpenSearch Dashboards Reporting plugin where missing imports in the `report_settings.tsx` component caused runtime errors. The imports were accidentally removed in a previous refactoring PR.
+
+## Details
+
+### What's New in v2.18.0
+
+Fixed missing EUI component imports in the report settings component that were accidentally removed during a previous code refactoring.
+
+### Technical Changes
+
+#### Bug Fix
+
+The following EUI component imports were restored to `report_settings.tsx`:
+
+| Component | Purpose |
+|-----------|---------|
+| `EuiFlexItem` | Flexible layout item |
+| `EuiFlexGroup` | Flexible layout container |
+| `EuiTextArea` | Text area input |
+| `EuiPageContentBody` | Page content body wrapper |
+| `EuiPageContent` | Page content wrapper |
+| `EuiHorizontalRule` | Horizontal divider |
+| `EuiPageHeader` | Page header component |
+| `EuiTitle` | Title component |
+| `EuiFieldText` | Text field input |
+
+These imports are required for the report settings UI to render correctly.
+
+### Root Cause
+
+The imports were accidentally removed by [PR #431](https://github.com/opensearch-project/dashboards-reporting/pull/431) during a code refactoring effort.
+
+### Usage Example
+
+The report settings component uses these EUI components to build the report configuration form:
+
+```tsx
+import {
+  EuiFlexItem,
+  EuiFlexGroup,
+  EuiTextArea,
+  EuiPageContentBody,
+  EuiPageContent,
+  EuiHorizontalRule,
+  EuiPageHeader,
+  EuiTitle,
+  EuiFieldText,
+} from '@elastic/eui';
+```
+
+## Limitations
+
+None specific to this fix.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#464](https://github.com/opensearch-project/dashboards-reporting/pull/464) | Fix missing imports in report_settings |
+| [#431](https://github.com/opensearch-project/dashboards-reporting/pull/431) | Original PR that removed imports |
+
+## References
+
+- [Release Notes v2.18.0](https://github.com/opensearch-project/dashboards-reporting/blob/main/release-notes/opensearch-dashboards-reporting.release-notes-2.18.0.0.md)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/dashboards-reporting/reporting.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -146,6 +146,10 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 - [Query Workbench Bugfixes](features/dashboards-query-workbench/query-workbench-bugfixes.md) - Bug fixes for modal mounting support and MDS error handling
 
+### Dashboards Reporting
+
+- [Reporting Bugfixes](features/dashboards-reporting/reporting-bugfixes.md) - Fix missing EUI component imports in report_settings component
+
 ### Job Scheduler
 
 - [Job Scheduler](features/job-scheduler/job-scheduler.md) - Return LockService from createComponents for Guice injection


### PR DESCRIPTION
## Summary

Add release report for OpenSearch Dashboards Reporting bugfixes in v2.18.0.

### Changes
- Created release report: `docs/releases/v2.18.0/features/dashboards-reporting/reporting-bugfixes.md`
- Updated feature report: `docs/features/dashboards-reporting/dashboards-reporting.md`
- Updated release index: `docs/releases/v2.18.0/index.md`

### Bug Fixed
- PR #464: Fix missing EUI component imports in report_settings component

Closes #585