### PR TITLE
docs: add dashboards-i18n report for v2.18.0

### DIFF
--- a/docs/features/opensearch-dashboards/i18n-localization.md
+++ b/docs/features/opensearch-dashboards/i18n-localization.md
@@ -147,6 +147,7 @@ i18n.translate('title', { defaultMessage: 'Workspace' });
 | v2.18.0 | [#8392](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8392) | Fix dynamic i18n in core |
 | v2.18.0 | [#8393](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8393) | Fix dynamic i18n in console plugin |
 | v2.18.0 | [#8394](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8394) | Fix dynamic i18n in dataSourceManagement |
+| v2.18.0 | [#8516](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8516) | Backport #8394 to 2.x branch |
 | v2.18.0 | [#8396](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8396) | Fix dynamic i18n in discover plugin |
 | v2.18.0 | [#8397](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8397) | Fix dynamic i18n in queryEnhancements |
 | v2.18.0 | [#8398](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8398) | Fix dynamic i18n in indexPatternManagement |

--- a/docs/releases/v2.18.0/features/opensearch-dashboards/dashboards-i18n.md
+++ b/docs/releases/v2.18.0/features/opensearch-dashboards/dashboards-i18n.md
@@ -1,0 +1,113 @@
+# Dashboards i18n
+
+## Summary
+
+This release fixes dynamic uses of i18n and corrects unprefixed and duplicate i18n identifiers in the dataSourceManagement plugin. These fixes ensure proper internationalization support and enable translation validation in CI/CD workflows.
+
+## Details
+
+### What's New in v2.18.0
+
+The dataSourceManagement plugin had several i18n issues that prevented proper translation validation:
+
+1. **Dynamic i18n usage**: Some code used dynamic string construction for i18n keys, which breaks static analysis
+2. **Unprefixed identifiers**: Some i18n keys lacked the required plugin prefix
+3. **Duplicate identifiers**: Some i18n keys were reused with different default messages
+
+### Technical Changes
+
+#### Fixed Dynamic i18n Patterns
+
+Before (problematic):
+```typescript
+// Dynamic default message - breaks translation extraction
+i18n.translate('dataSourceManagement.createDataSource.description', {
+  defaultMessage: useNewUX ? 'Connect OpenSearch Cluster' : 'Open Search',
+})
+```
+
+After (fixed):
+```typescript
+// Separate static translations
+useNewUX
+  ? i18n.translate('dataSourcesManagement.dataSources.createOpenSearchDataSourceBreadcrumbs', {
+      defaultMessage: 'Connect OpenSearch Cluster',
+    })
+  : i18n.translate('dataSourcesManagement.legacyUX.dataSources.createOpenSearchDataSourceBreadcrumbs', {
+      defaultMessage: 'Open Search',
+    })
+```
+
+#### Fixed Unprefixed Identifiers
+
+| Before | After |
+|--------|-------|
+| `dataSource.localCluster` | `dataSourcesManagement.localCluster` |
+| `dataSource.fetchDataSourceError` | `dataSourcesManagement.error.fetchDataSourceById` |
+| `dataSource.management.dataSourceColumn` | `dataSourcesManagement.dataSourceColumn` |
+| `dataSourceError.dataSourceErrorMenuHeaderLink` | `dataSourcesManagement.dataSourceError.dataSourceErrorMenuHeaderLink` |
+| `datasources.associatedObjectsTab.*` | `dataSourcesManagement.associatedObjectsTab.*` |
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `DataSourceOptionalLabelSuffix` | Reusable component for optional field labels with proper i18n |
+
+#### Refactored Toast Messages
+
+Changed from dynamic i18n in toast handlers to pre-translated messages:
+
+```typescript
+// Before
+handleDisplayToastMessage({
+  id: 'dataSourcesManagement.createDataSource.existingDatasourceNames',
+  defaultMessage: 'Unable to fetch some resources.',
+});
+
+// After
+handleDisplayToastMessage({
+  message: i18n.translate('dataSourcesManagement.createDataSource.existingDatasourceNames', {
+    defaultMessage: 'Unable to fetch some resources.',
+  }),
+});
+```
+
+### Files Changed
+
+| File | Changes |
+|------|---------|
+| `breadcrumbs.ts` | Fixed dynamic breadcrumb text |
+| `constants.tsx` | Fixed unprefixed LocalCluster identifier |
+| `create_button.tsx` | Split dynamic button text into separate translations |
+| `create_data_source_form.tsx` | Refactored section headers and optional labels |
+| `create_data_source_wizard.tsx` | Changed toast message handling |
+| `data_source_selectable.tsx` | Fixed error message i18n |
+| `data_source_selector.tsx` | Fixed placeholder and prepend text |
+| `data_source_table.tsx` | Changed toast message handling |
+| `associated_objects_*.tsx` | Fixed unprefixed identifiers |
+
+### Migration Notes
+
+No migration required. This is a bugfix that improves i18n compliance without changing functionality.
+
+## Limitations
+
+- This fix is specific to the dataSourceManagement plugin
+- Other plugins received similar fixes in separate PRs
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8394](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8394) | Main implementation (merged to main) |
+| [#8516](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8516) | Backport to 2.x branch |
+
+## References
+
+- [Issue #8394](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8394): Original PR
+- [i18n Framework Documentation](https://github.com/opensearch-project/OpenSearch-Dashboards/tree/main/packages/osd-i18n)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/i18n-localization.md)


### PR DESCRIPTION
## Summary

Add release report for Dashboards i18n bugfix in v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch-dashboards/dashboards-i18n.md`
- Feature report: Updated `docs/features/opensearch-dashboards/i18n-localization.md` with backport PR

### Key Changes in v2.18.0
- Fixed dynamic uses of i18n in dataSourceManagement plugin
- Corrected unprefixed and duplicate i18n identifiers
- Added DataSourceOptionalLabelSuffix component for reusable optional labels
- Refactored toast message handling for proper i18n

### Resources Used
- PR: #8394 (main), #8516 (backport to 2.x)

Closes #583