### PR TITLE
docs: add query-optimization report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -62,6 +62,7 @@
 - [Plugin Installation](opensearch/plugin-installation.md)
 - [Plugin Testing Framework](opensearch/plugin-testing-framework.md)
 - [Query Bug Fixes](opensearch/query-bug-fixes.md)
+- [Query Optimization](opensearch/query-optimization.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)
 - [Replication](opensearch/replication.md)
 - [Remote Store Metrics](opensearch/remote-store-metrics.md)

--- a/docs/features/opensearch/query-optimization.md
+++ b/docs/features/opensearch/query-optimization.md
@@ -1,0 +1,152 @@
+# Query Optimization
+
+## Summary
+
+Query Optimization in OpenSearch provides automatic query rewrites that improve search performance without requiring user intervention. These optimizations transform slow query patterns into equivalent but faster alternatives, particularly for Boolean queries with `must_not` clauses and sorted queries using approximation.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph "Query Processing Pipeline"
+        A[User Query] --> B[QueryBuilder]
+        B --> C{Query Rewrite Phase}
+        C --> D[BoolQueryBuilder.doRewrite]
+        D --> E{Has must_not Range?}
+        E -->|Yes| F[rewriteMustNotRangeClausesToShould]
+        E -->|No| G[Continue]
+        F --> H[RangeQueryBuilder.getComplement]
+        H --> I[Create nested should clauses]
+        I --> G
+        G --> J[Lucene Query]
+        J --> K[Query Execution]
+    end
+    
+    subgraph "Sort Optimization"
+        L[match_all + sort] --> M[ApproximateScoreQuery]
+        M --> N[TopDocsCollectorContext]
+        N --> O{shortcutTotalHitCount}
+        O --> P[Extract original query]
+        P --> Q[Use optimal threshold]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "must_not Rewrite"
+        A["must_not: range[a,b]"] --> B["Complement Calculation"]
+        B --> C["should: [lt a, gt b]"]
+    end
+    
+    subgraph "Sort Optimization"
+        D["match_all + sort"] --> E["Approximation"]
+        E --> F["totalHitsThreshold = numHits"]
+        F --> G["Early competitive iterator"]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `BoolQueryBuilder` | Extended with `rewriteMustNotRangeClausesToShould()` method for automatic query transformation |
+| `RangeQueryBuilder` | Added `getComplement()` method to generate complement range queries |
+| `ApproximateScoreQuery` | Enhanced with `createWeight()` for proper weight delegation |
+| `ApproximatePointRangeQuery` | Modified size calculation for optimal threshold handling |
+| `TopDocsCollectorContext` | Updated `shortcutTotalHitCount()` to handle `ApproximateScoreQuery` |
+
+### Configuration
+
+No configuration is required. These optimizations are applied automatically during query processing.
+
+### Usage Example
+
+**Automatic must_not Range Optimization:**
+
+```json
+// User sends this query
+POST /my-index/_search
+{
+  "query": {
+    "bool": {
+      "must_not": [
+        {
+          "range": {
+            "timestamp": {
+              "gte": "2024-01-01",
+              "lte": "2024-06-30"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+
+// OpenSearch internally rewrites to:
+{
+  "query": {
+    "bool": {
+      "must": {
+        "bool": {
+          "should": [
+            {"range": {"timestamp": {"lt": "2024-01-01"}}},
+            {"range": {"timestamp": {"gt": "2024-06-30"}}}
+          ],
+          "minimum_should_match": 1
+        }
+      }
+    }
+  }
+}
+```
+
+**Sort Query Optimization:**
+
+```json
+// Sorted match_all query benefits from optimization
+POST /my-index/_search
+{
+  "query": {
+    "match_all": {}
+  },
+  "sort": [
+    {"timestamp": "desc"}
+  ],
+  "size": 10
+}
+```
+
+## Limitations
+
+- **must_not Range Rewrite:**
+  - Only applies when all documents have exactly one value for the field
+  - Only one range query per field in `must_not` clause is supported
+  - Does not apply to non-INTERSECTS shape relations
+  - Requires access to LeafReaderContexts during rewrite phase
+
+- **Sort Optimization:**
+  - Only applies to approximated `match_all` queries
+  - Requires sorting on indexed numeric fields
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#18189](https://github.com/opensearch-project/OpenSearch/pull/18189) | Improve sort-query performance for approximated match_all queries |
+| v3.1.0 | [#17655](https://github.com/opensearch-project/OpenSearch/pull/17655) | Add BooleanQuery rewrite for must_not RangeQuery clauses |
+
+## References
+
+- [Issue #18206](https://github.com/opensearch-project/OpenSearch/issues/18206): Improve performance for approximated `match_all` sort queries
+- [Issue #17586](https://github.com/opensearch-project/OpenSearch/issues/17586): Feature Request - Rewrites for BooleanQuery
+- [Boolean Query Documentation](https://docs.opensearch.org/3.0/query-dsl/compound/bool/): Official Boolean query documentation
+- [Range Query Documentation](https://docs.opensearch.org/3.0/query-dsl/term/range/): Official Range query documentation
+
+## Change History
+
+- **v3.1.0** (2025): Initial implementation with must_not range rewrite and sort-query optimization

--- a/docs/releases/v3.1.0/features/opensearch/query-optimization.md
+++ b/docs/releases/v3.1.0/features/opensearch/query-optimization.md
@@ -1,0 +1,154 @@
+# Query Optimization
+
+## Summary
+
+OpenSearch v3.1.0 introduces two significant query optimization improvements that can dramatically improve search performance. The first optimization automatically rewrites `must_not` range queries in Boolean queries to use `should` clauses with the complement of the range, achieving 2-30x performance improvements. The second optimization improves sort-query performance for approximated `match_all` queries by retaining the default `totalHitsThreshold`, enabling earlier competitive iterator updates.
+
+## Details
+
+### What's New in v3.1.0
+
+Two query optimization features were added:
+
+1. **BooleanQuery Rewrite for must_not RangeQuery Clauses**: Automatically transforms slow `must_not` range queries into faster `should` clauses
+2. **Sort-Query Performance for Approximated match_all**: Fixes `totalHitsThreshold` handling for better performance with sorted queries
+
+### Technical Changes
+
+#### BooleanQuery must_not Range Rewrite
+
+When a Boolean query contains a `must_not` clause with a range query, OpenSearch now automatically rewrites it to use `should` clauses representing the complement of that range.
+
+```mermaid
+flowchart TB
+    subgraph Original["Original Query"]
+        A["bool"]
+        B["must_not"]
+        C["range: gte 07/01, lte 09/01"]
+        A --> B --> C
+    end
+    
+    subgraph Rewritten["Rewritten Query"]
+        D["bool"]
+        E["must"]
+        F["bool"]
+        G["should"]
+        H["range: lt 07/01"]
+        I["range: gt 09/01"]
+        D --> E --> F --> G
+        G --> H
+        G --> I
+    end
+    
+    Original -->|"Automatic Rewrite"| Rewritten
+```
+
+**Conditions for Rewrite:**
+- Only applies when all documents have exactly one value for the field
+- Only one range query per field in `must_not` clause
+- Preserves original `minimumShouldMatch` semantics
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `BoolQueryBuilder.rewriteMustNotRangeClausesToShould()` | Performs the must_not to should rewrite during query rewrite phase |
+| `RangeQueryBuilder.getComplement()` | Returns list of RangeQueryBuilder representing the complement of the range |
+| `ApproximateScoreQuery.createWeight()` | New method to properly delegate weight creation to resolved query |
+
+#### Performance Improvements
+
+**must_not Range Rewrite Benchmarks (nyc_taxis dataset):**
+
+| Excluded Range | Original p50 (ms) | Rewritten p50 (ms) | Improvement |
+|----------------|-------------------|--------------------| ------------|
+| Jul 1 - Sep 1 | 873 | 408 | ~2x |
+| Jan 1 - Sep 1 | 1214 | 111 | ~11x |
+| 1/1 12:00 - 1/1 12:01 | 599 | 19.5 | ~30x |
+
+**http_logs dataset:**
+
+| Excluded Range | Original p50 (ms) | Rewritten p50 (ms) | Improvement |
+|----------------|-------------------|--------------------| ------------|
+| 6/10 - 6/13 | 259 | 38.2 | ~7x |
+| 6/9 - 6/10 | 269 | 30.8 | ~9x |
+
+#### Sort-Query Optimization
+
+For approximated `match_all` queries with sorting, the `totalHitsThreshold` is now correctly set to the `numHits` value (default 10) instead of 10,000. This allows Lucene's competitive iterator to update earlier and skip unnecessary document comparisons.
+
+**Key Changes:**
+- `TopDocsCollectorContext.shortcutTotalHitCount()` now handles `ApproximateScoreQuery` by extracting the original query
+- `ApproximatePointRangeQuery.canApproximate()` uses `trackTotalHitsUpTo` without adding 1
+- `ApproximateScoreQuery.rewrite()` returns `this` to maintain query identity
+
+### Usage Example
+
+The optimization is automatic. No configuration changes are required.
+
+**Before (slow):**
+```json
+{
+  "query": {
+    "bool": {
+      "must_not": [
+        {
+          "range": {
+            "timestamp": {
+              "gte": "2024-07-01",
+              "lte": "2024-09-01"
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+**Internally rewritten to (fast):**
+```json
+{
+  "query": {
+    "bool": {
+      "must": {
+        "bool": {
+          "should": [
+            {"range": {"timestamp": {"lt": "2024-07-01"}}},
+            {"range": {"timestamp": {"gt": "2024-09-01"}}}
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+These optimizations are applied automatically. No migration steps are required.
+
+## Limitations
+
+- **must_not rewrite** only applies when:
+  - All documents have exactly one value for the range field
+  - Only one range query exists per field in `must_not` clause
+  - The range query uses `INTERSECTS` relation (default)
+- **Sort optimization** applies only to approximated `match_all` queries
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18189](https://github.com/opensearch-project/OpenSearch/pull/18189) | Improve sort-query performance by retaining the default `totalHitsThreshold` for approximated `match_all` queries |
+| [#17655](https://github.com/opensearch-project/OpenSearch/pull/17655) | Add BooleanQuery rewrite for must_not RangeQuery clauses |
+
+## References
+
+- [Issue #18206](https://github.com/opensearch-project/OpenSearch/issues/18206): Improve performance for approximated `match_all` sort queries
+- [Issue #17586](https://github.com/opensearch-project/OpenSearch/issues/17586): Feature Request - Rewrites for BooleanQuery
+- [Boolean Query Documentation](https://docs.opensearch.org/3.0/query-dsl/compound/bool/): Official docs for Boolean queries
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/query-optimization.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -16,6 +16,7 @@
 - [Plugin Installation](features/opensearch/plugin-installation.md) - Fix native plugin installation error caused by PGP public key change
 - [Plugin Testing Framework](features/opensearch/plugin-testing-framework.md) - Enable testing for ExtensiblePlugins using classpath plugins
 - [Query Bug Fixes](features/opensearch/query-bug-fixes.md) - Fixes for exists query, error handling, field validation, and IP field terms query
+- [Query Optimization](features/opensearch/query-optimization.md) - Automatic must_not range rewrite and sort-query performance improvements
 - [S3 Repository Enhancements](features/opensearch/s3-repository-enhancements.md) - SSE-KMS encryption support and S3 bucket owner verification
 - [Snapshot/Repository Fixes](features/opensearch/repository-fixes.md) - Fix infinite loop during concurrent snapshot/repository update and NPE for legacy snapshots
 - [Star-Tree Index Enhancements](features/opensearch/star-tree-index.md) - Production-ready status, date range queries, nested aggregations, index-level control


### PR DESCRIPTION
## Summary

This PR adds documentation for the Query Optimization feature in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/opensearch/query-optimization.md`
- Feature report: `docs/features/opensearch/query-optimization.md`

### Key Changes in v3.1.0

1. **BooleanQuery Rewrite for must_not RangeQuery Clauses** ([#17655](https://github.com/opensearch-project/OpenSearch/pull/17655))
   - Automatically rewrites `must_not` range queries to `should` clauses with complement ranges
   - Achieves 2-30x performance improvement depending on the query

2. **Sort-Query Performance for Approximated match_all** ([#18189](https://github.com/opensearch-project/OpenSearch/pull/18189))
   - Fixes `totalHitsThreshold` handling for approximated `match_all` queries
   - Enables earlier competitive iterator updates for better performance

### Related Issues
- Closes #910