### PR TITLE
docs: add Alerting Summary & Insights report for v2.18.0

### DIFF
--- a/docs/features/alerting-dashboards-plugin/alerting-summary-insights.md
+++ b/docs/features/alerting-dashboards-plugin/alerting-summary-insights.md
@@ -1,0 +1,191 @@
+# Alerting Summary & Insights
+
+## Summary
+
+Alerting Summary & Insights is an AI-powered feature in OpenSearch Dashboards that helps users understand and analyze alerts more effectively. By integrating with the OpenSearch Dashboards Assistant and large language models (LLMs), this feature provides context-aware alert summaries, log pattern analysis, and actionable insights directly from the alerts dashboard.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "User Interface"
+        AD[Alerts Dashboard]
+        PO[Popover UI]
+        SP[Sparkle Icon]
+    end
+    
+    subgraph "Alerting Dashboards Plugin"
+        TC[tableUtils.js]
+        CP[Context Provider]
+        PPL[PPL Query Builder]
+    end
+    
+    subgraph "Dashboards Assistant"
+        ICI[IncontextInsight]
+        GP[GeneratePopover]
+    end
+    
+    subgraph "ML Commons"
+        SA[Summary Agent]
+        IA[Insights Agent]
+        LLM[LLM Model]
+    end
+    
+    subgraph "OpenSearch"
+        MI[Monitor Index]
+        AI[Alert Index]
+        DI[Data Index]
+    end
+    
+    AD --> SP
+    SP --> PO
+    PO --> ICI
+    ICI --> GP
+    GP --> CP
+    CP --> TC
+    TC --> PPL
+    PPL --> DI
+    CP --> SA
+    SA --> LLM
+    GP --> IA
+    IA --> LLM
+    TC --> MI
+    TC --> AI
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User clicks alert] --> B[Context Provider triggered]
+    B --> C[Fetch monitor definition]
+    C --> D[Fetch active alerts]
+    D --> E{Visual Editor Monitor?}
+    E -->|Yes| F[Translate DSL to PPL]
+    F --> G[Execute log pattern query]
+    G --> H[Build context with patterns]
+    E -->|No| I[Build basic context]
+    H --> J[Send to Summary Agent]
+    I --> J
+    J --> K[LLM generates summary]
+    K --> L[Display in popover]
+    L --> M{User requests insight?}
+    M -->|Yes| N[Send to Insights Agent]
+    N --> O[Display insights]
+```
+
+### Components
+
+| Component | File | Description |
+|-----------|------|-------------|
+| Context Provider | `tableUtils.js` | Builds rich context for LLM including monitor definition, alerts, and log patterns |
+| PPL Query Map | `whereFilters.js` | Maps DSL filter operators to PPL equivalents |
+| IncontextInsight Wrapper | `plugin.tsx` | Integrates with dashboards-assistant for in-context prompting |
+| Assistant Service | `services.ts` | Provides access to assistant dashboards capabilities |
+
+### Configuration
+
+| Setting | Description | Default | Location |
+|---------|-------------|---------|----------|
+| `assistant.alertInsight.enabled` | Enable/disable alert insights | `false` | `opensearch_dashboards.yml` |
+| `DEFAULT_LOG_PATTERN_TOP_N` | Number of top log patterns | `3` | `constants.js` |
+| `DEFAULT_LOG_PATTERN_SAMPLE_SIZE` | Sample size for patterns | `20` | `constants.js` |
+| `DEFAULT_ACTIVE_ALERTS_TOP_N` | Max alerts in context | `10` | `constants.js` |
+| `DEFAULT_DSL_QUERY_DATE_FORMAT` | DSL date format | `YYYY-MM-DDTHH:mm:ssZ` | `constants.js` |
+| `DEFAULT_PPL_QUERY_DATE_FORMAT` | PPL date format | `YYYY-MM-DD HH:mm:ss` | `constants.js` |
+
+### Usage Example
+
+#### Enabling Alert Insights
+
+```yaml
+# opensearch_dashboards.yml
+assistant.alertInsight.enabled: true
+```
+
+#### Creating Required Agents
+
+Use Flow Framework to create the necessary agents:
+
+```json
+POST /_plugins/_flow_framework/workflow?provision=true
+{
+  "name": "Alert Summary Agent",
+  "description": "Create Alert Summary Agent",
+  "use_case": "REGISTER_AGENT",
+  "workflows": {
+    "provision": {
+      "nodes": [
+        {
+          "id": "create_alert_summary_agent",
+          "type": "register_agent",
+          "user_inputs": {
+            "type": "flow",
+            "name": "Alert Summary Agent",
+            "parameters": {
+              "prompt": "You are an OpenSearch Alert Assistant..."
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+#### Registering Root Agents
+
+```json
+POST /.plugins-ml-config/_doc/os_summary
+{
+  "type": "os_root_agent",
+  "configuration": {
+    "agent_id": "<SUMMARY_AGENT_ID>"
+  }
+}
+```
+
+### PPL Query Translation
+
+The feature translates DSL filters to PPL for log pattern analysis:
+
+| DSL Operator | PPL Equivalent |
+|--------------|----------------|
+| `is` | `match_phrase()` or `=` |
+| `is_not` | `not match_phrase()` or `!=` |
+| `is_null` | `isnull()` |
+| `is_not_null` | `isnotnull()` |
+| `is_greater` | `>` |
+| `is_less` | `<` |
+| `in_range` | `>= AND <=` |
+| `starts_with` | `match_phrase_prefix()` |
+| `contains` | `query_string()` |
+
+## Limitations
+
+- Log pattern analysis requires monitors created via visual editor
+- Requires dashboards-assistant plugin installation
+- LLM model must be deployed and configured
+- Context limited to 10 active alerts for token management
+- PPL patterns command required for log pattern extraction
+- Only first index supported for multi-index monitors
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#996](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/996) | Context aware alert analysis |
+| v2.18.0 | [#1119](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1119) | Support top N log pattern data |
+
+## References
+
+- [Issue #995](https://github.com/opensearch-project/alerting-dashboards-plugin/issues/995): Original feature request
+- [Alert Insights Documentation](https://docs.opensearch.org/2.18/dashboards/dashboards-assistant/alert-insight/): Official docs
+- [Flow Framework Templates](https://github.com/opensearch-project/flow-framework/tree/2.x/sample-templates): Agent templates
+- [OpenSearch Assistant Toolkit](https://docs.opensearch.org/2.18/ml-commons-plugin/opensearch-assistant/): Assistant overview
+
+## Change History
+
+- **v2.18.0** (2024-11-05): Initial implementation with context-aware alert analysis and log pattern support

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -311,6 +311,10 @@
 
 - [Alerting](alerting/alerting.md)
 
+## alerting-dashboards-plugin
+
+- [Alerting Summary & Insights](alerting-dashboards-plugin/alerting-summary-insights.md)
+
 ## query-insights
 
 - [Query Insights](query-insights/query-insights.md)

--- a/docs/releases/v2.18.0/features/alerting-dashboards-plugin/alerting-summary-insights.md
+++ b/docs/releases/v2.18.0/features/alerting-dashboards-plugin/alerting-summary-insights.md
@@ -1,0 +1,142 @@
+# Alerting Summary & Insights
+
+## Summary
+
+OpenSearch v2.18.0 introduces AI-powered alert insights in the Alerting Dashboards plugin. This feature integrates with the OpenSearch Dashboards Assistant to provide context-aware alert analysis, generating summaries and log pattern analysis for triggered alerts using large language models (LLMs).
+
+## Details
+
+### What's New in v2.18.0
+
+- **Context-aware alert analysis**: Users can generate AI-powered summaries directly from the alerts dashboard
+- **In-context prompting**: Popover interface for quick alert summarization without leaving the alerts view
+- **Log pattern analysis**: Automatic detection and display of top N log patterns for visual editor monitors
+- **Assistant integration**: Leverages the IncontextInsight component from dashboards-assistant plugin
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Alerting Dashboards Plugin"
+        AD[Alerts Dashboard]
+        TC[tableUtils.js]
+        CP[Context Provider]
+    end
+    
+    subgraph "Dashboards Assistant"
+        ICI[IncontextInsight Component]
+        GP[GeneratePopover]
+        SA[Summary Agent]
+    end
+    
+    subgraph "ML Commons"
+        LLM[LLM Model]
+        AG[Alert Agents]
+    end
+    
+    AD --> TC
+    TC --> CP
+    CP --> ICI
+    ICI --> GP
+    GP --> SA
+    SA --> AG
+    AG --> LLM
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `contextProvider` | Async function that builds alert context for LLM summarization |
+| `IncontextInsight` wrapper | Wraps alert links to enable AI insight generation |
+| `OPERATORS_PPL_QUERY_MAP` | Maps DSL filter operators to PPL equivalents for log pattern queries |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `assistant.alertInsight.enabled` | Enable alert insights feature | `false` |
+| `DEFAULT_LOG_PATTERN_TOP_N` | Number of top log patterns to display | `3` |
+| `DEFAULT_LOG_PATTERN_SAMPLE_SIZE` | Sample size for log pattern analysis | `20` |
+| `DEFAULT_ACTIVE_ALERTS_TOP_N` | Maximum active alerts sent to LLM | `10` |
+
+#### API Changes
+
+The feature uses the existing Assistant APIs:
+- `POST /api/assistant/summary` - Generate alert summaries
+- `POST /api/assistant/insight` - Generate alert insights
+
+### Usage Example
+
+When alert insights are enabled and configured:
+
+1. Navigate to **OpenSearch Plugins > Alerting**
+2. Hover over alerts to see the sparkle icon (✨)
+3. Click to generate AI-powered summary
+4. View log patterns and insights in the popover
+
+```javascript
+// Context provider builds rich context for LLM
+const contextProvider = async () => {
+  // 1. Get monitor definition
+  const monitorDefinition = await getMonitor(alert.monitor_id);
+  
+  // 2. Translate DSL filters to PPL for log pattern analysis
+  const pplFilters = uiFilters.map(filter => 
+    OPERATORS_PPL_QUERY_MAP[filter.operator].query(filter)
+  );
+  
+  // 3. Execute log pattern query
+  const topNLogPatternPPL = `${basePPL} | patterns ${patternField} | 
+    stats count() as count, take(${patternField}, ${sampleSize}) 
+    by patterns_field | sort - count | head ${topN}`;
+  
+  // 4. Return context for LLM
+  return {
+    context: `Monitor: ${monitorDefinition}...`,
+    additionalInfo: { topNLogPatternData, dsl, index }
+  };
+};
+```
+
+### Migration Notes
+
+To enable alert insights:
+
+1. Enable the feature in `opensearch_dashboards.yml`:
+   ```yaml
+   assistant.alertInsight.enabled: true
+   ```
+
+2. Create required ML agents using Flow Framework templates:
+   - Alert summary agent
+   - Alert summary with log patterns agent
+   - Alert insights agent
+
+3. Register root agents in `.plugins-ml-config` index
+
+## Limitations
+
+- Log pattern analysis only available for query monitors created via visual editor
+- Requires dashboards-assistant plugin to be installed
+- LLM model must be configured and deployed
+- Context size limited to top 10 active alerts to manage token usage
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#996](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/996) | Context aware alert analysis |
+| [#1119](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1119) | Support top N log pattern data in summary context provider |
+
+## References
+
+- [Issue #995](https://github.com/opensearch-project/alerting-dashboards-plugin/issues/995): Feature request for context-aware alert analysis
+- [Alert Insights Documentation](https://docs.opensearch.org/2.18/dashboards/dashboards-assistant/alert-insight/): Official documentation
+- [Flow Framework Templates](https://github.com/opensearch-project/flow-framework/tree/2.x/sample-templates): Agent templates
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/alerting-dashboards-plugin/alerting-summary-insights.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -100,6 +100,10 @@ This page contains feature reports for OpenSearch v2.18.0.
 - [Alerting Doc-Level Monitor](features/alerting/alerting-doc-level-monitor.md) - Doc-level monitor improvements including comments system indices, remote monitor logging, separate query indices for external monitors, and query index lifecycle optimization
 - [Alerting Bugfixes](features/alerting/alerting-bugfixes.md) - Query index management fixes, bucket-level monitor optimization, dashboard UX improvements, MDS compatibility fixes
 
+### Alerting Dashboards Plugin
+
+- [Alerting Summary & Insights](features/alerting-dashboards-plugin/alerting-summary-insights.md) - AI-powered alert insights with context-aware analysis, LLM-generated summaries, and log pattern detection for visual editor monitors
+
 ### Common Utils
 
 - [Doc-Level Monitor Query Indices](features/common-utils/doc-level-monitor-query-indices.md) - New `delete_query_index_in_every_run` flag for dynamic deletion of doc-level monitor query indices, designed for externally defined monitors


### PR DESCRIPTION
## Summary

Add documentation for the Alerting Summary & Insights feature introduced in OpenSearch v2.18.0.

## Changes

### Release Report
- `docs/releases/v2.18.0/features/alerting-dashboards-plugin/alerting-summary-insights.md`

### Feature Report
- `docs/features/alerting-dashboards-plugin/alerting-summary-insights.md`

## Feature Overview

This feature introduces AI-powered alert insights in the Alerting Dashboards plugin:

- **Context-aware alert analysis**: Generate AI-powered summaries directly from the alerts dashboard
- **In-context prompting**: Popover interface for quick alert summarization
- **Log pattern analysis**: Automatic detection of top N log patterns for visual editor monitors
- **Assistant integration**: Leverages the IncontextInsight component from dashboards-assistant plugin

## Related PRs

- [#996](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/996): Context aware alert analysis
- [#1119](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1119): Support top N log pattern data in summary context provider

## References

- [Issue #995](https://github.com/opensearch-project/alerting-dashboards-plugin/issues/995): Feature request
- [Alert Insights Documentation](https://docs.opensearch.org/2.18/dashboards/dashboards-assistant/alert-insight/)

Closes #558