### PR TITLE
docs: add security enhancements report for v2.18.0

### DIFF
--- a/docs/features/security/security-plugin.md
+++ b/docs/features/security/security-plugin.md
@@ -198,6 +198,14 @@ config:
 | v3.0.0 | [#1467](https://github.com/opensearch-project/security/pull/1467) | Refactored flaky test |
 | v3.0.0 | [#1498](https://github.com/opensearch-project/security/pull/1498) | Remove overrides of preserveIndicesUponCompletion |
 | v3.0.0 | [#1503](https://github.com/opensearch-project/security/pull/1503) | Remove usage of deprecated batchSize() method |
+| v2.18.0 | [#4756](https://github.com/opensearch-project/security/pull/4756) | Support datastreams as an AuditLog Sink |
+| v2.18.0 | [#4753](https://github.com/opensearch-project/security/pull/4753) | Auto-convert V6 configuration to V7 (2.x only) |
+| v2.18.0 | [#4779](https://github.com/opensearch-project/security/pull/4779) | Add circuit breaker override for security APIs |
+| v2.18.0 | [#4819](https://github.com/opensearch-project/security/pull/4819) | Improve certificate error messages |
+| v2.18.0 | [#4721](https://github.com/opensearch-project/security/pull/4721) | Add index permissions for remote index in AD |
+| v2.18.0 | [#4741](https://github.com/opensearch-project/security/pull/4741) | Fix header serialization for rolling upgrades |
+| v2.18.0 | [#4778](https://github.com/opensearch-project/security/pull/4778) | Fix env var password hashing for PBKDF2 |
+| v2.18.0 | [#2107](https://github.com/opensearch-project/security/pull/2107) | Add JWT to MultipleAuthentication |
 | v2.18.0 | [#4776](https://github.com/opensearch-project/security/pull/4776) | Add deprecation warning for GET/POST/PUT cache |
 | v2.18.0 | [#4768](https://github.com/opensearch-project/security/pull/4768) | Undeprecate securityadmin script |
 | v2.18.0 | [#4765](https://github.com/opensearch-project/security/pull/4765) | Add isActionPaginated to DelegatingRestHandler |
@@ -205,6 +213,8 @@ config:
 | v2.18.0 | [#4792](https://github.com/opensearch-project/security/pull/4792) | Fix CVE-2024-47554 (commons-io upgrade) |
 | v2.18.0 | [#4831](https://github.com/opensearch-project/security/pull/4831) | Fix bulk index requests in BWC tests |
 | v2.18.0 | [#4815](https://github.com/opensearch-project/security/pull/4815) | Fix integTest not called during release |
+| v2.18.0 | [#4754](https://github.com/opensearch-project/security/pull/4754) | Fix rolesMappingConfiguration in tests |
+| v2.18.0 | [#4726](https://github.com/opensearch-project/security/pull/4726) | Fix SSL exception handler in OpenSearchSecureSettingsFactory |
 | v2.17.0 | [#4603](https://github.com/opensearch-project/security/pull/4603) | Fix demo certificate hash validation |
 | v2.17.0 | [#4631](https://github.com/opensearch-project/security/pull/4631) | Fix authtoken endpoint |
 | v2.17.0 | [#4664](https://github.com/opensearch-project/security/pull/4664) | Handle null audit config |
@@ -216,6 +226,12 @@ config:
 
 ## References
 
+- [Issue #4493](https://github.com/opensearch-project/security/issues/4493): V6/V7 configuration consolidation proposal (v2.18.0)
+- [Issue #4687](https://github.com/opensearch-project/security/issues/4687): Circuit breaker issue with security APIs (v2.18.0)
+- [Issue #4601](https://github.com/opensearch-project/security/issues/4601): Certificate error message improvement (v2.18.0)
+- [Issue #3745](https://github.com/opensearch-project/security/issues/3745): Datastream support for audit logs (v2.18.0)
+- [Issue #4494](https://github.com/opensearch-project/security/issues/4494): Header serialization issue during upgrades (v2.18.0)
+- [Issue #4670](https://github.com/opensearch-project/security/issues/4670): Rolling upgrade serialization issue (v2.18.0)
 - [Issue #4728](https://github.com/opensearch-project/security/issues/4728): ASN1 refactoring for FIPS support (v2.18.0)
 - [Issue #4790](https://github.com/opensearch-project/security/issues/4790): CVE-2024-47554 tracking (v2.18.0)
 - [Issue #4274](https://github.com/opensearch-project/security/issues/4274): Blake2b hash issue
@@ -232,9 +248,10 @@ config:
 - [Documentation: Security Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/security-settings/)
 - [Documentation: Access Control API](https://docs.opensearch.org/3.0/security/access-control/api/)
 - [Documentation: Security APIs](https://docs.opensearch.org/3.0/api-reference/security/index/)
+- [Documentation: Audit Log Storage Types](https://docs.opensearch.org/2.18/security/audit-logs/storage-types/)
 
 ## Change History
 
 - **v3.0.0** (2025-05-06): Breaking changes - Blake2b hash fix, OpenSSL removal, whitelist→allowlist; Enhancements - optimized privilege evaluation, CIDR support in ignore_hosts, password validation improvements
-- **v2.18.0** (2024-11-05): Maintenance - cache endpoint deprecation warning, undeprecate securityadmin script, ASN1 refactoring for FIPS compatibility, CVE-2024-47554 fix, pagination support, BWC test fixes
+- **v2.18.0** (2024-11-05): Enhancements - datastream support for audit logs, auto-convert V6 to V7 configuration, circuit breaker override for security APIs, improved certificate error messages, JWT in MultipleAuthentication, remote index permissions for AD; Bugfixes - header serialization for rolling upgrades, PBKDF2 password hashing, SSL exception handler; Maintenance - cache endpoint deprecation warning, undeprecate securityadmin script, ASN1 refactoring for FIPS compatibility, CVE-2024-47554 fix
 - **v2.17.0** (2024-09-17): Bugfixes - demo certificate validation, auth token endpoint, audit config null handling, certificate SAN ordering, TermsAggregationEvaluator permissions; Refactoring - security provider instantiation for FIPS support, Log4j utility removal

--- a/docs/releases/v2.18.0/features/security/security-enhancements.md
+++ b/docs/releases/v2.18.0/features/security/security-enhancements.md
@@ -1,0 +1,124 @@
+# Security Enhancements
+
+## Summary
+
+OpenSearch v2.18.0 includes multiple security plugin enhancements focused on audit logging improvements, configuration management, authentication, and backward compatibility fixes. Key additions include datastream support for audit logs, automatic V6 to V7 configuration conversion, circuit breaker override for security APIs, and improved error messaging for certificate issues.
+
+## Details
+
+### What's New in v2.18.0
+
+#### Datastream Support for Audit Logs
+The security plugin now supports writing audit logs to data streams using the `internal_opensearch_data_stream` storage type. This enables better lifecycle management and time-series optimization for audit data.
+
+```yaml
+# opensearch.yml
+plugins.security.audit.type: internal_opensearch_data_stream
+plugins.security.audit.config.data_stream.name: opensearch-security-auditlog
+plugins.security.audit.config.data_stream.template.manage: true
+plugins.security.audit.config.data_stream.template.number_of_shards: 1
+plugins.security.audit.config.data_stream.template.number_of_replicas: 0
+```
+
+#### Auto-Convert V6 to V7 Configuration
+The `ConfigurationRepository` now automatically converts V6 configuration instances (like `RoleV6`, `RoleMappingsV6`) to V7 format at runtime. This eliminates duplicate privilege evaluation logic and enables type-safe `SecurityDynamicConfiguration<>` usage.
+
+```mermaid
+graph TB
+    subgraph "Before v2.18.0"
+        V6Config[V6 Config in Index] --> V6Model[ConfigModelV6]
+        V7Config[V7 Config in Index] --> V7Model[ConfigModelV7]
+        V6Model --> PE1[PrivilegesEvaluator]
+        V7Model --> PE1
+    end
+    
+    subgraph "After v2.18.0"
+        V6ConfigNew[V6 Config in Index] --> AutoConvert[Auto-Convert to V7]
+        V7ConfigNew[V7 Config in Index] --> ConfigRepo[ConfigurationRepository]
+        AutoConvert --> ConfigRepo
+        ConfigRepo --> V7Only[ConfigModelV7 Only]
+        V7Only --> PE2[PrivilegesEvaluator]
+    end
+```
+
+#### Circuit Breaker Override for Security APIs
+Security APIs now include an override to prevent tripping the circuit breaker, ensuring security operations remain available even under memory pressure.
+
+#### Improved Certificate Error Messages
+When a node with an incorrectly configured certificate attempts to connect, the error message now provides clearer information about the exact cause of the failure.
+
+### Technical Changes
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.audit.type` | Now supports `internal_opensearch_data_stream` | `internal_opensearch` |
+| `plugins.security.audit.config.data_stream.name` | Name of the audit log data stream | `opensearch-security-auditlog` |
+| `plugins.security.audit.config.data_stream.template.manage` | Whether OpenSearch manages the template | `true` |
+| `plugins.security.audit.config.data_stream.template.number_of_shards` | Number of shards for the data stream | `1` |
+| `plugins.security.audit.config.data_stream.template.number_of_replicas` | Number of replicas for the data stream | `0` |
+
+#### New Index Permissions
+
+| Permission | Description |
+|------------|-------------|
+| Remote index permissions for AD | Added index permissions for remote index access in Anomaly Detection |
+
+### Usage Example
+
+```yaml
+# Enable datastream-based audit logging
+plugins:
+  security:
+    audit:
+      type: internal_opensearch_data_stream
+      config:
+        data_stream:
+          name: security-audit-logs
+          template:
+            manage: true
+            number_of_shards: 2
+            number_of_replicas: 1
+```
+
+### Migration Notes
+
+- **V6 Configuration**: Existing V6 configurations in the security index remain unchanged. The conversion happens at runtime only.
+- **Audit Log Migration**: To switch to datastream-based audit logging, update `plugins.security.audit.type` to `internal_opensearch_data_stream`.
+- **Rolling Upgrades**: The `ensureCustomSerialization` fix addresses header serialization issues during rolling upgrades from 2.11-2.13 to 2.14+.
+
+## Limitations
+
+- V6 configuration format can still be used for updates, but V7 format is recommended
+- Datastream audit logs require OpenSearch 2.18.0+ on all nodes
+- JWT authentication in MultipleAuthentication requires proper configuration of all auth backends
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4756](https://github.com/opensearch-project/security/pull/4756) | Support datastreams as an AuditLog Sink |
+| [#4753](https://github.com/opensearch-project/security/pull/4753) | Auto-convert V6 configuration to V7 (2.x only) |
+| [#4779](https://github.com/opensearch-project/security/pull/4779) | Add circuit breaker override for security APIs |
+| [#4819](https://github.com/opensearch-project/security/pull/4819) | Improve certificate error messages |
+| [#4721](https://github.com/opensearch-project/security/pull/4721) | Add index permissions for remote index in AD |
+| [#4741](https://github.com/opensearch-project/security/pull/4741) | Fix header serialization for rolling upgrades |
+| [#4778](https://github.com/opensearch-project/security/pull/4778) | Fix env var password hashing for PBKDF2 |
+| [#2107](https://github.com/opensearch-project/security/pull/2107) | Add JWT to MultipleAuthentication |
+| [#4754](https://github.com/opensearch-project/security/pull/4754) | Fix rolesMappingConfiguration in tests |
+| [#4726](https://github.com/opensearch-project/security/pull/4726) | Fix SSL exception handler in OpenSearchSecureSettingsFactory |
+
+## References
+
+- [Issue #4493](https://github.com/opensearch-project/security/issues/4493): V6/V7 configuration consolidation proposal
+- [Issue #4687](https://github.com/opensearch-project/security/issues/4687): Circuit breaker issue with security APIs
+- [Issue #4601](https://github.com/opensearch-project/security/issues/4601): Certificate error message improvement
+- [Issue #3745](https://github.com/opensearch-project/security/issues/3745): Datastream support for audit logs
+- [Issue #4494](https://github.com/opensearch-project/security/issues/4494): Header serialization issue during upgrades
+- [Issue #4670](https://github.com/opensearch-project/security/issues/4670): Rolling upgrade serialization issue
+- [Documentation: Audit Log Storage Types](https://docs.opensearch.org/2.18/security/audit-logs/storage-types/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/security-plugin.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -179,6 +179,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### Security
 
+- [Security Enhancements](features/security/security-enhancements.md) - Datastream support for audit logs, auto-convert V6 to V7 configuration, circuit breaker override, improved certificate error messages, JWT in MultipleAuthentication
 - [Security Bugfixes](features/security/security-bugfixes.md) - Multiple bug fixes including system index access control, SAML audit logging, demo config detection, SSL dual mode propagation, stored field handling, and closed index mappings
 - [Security Plugin Maintenance](features/security/security-plugin-maintenance.md) - Cache endpoint deprecation warning, securityadmin script undeprecation, ASN1 refactoring for FIPS, CVE-2024-47554 fix, BWC test fixes
 


### PR DESCRIPTION
## Summary

This PR adds documentation for security enhancements in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/security/security-enhancements.md`
- Feature report updated: `docs/features/security/security-plugin.md`

### Key Changes in v2.18.0

**Enhancements:**
- Datastream support for audit logs (`internal_opensearch_data_stream` storage type)
- Auto-convert V6 configuration to V7 at runtime (2.x only)
- Circuit breaker override for security APIs
- Improved certificate error messages
- JWT authentication in MultipleAuthentication
- Remote index permissions for Anomaly Detection

**Bug Fixes:**
- Header serialization for rolling upgrades (2.11-2.13 to 2.14+)
- PBKDF2 password hashing from environment variables
- SSL exception handler in OpenSearchSecureSettingsFactory

### Related PRs
- #4756: Support datastreams as an AuditLog Sink
- #4753: Auto-convert V6 configuration to V7
- #4779: Add circuit breaker override
- #4819: Improve certificate error messages
- #4721: Add index permissions for remote index in AD
- #4741: Fix header serialization for rolling upgrades
- #4778: Fix env var password hashing for PBKDF2
- #2107: Add JWT to MultipleAuthentication

Closes #577