### PR TITLE
docs: add plugin-installation report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -54,6 +54,7 @@
 - [Offline Nodes (Background Tasks)](opensearch/offline-nodes.md)
 - [OpenSearch Core Dependencies](opensearch/opensearch-core-dependencies.md)
 - [Phone Number Analyzer](opensearch/phone-analyzer.md)
+- [Plugin Installation](opensearch/plugin-installation.md)
 - [Query Bug Fixes](opensearch/query-bug-fixes.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)
 - [Replication](opensearch/replication.md)

--- a/docs/features/opensearch/plugin-installation.md
+++ b/docs/features/opensearch/plugin-installation.md
@@ -1,0 +1,110 @@
+# Plugin Installation
+
+## Summary
+
+OpenSearch provides a command-line tool (`opensearch-plugin`) for managing plugins. This tool allows users to install, list, and remove plugins from their OpenSearch installation. Plugin installation includes signature verification using PGP keys to ensure artifact integrity and authenticity.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Plugin Installation Flow"
+        CLI[opensearch-plugin CLI]
+        Download[Download Plugin]
+        Verify[Verify Signature]
+        Install[Install Plugin]
+    end
+    
+    subgraph "Signature Verification"
+        PGP[PGP Public Key]
+        BC[BouncyCastle FIPS Provider]
+        SIG[Signature File]
+    end
+    
+    CLI --> Download
+    Download --> Verify
+    Verify --> Install
+    
+    PGP --> Verify
+    BC --> Verify
+    SIG --> Verify
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `InstallPluginCommand` | Main command handler for plugin installation |
+| `PluginCli` | Entry point for the plugin CLI tool |
+| `public_key.sig` | PGP public key for signature verification |
+| BouncyCastle FIPS | Cryptographic provider for PGP operations |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `--batch` | Skip confirmation prompts | false |
+| `--verbose` | Enable verbose output | false |
+
+### Usage Example
+
+```bash
+# Install a plugin by name
+./bin/opensearch-plugin install analysis-icu
+
+# Install multiple plugins
+./bin/opensearch-plugin install analysis-nori repository-s3
+
+# Install from URL
+./bin/opensearch-plugin install https://example.com/plugin.zip
+
+# Install from local file
+./bin/opensearch-plugin install file:/path/to/plugin.zip
+
+# Install using Maven coordinates
+./bin/opensearch-plugin install org.opensearch.plugin:opensearch-anomaly-detection:2.2.0.0
+
+# List installed plugins
+./bin/opensearch-plugin list
+
+# Remove a plugin
+./bin/opensearch-plugin remove opensearch-anomaly-detection
+```
+
+### Signature Verification
+
+OpenSearch verifies plugin signatures using PGP keys:
+
+- **v1.x/v2.x**: Uses `opensearch@amazon.com` key
+- **v3.x+**: Uses `release@opensearch.org` key
+
+The verification process:
+1. Downloads the plugin zip file
+2. Downloads the corresponding `.sig` signature file
+3. Loads the embedded PGP public key
+4. Initializes BouncyCastle FIPS provider
+5. Verifies the signature against the downloaded artifact
+
+## Limitations
+
+- Plugin versions must match the OpenSearch version
+- Some plugins require additional permissions (prompted during installation)
+- Signature verification requires network access to download signature files
+- Custom plugins from untrusted sources bypass signature verification
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#18147](https://github.com/opensearch-project/OpenSearch/pull/18147) | Fix native plugin installation error caused by PGP public key change |
+
+## References
+
+- [Issue #5308](https://github.com/opensearch-project/opensearch-build/issues/5308): New PGP key for signing artifacts starting 3.0.0
+- [Documentation](https://docs.opensearch.org/3.0/install-and-configure/plugins/): Installing plugins
+
+## Change History
+
+- **v3.1.0** (2026-01-10): Fixed signature verification failure caused by PGP public key change; added BouncyCastle FIPS provider initialization

--- a/docs/releases/v3.1.0/features/opensearch/plugin-installation.md
+++ b/docs/releases/v3.1.0/features/opensearch/plugin-installation.md
@@ -1,0 +1,88 @@
+# Plugin Installation Fix
+
+## Summary
+
+This release fixes a critical bug in the native plugin installation process that caused a `NullPointerException` when verifying plugin signatures. The issue was caused by a PGP public key change introduced in OpenSearch 3.0.0, where the new signing key (`release@opensearch.org`) required proper initialization of the BouncyCastle FIPS provider.
+
+## Details
+
+### What's New in v3.1.0
+
+The fix addresses a signature verification failure that occurred when installing bundled plugins (e.g., `analysis-icu`, `repository-s3`) using the `opensearch-plugin install` command.
+
+### Technical Changes
+
+#### Root Cause
+
+Starting from OpenSearch 3.0.0, artifacts are signed with a new PGP key (`release@opensearch.org`) instead of the previous key (`opensearch@amazon.com`). The signature verification code in `InstallPluginCommand.java` failed because the BouncyCastle FIPS provider was not properly registered before initializing the signature verifier.
+
+#### Code Changes
+
+The fix adds explicit registration of the BouncyCastle FIPS provider before signature verification:
+
+```java
+// Added imports
+import org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider;
+import java.security.Security;
+
+// In verifySignature method
+Security.addProvider(new BouncyCastleFipsProvider());
+signature.init(new JcaPGPContentVerifierBuilderProvider().setProvider("BCFIPS"), key);
+```
+
+#### Updated Public Key
+
+The `public_key.sig` file was updated with the new PGP public key for `release@opensearch.org`, replacing the previous `opensearch@amazon.com` key.
+
+### Error Before Fix
+
+```
+./bin/opensearch-plugin install analysis-icu --batch
+-> Installing analysis-icu
+-> Downloading analysis-icu from opensearch
+-> Failed installing analysis-icu
+-> Rolling back analysis-icu
+-> Rolled back analysis-icu
+Exception in thread "main" java.lang.NullPointerException: Cannot invoke "org.bouncycastle.openpgp.PGPPublicKey.getVersion()" because "<parameter2>" is null
+    at org.bouncycastle.openpgp.PGPSignature.init(Unknown Source)
+    at org.opensearch.tools.cli.plugin.InstallPluginCommand.verifySignature(InstallPluginCommand.java:635)
+```
+
+### Usage Example
+
+After the fix, plugin installation works correctly:
+
+```bash
+./bin/opensearch-plugin install repository-s3
+-> Installing repository-s3
+-> Downloading repository-s3 from opensearch
+[=================================================] 100%   
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+@     WARNING: plugin requires additional permissions     @
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+* java.io.FilePermission config#plus read
+...
+Continue with installation? [y/N]y
+-> Installed repository-s3 with folder name repository-s3
+```
+
+## Limitations
+
+- This fix is specific to OpenSearch 3.x releases that use the new `release@opensearch.org` signing key
+- Users running OpenSearch 2.x should continue using the previous key for signature verification
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18147](https://github.com/opensearch-project/OpenSearch/pull/18147) | Fix the native plugin installation error |
+
+## References
+
+- [Issue #5308](https://github.com/opensearch-project/opensearch-build/issues/5308): New PGP key for signing artifacts starting 3.0.0
+- [Issue #3747](https://github.com/opensearch-project/opensearch-build/issues/3747): Release version 3.0.0
+- [Documentation](https://docs.opensearch.org/3.0/install-and-configure/plugins/): Installing plugins
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/plugin-installation.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -6,4 +6,5 @@
 
 - [DocRequest Refactoring](features/opensearch/docrequest-refactoring.md) - Generic interface for single-document operations
 - [Network Configuration](features/opensearch/network-configuration.md) - Fix systemd seccomp filter for network.host: 0.0.0.0
+- [Plugin Installation](features/opensearch/plugin-installation.md) - Fix native plugin installation error caused by PGP public key change
 - [Query Bug Fixes](features/opensearch/query-bug-fixes.md) - Fixes for exists query, error handling, field validation, and IP field terms query


### PR DESCRIPTION
## Summary

This PR adds documentation for the Plugin Installation fix in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/opensearch/plugin-installation.md`
- Feature report: `docs/features/opensearch/plugin-installation.md`

### Key Changes in v3.1.0
- Fixed `NullPointerException` during native plugin installation caused by PGP public key change
- Added BouncyCastle FIPS provider initialization before signature verification
- Updated `public_key.sig` with new `release@opensearch.org` key

### Related Issue
- Closes #926