### PR TITLE
docs: add doc-level-monitor-query-indices report for v2.18.0

### DIFF
--- a/docs/features/alerting/alerting.md
+++ b/docs/features/alerting/alerting.md
@@ -79,6 +79,12 @@ graph TB
 | `plugins.alerting.alert_history_enabled` | Enable alert history | true |
 | `plugins.alerting.alert_history_max_age` | Max age of alert history | 30d |
 
+### Monitor Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `delete_query_index_in_every_run` | For doc-level monitors: when true, deletes and recreates the query index on each monitor run. Designed for externally defined monitors (e.g., Security Analytics) that manage their own query indices. | `false` |
+
 ### Usage Example
 
 Creating a per-query monitor:
@@ -180,6 +186,7 @@ POST _plugins/_alerting/monitors
 
 - [Alerting Documentation](https://docs.opensearch.org/3.0/observing-your-data/alerting/index/): Official alerting documentation
 - [Monitors Documentation](https://docs.opensearch.org/3.0/observing-your-data/alerting/monitors/): Monitor types and configuration
+- [Per Document Monitors](https://docs.opensearch.org/3.0/observing-your-data/alerting/per-document-monitors/): Per-document monitor documentation
 - [Composite Monitors](https://docs.opensearch.org/3.0/observing-your-data/alerting/composite-monitors/): Composite monitor documentation
 - [Alerting Security](https://docs.opensearch.org/3.0/observing-your-data/alerting/security/): Security configuration for alerting
 - [Notifications Plugin](https://docs.opensearch.org/3.0/observing-your-data/notifications/index/): Notifications integration
@@ -189,5 +196,5 @@ POST _plugins/_alerting/monitors
 ## Change History
 
 - **v3.0.0** (2025): Bug fixes for bucket selector aggregation, Java Agent migration, and dashboard subfield selection
-- **v2.18.0** (2024-11-05): Doc-level monitor improvements, query index lifecycle optimization, bucket-level monitor performance optimization for time-series indices, dashboard UX fit-and-finish updates, MDS compatibility fixes
+- **v2.18.0** (2024-11-05): Doc-level monitor improvements including dynamic query index deletion (`delete_query_index_in_every_run` flag), query index lifecycle optimization, bucket-level monitor performance optimization for time-series indices, dashboard UX fit-and-finish updates, MDS compatibility fixes
 - **v2.17.0** (2024-09-17): Monitor lock renewal fix, distribution build fixes, workspace navigation fix, trigger name validation fix, alerts card rendering fix, cypress and unit test fixes

--- a/docs/releases/v2.18.0/features/common-utils/doc-level-monitor-query-indices.md
+++ b/docs/releases/v2.18.0/features/common-utils/doc-level-monitor-query-indices.md
@@ -1,0 +1,136 @@
+# Doc-Level Monitor Query Indices
+
+## Summary
+
+This enhancement adds support for dynamic deletion of doc-level monitor query indices through a new `delete_query_index_in_every_run` configuration flag. This feature is designed for externally defined monitors (such as those created by Security Analytics) that manage their own query indices and need to recreate them on each monitor run.
+
+## Details
+
+### What's New in v2.18.0
+
+A new boolean field `delete_query_index_in_every_run` has been added to the Monitor model. When set to `true`, the doc-level monitor will automatically delete its query index at the end of each execution run and recreate it at the start of the next run.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Doc-Level Monitor Execution"
+        Start[Monitor Run Start]
+        CheckFlag{deleteQueryIndexInEveryRun?}
+        CreateIndex[Create Query Index]
+        IndexQueries[Index Queries]
+        Execute[Execute Monitor]
+        DeleteIndex[Delete Query Index]
+        End[Monitor Run End]
+    end
+    
+    Start --> CheckFlag
+    CheckFlag -->|true| CreateIndex
+    CheckFlag -->|false| IndexQueries
+    CreateIndex --> IndexQueries
+    IndexQueries --> Execute
+    Execute --> CheckFlag
+    CheckFlag -->|true| DeleteIndex
+    DeleteIndex --> End
+    CheckFlag -->|false| End
+```
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `delete_query_index_in_every_run` | When true, deletes and recreates the query index on each monitor run | `false` |
+
+#### API Changes
+
+The Monitor API now accepts the new field:
+
+```json
+{
+  "type": "monitor",
+  "monitor_type": "doc_level_monitor",
+  "delete_query_index_in_every_run": true,
+  ...
+}
+```
+
+### Usage Example
+
+Creating a doc-level monitor with dynamic query index deletion:
+
+```json
+POST _plugins/_alerting/monitors
+{
+  "type": "monitor",
+  "name": "external-doc-level-monitor",
+  "monitor_type": "doc_level_monitor",
+  "enabled": true,
+  "delete_query_index_in_every_run": true,
+  "schedule": {
+    "period": {
+      "interval": 1,
+      "unit": "MINUTES"
+    }
+  },
+  "inputs": [{
+    "doc_level_input": {
+      "description": "External monitor input",
+      "indices": ["logs-*"],
+      "queries": [{
+        "id": "query1",
+        "name": "error-detection",
+        "query": "level:ERROR",
+        "tags": ["error"]
+      }]
+    }
+  }],
+  "triggers": [{
+    "name": "error-trigger",
+    "severity": "1",
+    "condition": {
+      "script": {
+        "source": "return true",
+        "lang": "painless"
+      }
+    },
+    "actions": []
+  }],
+  "owner": "security_analytics"
+}
+```
+
+### Behavior Changes
+
+1. **Monitor Creation**: When `delete_query_index_in_every_run` is `true`, query indices are NOT created at monitor creation time
+2. **Monitor Execution**: Query index is created at the start of each run and deleted at the end
+3. **Monitor Update**: Existing queries are deleted before re-indexing if the query index exists
+4. **Monitor Deletion**: Query index is deleted directly without checking for other monitors' queries
+
+### Migration Notes
+
+- Existing monitors are unaffected (default value is `false`)
+- External systems (like Security Analytics) that manage their own query indices should set this flag to `true`
+- No migration required for existing monitors
+
+## Limitations
+
+- When enabled, query indices are ephemeral and not persisted between runs
+- May increase overhead for monitors that run frequently due to index creation/deletion
+- Not recommended for standard alerting use cases where query persistence is beneficial
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [common-utils#734](https://github.com/opensearch-project/common-utils/pull/734) | Add `deleteQueryIndexInEveryRun` flag to Monitor model |
+| [alerting#1664](https://github.com/opensearch-project/alerting/pull/1664) | Implement dynamic query index deletion for doc-level monitors |
+
+## References
+
+- [Per Document Monitors Documentation](https://docs.opensearch.org/2.18/observing-your-data/alerting/per-document-monitors/): Official documentation for per-document monitors
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/alerting/alerting.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -98,6 +98,10 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Alerting Doc-Level Monitor](features/alerting/alerting-doc-level-monitor.md) - Doc-level monitor improvements including comments system indices, remote monitor logging, separate query indices for external monitors, and query index lifecycle optimization
 - [Alerting Bugfixes](features/alerting/alerting-bugfixes.md) - Query index management fixes, bucket-level monitor optimization, dashboard UX improvements, MDS compatibility fixes
 
+### Common Utils
+
+- [Doc-Level Monitor Query Indices](features/common-utils/doc-level-monitor-query-indices.md) - New `delete_query_index_in_every_run` flag for dynamic deletion of doc-level monitor query indices, designed for externally defined monitors
+
 ### SQL
 
 - [SQL Error Handling](features/sql/sql-error-handling.md) - Improved error handling for malformed cursors and edge cases in query parsing


### PR DESCRIPTION
## Summary

This PR adds documentation for the Doc-Level Monitor Query Indices enhancement in OpenSearch v2.18.0.

### Changes

- Created release report: `docs/releases/v2.18.0/features/common-utils/doc-level-monitor-query-indices.md`
- Updated feature report: `docs/features/alerting/alerting.md` with new configuration option
- Updated release index: `docs/releases/v2.18.0/index.md` with link to new report

### Feature Overview

A new `delete_query_index_in_every_run` configuration flag was added to the Monitor model. When set to `true`, doc-level monitors will automatically delete their query index at the end of each execution run and recreate it at the start of the next run. This is designed for externally defined monitors (such as those created by Security Analytics) that manage their own query indices.

### Related PRs

- [common-utils#734](https://github.com/opensearch-project/common-utils/pull/734): Add `deleteQueryIndexInEveryRun` flag to Monitor model
- [alerting#1664](https://github.com/opensearch-project/alerting/pull/1664): Implement dynamic query index deletion for doc-level monitors

Closes #570