### PR TITLE
docs: add pull-based-ingestion report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -64,6 +64,7 @@
 - [Phone Number Analyzer](opensearch/phone-analyzer.md)
 - [Plugin Installation](opensearch/plugin-installation.md)
 - [Plugin Testing Framework](opensearch/plugin-testing-framework.md)
+- [Pull-based Ingestion](opensearch/pull-based-ingestion.md)
 - [Query Bug Fixes](opensearch/query-bug-fixes.md)
 - [Query Coordinator Context](opensearch/query-coordinator-context.md)
 - [Query Optimization](opensearch/query-optimization.md)

--- a/docs/features/opensearch/pull-based-ingestion.md
+++ b/docs/features/opensearch/pull-based-ingestion.md
@@ -1,0 +1,218 @@
+# Pull-based Ingestion
+
+## Summary
+
+Pull-based ingestion enables OpenSearch to ingest data from streaming sources such as Apache Kafka and Amazon Kinesis. Unlike traditional push-based ingestion where clients send data via REST APIs, pull-based ingestion allows OpenSearch to control data flow by retrieving data directly from streaming sources, providing exactly-once ingestion semantics and native backpressure handling.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Streaming Sources"
+        Kafka[Apache Kafka]
+        Kinesis[Amazon Kinesis]
+    end
+    
+    subgraph "OpenSearch Pull-based Ingestion"
+        Consumer[Ingestion Consumer]
+        Poller[Stream Poller]
+        Queue[Internal Blocking Queue]
+        Processor[Message Processor]
+        Engine[Ingestion Engine]
+        
+        Kafka --> Consumer
+        Kinesis --> Consumer
+        Consumer --> Poller
+        Poller --> Queue
+        Queue --> Processor
+        Processor --> Engine
+    end
+    
+    subgraph "Cluster Integration"
+        ClusterState[Cluster State Listener]
+        WriteBlock[Write Block Handler]
+        Metrics[Metrics Collection]
+        
+        ClusterState --> Poller
+        WriteBlock --> Poller
+        Poller --> Metrics
+        Processor --> Metrics
+    end
+    
+    subgraph "Storage"
+        Lucene[Lucene Index]
+        RemoteStore[Remote Store]
+        
+        Engine --> Lucene
+        Lucene --> RemoteStore
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Message in Stream] --> B{Poller Active?}
+    B -->|No - Paused/Blocked| C[Wait]
+    C --> B
+    B -->|Yes| D[Poll Messages]
+    D --> E{Already Processed?}
+    E -->|Yes| F[Skip - Increment Duplicate Count]
+    E -->|No| G[Add to Internal Queue]
+    G --> H[Message Processor]
+    H --> I{Parse Message}
+    I -->|Invalid| J[Increment Invalid Count]
+    I -->|Valid| K{Operation Type}
+    K -->|index| L[Index Document]
+    K -->|create| M[Create Document]
+    K -->|delete| N[Delete Document]
+    L --> O{Success?}
+    M --> O
+    N --> O
+    O -->|Yes| P[Update Metrics]
+    O -->|No - Transient| Q{Retries < 2?}
+    Q -->|Yes| R[Retry]
+    R --> H
+    Q -->|No| S{Error Strategy}
+    S -->|DROP| T[Drop Message]
+    S -->|BLOCK| U[Pause Ingestion]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `IngestionEngine` | Specialized engine for pull-based ingestion, manages stream poller lifecycle |
+| `DefaultStreamPoller` | Polls messages from streaming source, handles pause/resume and write blocks |
+| `MessageProcessorRunnable` | Processes messages from internal queue, handles retries and error strategies |
+| `PartitionedBlockingQueueContainer` | Manages internal queues between poller and processor threads |
+| `IngestionShardConsumer` | Interface for source-specific consumers (Kafka, Kinesis) |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `ingestion_source.type` | Streaming source type (`kafka` or `kinesis`) | Required |
+| `ingestion_source.pointer.init.reset` | Initial position (`earliest`, `latest`, `reset_by_offset`, `reset_by_timestamp`) | `earliest` |
+| `ingestion_source.pointer.init.reset.value` | Value for offset/timestamp reset | Required for reset modes |
+| `ingestion_source.error_strategy` | Error handling (`DROP` or `BLOCK`) | `DROP` |
+| `ingestion_source.max_batch_size` | Maximum records per poll | 1000 |
+| `ingestion_source.poll.timeout` | Poll timeout in milliseconds | 1000 |
+| `ingestion_source.num_processor_threads` | Number of processor threads | 1 |
+| `ingestion_source.internal_queue_size` | Internal queue size between poller and processor | 100 |
+| `ingestion_source.param.*` | Source-specific parameters (topic, bootstrap_servers, etc.) | Varies |
+
+### Usage Example
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "ingestion_source": {
+      "type": "kafka",
+      "pointer.init.reset": "earliest",
+      "error_strategy": "drop",
+      "internal_queue_size": 500,
+      "param": {
+        "topic": "my-topic",
+        "bootstrap_servers": "localhost:9092"
+      }
+    },
+    "index.number_of_shards": 3,
+    "index.number_of_replicas": 1,
+    "index.replication.type": "SEGMENT"
+  }
+}
+```
+
+### Message Format
+
+```json
+{
+  "_id": "doc-1",
+  "_version": "1",
+  "_op_type": "index",
+  "_source": {
+    "field1": "value1",
+    "field2": 123
+  }
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `_id` | No | Document ID (auto-generated if not provided) |
+| `_version` | No | External version for conflict detection |
+| `_op_type` | No | Operation type: `index`, `create`, or `delete` |
+| `_source` | Yes | Document content |
+
+### Management APIs
+
+**Pause Ingestion**
+```
+POST /<index>/ingestion/_pause
+```
+
+**Resume Ingestion**
+```
+POST /<index>/ingestion/_resume
+{
+  "reset_settings": [
+    {"shard": 0, "mode": "offset", "value": "100"}
+  ]
+}
+```
+
+**Get Ingestion State**
+```
+GET /<index>/ingestion/_state
+```
+
+### Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `total_polled_count` | Total messages polled from source |
+| `total_processed_count` | Total messages successfully processed |
+| `total_invalid_message_count` | Messages with invalid format |
+| `total_version_conflicts_count` | Messages dropped due to version conflicts |
+| `total_failed_count` | Total processing failures |
+| `total_failures_dropped_count` | Failures dropped (with DROP strategy) |
+| `total_consumer_error_count` | Consumer-level errors |
+| `total_poller_message_failure_count` | Poller message failures |
+| `total_poller_message_dropped_count` | Messages dropped by poller |
+| `total_duplicate_message_skipped_count` | Duplicate messages skipped |
+| `lag_in_millis` | Ingestion lag in milliseconds |
+
+## Limitations
+
+- Requires segment replication with remote-backed storage
+- Cannot convert existing push-based indexes to pull-based
+- Index shards must be >= stream partitions
+- Traditional REST API ingestion disabled for pull-based indexes
+- Consumer reset only works when ingestion is paused
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#16927](https://github.com/opensearch-project/OpenSearch/issues/16927) | Initial pull-based ingestion implementation |
+| v3.1.0 | [#17977](https://github.com/opensearch-project/OpenSearch/pull/17977) | Lag metrics for polling |
+| v3.1.0 | [#18088](https://github.com/opensearch-project/OpenSearch/pull/18088) | Error metrics and configurable queue size |
+| v3.1.0 | [#18250](https://github.com/opensearch-project/OpenSearch/pull/18250) | Transient failure retries and create mode |
+| v3.1.0 | [#18280](https://github.com/opensearch-project/OpenSearch/pull/18280) | Cluster write block support |
+| v3.1.0 | [#18332](https://github.com/opensearch-project/OpenSearch/pull/18332) | Consumer reset in Resume API |
+
+## References
+
+- [Issue #17442](https://github.com/opensearch-project/OpenSearch/issues/17442): Ingestion management APIs
+- [Issue #18279](https://github.com/opensearch-project/OpenSearch/issues/18279): Cluster write block support
+- [Documentation](https://docs.opensearch.org/3.0/api-reference/document-apis/pull-based-ingestion/): Pull-based ingestion
+- [Documentation](https://docs.opensearch.org/3.0/api-reference/document-apis/pull-based-ingestion-management/): Pull-based ingestion management
+
+## Change History
+
+- **v3.1.0**: Added lag metrics, error metrics, configurable queue size, transient failure retries, create mode, cluster write block support, consumer reset in Resume API. Breaking change: renamed `REWIND_BY_OFFSET`/`REWIND_BY_TIMESTAMP` to `RESET_BY_OFFSET`/`RESET_BY_TIMESTAMP`.
+- **v3.0.0**: Initial implementation with Kafka and Kinesis support, pause/resume APIs, basic metrics.

--- a/docs/releases/v3.1.0/features/opensearch/pull-based-ingestion.md
+++ b/docs/releases/v3.1.0/features/opensearch/pull-based-ingestion.md
@@ -1,0 +1,148 @@
+# Pull-based Ingestion Enhancements
+
+## Summary
+
+OpenSearch 3.1.0 enhances pull-based ingestion with comprehensive metrics, error handling improvements, cluster write block support, and consumer reset capabilities in the Resume API. These changes improve observability, reliability, and operational control for streaming data ingestion from sources like Apache Kafka and Amazon Kinesis.
+
+## Details
+
+### What's New in v3.1.0
+
+#### Lag Metrics for Polling
+PR #17977 adds lag metrics to monitor ingestion delay. The `Message` interface now includes a `getTimestamp()` method that returns the message timestamp for lag calculation.
+
+#### Error Metrics and Configurable Queue Size
+PR #18088 introduces detailed error metrics for both poller and processor components:
+
+| Metric Category | Metrics Added |
+|-----------------|---------------|
+| Message Processor | `total_processed_count`, `total_invalid_message_count`, `total_version_conflicts_count`, `total_failed_count`, `total_failures_dropped_count`, `total_processor_thread_interrupt_count` |
+| Consumer | `total_polled_count`, `total_consumer_error_count`, `total_poller_message_failure_count`, `total_poller_message_dropped_count`, `lag_in_millis` |
+
+A new configurable setting `index.ingestion_source.internal_queue_size` controls the internal blocking queue size (default: 100, range: 1-100000).
+
+#### Transient Failure Retries and Create Mode
+PR #18250 adds:
+- **Retry mechanism**: Failed messages are retried up to 2 times before being dropped (with DROP error strategy)
+- **Create mode support**: New `_op_type: "create"` for insert-only operations that won't update existing documents
+
+#### Cluster Write Block Support
+PR #18280 enables the stream poller to respect cluster write blocks. When a write block is active (local or global), the poller automatically pauses and resumes when the block is removed. The `GetIngestionState` API now includes `write_block_enabled` status.
+
+#### Consumer Reset in Resume API (Breaking Change)
+PR #18332 adds consumer reset capability to the Resume API, allowing offset/timestamp-based repositioning:
+
+```json
+POST /<index>/ingestion/_resume
+{
+  "reset_settings": [
+    {
+      "shard": 0,
+      "mode": "offset",
+      "value": "100"
+    }
+  ]
+}
+```
+
+**Breaking Change**: The `ResetState` enum values have been renamed:
+- `REWIND_BY_OFFSET` → `RESET_BY_OFFSET`
+- `REWIND_BY_TIMESTAMP` → `RESET_BY_TIMESTAMP`
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Pull-based Ingestion v3.1.0"
+        Source[Streaming Source<br/>Kafka/Kinesis]
+        Poller[Stream Poller]
+        Queue[Internal Queue<br/>Configurable Size]
+        Processor[Message Processor<br/>with Retries]
+        Engine[Ingestion Engine]
+        
+        Source --> Poller
+        Poller --> Queue
+        Queue --> Processor
+        Processor --> Engine
+        
+        ClusterState[Cluster State<br/>Write Block Listener]
+        ClusterState -.-> Poller
+        
+        Metrics[Metrics Collection]
+        Poller --> Metrics
+        Processor --> Metrics
+    end
+```
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.ingestion_source.internal_queue_size` | Size of internal blocking queue between poller and processor | 100 |
+
+#### API Changes
+
+**GetIngestionState Response** now includes:
+- `write_block_enabled`: Boolean indicating if write block is active
+- `batch_start_pointer`: Current batch start position
+- `total_duplicate_message_skipped_count`: Count of skipped duplicate messages
+
+**Resume API** now accepts `reset_settings` for consumer repositioning with modes:
+- `OFFSET`: Reset to specific offset/sequence number
+- `TIMESTAMP`: Reset to position based on timestamp in milliseconds
+
+### Usage Example
+
+```json
+// Resume ingestion with offset reset
+POST /my-index/ingestion/_resume
+{
+  "reset_settings": [
+    {
+      "shard": 0,
+      "mode": "offset",
+      "value": "500"
+    },
+    {
+      "shard": 1,
+      "mode": "timestamp",
+      "value": "1739459600000"
+    }
+  ]
+}
+```
+
+### Migration Notes
+
+Update any code using the old enum values:
+- Change `rewind_by_offset` to `reset_by_offset` in index settings
+- Change `rewind_by_timestamp` to `reset_by_timestamp` in index settings
+
+## Limitations
+
+- Consumer reset only works when ingestion is paused
+- Retry mechanism applies only with DROP error strategy
+- Write block detection requires ClusterApplierService registration
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17977](https://github.com/opensearch-project/OpenSearch/pull/17977) | Emit lag metric for pull-based ingestion poller |
+| [#18088](https://github.com/opensearch-project/OpenSearch/pull/18088) | Add ingestion error metrics and configurable queue size |
+| [#18250](https://github.com/opensearch-project/OpenSearch/pull/18250) | Support transient failure retries and create mode |
+| [#18280](https://github.com/opensearch-project/OpenSearch/pull/18280) | Support cluster write blocks |
+| [#18332](https://github.com/opensearch-project/OpenSearch/pull/18332) | Support consumer reset in Resume API |
+
+## References
+
+- [Issue #17442](https://github.com/opensearch-project/OpenSearch/issues/17442): Ingestion management APIs for pull-based ingestion
+- [Issue #18279](https://github.com/opensearch-project/OpenSearch/issues/18279): Support cluster write block in pull-based ingestion
+- [Documentation](https://docs.opensearch.org/3.0/api-reference/document-apis/pull-based-ingestion/): Pull-based ingestion
+- [Documentation](https://docs.opensearch.org/3.0/api-reference/document-apis/pull-based-ingestion-management/): Pull-based ingestion management
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/pull-based-ingestion.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -17,6 +17,7 @@
 - [Percentiles Aggregation](features/opensearch/percentiles-aggregation.md) - Switch to MergingDigest for up to 30x performance improvement
 - [Plugin Installation](features/opensearch/plugin-installation.md) - Fix native plugin installation error caused by PGP public key change
 - [Plugin Testing Framework](features/opensearch/plugin-testing-framework.md) - Enable testing for ExtensiblePlugins using classpath plugins
+- [Pull-based Ingestion](features/opensearch/pull-based-ingestion.md) - Lag metrics, error metrics, configurable queue, retries, create mode, write blocks, consumer reset
 - [Query Bug Fixes](features/opensearch/query-bug-fixes.md) - Fixes for exists query, error handling, field validation, and IP field terms query
 - [Query Optimization](features/opensearch/query-optimization.md) - Automatic must_not range rewrite and sort-query performance improvements
 - [Remote Store](features/opensearch/remote-store.md) - Close index rejection during migration and cluster state diff download fix


### PR DESCRIPTION
## Summary

Add documentation for Pull-based Ingestion enhancements in OpenSearch v3.1.0.

## Changes in v3.1.0

- **Lag metrics** (#17977): Message timestamp API for lag calculation
- **Error metrics & configurable queue** (#18088): Detailed poller/processor metrics, `internal_queue_size` setting
- **Transient failure retries & create mode** (#18250): Up to 2 retries, `_op_type: "create"` support
- **Cluster write block support** (#18280): Auto-pause on write blocks, `write_block_enabled` in GetIngestionState
- **Consumer reset in Resume API** (#18332): Offset/timestamp-based repositioning

## Breaking Change

Enum renamed: `REWIND_BY_OFFSET` → `RESET_BY_OFFSET`, `REWIND_BY_TIMESTAMP` → `RESET_BY_TIMESTAMP`

## Reports Created

- Release report: `docs/releases/v3.1.0/features/opensearch/pull-based-ingestion.md`
- Feature report: `docs/features/opensearch/pull-based-ingestion.md`

## Related Issue

Closes #902