### PR TITLE
docs: add warm storage tiering report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -89,6 +89,7 @@
 - [Tiered Caching](opensearch/tiered-caching.md)
 - [Transport Nodes Action Optimization](opensearch/transport-nodes-action-optimization.md)
 - [Unified Highlighter](opensearch/unified-highlighter.md)
+- [Warm Storage Tiering](opensearch/warm-storage-tiering.md)
 - [Wildcard Field](opensearch/wildcard-field.md)
 - [Workload Management](opensearch/workload-management.md)
 

--- a/docs/features/opensearch/warm-storage-tiering.md
+++ b/docs/features/opensearch/warm-storage-tiering.md
@@ -1,0 +1,204 @@
+# Warm Storage Tiering
+
+## Summary
+
+Warm Storage Tiering in OpenSearch provides a cost-effective way to manage data lifecycle by automatically moving less frequently accessed data from hot nodes (fast, expensive storage) to warm nodes (slower, cheaper storage backed by remote repositories like S3). This feature enables organizations to maintain searchability of historical data while optimizing storage costs through intelligent shard allocation and automated segment optimization.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Hot Tier"
+        HN[Hot Nodes<br/>Fast SSD Storage]
+        AFM[AutoForceMergeManager]
+        IDX[Active Indexes]
+    end
+    
+    subgraph "Warm Tier"
+        WN[Warm Nodes<br/>File Cache]
+        WDD[WarmDiskThresholdDecider]
+        SS[Searchable Snapshots]
+    end
+    
+    subgraph "Remote Storage"
+        RS[Remote Store<br/>S3 / Azure Blob / GCS]
+    end
+    
+    IDX --> HN
+    HN --> AFM
+    AFM -->|Optimize Segments| HN
+    HN -->|Snapshot & Migrate| RS
+    RS <-->|On-demand Fetch| WN
+    WDD -->|Allocation Decisions| WN
+    WN --> SS
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Ingestion
+        D[Documents] --> HN[Hot Node]
+    end
+    
+    subgraph "Hot Phase"
+        HN --> TX[Translog]
+        TX --> SEG[Segments]
+        SEG --> FM[Force Merge]
+    end
+    
+    subgraph Migration
+        FM --> SNAP[Snapshot]
+        SNAP --> RS[Remote Store]
+    end
+    
+    subgraph "Warm Phase"
+        RS --> FC[File Cache]
+        FC --> WN[Warm Node]
+        WN --> Q[Queries]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `WarmDiskThresholdDecider` | Allocation decider that manages shard placement on warm nodes based on remote addressable space and file cache capacity |
+| `AutoForceMergeManager` | Background service that automatically triggers force merge operations on eligible shards before warm migration |
+| `ForceMergeManagerSettings` | Configuration management for auto force merge behavior |
+| `ConfigurationValidator` | Validates node meets requirements (data node role, remote store enabled) |
+| `NodeValidator` | Monitors node resources (CPU, JVM, disk) to determine merge eligibility |
+| `ShardValidator` | Evaluates shard conditions (segment count, translog age) for merge candidacy |
+| `FileCacheSettings` | Manages file cache configuration including remote data ratio |
+
+### Configuration
+
+#### Cluster-Level Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.routing.allocation.disk.warm_threshold_enabled` | Enable/disable warm disk threshold allocation decider | `true` |
+| `cluster.auto_force_merge.enabled` | Enable/disable automatic force merge feature | `false` |
+| `cluster.filecache.remote_data_ratio` | Maximum ratio of remote data to local cache size | `5` |
+
+#### Node-Level Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `node.search.cache.size` | File cache size for warm nodes | 80% of available storage (dedicated warm nodes) |
+| `node.auto_force_merge.scheduler.interval` | Interval between force merge scheduling checks | `30m` |
+| `node.auto_force_merge.translog.age` | Minimum translog age before considering force merge | `30m` |
+| `node.auto_force_merge.segment.count` | Target segment count after force merge | `1` |
+| `node.auto_force_merge.merge_delay` | Delay between consecutive shard merges | `10s` |
+| `node.auto_force_merge.cpu.threshold` | CPU usage threshold to pause merge operations | `80%` |
+| `node.auto_force_merge.disk.threshold` | Disk usage threshold to pause merge operations | `90%` |
+| `node.auto_force_merge.jvm.threshold` | JVM heap usage threshold to pause merge operations | `75%` |
+| `node.auto_force_merge.threads.concurrency_multiplier` | Multiplier for concurrent merge threads | `2` |
+
+#### Index-Level Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.auto_force_merge.enabled` | Enable/disable auto force merge for specific index | `true` |
+
+### Usage Example
+
+#### Configure a Warm Node
+
+```yaml
+# opensearch.yml
+node.name: warm-node-1
+node.roles: [ warm ]
+node.search.cache.size: 100gb
+```
+
+#### Enable Auto Force Merge
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.auto_force_merge.enabled": true,
+    "node.auto_force_merge.scheduler.interval": "15m",
+    "node.auto_force_merge.translog.age": "1h",
+    "node.auto_force_merge.segment.count": 1
+  }
+}
+```
+
+#### Create Searchable Snapshot Index
+
+```json
+POST /_snapshot/my-repository/my-snapshot/_restore
+{
+  "storage_type": "remote_snapshot",
+  "indices": "my-index"
+}
+```
+
+#### ISM Policy for Hot-to-Warm Migration
+
+```json
+PUT _plugins/_ism/policies/hot-warm-policy
+{
+  "policy": {
+    "description": "Hot to warm tiering policy",
+    "default_state": "hot",
+    "states": [
+      {
+        "name": "hot",
+        "actions": [],
+        "transitions": [
+          {
+            "state_name": "warm",
+            "conditions": {
+              "min_index_age": "7d"
+            }
+          }
+        ]
+      },
+      {
+        "name": "warm",
+        "actions": [
+          {
+            "allocation": {
+              "require": { "data": "warm" }
+            }
+          }
+        ],
+        "transitions": []
+      }
+    ]
+  }
+}
+```
+
+## Limitations
+
+- Warm nodes require remote store to be enabled at the cluster level
+- Searchable snapshot indexes are read-only; write operations will fail
+- Search latency on warm tier is higher than hot tier due to remote data fetching
+- Auto force merge only operates on primary shards
+- Force merge operations are resource-intensive and may temporarily impact cluster performance
+- Remote object stores may incur per-request retrieval costs
+- Recommended to maintain a remote data to cache ratio of 5:1 or less for optimal performance
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#18082](https://github.com/opensearch-project/OpenSearch/pull/18082) | Add Warm Disk Threshold Allocation Decider for Warm shards |
+| v3.1.0 | [#18229](https://github.com/opensearch-project/OpenSearch/pull/18229) | Added Auto Force Merge Manager to enhance hot to warm migration |
+
+## References
+
+- [Issue #8535](https://github.com/opensearch-project/OpenSearch/issues/8535): Add support for a FileCacheDecider
+- [Searchable Snapshots Documentation](https://docs.opensearch.org/3.1/tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot/)
+- [Creating a Cluster - Hot and Warm Nodes](https://docs.opensearch.org/3.1/tuning-your-cluster/)
+- [ISM Policies](https://docs.opensearch.org/3.1/im-plugin/ism/policies/)
+
+## Change History
+
+- **v3.1.0** (2025-06-10): Added WarmDiskThresholdDecider for intelligent warm shard allocation and AutoForceMergeManager for automated segment optimization during hot-to-warm migration

--- a/docs/releases/v3.1.0/features/opensearch/warm-storage-tiering.md
+++ b/docs/releases/v3.1.0/features/opensearch/warm-storage-tiering.md
@@ -1,0 +1,148 @@
+# Warm Storage Tiering
+
+## Summary
+
+OpenSearch v3.1.0 introduces significant enhancements to warm storage tiering with two key features: the WarmDiskThresholdDecider for intelligent shard allocation on warm nodes, and the AutoForceMergeManager for automated segment optimization during hot-to-warm data migration. These improvements enable more efficient data lifecycle management and better resource utilization for tiered storage architectures.
+
+## Details
+
+### What's New in v3.1.0
+
+This release adds two major components to improve warm storage tiering:
+
+1. **WarmDiskThresholdDecider**: A new allocation decider that manages shard placement on warm nodes based on remote addressable space and file cache capacity
+2. **AutoForceMergeManager**: An automated force merge system that optimizes segments before data migrates from hot to warm tiers
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Hot Tier"
+        HN[Hot Nodes]
+        AFM[AutoForceMergeManager]
+    end
+    
+    subgraph "Warm Tier"
+        WN[Warm Nodes]
+        WDD[WarmDiskThresholdDecider]
+        FC[File Cache]
+    end
+    
+    subgraph "Remote Storage"
+        RS[Remote Store / S3]
+    end
+    
+    HN --> AFM
+    AFM -->|Force Merge| HN
+    HN -->|Migration| WN
+    WDD -->|Allocation Decision| WN
+    WN <--> FC
+    FC <--> RS
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `WarmDiskThresholdDecider` | Allocation decider for warm shards based on remote addressable space calculated from file cache size and remote data ratio |
+| `AutoForceMergeManager` | Manages automatic force merge operations on primary shards based on translog age and system conditions |
+| `ForceMergeManagerSettings` | Configuration settings for auto force merge behavior including thresholds and scheduling |
+| `ConfigurationValidator` | Validates node configuration requirements (data node, remote store enabled) |
+| `NodeValidator` | Validates node-level conditions (CPU, JVM, disk usage, thread availability) |
+| `ShardValidator` | Validates shard-level conditions (segment count, translog age) |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.routing.allocation.disk.warm_threshold_enabled` | Enable/disable warm disk threshold decider | `true` |
+| `cluster.auto_force_merge.enabled` | Enable/disable auto force merge feature | `false` |
+| `node.auto_force_merge.scheduler.interval` | Interval between force merge checks | `30m` |
+| `node.auto_force_merge.translog.age` | Minimum translog age before force merge | `30m` |
+| `node.auto_force_merge.segment.count` | Target segment count after merge | `1` |
+| `node.auto_force_merge.merge_delay` | Delay between shard merges | `10s` |
+| `node.auto_force_merge.cpu.threshold` | CPU usage threshold to pause merges | `80%` |
+| `node.auto_force_merge.disk.threshold` | Disk usage threshold to pause merges | `90%` |
+| `node.auto_force_merge.jvm.threshold` | JVM heap usage threshold to pause merges | `75%` |
+| `node.auto_force_merge.threads.concurrency_multiplier` | Multiplier for concurrent merge operations | `2` |
+| `index.auto_force_merge.enabled` | Per-index setting to enable/disable auto force merge | `true` |
+
+### WarmDiskThresholdDecider
+
+The WarmDiskThresholdDecider replaces the previous file cache allocation logic in `DiskThresholdDecider` with a dedicated decider for warm/remote-capable shards. It calculates total addressable space using:
+
+```
+totalAddressableSpace = remoteDataRatio × fileCacheSize
+```
+
+Key behaviors:
+- Uses low watermark threshold for `canAllocate` decisions
+- Uses high watermark threshold for `canRemain` decisions
+- Fails open when cluster info or file cache stats are unavailable
+- Respects the `cluster.routing.allocation.disk.warm_threshold_enabled` setting
+
+### AutoForceMergeManager
+
+The AutoForceMergeManager runs as a background task on data nodes to automatically trigger force merge operations. It:
+
+1. Validates cluster has warm nodes present
+2. Checks node resource conditions (CPU, disk, JVM, thread availability)
+3. Identifies eligible shards based on translog age and segment count
+4. Executes force merges with configurable delays between shards
+5. Respects per-index `index.auto_force_merge.enabled` setting
+
+### Usage Example
+
+Enable auto force merge cluster-wide:
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.auto_force_merge.enabled": true,
+    "node.auto_force_merge.scheduler.interval": "15m",
+    "node.auto_force_merge.translog.age": "1h"
+  }
+}
+```
+
+Disable auto force merge for a specific index:
+
+```json
+PUT /my-index/_settings
+{
+  "index.auto_force_merge.enabled": false
+}
+```
+
+### Migration Notes
+
+- The `search` node role no longer supports searchable snapshots as of OpenSearch 3.0; use the `warm` role instead
+- Existing clusters using file cache allocation will automatically use the new `WarmDiskThresholdDecider`
+- Auto force merge is disabled by default; enable it explicitly for hot-to-warm migration workflows
+
+## Limitations
+
+- Auto force merge only runs on data nodes with remote store enabled
+- Requires warm nodes to be present in the cluster for auto force merge to trigger
+- Force merge operations are resource-intensive and may impact query performance during execution
+- The feature respects resource thresholds but may still cause temporary performance degradation
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18082](https://github.com/opensearch-project/OpenSearch/pull/18082) | Add Warm Disk Threshold Allocation Decider for Warm shards |
+| [#18229](https://github.com/opensearch-project/OpenSearch/pull/18229) | Added Auto Force Merge Manager to enhance hot to warm migration |
+
+## References
+
+- [Issue #8535](https://github.com/opensearch-project/OpenSearch/issues/8535): Add support for a FileCacheDecider
+- [Searchable Snapshots Documentation](https://docs.opensearch.org/3.1/tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot/)
+- [Creating a Cluster - Warm Nodes](https://docs.opensearch.org/3.1/tuning-your-cluster/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/warm-storage-tiering.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -30,3 +30,4 @@
 - [Query Coordinator Context](features/opensearch/query-coordinator-context.md) - Search request access and validate API integration for index-aware query rewriting
 - [Composite Directory Factory](features/opensearch/composite-directory-factory.md) - Pluggable factory for custom composite directory implementations in warm indices
 - [Security Manager Replacement](features/opensearch/security-manager-replacement.md) - Enhanced Java Agent to intercept newByteChannel from FileSystemProvider
+- [Warm Storage Tiering](features/opensearch/warm-storage-tiering.md) - WarmDiskThresholdDecider and AutoForceMergeManager for hot-to-warm migration


### PR DESCRIPTION
## Summary

This PR adds documentation for the Warm Storage Tiering feature in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/opensearch/warm-storage-tiering.md`
- Feature report: `docs/features/opensearch/warm-storage-tiering.md`

### Key Changes in v3.1.0
- **WarmDiskThresholdDecider**: New allocation decider for warm shards based on remote addressable space and file cache capacity
- **AutoForceMergeManager**: Automated force merge system for segment optimization during hot-to-warm migration
- New cluster and node-level settings for controlling warm storage behavior

### PRs Investigated
- [#18082](https://github.com/opensearch-project/OpenSearch/pull/18082): Add Warm Disk Threshold Allocation Decider for Warm shards
- [#18229](https://github.com/opensearch-project/OpenSearch/pull/18229): Added Auto Force Merge Manager to enhance hot to warm migration

### Related Issue
Closes #903