### PR TITLE
docs: add Derived Source report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -35,6 +35,7 @@
 - [Cluster Manager Task Throttling](opensearch/cluster-manager-throttling.md)
 - [Cluster State Management](opensearch/cluster-state-management.md)
 - [Dependency Management](opensearch/dependency-management.md)
+- [Derived Source](opensearch/derived-source.md)
 - [Docker Compose v2 Support](opensearch/docker-compose-v2-support.md)
 - [Dynamic Threadpool Resize](opensearch/dynamic-threadpool-resize.md)
 - [Locale Provider](opensearch/locale-provider.md)

--- a/docs/features/opensearch/derived-source.md
+++ b/docs/features/opensearch/derived-source.md
@@ -1,0 +1,163 @@
+# Derived Source
+
+## Summary
+
+Derived Source is a storage optimization feature that eliminates the need to store the `_source` field during document ingestion. Instead of duplicating data, OpenSearch dynamically reconstructs documents from `doc_values` and stored fields on demand. This approach can reduce storage costs by up to 2x while maintaining full search functionality and supporting operations like reindexing, updates, scripted updates, and recovery.
+
+The feature is particularly beneficial for time-series data and aggregation-heavy workloads where the original document body is rarely needed but aggregations like `min`, `max`, `avg`, `sum`, or `terms` are frequently used.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Document Ingestion"
+        A[Incoming Document] --> B{Derived Source Enabled?}
+        B -->|No| C[Store _source field]
+        B -->|Yes| D[Skip _source storage]
+        C --> E[Store in indexed/doc_values/stored formats]
+        D --> E
+    end
+    
+    subgraph "Document Retrieval"
+        F[Search/Get Request] --> G{Derived Source Enabled?}
+        G -->|No| H[Read from _source]
+        G -->|Yes| I[DerivedFieldGenerator]
+        I --> J[Read from doc_values]
+        I --> K[Read from stored fields]
+        J --> L[Combine field values]
+        K --> L
+        L --> M[Reconstructed Document]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Fetch Phase"
+        A[Document Request] --> B[FieldMapper.deriveSource]
+        B --> C[DerivedFieldGenerator]
+        C --> D{Field Storage Type}
+        D -->|Doc Values| E[SortedNumericDocValuesFetcher]
+        D -->|Doc Values| F[SortedSetDocValuesFetcher]
+        D -->|Stored| G[StoredFieldFetcher]
+        E --> H[XContentBuilder]
+        F --> H
+        G --> H
+        H --> I[Final Document]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `DerivedFieldGenerator` | Core class that generates derived source based on field mapping and storage preferences |
+| `FieldValueFetcher` | Abstract base class for fetching field values from Lucene |
+| `SortedNumericDocValuesFetcher` | Fetches numeric values from sorted numeric doc values |
+| `SortedSetDocValuesFetcher` | Fetches string values from sorted set doc values (keyword, IP fields) |
+| `StoredFieldFetcher` | Fetches values from stored fields using `SingleFieldsVisitor` |
+| `FieldValueType` | Enum with values `DOC_VALUES` and `STORED` indicating storage preference |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.derived_source.enabled` | Enable derived source for the index | `false` |
+| `index.derived_source.translog.enabled` | Enable derived source for translog operations | `true` |
+
+### Supported Field Types
+
+| Field Type | Doc Values | Stored Field | Notes |
+|------------|-----------|--------------|-------|
+| Date | ✓ | ✓ | Uses first format from format list |
+| Date Nanos | ✓ | ✓ | Uses first format from format list |
+| Integer | ✓ | ✓ | Multi-value sorted |
+| Long | ✓ | ✓ | Multi-value sorted |
+| Float | ✓ | ✓ | Multi-value sorted |
+| Double | ✓ | ✓ | Multi-value sorted |
+| Half Float | ✓ | ✓ | Some precision loss possible |
+| Unsigned Long | ✓ | ✓ | Multi-value sorted |
+| Byte | ✓ | ✓ | Multi-value sorted |
+| Short | ✓ | ✓ | Multi-value sorted |
+| Scaled Float | ✓ | ✓ | Precision loss due to scaling factor |
+| Boolean | ✓ | ✓ | String values converted to boolean |
+| IP | ✓ | ✓ | Multi-value deduplicated and sorted |
+| Constant Keyword | N/A | ✓ | Returns constant value from mapping |
+| Geo Point | ✓ | ✓ | Always returns `{"lat": val, "lon": val}` format |
+| Keyword | ✓ | ✓ | Multi-value deduplicated and sorted |
+| Text | N/A | ✓ | Requires `store: true` |
+| Wildcard | ✓ | N/A | Requires doc_values enabled |
+
+### Usage Example
+
+```json
+PUT sample-index
+{
+  "settings": {
+    "index": {
+      "derived_source": {
+        "enabled": true
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "hostName": { "type": "keyword" },
+      "hostIp": { "type": "ip" },
+      "zone": { "type": "keyword" },
+      "@timestamp": { "type": "date" },
+      "cpu": { "type": "float" },
+      "jvm": { "type": "float" }
+    }
+  }
+}
+```
+
+### Performance Benchmarks
+
+| Workload | Storage Reduction | Indexing Throughput | Merge Time Reduction |
+|----------|------------------|---------------------|---------------------|
+| nyc_taxis | 41% | Up to 18% improvement | 20-48% |
+| http logs | 43% | Up to 18% improvement | 20-48% |
+| elb logs | 58% | Up to 18% improvement | 20-48% |
+
+Search latency may increase by 10-100% depending on the number of documents retrieved, as reading from multiple field locations is slower than reading from a single `_source` field.
+
+## Limitations
+
+- **Index-level setting**: Must be configured at index creation time, cannot be changed afterward
+- **Field restrictions**:
+  - Fields with `copy_to` parameter are not supported
+  - Keyword fields with `ignore_above` or `normalizer` are not supported
+  - Text fields require `store: true`
+  - Wildcard fields require `doc_values: true`
+- **Data representation changes**:
+  - Multi-value keyword fields are deduplicated and sorted
+  - Multi-value numeric fields are sorted
+  - Date fields use the first format from the format list
+  - Geo point values always output in `{"lat": lat_val, "lon": lon_val}` format
+- **Precision considerations**:
+  - Geo point fields may have precision loss (~4.19e-8 for latitude, ~8.38e-8 for longitude)
+  - Half float fields may have precision loss
+  - Scaled float fields have precision loss due to scaling factor
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#17759](https://github.com/opensearch-project/OpenSearch/pull/17759) | Adding support for derive source feature and implementing it for various type of field mappers |
+
+## References
+
+- [Issue #17073](https://github.com/opensearch-project/OpenSearch/issues/17073): Add support for deriving source field in FieldMapper
+- [Issue #9568](https://github.com/opensearch-project/OpenSearch/issues/9568): Optimizing Data Storage and Retrieval for Time Series data
+- [Issue #17048](https://github.com/opensearch-project/OpenSearch/issues/17048): META - Enabling Derived Source in OpenSearch
+- [Blog: Save up to 2x on storage with derived source](https://opensearch.org/blog/save-up-to-2x-on-storage-with-derived-source/)
+- [Documentation: Derived source](https://docs.opensearch.org/latest/field-types/metadata-fields/source/#derived-source)
+
+## Change History
+
+- **v3.1.0** (2026-01-10): Initial implementation - Added derive source support for basic field types including Date, Number, Boolean, IP, Keyword, Text, Geo Point, Constant Keyword, Scaled Float, and Wildcard

--- a/docs/releases/v3.1.0/features/opensearch/derived-source.md
+++ b/docs/releases/v3.1.0/features/opensearch/derived-source.md
@@ -1,0 +1,125 @@
+# Derived Source
+
+## Summary
+
+Derived Source is a storage optimization feature that eliminates the need to store the `_source` field during document ingestion. Instead of duplicating data in the `_source` field, OpenSearch dynamically reconstructs documents from `doc_values` and stored fields on demand. This can reduce storage costs by up to 2x while maintaining full search functionality and supporting operations like reindexing, updates, and recovery.
+
+## Details
+
+### What's New in v3.1.0
+
+This release introduces the foundational support for deriving source from field mappers. The implementation adds interfaces and methods to `FieldMapper` that enable building source from `doc_values` and stored fields for various field types.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Traditional Document Storage"
+        A[Document Ingestion] --> B[_source Field]
+        A --> C[Indexed Fields]
+        A --> D[Doc Values]
+        A --> E[Stored Fields]
+    end
+    
+    subgraph "Derived Source Storage"
+        F[Document Ingestion] --> G[Indexed Fields]
+        F --> H[Doc Values]
+        F --> I[Stored Fields]
+        J[Document Retrieval] --> K[DerivedFieldGenerator]
+        K --> H
+        K --> I
+        K --> L[Reconstructed Document]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `DerivedFieldGenerator` | Generates derived source field based on field mapping and storage type |
+| `FieldValueFetcher` | Base class for fetching field values from doc values or stored fields |
+| `SortedNumericDocValuesFetcher` | Fetches values from sorted numeric doc values |
+| `SortedSetDocValuesFetcher` | Fetches values from sorted set doc values (for keyword/IP fields) |
+| `StoredFieldFetcher` | Fetches values from stored fields |
+| `FieldValueType` | Enum indicating the type of field value (DOC_VALUES or STORED) |
+
+#### Supported Field Types
+
+| Field Type | Doc Values Support | Stored Field Support |
+|------------|-------------------|---------------------|
+| Date (millis/nanos) | ✓ | ✓ |
+| Number (integer, long, float, double, etc.) | ✓ | ✓ |
+| Scaled Float | ✓ | ✓ |
+| Boolean | ✓ | ✓ |
+| IP | ✓ | ✓ |
+| Constant Keyword | N/A | ✓ |
+| Geo Point | ✓ | ✓ |
+| Keyword | ✓ | ✓ |
+| Text | N/A | ✓ |
+| Wildcard | ✓ | N/A |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.derived_source.enabled` | Enable derived source for the index | `false` |
+| `index.derived_source.translog.enabled` | Enable derived source for translog operations | `true` (when derived_source enabled) |
+
+### Usage Example
+
+```json
+PUT sample-index
+{
+  "settings": {
+    "index": {
+      "derived_source": {
+        "enabled": true
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "timestamp": { "type": "date" },
+      "host": { "type": "keyword" },
+      "cpu": { "type": "float" },
+      "message": { "type": "text", "store": true }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- Derived source is an index-level setting that must be configured at index creation time
+- Cannot be changed after index creation to prevent mixed behavior
+- All fields must be of supported types for derived source to be enabled
+- Fields with `copy_to` parameter are not supported for derived source
+
+## Limitations
+
+- Fields with `copy_to` parameter cannot derive source
+- Keyword fields with `ignore_above` or `normalizer` are not supported
+- Text fields require `store: true` to derive source
+- Multi-value fields may have different ordering (sorted) compared to original
+- Date fields use the first format from the format list for output
+- Geo point values always output in `{"lat": lat_val, "lon": lon_val}` format
+- Some precision loss may occur for geo point and half_float fields
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17759](https://github.com/opensearch-project/OpenSearch/pull/17759) | Adding support for derive source feature and implementing it for various type of field mappers |
+
+## References
+
+- [Issue #17073](https://github.com/opensearch-project/OpenSearch/issues/17073): Add support for deriving source field in FieldMapper
+- [Issue #9568](https://github.com/opensearch-project/OpenSearch/issues/9568): Optimizing Data Storage and Retrieval for Time Series data
+- [Blog: Save up to 2x on storage with derived source](https://opensearch.org/blog/save-up-to-2x-on-storage-with-derived-source/)
+- [Documentation: Derived source](https://docs.opensearch.org/latest/field-types/metadata-fields/source/#derived-source)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/derived-source.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -5,6 +5,7 @@
 ### OpenSearch
 
 - [Approximation Framework](features/opensearch/approximation-framework.md) - BKD traversal optimization for skewed datasets with DFS strategy
+- [Derived Source](features/opensearch/derived-source.md) - Storage optimization by deriving _source from doc_values and stored fields
 - [Async Shard Batch Fetch](features/opensearch/async-shard-batch-fetch.md) - Enabled by default with 20s timeout for improved cluster manager resilience
 - [Crypto/KMS Plugin](features/opensearch/crypto-kms-plugin.md) - Decoupled plugin initialization and AWS SDK v2.x dependency upgrade
 - [Dependency Bumps](features/opensearch/dependency-bumps.md) - 21 dependency updates including CVE-2025-27820 fix, Netty, Gson, Azure SDK updates


### PR DESCRIPTION
## Summary

This PR adds documentation for the Derived Source feature introduced in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/opensearch/derived-source.md`
- Feature report: `docs/features/opensearch/derived-source.md`

### Feature Overview

Derived Source is a storage optimization feature that eliminates the need to store the `_source` field during document ingestion. Instead of duplicating data, OpenSearch dynamically reconstructs documents from `doc_values` and stored fields on demand. This can reduce storage costs by up to 2x.

### Key Changes in v3.1.0
- Added `DerivedFieldGenerator` for generating source from field storage
- Implemented `FieldValueFetcher` classes for doc values and stored fields
- Support for 10+ field types: Date, Number, Boolean, IP, Keyword, Text, Geo Point, etc.
- New index setting `index.derived_source.enabled`

### Resources Used
- PR: [#17759](https://github.com/opensearch-project/OpenSearch/pull/17759)
- Issue: [#17073](https://github.com/opensearch-project/OpenSearch/issues/17073)
- Blog: [Save up to 2x on storage with derived source](https://opensearch.org/blog/save-up-to-2x-on-storage-with-derived-source/)