### PR TITLE
docs: add SQL PIT refactor report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -159,6 +159,7 @@
 - [Security Lake Data Source](sql/security-lake-data-source.md)
 - [SQL Error Handling](sql/sql-error-handling.md)
 - [SQL Pagination](sql/sql-pagination.md)
+- [SQL PIT Refactor](sql/sql-pit-refactor.md)
 - [SQL Plugin Maintenance](sql/sql-plugin-maintenance.md)
 - [SQL Query Fixes](sql/sql-query-fixes.md)
 - [SQL/PPL Engine](sql/sql-ppl-engine.md)

--- a/docs/features/sql/sql-pit-refactor.md
+++ b/docs/features/sql/sql-pit-refactor.md
@@ -1,0 +1,166 @@
+# SQL Point in Time (PIT) Refactor
+
+## Summary
+
+The SQL plugin uses Point in Time (PIT) API instead of the deprecated Scroll API for join queries and pagination. PIT provides a consistent view of data during query execution, ensuring reliable results even when the underlying data changes. This refactoring improves the reliability and consistency of SQL query results, particularly for long-running queries and deep pagination scenarios.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "SQL Plugin"
+        REQ[SQL Request]
+        LEGACY[Legacy Engine<br/>Join Queries]
+        NEW[New Engine<br/>Pagination]
+    end
+    
+    subgraph "Physical Operators"
+        PAGINATE[Paginate<br/>Abstract Base]
+        SCROLL[Scroll<br/>Deprecated]
+        PIT_OP[PointInTime<br/>Preferred]
+    end
+    
+    subgraph "Request Builders"
+        SCROLL_REQ[OpenSearchScrollRequest]
+        QUERY_REQ[OpenSearchQueryRequest<br/>with PIT support]
+    end
+    
+    subgraph "OpenSearch Core"
+        PIT_API[Point in Time API]
+        SCROLL_API[Scroll API]
+        SEARCH[Search API]
+    end
+    
+    REQ --> LEGACY
+    REQ --> NEW
+    LEGACY --> PAGINATE
+    PAGINATE --> SCROLL
+    PAGINATE --> PIT_OP
+    NEW --> QUERY_REQ
+    NEW --> SCROLL_REQ
+    SCROLL --> SCROLL_API
+    PIT_OP --> PIT_API
+    QUERY_REQ --> PIT_API
+    SCROLL_REQ --> SCROLL_API
+    PIT_API --> SEARCH
+    SCROLL_API --> SEARCH
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[SQL Query] --> B{Query Type}
+    B -->|Join Query| C[Legacy Engine]
+    B -->|Simple Query| D[New Engine]
+    
+    C --> E{PIT Enabled?}
+    E -->|Yes| F[Create PIT]
+    E -->|No| G[Use Scroll]
+    
+    D --> H{Pagination Needed?}
+    H -->|Yes| I{PIT Enabled?}
+    H -->|No| J[Single Search]
+    
+    I -->|Yes| K[Create PIT]
+    I -->|No| L[Use Scroll]
+    
+    F --> M[Execute with search_after]
+    K --> M
+    G --> N[Execute with Scroll ID]
+    L --> N
+    
+    M --> O{More Results?}
+    N --> O
+    O -->|Yes| P[Return Results + Cursor]
+    O -->|No| Q[Delete PIT/Clear Scroll]
+    
+    P --> R[Next Page Request]
+    R --> M
+    Q --> S[Return Final Results]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `Paginate` | Abstract base class providing common pagination logic for both Scroll and PIT operators |
+| `PointInTime` | Physical operator implementing PIT-based table scans for join queries |
+| `Scroll` | Physical operator implementing Scroll-based table scans (legacy, deprecated) |
+| `OpenSearchQueryRequest` | Request class extended to support PIT-based pagination with `search_after` |
+| `OpenSearchScrollRequest` | Request class for Scroll-based pagination (legacy) |
+| `OpenSearchRequestBuilder` | Builds appropriate request type based on configuration |
+| `OpenSearchClient` | Extended with `createPit()` and `deletePit()` methods |
+| `OpenSearchNodeClient` | Node client implementation of PIT operations |
+| `OpenSearchRestClient` | REST client implementation of PIT operations |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.sql.pagination.api` | Enable/disable pagination API | `true` |
+| `plugins.sql.pagination.api.search_after` | Use PIT-based pagination instead of Scroll | `true` |
+| `plugins.sql.cursor.keep_alive` | PIT/Scroll context timeout | `1m` |
+
+### Usage Example
+
+```sql
+-- Join queries automatically use PIT when enabled
+SELECT e.name, d.department_name 
+FROM employees e 
+JOIN departments d ON e.dept_id = d.id
+WHERE e.salary > 50000;
+
+-- Paginated queries use PIT for consistent results
+POST _plugins/_sql
+{
+  "query": "SELECT * FROM logs WHERE timestamp > '2024-01-01'",
+  "fetch_size": 1000
+}
+
+-- Cursor-based pagination maintains PIT context
+POST _plugins/_sql
+{
+  "cursor": "d:eyJhIjp7fSwicyI6IkRYRjFaWEo1UVc1a1JtVjBZMmdCQUFBQUFBQUFBQU1..."
+}
+```
+
+### Comparison: PIT vs Scroll
+
+| Aspect | Point in Time (PIT) | Scroll |
+|--------|---------------------|--------|
+| Data Consistency | Fixed snapshot at PIT creation | Fixed snapshot at scroll creation |
+| Navigation | Forward and backward with `search_after` | Forward only |
+| Resource Usage | Retains segment copies | Keeps search context |
+| Failure Recovery | Lost on cluster/node failure | Lost on cluster/node failure |
+| Deprecation Status | Current, recommended | Deprecated |
+
+## Limitations
+
+- PIT contexts consume cluster resources (memory, disk for retained segments)
+- PIT data is lost on cluster or node failure
+- Additional API calls required to create/delete PIT contexts
+- Not compatible with cursors from Scroll-based pagination
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#2981](https://github.com/opensearch-project/sql/pull/2981) | Add missing refactoring of Scroll to PIT API calls for Joins and Pagination query |
+| v2.18.0 | [#3045](https://github.com/opensearch-project/sql/pull/3045) | Bug fixes for minor issues with SQL PIT refactor |
+| v2.18.0 | [#3106](https://github.com/opensearch-project/sql/pull/3106) | Fix: SQL pagination with `pretty` parameter |
+| v2.18.0 | [#3108](https://github.com/opensearch-project/sql/pull/3108) | Backport: PIT refactor bug fixes |
+
+## References
+
+- [Point in Time Documentation](https://docs.opensearch.org/2.18/search-plugins/searching-data/point-in-time/): Official PIT documentation
+- [PIT in SQL](https://docs.opensearch.org/2.18/search-plugins/searching-data/point-in-time/#pit-in-sql): SQL-specific PIT usage
+- [Point in Time API](https://docs.opensearch.org/2.18/search-plugins/searching-data/point-in-time-api/): PIT API reference
+- [SQL Pagination API](https://docs.opensearch.org/2.18/search-plugins/sql/sql-ppl-api/#paginating-results): Pagination documentation
+- [Paginate Results](https://docs.opensearch.org/2.18/search-plugins/searching-data/paginate/): General pagination guide
+
+## Change History
+
+- **v2.18.0** (2024-10-29): Initial implementation - Refactored SQL plugin to use PIT API for joins and pagination queries

--- a/docs/releases/v2.18.0/features/sql/sql-pit-refactor.md
+++ b/docs/releases/v2.18.0/features/sql/sql-pit-refactor.md
@@ -1,0 +1,159 @@
+# SQL PIT Refactor for Joins and Pagination
+
+## Summary
+
+This release refactors the SQL plugin to use Point in Time (PIT) API instead of the deprecated Scroll API for join queries and pagination. The change improves consistency and reliability of SQL query results by leveraging PIT's ability to maintain a fixed view of data during query execution.
+
+## Details
+
+### What's New in v2.18.0
+
+The SQL plugin now uses Point in Time (PIT) API for:
+- Join queries (table scans in legacy SQL engine)
+- Pagination queries in the new SQL engine
+- Cursor-based result retrieval
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "SQL Query Execution"
+        REQ[SQL Request]
+        LEGACY[Legacy Engine]
+        NEW[New Engine]
+    end
+    
+    subgraph "Physical Operators"
+        TS[TableScan]
+        SCROLL[Scroll Operator]
+        PIT_OP[PointInTime Operator]
+    end
+    
+    subgraph "OpenSearch APIs"
+        SCROLL_API[Scroll API - Deprecated]
+        PIT_API[Point in Time API]
+        SEARCH[Search API]
+    end
+    
+    REQ --> LEGACY
+    REQ --> NEW
+    LEGACY --> TS
+    TS -->|SQL_PAGINATION_API_SEARCH_AFTER=false| SCROLL
+    TS -->|SQL_PAGINATION_API_SEARCH_AFTER=true| PIT_OP
+    SCROLL --> SCROLL_API
+    PIT_OP --> PIT_API
+    PIT_API --> SEARCH
+    NEW --> PIT_API
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `Paginate` | Abstract base class for pagination operators (Scroll and PIT) |
+| `PointInTime` | Physical operator for PIT-based table scans in join queries |
+| `OpenSearchQueryRequest` (enhanced) | Extended to support PIT-based pagination with `search_after` |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.sql.pagination.api.search_after` | Enable PIT-based pagination instead of Scroll | `true` |
+
+#### API Changes
+
+The `OpenSearchClient` interface now includes PIT management methods:
+
+```java
+// Create PIT for given indices
+String createPit(CreatePitRequest createPitRequest);
+
+// Delete PIT
+void deletePit(DeletePitRequest deletePitRequest);
+```
+
+### Key Implementation Details
+
+#### Legacy Engine (Join Queries)
+
+The `TableScan` logical operator now conditionally creates either a `Scroll` or `PointInTime` physical operator:
+
+```java
+@Override
+public <T> PhysicalOperator[] toPhysical(Map<LogicalOperator, PhysicalOperator<T>> optimalOps) {
+    if (LocalClusterState.state().getSettingValue(SQL_PAGINATION_API_SEARCH_AFTER)) {
+        return new PhysicalOperator[] {new PointInTime(request, pageSize)};
+    }
+    return new PhysicalOperator[] {new Scroll(request, pageSize)};
+}
+```
+
+#### New Engine (Pagination)
+
+The `OpenSearchRequestBuilder` creates PIT-based requests when pagination is enabled:
+
+```java
+private OpenSearchRequest buildRequestWithPit(...) {
+    if (pageSize == null) {
+        if (startFrom + size > maxResultWindow) {
+            String pitId = createPit(indexName, cursorKeepAlive, client);
+            return new OpenSearchQueryRequest(indexName, sourceBuilder, 
+                exprValueFactory, includes, cursorKeepAlive, pitId);
+        }
+        // Non-paginated request
+        return new OpenSearchQueryRequest(indexName, sourceBuilder, exprValueFactory, includes);
+    }
+    // Paginated request with PIT
+    String pitId = createPit(indexName, cursorKeepAlive, client);
+    return new OpenSearchQueryRequest(indexName, sourceBuilder, 
+        exprValueFactory, includes, cursorKeepAlive, pitId);
+}
+```
+
+### Usage Example
+
+SQL queries automatically use PIT when the setting is enabled (default):
+
+```sql
+-- Join query (uses PIT internally)
+SELECT a.firstname, b.balance 
+FROM accounts a 
+JOIN transactions b ON a.account_id = b.account_id
+
+-- Paginated query (uses PIT internally)
+POST _plugins/_sql
+{
+  "query": "SELECT * FROM accounts",
+  "fetch_size": 100
+}
+```
+
+### Migration Notes
+
+- The change is transparent to users - no query syntax changes required
+- Existing cursors from Scroll-based pagination are not compatible with PIT-based pagination
+- To revert to Scroll API, set `plugins.sql.pagination.api.search_after` to `false`
+
+## Limitations
+
+- PIT contexts consume cluster resources and have a configurable timeout
+- In case of cluster or node failure, all PIT data is lost
+- PIT-based pagination requires additional API calls to create/delete PIT contexts
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2981](https://github.com/opensearch-project/sql/pull/2981) | Add missing refactoring of Scroll to PIT API calls for Joins and Pagination query |
+
+## References
+
+- [Point in Time Documentation](https://docs.opensearch.org/2.18/search-plugins/searching-data/point-in-time/): Official PIT documentation
+- [PIT in SQL](https://docs.opensearch.org/2.18/search-plugins/searching-data/point-in-time/#pit-in-sql): SQL-specific PIT usage
+- [SQL Pagination API](https://docs.opensearch.org/2.18/search-plugins/sql/sql-ppl-api/#paginating-results): Pagination documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/sql/sql-pit-refactor.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -106,6 +106,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 - [SQL Error Handling](features/sql/sql-error-handling.md) - Improved error handling for malformed cursors and edge cases in query parsing
 - [SQL Pagination](features/sql/sql-pagination.md) - Bug fixes for SQL pagination with `pretty` parameter and PIT refactor issues
+- [SQL PIT Refactor](features/sql/sql-pit-refactor.md) - Refactor SQL plugin to use Point in Time (PIT) API instead of Scroll API for joins and pagination
 - [SQL Plugin Maintenance](features/sql/sql-plugin-maintenance.md) - Security fix for CVE-2024-47554 (commons-io upgrade to 2.14.0) and test fixes for 2.18 branch
 - [SQL Query Fixes](features/sql/sql-query-fixes.md) - Fix alias resolution in legacy SQL with filters, correct regex character range in Grok compiler
 - [SQL Scheduler](features/sql/sql-scheduler.md) - Bugfix to remove scheduler index from SystemIndexDescriptor to prevent conflicts with Job Scheduler plugin


### PR DESCRIPTION
## Summary

This PR adds documentation for the SQL PIT (Point in Time) refactor feature in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/sql/sql-pit-refactor.md`
- Feature report: `docs/features/sql/sql-pit-refactor.md`

### Key Changes in v2.18.0
- Refactored SQL plugin to use Point in Time (PIT) API instead of Scroll API
- Added PIT support for join queries in legacy SQL engine
- Added PIT support for pagination queries in new SQL engine
- New `Paginate` abstract base class for pagination operators
- New `PointInTime` physical operator for PIT-based table scans
- Extended `OpenSearchClient` interface with `createPit()` and `deletePit()` methods

### Related PR
- [opensearch-project/sql#2981](https://github.com/opensearch-project/sql/pull/2981): Add missing refactoring of Scroll to PIT API calls for Joins and Pagination query

### References
- [Point in Time Documentation](https://docs.opensearch.org/2.18/search-plugins/searching-data/point-in-time/)
- [PIT in SQL](https://docs.opensearch.org/2.18/search-plugins/searching-data/point-in-time/#pit-in-sql)

Closes #568