### PR TITLE
docs: add File Cache report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -23,6 +23,7 @@
 - [Deprecated Code Cleanup](opensearch/deprecated-code-cleanup.md)
 - [DocRequest Refactoring](opensearch/docrequest-refactoring.md)
 - [Dynamic Settings](opensearch/dynamic-settings.md)
+- [File Cache](opensearch/file-cache.md)
 - [Cluster Permissions](opensearch/cluster-permissions.md)
 - [Flat Object Field](opensearch/flat-object-field.md)
 - [gRPC Transport & Services](opensearch/grpc-transport--services.md)

--- a/docs/features/opensearch/file-cache.md
+++ b/docs/features/opensearch/file-cache.md
@@ -1,0 +1,202 @@
+# File Cache
+
+## Summary
+
+File Cache is a local caching layer in OpenSearch that stores file data from remote storage to improve read performance. It is used by both Searchable Snapshots (for warm/search nodes) and Writable Warm indices (via Composite Directory). The cache uses an LRU eviction policy with reference counting to manage memory efficiently, and supports file pinning to prevent critical files from being evicted.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "File Cache System"
+        FC[FileCache]
+        SC[SegmentedCache]
+        LRU1[LRUCache Segment 1]
+        LRU2[LRUCache Segment 2]
+        LRUN[LRUCache Segment N]
+    end
+    
+    subgraph "Consumers"
+        SS[Searchable Snapshots]
+        CD[Composite Directory]
+        TM[Transfer Manager]
+    end
+    
+    subgraph "Statistics"
+        AFS[AggregateFileCacheStats]
+        OAS[Overall Stats]
+        FFS[Full File Stats]
+        BFS[Block File Stats]
+        PFS[Pinned File Stats]
+    end
+    
+    SS --> FC
+    CD --> FC
+    TM --> FC
+    
+    FC --> SC
+    SC --> LRU1
+    SC --> LRU2
+    SC --> LRUN
+    
+    FC --> AFS
+    AFS --> OAS
+    AFS --> FFS
+    AFS --> BFS
+    AFS --> PFS
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Cache Operations"
+        PUT[put - Add to cache]
+        GET[get - Retrieve from cache]
+        PIN[pin - Prevent eviction]
+        UNPIN[unpin - Allow eviction]
+        INCREF[incRef - Increase reference]
+        DECREF[decRef - Decrease reference]
+    end
+    
+    subgraph "Eviction Logic"
+        CHECK{refCount == 0 AND not pinned?}
+        EVICT[Add to LRU eviction list]
+        PROTECT[Protected from eviction]
+    end
+    
+    PUT --> INCREF
+    GET --> INCREF
+    DECREF --> CHECK
+    UNPIN --> CHECK
+    CHECK -->|Yes| EVICT
+    CHECK -->|No| PROTECT
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `FileCache` | Main entry point for file caching operations |
+| `SegmentedCache` | Divides cache into segments for concurrent access |
+| `LRUCache` | LRU implementation with reference counting and pinning support |
+| `RefCountedCache` | Interface defining cache operations with reference counting |
+| `CachedFullFileIndexInput` | Cached representation of a full file |
+| `FileCachedIndexInput` | Cached representation of a block-based file |
+| `AggregateFileCacheStats` | Aggregated statistics across all cache types |
+| `FileCacheStats` | Statistics for a specific cache type |
+| `FileStatsCounter` | Tracks statistics separately for full files vs block files |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `node.search.cache.size` | Size of the file cache | 80% of available disk |
+| `cluster.filecache.remote_data_ratio` | Ratio of remote data to file cache size for allocation decisions | 5 |
+
+### Usage Example
+
+**Configuring a warm node with file cache:**
+
+```yaml
+# opensearch.yml
+node.roles: [warm]
+node.search.cache.size: 100gb
+```
+
+**Accessing file cache statistics via Node Stats API:**
+
+```bash
+GET _nodes/stats/file_cache
+```
+
+Response:
+```json
+{
+  "nodes": {
+    "node_id": {
+      "aggregate_file_cache": {
+        "timestamp": 1704067200000,
+        "active": "50gb",
+        "active_in_bytes": 53687091200,
+        "total": "100gb",
+        "total_in_bytes": 107374182400,
+        "used": "75gb",
+        "used_in_bytes": 80530636800,
+        "pinned": "10gb",
+        "pinned_in_bytes": 10737418240,
+        "evictions": "25gb",
+        "evictions_in_bytes": 26843545600,
+        "active_percent": 67,
+        "used_percent": 75,
+        "hit_count": 50000,
+        "miss_count": 5000,
+        "over_all_stats": {
+          "active": "50gb",
+          "used": "75gb",
+          "evictions": "25gb",
+          "active_percent": 67,
+          "hit_count": 50000
+        },
+        "full_file_stats": {
+          "active": "20gb",
+          "used": "30gb",
+          "evictions": "5gb",
+          "active_percent": 67,
+          "hit_count": 20000
+        },
+        "block_file_stats": {
+          "active": "30gb",
+          "used": "45gb",
+          "evictions": "20gb",
+          "active_percent": 67,
+          "hit_count": 30000
+        },
+        "pinned_file_stats": {
+          "active": "10gb",
+          "used": "10gb",
+          "evictions": "0b",
+          "active_percent": 100,
+          "hit_count": 5000
+        }
+      }
+    }
+  }
+}
+```
+
+**Clearing file cache:**
+
+```bash
+POST /my-index/_cache/clear?file=true
+```
+
+## Limitations
+
+- File cache is only available on nodes with warm or search roles
+- Cache capacity is a soft limit; reference-counted and pinned entries may cause temporary over-subscription
+- Block-based caching loads 8MB chunks, which may not be optimal for all access patterns
+- Pinned files cannot be evicted even under memory pressure
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#17617](https://github.com/opensearch-project/OpenSearch/pull/17617) | Added File Cache Pinning |
+| v3.1.0 | [#17538](https://github.com/opensearch-project/OpenSearch/pull/17538) | Added File Cache Stats (block and full file level) |
+| v2.7.0 | Initial | File Cache introduced for Searchable Snapshots |
+
+## References
+
+- [Issue #17479](https://github.com/opensearch-project/OpenSearch/issues/17479): More refined stats in FileCache
+- [Issue #13648](https://github.com/opensearch-project/OpenSearch/issues/13648): File Pinning support in FileCache
+- [Issue #13149](https://github.com/opensearch-project/OpenSearch/issues/13149): META - Writable Warm Index
+- [Searchable Snapshots Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot/)
+- [Clear Cache API](https://docs.opensearch.org/3.0/api-reference/index-apis/clear-index-cache/)
+
+## Change History
+
+- **v3.1.0** (2025-05-28): Added file pinning support and granular statistics (full file, block file, pinned file stats)
+- **v2.7.0**: Initial implementation for Searchable Snapshots

--- a/docs/releases/v3.1.0/features/opensearch/file-cache.md
+++ b/docs/releases/v3.1.0/features/opensearch/file-cache.md
@@ -1,0 +1,176 @@
+# File Cache
+
+## Summary
+
+OpenSearch v3.1.0 introduces significant enhancements to the File Cache system, adding file pinning support and more granular statistics. These improvements enable better control over cache eviction behavior and provide deeper visibility into cache performance for both Writable Warm indices and Remote Snapshots.
+
+## Details
+
+### What's New in v3.1.0
+
+This release adds two major capabilities to the File Cache:
+
+1. **File Cache Pinning**: Ability to pin files in the cache to prevent eviction until explicitly unpinned
+2. **Enhanced File Cache Statistics**: Granular statistics broken down by file type (full file vs block) and pinning status
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph FileCache
+        FC[FileCache]
+        SC[SegmentedCache]
+        LRU[LRUCache]
+    end
+    
+    subgraph Stats
+        AFS[AggregateFileCacheStats]
+        FCS[FileCacheStats]
+        ARCS[AggregateRefCountedCacheStats]
+        RCS[RefCountedCacheStats]
+    end
+    
+    subgraph StatsCounters
+        FSC[FileStatsCounter]
+        DSC[DefaultStatsCounter]
+    end
+    
+    FC --> SC
+    SC --> LRU
+    LRU --> FSC
+    FSC --> DSC
+    
+    FC --> AFS
+    AFS --> FCS
+    SC --> ARCS
+    ARCS --> RCS
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `AggregateFileCacheStats` | Top-level statistics container aggregating overall, full-file, block-file, and pinned stats |
+| `FileCacheStats` | Statistics for a specific cache type (overall, full file, block, or pinned) |
+| `AggregateRefCountedCacheStats` | Internal cache statistics aggregating multiple `RefCountedCacheStats` |
+| `RefCountedCacheStats` | Detailed statistics including usage, active usage, pinned usage, hits, misses, evictions |
+| `FileStatsCounter` | Stats counter that tracks metrics separately for full files vs block files |
+| `FileCacheStatsType` | Enum defining stats types: `OVER_ALL_STATS`, `FULL_FILE_STATS`, `BLOCK_FILE_STATS`, `PINNED_FILE_STATS` |
+
+#### New APIs
+
+**File Cache Pinning Methods**:
+
+```java
+// Pin a file to prevent eviction
+fileCache.pin(Path key);
+
+// Unpin a file to allow eviction
+fileCache.unpin(Path key);
+
+// Get pinned usage
+fileCache.pinnedUsage();
+```
+
+**Enhanced Statistics**:
+
+```java
+// Get aggregate file cache stats
+AggregateFileCacheStats stats = fileCache.fileCacheStats();
+
+// Access different stat types
+stats.getUsed();           // Overall used bytes
+stats.getActive();         // Active (referenced) bytes
+stats.getPinnedUsage();    // Pinned bytes
+stats.getCacheHits();      // Hit count
+stats.getCacheMisses();    // Miss count
+```
+
+#### Statistics Response Structure
+
+The node stats API now returns enhanced file cache statistics:
+
+```json
+{
+  "aggregate_file_cache": {
+    "timestamp": 1234567890,
+    "active": "100mb",
+    "active_in_bytes": 104857600,
+    "total": "1gb",
+    "total_in_bytes": 1073741824,
+    "used": "500mb",
+    "used_in_bytes": 524288000,
+    "pinned": "50mb",
+    "pinned_in_bytes": 52428800,
+    "evictions": "200mb",
+    "evictions_in_bytes": 209715200,
+    "active_percent": 20,
+    "used_percent": 50,
+    "hit_count": 1000,
+    "miss_count": 100,
+    "over_all_stats": { ... },
+    "full_file_stats": { ... },
+    "block_file_stats": { ... },
+    "pinned_file_stats": { ... }
+  }
+}
+```
+
+### Usage Example
+
+File pinning is used internally by the Composite Directory for Writable Warm indices:
+
+```java
+// When caching a file for writable warm
+protected void cacheFile(String name) throws IOException {
+    Path filePath = getFilePath(name);
+    
+    // Add file to cache
+    fileCache.put(filePath, new CachedFullFileIndexInput(...));
+    
+    // Pin the file to prevent eviction until uploaded to remote
+    fileCache.pin(filePath);
+    
+    // Decrease ref count (file stays due to pinning)
+    fileCache.decRef(filePath);
+}
+
+// After file is uploaded to remote store
+public void afterSyncToRemote(String file) {
+    final Path filePath = getFilePath(file);
+    
+    // Unpin to allow eviction
+    fileCache.unpin(filePath);
+}
+```
+
+### Migration Notes
+
+- The `FileCacheStats` class has been refactored and is now part of `AggregateFileCacheStats`
+- The `CacheUsage` class has been removed; use `usage()` and `activeUsage()` methods directly
+- Node stats API response structure for file cache has changed to include nested statistics
+
+## Limitations
+
+- File pinning is currently used internally by Composite Directory; no public API for manual pinning
+- Pinned files count against cache capacity but cannot be evicted, which may impact cache efficiency if many files are pinned
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17538](https://github.com/opensearch-project/OpenSearch/pull/17538) | Added File Cache Stats - Block level and full file level stats |
+| [#17617](https://github.com/opensearch-project/OpenSearch/pull/17617) | Added File Cache Pinning support |
+
+## References
+
+- [Issue #17479](https://github.com/opensearch-project/OpenSearch/issues/17479): More refined stats in FileCache
+- [Issue #13648](https://github.com/opensearch-project/OpenSearch/issues/13648): File Pinning support in FileCache
+- [Issue #13149](https://github.com/opensearch-project/OpenSearch/issues/13149): META - Writable Warm Index
+- [Searchable Snapshots Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/file-cache.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -7,6 +7,7 @@
 - [Approximation Framework](features/opensearch/approximation-framework.md) - BKD traversal optimization for skewed datasets with DFS strategy
 - [Dependency Bumps](features/opensearch/dependency-bumps.md) - 21 dependency updates including CVE-2025-27820 fix, Netty, Gson, Azure SDK updates
 - [DocRequest Refactoring](features/opensearch/docrequest-refactoring.md) - Generic interface for single-document operations
+- [File Cache](features/opensearch/file-cache.md) - File pinning support and granular statistics for Writable Warm indices
 - [FIPS Support](features/opensearch/fips-support.md) - Update FipsMode check for improved BC-FIPS compatibility
 - [Lucene Upgrade](features/opensearch/lucene-upgrade.md) - Upgrade Apache Lucene from 10.1.0 to 10.2.1
 - [Network Configuration](features/opensearch/network-configuration.md) - Fix systemd seccomp filter for network.host: 0.0.0.0


### PR DESCRIPTION
## Summary

This PR adds documentation for the File Cache feature enhancements in OpenSearch v3.1.0.

### Changes in v3.1.0

1. **File Cache Pinning** ([#17617](https://github.com/opensearch-project/OpenSearch/pull/17617))
   - Ability to pin files in the cache to prevent eviction
   - Used by Composite Directory for Writable Warm indices

2. **Enhanced File Cache Statistics** ([#17538](https://github.com/opensearch-project/OpenSearch/pull/17538))
   - Granular statistics broken down by file type (full file vs block)
   - New `AggregateFileCacheStats` with overall, full file, block file, and pinned stats
   - Exposed via Node Stats API

### Reports Created

- Release report: `docs/releases/v3.1.0/features/opensearch/file-cache.md`
- Feature report: `docs/features/opensearch/file-cache.md`

### Related Issues

- Resolves investigation for GitHub Issue #917