### PR TITLE
docs: add Text to Visualization (t2viz) report for v2.18.0

### DIFF
--- a/docs/features/dashboards-assistant/text-to-visualization.md
+++ b/docs/features/dashboards-assistant/text-to-visualization.md
@@ -1,0 +1,221 @@
+# Text to Visualization (t2viz)
+
+## Summary
+
+Text to Visualization (t2viz) is an AI-powered feature in OpenSearch Dashboards that enables users to create data visualizations using natural language queries. By leveraging Large Language Models (LLMs) through ML Commons agents, users can describe their visualization needs in plain English, and the system automatically generates appropriate Vega-Lite specifications to render the visualization.
+
+This feature bridges the gap between data exploration and visualization creation, making it accessible to users who may not be familiar with visualization configuration or query languages.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "User Interface"
+        T2VPage[Text2Viz Page]
+        DiscoverPage[Discover Page]
+        VizList[Visualization List]
+    end
+    
+    subgraph "dashboards-assistant Plugin"
+        subgraph "Frontend"
+            T2VComponent[Text2Viz Component]
+            EditorPanel[Vega Editor]
+            SourceSelector[Source Selector]
+            Embeddable[NLQ Embeddable]
+        end
+        
+        subgraph "Backend Services"
+            T2VegaRoute[Text2Vega API]
+            T2PPLRoute[Text2PPL API]
+            Data2SummaryRoute[Data2Summary API]
+        end
+    end
+    
+    subgraph "OpenSearch"
+        MLCommons[ML Commons]
+        Agents[ML Agents]
+        SavedObjects[(Saved Objects)]
+    end
+    
+    subgraph "External"
+        LLM[LLM Provider]
+    end
+    
+    T2VPage --> T2VComponent
+    DiscoverPage --> T2VPage
+    T2VComponent --> T2VegaRoute
+    T2VComponent --> T2PPLRoute
+    T2VegaRoute --> Agents
+    T2PPLRoute --> Agents
+    Agents --> LLM
+    T2VComponent --> SavedObjects
+    Embeddable --> VizList
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User Input] --> B{Input Type}
+    B -->|Natural Language Question| C[Text2PPL Agent]
+    B -->|With Instructions| D[Text2Vega with Instructions Agent]
+    
+    C --> E[Generate PPL Query]
+    E --> F[Execute PPL]
+    F --> G[Get Sample Data + Schema]
+    G --> H[Text2Vega Agent]
+    H --> I[Generate Vega-Lite Spec]
+    
+    D --> I
+    
+    I --> J[Render Visualization]
+    J --> K{User Action}
+    K -->|Edit| L[Manual Vega Editing]
+    K -->|Save| M[Save as visualization-nlq]
+    L --> J
+    M --> N[Available in Dashboards]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `Text2Viz` | Main page component for creating NLQ visualizations |
+| `Text2Vega` | Service class that coordinates the text-to-visualization pipeline |
+| `EditorPanel` | Monaco-based code editor for manual Vega spec editing |
+| `SourceSelector` | Index pattern selection dropdown |
+| `NLQVisualizationEmbeddable` | Embeddable for rendering saved NLQ visualizations |
+| `NLQVisualizationEmbeddableFactory` | Factory for creating embeddables from saved objects |
+| `VisNLQSavedObject` | Saved object type for persisting NLQ visualizations |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `assistant.text2viz.enabled` | Enable text to visualization feature | `false` |
+| `assistant.chat.enabled` | Enable chat assistant (related feature) | `false` |
+| `assistant.alertInsight.enabled` | Enable alert insights | `false` |
+| `assistant.smartAnomalyDetector.enabled` | Enable smart anomaly detector | `false` |
+
+### API Reference
+
+#### Text to Vega API
+
+```
+POST /api/assistant/text2vega
+```
+
+Request body:
+```json
+{
+  "input_question": "Show sales by category",
+  "input_instruction": "Use a bar chart with blue colors",
+  "ppl": "source=sales | stats sum(amount) by category",
+  "dataSchema": "[{\"name\":\"category\",\"type\":\"string\"}]",
+  "sampleData": "[{\"category\":\"Electronics\",\"sum(amount)\":1000}]"
+}
+```
+
+#### Text to PPL API
+
+```
+POST /api/assistant/text2ppl
+```
+
+Request body:
+```json
+{
+  "index": "sales",
+  "question": "Show total sales by category"
+}
+```
+
+#### Data to Summary API
+
+```
+POST /api/assistant/data2summary
+```
+
+Request body:
+```json
+{
+  "sample_data": "[{...}]",
+  "sample_count": 10,
+  "total_count": 1000,
+  "question": "Summarize this data",
+  "ppl": "source=index | stats count()"
+}
+```
+
+### Usage Example
+
+```typescript
+// Programmatic usage of Text2Vega service
+const text2vega = new Text2Vega(http, searchClient, savedObjects);
+
+text2vega.invoke({
+  index: 'opensearch_dashboards_sample_data_ecommerce',
+  prompt: 'Show average order value by day',
+  dataSourceId: 'default'
+});
+
+// Subscribe to results
+text2vega.getResult$().subscribe((vegaSpec) => {
+  if (vegaSpec) {
+    // Render the visualization
+    console.log(JSON.stringify(vegaSpec, null, 2));
+  }
+});
+```
+
+### Saved Object Schema
+
+The `visualization-nlq` saved object type stores:
+
+```typescript
+interface VisNLQSavedObject {
+  id?: string;
+  title: string;
+  description?: string;
+  visualizationState: string;  // JSON string containing Vega spec
+  uiState: string;             // JSON string containing user input
+  searchSourceFields?: {
+    index?: IndexPattern;
+  };
+  version?: number;
+}
+```
+
+## Limitations
+
+- **Experimental Status**: This feature is experimental and not recommended for production environments
+- **LLM Dependency**: Requires external LLM provider (e.g., Amazon Bedrock with Claude) to be configured
+- **Input Size Limit**: Questions and instructions are limited to 400 characters each
+- **Visualization Types**: Currently only generates Vega-Lite specifications
+- **Agent Configuration**: Requires ML Commons agents to be properly configured
+- **Data Source Support**: Works with index patterns; other data source types have limited support
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.18.0 | [#264](https://github.com/opensearch-project/dashboards-assistant/pull/264) | Initial implementation of text to visualization |
+| v2.18.0 | [#295](https://github.com/opensearch-project/dashboards-assistant/pull/295) | Add discovery summary API |
+| v2.18.0 | [#349](https://github.com/opensearch-project/dashboards-assistant/pull/349) | Integration with Discover page |
+| v3.0.0 | [#510](https://github.com/opensearch-project/dashboards-assistant/pull/510) | Add metrics collection for t2viz |
+| v3.1.0 | [#546](https://github.com/opensearch-project/dashboards-assistant/pull/546) | Prevent navigation when PPL returns no results |
+
+## References
+
+- [Issue #294](https://github.com/opensearch-project/dashboards-assistant/issues/294): Feature request for data summary API
+- [Documentation](https://docs.opensearch.org/2.18/dashboards/dashboards-assistant/text-to-visualization/): Official text to visualization documentation
+- [ML Commons Agents](https://docs.opensearch.org/2.18/ml-commons-plugin/agents-tools/index/): Agent and tools documentation
+- [Flow Framework](https://docs.opensearch.org/2.18/automating-configurations/): Workflow automation for agent setup
+
+## Change History
+
+- **v3.1.0**: Added error handling for PPL queries with no results
+- **v3.0.0**: Added metrics collection for t2viz usage
+- **v2.18.0**: Initial implementation with Text2Vega, Text2PPL, and Data2Summary APIs

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -265,6 +265,7 @@
 ## dashboards-assistant
 
 - [AI Assistant / Chatbot](dashboards-assistant/ai-assistant-chatbot.md)
+- [Text to Visualization (t2viz)](dashboards-assistant/text-to-visualization.md)
 
 ## k-nn
 

--- a/docs/releases/v2.18.0/features/dashboards-assistant/text-to-visualization.md
+++ b/docs/releases/v2.18.0/features/dashboards-assistant/text-to-visualization.md
@@ -1,0 +1,151 @@
+# Text to Visualization (t2viz)
+
+## Summary
+
+Text to Visualization (t2viz) is a new feature in OpenSearch Dashboards that enables users to generate visualizations using natural language queries. Instead of manually configuring charts and graphs, users can describe what they want to see in plain text, and the system uses LLM-powered agents to automatically generate Vega-Lite specifications for the visualization.
+
+This feature was introduced in v2.18.0 as an experimental capability within the dashboards-assistant plugin.
+
+## Details
+
+### What's New in v2.18.0
+
+- New `visualization-nlq` saved object type for storing natural language query visualizations
+- New embeddable type `NLQVisualizationEmbeddable` for rendering t2viz visualizations in dashboards
+- Integration with Discover page to pass index patterns and query assistant input to t2viz
+- Data summary API (`/api/assistant/data2summary`) for generating summaries from data
+- Configuration options to enable/disable the feature via `assistant.text2viz.enabled`
+
+### Technical Changes
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        UI[Text2Viz UI]
+        Editor[Vega Editor Panel]
+        Embeddable[NLQ Visualization Embeddable]
+    end
+    
+    subgraph "dashboards-assistant Plugin"
+        T2V[Text2Vega Service]
+        T2PPL[Text2PPL Service]
+        Routes[API Routes]
+    end
+    
+    subgraph "OpenSearch ML Commons"
+        Agent[ML Agent]
+        LLM[LLM Model]
+    end
+    
+    UI --> T2V
+    T2V --> T2PPL
+    T2PPL --> Routes
+    Routes --> Agent
+    Agent --> LLM
+    LLM --> Agent
+    Agent --> Routes
+    Routes --> T2V
+    T2V --> Embeddable
+    Editor --> Embeddable
+```
+
+#### Data Flow
+
+```mermaid
+flowchart TB
+    A[User enters natural language query] --> B[Select index pattern]
+    B --> C[Text2PPL: Convert to PPL query]
+    C --> D[Execute PPL query]
+    D --> E[Get sample data and schema]
+    E --> F[Text2Vega: Generate Vega-Lite spec]
+    F --> G[Render visualization]
+    G --> H[Optional: Edit Vega spec manually]
+    H --> I[Save as visualization-nlq object]
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `Text2Viz` | Main React component for the t2viz page |
+| `Text2Vega` | Service class that orchestrates text-to-visualization conversion |
+| `NLQVisualizationEmbeddable` | Embeddable for rendering NLQ visualizations |
+| `NLQVisualizationEmbeddableFactory` | Factory for creating NLQ embeddables |
+| `EditorPanel` | Code editor for manual Vega spec editing |
+| `SourceSelector` | Index pattern selector component |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `assistant.text2viz.enabled` | Enable/disable text to visualization feature | `false` |
+
+#### API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/assistant/text2vega` | POST | Convert natural language to Vega-Lite spec |
+| `/api/assistant/text2ppl` | POST | Convert natural language to PPL query |
+| `/api/assistant/data2summary` | POST | Generate data summary using LLM |
+
+### Usage Example
+
+1. Navigate to **Visualize** > **Create visualization** > **Natural language**
+2. Select a data source (index pattern)
+3. Enter a natural language question:
+   ```
+   Show average bytes by machine OS over time
+   ```
+4. The system generates a Vega-Lite visualization
+5. Optionally edit the generated Vega spec
+6. Save the visualization
+
+### Migration Notes
+
+To enable text to visualization:
+
+1. Configure `opensearch_dashboards.yml`:
+   ```yaml
+   assistant.text2viz.enabled: true
+   ```
+
+2. Set up the required ML agents using Flow Framework (see documentation for agent configuration)
+
+3. Configure the root agent in `.plugins-ml-config`:
+   ```json
+   POST /.plugins-ml-config/_doc/os_text2vega
+   {
+     "type": "os_chat_root_agent",
+     "configuration": {
+       "agent_id": "<ROOT_AGENT_ID>"
+     }
+   }
+   ```
+
+## Limitations
+
+- Experimental feature - not recommended for production use
+- Requires ML Commons agents to be configured
+- Input size limit of 400 characters for questions and instructions
+- Currently only supports Vega-Lite visualization type
+- Requires LLM model (e.g., Claude) to be configured via connector
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#264](https://github.com/opensearch-project/dashboards-assistant/pull/264) | Add new feature to support text to visualization |
+| [#295](https://github.com/opensearch-project/dashboards-assistant/pull/295) | Add discovery summary API |
+| [#349](https://github.com/opensearch-project/dashboards-assistant/pull/349) | Take index pattern and user input to t2viz from discover |
+
+## References
+
+- [Issue #294](https://github.com/opensearch-project/dashboards-assistant/issues/294): Feature request for data summary API
+- [Documentation](https://docs.opensearch.org/2.18/dashboards/dashboards-assistant/text-to-visualization/): Official text to visualization docs
+- [ML Commons Agents](https://docs.opensearch.org/2.18/ml-commons-plugin/agents-tools/index/): Agent configuration guide
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-assistant/text-to-visualization.md)

--- a/docs/releases/v2.18.0/index.md
+++ b/docs/releases/v2.18.0/index.md
@@ -174,6 +174,7 @@ This page contains feature reports for OpenSearch v2.18.0.
 ### Dashboards Assistant
 
 - [Assistant Capabilities](features/dashboards-assistant/assistant-capabilities.md) - Capability-based UI rendering control, new API to check agent config existence, agentName renamed to agentConfigName
+- [Text to Visualization (t2viz)](features/dashboards-assistant/text-to-visualization.md) - AI-powered visualization generation from natural language queries using LLM agents
 
 ### Dashboards Maps
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Text to Visualization (t2viz) feature introduced in OpenSearch v2.18.0.

### Reports Created
- Release report: `docs/releases/v2.18.0/features/dashboards-assistant/text-to-visualization.md`
- Feature report: `docs/features/dashboards-assistant/text-to-visualization.md`

### Key Changes in v2.18.0
- New `visualization-nlq` saved object type for storing natural language query visualizations
- New embeddable type `NLQVisualizationEmbeddable` for rendering t2viz visualizations
- Integration with Discover page to pass index patterns and query assistant input
- Data summary API (`/api/assistant/data2summary`) for generating summaries
- Configuration option `assistant.text2viz.enabled`

### Resources Used
- PR: #264, #295, #349 (dashboards-assistant)
- Docs: https://docs.opensearch.org/2.18/dashboards/dashboards-assistant/text-to-visualization/
- Issue: #294 (dashboards-assistant)