### PR TITLE
docs: add Notifications Fit & Finish report for v2.18.0

### DIFF
--- a/docs/features/dashboards-notifications/dashboards-notifications.md
+++ b/docs/features/dashboards-notifications/dashboards-notifications.md
@@ -89,6 +89,9 @@ The plugin uses the following URL parameters for state management:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.18.0 | [#256](https://github.com/opensearch-project/dashboards-notifications/pull/256) | Fit & Finish - semantic headers, text sizes, context menus |
+| v2.18.0 | [#263](https://github.com/opensearch-project/dashboards-notifications/pull/263) | Fit & Finish UX Fixes - spacing, full-width content |
+| v2.18.0 | [#270](https://github.com/opensearch-project/dashboards-notifications/pull/270) | Fit & Finish UX Fixes Pt 2 - filter separation, default pill |
 | v2.18.0 | [#287](https://github.com/opensearch-project/dashboards-notifications/pull/287) | Fix typo in recipient |
 | v2.18.0 | [#290](https://github.com/opensearch-project/dashboards-notifications/pull/290) | Bug fix to switch to default datasource instead of local cluster |
 | v2.18.0 | [#271](https://github.com/opensearch-project/dashboards-notifications/pull/271) | Fix CI workflow for windows |
@@ -107,7 +110,7 @@ The plugin uses the following URL parameters for state management:
 
 ## Change History
 
-- **v2.18.0** (2024-11-05): Fixed default data source selection to use configured default instead of local cluster when MDS is enabled, fixed typo in recipient groups UI, updated CI workflows for Java 21
+- **v2.18.0** (2024-11-05): Fit & Finish UX improvements - standardized semantic headers (H1/H2/H3), consistent text sizes, smaller context menus, 16px content-to-header spacing, full-width content sections, separated table filters, added default pill to encryption method dropdown. Also fixed default data source selection and typo in recipient groups UI.
 - **v2.17.0** (2024-09-17): Changed navigation parent item name to "Notification channels", added description for left navigation, fixed link checker CI, added dataSourceId persistence for new navigation
 - **v2.15.0**: Bug fixes for MDS support in getServerFeatures API
 - **v2.14.0**: Added Multi-Data-Source (MDS) support

--- a/docs/releases/v2.18.0/features/dashboards-notifications/notifications-fit-and-finish.md
+++ b/docs/releases/v2.18.0/features/dashboards-notifications/notifications-fit-and-finish.md
@@ -1,0 +1,81 @@
+# Notifications Fit & Finish
+
+## Summary
+
+OpenSearch Dashboards Notifications v2.18.0 introduces comprehensive UX improvements as part of the "Fit & Finish" initiative. These changes standardize the visual appearance, improve spacing consistency, and enhance the overall user experience across all notification management pages including Channels, Email Senders, and Email Recipient Groups.
+
+## Details
+
+### What's New in v2.18.0
+
+The Fit & Finish updates bring the Notifications plugin UI in line with OpenSearch Dashboards design guidelines, focusing on:
+
+1. **Semantic Header Sizes**: Standardized heading hierarchy (H1, H2, H3)
+2. **Text Sizes**: Consistent use of `EuiText size="s"` for body text
+3. **Context Menus**: Smaller, more compact context menus
+4. **Spacing Improvements**: Consistent 16px content-to-header spacing
+5. **Full-Width Content**: Content sections now span the full page width
+6. **Filter Separation**: Table filters are now visually separated
+7. **Default Indicators**: Added default pill to encryption method dropdown
+
+### Technical Changes
+
+#### UI Component Updates
+
+| Component | Change |
+|-----------|--------|
+| ContentPanel | Changed from `EuiTitle` to `EuiText` with `size="s"` for section headers |
+| Page Headers | Updated to use semantic H1/H2/H3 hierarchy |
+| Context Menus | Added `size="s"` to `EuiContextMenuItem` components |
+| Modal Titles | Wrapped in `EuiText size="s"` with H2 elements |
+| Empty Prompts | Updated title and body text sizes |
+| Filter Groups | Separated into distinct `EuiFilterGroup` components |
+
+#### Spacing Standardization
+
+| Area | Before | After |
+|------|--------|-------|
+| Content padding | 10px | 0px (removed extra padding) |
+| Header to content | Variable | 16px |
+| Search to actions | 10px | 8px |
+| Filter button spacing | Combined | Separated groups |
+
+#### Pages Updated
+
+- **Channels Page**: Full-width content, updated empty state, consistent spacing
+- **Channel Details Page**: Improved header alignment, active indicator positioning
+- **Email Senders Page**: Removed extra padding, updated section headers
+- **Email Recipient Groups Page**: Consistent styling with other pages
+- **Create/Edit Channel Pages**: Updated form spacing and headers
+- **Create SMTP/SES Sender Pages**: Standardized form layouts
+- **Modal Dialogs**: Consistent title sizing across all modals
+
+### Usage Example
+
+The changes are automatic and require no configuration. Users will see improved visual consistency across all notification management pages.
+
+### Migration Notes
+
+No migration required. These are purely visual/UX improvements with no API or configuration changes.
+
+## Limitations
+
+- These changes only affect the Dashboards UI; backend functionality remains unchanged
+- Some visual differences may be noticeable when comparing with older versions
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#256](https://github.com/opensearch-project/dashboards-notifications/pull/256) | Updated Fit and Finish guidelines - semantic headers, text sizes, context menus |
+| [#263](https://github.com/opensearch-project/dashboards-notifications/pull/263) | Fit and Finish UX Fixes - spacing, full-width content, button styling |
+| [#270](https://github.com/opensearch-project/dashboards-notifications/pull/270) | Fit and Finish UX Fixes Pt 2 - filter separation, encryption method default pill |
+
+## References
+
+- [OpenSearch Notifications Documentation](https://docs.opensearch.org/2.18/observing-your-data/notifications/index/)
+- [dashboards-notifications Repository](https://github.com/opensearch-project/dashboards-notifications)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-notifications/dashboards-notifications.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -162,6 +162,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### Dashboards Notifications
 
 - [Notifications Bugfixes](features/dashboards-notifications/notifications-bugfixes.md) - Fix default data source selection, typo fixes, CI workflow updates
+- [Notifications Fit & Finish](features/dashboards-notifications/notifications-fit-and-finish.md) - UX improvements: semantic headers, consistent text sizes, smaller context menus, spacing standardization, full-width content
 
 ### Job Scheduler
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Notifications Fit & Finish UX improvements in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/dashboards-notifications/notifications-fit-and-finish.md`
- Feature report updated: `docs/features/dashboards-notifications/dashboards-notifications.md`

### Key Changes in v2.18.0
- Standardized semantic header sizes (H1/H2/H3)
- Consistent text sizes using `EuiText size="s"`
- Smaller context menus
- 16px content-to-header spacing
- Full-width content sections
- Separated table filters
- Added default pill to encryption method dropdown

### PRs Investigated
- [#256](https://github.com/opensearch-project/dashboards-notifications/pull/256): Updated Fit and Finish guidelines
- [#263](https://github.com/opensearch-project/dashboards-notifications/pull/263): Fit and Finish UX Fixes
- [#270](https://github.com/opensearch-project/dashboards-notifications/pull/270): Fit and Finish UX Fixes Pt 2

Closes #579