### PR TITLE
docs: add DocRequest Refactoring report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -19,6 +19,7 @@
 - [Cluster Stats API](opensearch/cluster-stats-api.md)
 - [Code Cleanup](opensearch/code-cleanup.md)
 - [Deprecated Code Cleanup](opensearch/deprecated-code-cleanup.md)
+- [DocRequest Refactoring](opensearch/docrequest-refactoring.md)
 - [Dynamic Settings](opensearch/dynamic-settings.md)
 - [Cluster Permissions](opensearch/cluster-permissions.md)
 - [Flat Object Field](opensearch/flat-object-field.md)

--- a/docs/features/opensearch/docrequest-refactoring.md
+++ b/docs/features/opensearch/docrequest-refactoring.md
@@ -1,0 +1,171 @@
+# DocRequest Interface
+
+## Summary
+
+The `DocRequest` interface provides a generic abstraction for ActionRequests that operate on a single document in OpenSearch. It serves as a foundation for categorizing document-level operations and enables the Security plugin to implement fine-grained resource-level access control for plugin-defined resources such as ML models, anomaly detectors, and report definitions.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "ActionRequest Hierarchy"
+        AR[ActionRequest]
+        DocR[DocRequest]
+        DWR[DocWriteRequest]
+        IR[IndexRequest]
+        UR[UpdateRequest]
+        DR[DeleteRequest]
+        GR[GetRequest]
+        
+        AR --> DocR
+        DocR --> DWR
+        DWR --> IR
+        DWR --> UR
+        DWR --> DR
+        DocR --> GR
+    end
+    
+    subgraph "Plugin Integration"
+        PR[Plugin Request]
+        SEC[Security Plugin]
+        RAE[ResourceAccessEvaluator]
+        
+        PR -.->|implements| DocR
+        SEC --> RAE
+        RAE -->|evaluates| DocR
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Request Processing"
+        REQ[DocRequest]
+        SF[Security Filter]
+        RAE[ResourceAccessEvaluator]
+        IDX[index]
+        ID[id]
+        TYPE[type]
+    end
+    
+    REQ --> SF
+    SF --> RAE
+    RAE --> IDX
+    RAE --> ID
+    RAE --> TYPE
+    RAE -->|ALLOW/DENY| SF
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `DocRequest` | Generic interface for single-document operations |
+| `DocRequest.index()` | Returns the target index name |
+| `DocRequest.id()` | Returns the document ID |
+| `DocRequest.type()` | Returns the resource type for sharing context |
+| `DocWriteRequest` | Extended interface for write operations (Index, Update, Delete) |
+| `GetRequest` | Read operation that now implements `DocRequest` |
+
+### Configuration
+
+This feature does not require configuration. It is a core API change that plugins can optionally leverage.
+
+For resource sharing functionality, the Security plugin settings are:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.experimental.resource_sharing.enabled` | Enable resource sharing | `false` |
+| `plugins.security.experimental.resource_sharing.protected_types` | Resource types with access control | `[]` |
+
+### Usage Example
+
+#### Implementing DocRequest in a Plugin
+
+```java
+/**
+ * Request to get a report definition - implements DocRequest for resource sharing
+ */
+public class GetReportDefinitionRequest extends ActionRequest implements DocRequest {
+    private final String index;
+    private final String reportId;
+    
+    public GetReportDefinitionRequest(String index, String reportId) {
+        this.index = index;
+        this.reportId = reportId;
+    }
+    
+    @Override
+    public String index() {
+        return index;
+    }
+    
+    @Override
+    public String id() {
+        return reportId;
+    }
+    
+    @Override
+    public String type() {
+        return "report_definition";
+    }
+    
+    @Override
+    public ActionRequestValidationException validate() {
+        return null;
+    }
+}
+```
+
+#### Security Plugin Integration
+
+When a plugin implements `DocRequest`, the Security plugin can automatically evaluate access:
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Plugin as Resource Plugin
+    participant SecFilter as Security Filter
+    participant RAE as ResourceAccessEvaluator
+    participant RSIDX as Sharing Index
+
+    User->>Plugin: Request (e.g., GET /resource/{id})
+    Plugin->>SecFilter: DocRequest
+    SecFilter->>RAE: Evaluate (user, action, DocRequest)
+    RAE->>RSIDX: Fetch sharing doc by resource_id
+    RSIDX-->>RAE: share_with + created_by
+    RAE->>RAE: Check access level
+    alt Allowed
+        RAE-->>SecFilter: ALLOW
+        SecFilter-->>Plugin: Proceed
+        Plugin-->>User: 200 OK
+    else Denied
+        RAE-->>SecFilter: DENY
+        SecFilter-->>User: 403 Forbidden
+    end
+```
+
+## Limitations
+
+- Only applicable to single-document operations
+- Resource sharing requires Security plugin with experimental feature enabled
+- The `type()` method must be overridden for custom resource types
+- Bulk operations are not directly supported (individual items in bulk use `DocWriteRequest`)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#18269](https://github.com/opensearch-project/OpenSearch/pull/18269) | Create generic DocRequest to better categorize ActionRequests |
+
+## References
+
+- [Issue #4500](https://github.com/opensearch-project/security/issues/4500): Resource Permissions and Sharing (Security plugin)
+- [Blog: Introducing resource sharing](https://opensearch.org/blog/introducing-resource-sharing-a-new-access-control-model-for-opensearch/): A new access control model for OpenSearch
+
+## Change History
+
+- **v3.1.0** (2025-05-15): Initial implementation - introduced `DocRequest` interface, updated `DocWriteRequest` to extend it, and made `GetRequest` implement it

--- a/docs/releases/v3.1.0/features/opensearch/docrequest-refactoring.md
+++ b/docs/releases/v3.1.0/features/opensearch/docrequest-refactoring.md
@@ -1,0 +1,145 @@
+# DocRequest Refactoring
+
+## Summary
+
+This release introduces a new `DocRequest` interface that provides a generic abstraction for ActionRequests that operate on a single document. This refactoring creates a cleaner hierarchy for document-related requests and enables the Security plugin to implement fine-grained resource-level access control for plugin-defined resources.
+
+## Details
+
+### What's New in v3.1.0
+
+The `DocRequest` interface is introduced as a superset of `DocWriteRequest`, providing a common abstraction for all requests that target a single document. This change:
+
+- Creates a new `DocRequest` interface with `index()` and `id()` methods
+- Updates `DocWriteRequest` to extend `DocRequest`
+- Updates `GetRequest` to implement `DocRequest`
+- Adds a `type()` method for resource sharing context
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.1.0"
+        AR1[ActionRequest]
+        DWR1[DocWriteRequest]
+        IR1[IndexRequest]
+        UR1[UpdateRequest]
+        DR1[DeleteRequest]
+        GR1[GetRequest]
+        
+        AR1 --> DWR1
+        DWR1 --> IR1
+        DWR1 --> UR1
+        DWR1 --> DR1
+        AR1 --> GR1
+    end
+    
+    subgraph "After v3.1.0"
+        AR2[ActionRequest]
+        DocR[DocRequest]
+        DWR2[DocWriteRequest]
+        IR2[IndexRequest]
+        UR2[UpdateRequest]
+        DR2[DeleteRequest]
+        GR2[GetRequest]
+        
+        AR2 --> DocR
+        DocR --> DWR2
+        DWR2 --> IR2
+        DWR2 --> UR2
+        DWR2 --> DR2
+        DocR --> GR2
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `DocRequest` | Generic interface for requests operating on a single document |
+| `DocRequest.index()` | Returns the index that the request operates on |
+| `DocRequest.id()` | Returns the document ID for the request |
+| `DocRequest.type()` | Returns the resource type for sharing context (default: "indices") |
+
+#### API Changes
+
+The new `DocRequest` interface:
+
+```java
+@PublicApi(since = "3.1.0")
+public interface DocRequest {
+    /**
+     * Get the index that this request operates on
+     * @return the index
+     */
+    String index();
+
+    /**
+     * Get the id of the document for this request
+     * @return the id
+     */
+    String id();
+
+    /**
+     * Get the type of the request for resource sharing context
+     * @return the type (default: "indices")
+     */
+    default String type() {
+        return "indices";
+    }
+}
+```
+
+### Usage Example
+
+Plugins can now implement `DocRequest` to enable resource-level access control:
+
+```java
+// Plugin-defined request for a sharable resource
+public class GetReportDefinitionRequest extends ActionRequest implements DocRequest {
+    private final String index;
+    private final String reportId;
+    
+    @Override
+    public String index() {
+        return index;
+    }
+    
+    @Override
+    public String id() {
+        return reportId;
+    }
+    
+    @Override
+    public String type() {
+        return "report_definition";  // Custom resource type for sharing
+    }
+}
+```
+
+### Migration Notes
+
+This is a non-breaking change. Existing code using `DocWriteRequest` or `GetRequest` will continue to work without modification. Plugin developers can optionally implement `DocRequest` to enable resource sharing capabilities.
+
+## Limitations
+
+- The `DocRequest` interface is primarily designed for single-document operations
+- Resource sharing functionality requires the Security plugin with resource sharing enabled
+- The `type()` method default value is "indices" for backward compatibility
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18269](https://github.com/opensearch-project/OpenSearch/pull/18269) | Create generic DocRequest to better categorize ActionRequests |
+
+## References
+
+- [Issue #4500](https://github.com/opensearch-project/security/issues/4500): Resource Permissions and Sharing (Security plugin)
+- [Blog: Introducing resource sharing](https://opensearch.org/blog/introducing-resource-sharing-a-new-access-control-model-for-opensearch/): A new access control model for OpenSearch
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/docrequest-refactoring.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -1,0 +1,7 @@
+# OpenSearch v3.1.0 Release
+
+## Features
+
+### OpenSearch
+
+- [DocRequest Refactoring](features/opensearch/docrequest-refactoring.md) - Generic interface for single-document operations


### PR DESCRIPTION
## Summary

This PR adds documentation for the DocRequest Refactoring feature introduced in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/opensearch/docrequest-refactoring.md`
- Feature report: `docs/features/opensearch/docrequest-refactoring.md`

### Key Changes in v3.1.0
- New `DocRequest` interface for single-document operations
- `DocWriteRequest` now extends `DocRequest`
- `GetRequest` now implements `DocRequest`
- Foundation for resource-level access control in Security plugin

### Resources Used
- PR: [#18269](https://github.com/opensearch-project/OpenSearch/pull/18269)
- Issue: [security#4500](https://github.com/opensearch-project/security/issues/4500)
- Blog: [Introducing resource sharing](https://opensearch.org/blog/introducing-resource-sharing-a-new-access-control-model-for-opensearch/)

Closes #929