### PR TITLE
docs: add Query Insights enhancements report for v2.18.0

### DIFF
--- a/docs/features/query-insights/query-insights.md
+++ b/docs/features/query-insights/query-insights.md
@@ -187,7 +187,15 @@ GET /_insights/live_queries?sort=latency&size=5
 | v3.0.0 | [#300](https://github.com/opensearch-project/query-insights/pull/300) | Top queries API verbose param |
 | v3.0.0 | [#298](https://github.com/opensearch-project/query-insights/pull/298) | Skip profile queries |
 | v3.0.0 | [#266](https://github.com/opensearch-project/query-insights/pull/266) | Strict hash check on top queries indices |
-| v2.18.0 | [#144](https://github.com/opensearch-project/query-insights/pull/144) | Set default true for field name and type setting |
+| v2.18.0 | [#84](https://github.com/opensearch-project/query-insights/pull/84) | Support time range parameter for historical top N queries |
+| v2.18.0 | [#111](https://github.com/opensearch-project/query-insights/pull/111) | Refactor query shape field data maps with WithFieldName interface |
+| v2.18.0 | [#120](https://github.com/opensearch-project/query-insights/pull/120) | Add data models for health stats API |
+| v2.18.0 | [#122](https://github.com/opensearch-project/query-insights/pull/122) | Create health_stats API for query insights |
+| v2.18.0 | [#124](https://github.com/opensearch-project/query-insights/pull/124) | Add OpenTelemetry counters for error metrics |
+| v2.18.0 | [#135](https://github.com/opensearch-project/query-insights/pull/135) | Add grouping settings for query field name and type |
+| v2.18.0 | [#140](https://github.com/opensearch-project/query-insights/pull/140) | Add field type to query shape |
+| v2.18.0 | [#142](https://github.com/opensearch-project/query-insights/pull/142) | Add cache eviction and listener for invalidating index field type mappings |
+| v2.18.0 | [#8627](https://github.com/opensearch-project/documentation-website/pull/8627) | Documentation for health_stats API and error metrics |
 | v2.17.0 | [#74](https://github.com/opensearch-project/query-insights/pull/74) | Fix listener startup when query metrics enabled |
 | v2.17.0 | [#64](https://github.com/opensearch-project/query-insights/pull/64) | Add query shape hash method |
 | v2.17.0 | [#71](https://github.com/opensearch-project/query-insights/pull/71) | Add more integration tests |
@@ -206,12 +214,16 @@ GET /_insights/live_queries?sort=latency&size=5
 - [Top N Queries Documentation](https://docs.opensearch.org/3.0/observing-your-data/query-insights/top-n-queries/)
 - [Live Queries Documentation](https://docs.opensearch.org/3.0/observing-your-data/query-insights/live-queries/)
 - [Query Metrics Documentation](https://docs.opensearch.org/3.0/observing-your-data/query-insights/query-metrics/)
+- [Query Insights Health Documentation](https://docs.opensearch.org/2.18/observing-your-data/query-insights/health/)
 - [Query Insights Dashboards](https://docs.opensearch.org/3.0/observing-your-data/query-insights/query-insights-dashboard/)
 - [GitHub Repository](https://github.com/opensearch-project/query-insights)
+- [Issue #9](https://github.com/opensearch-project/query-insights/issues/9): Enrich operational metrics in Query Insights
+- [Issue #12](https://github.com/opensearch-project/query-insights/issues/12): Historical top N queries from local index
+- [Issue #69](https://github.com/opensearch-project/query-insights/issues/69): Query shape field type RFC
 
 ## Change History
 
 - **v3.0.0**: Added Live Queries API, default index template, verbose parameter, profile query filtering, strict hash check
-- **v2.18.0**: Changed default values for grouping attribute settings (`field_name` and `field_type`) from `false` to `true` for more accurate query grouping
+- **v2.18.0**: Added Health Stats API for monitoring plugin health; added OpenTelemetry error metrics counters; added field name and type support for query shape grouping (defaults changed to `true`); added time range parameters for historical query retrieval; added cache eviction and cluster state listener for index field type mappings
 - **v2.17.0**: Fixed listener startup when query metrics enabled; added query shape hash method; fixed CVE-2023-2976; improved integration test coverage for query grouping; added code hygiene checks (Spotless, Checkstyle); fixed snapshot publishing configuration
 - **v2.12.0**: Initial release with Top N queries feature

--- a/docs/releases/v2.18.0/features/query-insights/query-insights.md
+++ b/docs/releases/v2.18.0/features/query-insights/query-insights.md
@@ -1,0 +1,194 @@
+# Query Insights Enhancements
+
+## Summary
+
+OpenSearch v2.18.0 introduces significant enhancements to the Query Insights plugin, including a new Health Stats API for monitoring plugin health, OpenTelemetry error metrics counters for observability, improved query shape grouping with field name and type support, historical query retrieval with time range parameters, and cache management improvements for field type mappings.
+
+## Details
+
+### What's New in v2.18.0
+
+This release focuses on three major areas:
+
+1. **Health Stats API & Error Metrics**: New API endpoint and OpenTelemetry counters for monitoring plugin health
+2. **Query Shape Enhancements**: Field name and type support for more accurate query grouping
+3. **Historical Query Retrieval**: Time range parameters for querying historical top N queries
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Query Insights Plugin v2.18.0"
+        A[Search Request] --> B[Query Listener]
+        B --> C[Collectors]
+        
+        C --> D[Latency Collector]
+        C --> E[CPU Collector]
+        C --> F[Memory Collector]
+        
+        D --> G[Processors]
+        E --> G
+        F --> G
+        
+        G --> H[Top N Processor]
+        H --> I[Query Grouper]
+        
+        I --> J{Grouping Enabled?}
+        J -->|Yes| K[Query Shape Builder]
+        K --> L[Field Name/Type Extraction]
+        L --> M[Index Field Type Cache]
+        
+        J -->|No| N[Individual Queries]
+        
+        H --> O[Exporters]
+        O --> P[Local Index Exporter]
+        P --> Q[(top_queries-* Index)]
+        
+        subgraph "New in v2.18.0"
+            R[Health Stats API]
+            S[OTel Error Counters]
+            T[Time Range Query]
+        end
+        
+        H --> R
+        O --> S
+        Q --> T
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `HealthStatsAction` | Transport action for health stats API |
+| `HealthStatsResponse` | Response model containing thread pool info and query stats |
+| `QueryInsightsHealthStats` | Data model for health statistics |
+| `IndexFieldTypeCache` | Cache for storing index field type mappings |
+| `ClusterStateListener` | Listener for invalidating cache on index changes |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `search.insights.top_queries.grouping.attributes.field_name` | Include field names in query shape for grouping | `true` |
+| `search.insights.top_queries.grouping.attributes.field_type` | Include field types in query shape for grouping | `true` |
+
+#### API Changes
+
+**Health Stats API (New)**
+
+```bash
+GET /_insights/health_stats
+```
+
+Response:
+```json
+{
+  "node_id": {
+    "ThreadPoolInfo": {
+      "query_insights_executor": {
+        "type": "scaling",
+        "core": 1,
+        "max": 5,
+        "keep_alive": "5m",
+        "queue_size": 2
+      }
+    },
+    "QueryRecordsQueueSize": 2,
+    "TopQueriesHealthStats": {
+      "latency": {
+        "TopQueriesHeapSize": 5,
+        "QueryGroupCount_Total": 0,
+        "QueryGroupCount_MaxHeap": 0
+      }
+    }
+  }
+}
+```
+
+**Top N Queries with Time Range (Enhanced)**
+
+```bash
+GET /_insights/top_queries?from=2024-08-25T15:00:00.000Z&to=2024-08-30T17:00:00.000Z
+```
+
+### Usage Example
+
+**Enable query grouping with field name and type:**
+```bash
+PUT _cluster/settings
+{
+  "persistent": {
+    "search.insights.top_queries.latency.enabled": true,
+    "search.insights.top_queries.group_by": "SIMILARITY",
+    "search.insights.top_queries.grouping.attributes.field_name": true,
+    "search.insights.top_queries.grouping.attributes.field_type": true,
+    "search.insights.top_queries.exporter.type": "local_index"
+  }
+}
+```
+
+**Query shape output with field types:**
+```
+bool []
+  must:
+    match [name, text]
+    range [age, integer]
+aggregation:
+  terms [age, integer]
+    aggregation:
+      max [join_date, date]
+sort:
+  desc [join_date, date]
+```
+
+**Check plugin health:**
+```bash
+GET /_insights/health_stats
+```
+
+**Retrieve historical queries:**
+```bash
+GET /_insights/top_queries?from=2024-10-01T00:00:00.000Z&to=2024-10-31T23:59:59.000Z
+```
+
+### Migration Notes
+
+- The default values for `field_name` and `field_type` grouping attributes are now `true` (previously `false`)
+- Existing query grouping configurations will automatically include field names and types
+- To maintain previous behavior, explicitly set these settings to `false`
+
+## Limitations
+
+- Health Stats API returns per-node statistics; aggregation across cluster must be done client-side
+- OpenTelemetry metrics require proper OTel collector configuration to be collected
+- Field type cache may consume additional memory for clusters with many indexes
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#84](https://github.com/opensearch-project/query-insights/pull/84) | Support time range parameter for historical top N queries |
+| [#111](https://github.com/opensearch-project/query-insights/pull/111) | Refactor query shape field data maps with WithFieldName interface |
+| [#120](https://github.com/opensearch-project/query-insights/pull/120) | Add data models for health stats API |
+| [#122](https://github.com/opensearch-project/query-insights/pull/122) | Create health_stats API for query insights |
+| [#124](https://github.com/opensearch-project/query-insights/pull/124) | Add OpenTelemetry counters for error metrics |
+| [#135](https://github.com/opensearch-project/query-insights/pull/135) | Add grouping settings for query field name and type |
+| [#140](https://github.com/opensearch-project/query-insights/pull/140) | Add field type to query shape |
+| [#142](https://github.com/opensearch-project/query-insights/pull/142) | Add cache eviction and listener for invalidating index field type mappings |
+| [#8627](https://github.com/opensearch-project/documentation-website/pull/8627) | Documentation for health_stats API and error metrics |
+
+## References
+
+- [Issue #9](https://github.com/opensearch-project/query-insights/issues/9): Enrich operational metrics in Query Insights
+- [Issue #12](https://github.com/opensearch-project/query-insights/issues/12): Historical top N queries from local index
+- [Issue #69](https://github.com/opensearch-project/query-insights/issues/69): Query shape field type RFC
+- [Issue #109](https://github.com/opensearch-project/query-insights/issues/109): Refactor query shape field data maps
+- [Query Insights Documentation](https://docs.opensearch.org/2.18/observing-your-data/query-insights/index/)
+- [Query Insights Health Documentation](https://docs.opensearch.org/2.18/observing-your-data/query-insights/health/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/query-insights/query-insights.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -125,6 +125,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### Query Insights
 
+- [Query Insights Enhancements](features/query-insights/query-insights.md) - Health Stats API, OpenTelemetry error metrics, field name/type grouping support, historical query time range parameters, cache management improvements
 - [Query Insights Settings](features/query-insights/query-insights-settings.md) - Change default values for grouping attribute settings (field_name, field_type) from false to true
 - [Query CI/CD](features/query-insights/query-ci-cd.md) - Upgrade deprecated actions/upload-artifact from v1/v2 to v3
 


### PR DESCRIPTION
## Summary

This PR adds documentation for Query Insights enhancements in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/query-insights/query-insights.md`
- Feature report: `docs/features/query-insights/query-insights.md` (updated)

### Key Changes in v2.18.0

1. **Health Stats API** - New `/_insights/health_stats` endpoint for monitoring plugin health
2. **OpenTelemetry Error Metrics** - Error counters for observability (LOCAL_INDEX_EXPORTER_BULK_FAILURES, DATA_INGEST_EXCEPTIONS, etc.)
3. **Query Shape Enhancements** - Field name and type support for more accurate query grouping
4. **Historical Query Retrieval** - Time range parameters (`from`/`to`) for querying historical top N queries
5. **Cache Management** - Cache eviction and cluster state listener for index field type mappings

### Related PRs
- [#84](https://github.com/opensearch-project/query-insights/pull/84) - Time range parameter for historical queries
- [#120](https://github.com/opensearch-project/query-insights/pull/120), [#122](https://github.com/opensearch-project/query-insights/pull/122) - Health Stats API
- [#124](https://github.com/opensearch-project/query-insights/pull/124) - OpenTelemetry error metrics
- [#135](https://github.com/opensearch-project/query-insights/pull/135), [#140](https://github.com/opensearch-project/query-insights/pull/140) - Field name/type grouping
- [#142](https://github.com/opensearch-project/query-insights/pull/142) - Cache eviction

Closes #576