### PR TITLE
docs: add approximation-framework report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -13,6 +13,7 @@
 
 ## opensearch
 
+- [Approximation Framework](opensearch/approximation-framework.md)
 - [Async Shard Fetch Metrics](opensearch/async-shard-fetch-metrics.md)
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
 - [Bulk API](opensearch/bulk-api.md)

--- a/docs/features/opensearch/approximation-framework.md
+++ b/docs/features/opensearch/approximation-framework.md
@@ -1,0 +1,158 @@
+# Approximation Framework
+
+## Summary
+
+The OpenSearch Approximation Framework is a query optimization technique that implements custom BKD tree traversal with early termination for range queries. It significantly improves query latency for time-series and event-based workloads by stopping document collection once the requested number of hits is reached, rather than scanning all matching documents.
+
+The framework is particularly effective for:
+- Fetching the latest N logs or events
+- Dashboard visualizations with sorted results
+- Range queries on numeric fields with size limits
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Query Processing"
+        Query[Range/Sort Query] --> Check{Can Approximate?}
+        Check -->|Yes| APQ[ApproximatePointRangeQuery]
+        Check -->|No| PRQ[Standard PointRangeQuery]
+    end
+    
+    subgraph "ApproximatePointRangeQuery"
+        APQ --> Sort{Sort Order?}
+        Sort -->|ASC/None| IL[intersectLeft]
+        Sort -->|DESC| IR[intersectRight]
+        IL --> BKD[BKD Tree Traversal]
+        IR --> BKD
+        BKD --> ET{docCount >= size?}
+        ET -->|Yes| Stop[Early Termination]
+        ET -->|No| Continue[Continue Traversal]
+    end
+    
+    subgraph "Result"
+        Stop --> Results[Return Top-N Documents]
+        Continue --> BKD
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "BKD Tree Structure"
+        Root[Root Node<br/>All Documents]
+        Root --> L1[Left Subtree<br/>Lower Values]
+        Root --> R1[Right Subtree<br/>Higher Values]
+        L1 --> L2[Leaf Nodes<br/>Smallest Values]
+        L1 --> L3[Leaf Nodes]
+        R1 --> R2[Leaf Nodes]
+        R1 --> R3[Leaf Nodes<br/>Largest Values]
+    end
+    
+    subgraph "ASC Sort Traversal"
+        A1[Start] --> A2[Visit L2 first]
+        A2 --> A3[Collect docs]
+        A3 --> A4{size reached?}
+        A4 -->|Yes| A5[Stop - Skip R1]
+        A4 -->|No| A6[Continue to L3]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ApproximatePointRangeQuery` | Custom query that wraps `PointRangeQuery` with early termination logic |
+| `ApproximateQuery` | Base class for approximate queries |
+| `intersectLeft()` | DFS traversal from smallest to largest values (ASC sort) |
+| `intersectRight()` | DFS traversal from largest to smallest values (DESC sort) |
+| `IntersectVisitor` | Custom visitor that tracks document count and triggers early termination |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `size` | Number of documents to collect before early termination | `track_total_hits_up_to` or `from + size` |
+| `sortOrder` | Sort direction (ASC/DESC) determining traversal order | `ASC` |
+
+### Supported Query Types
+
+| Query Type | Example | Optimization |
+|------------|---------|--------------|
+| Range Query | `{"range": {"@timestamp": {"gte": "now-1d"}}}` | Early termination on BKD traversal |
+| Match All + Sort | `{"match_all": {}, "sort": [{"@timestamp": "desc"}]}` | Rewritten to bounded range with early termination |
+| Range + Sort | `{"range": {...}, "sort": [...]}` | Optimized left/right traversal based on sort order |
+
+### Eligibility Criteria
+
+The framework applies when:
+- Query has no aggregations
+- `track_total_hits` is not set to `true`
+- Sort field matches the range query field (if sorting)
+- No `terminate_after` is specified
+
+### Usage Example
+
+```json
+// Fetch latest 100 error logs - automatically optimized
+GET logs/_search
+{
+  "query": {
+    "range": {
+      "@timestamp": {
+        "gte": "now-24h",
+        "lt": "now"
+      }
+    }
+  },
+  "sort": [{ "@timestamp": "desc" }],
+  "size": 100
+}
+```
+
+```json
+// Range query on numeric field
+GET metrics/_search
+{
+  "query": {
+    "range": {
+      "response_time": {
+        "gte": 100,
+        "lte": 500
+      }
+    }
+  },
+  "sort": [{ "response_time": "asc" }],
+  "size": 50
+}
+```
+
+## Limitations
+
+- Does not apply when `track_total_hits: true` is set
+- Does not apply when aggregations are present
+- Sort field must match the range query field for optimal performance
+- Performance gains vary based on data distribution (most effective on skewed datasets)
+- Queries with `terminate_after` are not optimized
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#18439](https://github.com/opensearch-project/OpenSearch/pull/18439) | BKD traversal optimization for skewed datasets |
+| v3.0.0 | - | Initial GA release of Approximation Framework |
+
+## References
+
+- [Issue #18341](https://github.com/opensearch-project/OpenSearch/issues/18341): Feature request for DFS traversal strategy
+- [OpenSearch Approximation Framework Blog](https://opensearch.org/blog/opensearch-approximation-framework/): Comprehensive overview
+- [META Issue #18619](https://github.com/opensearch-project/OpenSearch/issues/18619): Future enhancements tracking
+- [Nightly Benchmarks](https://benchmarks.opensearch.org/): Performance metrics dashboard
+
+## Change History
+
+- **v3.1.0** (2025-06-10): Enhanced BKD traversal with DFS strategy for skewed datasets, smart subtree skipping
+- **v3.0.0**: Initial GA release with basic early termination support

--- a/docs/releases/v3.1.0/features/opensearch/approximation-framework.md
+++ b/docs/releases/v3.1.0/features/opensearch/approximation-framework.md
@@ -1,0 +1,115 @@
+# Approximation Framework Enhancement
+
+## Summary
+
+This release enhances the Approximation Framework by updating the BKD tree traversal logic to improve performance on skewed datasets. The enhancement introduces a DFS-based traversal strategy that enables early termination when collecting top-N results, significantly reducing query latency for sorted range queries on datasets with uneven data distribution like `http_logs`.
+
+## Details
+
+### What's New in v3.1.0
+
+The v3.1.0 release improves the BKD tree traversal algorithm in `ApproximatePointRangeQuery` to handle skewed datasets more efficiently. The key changes include:
+
+- **DFS-based traversal**: Replaced BFS-like traversal with depth-first search that naturally produces results in sorted order
+- **Smart child skipping**: Added logic to skip subtrees when the current subtree contains enough documents to satisfy the query
+- **Optimized cloning**: Reduced unnecessary `PointTree` cloning by only cloning when both children need to be visited
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "BKD Tree Traversal"
+        Root[Root Node]
+        Root --> Left1[Left Child]
+        Root --> Right1[Right Child]
+        Left1 --> Left2[Left Grandchild]
+        Left1 --> Right2[Right Grandchild]
+        Left2 --> L1[Leaf 1]
+        Left2 --> L2[Leaf 2]
+    end
+    
+    subgraph "ASC Sort - intersectLeft"
+        direction TB
+        A1[Start at Root] --> A2[Check if docCount >= size]
+        A2 -->|No| A3[Compare cell with query]
+        A3 -->|INSIDE| A4{Left child has enough docs?}
+        A4 -->|Yes| A5[Process only left child]
+        A4 -->|No| A6[Process both children]
+        A3 -->|CROSSES| A6
+    end
+```
+
+#### Key Algorithm Changes
+
+| Aspect | Before v3.1.0 | After v3.1.0 |
+|--------|---------------|--------------|
+| Traversal Strategy | BFS-like, level by level | DFS, depth-first with early termination |
+| Child Processing | Always visit both children | Skip right child if left has enough docs |
+| Cloning | Clone before checking | Clone only when needed |
+| Leaf Handling | Mixed with internal node logic | Separate early return for leaf nodes |
+
+#### Modified Components
+
+| Component | Description |
+|-----------|-------------|
+| `ApproximatePointRangeQuery.intersectLeft()` | Optimized for ASC sort with smart subtree skipping |
+| `ApproximatePointRangeQuery.intersectRight()` | Optimized for DESC sort with smart subtree skipping |
+
+### Usage Example
+
+The optimization is automatically applied to range queries with sorting:
+
+```json
+{
+  "query": {
+    "range": {
+      "@timestamp": {
+        "gte": "2023-01-01T00:00:00",
+        "lt": "2023-01-03T00:00:00"
+      }
+    }
+  },
+  "sort": [{ "@timestamp": "asc" }],
+  "size": 100
+}
+```
+
+For skewed datasets like `http_logs`, the DFS traversal finds the required documents in the leftmost leaves (for ASC) or rightmost leaves (for DESC) without visiting unnecessary subtrees.
+
+### Performance Improvements
+
+Based on benchmark results:
+
+| Query Type | Dataset | Before | After | Improvement |
+|------------|---------|--------|-------|-------------|
+| `desc_sort_timestamp` (single segment) | http_logs | ~2,111 ms | ~6.1 ms | >99% |
+| `asc_sort_timestamp` | http_logs | ~15 ms | ~8 ms | ~47% |
+| `desc_sort_size` | http_logs | - | - | >80% |
+
+### Migration Notes
+
+No migration required. The optimization is applied automatically to eligible queries.
+
+## Limitations
+
+- The optimization is most effective on skewed datasets where data is unevenly distributed across the BKD tree
+- Queries with `track_total_hits: true` or aggregations do not benefit from this optimization
+- Performance gains depend on the data distribution and query selectivity
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18439](https://github.com/opensearch-project/OpenSearch/pull/18439) | Approximation Framework Enhancement: Update the BKD traversal logic to improve the performance on skewed data |
+
+## References
+
+- [Issue #18341](https://github.com/opensearch-project/OpenSearch/issues/18341): Feature request for improving ApproximatePointRangeQuery traversal
+- [OpenSearch Approximation Framework Blog](https://opensearch.org/blog/opensearch-approximation-framework/): Detailed explanation of the framework
+- [Nightly Benchmark Dashboard](https://benchmarks.opensearch.org/): Performance metrics
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/approximation-framework.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -4,6 +4,7 @@
 
 ### OpenSearch
 
+- [Approximation Framework](features/opensearch/approximation-framework.md) - BKD traversal optimization for skewed datasets with DFS strategy
 - [Dependency Bumps](features/opensearch/dependency-bumps.md) - 21 dependency updates including CVE-2025-27820 fix, Netty, Gson, Azure SDK updates
 - [DocRequest Refactoring](features/opensearch/docrequest-refactoring.md) - Generic interface for single-document operations
 - [FIPS Support](features/opensearch/fips-support.md) - Update FipsMode check for improved BC-FIPS compatibility


### PR DESCRIPTION
## Summary

This PR adds documentation for the Approximation Framework Enhancement in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/opensearch/approximation-framework.md`
- Feature report: `docs/features/opensearch/approximation-framework.md`

### Key Changes in v3.1.0
- Enhanced BKD tree traversal with DFS strategy for skewed datasets
- Smart subtree skipping when left/right child has enough documents
- Optimized cloning to reduce unnecessary PointTree operations
- Significant performance improvements on http_logs dataset (>99% for desc_sort_timestamp)

### Resources Used
- PR: [#18439](https://github.com/opensearch-project/OpenSearch/pull/18439)
- Issue: [#18341](https://github.com/opensearch-project/OpenSearch/issues/18341)
- Blog: [OpenSearch Approximation Framework](https://opensearch.org/blog/opensearch-approximation-framework/)