### PR TITLE
docs: add notifications-bugfixes report for v2.18.0

### DIFF
--- a/docs/features/dashboards-notifications/dashboards-notifications.md
+++ b/docs/features/dashboards-notifications/dashboards-notifications.md
@@ -89,6 +89,10 @@ The plugin uses the following URL parameters for state management:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.18.0 | [#287](https://github.com/opensearch-project/dashboards-notifications/pull/287) | Fix typo in recipient |
+| v2.18.0 | [#290](https://github.com/opensearch-project/dashboards-notifications/pull/290) | Bug fix to switch to default datasource instead of local cluster |
+| v2.18.0 | [#271](https://github.com/opensearch-project/dashboards-notifications/pull/271) | Fix CI workflow for windows |
+| v2.18.0 | [#280](https://github.com/opensearch-project/dashboards-notifications/pull/280) | Fix cache cypress hashfile path |
 | v2.17.0 | [#234](https://github.com/opensearch-project/dashboards-notifications/pull/234) | Change parent item name for new navigation |
 | v2.17.0 | [#242](https://github.com/opensearch-project/dashboards-notifications/pull/242) | Fix link checker |
 | v2.17.0 | [#244](https://github.com/opensearch-project/dashboards-notifications/pull/244) | Persist dataSourceId across applications |
@@ -103,6 +107,7 @@ The plugin uses the following URL parameters for state management:
 
 ## Change History
 
+- **v2.18.0** (2024-11-05): Fixed default data source selection to use configured default instead of local cluster when MDS is enabled, fixed typo in recipient groups UI, updated CI workflows for Java 21
 - **v2.17.0** (2024-09-17): Changed navigation parent item name to "Notification channels", added description for left navigation, fixed link checker CI, added dataSourceId persistence for new navigation
 - **v2.15.0**: Bug fixes for MDS support in getServerFeatures API
 - **v2.14.0**: Added Multi-Data-Source (MDS) support

--- a/docs/releases/v2.18.0/features/dashboards-notifications/notifications-bugfixes.md
+++ b/docs/releases/v2.18.0/features/dashboards-notifications/notifications-bugfixes.md
@@ -1,0 +1,94 @@
+# Notifications Bugfixes
+
+## Summary
+
+OpenSearch Dashboards Notifications v2.18.0 includes several bug fixes focused on improving the Multi-Data-Source (MDS) experience and fixing UI typos. The key fix addresses an issue where the plugin incorrectly defaulted to the local cluster instead of the configured default data source during initial page load.
+
+## Details
+
+### What's New in v2.18.0
+
+This release contains bug fixes for the Dashboards Notifications plugin, primarily addressing data source selection behavior and minor UI improvements.
+
+### Technical Changes
+
+#### Data Source Selection Fix (PR #290)
+
+The main bug fix addresses incorrect data source initialization behavior:
+
+**Problem**: When MDS was enabled and local cluster was disabled, the plugin would still try to use the local cluster as the default, causing errors.
+
+**Solution**: 
+- Changed `dataSourceObservable` default value from `LocalCluster` to an empty object `{}`
+- Added guard clause in `onSelectedDataSources` to handle empty data source arrays
+- Modified `updateDefaultRouteOfManagementApplications` to only append `dataSourceId` to the hash when the value is defined
+
+```typescript
+// Before: Always defaulted to local cluster
+export const dataSourceObservable = new BehaviorSubject<DataSourceOption>(LocalCluster);
+
+// After: Use empty object to let data source picker determine the default
+export const dataSourceObservable = new BehaviorSubject<DataSourceOption>({});
+```
+
+#### Route Handling Improvement
+
+The plugin now properly handles undefined data source values:
+
+```typescript
+const dataSourceValue = dataSourceObservable.value?.id;
+let hash = `#/`;
+// Only append dataSourceId when it's defined
+if (dataSourceValue !== undefined) {
+  hash = `#/?dataSourceId=${dataSourceValue}`;
+}
+```
+
+#### Error Response Code Fix
+
+Changed error response status codes from 500 to 404 for missing resources in `configRoutes.ts`, providing more accurate HTTP semantics.
+
+#### UI Typo Fix (PR #287)
+
+Fixed typo in the Email Recipient Groups UI:
+- Changed `recepient` to `recipient` in button variable name
+- Fixed application title from "Email recepient groups" to "Email recipient groups"
+
+#### CI/CD Improvements
+
+- Updated Java version from 11 to 21 in GitHub Actions workflows
+- Ensures compatibility with newer OpenSearch versions
+
+### Files Changed
+
+| File | Changes |
+|------|---------|
+| `public/pages/Main/Main.tsx` | Data source initialization logic |
+| `public/plugin.ts` | Route hash handling, typo fix |
+| `public/utils/constants.ts` | Default data source observable |
+| `server/routes/configRoutes.ts` | Error status codes, validation |
+| `public/pages/Emails/components/tables/RecipientGroupsTable.tsx` | Typo fix |
+| `.github/workflows/*.yml` | Java version update |
+
+## Limitations
+
+- These fixes are specific to MDS-enabled deployments
+- Users with local cluster disabled must ensure a default data source is configured
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#287](https://github.com/opensearch-project/dashboards-notifications/pull/287) | Fix typo in recipient |
+| [#290](https://github.com/opensearch-project/dashboards-notifications/pull/290) | Bug fix to switch to default datasource instead of local cluster |
+| [#271](https://github.com/opensearch-project/dashboards-notifications/pull/271) | Fix CI workflow for windows |
+| [#280](https://github.com/opensearch-project/dashboards-notifications/pull/280) | Fix cache cypress hashfile path |
+
+## References
+
+- [dashboards-notifications Repository](https://github.com/opensearch-project/dashboards-notifications)
+- [PR #290 Video Demo](https://github.com/user-attachments/assets/71861be4-3f4f-4cdf-a0cf-9d79bf8b5780)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-notifications/dashboards-notifications.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -150,6 +150,10 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 - [Reporting Bugfixes](features/dashboards-reporting/reporting-bugfixes.md) - Fix missing EUI component imports in report_settings component
 
+### Dashboards Notifications
+
+- [Notifications Bugfixes](features/dashboards-notifications/notifications-bugfixes.md) - Fix default data source selection, typo fixes, CI workflow updates
+
 ### Job Scheduler
 
 - [Job Scheduler](features/job-scheduler/job-scheduler.md) - Return LockService from createComponents for Guice injection


### PR DESCRIPTION
## Summary

Add release report for Notifications Bugfixes in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/dashboards-notifications/notifications-bugfixes.md`
- Feature report: `docs/features/dashboards-notifications/dashboards-notifications.md` (updated)

### Key Changes in v2.18.0
- Fixed default data source selection to use configured default instead of local cluster when MDS is enabled
- Fixed typo in recipient groups UI ("recepient" → "recipient")
- Updated CI workflows for Java 21
- Fixed CI workflow for Windows and Cypress cache

### PRs Investigated
- [#287](https://github.com/opensearch-project/dashboards-notifications/pull/287) - Fix typo in recipient
- [#290](https://github.com/opensearch-project/dashboards-notifications/pull/290) - Bug fix to switch to default datasource
- [#271](https://github.com/opensearch-project/dashboards-notifications/pull/271) - Fix CI workflow for windows
- [#280](https://github.com/opensearch-project/dashboards-notifications/pull/280) - Fix cache cypress hashfile path

Closes #584