### PR TITLE
docs: add crypto-kms-plugin report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -20,6 +20,7 @@
 - [Cluster Stats API](opensearch/cluster-stats-api.md)
 - [Cluster Manager Metrics](opensearch/cluster-manager-metrics.md)
 - [Code Cleanup](opensearch/code-cleanup.md)
+- [Crypto KMS Plugin](opensearch/crypto-kms-plugin.md)
 - [Deprecated Code Cleanup](opensearch/deprecated-code-cleanup.md)
 - [DocRequest Refactoring](opensearch/docrequest-refactoring.md)
 - [Dynamic Settings](opensearch/dynamic-settings.md)

--- a/docs/features/opensearch/crypto-kms-plugin.md
+++ b/docs/features/opensearch/crypto-kms-plugin.md
@@ -1,0 +1,107 @@
+# Crypto KMS Plugin
+
+## Summary
+
+The crypto-kms plugin provides AWS Key Management Service (KMS) integration for OpenSearch, enabling secure key management for encryption operations. It implements the `CryptoKeyProviderPlugin` interface to provide master key management through AWS KMS.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Node"
+        A[CryptoHandlerRegistry] --> B[CryptoKeyProviderPlugin]
+        B --> C[crypto-kms Plugin]
+        C --> D[KmsService]
+        D --> E[AWS KMS Client]
+    end
+    
+    subgraph "AWS"
+        E --> F[AWS KMS]
+        F --> G[Customer Master Key]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `CryptoHandlerRegistry` | Central registry for crypto plugins and key providers |
+| `CryptoKeyProviderPlugin` | Interface for key provider plugins |
+| `KmsService` | Service class that manages AWS KMS client lifecycle |
+| `SocketAccess` | Utility for privileged network operations |
+
+### Plugin Loading Flow
+
+```mermaid
+sequenceDiagram
+    participant OS as OpenSearch
+    participant CHR as CryptoHandlerRegistry
+    participant KMS as crypto-kms Plugin
+    participant AWS as AWS KMS
+    
+    OS->>CHR: Initialize with plugins
+    CHR->>CHR: Check CryptoPlugin (optional)
+    CHR->>CHR: Check CryptoKeyProviderPlugin
+    CHR->>KMS: Load crypto-kms plugin
+    KMS->>AWS: Build KMS client
+    AWS-->>KMS: Client ready
+    KMS-->>CHR: Plugin loaded
+    CHR-->>OS: Registry ready
+```
+
+### Configuration
+
+The crypto-kms plugin uses AWS credentials and region configuration:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| AWS credentials | Standard AWS credential chain | Environment/IAM role |
+| AWS region | KMS endpoint region | From environment |
+
+### Dependencies
+
+The plugin requires the following AWS SDK v2.x components:
+
+| Dependency | Purpose |
+|------------|---------|
+| `software.amazon.awssdk:kms` | KMS client |
+| `software.amazon.awssdk:auth` | AWS authentication |
+| `software.amazon.awssdk:http-auth-aws` | AWS v4 signature authentication |
+| `software.amazon.awssdk:http-auth` | HTTP authentication |
+| `software.amazon.awssdk:apache-client` | HTTP client |
+| `software.amazon.awssdk:checksums` | Checksum validation |
+| `software.amazon.awssdk:retries` | Retry logic |
+| `software.amazon.awssdk.crt:aws-crt` | AWS Common Runtime |
+
+### Usage Example
+
+Install the plugin:
+
+```bash
+bin/opensearch-plugin install crypto-kms
+```
+
+The plugin will automatically integrate with the CryptoHandlerRegistry when OpenSearch starts.
+
+## Limitations
+
+- Only one CryptoPlugin implementation is supported at a time
+- Requires proper AWS credentials configuration
+- Network access to AWS KMS endpoints required
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#18270](https://github.com/opensearch-project/OpenSearch/pull/18270) | Decouple CryptoPlugin and KeyProvider initialization |
+| v3.1.0 | [#18268](https://github.com/opensearch-project/OpenSearch/pull/18268) | Upgrade dependencies for AWS SDK v2.x |
+
+## References
+
+- [Issue #12472](https://github.com/opensearch-project/OpenSearch/issues/12472): Feature request to decouple CryptoPlugin and CryptoKeyProviderPlugin
+
+## Change History
+
+- **v3.1.0** (2026-01-10): Fixed plugin loading by decoupling CryptoPlugin and CryptoKeyProviderPlugin initialization; upgraded AWS SDK v2.x dependencies to fix NoClassDefFoundError

--- a/docs/releases/v3.1.0/features/opensearch/crypto-kms-plugin.md
+++ b/docs/releases/v3.1.0/features/opensearch/crypto-kms-plugin.md
@@ -1,0 +1,109 @@
+# Crypto/KMS Plugin
+
+## Summary
+
+OpenSearch v3.1.0 includes two important improvements to the crypto-kms plugin: decoupling the initialization of CryptoPlugin and CryptoKeyProviderPlugin in the CryptoHandlerRegistry, and upgrading dependencies to AWS SDK v2.x. These changes fix critical issues that prevented the crypto-kms plugin from loading on server startup.
+
+## Details
+
+### What's New in v3.1.0
+
+#### 1. Decoupled Plugin Initialization
+
+Previously, the `CryptoHandlerRegistry` required both a `CryptoPlugin` and a `CryptoKeyProviderPlugin` to be present for either to load. Since no `CryptoPlugin` implementation existed yet, the crypto-kms plugin (which is a `CryptoKeyProviderPlugin`) would fail to load even after successful installation.
+
+The fix modifies the `CryptoHandlerRegistry` constructor to allow independent loading of each plugin type:
+
+```java
+// Before: Early return if no CryptoPlugin present
+if (cryptoPlugins == null || cryptoPlugins.size() == 0) {
+    return;
+}
+
+// After: Independent initialization
+if (cryptoPlugins != null && !cryptoPlugins.isEmpty()) {
+    if (cryptoPlugins.size() > 1) {
+        throw new IllegalStateException("More than 1 implementation of crypto plugin found.");
+    }
+    cryptoHandlerPlugin.set(cryptoPlugins.get(0));
+}
+
+if (cryptoKeyProviderPlugins != null && !cryptoKeyProviderPlugins.isEmpty()) {
+    registry.set(loadCryptoFactories(cryptoKeyProviderPlugins));
+}
+```
+
+#### 2. AWS SDK v2.x Dependency Upgrade
+
+The crypto-kms plugin dependencies were updated to include missing AWS SDK v2.x components that caused `NoClassDefFoundError` during KMS client initialization:
+
+| New Dependency | Purpose |
+|----------------|---------|
+| `http-auth-aws` | AWS authentication scheme (AwsV4AuthScheme) |
+| `http-auth` | HTTP authentication support |
+| `checksums` | Checksum validation |
+| `checksums-spi` | Checksum SPI |
+| `retries` | Retry logic |
+| `aws-crt` | AWS Common Runtime |
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.1.0"
+        A1[CryptoHandlerRegistry] --> B1{CryptoPlugin exists?}
+        B1 -->|No| C1[Return - Nothing loaded]
+        B1 -->|Yes| D1[Load CryptoKeyProviderPlugin]
+    end
+    
+    subgraph "After v3.1.0"
+        A2[CryptoHandlerRegistry] --> B2{CryptoPlugin exists?}
+        B2 -->|Yes| C2[Load CryptoPlugin]
+        B2 -->|No| D2[Skip]
+        C2 --> E2{KeyProviderPlugin exists?}
+        D2 --> E2
+        E2 -->|Yes| F2[Load KeyProviderPlugin]
+        E2 -->|No| G2[Skip]
+    end
+```
+
+#### Modified Files
+
+| File | Change |
+|------|--------|
+| `server/src/main/java/org/opensearch/crypto/CryptoHandlerRegistry.java` | Decoupled plugin initialization logic |
+| `plugins/crypto-kms/build.gradle` | Added missing AWS SDK v2.x dependencies |
+
+### Error Fixed
+
+The following error no longer occurs when using the crypto-kms plugin:
+
+```
+java.lang.NoClassDefFoundError: software/amazon/awssdk/http/auth/aws/scheme/AwsV4AuthScheme
+    at software.amazon.awssdk.services.kms.DefaultKmsBaseClientBuilder.authSchemes
+    at org.opensearch.crypto.kms.KmsService.buildClient
+    at org.opensearch.crypto.kms.KmsService.createMasterKeyProvider
+```
+
+## Limitations
+
+- Only one `CryptoPlugin` implementation is supported at a time
+- The crypto-kms plugin still requires proper AWS credentials configuration
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18270](https://github.com/opensearch-project/OpenSearch/pull/18270) | Decouple the init of Crypto Plugin and KeyProvider in CryptoRegistry |
+| [#18268](https://github.com/opensearch-project/OpenSearch/pull/18268) | Upgrade crypto kms plugin dependencies for AWS SDK v2.x |
+
+## References
+
+- [Issue #12472](https://github.com/opensearch-project/OpenSearch/issues/12472): Original feature request to decouple CryptoPlugin and CryptoKeyProviderPlugin
+- [PR #17396](https://github.com/opensearch-project/OpenSearch/pull/17396): Previous AWS SDK v2.x migration (missing dependencies)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/crypto-kms-plugin.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -5,6 +5,7 @@
 ### OpenSearch
 
 - [Approximation Framework](features/opensearch/approximation-framework.md) - BKD traversal optimization for skewed datasets with DFS strategy
+- [Crypto/KMS Plugin](features/opensearch/crypto-kms-plugin.md) - Decoupled plugin initialization and AWS SDK v2.x dependency upgrade
 - [Dependency Bumps](features/opensearch/dependency-bumps.md) - 21 dependency updates including CVE-2025-27820 fix, Netty, Gson, Azure SDK updates
 - [DocRequest Refactoring](features/opensearch/docrequest-refactoring.md) - Generic interface for single-document operations
 - [File Cache](features/opensearch/file-cache.md) - File pinning support and granular statistics for Writable Warm indices


### PR DESCRIPTION
## Summary

Add documentation for Crypto/KMS Plugin improvements in OpenSearch v3.1.0.

### Changes in v3.1.0

1. **Decoupled Plugin Initialization** (PR #18270)
   - CryptoKeyProviderPlugin can now load independently without requiring a CryptoPlugin
   - Fixes issue where crypto-kms plugin failed to load on server startup

2. **AWS SDK v2.x Dependency Upgrade** (PR #18268)
   - Added missing AWS SDK v2.x dependencies (http-auth-aws, checksums, retries, aws-crt)
   - Fixes NoClassDefFoundError for AwsV4AuthScheme during KMS client initialization

### Reports Created
- Release report: `docs/releases/v3.1.0/features/opensearch/crypto-kms-plugin.md`
- Feature report: `docs/features/opensearch/crypto-kms-plugin.md`

### Related Issues
- Resolves investigation for GitHub Issue #913