### PR TITLE
docs: add observability-get-started report for v2.18.0

### DIFF
--- a/docs/features/dashboards-observability/getting-started-workflows.md
+++ b/docs/features/dashboards-observability/getting-started-workflows.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-The Getting Started workflows in OpenSearch Dashboards Observability provide pre-configured templates and sample data to help users quickly set up observability pipelines. These workflows include index patterns, dashboards, and visualizations for common data sources like CSV files and OpenTelemetry (OTel) services.
+The Getting Started workflows in OpenSearch Dashboards Observability provide guided onboarding for setting up observability pipelines. The workflows are organized around three signal types (Logs, Metrics, Traces) with support for multiple telemetry sources including OpenTelemetry, Nginx, Java, Python, and Golang.
 
 ## Details
 
@@ -12,105 +12,104 @@ The Getting Started workflows in OpenSearch Dashboards Observability provide pre
 graph TB
     subgraph "Getting Started UI"
         GS[Getting Started Component]
-        WF[Workflow Selector]
+        ST[Signal Type Selector]
+        TS[Telemetry Source Dropdown]
     end
     
-    subgraph "Workflow Artifacts"
-        CSV[CSV File Workflow]
-        OTEL[OTel Services Workflow]
+    subgraph "Signal Types"
+        LOGS[Logs]
+        METRICS[Metrics]
+        TRACES[Traces]
     end
     
-    subgraph "Assets"
-        NDJSON[NDJSON Files]
-        IP[Index Patterns]
-        DASH[Dashboards]
-        VIS[Visualizations]
+    subgraph "Telemetry Sources"
+        OTEL[OpenTelemetry]
+        NGINX[Nginx]
+        JAVA[Java]
+        PYTHON[Python]
+        GOLANG[Golang]
     end
     
-    GS --> WF
-    WF --> CSV
-    WF --> OTEL
-    CSV --> NDJSON
-    OTEL --> NDJSON
-    NDJSON --> IP
-    NDJSON --> DASH
-    NDJSON --> VIS
+    subgraph "Deployment Options"
+        SM[Self Managed]
+        AWS[AWS]
+    end
+    
+    subgraph "Auto Setup"
+        ASSETS[Asset Creation]
+        TEMPLATES[Index Templates]
+    end
+    
+    GS --> ST
+    ST --> LOGS
+    ST --> METRICS
+    ST --> TRACES
+    LOGS --> TS
+    METRICS --> TS
+    TRACES --> TS
+    TS --> OTEL
+    TS --> NGINX
+    OTEL --> SM
+    OTEL --> AWS
+    ASSETS --> TEMPLATES
 ```
 
 ### Components
 
 | Component | Description |
 |-----------|-------------|
-| `fluent-bit-csv-upload-1.0.0.ndjson` | Assets for CSV file upload workflow using Fluent Bit |
-| `otel-index-patterns-1.0.0.ndjson` | Index patterns for OpenTelemetry services |
+| `getting_started_routes.ts` | Defines TutorialId types and component/version/signal maps |
+| Signal Type Tabs | UI tabs for Logs, Metrics, Traces navigation |
+| Telemetry Source Dropdown | Dropdown with icons for selecting data source |
+| `createAllTemplatesSettled` | Server-side function for batch index template creation |
+| `createIndexTemplate` | Server-side function for individual index template creation |
 | Getting Started UI | Interactive wizard for selecting and configuring workflows |
 
 ### Supported Workflows
 
-| Workflow | Index Pattern | Description |
-|----------|---------------|-------------|
-| CSV File Upload | `logs-*` | Upload CSV files using Fluent Bit agent |
-| OTel Services | `otel-v1-apm-span-*`, `otel-v1-apm-service-map` | OpenTelemetry traces and service maps |
+| Signal Type | Telemetry Sources | Deployment Options |
+|-------------|-------------------|-------------------|
+| Logs | OpenTelemetry, Nginx, Java, Python, Golang | Self Managed, AWS |
+| Metrics | OpenTelemetry, Nginx | Self Managed, AWS |
+| Traces | OpenTelemetry, Java, Python, Golang | Self Managed, AWS |
 
 ### Configuration
 
-The workflows use NDJSON (Newline Delimited JSON) files containing:
-
-| Asset Type | Description |
-|------------|-------------|
-| `index-pattern` | Defines the index pattern for data discovery |
-| `visualization` | Markdown or chart visualizations |
-| `dashboard` | Dashboard layouts referencing visualizations |
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Signal Type | Primary data type selection | Logs |
+| Telemetry Source | Data source for the signal | OpenTelemetry |
+| Deployment Mode | Self-managed or AWS | Self Managed |
 
 ### Usage Example
 
-Using the CSV File Upload workflow:
-
 1. Navigate to **Observability** > **Getting Started**
-2. Select **CSV File Upload**
-3. Follow the Fluent Bit configuration instructions
-4. View ingested data in the created dashboard
-
-Fluent Bit configuration example:
-
-```ini
-[SERVICE]
-    Flush        1
-    Log_Level    info
-    Parsers_File parsers.conf
-
-[INPUT]
-    Name         tail
-    Path         /path/to/your/csv/files/*.csv
-    Parser       csv
-    Tag          csv
-
-[OUTPUT]
-    Name         opensearch
-    Match        *
-    Host         your-opensearch-host
-    Port         9200
-    Index        logs
-```
+2. Select signal type: **Logs**, **Metrics**, or **Traces**
+3. Choose telemetry source from dropdown (e.g., OpenTelemetry, Nginx)
+4. For OTEL: Select **Self Managed** or **AWS** tab
+5. Follow setup instructions - index templates are created automatically
 
 ## Limitations
 
-- Workflows are designed for specific data formats and may require customization
+- Telemetry source options vary by signal type
+- AWS deployment option only available for OpenTelemetry workflows
 - Index patterns must match the actual indices created by data ingestion pipelines
-- Sample data is for demonstration purposes only
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.18.0 | [#2194](https://github.com/opensearch-project/dashboards-observability/pull/2194) | GettingStarted Rework - signal-based organization |
+| v2.18.0 | [#2205](https://github.com/opensearch-project/dashboards-observability/pull/2205) | GettingStarted Fit and Finish - UI polish |
+| v2.18.0 | [#2200](https://github.com/opensearch-project/dashboards-observability/pull/2200) | Auto trigger schema setup |
 | v2.17.0 | [#2016](https://github.com/opensearch-project/dashboards-observability/pull/2016) | Update ndjson so workflow matches patterns created |
 
 ## References
 
-- [Observability Documentation](https://docs.opensearch.org/2.17/observing-your-data/)
-- [Fluent Bit OpenSearch Output](https://docs.fluentbit.io/manual/pipeline/outputs/opensearch)
+- [Observability Documentation](https://docs.opensearch.org/2.18/observing-your-data/)
 - [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/)
 
 ## Change History
 
+- **v2.18.0** (2024-11-12): Major restructure - reorganized into Logs/Metrics/Traces signal types, added telemetry source dropdown with icons, Self Managed/AWS tabs for OTEL, auto index template creation, UI polish
 - **v2.17.0** (2024-10-22): Fixed index pattern mismatches - CSV workflow now uses `logs-*` pattern, removed unused `otel-metrics*` from OTel workflow

--- a/docs/releases/v2.18.0/features/dashboards-observability/observability-get-started.md
+++ b/docs/releases/v2.18.0/features/dashboards-observability/observability-get-started.md
@@ -1,0 +1,127 @@
+# Observability Get Started
+
+## Summary
+
+The Getting Started experience in OpenSearch Dashboards Observability was significantly restructured in v2.18.0. The workflow is now organized around three signal types (Logs, Metrics, Traces) with improved UI polish and automatic index template creation during asset setup.
+
+## Details
+
+### What's New in v2.18.0
+
+1. **Signal-based Organization**: Getting Started is now structured around Logs, Metrics, and Traces instead of data source types
+2. **Telemetry Source Selection**: New dropdown with icons for OpenTelemetry, Nginx, Java, Python, and Golang
+3. **Self-Managed vs AWS Tabs**: OTEL workflows now separate self-managed and AWS deployment options
+4. **Auto Schema Setup**: Index templates are automatically created when observability assets are created
+5. **UI Polish**: Consistent capitalization, improved spacing, fixed breadcrumb/header navigation
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Getting Started v2.18.0"
+        GS[Getting Started Component]
+        ST[Signal Type Selector]
+        TS[Telemetry Source Dropdown]
+    end
+    
+    subgraph "Signal Types"
+        LOGS[Logs]
+        METRICS[Metrics]
+        TRACES[Traces]
+    end
+    
+    subgraph "Telemetry Sources"
+        OTEL[OpenTelemetry]
+        NGINX[Nginx]
+        JAVA[Java]
+        PYTHON[Python]
+        GOLANG[Golang]
+    end
+    
+    subgraph "Deployment Options"
+        SM[Self Managed]
+        AWS[AWS]
+    end
+    
+    subgraph "Auto Setup"
+        ASSETS[Asset Creation]
+        TEMPLATES[Index Templates]
+    end
+    
+    GS --> ST
+    ST --> LOGS
+    ST --> METRICS
+    ST --> TRACES
+    LOGS --> TS
+    METRICS --> TS
+    TRACES --> TS
+    TS --> OTEL
+    TS --> NGINX
+    OTEL --> SM
+    OTEL --> AWS
+    ASSETS --> TEMPLATES
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `getting_started_routes.ts` | Defines TutorialId types and component/version/signal maps |
+| Signal Type Tabs | UI tabs for Logs, Metrics, Traces navigation |
+| Telemetry Source Dropdown | Dropdown with icons for selecting data source |
+| `createAllTemplatesSettled` | Server-side function for batch index template creation |
+| `createIndexTemplate` | Server-side function for individual index template creation |
+
+#### Removed Components
+
+| Component | Reason |
+|-----------|--------|
+| `getting_started_queryAndAnalyze.tsx` | Workflow simplified |
+| `getting_started_integrationCards.tsx` | Replaced by signal-based navigation |
+| CSV file upload workflow | Removed in favor of telemetry-focused workflows |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Signal Type | Primary data type selection | Logs |
+| Telemetry Source | Data source for the signal | OpenTelemetry |
+| Deployment Mode | Self-managed or AWS | Self Managed |
+
+### Usage Example
+
+1. Navigate to **Observability** > **Getting Started**
+2. Select signal type: **Logs**, **Metrics**, or **Traces**
+3. Choose telemetry source from dropdown (e.g., OpenTelemetry, Nginx)
+4. For OTEL: Select **Self Managed** or **AWS** tab
+5. Follow setup instructions - index templates are created automatically
+
+### Migration Notes
+
+- The CSV file upload workflow has been removed
+- Users should migrate to signal-based workflows (Logs/Metrics/Traces)
+- Existing dashboards and index patterns remain functional
+
+## Limitations
+
+- Telemetry source options vary by signal type
+- AWS deployment option only available for OpenTelemetry workflows
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2194](https://github.com/opensearch-project/dashboards-observability/pull/2194) | GettingStarted Rework - major restructure |
+| [#2205](https://github.com/opensearch-project/dashboards-observability/pull/2205) | GettingStarted Fit and Finish - UI polish |
+| [#2200](https://github.com/opensearch-project/dashboards-observability/pull/2200) | Auto trigger schema setup |
+
+## References
+
+- [Observability Documentation](https://docs.opensearch.org/2.18/observing-your-data/)
+- [GitHub Issue #564](https://github.com/tkykenmt/opensearch-feature-explorer/issues/564): Enhancement tracking
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/dashboards-observability/getting-started-workflows.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -191,6 +191,10 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Observability UI Improvements](features/observability/observability-ui-improvements.md) - Services data picker fix, header control styling, custom traces table filters, Getting Started workflow restructure, CI build cache optimization
 - [Observability Bugfixes](features/observability/observability-bugfixes.md) - Multiple bug fixes including navigation fixes, workspace compatibility, MDS support improvements, and UI/UX enhancements
 
+### Dashboards Observability
+
+- [Observability Get Started](features/dashboards-observability/observability-get-started.md) - Major restructure of Getting Started workflows into Logs/Metrics/Traces signal types, telemetry source dropdown, Self Managed/AWS tabs, auto index template creation
+
 ### Security
 
 - [Security Enhancements](features/security/security-enhancements.md) - Datastream support for audit logs, auto-convert V6 to V7 configuration, circuit breaker override, improved certificate error messages, JWT in MultipleAuthentication


### PR DESCRIPTION
## Summary

Add release and feature reports for the Observability Get Started enhancement in v2.18.0.

## Changes

### Release Report
- `docs/releases/v2.18.0/features/dashboards-observability/observability-get-started.md`

### Feature Report Update
- `docs/features/dashboards-observability/getting-started-workflows.md`

## Key Changes in v2.18.0

- **Signal-based Organization**: Getting Started restructured around Logs, Metrics, Traces
- **Telemetry Source Selection**: New dropdown with icons for OpenTelemetry, Nginx, Java, Python, Golang
- **Self-Managed vs AWS Tabs**: OTEL workflows now separate deployment options
- **Auto Schema Setup**: Index templates automatically created during asset creation
- **UI Polish**: Consistent capitalization, improved spacing, fixed breadcrumb/header navigation

## Related PRs
- [#2194](https://github.com/opensearch-project/dashboards-observability/pull/2194) - GettingStarted Rework
- [#2205](https://github.com/opensearch-project/dashboards-observability/pull/2205) - GettingStarted Fit and Finish
- [#2200](https://github.com/opensearch-project/dashboards-observability/pull/2200) - Auto trigger schema setup

Closes #564