### PR TITLE
docs: add percentiles-aggregation report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -53,6 +53,7 @@
 - [Node Roles Configuration](opensearch/node-roles-configuration.md)
 - [Offline Nodes (Background Tasks)](opensearch/offline-nodes.md)
 - [OpenSearch Core Dependencies](opensearch/opensearch-core-dependencies.md)
+- [Percentiles Aggregation](opensearch/percentiles-aggregation.md)
 - [Phone Number Analyzer](opensearch/phone-analyzer.md)
 - [Plugin Installation](opensearch/plugin-installation.md)
 - [Query Bug Fixes](opensearch/query-bug-fixes.md)

--- a/docs/features/opensearch/percentiles-aggregation.md
+++ b/docs/features/opensearch/percentiles-aggregation.md
@@ -1,0 +1,152 @@
+# Percentiles Aggregation
+
+## Summary
+
+The percentiles aggregation is a multi-value metric aggregation that calculates approximate percentile values from numeric field data. It uses the t-digest algorithm to efficiently compute percentiles with configurable accuracy, making it useful for analyzing data distributions, identifying outliers, and understanding latency characteristics.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Percentiles Aggregation"
+        Query[Search Query] --> Agg[Percentiles Aggregation]
+        Agg --> TDigest[TDigestState]
+        TDigest --> MD[MergingDigest]
+        MD --> Centroids[Centroid Storage]
+    end
+    
+    subgraph "Shard Processing"
+        Shard1[Shard 1] --> Local1[Local TDigest]
+        Shard2[Shard 2] --> Local2[Local TDigest]
+        ShardN[Shard N] --> LocalN[Local TDigest]
+    end
+    
+    subgraph "Coordination"
+        Local1 --> Merge[Merge TDigests]
+        Local2 --> Merge
+        LocalN --> Merge
+        Merge --> Final[Final Percentiles]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Numeric Values] --> B[Add to TDigest]
+    B --> C[Compress into Centroids]
+    C --> D[Serialize for Transport]
+    D --> E[Merge on Coordinator]
+    E --> F[Calculate Percentiles]
+    F --> G[Return Results]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `TDigestState` | OpenSearch wrapper around t-digest library with custom serialization |
+| `MergingDigest` | Underlying t-digest implementation (v3.1.0+) |
+| `InternalTDigestPercentiles` | Internal aggregation result representation |
+| `PercentilesAggregationBuilder` | Builder for constructing percentiles aggregations |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `field` | Numeric field to calculate percentiles for | Required |
+| `percents` | Array of percentile values to calculate | `[1, 5, 25, 50, 75, 95, 99]` |
+| `tdigest.compression` | Accuracy vs memory tradeoff (higher = more accurate) | `100` |
+| `keyed` | Return results as a map with percentile keys | `true` |
+| `missing` | Value to use for documents missing the field | None |
+
+### Usage Example
+
+Basic percentiles query:
+
+```json
+GET my-index/_search
+{
+  "size": 0,
+  "aggs": {
+    "latency_percentiles": {
+      "percentiles": {
+        "field": "response_time",
+        "percents": [50, 90, 95, 99, 99.9]
+      }
+    }
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "aggregations": {
+    "latency_percentiles": {
+      "values": {
+        "50.0": 120.5,
+        "90.0": 450.2,
+        "95.0": 680.1,
+        "99.0": 1250.8,
+        "99.9": 2100.3
+      }
+    }
+  }
+}
+```
+
+With custom compression:
+
+```json
+GET my-index/_search
+{
+  "size": 0,
+  "aggs": {
+    "precise_percentiles": {
+      "percentiles": {
+        "field": "response_time",
+        "tdigest": {
+          "compression": 200
+        }
+      }
+    }
+  }
+}
+```
+
+### How t-digest Works
+
+The t-digest algorithm maintains a compact summary of a data distribution using "centroids" - weighted mean values that represent clusters of nearby data points. Key characteristics:
+
+1. **Accuracy at extremes**: More accurate at the tails (e.g., 99th percentile) than in the middle
+2. **Mergeable**: Digests from different shards can be combined without loss of accuracy
+3. **Memory efficient**: Uses O(compression) space regardless of data size
+4. **Streaming**: Can process data in a single pass
+
+## Limitations
+
+- Percentile values are approximate, not exact
+- Accuracy depends on the `compression` parameter
+- Higher compression values use more memory
+- The `MergingDigest` implementation (v3.1.0+) does not support weighted additions
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#18124](https://github.com/opensearch-project/OpenSearch/pull/18124) | Switch to MergingDigest for ~2-30x performance improvement |
+
+## References
+
+- [Issue #18122](https://github.com/opensearch-project/OpenSearch/issues/18122): Performance improvement request
+- [Percentile Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/metric/percentile/): Official documentation
+- [Percentile Ranks Documentation](https://docs.opensearch.org/3.0/aggregations/metric/percentile-ranks/): Related aggregation
+- [t-digest Paper](https://github.com/tdunning/t-digest): Algorithm details and implementation
+
+## Change History
+
+- **v3.1.0** (2025-05-28): Switched from AVLTreeDigest to MergingDigest for significant performance improvements (up to 30x faster for low-cardinality fields)

--- a/docs/releases/v3.1.0/features/opensearch/percentiles-aggregation.md
+++ b/docs/releases/v3.1.0/features/opensearch/percentiles-aggregation.md
@@ -1,0 +1,127 @@
+# Percentiles Aggregation Performance Improvement
+
+## Summary
+
+OpenSearch v3.1.0 significantly improves the performance of the `percentiles` aggregation by switching the underlying t-digest implementation from `AVLTreeDigest` to `MergingDigest`. This change delivers up to 30x latency improvement for certain workloads while maintaining the same accuracy and API compatibility.
+
+## Details
+
+### What's New in v3.1.0
+
+The percentiles aggregation now uses `MergingDigest` instead of `AVLTreeDigest` from the t-digest library. This is a drop-in replacement that provides substantial performance improvements without changing the aggregation API or behavior.
+
+### Technical Changes
+
+#### Implementation Switch
+
+The `TDigestState` class, which wraps the t-digest library for percentile calculations, now extends `MergingDigest` instead of `AVLTreeDigest`:
+
+```java
+// Before v3.1.0
+public class TDigestState extends AVLTreeDigest { ... }
+
+// v3.1.0 and later
+public class TDigestState extends MergingDigest { ... }
+```
+
+#### Backward Compatibility
+
+The serialization format has been updated to support both old and new implementations:
+
+- When communicating with nodes running versions before v3.1.0, the old centroid-based serialization is used
+- For v3.1.0+ nodes, the native `MergingDigest` byte serialization is used for exact state preservation
+
+```java
+public static void write(TDigestState state, StreamOutput out) throws IOException {
+    if (out.getVersion().before(Version.V_3_1_0)) {
+        // Legacy format for backward compatibility
+        out.writeDouble(state.compression);
+        out.writeVInt(state.centroidCount());
+        for (Centroid centroid : state.centroids()) {
+            out.writeDouble(centroid.mean());
+            out.writeVLong(centroid.count());
+        }
+    } else {
+        // New efficient format
+        int byteSize = state.byteSize();
+        out.writeVInt(byteSize);
+        ByteBuffer buf = ByteBuffer.allocate(byteSize);
+        state.asBytes(buf);
+        out.writeBytes(buf.array());
+    }
+}
+```
+
+#### Median Absolute Deviation Impact
+
+The `MergingDigest` implementation does not support weighted `add()` operations. The median absolute deviation calculation was updated to use iterative addition instead:
+
+```java
+for (Centroid centroid : valuesSketch.centroids()) {
+    final double deviation = Math.abs(approximateMedian - centroid.mean());
+    // Iterative add instead of weighted add
+    for (int i = 0; i < centroid.count(); i++) {
+        approximatedDeviationsSketch.add(deviation);
+    }
+}
+```
+
+### Performance Benchmarks
+
+Benchmarks on the http_logs dataset (247M documents) show significant improvements:
+
+| Field | Baseline Latency (ms) | New Latency (ms) | Improvement |
+|-------|----------------------|------------------|-------------|
+| @timestamp (high cardinality) | 13,085 | 6,293 | ~2x faster |
+| status (low cardinality) | 196,794 | 6,212 | ~31x faster |
+
+The improvement is especially pronounced for low-cardinality fields.
+
+### Usage Example
+
+The API remains unchanged:
+
+```json
+GET opensearch_dashboards_sample_data_ecommerce/_search
+{
+  "size": 0,
+  "aggs": {
+    "percentile_taxful_total_price": {
+      "percentiles": {
+        "field": "taxful_total_price",
+        "tdigest": {
+          "compression": 100
+        }
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- No configuration changes required
+- The `compression` parameter continues to work the same way
+- Rolling upgrades are supported with automatic serialization format negotiation
+- Existing queries will automatically benefit from the performance improvement
+
+## Limitations
+
+- The `MergingDigest` implementation does not support weighted additions, which required a workaround in the median absolute deviation calculation
+- During rolling upgrades, mixed-version clusters will use the legacy serialization format
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18124](https://github.com/opensearch-project/OpenSearch/pull/18124) | Switch percentiles implementation to MergingDigest |
+
+## References
+
+- [Issue #18122](https://github.com/opensearch-project/OpenSearch/issues/18122): Feature request for implementation switch
+- [Percentile Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/metric/percentile/): Official documentation
+- [t-digest Library](https://github.com/tdunning/t-digest): Upstream library with MergingDigest recommendation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/percentiles-aggregation.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -9,6 +9,7 @@
 - [FIPS Support](features/opensearch/fips-support.md) - Update FipsMode check for improved BC-FIPS compatibility
 - [Lucene Upgrade](features/opensearch/lucene-upgrade.md) - Upgrade Apache Lucene from 10.1.0 to 10.2.1
 - [Network Configuration](features/opensearch/network-configuration.md) - Fix systemd seccomp filter for network.host: 0.0.0.0
+- [Percentiles Aggregation](features/opensearch/percentiles-aggregation.md) - Switch to MergingDigest for up to 30x performance improvement
 - [Plugin Installation](features/opensearch/plugin-installation.md) - Fix native plugin installation error caused by PGP public key change
 - [Query Bug Fixes](features/opensearch/query-bug-fixes.md) - Fixes for exists query, error handling, field validation, and IP field terms query
 - [Snapshot/Repository Fixes](features/opensearch/repository-fixes.md) - Fix infinite loop during concurrent snapshot/repository update and NPE for legacy snapshots


### PR DESCRIPTION
## Summary

This PR adds documentation for the Percentiles Aggregation performance improvement in OpenSearch v3.1.0.

### Changes
- **Release Report**: `docs/releases/v3.1.0/features/opensearch/percentiles-aggregation.md`
  - Documents the switch from AVLTreeDigest to MergingDigest
  - Includes performance benchmarks (up to 30x improvement)
  - Covers backward compatibility and serialization changes

- **Feature Report**: `docs/features/opensearch/percentiles-aggregation.md`
  - Comprehensive documentation of the percentiles aggregation feature
  - Architecture diagrams and data flow
  - Configuration options and usage examples

### Key Changes in v3.1.0
- Switched t-digest implementation from `AVLTreeDigest` to `MergingDigest`
- Performance improvement: ~2x for high-cardinality fields, ~31x for low-cardinality fields
- Backward-compatible serialization for rolling upgrades

### Related
- Closes #921
- PR: opensearch-project/OpenSearch#18124
- Issue: opensearch-project/OpenSearch#18122