### PR TITLE
docs: add k-NN Performance & Engine report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -265,6 +265,7 @@
 
 - [Disk-Based Vector Search](k-nn/disk-based-vector-search.md)
 - [k-NN Byte Vector Support](k-nn/k-nn-byte-vector-support.md)
+- [k-NN Performance & Engine](k-nn/k-nn-performance-engine.md)
 - [Vector Search (k-NN)](k-nn/vector-search-k-nn.md)
 - [k-NN Explain API](k-nn/explain-api.md)
 - [k-NN Iterative Graph Build](k-nn/k-nn-iterative-graph-build.md)

--- a/docs/features/k-nn/k-nn-performance-engine.md
+++ b/docs/features/k-nn/k-nn-performance-engine.md
@@ -1,0 +1,194 @@
+# k-NN Performance & Engine
+
+## Summary
+
+The k-NN plugin provides approximate k-nearest neighbor (k-NN) search capabilities in OpenSearch. It supports multiple engines (FAISS, NMSLIB, Lucene) for building and searching vector indexes. This feature encompasses performance optimizations, engine selection, memory management, and rescoring mechanisms that enable efficient vector similarity search at scale.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "k-NN Plugin Architecture"
+        Query[k-NN Query] --> QP[Query Parser]
+        QP --> Router{Threshold Check}
+        Router -->|docs < threshold| Exact[Exact Search]
+        Router -->|docs >= threshold| Approx[Approximate Search]
+        
+        subgraph "Engines"
+            Approx --> FAISS[FAISS Engine]
+            Approx --> NMSLIB[NMSLIB Engine]
+            Approx --> Lucene[Lucene Engine]
+        end
+        
+        FAISS --> Rescore[Rescoring Layer]
+        NMSLIB --> Rescore
+        Lucene --> Rescore
+        Exact --> Results[Results]
+        Rescore --> Results
+    end
+    
+    subgraph "Memory Management"
+        Segment[Segment Close] --> DVP[DocValuesProducer]
+        DVP --> Cache[Native Cache]
+        Cache --> Release[Memory Release]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Indexing Flow"
+        Doc[Document] --> Vector[Vector Extraction]
+        Vector --> Check{Threshold Check}
+        Check -->|Below threshold| Store[Store Only]
+        Check -->|Above threshold| Build[Build Graph]
+        Build --> Native[Native Index]
+    end
+    
+    subgraph "Search Flow"
+        SQ[Search Query] --> Shard[Shard Search]
+        Shard --> Segment[Segment Search]
+        Segment --> TopK[Top-K per Segment]
+        TopK --> Merge[Merge Results]
+        Merge --> Oversample{Rescoring?}
+        Oversample -->|Yes| Rescore[Rescore with Full Vectors]
+        Oversample -->|No| Final[Final Results]
+        Rescore --> Final
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `KNNQueryBuilder` | Builds k-NN queries with parameters like k, filter, and method parameters |
+| `KNNWeight` | Lucene Weight implementation for k-NN scoring |
+| `KNNIterators` | Iterators for traversing vectors with optional filtering |
+| `RescoreContext` | Manages rescoring parameters including oversampling factor |
+| `KNN80DocValuesProducer` | Handles memory release when segments are closed |
+| `NativeEngineIndex` | Interface for native library index operations |
+| `ResultUtil` | Utility for reducing results to top-K |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `knn.default.engine` | Default engine for new k-NN indexes | `faiss` |
+| `index.knn` | Enable k-NN on the index | `false` |
+| `index.knn.advanced.approximate_threshold` | Document count threshold for approximate search | `15000` |
+| `index.knn.advanced.shard_level_rescoring_disabled` | Disable shard-level rescoring | `false` |
+| `knn.algo_param.index_thread_qty` | Number of threads for index construction | System dependent |
+| `knn.memory.circuit_breaker.limit` | Memory limit for native indexes | `50%` |
+| `knn.memory.circuit_breaker.enabled` | Enable memory circuit breaker | `true` |
+
+### Engine Comparison
+
+| Feature | FAISS | NMSLIB | Lucene |
+|---------|-------|--------|--------|
+| Default (v2.18+) | ✅ | ❌ | ❌ |
+| Binary Quantization | ✅ | ❌ | ❌ |
+| Product Quantization | ✅ | ❌ | ❌ |
+| Scalar Quantization | ✅ | ❌ | ✅ |
+| SIMD Support | ✅ (Linux) | ✅ | ✅ |
+| Disk-based Search | ✅ | ❌ | ✅ |
+| Indexing Throughput | High | Medium | Medium |
+| Search Latency | Low | Very Low | Low |
+
+### Rescoring Mechanism
+
+The rescoring mechanism improves recall by oversampling candidates and re-ranking with full precision vectors:
+
+| Dimension Range | Oversampling Factor | Use Case |
+|-----------------|---------------------|----------|
+| dim < 768 | 3.0x | Small embeddings (e.g., word2vec) |
+| 768 ≤ dim ≤ 1000 | 2.0x | Standard embeddings (e.g., BERT) |
+| dim > 1000 | 1.0x | Large embeddings (e.g., multimodal) |
+
+### Usage Example
+
+```yaml
+# Index creation with FAISS engine
+PUT /products-vectors
+{
+  "settings": {
+    "index": {
+      "knn": true,
+      "knn.advanced.approximate_threshold": 15000
+    }
+  },
+  "mappings": {
+    "properties": {
+      "product_embedding": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "space_type": "l2",
+          "parameters": {
+            "ef_construction": 256,
+            "m": 16
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+// Search query
+GET /products-vectors/_search
+{
+  "size": 10,
+  "query": {
+    "knn": {
+      "product_embedding": {
+        "vector": [0.1, 0.2, ...],
+        "k": 10
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- SIMD optimization for FAISS is only available on Linux
+- Binary quantization uses Hamming distance only
+- Compression levels above 32x are capped at 32x for oversampling
+- Memory circuit breaker may reject queries under high load
+- Exact search performance degrades with large document counts
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#2221](https://github.com/opensearch-project/k-NN/pull/2221) | Update default engine to FAISS |
+| v2.18.0 | [#2229](https://github.com/opensearch-project/k-NN/pull/2229) | Update approximate_threshold to 15K |
+| v2.18.0 | [#2172](https://github.com/opensearch-project/k-NN/pull/2172) | Shard-level rescoring control |
+| v2.18.0 | [#2149](https://github.com/opensearch-project/k-NN/pull/2149) | Dimension-based rescore context |
+| v2.18.0 | [#2059](https://github.com/opensearch-project/k-NN/pull/2059) | Short circuit for empty segments |
+| v2.18.0 | [#2146](https://github.com/opensearch-project/k-NN/pull/2146) | Optimize reduceToTopK |
+| v2.18.0 | [#2155](https://github.com/opensearch-project/k-NN/pull/2155) | KNNIterators filter support |
+| v2.18.0 | [#2200](https://github.com/opensearch-project/k-NN/pull/2200) | PQ compression level calculation |
+| v2.18.0 | [#2182](https://github.com/opensearch-project/k-NN/pull/2182) | Remove FSDirectory dependency |
+| v2.18.0 | [#1946](https://github.com/opensearch-project/k-NN/pull/1946) | DocValuesProducers for memory release |
+| v2.18.0 | [#2147](https://github.com/opensearch-project/k-NN/pull/2147) | KNN80DocValues fix |
+| v2.18.0 | [#2183](https://github.com/opensearch-project/k-NN/pull/2183) | Binary quantized vector score fix |
+
+## References
+
+- [k-NN Search Documentation](https://docs.opensearch.org/2.18/search-plugins/knn/index/): Official k-NN plugin documentation
+- [k-NN Performance Tuning](https://docs.opensearch.org/2.18/search-plugins/knn/performance-tuning/): Performance optimization guide
+- [k-NN Index Configuration](https://docs.opensearch.org/2.18/search-plugins/knn/knn-index/): Index settings and mappings
+- [k-NN Vector Quantization](https://docs.opensearch.org/2.18/search-plugins/knn/knn-vector-quantization/): Quantization options
+- [Issue #1885](https://github.com/opensearch-project/k-NN/issues/1885): Memory release improvements
+- [Issue #2163](https://github.com/opensearch-project/k-NN/issues/2163): Default engine change
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Default engine changed to FAISS, approximate threshold updated to 15K, rescoring improvements, memory management enhancements

--- a/docs/releases/v2.18.0/features/k-nn/k-nn-performance-engine.md
+++ b/docs/releases/v2.18.0/features/k-nn/k-nn-performance-engine.md
@@ -1,0 +1,145 @@
+# k-NN Performance & Engine
+
+## Summary
+
+OpenSearch 2.18.0 introduces significant performance improvements and engine changes to the k-NN plugin. The most notable change is switching the default engine from NMSLIB to FAISS, along with various optimizations for indexing, search, and memory management. These changes improve indexing throughput, reduce search latency, and provide better memory utilization.
+
+## Details
+
+### What's New in v2.18.0
+
+#### Default Engine Change to FAISS
+
+The default k-NN engine has been changed from NMSLIB to FAISS. FAISS offers better indexing throughput and supports more advanced features like binary quantization and product quantization. Existing indexes using NMSLIB will continue to work, but new indexes will use FAISS by default unless explicitly specified.
+
+#### Approximate Threshold Update
+
+The `index.knn.advanced.approximate_threshold` setting has been updated to 15,000 documents (from the previous default). This threshold determines when the k-NN plugin switches from exact search to approximate search, balancing indexing performance with search accuracy.
+
+#### Rescoring Improvements
+
+Multiple improvements to the rescoring mechanism:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.knn.advanced.shard_level_rescoring_disabled` | Enable/disable shard-level rescoring | `false` |
+| Oversampling factor (dim < 768) | Applied for smaller vector spaces | 3.0x |
+| Oversampling factor (768 ≤ dim ≤ 1000) | Balanced recall and performance | 2.0x |
+| Oversampling factor (dim > 1000) | No oversampling for large dimensions | 1.0x |
+
+#### Memory Management Improvements
+
+- **DocValuesProducers**: Added `KNN80DocValuesProducer` for proper memory release when closing indexes
+- **FileWatcher Removal**: Removed FileWatcher dependency, relying on DocValuesProducers for memory cleanup
+- **FSDirectory Removal**: Removed FSDirectory dependency from native engine construction for cleaner architecture
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "k-NN Search Flow"
+        Query[Search Query] --> Router[Query Router]
+        Router -->|< threshold| Exact[Exact Search]
+        Router -->|>= threshold| Approx[Approximate Search]
+        Approx --> FAISS[FAISS Engine]
+        Approx --> NMSLIB[NMSLIB Engine]
+        Approx --> Lucene[Lucene Engine]
+        FAISS --> Rescore[Rescoring]
+        Rescore --> Results[Final Results]
+    end
+    
+    subgraph "Memory Management"
+        Index[Index Close] --> DVP[DocValuesProducer]
+        DVP --> Release[Memory Release]
+    end
+```
+
+#### New/Updated Components
+
+| Component | Description |
+|-----------|-------------|
+| `KNN80DocValuesProducer` | Handles memory release when segment reader closes |
+| `RescoreContext` | Updated to support dimension-based oversampling |
+| `KNNIterators` | Refactored to support both filtered and unfiltered iteration |
+| `ResultUtil.reduceToTopK` | Optimized by removing pre-filling and reducing peek calls |
+
+#### Configuration Changes
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `knn.default.engine` | Default engine for new indexes | `faiss` |
+| `index.knn.advanced.approximate_threshold` | Document threshold for approximate search | `15000` |
+| `index.knn.advanced.shard_level_rescoring_disabled` | Disable shard-level rescoring | `false` |
+
+### Usage Example
+
+```json
+PUT /my-knn-index
+{
+  "settings": {
+    "index": {
+      "knn": true,
+      "knn.advanced.approximate_threshold": 15000
+    }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "space_type": "l2",
+          "parameters": {
+            "ef_construction": 256,
+            "m": 16
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+1. **Engine Migration**: New indexes will use FAISS by default. To continue using NMSLIB, explicitly specify `"engine": "nmslib"` in the mapping.
+2. **Threshold Adjustment**: If you previously relied on the default approximate threshold, review your workload to ensure the new 15K threshold is appropriate.
+3. **Rescoring Behavior**: Shard-level rescoring is enabled by default. For multi-segment scenarios with recall issues, consider disabling it.
+
+## Limitations
+
+- Binary quantized vectors use Hamming distance; ensure your use case is compatible
+- Compression levels above 32x are capped at 32x for oversampling calculations
+- SIMD optimization for FAISS is only supported on Linux
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2221](https://github.com/opensearch-project/k-NN/pull/2221) | Update default engine to FAISS |
+| [#2229](https://github.com/opensearch-project/k-NN/pull/2229) | Update approximate_threshold to 15K documents |
+| [#2172](https://github.com/opensearch-project/k-NN/pull/2172) | Enable/disable shard-level rescoring and update oversampling factor |
+| [#2149](https://github.com/opensearch-project/k-NN/pull/2149) | Update default rescore context based on dimension |
+| [#2059](https://github.com/opensearch-project/k-NN/pull/2059) | Add short circuit if no live docs in segments |
+| [#2146](https://github.com/opensearch-project/k-NN/pull/2146) | Optimize reduceToTopK in ResultUtil |
+| [#2155](https://github.com/opensearch-project/k-NN/pull/2155) | KNNIterators support with and without filters |
+| [#2200](https://github.com/opensearch-project/k-NN/pull/2200) | Add CompressionLevel calculation for PQ |
+| [#2182](https://github.com/opensearch-project/k-NN/pull/2182) | Remove FSDirectory dependency from native engine |
+| [#1946](https://github.com/opensearch-project/k-NN/pull/1946) | Add DocValuesProducers for memory release |
+| [#2147](https://github.com/opensearch-project/k-NN/pull/2147) | KNN80DocValues for BinaryDocValues fields only |
+| [#2183](https://github.com/opensearch-project/k-NN/pull/2183) | Score fix for binary quantized vectors |
+
+## References
+
+- [k-NN Performance Tuning](https://docs.opensearch.org/2.18/search-plugins/knn/performance-tuning/): Official performance tuning guide
+- [k-NN Index](https://docs.opensearch.org/2.18/search-plugins/knn/knn-index/): Index configuration documentation
+- [Issue #2163](https://github.com/opensearch-project/k-NN/issues/2163): Default engine change discussion
+- [Issue #1885](https://github.com/opensearch-project/k-NN/issues/1885): Memory release improvements
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/k-nn/k-nn-performance-engine.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -108,6 +108,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### k-NN
 
+- [k-NN Performance & Engine](features/k-nn/k-nn-performance-engine.md) - Default engine changed to FAISS, approximate threshold updated to 15K, rescoring improvements, memory management enhancements
 - [k-NN Documentation](features/k-nn/k-nn-documentation.md) - JavaDoc cleanup for RescoreContext class
 - [k-NN Maintenance](features/k-nn/k-nn-maintenance.md) - Lucene 9.12 codec compatibility, force merge performance optimization, benchmark folder removal, code refactoring
 


### PR DESCRIPTION
## Summary

This PR adds documentation for k-NN Performance & Engine enhancements in OpenSearch v2.18.0.

### Key Changes in v2.18.0

- **Default Engine Change**: Default k-NN engine changed from NMSLIB to FAISS
- **Approximate Threshold Update**: Updated to 15,000 documents for better indexing/search balance
- **Rescoring Improvements**: Dimension-based oversampling factors and shard-level rescoring control
- **Memory Management**: DocValuesProducers for proper memory release, FileWatcher removal
- **Performance Optimizations**: Short circuit for empty segments, optimized reduceToTopK, KNNIterators refactoring

### Reports Created

- Release report: `docs/releases/v2.18.0/features/k-nn/k-nn-performance-engine.md`
- Feature report: `docs/features/k-nn/k-nn-performance-engine.md`

### Related PRs

- #2221: Update default engine to FAISS
- #2229: Update approximate_threshold to 15K
- #2172: Shard-level rescoring control
- #2149: Dimension-based rescore context
- #2059: Short circuit for empty segments
- #2146: Optimize reduceToTopK
- #2155: KNNIterators filter support
- #2200: PQ compression level calculation
- #2182: Remove FSDirectory dependency
- #1946: DocValuesProducers for memory release
- #2147: KNN80DocValues fix
- #2183: Binary quantized vector score fix

Closes #578