### PR TITLE
docs: add platform-support report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -63,6 +63,7 @@
 - [Parallel Shard Refresh](opensearch/parallel-shard-refresh.md)
 - [Percentiles Aggregation](opensearch/percentiles-aggregation.md)
 - [Phone Number Analyzer](opensearch/phone-analyzer.md)
+- [Platform Support](opensearch/platform-support.md)
 - [Plugin Installation](opensearch/plugin-installation.md)
 - [Plugin Testing Framework](opensearch/plugin-testing-framework.md)
 - [Pull-based Ingestion](opensearch/pull-based-ingestion.md)

--- a/docs/features/opensearch/platform-support.md
+++ b/docs/features/opensearch/platform-support.md
@@ -1,0 +1,155 @@
+# Platform Support
+
+## Summary
+
+OpenSearch supports multiple CPU architectures and operating systems, enabling deployment across diverse hardware environments. The platform support includes x64 (amd64), ARM64 (aarch64), s390x, ppc64le, and riscv64 architectures on Linux, with x64 support on Windows and macOS.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Operating Systems"
+        LINUX[Linux]
+        WINDOWS[Windows]
+        MACOS[macOS]
+    end
+    
+    subgraph "CPU Architectures"
+        X64[x64/amd64]
+        ARM64[arm64/aarch64]
+        S390X[s390x]
+        PPC64LE[ppc64le]
+        RISCV64[riscv64]
+    end
+    
+    subgraph "Distribution Formats"
+        TAR[Tarball .tar.gz]
+        RPM[RPM Package]
+        DEB[DEB Package]
+        DOCKER[Docker Image]
+        ZIP[ZIP Archive]
+    end
+    
+    LINUX --> X64
+    LINUX --> ARM64
+    LINUX --> S390X
+    LINUX --> PPC64LE
+    LINUX --> RISCV64
+    
+    WINDOWS --> X64
+    MACOS --> X64
+    MACOS --> ARM64
+    
+    X64 --> TAR
+    X64 --> RPM
+    X64 --> DEB
+    X64 --> DOCKER
+    ARM64 --> TAR
+    ARM64 --> RPM
+    ARM64 --> DEB
+    ARM64 --> DOCKER
+    S390X --> TAR
+    PPC64LE --> TAR
+    RISCV64 --> TAR
+    RISCV64 --> DOCKER
+```
+
+### Supported Platforms
+
+| Architecture | Linux | Windows | macOS | Docker |
+|--------------|-------|---------|-------|--------|
+| x64 (amd64) | ✅ | ✅ | ✅ | ✅ |
+| ARM64 (aarch64) | ✅ | ❌ | ✅ | ✅ |
+| s390x | ✅ | ❌ | ❌ | ✅ |
+| ppc64le | ✅ | ❌ | ❌ | ✅ |
+| riscv64 | ✅ | ❌ | ❌ | ✅ |
+
+### Distribution Types
+
+| Type | Description | JDK Included |
+|------|-------------|--------------|
+| Standard Tarball | Full distribution with bundled JDK | Yes |
+| No-JDK Tarball | Distribution without JDK (BYOJDK) | No |
+| RPM Package | Red Hat/CentOS/Fedora package | Yes |
+| DEB Package | Debian/Ubuntu package | Yes |
+| Docker Image | Container image | Yes |
+
+### Build System Components
+
+| Component | Description |
+|-----------|-------------|
+| `Architecture.java` | Enum defining supported CPU architectures |
+| `DistributionDownloadPlugin.java` | Handles distribution artifact downloads |
+| `JavaVariant.java` | Manages JDK variants for different platforms |
+| `VersionProperties.java` | Platform-specific version properties |
+| `SystemCallFilter.java` | Seccomp syscall filters for each architecture |
+
+### Configuration
+
+The build system automatically detects the current architecture:
+
+```java
+// Architecture detection
+public static Architecture current() {
+    final String architecture = System.getProperty("os.arch", "");
+    switch (architecture) {
+        case "amd64":
+        case "x86_64":
+            return X64;
+        case "aarch64":
+            return ARM64;
+        case "s390x":
+            return S390X;
+        case "ppc64le":
+            return PPC64LE;
+        case "riscv64":
+            return RISCV64;
+        default:
+            throw new IllegalArgumentException("Unknown architecture: " + architecture);
+    }
+}
+```
+
+### Usage Example
+
+```bash
+# Download for your architecture
+# x64
+wget https://artifacts.opensearch.org/releases/bundle/opensearch/3.1.0/opensearch-3.1.0-linux-x64.tar.gz
+
+# ARM64
+wget https://artifacts.opensearch.org/releases/bundle/opensearch/3.1.0/opensearch-3.1.0-linux-arm64.tar.gz
+
+# RISC-V 64
+wget https://artifacts.opensearch.org/releases/bundle/opensearch/3.1.0/opensearch-3.1.0-linux-riscv64.tar.gz
+
+# Extract and run
+tar -xvf opensearch-3.1.0-linux-*.tar.gz
+cd opensearch-3.1.0
+./bin/opensearch
+```
+
+## Limitations
+
+- Windows support is limited to x64 architecture only
+- Some architectures (s390x, ppc64le, riscv64) may have limited JDK availability
+- Building from source on riscv64 requires providing your own protoc executable
+- Not all plugins may be available for all architectures
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#18156](https://github.com/opensearch-project/OpenSearch/pull/18156) | Add support for linux riscv64 platform |
+
+## References
+
+- [Issue #2341](https://github.com/opensearch-project/OpenSearch/issues/2341): RISC-V 64 support request
+- [OpenSearch Installation Guide](https://docs.opensearch.org/3.1/install-and-configure/): Official installation documentation
+- [Tarball Installation](https://docs.opensearch.org/3.1/install-and-configure/install-opensearch/tar/): Tarball installation guide
+
+## Change History
+
+- **v3.1.0** (2025-04-30): Added Linux riscv64 platform support

--- a/docs/releases/v3.1.0/features/opensearch/platform-support.md
+++ b/docs/releases/v3.1.0/features/opensearch/platform-support.md
@@ -1,0 +1,110 @@
+# Platform Support - Linux RISC-V 64
+
+## Summary
+
+OpenSearch v3.1.0 adds support for the Linux RISC-V 64-bit (riscv64) architecture, expanding the platform compatibility to include this emerging open-source instruction set architecture. This enables users to run OpenSearch on RISC-V hardware, supporting the growing ecosystem of RISC-V devices and servers.
+
+## Details
+
+### What's New in v3.1.0
+
+This release introduces full build and distribution support for the Linux riscv64 platform, making OpenSearch available on RISC-V 64-bit systems.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Supported Architectures"
+        X64[x64/amd64]
+        ARM64[arm64/aarch64]
+        S390X[s390x]
+        PPC64LE[ppc64le]
+        RISCV64[riscv64 - NEW]
+    end
+    
+    subgraph "Distribution Types"
+        TAR[Tarball]
+        DOCKER[Docker Image]
+        NOJDK[No-JDK Tarball]
+    end
+    
+    RISCV64 --> TAR
+    RISCV64 --> DOCKER
+    RISCV64 --> NOJDK
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `Architecture.RISCV64` | New architecture enum value in build system |
+| `linux-riscv64-tar` | Tarball distribution for riscv64 |
+| `no-jdk-linux-riscv64-tar` | No-JDK tarball for users providing their own JDK |
+| `docker-riscv64-export` | Docker image export for riscv64 |
+| `SystemCallFilter.Arch` | Seccomp filter support for riscv64 syscalls |
+
+#### Build System Changes
+
+| File | Change |
+|------|--------|
+| `Architecture.java` | Added `RISCV64` enum and detection for `riscv64` arch string |
+| `DistributionDownloadPlugin.java` | Added classifier mapping for riscv64 |
+| `JavaVariant.java` | Added `riscv64` to allowed architectures |
+| `VersionProperties.java` | Added `bundledJdkLinux_riscv64` property |
+| `SystemCallFilter.java` | Added seccomp syscall numbers for riscv64 |
+
+### Usage Example
+
+```bash
+# Download the riscv64 tarball
+wget https://artifacts.opensearch.org/releases/bundle/opensearch/3.1.0/opensearch-3.1.0-linux-riscv64.tar.gz
+
+# Extract
+tar -xvf opensearch-3.1.0-linux-riscv64.tar.gz
+
+# Run OpenSearch
+cd opensearch-3.1.0
+./bin/opensearch
+```
+
+For users who want to provide their own JDK:
+
+```bash
+# Download the no-jdk tarball
+wget https://artifacts.opensearch.org/releases/bundle/opensearch/3.1.0/opensearch-3.1.0-no-jdk-linux-riscv64.tar.gz
+
+# Set JAVA_HOME to your JDK installation
+export JAVA_HOME=/path/to/your/jdk
+
+# Run OpenSearch
+./bin/opensearch
+```
+
+### Migration Notes
+
+- Users on RISC-V hardware can now use official OpenSearch distributions
+- Cross-building on x86_64 Linux is supported
+- Building directly on riscv64 requires users to provide their own `protoc` executable (Maven repository does not ship prebuilt protoc for riscv64)
+
+## Limitations
+
+- **Protoc dependency**: When building from source directly on riscv64, users must provide their own protoc executable
+- **JDK availability**: Bundled JDK availability depends on upstream JDK distributions supporting riscv64
+- **Testing coverage**: As an emerging platform, testing coverage may be less comprehensive than x64/arm64
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18156](https://github.com/opensearch-project/OpenSearch/pull/18156) | Add support for linux riscv64 platform |
+
+## References
+
+- [Issue #2341](https://github.com/opensearch-project/OpenSearch/issues/2341): Original feature request for RISC-V 64 support
+- [OpenSearch Installation Guide](https://docs.opensearch.org/3.1/install-and-configure/): Official installation documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/platform-support.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -35,3 +35,4 @@
 - [Workload Management](features/opensearch/workload-management.md) - Paginated `/_list/wlm_stats` API with token-based pagination and sorting
 - [Rule-based Auto-tagging](features/opensearch/rule-based-auto-tagging.md) - Automatic workload group assignment based on index patterns and rules
 - [Parallel Shard Refresh](features/opensearch/parallel-shard-refresh.md) - Shard-level refresh scheduling for improved data freshness in remote store indexes
+- [Platform Support](features/opensearch/platform-support.md) - Add support for Linux riscv64 platform


### PR DESCRIPTION
## Summary

This PR adds documentation for the Platform Support feature in OpenSearch v3.1.0.

### Changes
- Added release report: `docs/releases/v3.1.0/features/opensearch/platform-support.md`
- Added feature report: `docs/features/opensearch/platform-support.md`
- Updated release index and features index

### Key Changes in v3.1.0
- Added Linux riscv64 platform support
- New distribution types: tarball, no-jdk tarball, and Docker image for riscv64
- Build system updates for architecture detection and distribution packaging
- Seccomp syscall filter support for riscv64

### Related
- Closes #898
- PR: opensearch-project/OpenSearch#18156
- Issue: opensearch-project/OpenSearch#2341