### PR TITLE
docs: add Query Insights release maintenance report for v3.1.0

### DIFF
--- a/docs/features/query-insights/query-insights.md
+++ b/docs/features/query-insights/query-insights.md
@@ -182,6 +182,8 @@ GET /_insights/live_queries?sort=latency&size=5
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#364](https://github.com/opensearch-project/query-insights/pull/364) | Fix flaky integration tests |
+| v3.1.0 | [#482](https://github.com/opensearch-project/query-insights/pull/482) | Add multi-node and health stats integration tests |
 | v3.0.0 | [#295](https://github.com/opensearch-project/query-insights/pull/295) | Inflight Queries API |
 | v3.0.0 | [#254](https://github.com/opensearch-project/query-insights/pull/254) | Default index template for local index |
 | v3.0.0 | [#300](https://github.com/opensearch-project/query-insights/pull/300) | Top queries API verbose param |
@@ -223,6 +225,7 @@ GET /_insights/live_queries?sort=latency&size=5
 
 ## Change History
 
+- **v3.1.0**: Fixed flaky integration tests; added multi-node cluster integration tests (`QueryInsightsClusterIT`); added health stats REST API integration tests (`HealthStatsRestIT`); improved test infrastructure with node targeting and retry logic
 - **v3.0.0**: Added Live Queries API, default index template, verbose parameter, profile query filtering, strict hash check
 - **v2.18.0**: Added Health Stats API for monitoring plugin health; added OpenTelemetry error metrics counters; added field name and type support for query shape grouping (defaults changed to `true`); added time range parameters for historical query retrieval; added cache eviction and cluster state listener for index field type mappings
 - **v2.17.0**: Fixed listener startup when query metrics enabled; added query shape hash method; fixed CVE-2023-2976; improved integration test coverage for query grouping; added code hygiene checks (Spotless, Checkstyle); fixed snapshot publishing configuration

--- a/docs/releases/v3.1.0/features/query-insights/query-insights-release-maintenance.md
+++ b/docs/releases/v3.1.0/features/query-insights/query-insights-release-maintenance.md
@@ -1,0 +1,75 @@
+# Query Insights Release Maintenance
+
+## Summary
+
+This release includes bug fixes for flaky integration tests in the Query Insights plugin. The changes improve test reliability by addressing timing issues, adding proper test infrastructure for multi-node scenarios, and fixing window boundary calculations.
+
+## Details
+
+### What's New in v3.1.0
+
+This release focuses on test stability improvements rather than new features. The changes ensure more reliable CI/CD pipelines by fixing intermittent test failures.
+
+### Technical Changes
+
+#### Test Infrastructure Improvements
+
+| Change | Description |
+|--------|-------------|
+| Multi-node test support | Added `getNodeClient(int nodeIndex)` method for targeting specific nodes |
+| Index creation consistency | Added `createIndexWithSettings()` to ensure consistent shard counts |
+| Retry logic | Added retry mechanisms for index discovery and cluster health checks |
+| Time buffer | Added 10-second buffer to timestamp queries to handle processing delays |
+
+#### Fixed Flaky Tests
+
+| Test Class | Fix Applied |
+|------------|-------------|
+| `QueryInsightsRestTestCase` | Added index creation with default settings, retry logic for top_queries index discovery |
+| `QueryInsightsExporterIT` | Increased search iterations and added delays between searches |
+| `TopQueriesServiceTests` | Set reasonable window size (1 hour) instead of `Long.MAX_VALUE` |
+| `LiveQueriesRestIT` | Added proper index mapping for aggregations and sorting |
+| `MinMaxQueryGrouperBySimilarityIT` | Added settings propagation delays and state clearing |
+
+#### New Test Classes (PR #482)
+
+| Test Class | Description |
+|------------|-------------|
+| `QueryInsightsClusterIT` | Multi-node integration tests for data collection and aggregation |
+| `HealthStatsRestIT` | Integration tests for health stats REST API |
+
+#### Window Size Changes
+
+Default window size increased from 1 minute to 5 minutes in test settings to prevent queries from being lost during window rotation:
+
+```java
+// Before
+"search.insights.top_queries.latency.window_size" : "1m"
+
+// After  
+"search.insights.top_queries.latency.window_size" : "5m"
+```
+
+### Migration Notes
+
+No migration required. These are internal test improvements only.
+
+## Limitations
+
+- `QueryInsightsClusterIT` is excluded from security integration tests due to SSL certificate limitations with multi-node setups in Java 21
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#364](https://github.com/opensearch-project/query-insights/pull/364) | Fix flaky integration tests |
+| [#482](https://github.com/opensearch-project/query-insights/pull/482) | Add multi-node and health stats integration tests, fix additional flaky tests |
+
+## References
+
+- [Query Insights Documentation](https://docs.opensearch.org/3.1/observing-your-data/query-insights/index/)
+- [Query Insights Health Documentation](https://docs.opensearch.org/3.1/observing-your-data/query-insights/health/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/query-insights/query-insights.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -49,3 +49,7 @@
 
 - [Security Dependency Updates](features/security/security-dependency-updates.md) - 24 dependency updates including Bouncy Castle 1.81, Kafka 4.0.0, and CVE-2024-52798 fix
 - [Security Permissions](features/security/security-permissions.md) - Add forecast roles and fix missing cluster:monitor and mapping get permissions
+
+### Query Insights
+
+- [Query Insights Release Maintenance](features/query-insights/query-insights-release-maintenance.md) - Fix flaky integration tests and add multi-node test infrastructure


### PR DESCRIPTION
## Summary

Add documentation for Query Insights release maintenance in v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/query-insights/query-insights-release-maintenance.md`
- Feature report updated: `docs/features/query-insights/query-insights.md`

### Key Changes in v3.1.0
- Fixed flaky integration tests with improved timing and retry logic
- Added multi-node cluster integration tests (`QueryInsightsClusterIT`)
- Added health stats REST API integration tests (`HealthStatsRestIT`)
- Improved test infrastructure with node targeting capabilities

### Related PRs
- [#364](https://github.com/opensearch-project/query-insights/pull/364): Fix flaky integration tests
- [#482](https://github.com/opensearch-project/query-insights/pull/482): Add multi-node and health stats integration tests

Closes #893