### PR TITLE
docs: add dashboards-maps bugfix report for v2.18.0

### DIFF
--- a/docs/features/dashboards-maps/maps-plugin-ui-updates.md
+++ b/docs/features/dashboards-maps/maps-plugin-ui-updates.md
@@ -163,6 +163,7 @@ if (showActionsInGroup) {
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.18.0 | [#680](https://github.com/opensearch-project/dashboards-maps/pull/680) | Fix flyout overlay issue with new application header |
 | v2.17.0 | [#653](https://github.com/opensearch-project/dashboards-maps/pull/653) | Conditionally use the new Page Header variant on the Maps listing page |
 | v2.17.0 | [#654](https://github.com/opensearch-project/dashboards-maps/pull/654) | Conditionally use the new Application Header variant on the Maps visualization page |
 | v2.17.0 | [#655](https://github.com/opensearch-project/dashboards-maps/pull/655) | Conditionally use full width for Maps listing page table |
@@ -176,4 +177,5 @@ if (showActionsInGroup) {
 
 ## Change History
 
+- **v2.18.0** (2024-10-22): Fix flyout overlay issue with new application header by adjusting pushMinBreakpoint to 1576px
 - **v2.17.0** (2024-09-17): Initial implementation of conditional new header UI support

--- a/docs/releases/v2.18.0/features/dashboards-maps/dashboards-maps-bugfix.md
+++ b/docs/releases/v2.18.0/features/dashboards-maps/dashboards-maps-bugfix.md
@@ -1,0 +1,80 @@
+# Dashboards Maps Bugfix
+
+## Summary
+
+This bugfix prevents the layers configuration flyout panel from overlapping the new application header in OpenSearch Dashboards Maps plugin. The fix adjusts the responsive breakpoint for the flyout's push behavior to accommodate the new header design.
+
+## Details
+
+### What's New in v2.18.0
+
+The Maps plugin's layer configuration panel was designed with the older fixed-height header in mind. With the introduction of the new application header (TriNeo project), the flyout panel started overlapping the header at certain window widths. This fix introduces a new breakpoint to force the flyout into overlay mode before it creates visual conflicts.
+
+### Technical Changes
+
+#### Problem
+
+The `EuiFlyout` component with `type="push"` was pushing page content to the left, but the new page header is no longer fixed height, causing the flyout to overlap the header at narrower window widths.
+
+#### Solution
+
+Added `pushMinBreakpoint={1576}` to the `EuiFlyout` component. Below this breakpoint (previously 992), the flyout switches to overlay mode instead of push mode, preventing the overlap issue.
+
+```mermaid
+graph TB
+    subgraph "Window Width Check"
+        A[Window Width] --> B{>= 1576px?}
+        B -->|Yes| C[Push Mode]
+        B -->|No| D[Overlay Mode]
+    end
+    
+    subgraph "Push Mode"
+        C --> E[Flyout pushes content left]
+        E --> F[Header remains visible]
+    end
+    
+    subgraph "Overlay Mode"
+        D --> G[Flyout overlays content]
+        G --> H[No header overlap]
+    end
+```
+
+#### Code Change
+
+```typescript
+// public/components/layer_config/layer_config_panel.tsx
+<EuiFlyout
+  type="push"
+  size="s"
+  onClose={onClose}
+  hideCloseButton={true}
+  className="layerConfigPanel"
+  // Flyout starts to overlap app header under this breakpoint, likely need
+  // to convert this to a panel considering the new layout.
+  pushMinBreakpoint={1576}
+>
+```
+
+### Migration Notes
+
+No migration required. This is a visual bug fix that takes effect automatically.
+
+## Limitations
+
+- This is a short-term fix; ideally the flyout should be converted to a panel component for better compatibility with the new layout system
+- The breakpoint value (1576px) is specific to the current header implementation and may need adjustment if the header design changes
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#680](https://github.com/opensearch-project/dashboards-maps/pull/680) | Fix: prevent overlay from overlapping new application header |
+
+## References
+
+- [Maps Documentation](https://docs.opensearch.org/2.18/dashboards/visualize/maps/): Official Maps plugin documentation
+- [EuiFlyout Documentation](https://eui.elastic.co/#/layout/flyout): Elastic UI Flyout component reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-maps/maps-plugin-ui-updates.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -146,6 +146,10 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 - [Query Workbench Bugfixes](features/dashboards-query-workbench/query-workbench-bugfixes.md) - Bug fixes for modal mounting support and MDS error handling
 
+### Dashboards Maps
+
+- [Dashboards Maps Bugfix](features/dashboards-maps/dashboards-maps-bugfix.md) - Fix flyout overlay issue with new application header
+
 ### Dashboards Reporting
 
 - [Reporting Bugfixes](features/dashboards-reporting/reporting-bugfixes.md) - Fix missing EUI component imports in report_settings component


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dashboards Maps bugfix in v2.18.0.

### Changes

- Created release report: `docs/releases/v2.18.0/features/dashboards-maps/dashboards-maps-bugfix.md`
- Updated feature report: `docs/features/dashboards-maps/maps-plugin-ui-updates.md` (added v2.18.0 to change history and related PRs)
- Updated release index: `docs/releases/v2.18.0/index.md`

### Bug Fix Details

The fix prevents the layers configuration flyout panel from overlapping the new application header by adjusting the `pushMinBreakpoint` from 992px to 1576px.

### Related

- Closes #582
- PR: [opensearch-project/dashboards-maps#680](https://github.com/opensearch-project/dashboards-maps/pull/680)