### PR TITLE
docs: add parallel-shard-refresh report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -60,6 +60,7 @@
 - [Node Roles Configuration](opensearch/node-roles-configuration.md)
 - [Offline Nodes (Background Tasks)](opensearch/offline-nodes.md)
 - [OpenSearch Core Dependencies](opensearch/opensearch-core-dependencies.md)
+- [Parallel Shard Refresh](opensearch/parallel-shard-refresh.md)
 - [Percentiles Aggregation](opensearch/percentiles-aggregation.md)
 - [Phone Number Analyzer](opensearch/phone-analyzer.md)
 - [Plugin Installation](opensearch/plugin-installation.md)

--- a/docs/features/opensearch/parallel-shard-refresh.md
+++ b/docs/features/opensearch/parallel-shard-refresh.md
@@ -1,0 +1,132 @@
+# Parallel Shard Refresh
+
+## Summary
+
+Parallel Shard Refresh is an experimental feature that enables individual shards within an index to refresh independently rather than at the index level. This capability improves data freshness for remote store indexes by allowing more granular control over refresh operations and better resource utilization through parallel execution across shards.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Cluster Level"
+        CS[Cluster Settings]
+        IS[IndicesService]
+    end
+    
+    subgraph "Index Level"
+        ISvc[IndexService]
+        RM[refreshMutex]
+        ART[AsyncRefreshTask]
+    end
+    
+    subgraph "Shard Level"
+        S1[IndexShard 1]
+        S2[IndexShard 2]
+        S3[IndexShard N]
+        ASRT1[AsyncShardRefreshTask]
+        ASRT2[AsyncShardRefreshTask]
+        ASRT3[AsyncShardRefreshTask]
+    end
+    
+    CS -->|shardLevelRefreshEnabled| IS
+    IS -->|onRefreshLevelChange| ISvc
+    ISvc --> RM
+    
+    RM -->|Index Mode| ART
+    ART --> S1
+    ART --> S2
+    ART --> S3
+    
+    RM -->|Shard Mode| S1
+    RM -->|Shard Mode| S2
+    RM -->|Shard Mode| S3
+    S1 --> ASRT1
+    S2 --> ASRT2
+    S3 --> ASRT3
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Cluster Setting Change] --> B{shardLevelRefreshEnabled?}
+    B -->|true| C[Stop Index-Level Refresh Task]
+    C --> D[Start Shard-Level Refresh Tasks]
+    D --> E[Each Shard Refreshes Independently]
+    
+    B -->|false| F[Stop Shard-Level Refresh Tasks]
+    F --> G[Start Index-Level Refresh Task]
+    G --> H[Index Refreshes All Shards Together]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `IndicesService` | Manages cluster-level refresh settings and propagates changes to all indexes |
+| `IndexService` | Coordinates refresh mode transitions with proper synchronization |
+| `IndexShard` | Manages individual shard refresh tasks when shard-level refresh is enabled |
+| `AsyncRefreshTask` | Existing index-level refresh task (used when shard-level refresh is disabled) |
+| `AsyncShardRefreshTask` | New shard-level refresh task that runs independently per shard |
+| `refreshMutex` | Synchronization object ensuring safe transitions between refresh modes |
+
+### Configuration
+
+| Setting | Description | Default | Scope |
+|---------|-------------|---------|-------|
+| `cluster.index.refresh.shard_level.enabled` | Enables parallel shard-level refresh across all indexes | `false` | Cluster (Dynamic) |
+| `index.refresh_interval` | Refresh interval for the index (applies to both modes) | `1s` | Index |
+
+### Usage Example
+
+Enable parallel shard refresh:
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.index.refresh.shard_level.enabled": true
+  }
+}
+```
+
+Verify the setting:
+
+```json
+GET /_cluster/settings?include_defaults=true&filter_path=*.cluster.index.refresh
+```
+
+Combine with custom refresh interval:
+
+```json
+PUT /my-index/_settings
+{
+  "index": {
+    "refresh_interval": "500ms"
+  }
+}
+```
+
+## Limitations
+
+- Experimental feature - API may change in future releases
+- Cluster-wide setting affects all indexes (no per-index control)
+- Benefits are most noticeable with indexes having multiple shards
+- Part of a larger initiative for remote store data freshness improvements
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#17782](https://github.com/opensearch-project/OpenSearch/pull/17782) | Implement parallel shard refresh behind cluster settings |
+
+## References
+
+- [Issue #17776](https://github.com/opensearch-project/OpenSearch/issues/17776): META - Improve Data Freshness for Remote Store Indexes
+- [Refresh Index API](https://docs.opensearch.org/3.0/api-reference/index-apis/refresh/): Official documentation on refresh operations
+
+## Change History
+
+- **v3.1.0** (2025-04-20): Initial implementation of parallel shard refresh with cluster setting control

--- a/docs/releases/v3.1.0/features/opensearch/parallel-shard-refresh.md
+++ b/docs/releases/v3.1.0/features/opensearch/parallel-shard-refresh.md
@@ -1,0 +1,101 @@
+# Parallel Shard Refresh
+
+## Summary
+
+OpenSearch v3.1.0 introduces parallel shard-level refresh capability, enabling individual shards within an index to refresh independently rather than at the index level. This experimental feature improves data freshness for remote store indexes by allowing more granular control over refresh operations and better resource utilization through parallel execution.
+
+## Details
+
+### What's New in v3.1.0
+
+This release introduces a new cluster setting `cluster.index.refresh.shard_level.enabled` that enables shard-level refresh scheduling. When enabled, each shard manages its own refresh task independently, allowing for parallel refresh operations across shards.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Index Level Refresh (Default)"
+        IS1[IndexService] --> ART[AsyncRefreshTask]
+        ART --> S1[Shard 0]
+        ART --> S2[Shard 1]
+        ART --> S3[Shard 2]
+    end
+    
+    subgraph "Shard Level Refresh (New)"
+        IS2[IndexService] --> |shardLevelRefreshEnabled=true| SM[Shard Manager]
+        SM --> ASRT1[AsyncShardRefreshTask]
+        SM --> ASRT2[AsyncShardRefreshTask]
+        SM --> ASRT3[AsyncShardRefreshTask]
+        ASRT1 --> SS1[Shard 0]
+        ASRT2 --> SS2[Shard 1]
+        ASRT3 --> SS3[Shard 2]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `AsyncShardRefreshTask` | New task class in `IndexShard` that handles shard-level refresh operations independently |
+| `refreshMutex` | Synchronization object in `IndexService` for safe transitions between refresh modes |
+| `shardLevelRefreshEnabled` | Flag tracking current refresh mode at index and shard level |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.index.refresh.shard_level.enabled` | Enables parallel shard-level refresh when set to `true`. Dynamic setting that can be changed at runtime. | `false` |
+
+### Usage Example
+
+Enable parallel shard refresh cluster-wide:
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.index.refresh.shard_level.enabled": true
+  }
+}
+```
+
+Disable parallel shard refresh:
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.index.refresh.shard_level.enabled": false
+  }
+}
+```
+
+### Migration Notes
+
+1. The feature is disabled by default for backward compatibility
+2. Enabling/disabling the setting triggers automatic rescheduling of refresh tasks
+3. The transition between index-level and shard-level refresh is handled safely with proper synchronization
+4. No index restart required - changes take effect dynamically
+
+## Limitations
+
+- Marked as experimental (`@ExperimentalApi`) - API may change in future releases
+- Part of a larger initiative to improve data freshness for remote store indexes
+- Performance benefits are most noticeable with indexes having multiple shards
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17782](https://github.com/opensearch-project/OpenSearch/pull/17782) | Implement parallel shard refresh behind cluster settings |
+
+## References
+
+- [Issue #17776](https://github.com/opensearch-project/OpenSearch/issues/17776): META - Improve Data Freshness for Remote Store Indexes
+- [Refresh Index API](https://docs.opensearch.org/3.0/api-reference/index-apis/refresh/): Official documentation on refresh operations
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/parallel-shard-refresh.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -32,3 +32,4 @@
 - [Composite Directory Factory](features/opensearch/composite-directory-factory.md) - Pluggable factory for custom composite directory implementations in warm indices
 - [Security Manager Replacement](features/opensearch/security-manager-replacement.md) - Enhanced Java Agent to intercept newByteChannel from FileSystemProvider
 - [Warm Storage Tiering](features/opensearch/warm-storage-tiering.md) - WarmDiskThresholdDecider and AutoForceMergeManager for hot-to-warm migration
+- [Parallel Shard Refresh](features/opensearch/parallel-shard-refresh.md) - Shard-level refresh scheduling for improved data freshness in remote store indexes


### PR DESCRIPTION
## Summary

This PR adds documentation for the Parallel Shard Refresh feature introduced in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/opensearch/parallel-shard-refresh.md`
- Feature report: `docs/features/opensearch/parallel-shard-refresh.md`

### Key Changes in v3.1.0
- New cluster setting `cluster.index.refresh.shard_level.enabled` to enable shard-level refresh
- `AsyncShardRefreshTask` class for independent shard refresh operations
- Safe transitions between index-level and shard-level refresh modes
- Part of the larger initiative to improve data freshness for remote store indexes

### Resources Used
- PR: [#17782](https://github.com/opensearch-project/OpenSearch/pull/17782)
- Meta Issue: [#17776](https://github.com/opensearch-project/OpenSearch/issues/17776)

Closes #901