### PR TITLE
docs: add security-dependency-updates report for v3.1.0

### DIFF
--- a/docs/features/security/security-plugin-dependencies.md
+++ b/docs/features/security/security-plugin-dependencies.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-The OpenSearch Security plugin maintains a set of third-party dependencies that provide essential functionality for security operations, including compression, logging, I/O operations, and build tooling. Regular updates to these dependencies ensure security, stability, and compatibility.
+The OpenSearch Security plugin maintains a set of third-party dependencies that provide essential functionality for security operations, including cryptography, compression, logging, I/O operations, messaging, and build tooling. Regular updates to these dependencies ensure security, stability, and compatibility.
 
 ## Details
 
@@ -10,28 +10,57 @@ The OpenSearch Security plugin maintains a set of third-party dependencies that 
 
 | Dependency | Purpose | Category |
 |------------|---------|----------|
+| Bouncy Castle | Cryptographic operations | Runtime |
+| Apache Kafka | Messaging and audit logging | Runtime |
+| Spring Framework | Application framework | Runtime |
+| Jackson | JSON serialization | Runtime |
+| Google Guava | Core utilities | Runtime |
 | snappy-java | Fast compression/decompression | Runtime |
 | commons-io | File and stream I/O utilities | Runtime |
+| commons-codec | Encoding/decoding utilities | Runtime |
+| commons-collections4 | Collection utilities | Runtime |
 | scala-library | Scala runtime support | Runtime |
 | logback-classic | Logging framework | Runtime |
 | checker-qual | Static analysis annotations | Build |
 | gradle.test-retry | Flaky test retry | Build |
+| JUnit Jupiter | Testing framework | Test |
+| Mockito | Mocking framework | Test |
+| Byte Buddy | Bytecode manipulation | Test |
+| ASM | Bytecode analysis | Test |
 
 ### Dependency Categories
 
 #### Runtime Dependencies
 These libraries are required at runtime for the Security plugin to function:
 
+- **Bouncy Castle**: Cryptographic provider for TLS, encryption, and certificate operations
+- **Apache Kafka**: Messaging system used for audit logging and event streaming
+- **Spring Framework**: Application framework for dependency injection and configuration
+- **Jackson**: JSON processing library for serialization/deserialization
+- **Google Guava**: Core utility library providing collections, caching, and primitives
 - **snappy-java**: Provides fast compression/decompression algorithms used for data serialization
 - **commons-io**: Apache Commons I/O library for file operations and stream handling
+- **commons-codec**: Encoding/decoding utilities for Base64, Hex, and other formats
+- **commons-collections4**: Extended collection implementations and utilities
 - **scala-library**: Scala standard library required for Scala-based components
 - **logback-classic**: SLF4J-compatible logging implementation
+
+#### Test Dependencies
+These libraries are used for testing:
+
+- **JUnit Jupiter**: Modern testing framework for unit and integration tests
+- **Mockito**: Mocking framework for creating test doubles
+- **Byte Buddy**: Runtime bytecode generation for mocking
+- **ASM**: Bytecode manipulation and analysis framework
+- **Awaitility**: DSL for asynchronous testing
 
 #### Build Dependencies
 These libraries are used during the build process:
 
 - **checker-qual**: Annotations for the Checker Framework static analysis tool
 - **gradle.test-retry**: Gradle plugin that automatically retries failed tests to handle flaky tests
+- **Shadow Plugin**: Gradle plugin for creating fat JARs
+- **Google Java Format**: Code formatting tool
 
 ### Update Process
 
@@ -52,6 +81,19 @@ Dependency updates in the Security plugin follow this process:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#5380](https://github.com/opensearch-project/security/pull/5380) | Bump bouncycastle_version 1.80 → 1.81 |
+| v3.1.0 | [#5131](https://github.com/opensearch-project/security/pull/5131) | Upgrade kafka_version 3.7.1 → 4.0.0 |
+| v3.1.0 | [#5284](https://github.com/opensearch-project/security/pull/5284) | Bump guava 33.4.6-jre → 33.4.8-jre |
+| v3.1.0 | [#5283](https://github.com/opensearch-project/security/pull/5283) | Bump spring_version 6.2.5 → 6.2.7 |
+| v3.1.0 | [#5296](https://github.com/opensearch-project/security/pull/5296) | Bump mockito-core 5.15.2 → 5.18.0 |
+| v3.1.0 | [#5293](https://github.com/opensearch-project/security/pull/5293) | Bump asm 9.7.1 → 9.8 |
+| v3.1.0 | [#5295](https://github.com/opensearch-project/security/pull/5295) | Bump commons-codec 1.16.1 → 1.18.0 |
+| v3.1.0 | [#5313](https://github.com/opensearch-project/security/pull/5313) | Bump byte-buddy 1.15.11 → 1.17.5 |
+| v3.1.0 | [#5328](https://github.com/opensearch-project/security/pull/5328) | Bump commons-io 2.18.0 → 2.19.0 |
+| v3.1.0 | [#5316](https://github.com/opensearch-project/security/pull/5316) | Bump commons-collections4 4.4 → 4.5 |
+| v3.1.0 | [#5371](https://github.com/opensearch-project/security/pull/5371) | Bump junit-jupiter 5.12.2 → 5.13.1 |
+| v3.1.0 | [#5292](https://github.com/opensearch-project/security/pull/5292) | Bump jackson-databind |
+| v3.1.0 | [#2231](https://github.com/opensearch-project/security-dashboards-plugin/pull/2231) | Fix CVE-2024-52798 |
 | v2.18.0 | [#4738](https://github.com/opensearch-project/security/pull/4738) | Bump snappy-java 1.1.10.6 → 1.1.10.7 |
 | v2.18.0 | [#4736](https://github.com/opensearch-project/security/pull/4736) | Bump gradle.test-retry 1.5.10 → 1.6.0 |
 | v2.18.0 | [#4750](https://github.com/opensearch-project/security/pull/4750) | Bump commons-io 2.16.1 → 2.17.0 |
@@ -61,6 +103,10 @@ Dependency updates in the Security plugin follow this process:
 ## References
 
 - [OpenSearch Security Repository](https://github.com/opensearch-project/security)
+- [OpenSearch Security Dashboards Plugin](https://github.com/opensearch-project/security-dashboards-plugin)
+- [CVE-2024-52798 Advisory](https://advisories.opensearch.org/advisories/CVE-2024-52798)
+- [Bouncy Castle](https://www.bouncycastle.org/)
+- [Apache Kafka](https://kafka.apache.org/)
 - [snappy-java](https://github.com/xerial/snappy-java)
 - [Apache Commons IO](https://commons.apache.org/proper/commons-io/)
 - [Scala Library](https://www.scala-lang.org/)
@@ -68,4 +114,5 @@ Dependency updates in the Security plugin follow this process:
 
 ## Change History
 
+- **v3.1.0** (2025-06-03): Major dependency updates including Bouncy Castle 1.81, Kafka 4.0.0, Spring 6.2.7, Guava 33.4.8, JUnit 5.13.1, and CVE-2024-52798 fix
 - **v2.18.0** (2024-10-22): Updated snappy-java, gradle.test-retry, commons-io, scala-library, checker-qual, and logback-classic

--- a/docs/releases/v3.1.0/features/security/security-dependency-updates.md
+++ b/docs/releases/v3.1.0/features/security/security-dependency-updates.md
@@ -1,0 +1,90 @@
+# Security Dependency Updates
+
+## Summary
+
+OpenSearch v3.1.0 includes 24 dependency updates for the Security plugin and Security Dashboards plugin. These updates address security vulnerabilities (including CVE-2024-52798), improve compatibility with newer library versions, and ensure the security components remain current with upstream dependencies.
+
+## Details
+
+### What's New in v3.1.0
+
+This release focuses on maintaining security and stability through comprehensive dependency updates across both the backend Security plugin and the frontend Security Dashboards plugin.
+
+### Technical Changes
+
+#### Key Dependency Updates
+
+| Category | Dependency | Previous Version | New Version |
+|----------|------------|------------------|-------------|
+| Cryptography | Bouncy Castle | 1.80 | 1.81 |
+| Messaging | Apache Kafka | 3.7.1 | 4.0.0 |
+| Framework | Spring | 6.2.5 | 6.2.7 |
+| Serialization | Jackson Databind | 2.18.x | 2.19.x |
+| Utilities | Google Guava | 33.4.6-jre | 33.4.8-jre |
+| Testing | JUnit Jupiter | 5.12.2 | 5.13.1 |
+| Testing | Mockito | 5.15.2 | 5.18.0 |
+| Bytecode | Byte Buddy | 1.15.11 | 1.17.5 |
+| Bytecode | ASM | 9.7.1 | 9.8 |
+| Utilities | Commons IO | 2.18.0 | 2.19.0 |
+| Utilities | Commons Codec | 1.16.1 | 1.18.0 |
+| Utilities | Commons Collections4 | 4.4 | 4.5 |
+| Metrics | Dropwizard Metrics | 4.2.30 | 4.2.31 |
+| Build | Shadow Plugin | 8.1.7 | 8.1.8 |
+
+#### Security Vulnerability Fixes
+
+- **CVE-2024-52798**: Fixed in Security Dashboards plugin through dev dependency updates ([PR #2231](https://github.com/opensearch-project/security-dashboards-plugin/pull/2231))
+
+#### Major Version Upgrades
+
+1. **Apache Kafka 4.0.0**: Major version upgrade from 3.7.1, requiring test updates to accommodate API changes
+2. **Bouncy Castle 1.81**: Updated cryptographic library with latest security patches
+3. **JUnit Jupiter 5.13.x**: Testing framework upgrade for improved test capabilities
+
+### Migration Notes
+
+These dependency updates are transparent to users. No configuration changes are required. The updates maintain backward compatibility with existing security configurations.
+
+## Limitations
+
+- Kafka 4.0.0 upgrade required internal test adjustments but does not affect user-facing functionality
+- Some dependency updates are automated via Dependabot and follow standard security plugin review processes
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#5380](https://github.com/opensearch-project/security/pull/5380) | security | Bump bouncycastle_version from 1.80 to 1.81 |
+| [#5131](https://github.com/opensearch-project/security/pull/5131) | security | Upgrade kafka_version from 3.7.1 to 4.0.0 |
+| [#5284](https://github.com/opensearch-project/security/pull/5284) | security | Bump guava from 33.4.6-jre to 33.4.8-jre |
+| [#5283](https://github.com/opensearch-project/security/pull/5283) | security | Bump spring_version from 6.2.5 to 6.2.7 |
+| [#5285](https://github.com/opensearch-project/security/pull/5285) | security | Bump error_prone_annotations |
+| [#5296](https://github.com/opensearch-project/security/pull/5296) | security | Bump mockito-core from 5.15.2 to 5.18.0 |
+| [#5294](https://github.com/opensearch-project/security/pull/5294) | security | Bump randomizedtesting-runner |
+| [#5293](https://github.com/opensearch-project/security/pull/5293) | security | Bump asm from 9.7.1 to 9.8 |
+| [#5295](https://github.com/opensearch-project/security/pull/5295) | security | Bump commons-codec from 1.16.1 to 1.18.0 |
+| [#5313](https://github.com/opensearch-project/security/pull/5313) | security | Bump byte-buddy from 1.15.11 to 1.17.5 |
+| [#5314](https://github.com/opensearch-project/security/pull/5314) | security | Bump awaitility from 4.2.2 to 4.3.0 |
+| [#5315](https://github.com/opensearch-project/security/pull/5315) | security | Bump spring-kafka-test |
+| [#5292](https://github.com/opensearch-project/security/pull/5292) | security | Bump jackson-databind |
+| [#5316](https://github.com/opensearch-project/security/pull/5316) | security | Bump commons-collections4 from 4.4 to 4.5 |
+| [#5330](https://github.com/opensearch-project/security/pull/5330) | security | Bump google-java-format |
+| [#5329](https://github.com/opensearch-project/security/pull/5329) | security | Bump shadow plugin from 8.1.7 to 8.1.8 |
+| [#5328](https://github.com/opensearch-project/security/pull/5328) | security | Bump commons-io from 2.18.0 to 2.19.0 |
+| [#5361](https://github.com/opensearch-project/security/pull/5361) | security | Bump metrics-core from 4.2.30 to 4.2.31 |
+| [#5371](https://github.com/opensearch-project/security/pull/5371) | security | Bump junit-jupiter from 5.12.2 to 5.13.1 |
+| [#5383](https://github.com/opensearch-project/security/pull/5383) | security | Bump junit-jupiter-api |
+| [#5381](https://github.com/opensearch-project/security/pull/5381) | security | Bump checker-qual |
+| [#1517](https://github.com/opensearch-project/security/pull/1517) | security | Increment version to 3.1.0-SNAPSHOT |
+| [#1301](https://github.com/opensearch-project/security/pull/1301) | security | Increment version to 3.1.0.0 |
+| [#2231](https://github.com/opensearch-project/security-dashboards-plugin/pull/2231) | security-dashboards-plugin | Fix CVE-2024-52798 |
+
+## References
+
+- [CVE-2024-52798 Advisory](https://advisories.opensearch.org/advisories/CVE-2024-52798): Security vulnerability fixed in this release
+- [Bouncy Castle Release Notes](https://github.com/bcgit/bc-java/blob/main/docs/releasenotes.html): Cryptographic library updates
+- [Apache Kafka 4.0.0](https://kafka.apache.org/): Major version upgrade details
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/security-plugin-dependencies.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -40,3 +40,7 @@
 ### Skills
 
 - [ML Skills](features/skills/ml-skills.md) - Fix httpclient5 dependency version conflict and apply Spotless formatting
+
+### Security
+
+- [Security Dependency Updates](features/security/security-dependency-updates.md) - 24 dependency updates including Bouncy Castle 1.81, Kafka 4.0.0, and CVE-2024-52798 fix


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security Dependency Updates in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/security/security-dependency-updates.md`
- Feature report: `docs/features/security/security-plugin-dependencies.md` (updated)

### Key Changes in v3.1.0
- 24 dependency updates across Security plugin and Security Dashboards plugin
- Bouncy Castle upgraded from 1.80 to 1.81
- Apache Kafka upgraded from 3.7.1 to 4.0.0 (major version)
- Spring Framework upgraded from 6.2.5 to 6.2.7
- CVE-2024-52798 fixed in Security Dashboards plugin
- Multiple test dependency updates (JUnit, Mockito, Byte Buddy)

Closes #896