### PR TITLE
docs: add ml-skills report for v3.1.0

### DIFF
--- a/docs/features/skills/skills-tools.md
+++ b/docs/features/skills/skills-tools.md
@@ -130,6 +130,7 @@ The PPLTool translates natural language questions into Piped Processing Language
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#575](https://github.com/opensearch-project/skills/pull/575) | Fix conflict in dependency versions |
 | v3.0.0 | [#547](https://github.com/opensearch-project/skills/pull/547) | Add WebSearchTool |
 | v3.0.0 | [#541](https://github.com/opensearch-project/skills/pull/541) | Fix PPLTool empty list bug |
 | v3.0.0 | [#529](https://github.com/opensearch-project/skills/pull/529) | Update ML Commons dependencies |
@@ -149,5 +150,6 @@ The PPLTool translates natural language questions into Piped Processing Language
 
 ## Change History
 
+- **v3.1.0** (2025-05-06): Fixed httpclient5 dependency version conflict in build.gradle, applied Spotless code formatting to WebSearchTool
 - **v3.0.0** (2025-02-25): Added WebSearchTool, fixed PPLTool empty list bug, updated dependencies, enhanced developer guide
 - **v2.18.0** (2024-11-12): Added LogPatternTool for log pattern analysis, added customizable prompt support for CreateAnomalyDetectorTool

--- a/docs/releases/v3.1.0/features/skills/ml-skills.md
+++ b/docs/releases/v3.1.0/features/skills/ml-skills.md
@@ -1,0 +1,62 @@
+# ML Skills
+
+## Summary
+
+This release fixes a dependency version conflict in the Skills plugin's build configuration. The `httpclient5` dependency was incorrectly using the `httpcore5` version variable, causing potential version mismatches. Additionally, code formatting was applied to `WebSearchTool.java` using Spotless.
+
+## Details
+
+### What's New in v3.1.0
+
+This is a maintenance release that addresses build configuration issues:
+
+1. **Dependency Version Fix**: Corrected the `httpclient5` dependency to use the proper `${versions.httpclient5}` variable instead of `${versions.httpcore5}`
+2. **Code Formatting**: Applied Spotless code formatting to `WebSearchTool.java` for consistent code style
+
+### Technical Changes
+
+#### Build Configuration Fix
+
+The `build.gradle` file had two locations where `httpclient5` was incorrectly referencing the `httpcore5` version:
+
+**Before:**
+```gradle
+force("org.apache.httpcomponents.client5:httpclient5:5.4.1")
+compileOnly(group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: "${versions.httpcore5}")
+```
+
+**After:**
+```gradle
+force("org.apache.httpcomponents.client5:httpclient5:${versions.httpclient5}")
+compileOnly(group: 'org.apache.httpcomponents.client5', name: 'httpclient5', version: "${versions.httpclient5}")
+```
+
+#### Code Formatting
+
+The `WebSearchTool.java` file received Spotless formatting changes including:
+- Import statement ordering (static imports first)
+- String concatenation alignment
+- Method parameter alignment
+- Conditional expression formatting
+
+### Migration Notes
+
+No migration required. This is a transparent fix that ensures correct dependency resolution.
+
+## Limitations
+
+None specific to this release.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#575](https://github.com/opensearch-project/skills/pull/575) | Fix conflict in dependency versions |
+
+## References
+
+- [Skills Repository](https://github.com/opensearch-project/skills): Source code
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/skills/skills-tools.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -36,3 +36,7 @@
 - [Rule-based Auto-tagging](features/opensearch/rule-based-auto-tagging.md) - Automatic workload group assignment based on index patterns and rules
 - [Parallel Shard Refresh](features/opensearch/parallel-shard-refresh.md) - Shard-level refresh scheduling for improved data freshness in remote store indexes
 - [Platform Support](features/opensearch/platform-support.md) - Add support for Linux riscv64 platform
+
+### Skills
+
+- [ML Skills](features/skills/ml-skills.md) - Fix httpclient5 dependency version conflict and apply Spotless formatting


### PR DESCRIPTION
## Summary\n\nThis PR adds documentation for the ML Skills bugfix in OpenSearch v3.1.0.\n\n### Changes\n- Created release report: `docs/releases/v3.1.0/features/skills/ml-skills.md`\n- Updated feature report: `docs/features/skills/skills-tools.md`\n- Updated release index: `docs/releases/v3.1.0/index.md`\n\n### PR Investigated\n- [#575](https://github.com/opensearch-project/skills/pull/575): Fix conflict in dependency versions\n\n### Key Findings\n- Fixed `httpclient5` dependency version conflict (was using `httpcore5` version variable)\n- Applied Spotless code formatting to `WebSearchTool.java`\n\nCloses #897"