### PR TITLE
docs: add neural-search-text-chunking report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -8,6 +8,7 @@
 - [Neural Search Rescore](neural-search/neural-search-rescore.md)
 - [Neural Sparse Search](neural-search/neural-sparse-search.md)
 - [Semantic Field](neural-search/semantic-field.md)
+- [Text Chunking](neural-search/text-chunking.md)
 
 ## opensearch
 

--- a/docs/features/neural-search/text-chunking.md
+++ b/docs/features/neural-search/text-chunking.md
@@ -1,0 +1,152 @@
+# Text Chunking
+
+## Summary
+
+Text chunking is an ingest processor in the neural-search plugin that splits long documents into shorter passages for improved semantic search and embedding generation. It supports multiple chunking algorithms including fixed token length and delimiter-based splitting, with configurable parameters for token limits, overlap, and handling of missing fields.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Ingest Pipeline"
+        DOC[Document] --> TCP[Text Chunking Processor]
+        TCP --> ALGO{Algorithm}
+        ALGO -->|fixed_token_length| FTL[Fixed Token Length Chunker]
+        ALGO -->|delimiter| DEL[Delimiter Chunker]
+        FTL --> OUT[Chunked Passages]
+        DEL --> OUT
+    end
+    subgraph "Downstream Processing"
+        OUT --> EMB[Text Embedding Processor]
+        EMB --> IDX[Index]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Input Document] --> B{Field Exists?}
+    B -->|Yes| C[Extract Text]
+    B -->|No & ignore_missing=true| D[Skip Field]
+    B -->|No & ignore_missing=false| E[Output Empty List]
+    C --> F{Algorithm}
+    F -->|fixed_token_length| G[Tokenize Text]
+    G --> H[Split by Token Limit]
+    H --> I[Apply Overlap]
+    F -->|delimiter| J[Split by Delimiter]
+    I --> K[Output Passages]
+    J --> K
+    D --> L[Pass Through]
+    E --> K
+    K --> M[Output Document]
+    L --> M
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `TextChunkingProcessor` | Main processor class that orchestrates text chunking |
+| `TextChunkingProcessorFactory` | Factory for creating processor instances from pipeline configuration |
+| `FixedTokenLengthChunker` | Splits text into passages of specified token count with optional overlap |
+| `DelimiterChunker` | Splits text on specified delimiter strings |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `field_map` | Maps input fields to output fields for chunking | Required |
+| `algorithm` | Specifies chunking algorithm and parameters | `fixed_token_length` |
+| `ignore_missing` | Skip missing fields instead of outputting empty list | `false` |
+| `description` | Optional description of the processor | - |
+| `tag` | Optional identifier tag for debugging | - |
+
+#### Fixed Token Length Algorithm Parameters
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `token_limit` | Maximum tokens per chunk | `384` |
+| `tokenizer` | Word tokenizer name | `standard` |
+| `overlap_rate` | Overlap percentage between chunks (0-0.5) | `0` |
+| `max_chunk_limit` | Maximum number of chunks allowed | `100` |
+
+#### Delimiter Algorithm Parameters
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `delimiter` | String delimiter for splitting | `\n\n` |
+| `max_chunk_limit` | Maximum number of chunks allowed | `100` |
+
+### Usage Example
+
+```json
+PUT _ingest/pipeline/text-chunking-pipeline
+{
+  "description": "A text chunking ingest pipeline",
+  "processors": [
+    {
+      "text_chunking": {
+        "ignore_missing": true,
+        "algorithm": {
+          "fixed_token_length": {
+            "token_limit": 384,
+            "overlap_rate": 0.2,
+            "tokenizer": "standard"
+          }
+        },
+        "field_map": {
+          "passage_text": "passage_chunk"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Cascaded Processors
+
+Multiple text chunking processors can be chained for complex splitting strategies:
+
+```json
+{
+  "processors": [
+    {
+      "text_chunking": {
+        "algorithm": { "delimiter": { "delimiter": "\n\n" } },
+        "field_map": { "text": "paragraphs" }
+      }
+    },
+    {
+      "text_chunking": {
+        "algorithm": { "fixed_token_length": { "token_limit": 500 } },
+        "field_map": { "paragraphs": "chunks" }
+      }
+    }
+  ]
+}
+```
+
+## Limitations
+
+- The default `token_limit` of 384 is optimized for OpenSearch pretrained models with 512 token input limits
+- `max_chunk_limit` throws an exception if exceeded; set to `-1` to disable
+- Nested field paths must use JSON object notation, not dot notation
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#907](https://github.com/opensearch-project/neural-search/pull/907) | Add ignore_missing field to text chunking processors |
+
+## References
+
+- [Issue #906](https://github.com/opensearch-project/neural-search/issues/906): Feature request for ignore_missing field
+- [Text Chunking Processor Documentation](https://docs.opensearch.org/latest/ingest-pipelines/processors/text-chunking/): Official documentation
+- [Text Chunking Guide](https://docs.opensearch.org/latest/search-plugins/text-chunking/): Usage guide for semantic search
+
+## Change History
+
+- **v2.18.0** (2024-10-29): Added `ignore_missing` parameter to skip missing fields during processing

--- a/docs/releases/v2.18.0/features/neural-search/neural-search-text-chunking.md
+++ b/docs/releases/v2.18.0/features/neural-search/neural-search-text-chunking.md
@@ -1,0 +1,101 @@
+# Neural Search Text Chunking Enhancement
+
+## Summary
+
+This release adds the `ignore_missing` parameter to text chunking processors in the neural-search plugin. When enabled, the processor skips fields that don't exist in the document instead of outputting an empty list, providing more flexible handling of optional text fields during ingestion.
+
+## Details
+
+### What's New in v2.18.0
+
+The text chunking processor now supports an `ignore_missing` boolean parameter that controls how the processor handles missing or null input fields.
+
+### Technical Changes
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `ignore_missing` | When `true`, missing fields are skipped and no output field is created. When `false`, missing fields result in an empty list in the output field. | `false` |
+
+#### Behavior Comparison
+
+**With `ignore_missing: false` (default):**
+- Input document without the mapped field produces an empty list in the output field
+- Maintains backward compatibility with existing pipelines
+
+**With `ignore_missing: true`:**
+- Input document without the mapped field is passed through unchanged
+- No output field is created for missing input fields
+- Useful for pipelines processing documents with optional text fields
+
+### Usage Example
+
+```json
+PUT _ingest/pipeline/text-chunking-pipeline
+{
+  "description": "Text chunking with ignore_missing enabled",
+  "processors": [
+    {
+      "text_chunking": {
+        "ignore_missing": true,
+        "field_map": {
+          "body": "body_chunk"
+        },
+        "algorithm": {
+          "fixed_token_length": {
+            "token_limit": 10,
+            "tokenizer": "letter"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+**Input document (missing `body` field):**
+```json
+{
+  "name": "OpenSearch"
+}
+```
+
+**Output with `ignore_missing: true`:**
+```json
+{
+  "name": "OpenSearch"
+}
+```
+
+**Output with `ignore_missing: false` (default):**
+```json
+{
+  "name": "OpenSearch",
+  "body_chunk": []
+}
+```
+
+### Migration Notes
+
+- Existing pipelines are unaffected as the default value is `false`
+- To adopt this feature, add `"ignore_missing": true` to your text chunking processor configuration
+
+## Limitations
+
+- The `ignore_missing` parameter only affects null/missing fields; empty strings are still processed and produce empty chunk results
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#907](https://github.com/opensearch-project/neural-search/pull/907) | Add ignore_missing field to text chunking processors |
+
+## References
+
+- [Issue #906](https://github.com/opensearch-project/neural-search/issues/906): Feature request for ignore_missing field
+- [Documentation](https://docs.opensearch.org/2.18/ingest-pipelines/processors/text-chunking/): Text chunking processor documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/neural-search/text-chunking.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -114,6 +114,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### Neural Search
 
+- [Neural Search Text Chunking](features/neural-search/neural-search-text-chunking.md) - Add `ignore_missing` parameter to text chunking processors for flexible handling of optional fields
 - [Neural Search Bugfixes](features/neural-search/neural-search-bugfixes.md) - Fixed incorrect document order for nested aggregations in hybrid query
 
 ### ML Commons


### PR DESCRIPTION
## Summary

This PR adds documentation for the Neural Search Text Chunking enhancement in v2.18.0.

### Changes
- **Release report**: `docs/releases/v2.18.0/features/neural-search/neural-search-text-chunking.md`
- **Feature report**: `docs/features/neural-search/text-chunking.md`
- Updated release index and features index

### Key Changes in v2.18.0
- Added `ignore_missing` parameter to text chunking processors
- When `true`, missing fields are skipped instead of outputting empty lists
- Default is `false` for backward compatibility

### Resources Used
- PR: [opensearch-project/neural-search#907](https://github.com/opensearch-project/neural-search/pull/907)
- Issue: [opensearch-project/neural-search#906](https://github.com/opensearch-project/neural-search/issues/906)
- Docs: https://docs.opensearch.org/2.18/ingest-pipelines/processors/text-chunking/