### PR TITLE
docs: add Lucene upgrade reports for neural-search and learning-to-rank plugins for v3.1.0

### DIFF
--- a/docs/features/opensearch/lucene-upgrade.md
+++ b/docs/features/opensearch/lucene-upgrade.md
@@ -71,8 +71,8 @@ GET /_nodes?filter_path=nodes.*.version
 |---------|-----|-------------|
 | v3.1.0 | [#17961](https://github.com/opensearch-project/OpenSearch/pull/17961) | Upgrade to Lucene 10.2.1 |
 | v3.1.0 | [#18395](https://github.com/opensearch-project/OpenSearch/pull/18395) | Replace deprecated TopScoreDocCollectorManager construction |
-| v3.1.0 | [neural-search#1336](https://github.com/opensearch-project/neural-search/pull/1336) | Update Lucene dependencies |
-| v3.1.0 | [learning-to-rank-base#186](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/186) | Lucene 10.2 upgrade changes |
+| v3.1.0 | [neural-search#1336](https://github.com/opensearch-project/neural-search/pull/1336) | Update Lucene dependencies for hybrid query |
+| v3.1.0 | [learning-to-rank-base#186](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/186) | Lucene 10.2 upgrade changes for RankerQuery |
 | v3.0.0 | [#16366](https://github.com/opensearch-project/OpenSearch/pull/16366) | Apache Lucene 10 update |
 | v2.18.0 | [#15333](https://github.com/opensearch-project/OpenSearch/pull/15333) | Update Apache Lucene to 9.12.0 |
 
@@ -83,9 +83,11 @@ GET /_nodes?filter_path=nodes.*.version
 - [Lucene 9.12.0 Changelog](https://lucene.apache.org/core/9_12_0/changes/Changes.html): Official Lucene 9.12.0 release notes
 - [Apache Lucene](https://lucene.apache.org/): Official Apache Lucene project
 - [OpenSearch Documentation](https://docs.opensearch.org/): OpenSearch official documentation
+- [Issue #1334](https://github.com/opensearch-project/neural-search/issues/1334): Neural-search build failure due to Lucene API changes
+- [Issue #184](https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/184): Learning to Rank build failure due to DisiPriorityQueue being abstract
 
 ## Change History
 
-- **v3.1.0**: Upgrade to Apache Lucene 10.2.1 with SeededKnnVectorQuery, binary quantized vector codecs, TopDocs#rrf, and API changes (DisiPriorityQueue, TopScoreDocCollectorManager)
+- **v3.1.0**: Upgrade to Apache Lucene 10.2.1 with SeededKnnVectorQuery, binary quantized vector codecs, TopDocs#rrf, and API changes (DisiPriorityQueue, TopScoreDocCollectorManager). Plugin updates: neural-search hybrid query refactoring, learning-to-rank RankerQuery fix.
 - **v3.0.0**: Upgrade to Apache Lucene 10
 - **v2.18.0**: Upgrade to Apache Lucene 9.12.0 with new Lucene912PostingsFormat, JDK 23 Panama Vectorization support, dynamic range facets, and various performance optimizations

--- a/docs/releases/v3.1.0/features/learning/lucene-upgrade.md
+++ b/docs/releases/v3.1.0/features/learning/lucene-upgrade.md
@@ -1,0 +1,58 @@
+# Lucene Upgrade
+
+## Summary
+
+The opensearch-learning-to-rank-base plugin was updated to be compatible with Lucene 10.2.1 in OpenSearch 3.1.0. This bugfix addresses the breaking change where `DisiPriorityQueue` became an abstract class, preventing direct instantiation.
+
+## Details
+
+### What's New in v3.1.0
+
+The Lucene 10.2.1 upgrade changed `DisiPriorityQueue` from a concrete class to an abstract class, requiring the use of a factory method for instantiation.
+
+### Technical Changes
+
+#### API Migration
+
+| Lucene Class | Before (10.1.0) | After (10.2.1) |
+|--------------|-----------------|----------------|
+| `DisiPriorityQueue` | `new DisiPriorityQueue(size)` | `DisiPriorityQueue.ofMaxSize(size)` |
+
+#### Modified Components
+
+| Component | File | Changes |
+|-----------|------|---------|
+| `RankerQuery` | `RankerQuery.java` | Updated DisiPriorityQueue initialization |
+
+#### Code Changes
+
+```java
+// RankerQuery.java - Before
+DisiPriorityQueue disiPriorityQueue = new DisiPriorityQueue(weights.size());
+
+// RankerQuery.java - After
+DisiPriorityQueue disiPriorityQueue = DisiPriorityQueue.ofMaxSize(weights.size());
+```
+
+### Migration Notes
+
+This is an internal plugin update. No user action is required. The Learning to Rank functionality remains unchanged from a user perspective.
+
+## Limitations
+
+- This update only addresses Lucene API compatibility; no new features are added
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#186](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/186) | Lucene 10.2 upgrade changes |
+
+## References
+
+- [Issue #184](https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/184): Unable to build/run due to DisiPriorityQueue being abstract
+- [Apache Lucene 10.2.1 Changes](https://lucene.apache.org/core/10_2_1/changes/Changes.html)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/learning/learning-to-rank.md)

--- a/docs/releases/v3.1.0/features/neural-search/lucene-upgrade.md
+++ b/docs/releases/v3.1.0/features/neural-search/lucene-upgrade.md
@@ -1,0 +1,87 @@
+# Lucene Upgrade
+
+## Summary
+
+The neural-search plugin was updated to be compatible with Lucene 10.2.1 in OpenSearch 3.1.0. This bugfix addresses breaking API changes in Lucene's `DisiPriorityQueue`, `DisjunctionDISIApproximation`, and `DocIdStream` classes that prevented the plugin from building and running.
+
+## Details
+
+### What's New in v3.1.0
+
+The Lucene 10.2.1 upgrade introduced breaking API changes that required updates to the neural-search plugin's hybrid query implementation:
+
+- **DisiPriorityQueue**: Changed from direct instantiation to factory method
+- **DisjunctionDISIApproximation**: Constructor signature changed to require Collection and cost parameter
+- **DocIdStream**: New abstract method `mayHaveRemaining()` and updated `forEach()` signature
+
+### Technical Changes
+
+#### API Migration
+
+| Lucene Class | Before (10.1.0) | After (10.2.1) |
+|--------------|-----------------|----------------|
+| `DisiPriorityQueue` | `new DisiPriorityQueue(size)` | `DisiPriorityQueue.ofMaxSize(size)` |
+| `DisjunctionDISIApproximation` | `new DisjunctionDISIApproximation(DisiPriorityQueue)` | `new DisjunctionDISIApproximation(Collection, long)` |
+| `DocIdStream.forEach()` | `forEach(CheckedIntConsumer)` | `forEach(int upTo, CheckedIntConsumer)` |
+
+#### Modified Components
+
+| Component | File | Changes |
+|-----------|------|---------|
+| `HybridQueryScorer` | `HybridQueryScorer.java` | Updated DisiPriorityQueue initialization and DisjunctionDISIApproximation construction |
+| `HybridQueryDocIdStream` | `HybridQueryDocIdStream.java` | Implemented `mayHaveRemaining()`, `count()`, updated `forEach()` signature |
+| `HybridBulkScorer` | `HybridBulkScorer.java` | Added getter for `maxDoc` field |
+
+#### Code Changes
+
+```java
+// HybridQueryScorer - Before
+DisiPriorityQueue subScorersPQ = new DisiPriorityQueue(numSubqueries);
+this.approximation = new HybridSubqueriesDISIApproximation(this.subScorersPQ);
+
+// HybridQueryScorer - After
+List<HybridDisiWrapper> hybridDisiWrappers = initializeSubScorersList();
+this.subScorersPQ = DisiPriorityQueue.ofMaxSize(numSubqueries);
+this.subScorersPQ.addAll(hybridDisiWrappers.toArray(new DisiWrapper[0]), 0, hybridDisiWrappers.size());
+this.approximation = new HybridSubqueriesDISIApproximation(hybridDisiWrappers, subScorersPQ);
+```
+
+```java
+// HybridQueryDocIdStream - New methods
+@Override
+public boolean mayHaveRemaining() {
+    return this.upTo + 1 < hybridBulkScorer.getMaxDoc();
+}
+
+@Override
+public int count(int upTo) throws IOException {
+    int[] count = new int[1];
+    forEach(upTo, (doc -> count[0]++));
+    return count[0];
+}
+```
+
+### Migration Notes
+
+This is an internal plugin update. No user action is required. The hybrid query functionality remains unchanged from a user perspective.
+
+## Limitations
+
+- This update only addresses Lucene API compatibility; no new features are added
+- The `hybridScores()` method was removed from `HybridQueryScorer` as part of the refactoring
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1336](https://github.com/opensearch-project/neural-search/pull/1336) | Update Lucene dependencies |
+
+## References
+
+- [Issue #1334](https://github.com/opensearch-project/neural-search/issues/1334): Cannot gradle run the neural search repo
+- [Issue #1338](https://github.com/opensearch-project/neural-search/issues/1338): Integration test failures
+- [Apache Lucene 10.2.1 Changes](https://lucene.apache.org/core/10_2_1/changes/Changes.html)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/lucene-upgrade.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -58,6 +58,14 @@
 
 - [Observability Release Maintenance](features/observability/observability-release-maintenance.md) - Version increments, release notes, and bug fixes for trace analytics
 
+### Neural Search
+
+- [Lucene Upgrade](features/neural-search/lucene-upgrade.md) - Update hybrid query implementation for Lucene 10.2.1 API compatibility
+
+### Learning to Rank
+
+- [Lucene Upgrade](features/learning/lucene-upgrade.md) - Update RankerQuery for Lucene 10.2.1 DisiPriorityQueue API change
+
 ### Notifications
 
 - [Notifications Maintenance](features/notifications/notifications-maintenance.md) - Migrate from javax.mail to jakarta.mail APIs and version increment to 3.1.0-SNAPSHOT


### PR DESCRIPTION
## Summary

Add release reports for Lucene 10.2.1 compatibility updates in neural-search and learning-to-rank plugins for OpenSearch v3.1.0.

## Reports Created

### Release Reports
- `docs/releases/v3.1.0/features/neural-search/lucene-upgrade.md` - Neural-search plugin Lucene compatibility update
- `docs/releases/v3.1.0/features/learning/lucene-upgrade.md` - Learning-to-rank plugin Lucene compatibility update

### Updated Files
- `docs/releases/v3.1.0/index.md` - Added Neural Search and Learning to Rank sections
- `docs/features/opensearch/lucene-upgrade.md` - Updated PR descriptions, references, and change history

## Key Changes in v3.1.0

### Neural Search Plugin (PR #1336)
- Updated `HybridQueryScorer` for new `DisiPriorityQueue.ofMaxSize()` factory method
- Updated `DisjunctionDISIApproximation` constructor to use Collection and cost parameter
- Implemented `mayHaveRemaining()` and `count()` methods in `HybridQueryDocIdStream`
- Updated `forEach()` signature to include `upTo` parameter

### Learning to Rank Plugin (PR #186)
- Updated `RankerQuery` to use `DisiPriorityQueue.ofMaxSize()` instead of direct instantiation

## Related Issues
- Resolves investigation for GitHub Issue #890