### PR TITLE
docs: add Anomaly Detection Bugfixes report for v2.18.0

### DIFF
--- a/docs/features/anomaly-detection/anomaly-detection.md
+++ b/docs/features/anomaly-detection/anomaly-detection.md
@@ -236,6 +236,9 @@ POST _plugins/_anomaly_detection/detectors/<detector_id>/_start
 | v3.0.0 | [#1424](https://github.com/opensearch-project/anomaly-detection/pull/1424) | Fix breaking changes for 3.0.0 release |
 | v3.0.0 | [#1450](https://github.com/opensearch-project/anomaly-detection/pull/1450) | Java Agent migration (SecurityManager removal) |
 | v3.0.0 | [#1441](https://github.com/opensearch-project/anomaly-detection/pull/1441) | Dual cluster gradle run for development |
+| v2.18.0 | [#887](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/887) | Fix custom result index session not rendering issue |
+| v2.18.0 | [#889](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/889) | Fix historical analysis route and custom result index reset |
+| v2.18.0 | [#898](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/898) | Fix preview not considering rules and imputation options |
 | v2.17.0 | [#1284](https://github.com/opensearch-project/anomaly-detection/pull/1284) | Fix inference logic and standardize config index mapping |
 | v2.17.0 | [#1287](https://github.com/opensearch-project/anomaly-detection/pull/1287) | Prevent resetting latest flag of real-time when starting historical |
 | v2.17.0 | [#1292](https://github.com/opensearch-project/anomaly-detection/pull/1292) | Correct handling of null max aggregation values |
@@ -254,5 +257,6 @@ POST _plugins/_anomaly_detection/detectors/<detector_id>/_start
 ## Change History
 
 - **v3.0.0** (2025-05-06): AWS SAM template for WAF logs, cross-cluster improvements, OpenSearch 3.0.0 compatibility updates, Java Agent migration
+- **v2.18.0** (2024-11-05): Dashboards bugfixes for custom result index rendering, historical analysis route path, custom result index field reset, and preview support for suppression rules and imputation options
 - **v2.17.0** (2024-09-17): Fixed inference logic with new `lastSeenExecutionEndTime` tracking, standardized config index mapping (`defaultFill` → `default_fill`), improved null checks for imputation options, bugfixes for real-time/historical task flag management, null aggregation handling, Dashboards data source integration
 - **v2.x**: High-cardinality detection, historical analysis, custom result indices

--- a/docs/releases/v2.18.0/features/anomaly-detection-dashboards/anomaly-detection-bugfixes.md
+++ b/docs/releases/v2.18.0/features/anomaly-detection-dashboards/anomaly-detection-bugfixes.md
@@ -1,0 +1,135 @@
+# Anomaly Detection Dashboards Bugfixes
+
+## Summary
+
+Three bug fixes for the Anomaly Detection Dashboards plugin in v2.18.0 addressing issues with custom result index rendering, historical analysis execution, and preview functionality. These fixes improve the reliability of detector configuration and preview workflows.
+
+## Details
+
+### What's New in v2.18.0
+
+This release includes three targeted bug fixes for the Anomaly Detection Dashboards plugin:
+
+1. **Custom Result Index Session Rendering** - Fixed an issue where the custom result index section was not rendering correctly due to incorrect checkbox component usage.
+
+2. **Historical Analysis and Custom Result Index** - Fixed two issues:
+   - Wrong route path when running historical analysis
+   - Custom result index field not resetting to `undefined` when disabled, causing validation errors on the create detector review page
+
+3. **Preview Not Considering Rules and Imputation** - Fixed a bug where the anomaly preview did not account for suppression rules and imputation options when generating sample anomalies.
+
+### Technical Changes
+
+#### Custom Result Index Rendering Fix (PR #887)
+
+Changed the checkbox component from `EuiCheckbox` to `EuiCompressedCheckbox` for proper rendering in the custom result index section:
+
+```tsx
+// Before
+<EuiCheckbox
+  id={'resultIndexConditionCheckbox'}
+  ...
+/>
+
+// After
+<EuiCompressedCheckbox
+  id={'resultIndexConditionCheckbox'}
+  ...
+/>
+```
+
+#### Historical Analysis Route Fix (PR #889)
+
+Fixed the URL construction for starting historical analysis with data source support:
+
+```typescript
+// Before (incorrect)
+const baseUrl = `${AD_NODE_API.DETECTOR}/${detectorId}`;
+const url = dataSourceId
+  ? `${baseUrl}/${dataSourceId}/start`
+  : `${baseUrl}/start`;
+
+// After (correct)
+const baseUrl = `${AD_NODE_API.DETECTOR}/${detectorId}/start`;
+const url = dataSourceId ? `${baseUrl}/${dataSourceId}` : baseUrl;
+```
+
+#### Custom Result Index Reset Fix (PR #889)
+
+Fixed the field reset behavior when disabling custom result index:
+
+```typescript
+// Before - caused validation error
+form.setFieldValue('resultIndex', '');
+
+// After - properly clears the field
+form.setFieldValue('resultIndex', undefined);
+```
+
+#### Preview Rules and Imputation Fix (PR #898)
+
+Extended the `prepareDetector` function to accept and pass imputation options and suppression rules to the preview:
+
+```typescript
+// Updated function signature
+export function prepareDetector(
+  featureValues: FeaturesFormikValues[],
+  shingleSizeValue: number,
+  categoryFields: string[],
+  ad: Detector,
+  forPreview: boolean = false,
+  imputationOption?: ImputationFormikValues,  // New parameter
+  suppressionRules?: RuleFormikValues[]       // New parameter
+): Detector {
+  // ...
+  return {
+    ...detector,
+    imputationOption: formikToImputationOption(imputationOption),
+    rules: formikToRules(suppressionRules),
+  };
+}
+```
+
+The `SampleAnomalies` component now passes these parameters when calling `prepareDetector`:
+
+```typescript
+prepareDetector(
+  props.featureList,
+  props.shingleSize,
+  props.categoryFields,
+  newDetector,
+  true,
+  props.imputationOption,      // Now passed
+  props.suppressionRules,      // Now passed
+);
+```
+
+### Files Changed
+
+| PR | Files Modified |
+|----|----------------|
+| #887 | `CustomResultIndex.tsx` (checkbox component fix) |
+| #889 | `CustomResultIndex.tsx` (field reset), `ad.ts` (route path) |
+| #898 | `ConfigureModel.tsx`, `SampleAnomalies.tsx`, `helpers.ts` (preview parameters) |
+
+## Limitations
+
+- These fixes are specific to the Dashboards UI; backend anomaly detection functionality is unchanged
+- The preview fix requires both imputation and suppression rules to be properly configured in the detector form
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#887](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/887) | Fix custom result index session not rendering issue |
+| [#889](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/889) | Fix issues in running historical analysis and custom result index section |
+| [#898](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/898) | Fix preview not considering rules and imputation options |
+
+## References
+
+- [Anomaly Detection Documentation](https://docs.opensearch.org/2.18/observing-your-data/ad/index/): Official documentation
+- [Anomaly Detection Dashboards Plugin](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin): Source repository
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/anomaly-detection/anomaly-detection.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -130,6 +130,10 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 - [Anomaly Detection Dependencies](features/anomaly-detection/anomaly-detection-dependencies.md) - Dependency updates (Jackson 2.18.0, JUnit Jupiter 5.11.2, Mockito 5.14.1) and removal of unused javassist dependency
 
+### Anomaly Detection Dashboards
+
+- [Anomaly Detection Bugfixes](features/anomaly-detection-dashboards/anomaly-detection-bugfixes.md) - Bug fixes for custom result index rendering, historical analysis route, and preview support for rules and imputation
+
 ### Security Analytics
 
 - [Security Analytics System Indices](features/security-analytics/security-analytics-system-indices.md) - Standardized system index settings (1 primary shard, 1-20 replicas), dedicated query indices option, correlation alert refresh policy fix


### PR DESCRIPTION
## Summary

Add release report for Anomaly Detection Dashboards bugfixes in v2.18.0.

## Reports Created

- **Release report**: `docs/releases/v2.18.0/features/anomaly-detection-dashboards/anomaly-detection-bugfixes.md`
- **Feature report**: Updated `docs/features/anomaly-detection/anomaly-detection.md`

## Key Changes in v2.18.0

Three bug fixes for the Anomaly Detection Dashboards plugin:

1. **PR #887**: Fix custom result index session not rendering issue (checkbox component fix)
2. **PR #889**: Fix historical analysis route path and custom result index field reset
3. **PR #898**: Fix preview not considering suppression rules and imputation options

## PRs Investigated

- [#887](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/887)
- [#889](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/889)
- [#898](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/898)

Closes #581