### PR TITLE
docs: add fips-support report for v3.1.0

### DIFF
--- a/docs/features/opensearch/cryptography-security-libraries.md
+++ b/docs/features/opensearch/cryptography-security-libraries.md
@@ -158,16 +158,19 @@ SSLContext sslContext = SSLContextBuilder.create()
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#18427](https://github.com/opensearch-project/OpenSearch/pull/18427) | Update FipsMode check to catch NoSuchMethodError |
 | v3.0.0 | [#17393](https://github.com/opensearch-project/OpenSearch/pull/17393) | Use BC libraries to parse PEM files, increase key length |
 | v3.0.0 | [#17507](https://github.com/opensearch-project/OpenSearch/pull/17507) | Migrate BC libs to their FIPS counterparts |
 
 ## References
 
 - [Issue #3420](https://github.com/opensearch-project/security/issues/3420): RFC - Proposal for supporting FIPS 140-2 enforced mode
+- [Issue #4254](https://github.com/opensearch-project/security/issues/4254): RFC - FIPS-140 Compliance Roadmap for OpenSearch
 - [PR #14912](https://github.com/opensearch-project/OpenSearch/pull/14912): Original comprehensive FIPS support PR
 - [Blog: Finding a replacement for JSM in OpenSearch 3.0](https://opensearch.org/blog/finding-a-replacement-for-jsm-in-opensearch-3-0/): Security architecture changes in 3.0
 - [Bouncy Castle FIPS Documentation](https://www.bouncycastle.org/fips-java/): Official BC-FIPS documentation
 
 ## Change History
 
+- **v3.1.0** (2026-01-10): Updated FipsMode check to catch NoSuchMethodError for improved compatibility with security plugin during BC-FIPS transition
 - **v3.0.0** (2025-05-06): Migrated from standard BC to BC-FIPS libraries; refactored PemUtils to use BC for PEM parsing; added java.security configuration for BC-FIPS providers

--- a/docs/releases/v3.1.0/features/opensearch/fips-support.md
+++ b/docs/releases/v3.1.0/features/opensearch/fips-support.md
@@ -1,0 +1,89 @@
+# FIPS Support
+
+## Summary
+
+This release improves FIPS (Federal Information Processing Standards) compatibility by updating the FipsMode detection logic in OpenSearch core. The change fixes an error that occurred when the security plugin hadn't yet converted to BC-FIPS jars due to OpenSAML incompatibility issues.
+
+## Details
+
+### What's New in v3.1.0
+
+The `FipsMode` check in the test framework has been updated to catch `NoSuchMethodError` in addition to `NoClassDefFoundError`. This resolves a timing issue where the security plugin uses reflection to detect FIPS mode, but the method signature differs between standard BouncyCastle and BC-FIPS libraries.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "FIPS Mode Detection"
+        Check[FipsMode.CHECK]
+        CSR[CryptoServicesRegistrar]
+        
+        Check --> |isInApprovedOnlyMode| CSR
+    end
+    
+    subgraph "Error Handling"
+        NCDF[NoClassDefFoundError]
+        NSME[NoSuchMethodError]
+        
+        CSR --> |Class missing| NCDF
+        CSR --> |Method missing| NSME
+        NCDF --> |return false| Result[FIPS Disabled]
+        NSME --> |return false| Result
+    end
+```
+
+#### Code Change
+
+The `FipsMode` class now handles both error types:
+
+```java
+public static Check CHECK = () -> {
+    try {
+        return CryptoServicesRegistrar.isInApprovedOnlyMode();
+    } catch (NoClassDefFoundError | NoSuchMethodError e) {
+        return false;
+    }
+};
+```
+
+### Background
+
+The security plugin has been transitioning to BC-FIPS libraries as part of the broader FIPS 140-2/140-3 compliance initiative. However, OpenSAML (used for SAML authentication) has [incompatibility issues](https://github.com/opensearch-project/security/issues/4915) with BC-FIPS, requiring a shadow JAR approach to isolate the conflicting dependencies.
+
+During this transition period, the security plugin may have the BC-FIPS classes available but with different method signatures than expected, causing `NoSuchMethodError` instead of `NoClassDefFoundError`.
+
+### Usage Example
+
+The FipsMode check is used in tests to conditionally skip or modify test behavior:
+
+```java
+if (FipsMode.CHECK.isFipsEnabled()) {
+    // Use FIPS-compliant algorithms
+} else {
+    // Use standard algorithms
+}
+```
+
+## Limitations
+
+- This is a test framework change; production FIPS mode detection is handled separately
+- Full FIPS compliance requires additional configuration and BC-FIPS libraries
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18427](https://github.com/opensearch-project/OpenSearch/pull/18427) | Update FipsMode check to catch NoSuchMethodError |
+
+## References
+
+- [Security Plugin CI Failure](https://github.com/opensearch-project/security/actions/runs/15408478290/job/43355642640?pr=5370): Original error that prompted this fix
+- [Issue #4915](https://github.com/opensearch-project/security/issues/4915): OpenSAML incompatibility with BC-FIPS
+- [Issue #3420](https://github.com/opensearch-project/security/issues/3420): RFC - Proposal for supporting FIPS 140-2 enforced mode
+- [Issue #4254](https://github.com/opensearch-project/security/issues/4254): RFC - FIPS-140 Compliance Roadmap for OpenSearch
+
+## Related Feature Report
+
+- [Cryptography & Security Libraries](../../../features/opensearch/cryptography-security-libraries.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -6,6 +6,7 @@
 
 - [Dependency Bumps](features/opensearch/dependency-bumps.md) - 21 dependency updates including CVE-2025-27820 fix, Netty, Gson, Azure SDK updates
 - [DocRequest Refactoring](features/opensearch/docrequest-refactoring.md) - Generic interface for single-document operations
+- [FIPS Support](features/opensearch/fips-support.md) - Update FipsMode check for improved BC-FIPS compatibility
 - [Lucene Upgrade](features/opensearch/lucene-upgrade.md) - Upgrade Apache Lucene from 10.1.0 to 10.2.1
 - [Network Configuration](features/opensearch/network-configuration.md) - Fix systemd seccomp filter for network.host: 0.0.0.0
 - [Plugin Installation](features/opensearch/plugin-installation.md) - Fix native plugin installation error caused by PGP public key change


### PR DESCRIPTION
## Summary

This PR adds documentation for the FIPS Support feature in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/opensearch/fips-support.md`
- Feature report: `docs/features/opensearch/cryptography-security-libraries.md` (updated)

### Key Changes in v3.1.0
- Updated FipsMode check to catch `NoSuchMethodError` in addition to `NoClassDefFoundError`
- Improves compatibility with security plugin during BC-FIPS transition
- Resolves timing issue when security plugin hasn't yet converted to BC-FIPS jars

### Resources Used
- PR: [#18427](https://github.com/opensearch-project/OpenSearch/pull/18427)
- Issue: [#4254](https://github.com/opensearch-project/security/issues/4254) - RFC FIPS-140 Compliance Roadmap
- Issue: [#3420](https://github.com/opensearch-project/security/issues/3420) - RFC FIPS 140-2 enforced mode