### PR TITLE
docs: add query-bug-fixes report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -54,6 +54,7 @@
 - [Offline Nodes (Background Tasks)](opensearch/offline-nodes.md)
 - [OpenSearch Core Dependencies](opensearch/opensearch-core-dependencies.md)
 - [Phone Number Analyzer](opensearch/phone-analyzer.md)
+- [Query Bug Fixes](opensearch/query-bug-fixes.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)
 - [Replication](opensearch/replication.md)
 - [Remote Store Metrics](opensearch/remote-store-metrics.md)

--- a/docs/features/opensearch/query-bug-fixes.md
+++ b/docs/features/opensearch/query-bug-fixes.md
@@ -1,0 +1,118 @@
+# Query Bug Fixes
+
+## Summary
+
+This feature tracks bug fixes and improvements to OpenSearch query handling, including exists queries, error responses, field validation, and field type support. These fixes improve query reliability, provide better error messages, and extend functionality for specific field types.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Query Processing"
+        QP[Query Parser] --> QB[Query Builder]
+        QB --> QR[Query Rewriter]
+        QR --> LE[Lucene Execution]
+    end
+    
+    subgraph "Error Handling"
+        EH[ExceptionsHelper] --> RS[REST Status]
+        RS --> |400| BR[Bad Request]
+        RS --> |500| ISE[Internal Server Error]
+    end
+    
+    subgraph "Field Types"
+        FT[Field Type] --> EQ[Exists Query]
+        FT --> TQ[Terms Query]
+        FT --> DV[Doc Values]
+    end
+    
+    QB --> EH
+    QR --> FT
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| ExistsQueryBuilder | Builds exists queries for fields, handles object fields with subfields |
+| QueryStringQueryBuilder | Parses query string syntax with field validation |
+| IpFieldMapper | Handles IP field indexing and querying including CIDR notation |
+| ExceptionsHelper | Maps exceptions to appropriate HTTP status codes |
+| MatrixStatsAggregator | Computes matrix statistics across multiple fields |
+
+### Configuration
+
+No specific configuration required. These are core query processing improvements.
+
+### Usage Example
+
+```json
+// Exists query on object field with derived subfields
+PUT test
+{
+  "mappings": {
+    "properties": {
+      "log": {
+        "properties": {
+          "request": { "type": "text" }
+        }
+      }
+    },
+    "derived": {
+      "log.timestamp": {
+        "type": "date",
+        "script": { "source": "emit(params._source.log.request)" }
+      }
+    }
+  }
+}
+
+POST test/_search
+{
+  "query": {
+    "exists": { "field": "log" }
+  }
+}
+
+// IP terms query with many CIDR ranges
+POST test/_search
+{
+  "query": {
+    "terms": {
+      "client_ip": [
+        "192.168.0.0/16",
+        "10.0.0.0/8",
+        "172.16.0.0/12"
+      ]
+    }
+  }
+}
+```
+
+## Limitations
+
+- Derived fields do not support exists queries; they are silently skipped when querying parent object fields
+- The IP field enhancement requires Lucene 10.2+ for `DocValuesMultiRangeQuery` support
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#17843](https://github.com/opensearch-project/OpenSearch/pull/17843) | Fix object field exists query |
+| v3.1.0 | [#18161](https://github.com/opensearch-project/OpenSearch/pull/18161) | Use Bad Request status for InputCoercionException |
+| v3.1.0 | [#18194](https://github.com/opensearch-project/OpenSearch/pull/18194) | Null check field names in QueryStringQueryBuilder |
+| v3.1.0 | [#18357](https://github.com/opensearch-project/OpenSearch/pull/18357) | DocValues-only IP field supports terms_query with >1025 IP masks |
+| v3.1.0 | [#18242](https://github.com/opensearch-project/OpenSearch/pull/18242) | Fix MatrixStatsAggregator reuse when mode parameter changes |
+
+## References
+
+- [Issue #17808](https://github.com/opensearch-project/OpenSearch/issues/17808): Object Field exists query returns wrong result
+- [Issue #18131](https://github.com/opensearch-project/OpenSearch/issues/18131): XContent parsing exceptions return 500 status
+- [Issue #17394](https://github.com/opensearch-project/OpenSearch/issues/17394): Unlimit IP/masks terms query for doc_values only fields
+- [Query string documentation](https://docs.opensearch.org/3.0/query-dsl/full-text/query-string/)
+
+## Change History
+
+- **v3.1.0** (2026-01-10): Initial implementation with five bug fixes for query handling

--- a/docs/releases/v3.1.0/features/opensearch/query-bug-fixes.md
+++ b/docs/releases/v3.1.0/features/opensearch/query-bug-fixes.md
@@ -1,0 +1,143 @@
+# Query Bug Fixes
+
+## Summary
+
+OpenSearch v3.1.0 includes several bug fixes that improve query handling, error responses, and field type support. These fixes address issues with object field exists queries, HTTP status codes for parsing errors, null field validation in query builders, IP field terms queries on doc-values-only fields, and aggregator reuse.
+
+## Details
+
+### What's New in v3.1.0
+
+This release addresses five query-related issues:
+
+1. **Object field exists query fix** - Resolves incorrect results when querying object fields with derived subfields or user-defined fields starting with underscore
+2. **Bad Request status for InputCoercionException** - Returns HTTP 400 instead of 500 for invalid numeric input values
+3. **Null check in QueryStringQueryBuilder** - Validates field names to prevent IllegalStateException
+4. **IP field terms_query enhancement** - Supports more than 1024 IP/masks in doc-values-only fields
+5. **MatrixStatsAggregator reuse fix** - Fixes aggregator reuse when mode parameter changes
+
+### Technical Changes
+
+#### Object Field Exists Query Fix
+
+Previously, exists queries on object fields would skip subfields starting with `_` to avoid exceptions from internal fields. This caused issues when:
+- User-defined subfield names started with `_`
+- Object fields contained derived type subfields
+
+The fix changes `DerivedFieldType.existsQuery()` to throw `UnsupportedOperationException` instead of `IllegalArgumentException`, and `ExistsQueryBuilder` now catches and ignores subfields that don't support exists queries.
+
+```java
+// DerivedFieldType.java - Changed exception type
+@Override
+public Query existsQuery(QueryShardContext context) {
+    throw new UnsupportedOperationException(
+        "Field [" + name() + "] of type [" + typeName() + "] does not support exist queries"
+    );
+}
+```
+
+#### InputCoercionException Handling
+
+Jackson's `InputCoercionException` is thrown for valid but incompatible input values (e.g., integer overflow). The fix adds this exception type to `ExceptionsHelper.status()` to return HTTP 400 Bad Request.
+
+```java
+// ExceptionsHelper.java
+} else if (t instanceof InputCoercionException) {
+    return RestStatus.BAD_REQUEST;
+}
+```
+
+#### QueryStringQueryBuilder Null Check
+
+Added validation to prevent null field names in the `fields` array, which previously caused an `IllegalStateException` with HTTP 500.
+
+```java
+// QueryStringQueryBuilder.java
+if (parser.currentToken() == XContentParser.Token.VALUE_NULL) {
+    throw new ParsingException(
+        parser.getTokenLocation(),
+        "[query_string] field name in [" + currentFieldName + "] cannot be null"
+    );
+}
+```
+
+#### IP Field Terms Query Enhancement
+
+For doc-values-only IP fields, the previous implementation was limited by `maxClauses` (1024) when using IP masks. The fix uses Lucene's `DocValuesMultiRangeQuery.SortedSetStabbingBuilder` to handle unlimited IP/masks.
+
+```java
+// IpFieldMapper.java - New doc-values query builder
+DocValuesMultiRangeQuery.SortedSetStabbingBuilder builder = 
+    new DocValuesMultiRangeQuery.SortedSetStabbingBuilder(name());
+masks.forEach(q -> builder.add(
+    new BytesRef(q.getLowerPoint()), 
+    new BytesRef(q.getUpperPoint())
+));
+ipsBytes.forEach(builder::add);
+return builder.build();
+```
+
+### Usage Example
+
+```json
+// Object field exists query now works correctly
+POST test/_search
+{
+  "query": {
+    "exists": {
+      "field": "log"
+    }
+  }
+}
+
+// IP terms query with >1024 masks on doc-values-only field
+POST test/_search
+{
+  "query": {
+    "terms": {
+      "ip_field.dv": ["192.168.0.0/16", "10.0.0.0/8", ...]
+    }
+  }
+}
+
+// Query string with null field now returns 400
+POST test/_search
+{
+  "query": {
+    "query_string": {
+      "query": "test",
+      "fields": ["field1", null]  // Returns 400 Bad Request
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- Applications relying on HTTP 500 status for `InputCoercionException` should update error handling to expect HTTP 400
+- Queries using IP masks on doc-values-only fields are no longer limited to 1024 terms
+
+## Limitations
+
+- Derived fields still do not support exists queries directly; they are silently skipped when querying parent object fields
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17843](https://github.com/opensearch-project/OpenSearch/pull/17843) | Fix object field exists query |
+| [#18161](https://github.com/opensearch-project/OpenSearch/pull/18161) | Use Bad Request status for InputCoercionException |
+| [#18194](https://github.com/opensearch-project/OpenSearch/pull/18194) | Null check field names in QueryStringQueryBuilder |
+| [#18357](https://github.com/opensearch-project/OpenSearch/pull/18357) | DocValues-only IP field supports terms_query with more than 1025 IP masks |
+| [#18242](https://github.com/opensearch-project/OpenSearch/pull/18242) | Fix MatrixStatsAggregator reuse when mode parameter changes |
+
+## References
+
+- [Issue #17808](https://github.com/opensearch-project/OpenSearch/issues/17808): Object Field exists query returns wrong result
+- [Issue #18131](https://github.com/opensearch-project/OpenSearch/issues/18131): XContent parsing exceptions return 500 status
+- [Issue #17394](https://github.com/opensearch-project/OpenSearch/issues/17394): Unlimit IP/masks terms query for doc_values only fields
+- [Query string documentation](https://docs.opensearch.org/3.0/query-dsl/full-text/query-string/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/query-bug-fixes.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -6,3 +6,4 @@
 
 - [DocRequest Refactoring](features/opensearch/docrequest-refactoring.md) - Generic interface for single-document operations
 - [Network Configuration](features/opensearch/network-configuration.md) - Fix systemd seccomp filter for network.host: 0.0.0.0
+- [Query Bug Fixes](features/opensearch/query-bug-fixes.md) - Fixes for exists query, error handling, field validation, and IP field terms query


### PR DESCRIPTION
## Summary

This PR adds documentation for Query Bug Fixes in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/opensearch/query-bug-fixes.md`
- Feature report: `docs/features/opensearch/query-bug-fixes.md`

### Key Changes in v3.1.0
- Fix object field exists query for derived subfields and underscore-prefixed fields
- Return HTTP 400 Bad Request for InputCoercionException instead of 500
- Add null check for field names in QueryStringQueryBuilder
- Support >1024 IP/masks in terms_query for doc-values-only IP fields
- Fix MatrixStatsAggregator reuse when mode parameter changes

### Related PRs
- #17843: Fix object field exists query
- #18161: Use Bad Request status for InputCoercionException
- #18194: Null check field names in QueryStringQueryBuilder
- #18357: DocValues-only IP field supports terms_query with >1025 IP masks
- #18242: Fix MatrixStatsAggregator reuse when mode parameter changes

Closes #927