### PR TITLE
docs: add Query Coordinator Context report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -62,6 +62,7 @@
 - [Plugin Installation](opensearch/plugin-installation.md)
 - [Plugin Testing Framework](opensearch/plugin-testing-framework.md)
 - [Query Bug Fixes](opensearch/query-bug-fixes.md)
+- [Query Coordinator Context](opensearch/query-coordinator-context.md)
 - [Query Optimization](opensearch/query-optimization.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)
 - [Replication](opensearch/replication.md)

--- a/docs/features/opensearch/query-coordinator-context.md
+++ b/docs/features/opensearch/query-coordinator-context.md
@@ -1,0 +1,140 @@
+# Query Coordinator Context
+
+## Summary
+
+`QueryCoordinatorContext` is a specialized query rewrite context that provides coordinator-level information during query rewriting in OpenSearch. It enables plugins to access search request details, target indices, and pipeline context variables when rewriting queries on the coordinator node, which is essential for features that need index-aware query transformation.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Coordinator Node"
+        SR[Search Request] --> SS[SearchService]
+        SS --> QCC[QueryCoordinatorContext]
+        
+        subgraph "QueryCoordinatorContext"
+            QRC[QueryRewriteContext]
+            IR[IndicesRequest]
+            CV[Context Variables]
+        end
+        
+        QCC --> QRW[Query Rewrite]
+        QRW --> QB[Query Builders]
+    end
+    
+    subgraph "Plugin Integration"
+        QB --> NQ[Neural Query]
+        QB --> TQ[Template Query]
+        NQ --> TI[Target Indices]
+        IR --> TI
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Client Request] --> B[SearchService]
+    B --> C[getRewriteContext]
+    C --> D[QueryCoordinatorContext]
+    D --> E[Query.rewrite]
+    E --> F[Plugin QueryBuilder]
+    F --> G[getSearchRequest]
+    G --> H[Index-aware Rewrite]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `QueryCoordinatorContext` | Wrapper around `QueryRewriteContext` that provides coordinator-level context |
+| `IndicesRequest` | Interface providing access to target indices |
+| `PipelinedRequest` | Specialized request with pipeline processing context |
+| `SearchService` | Creates `QueryCoordinatorContext` for query rewriting |
+
+### Key Methods
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `getSearchRequest()` | `IndicesRequest` | Returns the search request with target indices |
+| `getContextVariables()` | `Map<String, Object>` | Returns pipeline context variables (empty for non-pipelined requests) |
+| `convertToCoordinatorContext()` | `QueryCoordinatorContext` | Returns self (for interface compatibility) |
+
+### Configuration
+
+This feature is internal infrastructure and does not require configuration. It is automatically used when:
+
+- Search queries are executed
+- Explain API is called
+- Validate Query API is called
+
+### Usage Example
+
+```java
+// In a custom QueryBuilder's doRewrite method
+@Override
+protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) {
+    QueryCoordinatorContext coordinatorContext = queryRewriteContext.convertToCoordinatorContext();
+    
+    if (coordinatorContext != null) {
+        // Access target indices
+        IndicesRequest request = coordinatorContext.getSearchRequest();
+        String[] targetIndices = request.indices();
+        
+        // Access pipeline context variables (if available)
+        Map<String, Object> contextVars = coordinatorContext.getContextVariables();
+        
+        // Perform index-aware query rewriting
+        // e.g., look up index mapping to determine field types
+    }
+    
+    return this;
+}
+```
+
+### Integration with Neural Search
+
+The primary use case is enabling the neural-search plugin's semantic field feature:
+
+```java
+// Neural query can now access index mapping during rewrite
+public class NeuralQueryBuilder extends AbstractQueryBuilder<NeuralQueryBuilder> {
+    @Override
+    protected QueryBuilder doRewrite(QueryRewriteContext context) {
+        QueryCoordinatorContext coordContext = context.convertToCoordinatorContext();
+        if (coordContext != null) {
+            // Get target indices to look up semantic field configuration
+            String[] indices = coordContext.getSearchRequest().indices();
+            // Determine model_id from index mapping
+            // Rewrite to appropriate KNN or sparse query
+        }
+        return super.doRewrite(context);
+    }
+}
+```
+
+## Limitations
+
+- Context variables are only available when the request is a `PipelinedRequest`
+- Index mapping lookup requires additional calls to cluster state
+- Only available during coordinator-level query rewriting (not shard-level)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#17890](https://github.com/opensearch-project/OpenSearch/pull/17890) | Allow to get the search request from the QueryCoordinatorContext |
+| v3.1.0 | [#18272](https://github.com/opensearch-project/OpenSearch/pull/18272) | Use QueryCoordinatorContext for the rewrite in validate API |
+| v2.19.0 | [#16818](https://github.com/opensearch-project/OpenSearch/pull/16818) | Introduce Template query (initial QueryCoordinatorContext) |
+
+## References
+
+- [Issue #1211](https://github.com/opensearch-project/neural-search/issues/1211): RFC - Support Semantic Field Type to Simplify Neural Search Set Up
+- [Issue #803](https://github.com/opensearch-project/neural-search/issues/803): Semantic field feature request
+
+## Change History
+
+- **v3.1.0** (2025-05-15): Added `getSearchRequest()` method, broadened constructor to accept `IndicesRequest`, integrated with Validate Query API
+- **v2.19.0** (2025-01-23): Initial implementation with Template query support

--- a/docs/releases/v3.1.0/features/opensearch/query-coordinator-context.md
+++ b/docs/releases/v3.1.0/features/opensearch/query-coordinator-context.md
@@ -1,0 +1,110 @@
+# Query Coordinator Context
+
+## Summary
+
+This release enhances the `QueryCoordinatorContext` class to provide access to the search request and target indices information during query rewriting on the coordinator node. This enables plugins (particularly the neural-search plugin) to make index-aware decisions during query rewriting, which is essential for features like the semantic field type.
+
+## Details
+
+### What's New in v3.1.0
+
+Two key improvements were made to the query rewriting infrastructure:
+
+1. **Search Request Access** (PR #17890): The `QueryCoordinatorContext` now accepts any `IndicesRequest` (not just `PipelinedRequest`) and exposes a `getSearchRequest()` method, allowing plugins to access target indices during query rewriting.
+
+2. **Validate API Integration** (PR #18272): The Validate Query API now uses `QueryCoordinatorContext` for query rewriting, ensuring consistent behavior with the search API and proper validation of neural queries against semantic fields.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Query Rewriting Flow"
+        SR[Search Request] --> SS[SearchService]
+        SS --> QCC[QueryCoordinatorContext]
+        QCC --> QRW[Query Rewrite]
+        QRW --> Plugin[Plugin Query Builders]
+    end
+    
+    subgraph "QueryCoordinatorContext"
+        QCC --> IR[IndicesRequest]
+        QCC --> CV[Context Variables]
+        QCC --> RC[Rewrite Context]
+    end
+    
+    Plugin --> TI[Target Indices Info]
+    IR --> TI
+```
+
+#### Modified Components
+
+| Component | Change | Description |
+|-----------|--------|-------------|
+| `QueryCoordinatorContext` | Modified | Now accepts `IndicesRequest` instead of `PipelinedRequest`, added `getSearchRequest()` method |
+| `SearchService` | Modified | `getRewriteContext()` now accepts `IndicesRequest` parameter |
+| `TransportExplainAction` | Modified | Uses `SearchService.getRewriteContext()` with request parameter |
+| `TransportValidateQueryAction` | Modified | Uses `QueryCoordinatorContext` for query rewriting |
+
+#### API Changes
+
+```java
+// QueryCoordinatorContext constructor change
+// Before (v3.0.0)
+public QueryCoordinatorContext(QueryRewriteContext rewriteContext, PipelinedRequest searchRequest)
+
+// After (v3.1.0)
+public QueryCoordinatorContext(QueryRewriteContext rewriteContext, IndicesRequest searchRequest)
+
+// New method added
+public IndicesRequest getSearchRequest()
+```
+
+### Usage Example
+
+Plugins can now access target indices during query rewriting:
+
+```java
+@Override
+protected QueryBuilder doRewrite(QueryRewriteContext queryRewriteContext) {
+    // Convert to coordinator context to access search request
+    QueryCoordinatorContext coordinatorContext = queryRewriteContext.convertToCoordinatorContext();
+    
+    if (coordinatorContext != null) {
+        // Get target indices from the search request
+        IndicesRequest searchRequest = coordinatorContext.getSearchRequest();
+        String[] indices = searchRequest.indices();
+        
+        // Make index-aware rewriting decisions
+        // e.g., check index mapping for semantic field configuration
+    }
+    
+    return super.doRewrite(queryRewriteContext);
+}
+```
+
+### Migration Notes
+
+- Plugins using `QueryCoordinatorContext` should update to use the new `getSearchRequest()` method instead of casting to `PipelinedRequest`
+- The `getContextVariables()` method still works but returns empty map for non-pipelined requests
+
+## Limitations
+
+- The `getContextVariables()` method only returns pipeline context variables when the request is a `PipelinedRequest`
+- For other `IndicesRequest` types, context variables will be empty
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17890](https://github.com/opensearch-project/OpenSearch/pull/17890) | Allow to get the search request from the QueryCoordinatorContext |
+| [#18272](https://github.com/opensearch-project/OpenSearch/pull/18272) | Use QueryCoordinatorContext for the rewrite in validate API |
+
+## References
+
+- [Issue #1211](https://github.com/opensearch-project/neural-search/issues/1211): RFC - Support Semantic Field Type to Simplify Neural Search Set Up
+- [Issue #803](https://github.com/opensearch-project/neural-search/issues/803): Semantic field feature request
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/query-coordinator-context.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -25,3 +25,4 @@
 - [gRPC Transport](features/opensearch/grpc-transport.md) - Performance optimization with pass-by-reference pattern and package reorganization
 - [Unified Highlighter](features/opensearch/unified-highlighter.md) - Add matched_fields support for blending matches from multiple fields
 - [System Ingest Pipeline](features/opensearch/system-ingest-pipeline.md) - Automatic pipeline generation for plugin developers with bulk update support
+- [Query Coordinator Context](features/opensearch/query-coordinator-context.md) - Search request access and validate API integration for index-aware query rewriting


### PR DESCRIPTION
## Summary

This PR adds documentation for the Query Coordinator Context feature in OpenSearch v3.1.0.

### Changes

- **Release Report**: `docs/releases/v3.1.0/features/opensearch/query-coordinator-context.md`
- **Feature Report**: `docs/features/opensearch/query-coordinator-context.md`
- Updated release index and features index

### Key Changes in v3.1.0

1. **Search Request Access** (PR #17890): `QueryCoordinatorContext` now accepts any `IndicesRequest` and exposes `getSearchRequest()` method for plugins to access target indices during query rewriting.

2. **Validate API Integration** (PR #18272): The Validate Query API now uses `QueryCoordinatorContext` for query rewriting, ensuring consistent behavior with the search API.

### Related Issue

Closes #908