### PR TITLE
docs: add network-configuration report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -47,6 +47,7 @@
 - [Merge & Segment Settings](opensearch/merge-segment-settings.md)
 - [Multi-Search API](opensearch/multi-search-api.md)
 - [Nested Aggregations](opensearch/nested-aggregations.md)
+- [Network Configuration](opensearch/network-configuration.md)
 - [Node Join/Leave](opensearch/node-join-leave.md)
 - [Nodes Info API](opensearch/nodes-info-api.md)
 - [Node Roles Configuration](opensearch/node-roles-configuration.md)

--- a/docs/features/opensearch/network-configuration.md
+++ b/docs/features/opensearch/network-configuration.md
@@ -1,0 +1,112 @@
+# Network Configuration
+
+## Summary
+
+OpenSearch network configuration controls how nodes bind to network interfaces and communicate with clients and other nodes. The `network.host` setting is particularly important for production deployments, as setting it to a non-loopback address (like `0.0.0.0`) triggers production-mode bootstrap checks that verify system security settings.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Node"
+        subgraph "Network Layer"
+            HTTP[HTTP Transport<br/>Port 9200]
+            Transport[Internal Transport<br/>Port 9300]
+        end
+        subgraph "Bootstrap"
+            BC[Bootstrap Checks]
+            SCF[System Call Filter]
+        end
+    end
+    
+    Client[External Clients] -->|REST API| HTTP
+    OtherNodes[Other Nodes] -->|Cluster Communication| Transport
+    
+    BC -->|Validates| SCF
+    SCF -->|Uses| Seccomp[seccomp syscall]
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    Start[OpenSearch Start] --> CheckHost{network.host<br/>non-loopback?}
+    CheckHost -->|Yes| ProdMode[Production Mode]
+    CheckHost -->|No| DevMode[Development Mode]
+    
+    ProdMode --> Bootstrap[Run Bootstrap Checks]
+    Bootstrap --> SCFCheck[System Call Filter Check]
+    SCFCheck --> SeccompCall[seccomp syscall]
+    SeccompCall -->|Allowed| Success[Start Successfully]
+    SeccompCall -->|Blocked| Fail[Startup Failure]
+    
+    DevMode --> Success
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `network.host` | Main setting to bind OpenSearch to network interfaces |
+| `network.bind_host` | Address for incoming connections |
+| `network.publish_host` | Address published to other cluster nodes |
+| Bootstrap Checks | Production-mode validations run at startup |
+| System Call Filter | Security mechanism using Linux seccomp |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `network.host` | Binds to specified address. Use `0.0.0.0` for all interfaces | `_local_` |
+| `network.bind_host` | Address for incoming connections | Value of `network.host` |
+| `network.publish_host` | Address published to other nodes | Value of `network.host` |
+| `http.port` | HTTP port or range | `9200-9300` |
+| `transport.port` | Transport port or range | `9300-9400` |
+
+### Usage Example
+
+```yaml
+# opensearch.yml - Production configuration
+network.host: 0.0.0.0
+http.port: 9200
+transport.port: 9300
+
+# Discovery settings (required for production)
+discovery.seed_hosts: ["node1.example.com", "node2.example.com"]
+cluster.initial_cluster_manager_nodes: ["node1", "node2"]
+```
+
+### Systemd Configuration
+
+For systemd-based installations, the service file must allow necessary system calls:
+
+```ini
+# /lib/systemd/system/opensearch.service (excerpt)
+SystemCallFilter=seccomp mincore
+SystemCallFilter=madvise mlock mlock2 munlock get_mempolicy sched_getaffinity sched_setaffinity fcntl
+SystemCallFilter=@system-service
+```
+
+## Limitations
+
+- Setting `network.host` to a non-loopback address requires proper discovery configuration
+- System call filters require kernel support for seccomp
+- Systemd service hardening may conflict with OpenSearch security requirements
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#18309](https://github.com/opensearch-project/OpenSearch/pull/18309) | Add seccomp in systemd config |
+
+## References
+
+- [Issue #18273](https://github.com/opensearch-project/OpenSearch/issues/18273): Bug report - fails to start on Debian with network.host: 0.0.0.0
+- [Network Settings Documentation](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/network-settings/): Official network configuration guide
+- [Compatible Operating Systems](https://docs.opensearch.org/3.0/install-and-configure/os-comp/): Supported Linux distributions
+
+## Change History
+
+- **v3.1.0** (2026-01-10): Fixed systemd service file to allow seccomp system call, enabling proper startup with `network.host: 0.0.0.0`

--- a/docs/releases/v3.1.0/features/opensearch/network-configuration.md
+++ b/docs/releases/v3.1.0/features/opensearch/network-configuration.md
@@ -1,0 +1,88 @@
+# Network Configuration
+
+## Summary
+
+This release fixes a critical bug where OpenSearch failed to start on systemd-based Linux distributions (such as Debian 12) when using `network.host: 0.0.0.0`. The issue occurred because the systemd service file was missing the `seccomp` system call in its `SystemCallFilter` configuration, preventing OpenSearch's bootstrap checks from completing successfully.
+
+## Details
+
+### What's New in v3.1.0
+
+The `seccomp` system call has been added to the `SystemCallFilter` directive in the OpenSearch systemd service file. This allows OpenSearch to properly install its system call filters when binding to non-loopback addresses.
+
+### Technical Changes
+
+#### Root Cause
+
+When `network.host` is set to `0.0.0.0` (or any non-loopback address), OpenSearch triggers production-mode bootstrap checks. One of these checks verifies that system call filters are properly installed using the `seccomp` system call. However, the systemd service file's `SystemCallFilter` directive was blocking this call, causing the bootstrap check to fail with:
+
+```
+system call filters failed to install; check the logs and fix your configuration
+```
+
+The underlying error in logs showed:
+```
+java.lang.UnsupportedOperationException: seccomp(BOGUS_OPERATION): Operation not permitted
+```
+
+#### Fix Applied
+
+The systemd service file (`opensearch.service`) was updated to allow the `seccomp` and `mincore` system calls:
+
+**Before:**
+```ini
+SystemCallFilter=madvise mincore mlock mlock2 munlock get_mempolicy sched_getaffinity sched_setaffinity fcntl
+```
+
+**After:**
+```ini
+SystemCallFilter=seccomp mincore
+SystemCallFilter=madvise mlock mlock2 munlock get_mempolicy sched_getaffinity sched_setaffinity fcntl
+```
+
+#### Affected File
+
+| File | Description |
+|------|-------------|
+| `distribution/packages/src/common/systemd/opensearch.service` | Systemd unit file for OpenSearch service |
+
+### Configuration Context
+
+The `network.host` setting controls which network interfaces OpenSearch binds to:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `network.host` | Binds OpenSearch to an address. Use `0.0.0.0` for all interfaces | `_local_` (loopback only) |
+| `network.bind_host` | Address for incoming connections | Value of `network.host` |
+| `network.publish_host` | Address published to other nodes | Value of `network.host` |
+
+When `network.host` is set to a non-loopback address, OpenSearch enforces production bootstrap checks including system call filter verification.
+
+### Migration Notes
+
+Users who previously worked around this issue by manually editing `/lib/systemd/system/opensearch.service` should:
+
+1. Remove any manual modifications to the systemd service file
+2. Upgrade to v3.1.0 or later
+3. Reload systemd: `sudo systemctl daemon-reload`
+4. Restart OpenSearch: `sudo systemctl restart opensearch`
+
+## Limitations
+
+- This fix only applies to systemd-based installations (RPM/DEB packages)
+- Docker and tarball installations are not affected as they don't use systemd
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18309](https://github.com/opensearch-project/OpenSearch/pull/18309) | Add seccomp in systemd config |
+
+## References
+
+- [Issue #18273](https://github.com/opensearch-project/OpenSearch/issues/18273): Bug report - 3.0.0 fails to start on Debian due to bootstrap checks
+- [Network Settings Documentation](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/network-settings/): Official network configuration guide
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/network-configuration.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -5,3 +5,4 @@
 ### OpenSearch
 
 - [DocRequest Refactoring](features/opensearch/docrequest-refactoring.md) - Generic interface for single-document operations
+- [Network Configuration](features/opensearch/network-configuration.md) - Fix systemd seccomp filter for network.host: 0.0.0.0


### PR DESCRIPTION
## Summary

This PR adds documentation for the Network Configuration fix in OpenSearch v3.1.0.

### Issue Investigated
- GitHub Issue: #928

### Changes
- **Release Report**: `docs/releases/v3.1.0/features/opensearch/network-configuration.md`
- **Feature Report**: `docs/features/opensearch/network-configuration.md`
- Updated release and feature indexes

### Key Findings

This release fixes a critical bug where OpenSearch failed to start on systemd-based Linux distributions (Debian 12, etc.) when using `network.host: 0.0.0.0`. The fix adds the `seccomp` system call to the systemd service file's `SystemCallFilter` directive.

### Related PRs
- [opensearch-project/OpenSearch#18309](https://github.com/opensearch-project/OpenSearch/pull/18309): Add seccomp in systemd config

### Related Issues
- [opensearch-project/OpenSearch#18273](https://github.com/opensearch-project/OpenSearch/issues/18273): Bug report