### PR TITLE
docs: add Observability Release Maintenance report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -251,6 +251,7 @@
 ## observability
 
 - [Observability Integrations](observability/observability-integrations.md)
+- [Release Maintenance](observability/release-maintenance.md)
 
 ## performance-analyzer
 

--- a/docs/features/observability/release-maintenance.md
+++ b/docs/features/observability/release-maintenance.md
@@ -1,0 +1,67 @@
+# Observability Release Maintenance
+
+## Summary
+
+This feature tracks the release maintenance activities for the OpenSearch Observability plugins, including version increments, release notes, and routine maintenance tasks across both the backend plugin (observability) and frontend plugin (dashboards-observability).
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Observability Plugins"
+        OBS[observability<br/>Backend Plugin]
+        DOBS[dashboards-observability<br/>Frontend Plugin]
+    end
+    
+    subgraph "Release Maintenance"
+        VI[Version Increment]
+        RN[Release Notes]
+        WF[Workflow Updates]
+    end
+    
+    OBS --> VI
+    OBS --> RN
+    DOBS --> VI
+    DOBS --> RN
+    DOBS --> WF
+```
+
+### Components
+
+| Component | Repository | Description |
+|-----------|------------|-------------|
+| observability | opensearch-project/observability | Backend plugin for observability features |
+| dashboards-observability | opensearch-project/dashboards-observability | Frontend plugin for observability UI |
+
+### Release Process
+
+The release maintenance process includes:
+
+1. **Version Increment**: Automated version bumps via trigger bot
+2. **Release Notes**: Manual creation of release notes documenting changes
+3. **Workflow Updates**: CI/CD workflow version updates
+
+## Limitations
+
+- Release maintenance PRs are routine and do not introduce new functionality
+- Version increments are typically automated
+
+## Related PRs
+
+| Version | PR | Repository | Description |
+|---------|-----|------------|-------------|
+| v3.1.0 | [#1922](https://github.com/opensearch-project/observability/pull/1922) | observability | Increment version to 3.1.0-SNAPSHOT |
+| v3.1.0 | [#1929](https://github.com/opensearch-project/observability/pull/1929) | observability | Adding release notes for 3.1.0 |
+| v3.1.0 | [#2443](https://github.com/opensearch-project/dashboards-observability/pull/2443) | dashboards-observability | Increment version to 3.1.0.0 |
+| v3.1.0 | [#2464](https://github.com/opensearch-project/dashboards-observability/pull/2464) | dashboards-observability | Adding release notes for 3.1.0 |
+
+## References
+
+- [observability repository](https://github.com/opensearch-project/observability)
+- [dashboards-observability repository](https://github.com/opensearch-project/dashboards-observability)
+
+## Change History
+
+- **v3.1.0** (2025-06-13): Version increment and release notes for both plugins

--- a/docs/releases/v3.1.0/features/observability/observability-release-maintenance.md
+++ b/docs/releases/v3.1.0/features/observability/observability-release-maintenance.md
@@ -1,0 +1,66 @@
+# Observability Release Maintenance
+
+## Summary
+
+This release item covers routine maintenance activities for the Observability plugins in OpenSearch v3.1.0, including version increments and release notes updates for both the backend plugin (observability) and the frontend plugin (dashboards-observability).
+
+## Details
+
+### What's New in v3.1.0
+
+The v3.1.0 release of the Observability plugins includes:
+
+**Backend Plugin (observability)**:
+- Version increment to 3.1.0-SNAPSHOT
+- Release notes documentation
+
+**Frontend Plugin (dashboards-observability)**:
+- Version increment to 3.1.0.0
+- Release notes documentation
+- Bug fixes for Jaeger trace end time processing
+- Bug fixes for NFW Integration Vega visualization warnings
+- Enhancements to trace analytics with merged custom source and data prepper modes
+- Span Flyout support for new trace format
+
+### Technical Changes
+
+#### Bug Fixes
+| Fix | Description | PR |
+|-----|-------------|-----|
+| Jaeger End Time | Fix jaeger end time processing in trace analytics | [#2460](https://github.com/opensearch-project/dashboards-observability/pull/2460) |
+| Vega Vis Warning | NFW Integration Vega Vis warning message fix | [#2452](https://github.com/opensearch-project/dashboards-observability/pull/2452) |
+
+#### Enhancements
+| Enhancement | Description | PR |
+|-------------|-------------|-----|
+| Trace Analytics Mode | Merge custom source and data prepper mode in trace analytics | [#2457](https://github.com/opensearch-project/dashboards-observability/pull/2457) |
+| Span Flyout | Support new format in Span Flyout | [#2450](https://github.com/opensearch-project/dashboards-observability/pull/2450) |
+
+#### Infrastructure
+| Change | Description | PR |
+|--------|-------------|-----|
+| Version Bump | Workflows - Version bump to 3.1.0 | [#2451](https://github.com/opensearch-project/dashboards-observability/pull/2451) |
+
+## Limitations
+
+- This is a maintenance release with no new major features
+- Bug fixes are specific to trace analytics functionality
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#1922](https://github.com/opensearch-project/observability/pull/1922) | observability | Increment version to 3.1.0-SNAPSHOT |
+| [#1929](https://github.com/opensearch-project/observability/pull/1929) | observability | Adding release notes for 3.1.0 |
+| [#2443](https://github.com/opensearch-project/dashboards-observability/pull/2443) | dashboards-observability | Increment version to 3.1.0.0 |
+| [#2464](https://github.com/opensearch-project/dashboards-observability/pull/2464) | dashboards-observability | Adding release notes for 3.1.0 |
+
+## References
+
+- [Issue #1924](https://github.com/opensearch-project/observability/issues/1924): Release notes tracking issue (observability)
+- [Issue #2444](https://github.com/opensearch-project/dashboards-observability/issues/2444): Release notes tracking issue (dashboards-observability)
+
+## Related Feature Report
+
+- [Observability UI](../../../features/dashboards-observability/observability-ui.md)
+- [Trace Analytics](../../../features/dashboards-observability/trace-analytics.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -53,3 +53,7 @@
 ### Query Insights
 
 - [Query Insights Release Maintenance](features/query-insights/query-insights-release-maintenance.md) - Fix flaky integration tests and add multi-node test infrastructure
+
+### Observability
+
+- [Observability Release Maintenance](features/observability/observability-release-maintenance.md) - Version increments, release notes, and bug fixes for trace analytics


### PR DESCRIPTION
## Summary

This PR adds documentation for the Observability Release Maintenance item in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/observability/observability-release-maintenance.md`
- Feature report: `docs/features/observability/release-maintenance.md`

### Key Changes in v3.1.0

**Backend Plugin (observability)**:
- Version increment to 3.1.0-SNAPSHOT (#1922)
- Release notes for 3.1.0 (#1929)

**Frontend Plugin (dashboards-observability)**:
- Version increment to 3.1.0.0 (#2443)
- Release notes for 3.1.0 (#2464)
- Bug fixes: Jaeger end time processing, NFW Integration Vega Vis warning
- Enhancements: Trace analytics mode merge, Span Flyout new format support

### Related Issue
Closes #892