### PR TITLE
docs: add Composite Directory Factory report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -21,6 +21,7 @@
 - [Cluster Stats API](opensearch/cluster-stats-api.md)
 - [Cluster Manager Metrics](opensearch/cluster-manager-metrics.md)
 - [Code Cleanup](opensearch/code-cleanup.md)
+- [Composite Directory Factory](opensearch/composite-directory-factory.md)
 - [Crypto KMS Plugin](opensearch/crypto-kms-plugin.md)
 - [Deprecated Code Cleanup](opensearch/deprecated-code-cleanup.md)
 - [DocRequest Refactoring](opensearch/docrequest-refactoring.md)

--- a/docs/features/opensearch/composite-directory-factory.md
+++ b/docs/features/opensearch/composite-directory-factory.md
@@ -1,0 +1,142 @@
+# Composite Directory Factory
+
+## Summary
+
+Composite Directory Factory is a pluggable extension point in OpenSearch that enables custom implementations of composite directories for warm indices. Composite directories abstract data locality by managing both local and remote storage through a unified interface, using FileCache to optimize read performance. This factory pattern allows plugins to provide custom composite directory implementations tailored to specific storage requirements.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Plugin Registration"
+        ISP[IndexStorePlugin] --> |getCompositeDirectoryFactories| CDFs[CompositeDirectoryFactory Map]
+    end
+    
+    subgraph "Node Initialization"
+        Node[Node.java] --> |collects| CDFs
+        CDFs --> |registers| Registry[Factory Registry]
+        Registry --> |includes| DCDF[DefaultCompositeDirectoryFactory]
+    end
+    
+    subgraph "Index Creation"
+        IM[IndexModule] --> |receives| Registry
+        IM --> |creates| ISvc[IndexService]
+        ISvc --> |selects factory via| Setting[index.composite_store.type]
+    end
+    
+    subgraph "Shard Initialization"
+        ISvc --> |warm index| CDF{Selected Factory}
+        CDF --> |creates| CD[CompositeDirectory]
+        CD --> |wraps| LD[Local Directory]
+        CD --> |wraps| RD[Remote Directory]
+        CD --> |uses| FC[FileCache]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Read Path"
+        R1[Read Request] --> CD[CompositeDirectory]
+        CD --> FC{FileCache Check}
+        FC --> |hit| Local[Return from Local]
+        FC --> |miss| Remote[Fetch from Remote]
+        Remote --> Cache[Cache Locally]
+        Cache --> Local
+    end
+    
+    subgraph "Write Path"
+        W1[Write Request] --> Primary[Primary Shard]
+        Primary --> Lucene[Index to Lucene]
+        Lucene --> Segments[Create Segments]
+        Segments --> Upload[Upload to Remote]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `IndexStorePlugin.CompositeDirectoryFactory` | Interface for creating composite directories per shard |
+| `DefaultCompositeDirectoryFactory` | Default implementation using `CompositeDirectory` |
+| `CompositeDirectory` | Directory implementation that abstracts local/remote storage |
+| `FileCache` | LRU cache for locally caching remote file data |
+| `TransferManager` | Handles data transfer between local and remote storage |
+
+### Configuration
+
+| Setting | Description | Default | Scope |
+|---------|-------------|---------|-------|
+| `index.composite_store.type` | Composite directory factory type to use | `default` | Index, Node |
+
+### Usage Example
+
+#### Implementing a Custom Factory
+
+```java
+public class MyCompositeDirectoryFactory implements IndexStorePlugin.CompositeDirectoryFactory {
+    
+    @Override
+    public Directory newDirectory(
+        IndexSettings indexSettings,
+        ShardPath shardPath,
+        IndexStorePlugin.DirectoryFactory localDirectoryFactory,
+        Directory remoteDirectory,
+        FileCache fileCache
+    ) throws IOException {
+        Directory localDirectory = localDirectoryFactory.newDirectory(indexSettings, shardPath);
+        return new MyCustomCompositeDirectory(localDirectory, remoteDirectory, fileCache);
+    }
+}
+```
+
+#### Registering via Plugin
+
+```java
+public class MyStoragePlugin extends Plugin implements IndexStorePlugin {
+    
+    @Override
+    public Map<String, CompositeDirectoryFactory> getCompositeDirectoryFactories() {
+        return Map.of("my-storage", new MyCompositeDirectoryFactory());
+    }
+}
+```
+
+#### Using the Custom Factory
+
+```json
+PUT /my-warm-index
+{
+  "settings": {
+    "index.composite_store.type": "my-storage",
+    "index.number_of_replicas": 0
+  }
+}
+```
+
+## Limitations
+
+- Only applicable to warm indices with the `WRITABLE_WARM_INDEX_SETTING` feature flag enabled
+- Hot indices do not currently support composite directories
+- The factory type `default` is reserved and cannot be overridden by plugins
+- Custom implementations must handle all aspects of local/remote coordination
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#17988](https://github.com/opensearch-project/OpenSearch/pull/17988) | Add composite directory factory |
+
+## References
+
+- [Issue #17982](https://github.com/opensearch-project/OpenSearch/issues/17982): Need for Composite Directory Factory
+- [Issue #12809](https://github.com/opensearch-project/OpenSearch/issues/12809): Writable Warm feature
+- [Issue #12781](https://github.com/opensearch-project/OpenSearch/issues/12781): Composite Directory
+- [Remote-backed storage documentation](https://docs.opensearch.org/3.1/tuning-your-cluster/availability-and-recovery/remote-store/index/)
+
+## Change History
+
+- **v3.1.0**: Initial implementation - pluggable composite directory factory with default implementation

--- a/docs/releases/v3.1.0/features/opensearch/composite-directory-factory.md
+++ b/docs/releases/v3.1.0/features/opensearch/composite-directory-factory.md
@@ -1,0 +1,124 @@
+# Composite Directory Factory
+
+## Summary
+
+OpenSearch v3.1.0 introduces a pluggable Composite Directory Factory that enables custom implementations of composite directories for warm indices. This enhancement allows plugins to provide their own composite directory implementations, giving users flexibility in how data locality is managed between local and remote storage.
+
+## Details
+
+### What's New in v3.1.0
+
+The Composite Directory Factory provides a standardized interface for creating composite directories that abstract data locality (local vs. remote storage) using FileCache. Previously, the `CompositeDirectory` was instantiated directly in `IndexService.java` without any factory pattern, limiting extensibility.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Index Creation Flow"
+        IS[IndexSettings] --> IM[IndexModule]
+        IM --> ISvc[IndexService]
+    end
+    
+    subgraph "Directory Factory Selection"
+        ISvc --> CDF{CompositeDirectoryFactory}
+        CDF --> |default| DCDF[DefaultCompositeDirectoryFactory]
+        CDF --> |custom| PCDF[Plugin CompositeDirectoryFactory]
+    end
+    
+    subgraph "Directory Creation"
+        DCDF --> CD[CompositeDirectory]
+        PCDF --> CCD[Custom CompositeDirectory]
+        CD --> |uses| FC[FileCache]
+        CD --> |uses| LD[Local Directory]
+        CD --> |uses| RD[Remote Directory]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `IndexStorePlugin.CompositeDirectoryFactory` | New interface for creating composite directories per shard |
+| `DefaultCompositeDirectoryFactory` | Default implementation using the existing `CompositeDirectory` |
+| `INDEX_COMPOSITE_STORE_TYPE_SETTING` | New index setting to select composite directory factory type |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.composite_store.type` | Specifies which composite directory factory to use | `default` |
+
+#### API Changes
+
+New plugin extension point in `IndexStorePlugin`:
+
+```java
+interface CompositeDirectoryFactory {
+    Directory newDirectory(
+        IndexSettings indexSettings,
+        ShardPath shardPath,
+        DirectoryFactory localDirectoryFactory,
+        Directory remoteDirectory,
+        FileCache fileCache
+    ) throws IOException;
+}
+
+default Map<String, CompositeDirectoryFactory> getCompositeDirectoryFactories() {
+    return Collections.emptyMap();
+}
+```
+
+### Usage Example
+
+Plugins can register custom composite directory factories:
+
+```java
+public class MyPlugin extends Plugin implements IndexStorePlugin {
+    @Override
+    public Map<String, CompositeDirectoryFactory> getCompositeDirectoryFactories() {
+        return Map.of("my-custom", new MyCustomCompositeDirectoryFactory());
+    }
+}
+```
+
+Then configure an index to use the custom factory:
+
+```json
+PUT /my-warm-index
+{
+  "settings": {
+    "index.composite_store.type": "my-custom"
+  }
+}
+```
+
+### Migration Notes
+
+- Existing warm indices continue to work with the default composite directory factory
+- No migration required for existing deployments
+- Custom implementations can be added via plugins without modifying core OpenSearch
+
+## Limitations
+
+- Currently only applicable to warm indices (requires `WRITABLE_WARM_INDEX_SETTING` feature flag)
+- Hot indices do not yet support composite directories
+- The `CompositeDirectory` class fields were changed from private to protected to enable extension
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17988](https://github.com/opensearch-project/OpenSearch/pull/17988) | Add composite directory factory |
+
+## References
+
+- [Issue #17982](https://github.com/opensearch-project/OpenSearch/issues/17982): Need for Composite Directory Factory
+- [Issue #12809](https://github.com/opensearch-project/OpenSearch/issues/12809): Writable Warm feature
+- [Issue #12781](https://github.com/opensearch-project/OpenSearch/issues/12781): Composite Directory
+- [Remote-backed storage documentation](https://docs.opensearch.org/3.1/tuning-your-cluster/availability-and-recovery/remote-store/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/composite-directory-factory.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -28,4 +28,5 @@
 - [Unified Highlighter](features/opensearch/unified-highlighter.md) - Add matched_fields support for blending matches from multiple fields
 - [System Ingest Pipeline](features/opensearch/system-ingest-pipeline.md) - Automatic pipeline generation for plugin developers with bulk update support
 - [Query Coordinator Context](features/opensearch/query-coordinator-context.md) - Search request access and validate API integration for index-aware query rewriting
+- [Composite Directory Factory](features/opensearch/composite-directory-factory.md) - Pluggable factory for custom composite directory implementations in warm indices
 - [Security Manager Replacement](features/opensearch/security-manager-replacement.md) - Enhanced Java Agent to intercept newByteChannel from FileSystemProvider


### PR DESCRIPTION
## Summary

Add documentation for the Composite Directory Factory feature introduced in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/opensearch/composite-directory-factory.md`
- Feature report: `docs/features/opensearch/composite-directory-factory.md`

### Key Changes in v3.1.0
- New `IndexStorePlugin.CompositeDirectoryFactory` interface for pluggable composite directory implementations
- `DefaultCompositeDirectoryFactory` as the default implementation
- New `index.composite_store.type` setting to select composite directory factory
- Enables plugins to provide custom composite directory implementations for warm indices

### Resources Used
- PR: [#17988](https://github.com/opensearch-project/OpenSearch/pull/17988)
- Issue: [#17982](https://github.com/opensearch-project/OpenSearch/issues/17982)

Closes #904