### PR TITLE
docs: add lucene-upgrade report for v3.1.0

### DIFF
--- a/docs/features/opensearch/lucene-upgrade.md
+++ b/docs/features/opensearch/lucene-upgrade.md
@@ -69,16 +69,23 @@ GET /_nodes?filter_path=nodes.*.version
 
 | Version | PR | Description |
 |---------|-----|-------------|
-| v2.18.0 | [#15333](https://github.com/opensearch-project/OpenSearch/pull/15333) | Update Apache Lucene to 9.12.0 |
+| v3.1.0 | [#17961](https://github.com/opensearch-project/OpenSearch/pull/17961) | Upgrade to Lucene 10.2.1 |
+| v3.1.0 | [#18395](https://github.com/opensearch-project/OpenSearch/pull/18395) | Replace deprecated TopScoreDocCollectorManager construction |
+| v3.1.0 | [neural-search#1336](https://github.com/opensearch-project/neural-search/pull/1336) | Update Lucene dependencies |
+| v3.1.0 | [learning-to-rank-base#186](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/186) | Lucene 10.2 upgrade changes |
 | v3.0.0 | [#16366](https://github.com/opensearch-project/OpenSearch/pull/16366) | Apache Lucene 10 update |
+| v2.18.0 | [#15333](https://github.com/opensearch-project/OpenSearch/pull/15333) | Update Apache Lucene to 9.12.0 |
 
 ## References
 
+- [Lucene 10.2.1 Changelog](https://lucene.apache.org/core/10_2_1/changes/Changes.html): Official Lucene 10.2.1 release notes
+- [Lucene 10.2.0 Changelog](https://lucene.apache.org/core/10_2_0/changes/Changes.html): Official Lucene 10.2.0 release notes
 - [Lucene 9.12.0 Changelog](https://lucene.apache.org/core/9_12_0/changes/Changes.html): Official Lucene 9.12.0 release notes
 - [Apache Lucene](https://lucene.apache.org/): Official Apache Lucene project
 - [OpenSearch Documentation](https://docs.opensearch.org/): OpenSearch official documentation
 
 ## Change History
 
+- **v3.1.0**: Upgrade to Apache Lucene 10.2.1 with SeededKnnVectorQuery, binary quantized vector codecs, TopDocs#rrf, and API changes (DisiPriorityQueue, TopScoreDocCollectorManager)
 - **v3.0.0**: Upgrade to Apache Lucene 10
 - **v2.18.0**: Upgrade to Apache Lucene 9.12.0 with new Lucene912PostingsFormat, JDK 23 Panama Vectorization support, dynamic range facets, and various performance optimizations

--- a/docs/releases/v3.1.0/features/opensearch/lucene-upgrade.md
+++ b/docs/releases/v3.1.0/features/opensearch/lucene-upgrade.md
@@ -1,0 +1,72 @@
+# Lucene Upgrade
+
+## Summary
+
+OpenSearch 3.1.0 upgrades Apache Lucene from 10.1.0 to 10.2.1, bringing bug fixes, performance optimizations, and new features for vector search. This upgrade includes API changes that required updates across multiple OpenSearch repositories.
+
+## Details
+
+### What's New in v3.1.0
+
+The Lucene 10.2.1 upgrade introduces:
+
+- **Bug fixes**: Fixes for DISIDocIdStream, TermOrdValComparator, and lead cost computations
+- **New features**: SeededKnnVectorQuery, binary quantized vector codecs, TopDocs#rrf for Reciprocal Rank Fusion
+- **API changes**: DocIdSetIterator#intoBitSet, Bits#applyMask, DocIdSetIterator#docIDRunEnd
+- **Performance**: Dense conjunction speedups, postings encoded as bit sets
+
+### Technical Changes
+
+#### API Changes
+
+| API | Change Type | Description |
+|-----|-------------|-------------|
+| `DisiPriorityQueue` | Constructor change | Use `DisiPriorityQueue.ofMaxSize(int)` instead of constructor |
+| `TopScoreDocCollectorManager` | Deprecated constructor | Use new constructor without deprecated parameters |
+| `DocIdSetIterator#intoBitSet` | New method | Convert iterator to bit set |
+| `Bits#applyMask` | New method | Apply mask to bits |
+| `DocIdSetIterator#docIDRunEnd` | New method | Get end of document ID run |
+
+#### New Vector Search Features
+
+| Feature | Description |
+|---------|-------------|
+| `SeededKnnVectorQuery` | KNN query with seeding for improved recall |
+| Binary quantized vector codecs | Efficient storage for quantized vectors |
+| `TopDocs#rrf` | Reciprocal Rank Fusion for combining search results |
+
+### Migration Notes
+
+Code using Lucene APIs directly may need updates:
+
+```java
+// Before (Lucene 10.1.0)
+DisiPriorityQueue queue = new DisiPriorityQueue(size);
+
+// After (Lucene 10.2.1)
+DisiPriorityQueue queue = DisiPriorityQueue.ofMaxSize(size);
+```
+
+## Limitations
+
+- Plugins using Lucene APIs directly must be updated for compatibility
+- Index format remains compatible; no reindexing required
+
+## Related PRs
+
+| Repository | PR | Description |
+|------------|-----|-------------|
+| OpenSearch | [#17961](https://github.com/opensearch-project/OpenSearch/pull/17961) | Core Lucene upgrade to 10.2.1 |
+| OpenSearch | [#18395](https://github.com/opensearch-project/OpenSearch/pull/18395) | Replace deprecated TopScoreDocCollectorManager construction |
+| neural-search | [#1336](https://github.com/opensearch-project/neural-search/pull/1336) | Update Lucene dependencies |
+| opensearch-learning-to-rank-base | [#186](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/186) | Lucene 10.2 upgrade changes |
+
+## References
+
+- [Apache Lucene 10.2.1 Release Notes](https://lucene.apache.org/core/10_2_1/changes/Changes.html)
+- [Apache Lucene 10.2.0 Release Notes](https://lucene.apache.org/core/10_2_0/changes/Changes.html)
+- [Issue #184](https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/184): Learning to Rank compatibility issue
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/lucene-upgrade.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -6,6 +6,7 @@
 
 - [Dependency Bumps](features/opensearch/dependency-bumps.md) - 21 dependency updates including CVE-2025-27820 fix, Netty, Gson, Azure SDK updates
 - [DocRequest Refactoring](features/opensearch/docrequest-refactoring.md) - Generic interface for single-document operations
+- [Lucene Upgrade](features/opensearch/lucene-upgrade.md) - Upgrade Apache Lucene from 10.1.0 to 10.2.1
 - [Network Configuration](features/opensearch/network-configuration.md) - Fix systemd seccomp filter for network.host: 0.0.0.0
 - [Plugin Installation](features/opensearch/plugin-installation.md) - Fix native plugin installation error caused by PGP public key change
 - [Query Bug Fixes](features/opensearch/query-bug-fixes.md) - Fixes for exists query, error handling, field validation, and IP field terms query


### PR DESCRIPTION
## Summary

Add documentation for Lucene upgrade from 10.1.0 to 10.2.1 in OpenSearch v3.1.0.

## Changes

- Created release report: `docs/releases/v3.1.0/features/opensearch/lucene-upgrade.md`
- Updated feature report: `docs/features/opensearch/lucene-upgrade.md`
- Updated release index: `docs/releases/v3.1.0/index.md`

## Key Changes in v3.1.0

- Upgrade Apache Lucene from 10.1.0 to 10.2.1
- New features: SeededKnnVectorQuery, binary quantized vector codecs, TopDocs#rrf
- API changes: DisiPriorityQueue constructor, TopScoreDocCollectorManager deprecation
- Bug fixes and performance optimizations

## Related PRs

- opensearch-project/OpenSearch#17961: Core Lucene upgrade
- opensearch-project/OpenSearch#18395: Replace deprecated TopScoreDocCollectorManager
- opensearch-project/neural-search#1336: Update Lucene dependencies
- opensearch-project/opensearch-learning-to-rank-base#186: Lucene 10.2 upgrade changes

Closes #923