### PR TITLE
docs: add Async Shard Batch Fetch report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -14,6 +14,7 @@
 ## opensearch
 
 - [Approximation Framework](opensearch/approximation-framework.md)
+- [Async Shard Batch Fetch](opensearch/async-shard-batch-fetch.md)
 - [Async Shard Fetch Metrics](opensearch/async-shard-fetch-metrics.md)
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
 - [Bulk API](opensearch/bulk-api.md)

--- a/docs/features/opensearch/async-shard-batch-fetch.md
+++ b/docs/features/opensearch/async-shard-batch-fetch.md
@@ -1,0 +1,136 @@
+# Async Shard Batch Fetch
+
+## Summary
+
+Async Shard Batch Fetch is a cluster manager optimization that batches shard metadata fetch operations during node joins and restarts. Instead of fetching metadata per-shard (which can cause memory spikes with large shard counts), this feature groups fetch requests into batches, significantly reducing memory pressure and improving cluster manager resilience.
+
+This feature addresses scalability issues in clusters with tens of thousands of shards, where the original per-shard async fetch approach could consume gigabytes of memory and cause cluster manager instability.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Cluster Manager Node"
+        subgraph "Allocation Service"
+            AS[AllocationService]
+            RA[RoutingAllocation]
+        end
+        
+        subgraph "Shard Allocators"
+            GA[GatewayAllocator<br/>Legacy per-shard]
+            SBGA[ShardsBatchGatewayAllocator<br/>Batch mode]
+        end
+        
+        subgraph "Batch Allocators"
+            PSBA[PrimaryShardBatchAllocator]
+            RSBA[ReplicaShardBatchAllocator]
+        end
+        
+        subgraph "Async Fetch"
+            ASBF[AsyncShardBatchFetch]
+            ASFC[AsyncShardFetchCache]
+        end
+    end
+    
+    subgraph "Data Nodes"
+        DN1[Data Node 1]
+        DN2[Data Node 2]
+        DN3[Data Node N]
+    end
+    
+    AS --> RA
+    RA -->|batch_enabled=false| GA
+    RA -->|batch_enabled=true| SBGA
+    SBGA --> PSBA
+    SBGA --> RSBA
+    PSBA --> ASBF
+    RSBA --> ASBF
+    ASBF --> ASFC
+    ASBF -->|TransportNodesListGatewayStartedShardsBatch| DN1
+    ASBF -->|TransportNodesListGatewayStartedShardsBatch| DN2
+    ASBF -->|TransportNodesListGatewayStartedShardsBatch| DN3
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Node Join/Leave Event] --> B[Reroute Triggered]
+    B --> C[AllocationService]
+    C --> D{Batch Mode Enabled?}
+    D -->|Yes| E[ShardsBatchGatewayAllocator]
+    D -->|No| F[GatewayAllocator<br/>Per-shard fetch]
+    E --> G[Create Shard Batches]
+    G --> H[PrimaryShardBatchAllocator]
+    G --> I[ReplicaShardBatchAllocator]
+    H --> J[AsyncShardBatchFetch]
+    I --> J
+    J --> K[Batch Request to All Nodes]
+    K --> L[Aggregate Responses]
+    L --> M[Make Allocation Decisions]
+    M --> N[Update Cluster State]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ShardsBatchGatewayAllocator` | Main allocator that handles batch-based shard allocation |
+| `PrimaryShardBatchAllocator` | Allocates primary shards using batch fetch |
+| `ReplicaShardBatchAllocator` | Allocates replica shards using batch fetch |
+| `AsyncShardBatchFetch` | Handles async batch fetch operations to data nodes |
+| `TransportNodesListGatewayStartedShardsBatch` | Transport action for batch shard metadata requests |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.allocator.existing_shards_allocator.batch_enabled` | Enable batch mode for shard allocation | `true` (v3.1.0+) |
+| `cluster.allocator.shard.batch.primary_allocator_timeout` | Timeout for primary shard batch allocation | `20s` (v3.1.0+) |
+| `cluster.allocator.shard.batch.replica_allocator_timeout` | Timeout for replica shard batch allocation | `20s` (v3.1.0+) |
+
+### Usage Example
+
+```yaml
+# opensearch.yml - Default configuration (recommended)
+# Batch mode is enabled by default in v3.1.0+
+
+# To customize timeouts for large clusters:
+cluster.allocator.shard.batch.primary_allocator_timeout: 30s
+cluster.allocator.shard.batch.replica_allocator_timeout: 30s
+
+# To disable batch mode (not recommended):
+cluster.allocator.existing_shards_allocator.batch_enabled: false
+```
+
+## Limitations
+
+- **Shard ID collision**: When multiple replica shards exist for the same shard ID in different states (INITIALIZING and UNASSIGNED), the batch may only track one, potentially delaying allocation ([#18098](https://github.com/opensearch-project/OpenSearch/issues/18098))
+- **Minimum timeout**: Allocator timeout cannot be set below 20 seconds when enabled
+- **Memory during batch**: While batching reduces overall memory, large batches still require memory for aggregated responses
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#18139](https://github.com/opensearch-project/OpenSearch/pull/18139) | Enabled Async Shard Batch Fetch by default |
+| v2.18.0 | [#15976](https://github.com/opensearch-project/OpenSearch/pull/15976) | Added OTel metrics for async shard fetch |
+| v2.14.0 | [#12440](https://github.com/opensearch-project/OpenSearch/pull/12440) | Batch allocator timeout settings |
+| v2.14.0 | [#12010](https://github.com/opensearch-project/OpenSearch/pull/12010) | Batch mode implementation |
+| v2.9.0 | [#8960](https://github.com/opensearch-project/OpenSearch/pull/8960) | Initial batch fetch transport actions |
+
+## References
+
+- [Issue #8098](https://github.com/opensearch-project/OpenSearch/issues/8098): META - Cluster Manager Async Shard Fetch Revamp
+- [Issue #5098](https://github.com/opensearch-project/OpenSearch/issues/5098): Original issue - Async shard fetches causing memory spikes with >50k shards
+- [Issue #17713](https://github.com/opensearch-project/OpenSearch/issues/17713): Feature request to enable by default
+- [Issue #18098](https://github.com/opensearch-project/OpenSearch/issues/18098): Known issue with replica shard assignment in batch mode
+
+## Change History
+
+- **v3.1.0** (2025-04-30): Enabled by default, updated timeout defaults to 20s
+- **v2.18.0** (2024-10-22): Added OTel metrics for async shard fetch success/failure
+- **v2.14.0** (2024-05-21): Added configurable timeout settings for batch allocators
+- **v2.9.0** (2023-07-18): Initial batch fetch implementation (experimental, disabled by default)

--- a/docs/releases/v3.1.0/features/opensearch/async-shard-batch-fetch.md
+++ b/docs/releases/v3.1.0/features/opensearch/async-shard-batch-fetch.md
@@ -1,0 +1,95 @@
+# Async Shard Batch Fetch
+
+## Summary
+
+OpenSearch v3.1.0 enables Async Shard Batch Fetch by default, improving cluster manager resilience and reducing memory pressure during node restarts. This feature batches shard metadata fetch operations instead of fetching per-shard, significantly reducing the load on the cluster manager when handling large numbers of shards.
+
+## Details
+
+### What's New in v3.1.0
+
+- **Enabled by default**: The `cluster.allocator.existing_shards_allocator.batch_enabled` setting now defaults to `true`
+- **Updated timeout defaults**: Both `primary_allocator_timeout` and `replica_allocator_timeout` now default to 20 seconds (previously `-1` meaning no timeout)
+
+### Technical Changes
+
+#### Configuration Changes
+
+| Setting | Old Default | New Default | Description |
+|---------|-------------|-------------|-------------|
+| `cluster.allocator.existing_shards_allocator.batch_enabled` | `false` | `true` | Enable batch mode for shard allocation |
+| `cluster.allocator.shard.batch.primary_allocator_timeout` | `-1` (disabled) | `20s` | Timeout for primary shard batch allocation |
+| `cluster.allocator.shard.batch.replica_allocator_timeout` | `-1` (disabled) | `20s` | Timeout for replica shard batch allocation |
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph "Cluster Manager"
+        AS[AllocationService]
+        SBGA[ShardsBatchGatewayAllocator]
+        PSA[PrimaryShardBatchAllocator]
+        RSA[ReplicaShardBatchAllocator]
+    end
+    
+    subgraph "Data Nodes"
+        DN1[Data Node 1]
+        DN2[Data Node 2]
+        DN3[Data Node N]
+    end
+    
+    AS -->|batch mode enabled| SBGA
+    SBGA --> PSA
+    SBGA --> RSA
+    PSA -->|batch fetch| DN1
+    PSA -->|batch fetch| DN2
+    PSA -->|batch fetch| DN3
+    RSA -->|batch fetch| DN1
+    RSA -->|batch fetch| DN2
+    RSA -->|batch fetch| DN3
+```
+
+### Usage Example
+
+The feature is now enabled by default. To disable it (not recommended):
+
+```yaml
+# opensearch.yml
+cluster.allocator.existing_shards_allocator.batch_enabled: false
+```
+
+To adjust timeout settings:
+
+```yaml
+# opensearch.yml
+cluster.allocator.shard.batch.primary_allocator_timeout: 30s
+cluster.allocator.shard.batch.replica_allocator_timeout: 30s
+```
+
+### Migration Notes
+
+- **Automatic enablement**: Clusters upgrading to v3.1.0 will automatically use batch mode
+- **No action required**: The default settings are optimized for most use cases
+- **Timeout behavior**: The 20-second default timeout prevents indefinite blocking during allocation
+
+## Limitations
+
+- **Known issue**: When multiple replica shards exist for the same shard ID (one INITIALIZING, one UNASSIGNED), the UNASSIGNED shard may be temporarily blocked until the INITIALIZING shard completes or times out ([#18098](https://github.com/opensearch-project/OpenSearch/issues/18098))
+- **Minimum timeout**: The allocator timeout cannot be set below 20 seconds when enabled
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18139](https://github.com/opensearch-project/OpenSearch/pull/18139) | Enabled Async Shard Batch Fetch by default |
+
+## References
+
+- [Issue #17713](https://github.com/opensearch-project/OpenSearch/issues/17713): Feature request to enable by default
+- [Issue #18098](https://github.com/opensearch-project/OpenSearch/issues/18098): Known issue with replica shard assignment
+- [Issue #8098](https://github.com/opensearch-project/OpenSearch/issues/8098): META - Cluster Manager Async Shard Fetch Revamp
+- [Issue #5098](https://github.com/opensearch-project/OpenSearch/issues/5098): Original issue - Async shard fetches causing memory spikes
+
+## Related Feature Report
+
+- [Async Shard Batch Fetch feature documentation](../../../features/opensearch/async-shard-batch-fetch.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -5,6 +5,7 @@
 ### OpenSearch
 
 - [Approximation Framework](features/opensearch/approximation-framework.md) - BKD traversal optimization for skewed datasets with DFS strategy
+- [Async Shard Batch Fetch](features/opensearch/async-shard-batch-fetch.md) - Enabled by default with 20s timeout for improved cluster manager resilience
 - [Crypto/KMS Plugin](features/opensearch/crypto-kms-plugin.md) - Decoupled plugin initialization and AWS SDK v2.x dependency upgrade
 - [Dependency Bumps](features/opensearch/dependency-bumps.md) - 21 dependency updates including CVE-2025-27820 fix, Netty, Gson, Azure SDK updates
 - [DocRequest Refactoring](features/opensearch/docrequest-refactoring.md) - Generic interface for single-document operations


### PR DESCRIPTION
## Summary

Add documentation for the Async Shard Batch Fetch feature enabled by default in OpenSearch v3.1.0.

## Changes

### Release Report
- `docs/releases/v3.1.0/features/opensearch/async-shard-batch-fetch.md`
  - Documents the v3.1.0 changes: enabled by default, 20s timeout defaults
  - Includes configuration changes, architecture diagram, and known limitations

### Feature Report
- `docs/features/opensearch/async-shard-batch-fetch.md`
  - Comprehensive documentation of the batch shard fetch feature
  - Architecture and data flow diagrams
  - Configuration reference
  - Change history from v2.9.0 to v3.1.0

### Index Updates
- Updated `docs/releases/v3.1.0/index.md`
- Updated `docs/features/index.md`

## Related Issue
Closes #907