### PR TITLE
docs: add paginated WLM stats API report for v3.1.0

### DIFF
--- a/docs/features/opensearch/workload-management.md
+++ b/docs/features/opensearch/workload-management.md
@@ -75,6 +75,8 @@ flowchart TB
 | `QueryGroupMetadata` | Persistable metadata stored in ClusterState for durability |
 | `ResourceCancellationFramework` | Node-level framework for canceling queries exceeding limits |
 | `WLM Stats API` | Provides per-node query group statistics and metrics |
+| `WLM Paginated Stats API` | Scalable paginated endpoint for stats retrieval (v3.1.0+) |
+| `WlmPaginationStrategy` | Pagination logic for WLM stats with sorting and token management (v3.1.0+) |
 | `Query Group CRUD APIs` | REST APIs for managing query group lifecycle |
 | `DEFAULT_QUERY_GROUP` | Built-in query group for requests without explicit group assignment |
 
@@ -160,6 +162,24 @@ queryGroupId: preXpc67RbKKeCyka72_Gw
 GET _wlm/stats
 ```
 
+**Get Paginated Stats (v3.1.0+):**
+```
+GET _list/wlm_stats?size=50&sort=node_id&order=asc&v=true
+```
+
+**Paginated Stats Response:**
+```
+NODE_ID | WORKLOAD_GROUP_ID | TOTAL_COMPLETIONS | TOTAL_REJECTIONS | TOTAL_CANCELLATIONS | CPU_USAGE | MEMORY_USAGE
+node-1  | analytics         | 1000              | 5                | 2                   | 0.45      | 0.30
+node-1  | DEFAULT_WORKLOAD_GROUP | 5000         | 0                | 0                   | 0.10      | 0.05
+next_token: <encrypted_token>
+```
+
+**Fetch Next Page:**
+```
+GET _list/wlm_stats?size=50&sort=node_id&order=asc&next_token=<encrypted_token>
+```
+
 **Stats Response:**
 ```json
 {
@@ -218,6 +238,7 @@ GET _wlm/stats
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#17638](https://github.com/opensearch-project/OpenSearch/pull/17638) | Add paginated wlm/stats API |
 | v2.18.0 | [#15651](https://github.com/opensearch-project/OpenSearch/pull/15651) | Add cancellation framework changes in WLM |
 | v2.18.0 | [#15777](https://github.com/opensearch-project/OpenSearch/pull/15777) | QueryGroup Stats API logic |
 | v2.18.0 | [#15925](https://github.com/opensearch-project/OpenSearch/pull/15925) | Add WLM resiliency orchestrator (QueryGroup Service) |
@@ -229,9 +250,11 @@ GET _wlm/stats
 ## References
 
 - [RFC #12342](https://github.com/opensearch-project/OpenSearch/issues/12342): Search Query Sandboxing: User Experience
-- [Workload Management Documentation](https://docs.opensearch.org/2.18/tuning-your-cluster/availability-and-recovery/workload-management/wlm-feature-overview/)
-- [Query Group Lifecycle API](https://docs.opensearch.org/2.18/tuning-your-cluster/availability-and-recovery/workload-management/query-group-lifecycle-api/)
+- [Issue #17592](https://github.com/opensearch-project/OpenSearch/issues/17592): Feature request for paginating _wlm/stats API
+- [Workload Management Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/workload-management/wlm-feature-overview/)
+- [Query Group Lifecycle API](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/workload-management/workload-group-lifecycle-api/)
 
 ## Change History
 
+- **v3.1.0** (2026-01-10): Added paginated `/_list/wlm_stats` API with token-based pagination, sorting by node_id or workload_group, and configurable page size
 - **v2.18.0** (2024-10-22): Initial implementation with QueryGroup CRUD APIs, Stats API, resource cancellation framework, resiliency orchestrator, persistence, and enhanced rejection logic

--- a/docs/releases/v3.1.0/features/opensearch/workload-management.md
+++ b/docs/releases/v3.1.0/features/opensearch/workload-management.md
@@ -1,0 +1,131 @@
+# Paginated WLM Stats API
+
+## Summary
+
+This release adds pagination support to the Workload Management (WLM) Stats API through a new `/_list/wlm_stats` endpoint. The original `/_wlm/stats` API returns all statistics in a single response, which becomes inefficient as cluster size grows. The new paginated endpoint addresses scalability issues by allowing users to retrieve statistics in smaller chunks with token-based pagination.
+
+## Details
+
+### What's New in v3.1.0
+
+- New `/_list/wlm_stats` API endpoint with pagination support
+- Token-based pagination using `next_token` parameter
+- Configurable page size (1-100 results per page, default: 10)
+- Sorting by `node_id` (default) or `workload_group`
+- Sort order support (`asc`/`desc`)
+- Tabular output format similar to `_cat` APIs
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Client"
+        REQ[API Request]
+    end
+    
+    subgraph "OpenSearch Node"
+        subgraph "REST Layer"
+            REST[RestWlmStatsAction]
+            REST -->|/_list/wlm_stats| PAGINATE[Pagination Handler]
+            REST -->|/_wlm/stats| LEGACY[Legacy Handler]
+        end
+        
+        subgraph "Pagination"
+            PAGINATE --> STRATEGY[WlmPaginationStrategy]
+            STRATEGY --> TOKEN[WlmStrategyToken]
+            TOKEN -->|Encrypt/Decrypt| CURSOR[Cursor State]
+        end
+        
+        subgraph "WLM Core"
+            LEGACY --> STATS[WlmStatsResponse]
+            PAGINATE --> STATS
+        end
+    end
+    
+    REQ --> REST
+    STRATEGY -->|Paginated Results| TABLE[Table Response]
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `WlmPaginationStrategy` | Implements pagination logic for WLM stats, handling sorting, page extraction, and token generation |
+| `WlmStrategyToken` | Encapsulates pagination state including node ID, workload group ID, hash, sort order, and sort field |
+| `SortBy` | Enum defining sortable fields: `NODE_ID`, `WORKLOAD_GROUP` |
+| `SortOrder` | Enum for sort direction: `ASC`, `DESC` |
+
+#### New API Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /_list/wlm_stats` | Paginated WLM stats for all nodes |
+| `GET /_list/wlm_stats/{nodeId}/stats` | Paginated stats for specific node |
+| `GET /_list/wlm_stats/stats/{workloadGroupId}` | Paginated stats for specific workload group |
+| `GET /_list/wlm_stats/{nodeId}/stats/{workloadGroupId}` | Paginated stats for specific node and workload group |
+
+#### API Parameters
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `size` | int | Number of results per page (1-100) | 10 |
+| `next_token` | string | Pagination token for next page | - |
+| `sort` | string | Sort field: `node_id` or `workload_group` | `node_id` |
+| `order` | string | Sort order: `asc` or `desc` | `asc` |
+| `v` | boolean | Include column headers | false |
+
+### Usage Example
+
+**Fetch first page sorted by workload group:**
+```
+GET /_list/wlm_stats?size=50&sort=workload_group&order=asc&v=true
+```
+
+**Response:**
+```
+NODE_ID | WORKLOAD_GROUP_ID | TOTAL_COMPLETIONS | TOTAL_REJECTIONS | TOTAL_CANCELLATIONS | CPU_USAGE | MEMORY_USAGE
+node-1  | analytics         | 1000              | 5                | 2                   | 0.45      | 0.30
+node-1  | DEFAULT_WORKLOAD_GROUP | 5000         | 0                | 0                   | 0.10      | 0.05
+...
+next_token: <encrypted_token>
+```
+
+**Fetch next page:**
+```
+GET /_list/wlm_stats?size=50&sort=workload_group&order=asc&next_token=<encrypted_token>
+```
+
+### Pagination Token Design
+
+The pagination token encodes:
+- Current node ID and workload group ID (cursor position)
+- Total workload group count (for state validation)
+- SHA-256 hash of all (nodeId|workloadGroupId) pairs (for detecting state changes)
+- Sort order and sort field (for consistent pagination)
+
+If the cluster state changes during pagination (workload groups added/removed), the token becomes invalid and returns an error prompting the user to restart pagination.
+
+## Limitations
+
+- Sorting by CPU or memory usage is not supported because these values fluctuate frequently, causing inconsistent pagination results
+- Maximum page size is 100 results
+- Token becomes invalid if workload groups are added or removed during pagination
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17638](https://github.com/opensearch-project/OpenSearch/pull/17638) | Add paginated wlm/stats API |
+
+## References
+
+- [Issue #17592](https://github.com/opensearch-project/OpenSearch/issues/17592): Feature request for paginating _wlm/stats API
+- [Workload Management Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/workload-management/wlm-feature-overview/)
+- [Issue #14257](https://github.com/opensearch-project/OpenSearch/issues/14257): Pagination for _cat APIs
+- [Issue #15014](https://github.com/opensearch-project/OpenSearch/issues/15014): Introduction of _list APIs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/workload-management.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -32,4 +32,5 @@
 - [Composite Directory Factory](features/opensearch/composite-directory-factory.md) - Pluggable factory for custom composite directory implementations in warm indices
 - [Security Manager Replacement](features/opensearch/security-manager-replacement.md) - Enhanced Java Agent to intercept newByteChannel from FileSystemProvider
 - [Warm Storage Tiering](features/opensearch/warm-storage-tiering.md) - WarmDiskThresholdDecider and AutoForceMergeManager for hot-to-warm migration
+- [Workload Management](features/opensearch/workload-management.md) - Paginated `/_list/wlm_stats` API with token-based pagination and sorting
 - [Parallel Shard Refresh](features/opensearch/parallel-shard-refresh.md) - Shard-level refresh scheduling for improved data freshness in remote store indexes


### PR DESCRIPTION
## Summary

This PR adds documentation for the paginated WLM Stats API feature introduced in OpenSearch v3.1.0.

### Changes

- **Release Report**: `docs/releases/v3.1.0/features/opensearch/workload-management.md`
  - New `/_list/wlm_stats` API endpoint with pagination support
  - Token-based pagination using `next_token` parameter
  - Sorting by `node_id` or `workload_group`
  - Configurable page size (1-100)

- **Feature Report Update**: `docs/features/opensearch/workload-management.md`
  - Added paginated stats API examples
  - Added new pagination components to components table
  - Added v3.1.0 PR to related PRs
  - Updated change history with v3.1.0 entry

- **Release Index Update**: `docs/releases/v3.1.0/index.md`
  - Added link to workload management release report

### Related

- Closes #900
- PR: opensearch-project/OpenSearch#17638
- Issue: opensearch-project/OpenSearch#17592