### PR TITLE
docs: add security-permissions report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -139,7 +139,9 @@
 - [Security Auth Enhancements](security/security-auth-enhancements.md)
 - [Security Bugfixes](security/security-bugfixes.md)
 - [Security Configuration](security/security-configuration.md)
+- [Security Permissions](security/security-permissions.md)
 - [Security Plugin](security/security-plugin.md)
+- [Security Plugin Dependencies](security/security-plugin-dependencies.md)
 
 ## security-dashboards
 

--- a/docs/features/security/security-permissions.md
+++ b/docs/features/security/security-permissions.md
@@ -1,0 +1,154 @@
+# Security Permissions
+
+## Summary
+
+OpenSearch Security plugin provides predefined roles for various features including Forecasting, Anomaly Detection, Machine Learning, and more. These roles define cluster-level and index-level permissions that control access to plugin functionality. The Security plugin's `roles.yml` configuration file contains reserved roles that are automatically available after installation.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Security Plugin"
+        RolesYml[roles.yml]
+        RolesMapping[roles_mapping.yml]
+    end
+    
+    subgraph "Predefined Roles"
+        ForecastRead[forecast_read_access]
+        ForecastFull[forecast_full_access]
+        AnomalyRead[anomaly_read_access]
+        AnomalyFull[anomaly_full_access]
+        MLRead[ml_read_access]
+        MLFull[ml_full_access]
+    end
+    
+    subgraph "Permission Types"
+        ClusterPerm[Cluster Permissions]
+        IndexPerm[Index Permissions]
+    end
+    
+    RolesYml --> ForecastRead
+    RolesYml --> ForecastFull
+    RolesYml --> AnomalyRead
+    RolesYml --> AnomalyFull
+    RolesYml --> MLRead
+    RolesYml --> MLFull
+    
+    ForecastRead --> ClusterPerm
+    ForecastRead --> IndexPerm
+    ForecastFull --> ClusterPerm
+    ForecastFull --> IndexPerm
+    
+    RolesMapping --> Users[Users/Backend Roles]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `roles.yml` | Defines predefined roles with cluster and index permissions |
+| `roles_mapping.yml` | Maps users and backend roles to security roles |
+| Cluster Permissions | Control access to cluster-wide operations |
+| Index Permissions | Control access to specific indices and operations |
+
+### Forecast Roles Configuration
+
+#### forecast_read_access
+
+Provides read-only access to forecast resources:
+
+```yaml
+forecast_read_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/plugin/forecast/forecaster/info'
+    - 'cluster:admin/plugin/forecast/forecaster/stats'
+    - 'cluster:admin/plugin/forecast/forecaster/suggest'
+    - 'cluster:admin/plugin/forecast/forecaster/validate'
+    - 'cluster:admin/plugin/forecast/forecasters/get'
+    - 'cluster:admin/plugin/forecast/forecasters/info'
+    - 'cluster:admin/plugin/forecast/forecasters/search'
+    - 'cluster:admin/plugin/forecast/result/topForecasts'
+    - 'cluster:admin/plugin/forecast/tasks/search'
+  index_permissions:
+    - index_patterns:
+        - 'opensearch-forecast-result*'
+      allowed_actions:
+        - 'indices:admin/mappings/fields/get*'
+        - 'indices:admin/resolve/index'
+        - 'indices:data/read*'
+```
+
+#### forecast_full_access
+
+Provides full access to all forecasting functionality:
+
+```yaml
+forecast_full_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/plugin/forecast/*'
+    - 'cluster:admin/settings/update'
+    - 'cluster_monitor'
+  index_permissions:
+    - index_patterns:
+        - '*'
+      allowed_actions:
+        - 'indices:admin/aliases/get'
+        - 'indices:admin/mapping/get'
+        - 'indices:admin/mapping/put'
+        - 'indices:admin/mappings/fields/get*'
+        - 'indices:admin/mappings/get'
+        - 'indices:admin/resolve/index'
+        - 'indices:data/read*'
+        - 'indices:data/read/field_caps*'
+        - 'indices:data/read/search'
+        - 'indices:data/write*'
+        - 'indices_monitor'
+```
+
+### Usage Example
+
+Map roles to users in `roles_mapping.yml`:
+
+```yaml
+forecast_full_access:
+  reserved: false
+  users:
+    - "forecast_admin"
+  backend_roles:
+    - "forecast_admins"
+
+forecast_read_access:
+  reserved: false
+  users:
+    - "forecast_viewer"
+  backend_roles:
+    - "forecast_viewers"
+```
+
+## Limitations
+
+- Forecast roles are separate from Anomaly Detection roles (`anomaly_read_access`, `anomaly_full_access`)
+- Cross-cluster forecasting requires `cluster_monitor` permission and proper cluster connectivity
+- Reserved roles cannot be modified through the API; changes require editing `roles.yml` directly
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#5386](https://github.com/opensearch-project/security/pull/5386) | Add forecast roles and permissions |
+| v3.1.0 | [#5405](https://github.com/opensearch-project/security/pull/5405) | Add missing cluster:monitor permission |
+| v3.1.0 | [#5412](https://github.com/opensearch-project/security/pull/5412) | Add missing mapping get permission |
+
+## References
+
+- [OpenSearch Security Permissions Documentation](https://docs.opensearch.org/3.0/security/access-control/permissions/)
+- [Defining Users and Roles](https://docs.opensearch.org/3.0/security/access-control/users-roles/)
+- [Security Dashboards Plugin PR #2253](https://github.com/opensearch-project/security-dashboards-plugin/pull/2253): Frontend dropdown update
+
+## Change History
+
+- **v3.1.0** (2025-06): Added `forecast_read_access` and `forecast_full_access` roles with complete permissions for forecasting feature including `cluster_monitor` and `indices:admin/mappings/get`

--- a/docs/releases/v3.1.0/features/security/security-permissions.md
+++ b/docs/releases/v3.1.0/features/security/security-permissions.md
@@ -1,0 +1,123 @@
+# Security Permissions
+
+## Summary
+
+This release fixes missing security permissions for the Forecasting plugin, ensuring users with `forecast_full_access` role can properly create and manage forecasters, including cross-cluster forecasters. Three permissions were added: `cluster_monitor` for cluster monitoring, `indices:admin/mappings/get` for mapping retrieval, and the complete forecast roles configuration.
+
+## Details
+
+### What's New in v3.1.0
+
+Three PRs addressed permission gaps in the Security plugin's predefined roles for the Forecasting feature:
+
+1. **New Forecast Roles** (PR #5386): Added `forecast_read_access` and `forecast_full_access` roles to support the forecasting feature
+2. **Cluster Monitor Permission** (PR #5405): Added missing `cluster_monitor` permission for cross-cluster forecaster creation
+3. **Mapping Get Permission** (PR #5412): Added missing `indices:admin/mappings/get` permission for index mapping retrieval
+
+### Technical Changes
+
+#### New Roles Added
+
+| Role | Description |
+|------|-------------|
+| `forecast_read_access` | Read-only access to forecast resources |
+| `forecast_full_access` | Full access to all forecasting functionality |
+
+#### forecast_read_access Permissions
+
+```yaml
+forecast_read_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/plugin/forecast/forecaster/info'
+    - 'cluster:admin/plugin/forecast/forecaster/stats'
+    - 'cluster:admin/plugin/forecast/forecaster/suggest'
+    - 'cluster:admin/plugin/forecast/forecaster/validate'
+    - 'cluster:admin/plugin/forecast/forecasters/get'
+    - 'cluster:admin/plugin/forecast/forecasters/info'
+    - 'cluster:admin/plugin/forecast/forecasters/search'
+    - 'cluster:admin/plugin/forecast/result/topForecasts'
+    - 'cluster:admin/plugin/forecast/tasks/search'
+  index_permissions:
+    - index_patterns:
+        - 'opensearch-forecast-result*'
+      allowed_actions:
+        - 'indices:admin/mappings/fields/get*'
+        - 'indices:admin/resolve/index'
+        - 'indices:data/read*'
+```
+
+#### forecast_full_access Permissions
+
+```yaml
+forecast_full_access:
+  reserved: true
+  cluster_permissions:
+    - 'cluster:admin/plugin/forecast/*'
+    - 'cluster:admin/settings/update'
+    - 'cluster_monitor'  # Added in PR #5405
+  index_permissions:
+    - index_patterns:
+        - '*'
+      allowed_actions:
+        - 'indices:admin/aliases/get'
+        - 'indices:admin/mapping/get'
+        - 'indices:admin/mapping/put'
+        - 'indices:admin/mappings/fields/get*'
+        - 'indices:admin/mappings/get'  # Added in PR #5412
+        - 'indices:admin/resolve/index'
+        - 'indices:data/read*'
+        - 'indices:data/read/field_caps*'
+        - 'indices:data/read/search'
+        - 'indices:data/write*'
+        - 'indices_monitor'
+```
+
+### Usage Example
+
+To assign forecast access to a user, map the role in `roles_mapping.yml`:
+
+```yaml
+forecast_full_access:
+  reserved: false
+  users:
+    - "forecast_admin"
+  backend_roles:
+    - "forecast_admins"
+
+forecast_read_access:
+  reserved: false
+  users:
+    - "forecast_viewer"
+  backend_roles:
+    - "forecast_viewers"
+```
+
+### Migration Notes
+
+- Users upgrading from previous versions need to update their `roles.yml` configuration to include the new forecast roles
+- Existing anomaly detection users can use similar role patterns for forecasting
+- The `cluster_monitor` permission is required for cross-cluster forecaster operations
+
+## Limitations
+
+- The forecast roles are specific to the Forecasting plugin and do not cover Anomaly Detection (which has separate `anomaly_read_access` and `anomaly_full_access` roles)
+- Cross-cluster forecasting requires additional cluster connectivity configuration
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5386](https://github.com/opensearch-project/security/pull/5386) | Add forecast roles and permissions |
+| [#5405](https://github.com/opensearch-project/security/pull/5405) | Add missing cluster:monitor permission |
+| [#5412](https://github.com/opensearch-project/security/pull/5412) | Add missing mapping get permission |
+
+## References
+
+- [Security Dashboards Plugin PR #2253](https://github.com/opensearch-project/security-dashboards-plugin/pull/2253): Frontend dropdown update for forecast permissions
+- [OpenSearch Security Permissions Documentation](https://docs.opensearch.org/3.0/security/access-control/permissions/)
+- [Defining Users and Roles](https://docs.opensearch.org/3.0/security/access-control/users-roles/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/security/security-permissions.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -44,3 +44,4 @@
 ### Security
 
 - [Security Dependency Updates](features/security/security-dependency-updates.md) - 24 dependency updates including Bouncy Castle 1.81, Kafka 4.0.0, and CVE-2024-52798 fix
+- [Security Permissions](features/security/security-permissions.md) - Add forecast roles and fix missing cluster:monitor and mapping get permissions


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security Permissions bugfix in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/security/security-permissions.md`
- Feature report: `docs/features/security/security-permissions.md`

### Key Changes in v3.1.0
- Added `forecast_read_access` and `forecast_full_access` roles for the Forecasting plugin
- Added missing `cluster_monitor` permission for cross-cluster forecaster creation
- Added missing `indices:admin/mappings/get` permission for index mapping retrieval

### Related PRs
- [security#5386](https://github.com/opensearch-project/security/pull/5386): Add forecast roles and permissions
- [security#5405](https://github.com/opensearch-project/security/pull/5405): Add missing cluster:monitor permission
- [security#5412](https://github.com/opensearch-project/security/pull/5412): Add missing mapping get permission

Closes #895