### PR TITLE
docs: add Lucene 9.12.0 upgrade report for v2.18.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -42,6 +42,7 @@
 - [Java Runtime & JPMS](opensearch/java-runtime-and-jpms.md)
 - [Lucene 10 Upgrade](opensearch/lucene-10-upgrade.md)
 - [Lucene Similarity](opensearch/lucene-similarity.md)
+- [Lucene Upgrade](opensearch/lucene-upgrade.md)
 - [Merge & Segment Settings](opensearch/merge-segment-settings.md)
 - [Multi-Search API](opensearch/multi-search-api.md)
 - [Nested Aggregations](opensearch/nested-aggregations.md)

--- a/docs/features/opensearch/lucene-upgrade.md
+++ b/docs/features/opensearch/lucene-upgrade.md
@@ -1,0 +1,84 @@
+# Lucene Upgrade
+
+## Summary
+
+OpenSearch relies on Apache Lucene as its core search library. Lucene upgrades bring performance improvements, new features, bug fixes, and security enhancements to OpenSearch. These upgrades are essential for maintaining compatibility with the latest search capabilities and ensuring optimal performance.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph OpenSearch
+        OS[OpenSearch Core]
+        Codec[Codec Layer]
+        Index[Index Management]
+    end
+    
+    subgraph Lucene
+        LC[Lucene Core]
+        PF[Postings Format]
+        DV[Doc Values]
+        KNN[KNN Vectors]
+        Analysis[Analysis]
+    end
+    
+    OS --> Codec
+    Codec --> LC
+    Index --> LC
+    LC --> PF
+    LC --> DV
+    LC --> KNN
+    LC --> Analysis
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Lucene Core | Core search library providing indexing and search capabilities |
+| Postings Format | Encodes term frequencies, positions, and skip data |
+| Doc Values | Column-oriented storage for sorting and aggregations |
+| KNN Vectors | Vector similarity search support |
+| Analysis | Text analysis and tokenization |
+
+### Configuration
+
+No specific configuration is required for Lucene upgrades. The version is managed at the OpenSearch build level.
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| N/A | Lucene version is bundled with OpenSearch | Determined by OpenSearch version |
+
+### Usage Example
+
+Lucene version can be verified through the nodes info API:
+
+```bash
+GET /_nodes?filter_path=nodes.*.version
+```
+
+## Limitations
+
+- Lucene upgrades may require index format changes
+- Major Lucene version upgrades may require reindexing
+- Some Lucene features may not be exposed through OpenSearch APIs
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#15333](https://github.com/opensearch-project/OpenSearch/pull/15333) | Update Apache Lucene to 9.12.0 |
+| v3.0.0 | [#16366](https://github.com/opensearch-project/OpenSearch/pull/16366) | Apache Lucene 10 update |
+
+## References
+
+- [Lucene 9.12.0 Changelog](https://lucene.apache.org/core/9_12_0/changes/Changes.html): Official Lucene 9.12.0 release notes
+- [Apache Lucene](https://lucene.apache.org/): Official Apache Lucene project
+- [OpenSearch Documentation](https://docs.opensearch.org/): OpenSearch official documentation
+
+## Change History
+
+- **v3.0.0**: Upgrade to Apache Lucene 10
+- **v2.18.0**: Upgrade to Apache Lucene 9.12.0 with new Lucene912PostingsFormat, JDK 23 Panama Vectorization support, dynamic range facets, and various performance optimizations

--- a/docs/releases/v2.18.0/features/opensearch/lucene-upgrade.md
+++ b/docs/releases/v2.18.0/features/opensearch/lucene-upgrade.md
@@ -1,0 +1,82 @@
+# Lucene 9.12.0 Upgrade
+
+## Summary
+
+OpenSearch v2.18.0 upgrades the underlying Apache Lucene library from 9.11.1 to 9.12.0. This upgrade brings significant performance improvements, new features, and optimizations to the search engine core, including a new default postings format with improved skip data handling, JDK 23 support for Panama Vectorization, and various query and indexing optimizations.
+
+## Details
+
+### What's New in v2.18.0
+
+The Lucene 9.12.0 upgrade introduces several key improvements:
+
+- **New Lucene912PostingsFormat**: The default postings format now uses only 2 levels of skip data inlined into postings, improving performance for queries that need skipping such as conjunctions
+- **JDK 23 Support**: Panama Vectorization Provider now supports JDK 23
+- **Dynamic Range Facets**: New faceting feature that automatically picks balanced numeric ranges based on value distribution
+- **Search Concurrency Configuration**: TieredMergePolicy and LogMergePolicy now support configurable search concurrency
+- **Memory Optimizations**: Reduced memory allocations and improved heap usage for HNSW and scalar quantized vector writers
+
+### Technical Changes
+
+#### Version Update
+
+| Component | Previous | New |
+|-----------|----------|-----|
+| Apache Lucene | 9.11.1 | 9.12.0 |
+
+#### Key Improvements from Lucene 9.12.0
+
+**Performance Optimizations:**
+- Lucene912PostingsFormat with 2-level skip data inlined into postings for faster conjunction queries
+- OnHeapHnswGraph no longer allocates a lock for every graph node
+- Optimized decoding logic for blocks of postings
+- Improved NumericComparator competitive iterator logic
+- Max WAND optimizations with ToParentBlockJoinQuery when using ScoreMode.Max
+
+**New API Features:**
+- `TermInSetQuery#getBytesRefIterator` for iterating over query terms
+- `FlatVectorsFormat` exposed as a first-class format configurable via custom Codec
+- `IndexSearcher#searchLeaf` protected method for customizing per-leaf search behavior
+- `BitSet#nextSetBit(int, int)` for getting first set bit in range
+- `DrillSideways#search` method supporting any CollectorManagers
+
+**Memory and Arena Improvements:**
+- Shared Arena grouping for files from the same segment to reduce performance degradation when closing many index files
+- Configurable `sharedArenaMaxPermits` system property for controlling mmapped file associations
+
+### Usage Example
+
+No configuration changes are required. The upgrade is transparent to users. The new postings format is automatically used for new segments.
+
+To verify the Lucene version:
+
+```bash
+GET /_nodes?filter_path=nodes.*.version,nodes.*.build_hash
+```
+
+### Migration Notes
+
+- This is a transparent upgrade with no breaking changes
+- Existing indices remain compatible
+- New segments will automatically use Lucene912PostingsFormat
+- No reindexing required
+
+## Limitations
+
+- The new postings format optimizations primarily benefit conjunction queries
+- JDK 23 Panama Vectorization requires running on JDK 23 or later
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#15333](https://github.com/opensearch-project/OpenSearch/pull/15333) | Update Apache Lucene to 9.12.0 |
+
+## References
+
+- [Lucene 9.12.0 Changelog](https://lucene.apache.org/core/9_12_0/changes/Changes.html): Official release notes
+- [OpenSearch PR #15333](https://github.com/opensearch-project/OpenSearch/pull/15333): Main implementation PR
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/lucene-upgrade.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -8,6 +8,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 
 ### OpenSearch
 
+- [Lucene 9.12.0 Upgrade](features/opensearch/lucene-upgrade.md) - Upgrade Apache Lucene from 9.11.1 to 9.12.0 with new postings format, JDK 23 support, and performance optimizations
 - [List APIs (Paginated)](features/opensearch/list-apis-paginated.md) - New `_list/indices` and `_list/shards` APIs with pagination support, plus cat API response limits
 - [Cluster Stats API](features/opensearch/cluster-stats-api.md) - URI path filtering support for selective metric retrieval
 - [OpenSearch Core Dependencies](features/opensearch/opensearch-core-dependencies.md) - 26 dependency updates including Lucene 9.12.0, Netty 4.1.114, gRPC 1.68.0, Protobuf 3.25.5


### PR DESCRIPTION
## Summary

This PR adds documentation for the Apache Lucene 9.12.0 upgrade in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/opensearch/lucene-upgrade.md`
- Feature report: `docs/features/opensearch/lucene-upgrade.md`

### Key Changes in v2.18.0

- **Lucene 9.12.0 Upgrade**: Updates Apache Lucene from 9.11.1 to 9.12.0
- **New Lucene912PostingsFormat**: Default postings format with 2-level skip data inlined into postings for faster conjunction queries
- **JDK 23 Support**: Panama Vectorization Provider now supports JDK 23
- **Dynamic Range Facets**: New faceting feature that automatically picks balanced numeric ranges
- **Memory Optimizations**: Reduced memory allocations and improved heap usage for HNSW and vector writers

### Resources Used
- PR: [#15333](https://github.com/opensearch-project/OpenSearch/pull/15333)
- Docs: [Lucene 9.12.0 Changelog](https://lucene.apache.org/core/9_12_0/changes/Changes.html)