### PR TITLE
docs: add Remote Store report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -65,6 +65,7 @@
 - [Query Optimization](opensearch/query-optimization.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)
 - [Replication](opensearch/replication.md)
+- [Remote Store](opensearch/remote-store.md)
 - [Remote Store Metrics](opensearch/remote-store-metrics.md)
 - [S3 Repository](opensearch/s3-repository.md)
 - [Search Backpressure](opensearch/search-backpressure.md)

--- a/docs/features/opensearch/remote-store.md
+++ b/docs/features/opensearch/remote-store.md
@@ -1,0 +1,140 @@
+# Remote Store
+
+## Summary
+
+Remote Store (remote-backed storage) is an OpenSearch feature that automatically creates backups of all index transactions and sends them to remote storage. It provides data durability and disaster recovery capabilities by storing segment data and cluster state in remote storage systems like Amazon S3. Remote Store requires segment replication to be enabled and supports migration from document-replication-based clusters through a rolling upgrade mechanism.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Cluster"
+        CM[Cluster Manager]
+        DN1[Data Node 1]
+        DN2[Data Node 2]
+    end
+    
+    subgraph "Remote Store"
+        RS[Remote Segment Store]
+        RCS[Remote Cluster State]
+    end
+    
+    subgraph "Migration Control"
+        MC[Migration Settings]
+        VAL[Validation Layer]
+    end
+    
+    CM -->|Publish State| RCS
+    DN1 -->|Upload Segments| RS
+    DN2 -->|Download Segments| RS
+    
+    MC -->|compatibility_mode| VAL
+    MC -->|migration.direction| VAL
+    VAL -->|Block Close Index| DN1
+    VAL -->|Block Close Index| DN2
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Write Path"
+        W1[Index Document] --> W2[Local Segment]
+        W2 --> W3[Upload to Remote Store]
+    end
+    
+    subgraph "Read Path"
+        R1[Search Request] --> R2{Segment Available?}
+        R2 -->|Yes| R3[Read Local]
+        R2 -->|No| R4[Download from Remote]
+        R4 --> R3
+    end
+    
+    subgraph "Cluster State"
+        CS1[State Change] --> CS2[Publish to Remote]
+        CS2 --> CS3[Diff Download]
+        CS3 --> CS4[Apply to Nodes]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `RemoteStoreNodeService` | Manages remote store node settings and migration direction |
+| `RemoteClusterStateService` | Handles cluster state publication and retrieval from remote store |
+| `RemoteStorePinnedTimestampService` | Manages pinned timestamps for remote store operations |
+| `TransportCloseIndexAction` | Validates close index requests during migration |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.remote_store.compatibility_mode` | Controls node compatibility during migration (`strict`, `mixed`) | `strict` |
+| `cluster.migration.direction` | Migration direction (`none`, `remote_store`) | `none` |
+| `node.attr.remote_store.segment.repository` | Repository name for segment storage | - |
+| `node.attr.remote_store.translog.repository` | Repository name for translog storage | - |
+| `cluster.remote_store.pinned_timestamps.enabled` | Enable pinned timestamps feature | `false` |
+
+### Usage Example
+
+#### Configuring Remote Store Migration
+
+```yaml
+# opensearch.yml - Node configuration
+node.attr.remote_store.segment.repository: my-segment-repo
+node.attr.remote_store.translog.repository: my-translog-repo
+node.attr.remote_store.state.repository: my-state-repo
+```
+
+```bash
+# Enable mixed mode for migration
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.remote_store.compatibility_mode": "mixed",
+    "cluster.migration.direction": "remote_store"
+  }
+}
+```
+
+#### Completing Migration
+
+```bash
+# After all nodes are migrated, clear migration settings
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.remote_store.compatibility_mode": null,
+    "cluster.migration.direction": null
+  }
+}
+```
+
+## Limitations
+
+- Requires segment replication to be enabled
+- Close index operations are blocked during migration (when `compatibility_mode=mixed` and `migration.direction=remote_store`)
+- OpenSearch 2.15+ nodes cannot revert to document replication after migration
+- Migration must be performed as a rolling upgrade
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#18327](https://github.com/opensearch-project/OpenSearch/pull/18327) | Disabling _close API invocation during remote migration |
+| v3.1.0 | [#18256](https://github.com/opensearch-project/OpenSearch/pull/18256) | Apply cluster state metadata and routing table diff when building cluster state from remote |
+
+## References
+
+- [Issue #18328](https://github.com/opensearch-project/OpenSearch/issues/18328): Reject close index requests during DocRep to SegRep migration
+- [Issue #18045](https://github.com/opensearch-project/OpenSearch/issues/18045): Remote Cluster State Diff Download Failures during IndicesAliases Action
+- [Migrating to remote-backed storage](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/remote-store/migrating-to-remote/): Official migration documentation
+- [Remote-backed storage](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/remote-store/index/): Remote store overview
+- [Remote Store Stats API](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/remote-store/remote-store-stats-api/): API documentation
+
+## Change History
+
+- **v3.1.0** (2026-01-10): Added close index request rejection during migration; Fixed cluster state diff download failures during alias operations

--- a/docs/releases/v3.1.0/features/opensearch/remote-store.md
+++ b/docs/releases/v3.1.0/features/opensearch/remote-store.md
@@ -1,0 +1,122 @@
+# Remote Store
+
+## Summary
+
+This release includes two improvements to Remote Store functionality: rejection of close index requests during remote store migration, and a bug fix for cluster state diff downloads during alias operations. These changes improve the stability and reliability of the remote store migration process.
+
+## Details
+
+### What's New in v3.1.0
+
+#### 1. Close Index Request Rejection During Migration
+
+When migrating from document replication to remote-backed storage (segment replication), the `_close` API is now blocked to prevent potential data inconsistencies. This validation occurs when:
+
+- `cluster.remote_store.compatibility_mode` is set to `mixed`
+- `cluster.migration.direction` is set to `remote_store`
+
+```mermaid
+flowchart TB
+    A[Close Index Request] --> B{Check Migration State}
+    B -->|compatibility_mode=mixed AND<br/>migration.direction=remote_store| C[Reject Request]
+    B -->|Otherwise| D[Process Request]
+    C --> E[IllegalStateException:<br/>Cannot close index while<br/>remote migration is ongoing]
+```
+
+#### 2. Cluster State Diff Download Fix
+
+Fixed a bug where performing an `_aliases` request that removes an index and assigns its name as an alias to another index in the same request caused cluster state diff download failures. The error occurred because deleted indices and routing tables were not properly removed before building the updated cluster state.
+
+**Before the fix:**
+```
+java.lang.IllegalStateException: index, alias, and data stream names need to be unique, 
+but the following duplicates were found [index-2 (alias of [index-1/...]) conflicts with index]
+```
+
+**Impact of the bug:**
+- Cluster manager stepping down due to publication failure
+- Full cluster state download triggered by node-joins
+- High latency for alias operations
+
+### Technical Changes
+
+#### New Validation in TransportCloseIndexAction
+
+```java
+private void validateRemoteMigration() {
+    ClusterSettings clusterSettings = clusterService.getClusterSettings();
+    CompatibilityMode compatibilityMode = clusterSettings.get(
+        RemoteStoreNodeService.REMOTE_STORE_COMPATIBILITY_MODE_SETTING);
+    Direction migrationDirection = clusterSettings.get(
+        RemoteStoreNodeService.MIGRATION_DIRECTION_SETTING);
+    if (compatibilityMode == CompatibilityMode.MIXED 
+        && migrationDirection == Direction.REMOTE_STORE) {
+        throw new IllegalStateException(
+            "Cannot close index while remote migration is ongoing");
+    }
+}
+```
+
+#### RemoteClusterStateService Changes
+
+The `readClusterStateInParallel` method now accepts transformers to handle deleted indices and routing tables before building the cluster state:
+
+| Parameter | Description |
+|-----------|-------------|
+| `metadataTransformer` | Consumer to remove deleted indices from metadata |
+| `routingTableTransformer` | Consumer to remove deleted routing tables |
+
+### Configuration
+
+| Setting | Description | Values |
+|---------|-------------|--------|
+| `cluster.remote_store.compatibility_mode` | Controls node compatibility during migration | `strict` (default), `mixed` |
+| `cluster.migration.direction` | Specifies migration direction | `none` (default), `remote_store` |
+
+### Usage Example
+
+During remote store migration, attempting to close an index will fail:
+
+```bash
+# Set migration mode
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.remote_store.compatibility_mode": "mixed",
+    "cluster.migration.direction": "remote_store"
+  }
+}
+
+# This will fail during migration
+POST /my-index/_close
+# Response: 400 Bad Request
+# "Cannot close index while remote migration is ongoing"
+```
+
+### Migration Notes
+
+- Complete the remote store migration before closing any indexes
+- The restriction is automatically lifted when migration completes and `compatibility_mode` returns to `strict`
+- The alias operation fix is transparent and requires no user action
+
+## Limitations
+
+- Close index operations are blocked during the entire migration period
+- No workaround available for closing indexes during migration - migration must complete first
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18327](https://github.com/opensearch-project/OpenSearch/pull/18327) | Disabling _close API invocation during remote migration |
+| [#18256](https://github.com/opensearch-project/OpenSearch/pull/18256) | Apply cluster state metadata and routing table diff when building cluster state from remote |
+
+## References
+
+- [Issue #18328](https://github.com/opensearch-project/OpenSearch/issues/18328): Reject close index requests during DocRep to SegRep migration
+- [Issue #18045](https://github.com/opensearch-project/OpenSearch/issues/18045): Remote Cluster State Diff Download Failures during IndicesAliases Action
+- [Migrating to remote-backed storage](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/remote-store/migrating-to-remote/): Official migration documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/remote-store.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -17,6 +17,7 @@
 - [Plugin Testing Framework](features/opensearch/plugin-testing-framework.md) - Enable testing for ExtensiblePlugins using classpath plugins
 - [Query Bug Fixes](features/opensearch/query-bug-fixes.md) - Fixes for exists query, error handling, field validation, and IP field terms query
 - [Query Optimization](features/opensearch/query-optimization.md) - Automatic must_not range rewrite and sort-query performance improvements
+- [Remote Store](features/opensearch/remote-store.md) - Close index rejection during migration and cluster state diff download fix
 - [S3 Repository Enhancements](features/opensearch/s3-repository-enhancements.md) - SSE-KMS encryption support and S3 bucket owner verification
 - [Snapshot/Repository Fixes](features/opensearch/repository-fixes.md) - Fix infinite loop during concurrent snapshot/repository update and NPE for legacy snapshots
 - [Star-Tree Index Enhancements](features/opensearch/star-tree-index.md) - Production-ready status, date range queries, nested aggregations, index-level control


### PR DESCRIPTION
## Summary

This PR adds documentation for the Remote Store feature updates in OpenSearch v3.1.0.

### Changes in v3.1.0

1. **Close Index Request Rejection During Migration** (PR #18327)
   - Blocks `_close` API when `compatibility_mode=mixed` and `migration.direction=remote_store`
   - Prevents potential data inconsistencies during DocRep to SegRep migration

2. **Cluster State Diff Download Fix** (PR #18256)
   - Fixed bug where alias operations that remove an index and assign its name as an alias caused diff download failures
   - Prevents cluster manager stepping down and full cluster state downloads

### Reports Created

- Release report: `docs/releases/v3.1.0/features/opensearch/remote-store.md`
- Feature report: `docs/features/opensearch/remote-store.md` (new)

### Related Issues

- Resolves investigation for GitHub Issue #909