### PR TITLE
docs: add Neural Search Reranking report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -6,6 +6,7 @@
 - [Hybrid Query](neural-search/hybrid-query.md)
 - [Neural Search Compatibility](neural-search/neural-search-compatibility.md)
 - [Neural Search Rescore](neural-search/neural-search-rescore.md)
+- [Neural Search Reranking](neural-search/neural-search-reranking.md)
 - [Neural Sparse Search](neural-search/neural-sparse-search.md)
 - [Semantic Field](neural-search/semantic-field.md)
 - [Text Chunking](neural-search/text-chunking.md)

--- a/docs/features/neural-search/neural-search-reranking.md
+++ b/docs/features/neural-search/neural-search-reranking.md
@@ -1,0 +1,204 @@
+# Neural Search Reranking
+
+## Summary
+
+Neural Search Reranking provides mechanisms to reorder search results after initial retrieval to improve relevance. OpenSearch supports multiple reranking approaches through search pipelines: ML-based cross-encoder reranking, field-based reranking using document values, and query-level rescoring within hybrid queries. These capabilities enable sophisticated relevance tuning for neural search applications.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Search Pipeline Reranking"
+        Query[Search Query] --> Initial[Initial Search]
+        Initial --> Results[Search Results]
+        Results --> Pipeline[Search Pipeline]
+        
+        subgraph "Rerank Processor"
+            Pipeline --> RT{Rerank Type}
+            RT --> |ml_opensearch| ML[ML Model Reranking]
+            RT --> |by_field| BF[Field-Based Reranking]
+            ML --> |"Cross-encoder scoring"| Reranked[Reranked Results]
+            BF --> |"Read field value"| Reranked
+        end
+    end
+    
+    subgraph "Query-Level Rescoring"
+        HQ[Hybrid Query] --> Shard[Shard Execution]
+        Shard --> Rescore[Rescore Query]
+        Rescore --> Norm[Score Normalization]
+        Norm --> Final[Final Results]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Rerank Processor Flow"
+        SR[Search Results] --> Extract[Extract Documents]
+        Extract --> Score[Compute New Scores]
+        Score --> Sort[Sort by New Score]
+        Sort --> Return[Return Reranked Results]
+    end
+    
+    subgraph "Hybrid Rescore Flow"
+        HQ[Hybrid Query] --> Sub[Execute Sub-queries]
+        Sub --> Collect[Collect Top K per Shard]
+        Collect --> RS[Apply Rescore]
+        RS --> Merge[Merge Shards]
+        Merge --> NP[Normalize & Combine]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `RerankProcessor` | Base search response processor for reranking |
+| `MLOpenSearchRerankProcessor` | Reranks using ML models (cross-encoders) |
+| `ByFieldRerankProcessor` | Reranks by document field values |
+| `RerankType` | Enum defining rerank types (`ml_opensearch`, `by_field`) |
+| `ProcessorUtils` | Utility methods for processor operations |
+| `HybridQueryPhaseSearcher` | Handles rescore in hybrid query execution |
+
+### Configuration
+
+#### Rerank Processor Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `context.document_fields` | Fields to pass to ML model for reranking | Required for `ml_opensearch` |
+| `ml_opensearch.model_id` | ID of the deployed cross-encoder model | Required for `ml_opensearch` |
+| `by_field.target_field` | Dot-path to numeric field for reranking | Required for `by_field` |
+| `by_field.remove_target_field` | Remove target field from results | `false` |
+| `by_field.keep_previous_score` | Preserve original score | `false` |
+
+#### Rescore Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `window_size` | Number of top documents to rescore | 10 |
+| `query_weight` | Weight for original query score | 1.0 |
+| `rescore_query_weight` | Weight for rescore query score | 1.0 |
+| `score_mode` | How to combine scores (`total`, `multiply`, `avg`, `max`, `min`) | `total` |
+
+### Usage Examples
+
+#### Cross-Encoder Reranking Pipeline
+
+```json
+PUT /_search/pipeline/cross_encoder_pipeline
+{
+  "response_processors": [
+    {
+      "rerank": {
+        "ml_opensearch": {
+          "model_id": "cross-encoder-model-id"
+        },
+        "context": {
+          "document_fields": ["title", "content"]
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Field-Based Reranking Pipeline
+
+```json
+PUT /_search/pipeline/byfield_pipeline
+{
+  "response_processors": [
+    {
+      "rerank": {
+        "by_field": {
+          "target_field": "ml_predictions.relevance_score",
+          "keep_previous_score": true,
+          "remove_target_field": false
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Hybrid Query with Rescore
+
+```json
+GET /my-index/_search
+{
+  "query": {
+    "hybrid": {
+      "queries": [
+        { "match": { "text": "search terms" } },
+        { "neural": { "embedding": { "query_text": "semantic query", "model_id": "model-id", "k": 10 } } }
+      ]
+    }
+  },
+  "rescore": {
+    "window_size": 50,
+    "query": {
+      "rescore_query": {
+        "match_phrase": { "text": { "query": "important phrase", "slop": 2 } }
+      },
+      "query_weight": 0.7,
+      "rescore_query_weight": 1.5
+    }
+  }
+}
+```
+
+#### Chained Reranking with Cohere
+
+```json
+PUT /_search/pipeline/cohere_rerank_pipeline
+{
+  "response_processors": [
+    {
+      "rerank": {
+        "ml_opensearch": {
+          "model_id": "cohere-rerank-connector-id"
+        },
+        "context": {
+          "document_fields": ["passage_text"]
+        }
+      }
+    }
+  ]
+}
+```
+
+## Limitations
+
+- Cross-encoder reranking requires a deployed ML model with appropriate permissions
+- `by_field` reranking requires the target field to be numeric and present in `_source`
+- Nested field paths must use dot notation
+- Hybrid query rescore does not work with sorting
+- Rescore is applied at shard level before normalization in hybrid queries
+- Large rescore window sizes increase latency
+- One-to-one inference cannot write to search extension due to ordering concerns with reranking
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#932](https://github.com/opensearch-project/neural-search/pull/932) | ByFieldRerankProcessor for second level reranking |
+| v2.18.0 | [#917](https://github.com/opensearch-project/neural-search/pull/917) | Added rescorer in hybrid query |
+| v2.12.0 | - | Initial rerank processor implementation |
+
+## References
+
+- [Reranking Search Results](https://docs.opensearch.org/2.18/search-plugins/search-relevance/reranking-search-results/): Overview of reranking capabilities
+- [Rerank Processor](https://docs.opensearch.org/2.18/search-plugins/search-pipelines/rerank-processor/): Rerank processor reference
+- [Reranking by Field](https://docs.opensearch.org/2.18/search-plugins/search-relevance/rerank-by-field/): Field-based reranking guide
+- [Reranking with Cohere](https://docs.opensearch.org/2.18/ml-commons-plugin/tutorials/reranking-cohere/): Tutorial for Cohere Rerank integration
+- [Issue #926](https://github.com/opensearch-project/neural-search/issues/926): ByFieldRerankProcessor feature request
+- [Issue #914](https://github.com/opensearch-project/neural-search/issues/914): Hybrid query rescore bug report
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Added ByFieldRerankProcessor for field-based reranking, enabled rescore support in hybrid queries
+- **v2.12.0** (2024-02-20): Initial rerank processor implementation with ML-based reranking

--- a/docs/releases/v2.18.0/features/neural-search/neural-search-reranking.md
+++ b/docs/releases/v2.18.0/features/neural-search/neural-search-reranking.md
@@ -1,0 +1,153 @@
+# Neural Search Reranking
+
+## Summary
+
+OpenSearch v2.18.0 introduces two significant reranking enhancements for neural search: the ByFieldRerankProcessor for second-level reranking based on document fields, and hybrid query rescorer support that enables standard OpenSearch rescore functionality within hybrid queries. These features provide more flexible relevance tuning options for neural search applications.
+
+## Details
+
+### What's New in v2.18.0
+
+#### ByFieldRerankProcessor
+
+A new rerank type `by_field` allows reranking search results based on a numeric field value stored in the document's `_source`. This is useful when:
+- An ML model has already computed relevance scores stored in document fields
+- A previous search response processor has aggregated scores that should be used for final ranking
+- Business logic requires reordering results by a specific field value
+
+#### Hybrid Query Rescorer
+
+The hybrid query now supports OpenSearch's standard rescore functionality. Previously, rescore queries were ignored when used with hybrid queries. This fix enables applying rescorers at the shard level before score normalization occurs.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Reranking Pipeline Flow"
+        SR[Search Results] --> RP[Rerank Processor]
+        RP --> BF{Rerank Type}
+        BF --> |by_field| BFRP[ByFieldRerankProcessor]
+        BF --> |ml_opensearch| MLRP[ML Rerank Processor]
+        BF --> |cross_encoder| CERP[Cross-Encoder Processor]
+        BFRP --> |"Read target_field"| RR[Reranked Results]
+        MLRP --> RR
+        CERP --> RR
+    end
+    
+    subgraph "Hybrid Query with Rescore"
+        HQ[Hybrid Query] --> SL[Shard-Level Execution]
+        SL --> RS[Rescore Applied]
+        RS --> NP[Normalization Processor]
+        NP --> FR[Final Results]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ByFieldRerankProcessor` | Search response processor that reranks results by a document field value |
+| `ProcessorUtils` | Utility class for processor operations |
+| `RerankType.BY_FIELD` | New enum value for by_field rerank type |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `target_field` | Dot-path to the numeric field used for reranking (e.g., `reviews.stars`) | Required |
+| `remove_target_field` | Whether to remove the target field from results after reranking | `false` |
+| `keep_previous_score` | Whether to preserve the original score alongside the new score | `false` |
+
+### Usage Example
+
+#### ByFieldRerankProcessor Pipeline
+
+```json
+PUT /_search/pipeline/rerank_byfield_pipeline
+{
+  "response_processors": [
+    {
+      "rerank": {
+        "by_field": {
+          "target_field": "ml_score.relevance",
+          "keep_previous_score": true,
+          "remove_target_field": false
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Search with ByField Reranking
+
+```json
+GET /my-index/_search?search_pipeline=rerank_byfield_pipeline
+{
+  "query": {
+    "match": {
+      "content": "search query"
+    }
+  }
+}
+```
+
+#### Hybrid Query with Rescore
+
+```json
+GET /my-index/_search
+{
+  "query": {
+    "hybrid": {
+      "queries": [
+        { "match": { "text": "search terms" } },
+        { "neural": { "embedding": { "query_text": "semantic query", "model_id": "model-id", "k": 10 } } }
+      ]
+    }
+  },
+  "rescore": {
+    "window_size": 100,
+    "query": {
+      "rescore_query": {
+        "match_phrase": { "text": { "query": "exact phrase", "slop": 2 } }
+      },
+      "query_weight": 0.7,
+      "rescore_query_weight": 1.2
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- The `by_field` rerank type is a new addition; existing rerank pipelines using `ml_opensearch` continue to work unchanged
+- Hybrid query rescore is automatically available; no configuration changes needed
+- Rescore scores are applied at shard level before normalization, so final scores will be in the normalized range (typically 0-1)
+
+## Limitations
+
+- `by_field` reranking requires the target field to exist in `_source` and contain a numeric value
+- Nested field paths must use dot notation (e.g., `parent.child.score`)
+- Hybrid query rescore does not work with sorting (same as traditional query behavior)
+- Rescore window size affects performance; larger windows increase latency
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#932](https://github.com/opensearch-project/neural-search/pull/932) | ByFieldRerankProcessor for second level reranking |
+| [#917](https://github.com/opensearch-project/neural-search/pull/917) | Added rescorer in hybrid query |
+
+## References
+
+- [Issue #926](https://github.com/opensearch-project/neural-search/issues/926): Feature request for ByFieldRerankProcessor
+- [Issue #914](https://github.com/opensearch-project/neural-search/issues/914): Bug report - rescore queries didn't modify scores with hybrid query
+- [Rerank Processor Documentation](https://docs.opensearch.org/2.18/search-plugins/search-pipelines/rerank-processor/): Official rerank processor reference
+- [Reranking by Field Documentation](https://docs.opensearch.org/2.18/search-plugins/search-relevance/rerank-by-field/): Official by_field reranking guide
+- [Reranking Search Results](https://docs.opensearch.org/2.18/search-plugins/search-relevance/reranking-search-results/): Overview of reranking capabilities
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/neural-search/neural-search-reranking.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -120,6 +120,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### Neural Search
 
+- [Neural Search Reranking](features/neural-search/neural-search-reranking.md) - ByFieldRerankProcessor for field-based reranking and hybrid query rescorer support
 - [Neural Search Text Chunking](features/neural-search/neural-search-text-chunking.md) - Add `ignore_missing` parameter to text chunking processors for flexible handling of optional fields
 - [Neural Search Bugfixes](features/neural-search/neural-search-bugfixes.md) - Fixed incorrect document order for nested aggregations in hybrid query
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Neural Search Reranking enhancement in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/neural-search/neural-search-reranking.md`
- Feature report: `docs/features/neural-search/neural-search-reranking.md`

### Key Changes in v2.18.0

1. **ByFieldRerankProcessor** (PR #932)
   - New `by_field` rerank type for reranking by document field values
   - Supports `target_field`, `remove_target_field`, and `keep_previous_score` options
   - Useful for second-level reranking when ML scores are pre-computed

2. **Hybrid Query Rescorer** (PR #917)
   - Enables standard OpenSearch rescore functionality in hybrid queries
   - Rescore applied at shard level before score normalization
   - Fixes bug where rescore queries were previously ignored

### Related Issues
- Issue #563: Neural Search Reranking enhancement tracking
- Issue #926: ByFieldRerankProcessor feature request
- Issue #914: Hybrid query rescore bug report

### References
- [Rerank Processor Documentation](https://docs.opensearch.org/2.18/search-plugins/search-pipelines/rerank-processor/)
- [Reranking by Field Documentation](https://docs.opensearch.org/2.18/search-plugins/search-relevance/rerank-by-field/)