### PR TITLE
docs: add Flow Framework report for v2.18.0

### DIFF
--- a/docs/features/flow-framework/flow-framework.md
+++ b/docs/features/flow-framework/flow-framework.md
@@ -198,6 +198,8 @@ POST /_plugins/_flow_framework/workflow/<id>/_deprovision
 | v3.0.0 | [#1107](https://github.com/opensearch-project/flow-framework/pull/1107) | Fix bug handleReprovision missing wait_for_completion_timeout response |
 | v3.0.0 | [#1113](https://github.com/opensearch-project/flow-framework/pull/1113) | Add new attributes field to ToolStep |
 | v3.0.0 | [#936](https://github.com/opensearch-project/flow-framework/pull/936) | Add text to visualization agent template |
+| v2.18.0 | [#899](https://github.com/opensearch-project/flow-framework/pull/899) | Add optional config field to tool step |
+| v2.18.0 | [#898](https://github.com/opensearch-project/flow-framework/pull/898) | Incrementally remove resources from workflow state during deprovisioning |
 | v2.18.0 | [#918](https://github.com/opensearch-project/flow-framework/pull/918) | Fixed template update location and improved logger statements in ReprovisionWorkflowTransportAction |
 | v2.18.0 | [#894](https://github.com/opensearch-project/flow-framework/pull/894) | Update workflow state without using painless script |
 | v2.17.0 | [#804](https://github.com/opensearch-project/flow-framework/pull/804) | Adds reprovision API to support updating search pipelines, ingest pipelines, index settings |
@@ -213,9 +215,12 @@ POST /_plugins/_flow_framework/workflow/<id>/_deprovision
 - [Issue #1097](https://github.com/opensearch-project/flow-framework/issues/1097): Action listener completion
 - [Issue #1106](https://github.com/opensearch-project/flow-framework/issues/1106): Reprovision timeout response
 - [Issue #1112](https://github.com/opensearch-project/flow-framework/issues/1112): ToolStep attributes field
+- [Issue #878](https://github.com/opensearch-project/flow-framework/issues/878): ML-commons config field in MLToolSpec
+- [Issue #780](https://github.com/opensearch-project/flow-framework/issues/780): Update WorkflowState resources during deprovisioning
+- [Issue #691](https://github.com/opensearch-project/flow-framework/issues/691): Handle deprovision with workflow state update failure
 
 ## Change History
 
 - **v3.0.0** (2025-05-06): OpenSearch 3.0 compatibility fixes, per-tenant provisioning throttling, REST status code corrections, config parser fix for tenant_id, synchronous provisioning action listener fix, reprovision timeout response fix, ToolStep attributes field, text-to-visualization templates
-- **v2.18.0** (2024-11-05): Removed Painless scripts for workflow state updates, implemented optimistic locking with sequence numbers and primary terms for better concurrency control; Fixed template update location in ReprovisionWorkflowTransportAction to resolve flaky integration tests, improved logger statements for better debugging
+- **v2.18.0** (2024-11-05): Added optional config field to tool step for static tool parameters; Incremental resource removal during deprovisioning for better reliability; Removed Painless scripts for workflow state updates with optimistic locking; Fixed template update location in ReprovisionWorkflowTransportAction
 - **v2.17.0** (2024-10-01): Initial Reprovision API implementation supporting updates to search pipelines, ingest pipelines, and index settings

--- a/docs/releases/v2.18.0/features/flow-framework/flow-framework.md
+++ b/docs/releases/v2.18.0/features/flow-framework/flow-framework.md
@@ -1,0 +1,130 @@
+# Flow Framework
+
+## Summary
+
+OpenSearch 2.18.0 introduces two key enhancements to the Flow Framework plugin: an optional `config` field for tool steps and incremental resource removal during deprovisioning. These changes improve workflow flexibility for AI/ML tool configuration and provide better reliability during workflow cleanup operations.
+
+## Details
+
+### What's New in v2.18.0
+
+#### 1. Optional Config Field for Tool Step
+
+PR #899 adds support for an optional `config` map in the `ToolStep` workflow step. This allows users to configure static parameters for ML tools that persist during tool execution.
+
+**Key Changes:**
+- Added `CONFIG_FIELD` constant to `CommonValue.java`
+- Modified `ToolStep.java` to accept and process the `config` field
+- The config map is passed to `MLToolSpec.builder().configMap(config)`
+
+**Use Case:** Configure tool-specific settings that remain constant throughout execution, such as API endpoints, default parameters, or behavior flags.
+
+#### 2. Incremental Resource Removal During Deprovisioning
+
+PR #898 improves the deprovisioning workflow by incrementally removing resources from the workflow state as they are deleted, rather than updating the state only at the end.
+
+**Key Changes:**
+- Added `deleteResourceFromStateIndex()` method to `FlowFrameworkIndicesHandler`
+- Modified `DeprovisionWorkflowTransportAction` to call incremental deletion after each successful resource removal
+- Maintains a backup full-list update at the end for redundancy
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+flowchart TB
+    subgraph "Deprovisioning Flow"
+        A[Start Deprovision] --> B[Get Resources List]
+        B --> C{More Resources?}
+        C -->|Yes| D[Delete Resource]
+        D --> E[Update State Index]
+        E -->|Remove from list| C
+        C -->|No| F[Final State Update]
+        F --> G[Complete]
+    end
+    
+    subgraph "Tool Step Enhancement"
+        T1[Parse Tool Step] --> T2[Extract Config Field]
+        T2 --> T3[Build MLToolSpec]
+        T3 --> T4[Set configMap]
+        T4 --> T5[Create Tool]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `CONFIG_FIELD` | New constant for the `config` field in tool steps |
+| `deleteResourceFromStateIndex()` | Method to incrementally remove resources from workflow state |
+| `ToolStep.OPTIONAL_INPUTS` | Updated to include `CONFIG_FIELD` |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `config` (Tool Step) | Optional map of static configuration parameters for tools | Empty map |
+
+### Usage Example
+
+#### Tool Step with Config Field
+
+```yaml
+workflows:
+  provision:
+    nodes:
+      - id: create_tool
+        type: create_tool
+        user_inputs:
+          type: VectorDBTool
+          name: my_vector_tool
+          description: Vector search tool
+          parameters:
+            index: my-index
+            source_field: text
+          config:
+            max_results: "10"
+            include_metadata: "true"
+```
+
+#### Deprovisioning Behavior
+
+```bash
+# Deprovision workflow - resources are now removed incrementally
+POST /_plugins/_flow_framework/workflow/<id>/_deprovision
+
+# Check status during deprovisioning - resources_created shrinks incrementally
+GET /_plugins/_flow_framework/workflow/<id>/_status
+```
+
+### Migration Notes
+
+No migration required. Both changes are backward compatible:
+- The `config` field is optional; existing workflows continue to work
+- Incremental deprovisioning is transparent to API users
+
+## Limitations
+
+- The `config` field only accepts `Map<String, String>` values
+- Incremental state updates have a 1-second timeout; failures are logged but don't block deprovisioning
+- The backup full-list update at the end ensures consistency even if incremental updates fail
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#899](https://github.com/opensearch-project/flow-framework/pull/899) | Add optional config field to tool step |
+| [#898](https://github.com/opensearch-project/flow-framework/pull/898) | Incrementally remove resources from workflow state during deprovisioning |
+
+## References
+
+- [Issue #878](https://github.com/opensearch-project/flow-framework/issues/878): ML-commons introducing new optional field "config" in MLToolSpec
+- [Issue #780](https://github.com/opensearch-project/flow-framework/issues/780): Update WorkflowState resources during deprovisioning
+- [Issue #691](https://github.com/opensearch-project/flow-framework/issues/691): Handle successful deprovision with failure in workflow state update
+- [ML-Commons PR #2977](https://github.com/opensearch-project/ml-commons/pull/2977): Related ML-Commons change for config field
+- [Deprovision Workflow API](https://docs.opensearch.org/2.18/automating-configurations/api/deprovision-workflow/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/flow-framework/flow-framework.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -89,6 +89,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### Flow Framework
 
+- [Flow Framework](features/flow-framework/flow-framework.md) - Add optional config field to tool step, incremental resource removal during deprovisioning
 - [Flow Framework Workflow State](features/flow-framework/flow-framework-workflow-state.md) - Remove Painless scripts for workflow state updates, implement optimistic locking
 - [Flow Framework Bugfixes](features/flow-framework/flow-framework-bugfixes.md) - Fix template update location in ReprovisionWorkflowTransportAction, improved logger statements
 - [Query Assist Data Summary Agent](features/flow-framework/query-assist.md) - Add sample template for Query Assist Data Summary Agent using Claude on Bedrock


### PR DESCRIPTION
## Summary

This PR adds documentation for Flow Framework enhancements in OpenSearch v2.18.0.

### Changes

**Release Report** (`docs/releases/v2.18.0/features/flow-framework/flow-framework.md`):
- Documents PR #899: Optional `config` field for tool step
- Documents PR #898: Incremental resource removal during deprovisioning

**Feature Report** (`docs/features/flow-framework/flow-framework.md`):
- Added PRs #899 and #898 to Related PRs table
- Updated Change History for v2.18.0
- Added new issue references

**Release Index** (`docs/releases/v2.18.0/index.md`):
- Added link to new Flow Framework release report

### Key Features Documented

1. **Optional Config Field for Tool Step** (PR #899)
   - Allows static configuration parameters for ML tools
   - Config map persists during tool execution

2. **Incremental Resource Removal During Deprovisioning** (PR #898)
   - Resources are removed from workflow state incrementally
   - Improves reliability of deprovisioning operations
   - Maintains backup full-list update for redundancy

### Related Issue
Closes #562