### PR TITLE
docs: add reporting-release-maintenance report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -153,6 +153,7 @@
 - [CI/CD Workflow](reporting/ci-workflow.md)
 - [Integration Test Stability](reporting/integration-test-stability.md)
 - [Java Agent Migration](reporting/java-agent-migration.md)
+- [Release Maintenance](reporting/release-maintenance.md)
 
 ## dashboards-reporting
 

--- a/docs/features/reporting/release-maintenance.md
+++ b/docs/features/reporting/release-maintenance.md
@@ -1,0 +1,86 @@
+# Release Maintenance
+
+## Summary
+
+The OpenSearch Reporting plugin follows a standard release maintenance process that includes automated version increments and release notes generation. This ensures the plugin stays synchronized with OpenSearch core releases and maintains proper documentation of changes.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Release Automation"
+        TB[Trigger Bot] --> |Creates PR| VI[Version Increment]
+        VI --> |Updates| BG[build.gradle]
+        VI --> |Updates| WF[Workflow Files]
+    end
+    
+    subgraph "Release Notes"
+        M[Maintainer] --> |Creates PR| RN[Release Notes]
+        RN --> |Adds| RNF[release-notes/*.md]
+    end
+    
+    subgraph "Build System"
+        BG --> |Defines| VER[Plugin Version]
+        WF --> |Configures| DRN[Draft Release Notes]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `build.gradle` | Defines plugin version and OpenSearch compatibility |
+| `draft-release-notes-workflow.yml` | GitHub Actions workflow for generating draft release notes |
+| `release-notes/` | Directory containing release notes for each version |
+
+### Configuration
+
+| Setting | Description | Location |
+|---------|-------------|----------|
+| `opensearch_version` | Target OpenSearch version | `build.gradle` |
+| `buildVersionQualifier` | Version qualifier (e.g., beta1, rc1) | `build.gradle` |
+| `version` | Draft release notes version | `.github/workflows/draft-release-notes-workflow.yml` |
+
+### Release Notes Format
+
+Release notes follow a standard format:
+
+```markdown
+## Version X.Y.Z.W Release Notes
+
+Compatible with OpenSearch X.Y.Z
+
+### Maintenance
+- [AUTO] Increment version to X.Y.Z-SNAPSHOT ([#PR](url))
+- Adding release notes for X.Y.Z ([#PR](url))
+
+### Features
+- Feature description ([#PR](url))
+
+### Bug Fixes
+- Bug fix description ([#PR](url))
+```
+
+## Limitations
+
+- Version increments are automated and should not be manually modified
+- Release notes must be added before the release branch is cut
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#1092](https://github.com/opensearch-project/reporting/pull/1092) | [AUTO] Increment version to 3.1.0-SNAPSHOT |
+| v3.1.0 | [#1101](https://github.com/opensearch-project/reporting/pull/1101) | Adding release notes for 3.1.0 |
+
+## References
+
+- [Issue #1095](https://github.com/opensearch-project/reporting/issues/1095): [RELEASE] Release version 3.1.0
+- [Reporting Repository](https://github.com/opensearch-project/reporting): Export and automate PNG, PDF, and CSV reports in OpenSearch Dashboards
+- [Release Notes Guidelines](https://github.com/opensearch-project/opensearch-plugins/blob/main/RELEASE_NOTES.md): Official release notes format
+
+## Change History
+
+- **v3.1.0** (2025-06-13): Version increment to 3.1.0-SNAPSHOT and release notes added

--- a/docs/releases/v3.1.0/features/reporting/reporting-release-maintenance.md
+++ b/docs/releases/v3.1.0/features/reporting/reporting-release-maintenance.md
@@ -1,0 +1,55 @@
+# Reporting Release Maintenance
+
+## Summary
+
+Standard release maintenance for the OpenSearch Reporting plugin for v3.1.0. This includes automated version increment to 3.1.0-SNAPSHOT and the addition of release notes documenting the changes in this version.
+
+## Details
+
+### What's New in v3.1.0
+
+This release contains maintenance updates to prepare the Reporting plugin for the v3.1.0 release cycle:
+
+1. **Version Increment**: Automated version bump from 3.0.0-beta1 to 3.1.0-SNAPSHOT
+2. **Release Notes**: Added release notes documenting the v3.1.0.0 changes
+
+### Technical Changes
+
+#### Build Configuration Updates
+
+| File | Change | Description |
+|------|--------|-------------|
+| `build.gradle` | Version update | `opensearch_version` changed from `3.0.0-beta1-SNAPSHOT` to `3.1.0-SNAPSHOT` |
+| `build.gradle` | Qualifier removal | `buildVersionQualifier` changed from `beta1` to empty string |
+| `.github/workflows/draft-release-notes-workflow.yml` | Version update | Draft release notes version changed from `3.0.0.0` to `3.1.0.0` |
+
+#### Release Notes Content
+
+The release notes file `release-notes/opensearch-reporting.release-notes-3.1.0.0.md` was added with:
+
+- Compatibility statement: Compatible with OpenSearch 3.1.0
+- Maintenance section listing the version increment PR
+
+### Migration Notes
+
+No migration required. This is a maintenance release with no breaking changes.
+
+## Limitations
+
+None specific to this release.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1092](https://github.com/opensearch-project/reporting/pull/1092) | [AUTO] Increment version to 3.1.0-SNAPSHOT |
+| [#1101](https://github.com/opensearch-project/reporting/pull/1101) | Adding release notes for 3.1.0 |
+
+## References
+
+- [Issue #1095](https://github.com/opensearch-project/reporting/issues/1095): [RELEASE] Release version 3.1.0
+- [Reporting Repository](https://github.com/opensearch-project/reporting): Export and automate PNG, PDF, and CSV reports in OpenSearch Dashboards
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/reporting/release-maintenance.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -41,6 +41,10 @@
 
 - [ML Skills](features/skills/ml-skills.md) - Fix httpclient5 dependency version conflict and apply Spotless formatting
 
+### Reporting
+
+- [Reporting Release Maintenance](features/reporting/reporting-release-maintenance.md) - Version increment to 3.1.0-SNAPSHOT and release notes for v3.1.0
+
 ### Security
 
 - [Security Dependency Updates](features/security/security-dependency-updates.md) - 24 dependency updates including Bouncy Castle 1.81, Kafka 4.0.0, and CVE-2024-52798 fix


### PR DESCRIPTION
## Summary

Add documentation for the Reporting Release Maintenance item in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/reporting/reporting-release-maintenance.md`
- Feature report: `docs/features/reporting/release-maintenance.md`

### Key Changes in v3.1.0
- Version increment from 3.0.0-beta1 to 3.1.0-SNAPSHOT
- Release notes added for v3.1.0.0

### Related PRs
- [#1092](https://github.com/opensearch-project/reporting/pull/1092): [AUTO] Increment version to 3.1.0-SNAPSHOT
- [#1101](https://github.com/opensearch-project/reporting/pull/1101): Adding release notes for 3.1.0

Closes #894"