### PR TITLE
docs: add Snapshot/Repository Fixes report for v3.1.0

### DIFF
--- a/docs/features/opensearch/snapshot-restore-enhancements.md
+++ b/docs/features/opensearch/snapshot-restore-enhancements.md
@@ -117,21 +117,27 @@ POST /_snapshot/{repository}/{snapshot}/_restore
 - Cannot rename aliases to names that conflict with existing indexes
 - Clone optimization only benefits document replication clusters
 - Repository data fetch still required for remote store enabled clusters during clone
+- When repository is updated during snapshot creation, the snapshot operation will fail and must be retried
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#17532](https://github.com/opensearch-project/OpenSearch/pull/17532) | Fix infinite loop when simultaneously creating snapshot and updating repository |
+| v3.1.0 | [#18218](https://github.com/opensearch-project/OpenSearch/pull/18218) | Avoid NPE on SnapshotInfo if 'shallow' boolean not present |
 | v2.18.0 | [#16292](https://github.com/opensearch-project/OpenSearch/pull/16292) | Add support for renaming aliases during snapshot restore |
 | v2.18.0 | [#16296](https://github.com/opensearch-project/OpenSearch/pull/16296) | Optimise clone operation for incremental full cluster snapshots |
 
 ## References
 
+- [Issue #17531](https://github.com/opensearch-project/OpenSearch/issues/17531): Bug report for infinite loop during concurrent snapshot/repository update
+- [Issue #18187](https://github.com/opensearch-project/OpenSearch/issues/18187): Bug report for NPE when restoring legacy searchable snapshots
 - [Issue #15632](https://github.com/opensearch-project/OpenSearch/issues/15632): Original feature request for alias renaming
 - [Issue #16295](https://github.com/opensearch-project/OpenSearch/issues/16295): Clone optimization request
-- [Snapshot Restore Documentation](https://docs.opensearch.org/2.18/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/): Official documentation
-- [Restore Snapshot API](https://docs.opensearch.org/2.18/api-reference/snapshots/restore-snapshot/): API reference
+- [Snapshot Restore Documentation](https://docs.opensearch.org/3.0/api-reference/snapshots/create-repository/): Official documentation
+- [Restore Snapshot API](https://docs.opensearch.org/3.0/api-reference/snapshots/restore-snapshot/): API reference
 
 ## Change History
 
+- **v3.1.0** (2026-01-10): Fixed infinite loop when updating repository during snapshot creation; fixed NPE when restoring legacy searchable snapshots
 - **v2.18.0** (2024-11-05): Added alias renaming support during snapshot restore; optimized clone operations for doc-rep clusters

--- a/docs/releases/v3.1.0/features/opensearch/repository-fixes.md
+++ b/docs/releases/v3.1.0/features/opensearch/repository-fixes.md
@@ -1,0 +1,85 @@
+# Snapshot/Repository Fixes
+
+## Summary
+
+OpenSearch v3.1.0 includes two critical bug fixes for snapshot and repository operations. The first fix prevents an infinite loop that could occur when simultaneously creating a snapshot and updating the repository configuration. The second fix addresses a NullPointerException when restoring searchable snapshots created in older OpenSearch versions that lack the `remote_store_index_shallow_copy` field.
+
+## Details
+
+### What's New in v3.1.0
+
+These fixes improve the stability and backward compatibility of snapshot operations:
+
+1. **Infinite Loop Prevention**: Fixed a race condition where updating a repository while a snapshot creation is in progress could cause the snapshot operation to enter an infinite loop.
+
+2. **NPE Fix for Legacy Snapshots**: Fixed a NullPointerException that occurred when restoring searchable snapshots created in OpenSearch versions prior to 2.10 (before the `remote_store_index_shallow_copy` field was introduced).
+
+### Technical Changes
+
+#### Fix 1: Repository Update During Snapshot Creation
+
+When a repository is updated, `RepositoriesService` creates a new repository instance and closes the old one. Previously, an ongoing snapshot creation that depended on the closed repository would enter an infinite loop in `BlobStoreRepository.executeConsistentStateUpdate()` because the condition check would always fail.
+
+**Solution**: Added a `closed` flag to `BlobStoreRepository` that is set when the repository is closed. The `executeConsistentStateUpdate()` method now checks this flag and returns a `RepositoryException` if the repository has been closed, allowing the snapshot operation to fail gracefully with a clear error message.
+
+```java
+// BlobStoreRepository.java
+private volatile boolean closed;
+
+@Override
+protected void doClose() {
+    // ...
+    closed = true;
+    store.close();
+    // ...
+}
+
+public void executeConsistentStateUpdate(...) {
+    if (this.closed) {
+        onFailure.accept(new RepositoryException(metadata.name(), 
+            "the repository has been changed, try again"));
+        return;
+    }
+    // ... continue with normal operation
+}
+```
+
+#### Fix 2: NPE on SnapshotInfo Shallow Copy Field
+
+Snapshots created in older OpenSearch versions (before 2.10) do not contain the `remote_store_index_shallow_copy` field in their metadata. When restoring such snapshots as searchable snapshots, the code attempted to call `booleanValue()` on a null `Boolean` object.
+
+**Solution**: Changed the null-unsafe boolean check to use `Boolean.TRUE.equals()` which safely handles null values.
+
+```java
+// Before (NPE-prone)
+} else if (snapshotInfo.isRemoteStoreIndexShallowCopyEnabled()) {
+
+// After (null-safe)
+} else if (Boolean.TRUE.equals(snapshotInfo.isRemoteStoreIndexShallowCopyEnabled())) {
+```
+
+### Migration Notes
+
+No migration steps required. These are bug fixes that improve stability without changing any APIs or configurations.
+
+## Limitations
+
+- The infinite loop fix causes the snapshot operation to fail with a `RepositoryException` when the repository is updated during snapshot creation. Users should retry the snapshot operation after the repository update completes.
+- Backward compatibility testing for snapshots created in very old OpenSearch versions may still have gaps.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17532](https://github.com/opensearch-project/OpenSearch/pull/17532) | Fix simultaneously creating a snapshot and updating the repository can potentially trigger an infinite loop |
+| [#18218](https://github.com/opensearch-project/OpenSearch/pull/18218) | Avoid NPE if on SnapshotInfo if 'shallow' boolean not present |
+
+## References
+
+- [Issue #17531](https://github.com/opensearch-project/OpenSearch/issues/17531): Bug report for infinite loop during concurrent snapshot/repository update
+- [Issue #18187](https://github.com/opensearch-project/OpenSearch/issues/18187): Bug report for NPE when restoring legacy searchable snapshots
+- [Snapshot Repository Documentation](https://docs.opensearch.org/3.0/api-reference/snapshots/create-repository/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/snapshot-restore-enhancements.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -8,3 +8,4 @@
 - [Network Configuration](features/opensearch/network-configuration.md) - Fix systemd seccomp filter for network.host: 0.0.0.0
 - [Plugin Installation](features/opensearch/plugin-installation.md) - Fix native plugin installation error caused by PGP public key change
 - [Query Bug Fixes](features/opensearch/query-bug-fixes.md) - Fixes for exists query, error handling, field validation, and IP field terms query
+- [Snapshot/Repository Fixes](features/opensearch/repository-fixes.md) - Fix infinite loop during concurrent snapshot/repository update and NPE for legacy snapshots


### PR DESCRIPTION
## Summary

This PR adds documentation for Snapshot/Repository Fixes in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/opensearch/repository-fixes.md`
- Feature report: `docs/features/opensearch/snapshot-restore-enhancements.md` (updated)

### Key Changes in v3.1.0

1. **Fix infinite loop during concurrent snapshot/repository update** (PR #17532)
   - When a repository is updated while a snapshot creation is in progress, the snapshot operation could enter an infinite loop
   - Added a `closed` flag to `BlobStoreRepository` to detect when the repository has been closed and fail gracefully

2. **Fix NPE when restoring legacy searchable snapshots** (PR #18218)
   - Snapshots created in OpenSearch versions prior to 2.10 lack the `remote_store_index_shallow_copy` field
   - Changed to use `Boolean.TRUE.equals()` for null-safe comparison

### Resources Used
- PR: #17532, #18218
- Issues: #17531, #18187
- Docs: https://docs.opensearch.org/3.0/api-reference/snapshots/create-repository/