### PR TITLE
docs: add star-tree index report for v3.1.0

### DIFF
--- a/docs/features/opensearch/star-tree-index.md
+++ b/docs/features/opensearch/star-tree-index.md
@@ -77,24 +77,26 @@ flowchart TB
 |---------|-------------|---------|
 | `index.composite_index` | Enable composite index support | `false` |
 | `index.append_only.enabled` | Required for star-tree (immutable data) | `false` |
-| `indices.composite_index.star_tree.enabled` | Enable star-tree search optimization | `true` |
+| `indices.composite_index.star_tree.enabled` | Enable star-tree search optimization cluster-wide | `true` |
+| `index.search.star_tree_index.enabled` | Enable star-tree search per index (v3.1.0+) | `true` |
 | `max_leaf_docs` | Maximum documents per leaf node | `10000` |
 | `skip_star_node_creation_for_dimensions` | Dimensions to skip star node creation | `[]` |
 
 ### Supported Features
 
-#### Queries (as of v3.0.0)
+#### Queries
 - Term query
 - Terms query
-- Range query
+- Range query (including date range queries as of v3.1.0)
 - Match all docs query
 - Boolean query (MUST, FILTER, SHOULD clauses)
 
-#### Aggregations (as of v3.0.0)
+#### Aggregations
 - Metric aggregations: sum, min, max, avg, value_count
 - Date histogram with metric sub-aggregations
 - Terms aggregations (keyword and numeric)
 - Range aggregations with metric sub-aggregations
+- Nested bucket aggregations (v3.1.0+): terms → terms → metric, date_histogram → terms → metric, etc.
 
 ### Usage Example
 
@@ -160,14 +162,17 @@ POST /logs/_search
 - Cannot be removed once created; requires reindex to disable
 - High cardinality dimensions increase storage and query latency
 - Multi-values/array values not supported
-- Date field queries not yet supported
 - Boolean `must_not` clauses not supported
 - `minimum_should_match` parameter not supported
+- Nested aggregations limited to 3-4 levels
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#18070](https://github.com/opensearch-project/OpenSearch/pull/18070) | Remove feature flag, add index-level star-tree search setting |
+| v3.1.0 | [#18048](https://github.com/opensearch-project/OpenSearch/pull/18048) | Support nested bucket aggregations |
+| v3.1.0 | [#17855](https://github.com/opensearch-project/OpenSearch/pull/17855) | Support date range queries in aggregations |
 | v3.0.0 | [#17941](https://github.com/opensearch-project/OpenSearch/pull/17941) | Boolean query support |
 | v3.0.0 | [#17275](https://github.com/opensearch-project/OpenSearch/pull/17275) | Unsigned-long query support |
 | v3.0.0 | [#17273](https://github.com/opensearch-project/OpenSearch/pull/17273) | Range aggregations |
@@ -176,17 +181,20 @@ POST /logs/_search
 
 ## References
 
+- [Issue #17443](https://github.com/opensearch-project/OpenSearch/issues/17443): Date range query support
+- [Issue #17274](https://github.com/opensearch-project/OpenSearch/issues/17274): Nested bucket aggregations
 - [Issue #16551](https://github.com/opensearch-project/OpenSearch/issues/16551): Bucket terms aggregation feature request
 - [Issue #16553](https://github.com/opensearch-project/OpenSearch/issues/16553): Range aggregations feature request
 - [Issue #15231](https://github.com/opensearch-project/OpenSearch/issues/15231): Unsigned long support
 - [Issue #17267](https://github.com/opensearch-project/OpenSearch/issues/17267): Boolean query support
 - [Issue #15257](https://github.com/opensearch-project/OpenSearch/issues/15257): Star-tree tracking issue
-- [Documentation](https://docs.opensearch.org/3.0/search-plugins/star-tree-index/): Official star-tree index documentation
-- [Field Type Documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/star-tree/): Star-tree field type reference
+- [Documentation](https://docs.opensearch.org/3.1/search-plugins/star-tree-index/): Official star-tree index documentation
+- [Field Type Documentation](https://docs.opensearch.org/3.1/field-types/supported-field-types/star-tree/): Star-tree field type reference
 - [Blog: The power of star-tree indexes](https://opensearch.org/blog/the-power-of-star-tree-indexes-supercharging-opensearch-aggregations/): Performance analysis and use cases
 
 ## Change History
 
+- **v3.1.0** (2025-06-10): Production-ready status, removed feature flag, added index-level setting, date range query support, nested bucket aggregations
 - **v3.0.0** (2025-05-12): Added boolean query support, terms aggregations, range aggregations, unsigned-long support
 - **v2.19** (2024-12-10): Added date histogram aggregations, term/terms/range query support
 - **v2.18** (2024-10-22): Initial experimental release with metric aggregations (sum, min, max, avg, value_count)

--- a/docs/releases/v3.1.0/features/opensearch/star-tree-index.md
+++ b/docs/releases/v3.1.0/features/opensearch/star-tree-index.md
@@ -1,0 +1,142 @@
+# Star-Tree Index Enhancements
+
+## Summary
+
+OpenSearch v3.1.0 graduates star-tree index from experimental to production-ready status. This release removes the experimental feature flag, adds index-level control for star-tree search, introduces date range query support in aggregations, and enables nested bucket aggregations for more complex analytics scenarios.
+
+## Details
+
+### What's New in v3.1.0
+
+#### Production-Ready Status
+Star-tree index is no longer experimental. The feature flag `opensearch.experimental.feature.composite_index.star_tree.enabled` has been removed, and star-tree functionality is now enabled by default.
+
+#### New Index-Level Setting
+A new setting `index.search.star_tree_index.enabled` allows per-index control over star-tree search optimization:
+
+| Setting | Scope | Default | Description |
+|---------|-------|---------|-------------|
+| `index.search.star_tree_index.enabled` | Index | `true` | Enable/disable star-tree search for specific index |
+| `indices.composite_index.star_tree.enabled` | Cluster | `true` | Enable/disable star-tree search cluster-wide |
+
+#### Date Range Query Support
+Star-tree aggregations now support date range queries with half-open intervals `[gte, lt)` aligned to calendar intervals. This enables time-based filtering in star-tree optimized aggregations.
+
+#### Nested Bucket Aggregations
+Star-tree now supports nested bucket aggregations up to 3-4 levels deep:
+- Terms → Terms → Metric
+- Date Histogram → Terms → Metric
+- Range → Terms → Metric
+- Terms → Range → Metric
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "v3.1.0 Enhancements"
+        Query[Aggregation Query]
+        
+        Query --> DateFilter{Date Range<br/>Filter?}
+        DateFilter -->|Yes| DateMapper[StarDateFieldMapper]
+        DateFilter -->|No| DimFilter[DimensionFilterMapper]
+        
+        DateMapper --> Traverse[Star-Tree Traversal]
+        DimFilter --> Traverse
+        
+        Traverse --> NestedCheck{Nested<br/>Aggregation?}
+        NestedCheck -->|Yes| Recursive[Recursive Validation]
+        NestedCheck -->|No| Collect[Collect Results]
+        
+        Recursive --> ValidateStructure[validateNestedAggregationStructure]
+        ValidateStructure --> Collect
+        
+        Collect --> Return[Return Aggregated Results]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `StarDateFieldMapper` | Maps date dimension filters for star-tree traversal |
+| `MatchAllFilter` | Dimension filter for match-all queries |
+| `getDimensionFilters()` | New method in `StarTreePreComputeCollector` for nested aggregations |
+| `RemapGlobalOrdsStarTree` | Collection strategy for global ordinals in nested terms aggregations |
+| `validateNestedAggregationStructure()` | Recursive validation for nested aggregation compatibility |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.search.star_tree_index.enabled` | Enable/disable star-tree search per index | `true` |
+
+### Usage Example
+
+```json
+// Nested aggregation with date range filter
+POST /logs/_search
+{
+  "size": 0,
+  "query": {
+    "range": {
+      "@timestamp": {
+        "gte": "2025-01-01",
+        "lt": "2025-02-01"
+      }
+    }
+  },
+  "aggs": {
+    "by_status": {
+      "terms": { "field": "status" },
+      "aggs": {
+        "by_method": {
+          "terms": { "field": "method" },
+          "aggs": {
+            "avg_latency": { "avg": { "field": "latency" } }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+```json
+// Disable star-tree search for specific index
+PUT /my-index/_settings
+{
+  "index.search.star_tree_index.enabled": false
+}
+```
+
+### Migration Notes
+
+- **No action required**: Star-tree indexes created in v3.0.0 continue to work
+- **Feature flag removal**: Remove any JVM options setting `opensearch.experimental.feature.composite_index.star_tree.enabled`
+- **Per-index control**: Use `index.search.star_tree_index.enabled` to disable star-tree search on specific indexes if needed
+
+## Limitations
+
+- Date range queries use half-open intervals `[gte, lt)` aligned to calendar intervals
+- Nested aggregations limited to 3-4 levels (BUCKET → BUCKET → BUCKET → METRIC)
+- Updates and deletions still not supported (append-only requirement remains)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17855](https://github.com/opensearch-project/OpenSearch/pull/17855) | Support date range queries in star-tree aggregations |
+| [#18048](https://github.com/opensearch-project/OpenSearch/pull/18048) | Support nested bucket aggregations (terms, date histogram, range) |
+| [#18070](https://github.com/opensearch-project/OpenSearch/pull/18070) | Remove feature flag, add index-level star-tree search setting |
+
+## References
+
+- [Issue #17443](https://github.com/opensearch-project/OpenSearch/issues/17443): Date range query support request
+- [Issue #17274](https://github.com/opensearch-project/OpenSearch/issues/17274): Nested bucket aggregations request
+- [Documentation](https://docs.opensearch.org/3.1/search-plugins/star-tree-index/): Official star-tree index documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/star-tree-index.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -14,3 +14,4 @@
 - [Plugin Installation](features/opensearch/plugin-installation.md) - Fix native plugin installation error caused by PGP public key change
 - [Query Bug Fixes](features/opensearch/query-bug-fixes.md) - Fixes for exists query, error handling, field validation, and IP field terms query
 - [Snapshot/Repository Fixes](features/opensearch/repository-fixes.md) - Fix infinite loop during concurrent snapshot/repository update and NPE for legacy snapshots
+- [Star-Tree Index Enhancements](features/opensearch/star-tree-index.md) - Production-ready status, date range queries, nested aggregations, index-level control


### PR DESCRIPTION
## Summary

Add release report and update feature report for Star-Tree Index enhancements in OpenSearch v3.1.0.

## Key Changes in v3.1.0

- **Production-ready status**: Removed experimental feature flag `opensearch.experimental.feature.composite_index.star_tree.enabled`
- **Index-level control**: New `index.search.star_tree_index.enabled` setting for per-index star-tree search control
- **Date range query support**: Star-tree aggregations now support date range queries with half-open intervals
- **Nested bucket aggregations**: Support for nested bucket aggregations (terms, date histogram, range) up to 3-4 levels

## Related PRs

- [#17855](https://github.com/opensearch-project/OpenSearch/pull/17855): Date range query support
- [#18048](https://github.com/opensearch-project/OpenSearch/pull/18048): Nested bucket aggregations
- [#18070](https://github.com/opensearch-project/OpenSearch/pull/18070): Feature flag removal, index-level setting

## Files Changed

- `docs/releases/v3.1.0/features/opensearch/star-tree-index.md` (new)
- `docs/features/opensearch/star-tree-index.md` (updated)
- `docs/releases/v3.1.0/index.md` (updated)

Closes #919