### PR TITLE
docs: add Security Manager Replacement report for v3.1.0

### DIFF
--- a/docs/features/multi-plugin/jdk-21-java-agent-migration.md
+++ b/docs/features/multi-plugin/jdk-21-java-agent-migration.md
@@ -133,6 +133,7 @@ jobs:
 
 | Version | PR | Repository | Description |
 |---------|-----|------------|-------------|
+| v3.1.0 | [#17989](https://github.com/opensearch-project/OpenSearch/pull/17989) | OpenSearch | Enhance Java Agent to intercept newByteChannel from FileSystemProvider |
 | v3.0.0 | [#17900](https://github.com/opensearch-project/OpenSearch/pull/17900) | OpenSearch | Custom Gradle plugin for Java Agent |
 | v3.0.0 | [#730](https://github.com/opensearch-project/flow-framework/pull/730) | flow-framework | JDK 21 target compatibility |
 | v3.0.0 | [#1108](https://github.com/opensearch-project/flow-framework/pull/1108) | flow-framework | Java Agent Gradle plugin |
@@ -155,4 +156,5 @@ jobs:
 
 ## Change History
 
+- **v3.1.0** (2026-01-14): Enhanced Java Agent to intercept `newByteChannel` from `FileSystemProvider.class`, improved argument type handling for `Set<OpenOption>`, fixed policy variable expansion
 - **v3.0.0** (2025-05-06): JDK 21 minimum requirement, Java Agent Gradle plugin, SecurityManager phase-out across all plugins

--- a/docs/releases/v3.1.0/features/opensearch/security-manager-replacement.md
+++ b/docs/releases/v3.1.0/features/opensearch/security-manager-replacement.md
@@ -1,0 +1,125 @@
+# Security Manager Replacement
+
+## Summary
+
+This release enhances the Java Agent to intercept `newByteChannel` method from `FileSystemProvider.class`, expanding the file operation interception coverage. This improvement ensures that file access through `Files.readAllLines()`, `Files.newOutputStream()`, and similar methods that internally use `FileSystemProvider.newByteChannel()` are properly monitored and authorized by the Java Agent security model.
+
+## Details
+
+### What's New in v3.1.0
+
+The Java Agent's file interception capabilities have been expanded to cover additional file access patterns:
+
+1. **FileSystemProvider Interception**: Added `FileSystemProvider.class` to the list of intercepted types
+2. **newByteChannel Support**: The `FileInterceptor` now properly handles `newByteChannel` method calls
+3. **Argument Type Handling**: Enhanced argument parsing to support `Set<OpenOption>` and `Object[]` in addition to `OpenOption[]`
+4. **Policy Variable Expansion**: Fixed system property expansion in policy files using `${{property}}` syntax
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Java Agent Interceptors"
+        SI[SocketChannelInterceptor]
+        FI[FileInterceptor]
+    end
+    
+    subgraph "Intercepted Types (v3.0.0)"
+        FC[FileChannel.class]
+        F[Files.class]
+        S[Socket.class]
+    end
+    
+    subgraph "New in v3.1.0"
+        FSP[FileSystemProvider.class]
+    end
+    
+    FI --> FC
+    FI --> F
+    FI --> FSP
+    SI --> S
+    
+    subgraph "File Operations"
+        NBC[newByteChannel]
+        OPEN[open]
+        COPY[copy]
+        MOVE[move]
+        DELETE[delete]
+    end
+    
+    FSP --> NBC
+    FC --> OPEN
+    F --> COPY
+    F --> MOVE
+    F --> DELETE
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `FileSystemProvider` interception | Intercepts file operations via NIO FileSystemProvider |
+| `Set<OpenOption>` handling | Supports Set-based open options from FileSystemProvider |
+| Policy variable expansion | Expands `${{property}}` syntax in permission names |
+
+#### API Changes
+
+The `FileInterceptor` now handles three argument types for `newByteChannel` and `open` methods:
+
+| Argument Type | Source | Example |
+|---------------|--------|---------|
+| `OpenOption[]` | `FileChannel.open()` | Direct array of options |
+| `Set<OpenOption>` | `FileSystemProvider.newByteChannel()` | Set from Files API |
+| `Object[]` | Generic fallback | Any object array |
+
+### Usage Example
+
+```java
+// These operations are now properly intercepted:
+
+// Via Files API (uses FileSystemProvider.newByteChannel internally)
+List<String> lines = Files.readAllLines(path);
+OutputStream os = Files.newOutputStream(path);
+
+// Via FileChannel (already intercepted in v3.0.0)
+FileChannel channel = FileChannel.open(path, StandardOpenOption.READ);
+```
+
+### Migration Notes
+
+Plugin developers using `Files.readAllLines()`, `Files.newOutputStream()`, or similar methods should ensure their `plugin-security.policy` files include appropriate `FilePermission` grants:
+
+```policy
+grant {
+  permission java.io.FilePermission "/path/to/file", "read";
+  permission java.io.FilePermission "/path/to/file", "read,write";
+}
+```
+
+## Limitations
+
+- The Java Agent focuses on file and network operations; other JSM permission types (reflection, thread context) are not intercepted
+- Performance overhead from bytecode instrumentation is minimal but present
+- Policy files must use `${{property}}` syntax (double braces) for system property expansion
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17989](https://github.com/opensearch-project/OpenSearch/pull/17989) | Enhance Java Agent to intercept newByteChannel from FileSystemProvider |
+| [#17861](https://github.com/opensearch-project/OpenSearch/pull/17861) | Phase off SecurityManager usage in favor of Java Agent (v3.0.0) |
+| [#17753](https://github.com/opensearch-project/OpenSearch/pull/17753) | Add policy parser for Java Agent (v3.0.0) |
+| [#17894](https://github.com/opensearch-project/OpenSearch/pull/17894) | Limit stack walking to frames before AccessController.doPrivileged (v3.0.0) |
+
+## References
+
+- [Issue #1687](https://github.com/opensearch-project/OpenSearch/issues/1687): RFC - Replace Java Security Manager (JSM)
+- [Blog: Finding a replacement for JSM in OpenSearch 3.0](https://opensearch.org/blog/finding-a-replacement-for-jsm-in-opensearch-3-0/)
+- [JEP 411](https://openjdk.org/jeps/411): Deprecate the Security Manager for Removal
+- [JEP 486](https://openjdk.org/jeps/486): Permanently Disable the Security Manager (JDK 24)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/multi-plugin/jdk-21-java-agent-migration.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -27,3 +27,4 @@
 - [Unified Highlighter](features/opensearch/unified-highlighter.md) - Add matched_fields support for blending matches from multiple fields
 - [System Ingest Pipeline](features/opensearch/system-ingest-pipeline.md) - Automatic pipeline generation for plugin developers with bulk update support
 - [Query Coordinator Context](features/opensearch/query-coordinator-context.md) - Search request access and validate API integration for index-aware query rewriting
+- [Security Manager Replacement](features/opensearch/security-manager-replacement.md) - Enhanced Java Agent to intercept newByteChannel from FileSystemProvider


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security Manager Replacement enhancement in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/opensearch/security-manager-replacement.md`
- Feature report updated: `docs/features/multi-plugin/jdk-21-java-agent-migration.md`

### Key Changes in v3.1.0
- Enhanced Java Agent to intercept `newByteChannel` from `FileSystemProvider.class`
- Improved argument type handling for `Set<OpenOption>` in addition to `OpenOption[]`
- Fixed policy variable expansion using `${{property}}` syntax

### Resources Used
- PR: [#17989](https://github.com/opensearch-project/OpenSearch/pull/17989)
- PR: [#17861](https://github.com/opensearch-project/OpenSearch/pull/17861)
- Blog: [Finding a replacement for JSM in OpenSearch 3.0](https://opensearch.org/blog/finding-a-replacement-for-jsm-in-opensearch-3-0/)
- Issue: [#1687](https://github.com/opensearch-project/OpenSearch/issues/1687)

Closes #906