### PR TITLE
docs: add notifications maintenance report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -276,6 +276,10 @@
 
 - [OpenSearch Dashboards Notifications](dashboards-notifications/dashboards-notifications.md)
 
+## notifications
+
+- [Notifications Plugin](notifications/notifications-plugin.md)
+
 ## dashboards-query-workbench
 
 - [Query Workbench](dashboards-query-workbench/query-workbench.md)

--- a/docs/features/notifications/notifications-plugin.md
+++ b/docs/features/notifications/notifications-plugin.md
@@ -1,0 +1,110 @@
+# Notifications Plugin
+
+## Summary
+
+The OpenSearch Notifications plugin enables other plugins to send notifications via multiple channels including Email (SMTP and Amazon SES), Slack, Amazon Chime, Microsoft Teams, and custom webhooks. It provides a unified notification infrastructure for alerting, reporting, and other OpenSearch features that need to communicate with external systems.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Cluster"
+        A[Alerting Plugin] --> N[Notifications Plugin]
+        B[Reporting Plugin] --> N
+        C[Index Management] --> N
+        D[Other Plugins] --> N
+    end
+    
+    subgraph "Notifications Core"
+        N --> T[Transport Layer]
+        T --> SMTP[SMTP Client]
+        T --> SES[SES Client]
+        T --> WH[Webhook Client]
+    end
+    
+    subgraph "Destinations"
+        SMTP --> E[Email Server]
+        SES --> AWS[Amazon SES]
+        WH --> S[Slack]
+        WH --> CH[Chime]
+        WH --> MS[Teams]
+        WH --> CW[Custom Webhook]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `notifications-core` | Core notification processing and transport logic |
+| `notifications` | OpenSearch plugin integration |
+| `DestinationSmtpClient` | SMTP email delivery client |
+| `DestinationSesClient` | Amazon SES email delivery client |
+| `EmailMimeProvider` | MIME message construction for emails |
+| `WebhookClient` | HTTP webhook delivery for Slack, Chime, Teams |
+
+### Supported Channels
+
+| Channel | Protocol | Authentication |
+|---------|----------|----------------|
+| Email (SMTP) | SMTP/SMTPS | Username/Password, STARTTLS |
+| Email (SES) | AWS API | IAM Role, Access Keys |
+| Slack | HTTPS Webhook | Webhook URL |
+| Amazon Chime | HTTPS Webhook | Webhook URL |
+| Microsoft Teams | HTTPS Webhook | Webhook URL |
+| Custom Webhook | HTTP/HTTPS | Basic Auth, Headers |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `opensearch.notifications.core.email.minimum_header_length` | Minimum email header length | 32 |
+| `opensearch.notifications.core.email.size_limit` | Maximum email size in bytes | 10000000 |
+| `opensearch.notifications.core.http.max_connections` | Max HTTP connections | 60 |
+| `opensearch.notifications.core.http.connection_timeout` | Connection timeout (ms) | 5000 |
+| `opensearch.notifications.core.http.socket_timeout` | Socket timeout (ms) | 50000 |
+
+### Usage Example
+
+```json
+POST _plugins/_notifications/configs
+{
+  "config_id": "my-email-channel",
+  "config": {
+    "name": "Email Channel",
+    "description": "Send notifications via email",
+    "config_type": "email",
+    "is_enabled": true,
+    "email": {
+      "email_account_id": "account-id",
+      "recipient_list": [
+        { "recipient": "user@example.com" }
+      ]
+    }
+  }
+}
+```
+
+## Limitations
+
+- Email attachments have size limits based on configuration
+- Webhook destinations require network access from OpenSearch nodes
+- SES requires proper IAM permissions and verified email addresses
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#1036](https://github.com/opensearch-project/notifications/pull/1036) | Upgrade javax to jakarta mail |
+| v3.1.0 | [#1027](https://github.com/opensearch-project/notifications/pull/1027) | Version increment to 3.1.0-SNAPSHOT |
+
+## References
+
+- [OpenSearch Notifications Repository](https://github.com/opensearch-project/notifications)
+- [Jakarta Mail 2.0 Specification](https://jakarta.ee/specifications/mail/2.0/)
+
+## Change History
+
+- **v3.1.0** (2026-01-10): Migrated from javax.mail to jakarta.mail APIs to avoid version conflicts; updated greenmail test dependency to 2.0.1

--- a/docs/releases/v3.1.0/features/notifications/notifications-maintenance.md
+++ b/docs/releases/v3.1.0/features/notifications/notifications-maintenance.md
@@ -1,0 +1,67 @@
+# Notifications Maintenance
+
+## Summary
+
+This release includes maintenance updates for the OpenSearch Notifications plugin, focusing on dependency modernization and version alignment. The key change is the migration from `javax.mail` to `jakarta.mail` APIs to avoid version conflicts with other OpenSearch components.
+
+## Details
+
+### What's New in v3.1.0
+
+The Notifications plugin received two maintenance updates:
+
+1. **Jakarta Mail Migration**: Upgraded from deprecated `javax.mail` (JavaMail 1.6.2) to `jakarta.mail` (Jakarta Mail 2.0.1) to resolve version conflicts and align with modern Java EE standards.
+
+2. **Version Increment**: Standard version bump to 3.1.0-SNAPSHOT for the new release cycle.
+
+### Technical Changes
+
+#### Dependency Updates
+
+| Old Dependency | New Dependency | Version |
+|----------------|----------------|---------|
+| `com.sun.mail:javax.mail` | `com.sun.mail:jakarta.mail` | 1.6.2 → 2.0.1 |
+| `javax.activation:activation` | `com.sun.activation:jakarta.activation` | 1.1 → 2.0.1 |
+| `com.icegreen:greenmail` | `com.icegreen:greenmail` | 1.6.14 → 2.0.1 |
+
+#### Code Changes
+
+The migration required updating import statements across multiple Kotlin files:
+
+| File | Change |
+|------|--------|
+| `DestinationSesClient.kt` | `javax.mail.*` → `jakarta.mail.*` |
+| `DestinationSmtpClient.kt` | `javax.mail.*` → `jakarta.mail.*` |
+| `EmailMimeProvider.kt` | `javax.activation.*`, `javax.mail.*` → `jakarta.*` |
+| `SesDestinationTransport.kt` | `javax.mail.*` → `jakarta.mail.*` |
+| `SmtpDestinationTransport.kt` | `javax.mail.*` → `jakarta.mail.*` |
+| `SmtpDestinationTests.kt` | `javax.mail.*` → `jakarta.mail.*` |
+
+### Migration Notes
+
+This is a transparent change for users. The Jakarta Mail API is backward compatible with the JavaMail API at the functional level. No configuration changes are required.
+
+For plugin developers extending the Notifications plugin:
+- Update any custom code using `javax.mail` imports to use `jakarta.mail`
+- Ensure your dependencies don't conflict with Jakarta Mail 2.0.1
+
+## Limitations
+
+- No functional changes or new features in this release
+- This is purely a maintenance/dependency update
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1036](https://github.com/opensearch-project/notifications/pull/1036) | Upgrade javax to jakarta to avoid version conflicts |
+| [#1027](https://github.com/opensearch-project/notifications/pull/1027) | Increment version to 3.1.0-SNAPSHOT |
+
+## References
+
+- [Jakarta Mail 2.0 Specification](https://jakarta.ee/specifications/mail/2.0/)
+- [OpenSearch Notifications Repository](https://github.com/opensearch-project/notifications)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/notifications/notifications-plugin.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -57,3 +57,7 @@
 ### Observability
 
 - [Observability Release Maintenance](features/observability/observability-release-maintenance.md) - Version increments, release notes, and bug fixes for trace analytics
+
+### Notifications
+
+- [Notifications Maintenance](features/notifications/notifications-maintenance.md) - Migrate from javax.mail to jakarta.mail APIs and version increment to 3.1.0-SNAPSHOT


### PR DESCRIPTION
## Summary

Add documentation for Notifications Maintenance in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/notifications/notifications-maintenance.md`
- Feature report: `docs/features/notifications/notifications-plugin.md`

### Key Changes in v3.1.0
- Migration from `javax.mail` to `jakarta.mail` APIs to avoid version conflicts
- Updated dependencies: jakarta.mail 2.0.1, jakarta.activation 2.0.1, greenmail 2.0.1
- Version increment to 3.1.0-SNAPSHOT

### Related PRs
- [#1036](https://github.com/opensearch-project/notifications/pull/1036): Upgrade javax to jakarta
- [#1027](https://github.com/opensearch-project/notifications/pull/1027): Version increment

Closes #891