### PR TITLE
docs: add ML Commons Model & Inference report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -200,6 +200,7 @@
 - [ML Commons Connector Blueprints](ml-commons/ml-commons-blueprints.md)
 - [ML Commons MCP (Model Context Protocol)](ml-commons/ml-commons-mcp.md)
 - [ML Commons Memory Metadata](ml-commons/ml-commons-memory-metadata.md)
+- [ML Commons Model & Inference](ml-commons/ml-commons-model-inference.md)
 - [ML Commons Stability and Reliability](ml-commons/ml-commons-stability.md)
 - [ML Commons Test Fixes](ml-commons/ml-commons-test-fixes.md)
 - [ML Config API](ml-commons/ml-config-api.md)

--- a/docs/features/ml-commons/ml-commons-model-inference.md
+++ b/docs/features/ml-commons/ml-commons-model-inference.md
@@ -1,0 +1,279 @@
+# ML Commons Model & Inference
+
+## Summary
+
+ML Commons Model & Inference provides capabilities for deploying, managing, and using machine learning models within OpenSearch. This includes support for both local models hosted on OpenSearch clusters and remote models accessed through external services. The feature enables ML-powered search enhancements through inference processors, agent tools, and RAG (Retrieval-Augmented Generation) pipelines.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "ML Commons Model & Inference"
+        subgraph "Model Management"
+            Register[Register Model]
+            Deploy[Deploy Model]
+            AutoDeploy[Auto Deploy]
+            Redeploy[Auto Redeploy]
+        end
+        
+        subgraph "Model Types"
+            Local[Local Models]
+            Remote[Remote Models]
+        end
+        
+        subgraph "Inference"
+            Predict[Predict API]
+            IngestProc[Ingest Processor]
+            SearchProc[Search Processor]
+        end
+        
+        subgraph "Agent Framework"
+            Agents[Agents]
+            Tools[Tools]
+            ToolSpec[MLToolSpec]
+        end
+    end
+    
+    Register --> Deploy
+    Deploy --> Local
+    Deploy --> Remote
+    AutoDeploy --> Remote
+    Redeploy -.->|filtered out| Remote
+    
+    Local --> Predict
+    Remote --> Predict
+    Predict --> IngestProc
+    Predict --> SearchProc
+    
+    Agents --> Tools
+    Tools --> ToolSpec
+    ToolSpec --> Predict
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Search Pipeline"
+        Query[Search Query]
+        Hits[Search Hits]
+        Ext[Search Extension]
+    end
+    
+    subgraph "ML Inference Processor"
+        InputMap[Input Map]
+        Model[ML Model]
+        OutputMap[Output Map]
+    end
+    
+    Query --> InputMap
+    Hits --> InputMap
+    InputMap --> Model
+    Model --> OutputMap
+    OutputMap -->|one_to_one: true| Hits
+    OutputMap -->|one_to_one: false| Ext
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| MLModelAutoRedeployer | Handles automatic model redeployment, filters remote models |
+| ML Inference Search Processor | Invokes ML models during search request/response processing |
+| MLToolSpec | Specification for agent tools with static configuration support |
+| RAG Pipeline | Retrieval-Augmented Generation pipeline with optional llmQuestion |
+| Trusted Endpoints | Whitelist of allowed external service URLs |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ml_commons.only_run_on_ml_node` | Restrict ML tasks to ML nodes | `true` |
+| `plugins.ml_commons.model_access_control_enabled` | Enable model access control | `true` |
+| `plugins.ml_commons.native_memory_threshold` | Memory threshold for native models | `90` |
+| `plugins.ml_commons.remote_inference.enabled` | Enable remote model inference | `true` |
+| `plugins.ml_commons.agent_framework_enabled` | Enable agent framework | `true` |
+
+### ML Inference Search Response Processor
+
+The ML inference search response processor enables invoking ML models during search response processing.
+
+#### Input Mapping
+
+Supports mapping document fields and query values to model inputs:
+
+```json
+"input_map": [
+  {
+    "text_docs": "document_field",
+    "query_text": "$.query.term.field.value"
+  }
+]
+```
+
+#### Output Mapping
+
+Supports writing to document hits or search extension:
+
+```json
+// Write to document hits (one_to_one: true)
+"output_map": [
+  {
+    "embedding": "$.inference_results[*].output[*].data"
+  }
+]
+
+// Write to search extension (one_to_one: false)
+"output_map": [
+  {
+    "ext.ml_inference.summary": "response"
+  }
+]
+```
+
+### Agent Tools Configuration
+
+MLToolSpec supports static parameters through the `config` field:
+
+```json
+{
+  "tools": [
+    {
+      "type": "SearchIndexTool",
+      "description": "Search tool with pre-configured index",
+      "config": {
+        "input": "{\"index\": \"my-index\", \"query\": {\"match_all\": {}}}"
+      }
+    }
+  ]
+}
+```
+
+### RAG Pipeline
+
+The RAG pipeline supports flexible question/message configuration:
+
+```json
+{
+  "parameters": {
+    "llmMessages": [
+      {"role": "user", "content": "Previous context..."},
+      {"role": "assistant", "content": "Previous response..."}
+    ]
+    // llmQuestion is optional when llmMessages is provided
+  }
+}
+```
+
+### Trusted Endpoints
+
+Supported AWS service endpoints:
+- Amazon Bedrock
+- Amazon SageMaker
+- Amazon Comprehend
+- Amazon Textract
+
+### Usage Example
+
+#### Cross-Encoder Reranking Pipeline
+
+```json
+PUT /_search/pipeline/rerank_pipeline
+{
+  "response_processors": [
+    {
+      "ml_inference": {
+        "model_id": "<cross_encoder_model_id>",
+        "function_name": "TEXT_SIMILARITY",
+        "model_input": "{ \"text_docs\": ${input_map.text_docs}, \"query_text\": \"${input_map.query_text}\" }",
+        "input_map": [
+          {
+            "text_docs": "content",
+            "query_text": "$.query.term.content.value"
+          }
+        ],
+        "output_map": [
+          {
+            "rank_score": "$.inference_results[*].output[*].data"
+          }
+        ],
+        "full_response_path": false,
+        "one_to_one": true
+      }
+    },
+    {
+      "rerank": {
+        "by_field": {
+          "target_field": "rank_score",
+          "remove_target_field": true
+        }
+      }
+    }
+  ]
+}
+```
+
+#### LLM Summarization Pipeline
+
+```json
+PUT /_search/pipeline/summarize_pipeline
+{
+  "response_processors": [
+    {
+      "ml_inference": {
+        "model_id": "<llm_model_id>",
+        "function_name": "REMOTE",
+        "input_map": [
+          {
+            "context": "review"
+          }
+        ],
+        "output_map": [
+          {
+            "ext.ml_inference.llm_response": "response"
+          }
+        ],
+        "model_config": {
+          "prompt": "Summarize: ${parameters.context.toString()}"
+        },
+        "one_to_one": false
+      }
+    }
+  ]
+}
+```
+
+## Limitations
+
+- Search extension output (`ext.*`) only works with many-to-one inference (`one_to_one: false`)
+- One-to-one inference cannot write to search extension due to ordering concerns with reranking
+- Remote model auto-redeployment is filtered out (auto-deploy on first request is used instead)
+- Local models require explicit deployment before use
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#2976](https://github.com/opensearch-project/ml-commons/pull/2976) | Filter out remote model auto redeployment |
+| v2.18.0 | [#3072](https://github.com/opensearch-project/ml-commons/pull/3072) | Allow llmQuestion to be optional when llmMessages is used |
+| v2.18.0 | [#3061](https://github.com/opensearch-project/ml-commons/pull/3061) | Support ML Inference Search Processor Writing to Search Extension |
+| v2.18.0 | [#2899](https://github.com/opensearch-project/ml-commons/pull/2899) | Enable pass query string to input_map in ml inference search response processor |
+| v2.18.0 | [#2977](https://github.com/opensearch-project/ml-commons/pull/2977) | Add config field in MLToolSpec for static parameters |
+| v2.18.0 | [#3154](https://github.com/opensearch-project/ml-commons/pull/3154) | Add textract and comprehend url to trusted endpoints |
+
+## References
+
+- [Issue #2897](https://github.com/opensearch-project/ml-commons/issues/2897): Query text in input_map feature request
+- [Issue #2878](https://github.com/opensearch-project/ml-commons/issues/2878): Search extension output feature request
+- [Issue #3067](https://github.com/opensearch-project/ml-commons/issues/3067): Optional llmQuestion feature request
+- [Issue #2836](https://github.com/opensearch-project/ml-commons/issues/2836): Static tool parameters feature request
+- [Issue #2918](https://github.com/opensearch-project/ml-commons/issues/2918): MLToolSpec config field feature request
+- [ML inference search response processor documentation](https://docs.opensearch.org/2.18/search-plugins/search-pipelines/ml-inference-search-response/)
+- [Agents and tools documentation](https://docs.opensearch.org/2.18/ml-commons-plugin/agents-tools/index/)
+- [ML Commons cluster settings](https://docs.opensearch.org/2.18/ml-commons-plugin/cluster-settings/)
+
+## Change History
+
+- **v2.18.0** (2024-11-12): Added remote model auto-redeployment filtering, optional llmQuestion for RAG, search extension output support, query string in input_map, MLToolSpec config field, AWS Textract/Comprehend trusted endpoints

--- a/docs/releases/v2.18.0/features/ml-commons/ml-commons-model-inference.md
+++ b/docs/releases/v2.18.0/features/ml-commons/ml-commons-model-inference.md
@@ -1,0 +1,170 @@
+# ML Commons Model & Inference
+
+## Summary
+
+OpenSearch v2.18.0 introduces several enhancements to the ML Commons plugin's model and inference capabilities. Key improvements include filtering out remote model auto-redeployment, making `llmQuestion` optional when `llmMessages` is used in RAG pipelines, supporting ML inference search processor writing to search extensions, enabling query string passing to `input_map` in ML inference search response processor, adding a `config` field in `MLToolSpec` for static parameters, and adding AWS Textract and Comprehend URLs to trusted endpoints.
+
+## Details
+
+### What's New in v2.18.0
+
+#### Remote Model Auto-Redeployment Filtering
+
+The `MLModelAutoRedeployer` now filters out remote models from auto-redeployment. Since ML Commons supports remote model auto-deployment when the first prediction request arrives, explicit auto-redeployment is unnecessary for remote models, reducing redundant operations.
+
+#### Optional llmQuestion for RAG Pipelines
+
+When using `llmMessages` in RAG (Retrieval-Augmented Generation) request parameters, the `llmQuestion` field is now optional. This provides more flexibility when constructing conversational AI pipelines where the question context is already embedded in the message history.
+
+#### ML Inference Search Processor Writing to Search Extension
+
+The ML inference search response processor now supports writing prediction results to the search extension (`ext`) field when using many-to-one inference mode. Previously, results were only written to individual document hits. This enables use cases like LLM summarization of search results where a single aggregated response is more appropriate.
+
+```json
+"output_map": [
+  {
+    "ext.ml_inference.llm_response": "response"
+  }
+]
+```
+
+Note: This feature is not supported for one-to-one inference because the order of inference matters and other processors might rerank results, disrupting the mapping between inputs and outputs.
+
+#### Query String Passing to input_map
+
+The ML inference search response processor now supports passing query string values to the `input_map`. This enables use cases like cross-encoder reranking where the original query text needs to be compared against document content.
+
+```json
+"input_map": [
+  {
+    "text_docs": "dairy",
+    "query_text": "$.query.term.dairy.value"
+  }
+]
+```
+
+#### Static Parameters in MLToolSpec
+
+A new `config` field has been added to `MLToolSpec` to support static parameters in tool execution. This allows pre-configuring tool parameters at agent registration time rather than requiring them at execution time.
+
+```json
+{
+  "tools": [
+    {
+      "type": "SearchIndexTool",
+      "config": {
+        "input": "{\"index\": \"sample-index\", \"query\": {\"query\": { \"match_all\": {}}} }"
+      }
+    }
+  ]
+}
+```
+
+#### AWS Textract and Comprehend Trusted Endpoints
+
+AWS Textract and Comprehend service URLs have been added to the trusted endpoints list, enabling integration with these AWS AI services through ML Commons connectors.
+
+### Technical Changes
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `config` field in MLToolSpec | Static parameters for tool execution | N/A |
+
+#### API Changes
+
+| Change | Description |
+|--------|-------------|
+| `llmQuestion` optional | No longer required when `llmMessages` is provided |
+| `ext` output path | ML inference processor can write to search extension |
+| Query path in input_map | Supports `$.query.*` JSON path for query values |
+
+### Usage Example
+
+#### LLM Summarization with Search Extension Output
+
+```json
+PUT /_search/pipeline/summarize_pipeline
+{
+  "response_processors": [
+    {
+      "ml_inference": {
+        "model_id": "<llm_model_id>",
+        "function_name": "REMOTE",
+        "input_map": [
+          {
+            "context": "review"
+          }
+        ],
+        "output_map": [
+          {
+            "ext.ml_inference.llm_response": "response"
+          }
+        ],
+        "model_config": {
+          "prompt": "Summarize the following documents: ${parameters.context.toString()}"
+        },
+        "one_to_one": false
+      }
+    }
+  ]
+}
+```
+
+#### Cross-Encoder Reranking with Query Text
+
+```json
+PUT /_search/pipeline/rerank_pipeline
+{
+  "response_processors": [
+    {
+      "ml_inference": {
+        "model_id": "<cross_encoder_model_id>",
+        "function_name": "TEXT_SIMILARITY",
+        "input_map": [
+          {
+            "text_docs": "content",
+            "query_text": "$.query.term.content.value"
+          }
+        ],
+        "output_map": [
+          {
+            "rank_score": "$.inference_results[*].output[*].data"
+          }
+        ],
+        "one_to_one": true
+      }
+    }
+  ]
+}
+```
+
+## Limitations
+
+- Writing to search extension (`ext`) is only supported for many-to-one inference (`one_to_one: false`)
+- One-to-one inference cannot write to search extension due to ordering concerns with reranking processors
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2976](https://github.com/opensearch-project/ml-commons/pull/2976) | Filter out remote model auto redeployment |
+| [#3072](https://github.com/opensearch-project/ml-commons/pull/3072) | Allow llmQuestion to be optional when llmMessages is used |
+| [#3061](https://github.com/opensearch-project/ml-commons/pull/3061) | Support ML Inference Search Processor Writing to Search Extension |
+| [#2899](https://github.com/opensearch-project/ml-commons/pull/2899) | Enable pass query string to input_map in ml inference search response processor |
+| [#2977](https://github.com/opensearch-project/ml-commons/pull/2977) | Add config field in MLToolSpec for static parameters |
+| [#3154](https://github.com/opensearch-project/ml-commons/pull/3154) | Add textract and comprehend url to trusted endpoints |
+
+## References
+
+- [Issue #2897](https://github.com/opensearch-project/ml-commons/issues/2897): Query text in input_map feature request
+- [Issue #2878](https://github.com/opensearch-project/ml-commons/issues/2878): Search extension output feature request
+- [Issue #3067](https://github.com/opensearch-project/ml-commons/issues/3067): Optional llmQuestion feature request
+- [Issue #2836](https://github.com/opensearch-project/ml-commons/issues/2836): Static tool parameters feature request
+- [Issue #2918](https://github.com/opensearch-project/ml-commons/issues/2918): MLToolSpec config field feature request
+- [ML inference search response processor documentation](https://docs.opensearch.org/2.18/search-plugins/search-pipelines/ml-inference-search-response/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/ml-commons/ml-commons-model-inference.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -119,6 +119,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### ML Commons
 
+- [ML Commons Model & Inference](features/ml-commons/ml-commons-model-inference.md) - Remote model auto-redeployment filtering, optional llmQuestion for RAG, search extension output support, query string in input_map, MLToolSpec config field, AWS Textract/Comprehend trusted endpoints
 - [ML Commons Bugfixes](features/ml-commons/ml-commons-bugfixes.md) - 11 bug fixes for RAG pipelines, ML inference processors, connector time fields, model deployment stability, master key race condition, Bedrock BWC, and agent logging
 - [ML Commons Configuration](features/ml-commons/ml-commons-configuration.md) - Change `.plugins-ml-config` index to use `auto_expand_replicas: 0-all` for maximum availability
 - [ML Commons Connectors & Blueprints](features/ml-commons/ml-commons-connectors-blueprints.md) - Bedrock Converse blueprint, cross-account model invocation tutorial, role temporary credential support, Titan Embedding V2 blueprint


### PR DESCRIPTION
## Summary

This PR adds documentation for the ML Commons Model & Inference enhancements in OpenSearch v2.18.0.

## Changes

### Release Report
- `docs/releases/v2.18.0/features/ml-commons/ml-commons-model-inference.md`

### Feature Report
- `docs/features/ml-commons/ml-commons-model-inference.md`

## Key Features Documented

1. **Remote Model Auto-Redeployment Filtering** - MLModelAutoRedeployer now filters out remote models from auto-redeployment
2. **Optional llmQuestion for RAG** - llmQuestion is now optional when llmMessages is provided
3. **Search Extension Output** - ML inference processor can write to `ext.*` for many-to-one inference
4. **Query String in input_map** - Support for passing query values to input_map using JSON path
5. **MLToolSpec Config Field** - New config field for static parameters in agent tools
6. **AWS Textract/Comprehend Endpoints** - Added to trusted endpoints list

## Related PRs

- opensearch-project/ml-commons#2976
- opensearch-project/ml-commons#3072
- opensearch-project/ml-commons#3061
- opensearch-project/ml-commons#2899
- opensearch-project/ml-commons#2977
- opensearch-project/ml-commons#3154

Closes #573