### PR TITLE
docs: add cluster-manager-metrics report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -18,6 +18,7 @@
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
 - [Bulk API](opensearch/bulk-api.md)
 - [Cluster Stats API](opensearch/cluster-stats-api.md)
+- [Cluster Manager Metrics](opensearch/cluster-manager-metrics.md)
 - [Code Cleanup](opensearch/code-cleanup.md)
 - [Deprecated Code Cleanup](opensearch/deprecated-code-cleanup.md)
 - [DocRequest Refactoring](opensearch/docrequest-refactoring.md)

--- a/docs/features/opensearch/cluster-manager-metrics.md
+++ b/docs/features/opensearch/cluster-manager-metrics.md
@@ -1,0 +1,177 @@
+# Cluster Manager Metrics
+
+## Summary
+
+Cluster Manager Metrics provide observability into the cluster manager node's operations, including task execution latency, node departure events, and filesystem health. These metrics help operators identify performance bottlenecks, diagnose cluster instability, and monitor the health of the cluster manager.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Cluster Manager Node"
+        subgraph "Task Management"
+            PTE[PrioritizedOpenSearchThreadPoolExecutor]
+            CMS[ClusterManagerService]
+            PT[Pending Tasks Queue]
+        end
+        
+        subgraph "Coordination"
+            COORD[Coordinator]
+            FC[FollowersChecker]
+        end
+        
+        subgraph "Health Monitoring"
+            FSH[FsHealthService]
+        end
+    end
+    
+    subgraph "Metrics Framework"
+        MR[MetricsRegistry]
+        CMM[ClusterManagerMetrics]
+    end
+    
+    subgraph "Metrics Output"
+        TIE[time_in_execution]
+        NLC[node.left.count]
+        FSC[fsHealth.failure.count]
+    end
+    
+    PTE --> TIE
+    CMS --> PT
+    COORD --> CMM
+    FC --> CMM
+    CMM --> NLC
+    FSH --> MR
+    MR --> FSC
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Task Execution Metrics"
+        T1[Task Submitted] --> T2[beforeExecute: Record Start Time]
+        T2 --> T3[Task Executing]
+        T3 --> T4[getPending: Calculate Execution Time]
+        T4 --> T5[afterExecute: Cleanup Metrics]
+    end
+    
+    subgraph "Node Left Metrics"
+        N1[Node Failure Detected] --> N2[Determine Reason]
+        N2 --> N3[Increment Counter with Tags]
+    end
+    
+    subgraph "FS Health Metrics"
+        F1[Health Check Runs] --> F2{Status?}
+        F2 -->|UNHEALTHY| F3[Increment Counter]
+        F2 -->|HEALTHY| F4[No Action]
+    end
+```
+
+### Components
+
+| Component | Class | Description |
+|-----------|-------|-------------|
+| Task Metrics Tracker | `TaskMetrics` | Inner class in `PrioritizedOpenSearchThreadPoolExecutor` that tracks task start time |
+| Pending Task | `PendingClusterTask` | Extended to include `timeInExecution` field |
+| Pending Tasks Response | `PendingClusterTasksResponse` | Extended to serialize execution time in API response |
+| Cluster Manager Metrics | `ClusterManagerMetrics` | Central metrics class with `nodeLeftCounter` |
+| Coordinator | `Coordinator` | Emits node-left metrics when removing nodes |
+| FS Health Service | `FsHealthService` | Emits filesystem health failure metrics |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `monitor.fs.health.enabled` | Enable filesystem health monitoring | `true` |
+| `monitor.fs.health.refresh_interval` | Interval between health checks | `30s` |
+| `monitor.fs.health.slow_path_logging_threshold` | Threshold for slow path logging | `5s` |
+
+### Metrics Reference
+
+#### time_in_execution (API Field)
+
+Available in `/_cluster/pending_tasks` response:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `time_in_execution_millis` | Long | Milliseconds the task has been executing |
+| `time_in_execution` | String | Human-readable duration (e.g., "19.7s") |
+
+#### node.left.count (Counter)
+
+Incremented when a node leaves the cluster:
+
+| Tag | Description |
+|-----|-------------|
+| `follower_node_id` | The ID of the node that left |
+| `reason` | Reason for departure |
+
+Reason values:
+- `disconnected`: Node connection was lost
+- `lagging`: Node fell behind in cluster state updates
+- `follower.check.fail`: Follower check retry count exceeded
+- `health.check.fail`: Node health check failed
+
+#### fsHealth.failure.count (Counter)
+
+Incremented when filesystem health check fails. No tags.
+
+### Usage Example
+
+#### Query Pending Tasks with Execution Time
+
+```bash
+curl -X GET "localhost:9200/_cluster/pending_tasks?pretty"
+```
+
+```json
+{
+  "tasks": [
+    {
+      "insert_order": 1,
+      "priority": "URGENT",
+      "source": "create-index [test], cause [api]",
+      "executing": true,
+      "time_in_queue_millis": 5000,
+      "time_in_queue": "5s",
+      "time_in_execution_millis": 4500,
+      "time_in_execution": "4.5s"
+    }
+  ]
+}
+```
+
+#### Interpreting Metrics
+
+- High `time_in_execution` values indicate slow cluster state updates
+- Frequent `node.left.count` increments suggest cluster instability
+- `fsHealth.failure.count` increments indicate storage issues
+
+## Limitations
+
+- Task execution time is only tracked for tasks currently in the executor
+- Node-left metrics require the metrics framework to be enabled
+- FS health metrics depend on health monitoring being enabled
+- Metrics are node-local and need aggregation for cluster-wide view
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#17780](https://github.com/opensearch-project/OpenSearch/pull/17780) | Added time_in_execution to pending tasks API |
+| v3.1.0 | [#18421](https://github.com/opensearch-project/OpenSearch/pull/18421) | Added node-left metric with reason tags |
+| v3.1.0 | [#18435](https://github.com/opensearch-project/OpenSearch/pull/18435) | Added FS health check failure metric |
+
+## References
+
+- [Issue #11818](https://github.com/opensearch-project/OpenSearch/issues/11818): Original feature request for task execution latency
+- [CAT Pending Tasks API](https://docs.opensearch.org/3.0/api-reference/cat/cat-pending-tasks/): API documentation
+- [Metrics Reference](https://docs.opensearch.org/3.0/monitoring-your-cluster/pa/reference/): Performance Analyzer metrics
+- [Cluster Manager Task Throttling](https://docs.opensearch.org/3.0/tuning-your-cluster/cluster-manager-task-throttling/): Related cluster manager documentation
+
+## Change History
+
+- **v3.1.0** (2025-06): Initial implementation with three metrics: task execution time, node-left counter, and FS health failure counter

--- a/docs/releases/v3.1.0/features/opensearch/cluster-manager-metrics.md
+++ b/docs/releases/v3.1.0/features/opensearch/cluster-manager-metrics.md
@@ -1,0 +1,140 @@
+# Cluster Manager Metrics
+
+## Summary
+
+OpenSearch v3.1.0 introduces three new metrics for cluster manager monitoring: task execution time in the pending tasks API, node-left counter with detailed reason tags, and filesystem health check failure counter. These metrics provide better visibility into cluster manager operations and help diagnose cluster stability issues.
+
+## Details
+
+### What's New in v3.1.0
+
+This release adds three distinct metrics to improve cluster manager observability:
+
+1. **Task Execution Time** (`time_in_execution`): Shows how long a pending task has been executing
+2. **Node Left Counter** (`node.left.count`): Tracks when nodes leave the cluster with reason tags
+3. **FS Health Check Failure Counter** (`fsHealth.failure.count`): Counts filesystem health check failures
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Cluster Manager"
+        PT[Pending Tasks API]
+        CM[ClusterManagerMetrics]
+        FS[FsHealthService]
+    end
+    
+    subgraph "Metrics"
+        TIE[time_in_execution]
+        NLC[node.left.count]
+        FSC[fsHealth.failure.count]
+    end
+    
+    PT --> TIE
+    CM --> NLC
+    FS --> FSC
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `TaskMetrics` | Tracks task execution start time in `PrioritizedOpenSearchThreadPoolExecutor` |
+| `nodeLeftCounter` | Counter in `ClusterManagerMetrics` for node departure events |
+| `fsHealthFailCounter` | Counter in `FsHealthService` for health check failures |
+
+#### New API Response Fields
+
+The `/_cluster/pending_tasks` API response now includes execution time:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `time_in_execution_millis` | Long | Execution time in milliseconds (0 if not executing) |
+| `time_in_execution` | String | Human-readable execution time |
+
+#### New Metrics Tags
+
+The `node.left.count` metric includes tags for detailed tracking:
+
+| Tag | Description | Values |
+|-----|-------------|--------|
+| `follower_node_id` | ID of the node that left | Node ID string |
+| `reason` | Reason for node departure | `disconnected`, `lagging`, `follower.check.fail`, `health.check.fail` |
+
+### Usage Example
+
+#### Pending Tasks with Execution Time
+
+```bash
+GET /_cluster/pending_tasks?pretty
+```
+
+Response:
+```json
+{
+  "tasks": [
+    {
+      "insert_order": 5,
+      "priority": "URGENT",
+      "source": "create-index [my_new_index], cause [api]",
+      "executing": true,
+      "time_in_queue_millis": 19703,
+      "time_in_queue": "19.7s",
+      "time_in_execution_millis": 19701,
+      "time_in_execution": "19.7s"
+    },
+    {
+      "insert_order": 6,
+      "priority": "URGENT",
+      "source": "create-index [my_new_index_2], cause [api]",
+      "executing": false,
+      "time_in_queue_millis": 8999,
+      "time_in_queue": "8.9s",
+      "time_in_execution_millis": 0,
+      "time_in_execution": "0s"
+    }
+  ]
+}
+```
+
+#### Monitoring Node Left Events
+
+The `node.left.count` metric can be monitored through the metrics framework with tags:
+- `follower_node_id`: Identifies which node left
+- `reason`: Explains why the node was removed (disconnected, lagging, follower check failure, health check failure)
+
+#### Monitoring FS Health Failures
+
+The `fsHealth.failure.count` metric increments each time a filesystem health check fails, helping identify storage issues affecting cluster stability.
+
+### Migration Notes
+
+- The new `time_in_execution` fields are automatically available in the pending tasks API
+- Metrics are available through the OpenSearch metrics framework
+- No configuration changes required to enable these metrics
+
+## Limitations
+
+- `time_in_execution` is only meaningful for tasks with `executing: true`
+- Node left metrics require the metrics framework to be enabled
+- FS health check metrics are only emitted when health checks are enabled
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17780](https://github.com/opensearch-project/OpenSearch/pull/17780) | Added time_in_execution attribute to /_cluster/pending_tasks response |
+| [#18421](https://github.com/opensearch-project/OpenSearch/pull/18421) | Added node-left metric to cluster manager |
+| [#18435](https://github.com/opensearch-project/OpenSearch/pull/18435) | Added FS Health Check Failure metric |
+
+## References
+
+- [Issue #11818](https://github.com/opensearch-project/OpenSearch/issues/11818): Feature request for latency metrics of task execution
+- [CAT Pending Tasks API](https://docs.opensearch.org/3.0/api-reference/cat/cat-pending-tasks/): API documentation
+- [Metrics Reference](https://docs.opensearch.org/3.0/monitoring-your-cluster/pa/reference/): Performance Analyzer metrics
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/cluster-manager-metrics.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -15,3 +15,4 @@
 - [Query Bug Fixes](features/opensearch/query-bug-fixes.md) - Fixes for exists query, error handling, field validation, and IP field terms query
 - [Snapshot/Repository Fixes](features/opensearch/repository-fixes.md) - Fix infinite loop during concurrent snapshot/repository update and NPE for legacy snapshots
 - [Star-Tree Index Enhancements](features/opensearch/star-tree-index.md) - Production-ready status, date range queries, nested aggregations, index-level control
+- [Cluster Manager Metrics](features/opensearch/cluster-manager-metrics.md) - Task execution time, node-left counter, and FS health failure metrics


### PR DESCRIPTION
## Summary

This PR adds documentation for the Cluster Manager Metrics feature in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/opensearch/cluster-manager-metrics.md`
- Feature report: `docs/features/opensearch/cluster-manager-metrics.md`

### Key Changes in v3.1.0
- **Task Execution Time** (`time_in_execution`): New fields in `/_cluster/pending_tasks` API showing how long tasks have been executing
- **Node Left Counter** (`node.left.count`): Metric tracking node departures with reason tags (disconnected, lagging, follower.check.fail, health.check.fail)
- **FS Health Check Failure Counter** (`fsHealth.failure.count`): Metric counting filesystem health check failures

### Related PRs
- [#17780](https://github.com/opensearch-project/OpenSearch/pull/17780): Added time_in_execution attribute
- [#18421](https://github.com/opensearch-project/OpenSearch/pull/18421): Added node-left metric
- [#18435](https://github.com/opensearch-project/OpenSearch/pull/18435): Added FS Health Check Failure metric

Closes #918