### PR TITLE
docs: add unified-highlighter report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -79,6 +79,7 @@
 - [Thread Context Permissions](opensearch/thread-context-permissions.md)
 - [Tiered Caching](opensearch/tiered-caching.md)
 - [Transport Nodes Action Optimization](opensearch/transport-nodes-action-optimization.md)
+- [Unified Highlighter](opensearch/unified-highlighter.md)
 - [Wildcard Field](opensearch/wildcard-field.md)
 - [Workload Management](opensearch/workload-management.md)
 

--- a/docs/features/opensearch/unified-highlighter.md
+++ b/docs/features/opensearch/unified-highlighter.md
@@ -1,0 +1,153 @@
+# Unified Highlighter
+
+## Summary
+
+The unified highlighter is the default highlighter in OpenSearch, based on the Lucene Unified Highlighter. It provides flexible text highlighting by dividing text into sentences and scoring them using the BM25 algorithm. The unified highlighter supports exact phrase and multi-term highlighting, including fuzzy, prefix, and regex queries. Starting from v3.1.0, it also supports the `matched_fields` option to combine matches from multiple fields into a single highlighted snippet.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Search Request"
+        Query[Search Query]
+        HL[Highlight Request]
+    end
+    
+    subgraph "Unified Highlighter"
+        UH[CustomUnifiedHighlighter]
+        Builder[UnifiedHighlighter.Builder]
+        CFH[CustomFieldHighlighter]
+    end
+    
+    subgraph "Offset Sources"
+        Postings[Postings]
+        TV[Term Vectors]
+        Analysis[Text Reanalysis]
+    end
+    
+    subgraph "Output"
+        Snippet[Highlighted Snippets]
+    end
+    
+    Query --> UH
+    HL --> Builder
+    Builder --> UH
+    UH --> CFH
+    CFH --> Postings
+    CFH --> TV
+    CFH --> Analysis
+    Postings --> Snippet
+    TV --> Snippet
+    Analysis --> Snippet
+```
+
+### Offset Source Selection
+
+The unified highlighter automatically selects the best offset source based on field configuration:
+
+| Configuration | Offset Source |
+|---------------|---------------|
+| `term_vector: with_positions_offsets` | Term vectors |
+| `index_options: offsets` | Postings |
+| Default | Text reanalysis |
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `CustomUnifiedHighlighter` | OpenSearch's extension of Lucene's UnifiedHighlighter with custom break iterator and no-match handling |
+| `CustomFieldHighlighter` | Handles per-field highlighting with locale-aware break iteration |
+| `CustomPassageFormatter` | Formats highlighted passages with configurable pre/post tags |
+| `UnifiedHighlighter.Builder` | Configures highlighter with field matcher and masked fields function |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `type` | Highlighter type | `unified` |
+| `fragment_size` | Size of highlighted fragment in characters | 100 |
+| `number_of_fragments` | Maximum number of fragments to return | 5 |
+| `pre_tags` | HTML tags before highlighted terms | `["<em>"]` |
+| `post_tags` | HTML tags after highlighted terms | `["</em>"]` |
+| `matched_fields` | Additional fields to blend matches from (v3.1.0+) | None |
+| `require_field_match` | Only highlight fields that match the query | `true` |
+| `boundary_scanner` | How to split fragments (`sentence`, `word`) | `sentence` |
+| `boundary_scanner_locale` | Locale for boundary scanner | `Locale.ROOT` |
+| `no_match_size` | Characters to return if no match found | 0 |
+
+### Usage Example
+
+Basic highlighting:
+
+```json
+GET my-index/_search
+{
+  "query": {
+    "match": {
+      "content": "OpenSearch highlighting"
+    }
+  },
+  "highlight": {
+    "type": "unified",
+    "fields": {
+      "content": {
+        "fragment_size": 150,
+        "number_of_fragments": 3
+      }
+    }
+  }
+}
+```
+
+Using `matched_fields` (v3.1.0+):
+
+```json
+GET my-index/_search
+{
+  "query": {
+    "multi_match": {
+      "query": "running",
+      "fields": ["content", "content.english"]
+    }
+  },
+  "highlight": {
+    "type": "unified",
+    "fields": {
+      "content": {
+        "matched_fields": ["content.english"]
+      }
+    }
+  }
+}
+```
+
+### Best Practices
+
+1. **For large fields**: Use `index_options: offsets` to avoid reanalysis overhead
+2. **For multi-field matching**: Use `matched_fields` to blend matches from different analyzers
+3. **For sentence-level highlighting**: Set `fragment_size: 0` to return whole sentences
+4. **For performance**: Consider using postings over term vectors to reduce index size
+
+## Limitations
+
+- Does not support span queries
+- Text reanalysis can be slow for very large fields
+- `matched_fields` requires all fields to have compatible content
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#18166](https://github.com/opensearch-project/OpenSearch/pull/18166) | Add support for matched_fields with the unified highlighter |
+
+## References
+
+- [Issue #18164](https://github.com/opensearch-project/OpenSearch/issues/18164): Feature request for matched_fields support
+- [Highlight Query Matches](https://docs.opensearch.org/3.0/search-plugins/searching-data/highlight/): Official highlighting documentation
+- [Documentation PR #9793](https://github.com/opensearch-project/documentation-website/pull/9793): Documentation for matched_fields support
+
+## Change History
+
+- **v3.1.0** (2025-05-19): Added `matched_fields` support using Lucene 10's `withMaskedFieldsFunc` API

--- a/docs/releases/v3.1.0/features/opensearch/unified-highlighter.md
+++ b/docs/releases/v3.1.0/features/opensearch/unified-highlighter.md
@@ -1,0 +1,170 @@
+# Unified Highlighter: matched_fields Support
+
+## Summary
+
+OpenSearch 3.1.0 adds support for the `matched_fields` option in the unified highlighter. Previously, this option was silently ignored when using the unified highlighter and only worked with the Fast Vector Highlighter (FVH). This enhancement allows users to combine matches from multiple fields (such as multi-fields with different analyzers) into a single highlighted snippet without requiring term vectors.
+
+## Details
+
+### What's New in v3.1.0
+
+The `matched_fields` option enables blending matches from multiple fields into a single highlighted result. This is particularly useful when a field is analyzed differently using sub-fields (multi-fields). For example, you might have a main field analyzed with a stemming analyzer and a sub-field with a standard analyzer to capture exact matches.
+
+Before this change, achieving this functionality required using the FVH highlighter with term vectors stored (`term_vector: with_positions_offsets`), which significantly increases index size. Now, the unified highlighter supports this feature natively using Lucene 10's `withMaskedFieldsFunc` API.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Search Request"
+        Q[Query] --> UH[Unified Highlighter]
+        MF[matched_fields option] --> UH
+    end
+    
+    subgraph "Lucene 10 Integration"
+        UH --> Builder[UnifiedHighlighter.Builder]
+        Builder --> |withMaskedFieldsFunc| MaskedFields[Masked Fields Function]
+        Builder --> |withFieldMatcher| FM[Field Matcher]
+    end
+    
+    subgraph "Highlighting"
+        MaskedFields --> Blend[Blend Matches]
+        FM --> Blend
+        Blend --> Snippet[Highlighted Snippet]
+    end
+```
+
+#### Key Implementation Changes
+
+| Component | Change |
+|-----------|--------|
+| `CustomUnifiedHighlighter` | Refactored to use `UnifiedHighlighter.Builder` pattern instead of direct constructor |
+| `CustomFieldHighlighter` | Updated to accept `passageSortComparator` parameter |
+| `UnifiedHighlighter` (OpenSearch) | Added `newBuilder()` method to configure `maskedFieldsFunc` and `fieldMatcher` |
+
+#### API Usage
+
+The `matched_fields` option can now be used with the unified highlighter:
+
+```json
+GET my-index/_search
+{
+  "query": {
+    "multi_match": {
+      "query": "running scissors",
+      "fields": ["content", "content.english"]
+    }
+  },
+  "highlight": {
+    "type": "unified",
+    "fields": {
+      "content": {
+        "matched_fields": ["content.english"]
+      }
+    }
+  }
+}
+```
+
+### Usage Example
+
+Consider an index with a text field analyzed differently:
+
+```json
+PUT my-index
+{
+  "mappings": {
+    "properties": {
+      "content": {
+        "type": "text",
+        "analyzer": "standard",
+        "fields": {
+          "english": {
+            "type": "text",
+            "analyzer": "english"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Index a document:
+
+```json
+POST my-index/_doc/1
+{
+  "content": "running with scissors is dangerous"
+}
+```
+
+Search with `matched_fields` to highlight matches from both analyzers:
+
+```json
+GET my-index/_search
+{
+  "query": {
+    "query_string": {
+      "query": "content.english:run scissors",
+      "fields": ["content"]
+    }
+  },
+  "highlight": {
+    "type": "unified",
+    "fields": {
+      "content": {
+        "matched_fields": ["content.english"]
+      }
+    }
+  }
+}
+```
+
+The response highlights both "running" (matched via stemming in `content.english`) and "scissors":
+
+```json
+{
+  "highlight": {
+    "content": ["<em>running</em> with <em>scissors</em> is dangerous"]
+  }
+}
+```
+
+### Migration Notes
+
+- No migration required for existing indices
+- If you were using FVH solely for `matched_fields` support, you can now switch to the unified highlighter
+- Switching to unified highlighter may reduce index size if term vectors were only stored for highlighting
+
+### Comparison with FVH
+
+| Aspect | Unified Highlighter | FVH |
+|--------|---------------------|-----|
+| `matched_fields` support | ✅ (v3.1.0+) | ✅ |
+| Requires term vectors | ❌ | ✅ |
+| Index size impact | Lower | Higher |
+| Performance | Good (uses postings/reanalysis) | Fast (uses term vectors) |
+
+## Limitations
+
+- The unified highlighter still does not support span queries (same as before)
+- Performance may vary compared to FVH depending on field size and offset source
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18166](https://github.com/opensearch-project/OpenSearch/pull/18166) | Add support for matched_fields with the unified highlighter |
+
+## References
+
+- [Issue #18164](https://github.com/opensearch-project/OpenSearch/issues/18164): Feature request for matched_fields support
+- [Documentation PR #9793](https://github.com/opensearch-project/documentation-website/pull/9793): Documentation update
+- [Highlight Query Matches](https://docs.opensearch.org/3.0/search-plugins/searching-data/highlight/): Official highlighting documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/unified-highlighter.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -19,3 +19,4 @@
 - [Star-Tree Index Enhancements](features/opensearch/star-tree-index.md) - Production-ready status, date range queries, nested aggregations, index-level control
 - [Cluster Manager Metrics](features/opensearch/cluster-manager-metrics.md) - Task execution time, node-left counter, and FS health failure metrics
 - [gRPC Transport](features/opensearch/grpc-transport.md) - Performance optimization with pass-by-reference pattern and package reorganization
+- [Unified Highlighter](features/opensearch/unified-highlighter.md) - Add matched_fields support for blending matches from multiple fields


### PR DESCRIPTION
## Summary

Add documentation for the Unified Highlighter `matched_fields` support introduced in OpenSearch v3.1.0.

## Changes

### Release Report
- `docs/releases/v3.1.0/features/opensearch/unified-highlighter.md`
  - Documents the new `matched_fields` support for the unified highlighter
  - Explains the technical implementation using Lucene 10's `withMaskedFieldsFunc` API
  - Provides usage examples and migration notes

### Feature Report
- `docs/features/opensearch/unified-highlighter.md`
  - Comprehensive documentation of the unified highlighter feature
  - Architecture diagram showing offset source selection
  - Configuration options and best practices

## Related Issue
Closes #914

## References
- [PR #18166](https://github.com/opensearch-project/OpenSearch/pull/18166): Implementation PR
- [Issue #18164](https://github.com/opensearch-project/OpenSearch/issues/18164): Feature request