### PR TITLE
docs: add plugin-testing-framework report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -60,6 +60,7 @@
 - [Percentiles Aggregation](opensearch/percentiles-aggregation.md)
 - [Phone Number Analyzer](opensearch/phone-analyzer.md)
 - [Plugin Installation](opensearch/plugin-installation.md)
+- [Plugin Testing Framework](opensearch/plugin-testing-framework.md)
 - [Query Bug Fixes](opensearch/query-bug-fixes.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)
 - [Replication](opensearch/replication.md)

--- a/docs/features/opensearch/plugin-testing-framework.md
+++ b/docs/features/opensearch/plugin-testing-framework.md
@@ -1,0 +1,154 @@
+# Plugin Testing Framework
+
+## Summary
+
+The Plugin Testing Framework enables comprehensive testing of OpenSearch plugins, including support for ExtensiblePlugins and their extensions within the integration test framework. This feature allows plugin developers to test plugin extension mechanisms that were previously untestable in the classpath plugin pattern used by `internalClusterTest`.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Test Framework"
+        TC[Test Class] --> NCS[NodeConfigurationSource]
+        NCS -->|nodePlugins| PI1[Plugin Classes]
+        NCS -->|additionalNodePlugins| PI2[PluginInfo Objects]
+    end
+    
+    subgraph "Node Initialization"
+        MN[MockNode] --> PS[PluginsService]
+        PI1 --> MN
+        PI2 --> MN
+    end
+    
+    subgraph "Plugin Loading"
+        PS --> LP[Load Plugins]
+        LP --> LE[Load Extensions]
+        LE --> EP[ExtensiblePlugin]
+        EXT[Extending Plugin] -->|extendedPlugins| EP
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Test defines plugins] --> B{Plugin type?}
+    B -->|Class| C[nodePlugins]
+    B -->|PluginInfo| D[additionalNodePlugins]
+    C --> E[Convert to PluginInfo]
+    D --> F[Use directly]
+    E --> G[Merge plugin lists]
+    F --> G
+    G --> H[PluginsService loads plugins]
+    H --> I[Load extensions for ExtensiblePlugins]
+    I --> J[Test executes with full plugin support]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `PluginInfo` | Metadata class containing plugin name, version, classname, and `extendedPlugins` list |
+| `ExtensiblePlugin` | Interface for plugins that can be extended by other plugins |
+| `ExtensionLoader` | Loads extensions for an ExtensiblePlugin using Java ServiceLoader |
+| `PluginsService` | Core service managing plugin lifecycle and extension loading |
+| `MockNode` | Test node supporting both `Class<Plugin>` and `PluginInfo` configurations |
+| `OpenSearchIntegTestCase` | Base class for integration tests with `additionalNodePlugins()` support |
+| `InternalTestCluster` | Test cluster combining `nodePlugins()` and `additionalNodePlugins()` |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `extendedPlugins` | List of plugin names this plugin extends | Empty list |
+
+### Usage Example
+
+```java
+// 1. Define extension interface
+public interface MyExtension {
+    void doSomething();
+}
+
+// 2. Define extensible plugin
+public class MyExtensiblePlugin extends Plugin implements ExtensiblePlugin {
+    private List<MyExtension> extensions = new ArrayList<>();
+    
+    @Override
+    public void loadExtensions(ExtensionLoader loader) {
+        for (MyExtension ext : loader.loadExtensions(MyExtension.class)) {
+            extensions.add(ext);
+        }
+    }
+}
+
+// 3. Define extending plugin
+public class MyExtendingPlugin extends Plugin implements MyExtension {
+    @Override
+    public void doSomething() {
+        // Extension implementation
+    }
+}
+
+// 4. Create service file: META-INF/services/com.example.MyExtension
+// Contents: com.example.MyExtendingPlugin
+
+// 5. Write integration test
+public class MyPluginIT extends OpenSearchIntegTestCase {
+    @Override
+    protected Collection<PluginInfo> additionalNodePlugins() {
+        return List.of(
+            new PluginInfo(
+                MyExtensiblePlugin.class.getName(),
+                "My extensible plugin",
+                "1.0.0",
+                Version.CURRENT,
+                "17",
+                MyExtensiblePlugin.class.getName(),
+                null,
+                Collections.emptyList(),
+                false
+            ),
+            new PluginInfo(
+                MyExtendingPlugin.class.getName(),
+                "My extending plugin", 
+                "1.0.0",
+                Version.CURRENT,
+                "17",
+                MyExtendingPlugin.class.getName(),
+                null,
+                List.of(MyExtensiblePlugin.class.getName()),
+                false
+            )
+        );
+    }
+    
+    public void testExtensionLoaded() {
+        // Test that extensions work correctly
+    }
+}
+```
+
+## Limitations
+
+- Extensions are discovered via Java ServiceLoader, requiring `META-INF/services` files
+- Only works within OpenSearch's test framework (`OpenSearchIntegTestCase`, `OpenSearchSingleNodeTestCase`)
+- Plugin classes must be on the test classpath
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#16908](https://github.com/opensearch-project/OpenSearch/pull/16908) | Enable testing for ExtensiblePlugins using classpath plugins |
+
+## References
+
+- [PR #16908](https://github.com/opensearch-project/OpenSearch/pull/16908): Main implementation
+- [Introduction to OpenSearch Plugins](https://opensearch.org/blog/plugins-intro/): Plugin architecture overview
+- [Backwards Compatibility Testing](https://opensearch.org/blog/bwc-testing-for-opensearch/): BWC testing framework
+
+## Change History
+
+- **v3.1.0** (2025-05-08): Initial implementation - Enable testing for ExtensiblePlugins using classpath plugins

--- a/docs/releases/v3.1.0/features/opensearch/plugin-testing-framework.md
+++ b/docs/releases/v3.1.0/features/opensearch/plugin-testing-framework.md
@@ -1,0 +1,139 @@
+# Plugin Testing Framework
+
+## Summary
+
+This release enables testing for ExtensiblePlugins using classpath plugins in OpenSearch's integration test framework. Previously, it was impossible to test an extensible plugin and its extension simultaneously in the `internalClusterTest` framework because extensions could not be loaded for classpath plugins. This enhancement allows plugin developers to properly test plugin extension mechanisms.
+
+## Details
+
+### What's New in v3.1.0
+
+The test framework now accepts `Collection<PluginInfo>` instead of `Collection<Class<? extends Plugin>>`, enabling configuration of additional settings like `extendedPlugins` for classpath plugins.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.1.0"
+        A1[Test Class] -->|Class&lt;Plugin&gt;| B1[MockNode]
+        B1 -->|Class list| C1[PluginsService]
+        C1 --> D1[Plugin loaded]
+        D1 -.->|Extensions NOT loaded| E1[ExtensiblePlugin]
+    end
+    
+    subgraph "After v3.1.0"
+        A2[Test Class] -->|PluginInfo| B2[MockNode]
+        B2 -->|PluginInfo list| C2[PluginsService]
+        C2 --> D2[Plugin loaded]
+        D2 -->|Extensions loaded| E2[ExtensiblePlugin]
+        F2[Extending Plugin] -->|extendedPlugins| E2
+    end
+```
+
+#### Modified Components
+
+| Component | Change |
+|-----------|--------|
+| `Node.java` | Constructor now accepts `Collection<PluginInfo>` instead of `Collection<Class<? extends Plugin>>` |
+| `PluginsService.java` | New constructor accepting `Collection<PluginInfo>`, moved `loadExtensions()` call to after all plugins loaded |
+| `MockNode.java` | Updated to work with `PluginInfo` collections, added backward-compatible constructor |
+| `OpenSearchIntegTestCase.java` | Added `additionalNodePlugins()` method returning `Collection<PluginInfo>` |
+| `OpenSearchSingleNodeTestCase.java` | Updated to use `PluginInfo` for plugin configuration |
+| `InternalTestCluster.java` | Combines `nodePlugins()` and `additionalNodePlugins()` for full plugin configuration |
+| `ExternalTestCluster.java` | New constructor accepting `Collection<PluginInfo>` |
+| `NodeConfigurationSource.java` | Added `additionalNodePlugins()` method |
+
+#### New API
+
+```java
+// In OpenSearchIntegTestCase
+protected Collection<PluginInfo> additionalNodePlugins() {
+    return Collections.emptyList();
+}
+```
+
+### Usage Example
+
+```java
+@OpenSearchIntegTestCase.ClusterScope(scope = OpenSearchIntegTestCase.Scope.TEST, numDataNodes = 0)
+public class ClasspathPluginIT extends OpenSearchIntegTestCase {
+
+    // Define an extension interface
+    public interface SampleExtension {}
+
+    // Define an extensible plugin
+    public static class SampleExtensiblePlugin extends Plugin implements ExtensiblePlugin {
+        @Override
+        public void loadExtensions(ExtensiblePlugin.ExtensionLoader loader) {
+            for (SampleExtension e : loader.loadExtensions(SampleExtension.class)) {
+                // Extensions are now properly loaded
+            }
+        }
+    }
+
+    // Define an extending plugin
+    public static class SampleExtendingPlugin extends Plugin implements SampleExtension {}
+
+    @Override
+    protected Collection<PluginInfo> additionalNodePlugins() {
+        return List.of(
+            new PluginInfo(
+                SampleExtensiblePlugin.class.getName(),
+                "classpath plugin",
+                "NA",
+                Version.CURRENT,
+                "1.8",
+                SampleExtensiblePlugin.class.getName(),
+                null,
+                Collections.emptyList(),  // No extended plugins
+                false
+            ),
+            new PluginInfo(
+                SampleExtendingPlugin.class.getName(),
+                "classpath plugin",
+                "NA",
+                Version.CURRENT,
+                "1.8",
+                SampleExtendingPlugin.class.getName(),
+                null,
+                List.of(SampleExtensiblePlugin.class.getName()),  // Extends SampleExtensiblePlugin
+                false
+            )
+        );
+    }
+
+    public void testPluginExtensionWithClasspathPlugins() throws IOException {
+        internalCluster().startNode();
+        // Extensions are now loaded and available
+    }
+}
+```
+
+### Migration Notes
+
+1. **Existing tests**: Tests using `nodePlugins()` continue to work unchanged (backward compatible)
+2. **New extensible plugin tests**: Override `additionalNodePlugins()` to return `PluginInfo` objects with `extendedPlugins` configured
+3. **Service file**: Create `META-INF/services/<ExtensionInterface>` file listing extending plugin classes
+
+## Limitations
+
+- Requires creating `META-INF/services` files for extension discovery via Java ServiceLoader
+- Only applicable to integration tests using `OpenSearchIntegTestCase` or `OpenSearchSingleNodeTestCase`
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16908](https://github.com/opensearch-project/OpenSearch/pull/16908) | Enable testing for ExtensiblePlugins using classpath plugins |
+
+## References
+
+- [PR #16908](https://github.com/opensearch-project/OpenSearch/pull/16908): Main implementation
+- [OpenSearch Plugin Development](https://opensearch.org/blog/plugins-intro/): Introduction to OpenSearch plugins
+- [Backwards Compatibility Testing](https://opensearch.org/blog/bwc-testing-for-opensearch/): BWC testing framework for plugins
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/plugin-testing-framework.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -14,6 +14,7 @@
 - [Network Configuration](features/opensearch/network-configuration.md) - Fix systemd seccomp filter for network.host: 0.0.0.0
 - [Percentiles Aggregation](features/opensearch/percentiles-aggregation.md) - Switch to MergingDigest for up to 30x performance improvement
 - [Plugin Installation](features/opensearch/plugin-installation.md) - Fix native plugin installation error caused by PGP public key change
+- [Plugin Testing Framework](features/opensearch/plugin-testing-framework.md) - Enable testing for ExtensiblePlugins using classpath plugins
 - [Query Bug Fixes](features/opensearch/query-bug-fixes.md) - Fixes for exists query, error handling, field validation, and IP field terms query
 - [S3 Repository Enhancements](features/opensearch/s3-repository-enhancements.md) - SSE-KMS encryption support and S3 bucket owner verification
 - [Snapshot/Repository Fixes](features/opensearch/repository-fixes.md) - Fix infinite loop during concurrent snapshot/repository update and NPE for legacy snapshots


### PR DESCRIPTION
## Summary

Add documentation for the Plugin Testing Framework feature introduced in OpenSearch v3.1.0.

### Changes
- Release report: `docs/releases/v3.1.0/features/opensearch/plugin-testing-framework.md`
- Feature report: `docs/features/opensearch/plugin-testing-framework.md`
- Updated release index and features index

### Feature Overview
This feature enables testing for ExtensiblePlugins using classpath plugins in OpenSearch's integration test framework. It allows plugin developers to properly test plugin extension mechanisms by accepting `Collection<PluginInfo>` instead of `Collection<Class<? extends Plugin>>`.

### Related
- OpenSearch PR: [#16908](https://github.com/opensearch-project/OpenSearch/pull/16908)
- Issue: #911