### PR TITLE
docs: add ML Commons Maintenance report for v3.1.0

### DIFF
--- a/docs/features/ml-commons/ml-commons-bugfixes.md
+++ b/docs/features/ml-commons/ml-commons-bugfixes.md
@@ -74,6 +74,13 @@ graph TB
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#3838](https://github.com/opensearch-project/ml-commons/pull/3838) | Exclude trusted connector check for hidden model |
+| v3.1.0 | [#3825](https://github.com/opensearch-project/ml-commons/pull/3825) | Add more logging to deploy/undeploy flows for better debugging |
+| v3.1.0 | [#3824](https://github.com/opensearch-project/ml-commons/pull/3824) | Remove libs folder |
+| v3.1.0 | [#3809](https://github.com/opensearch-project/ml-commons/pull/3809) | Upgrade HTTP client to version align with core |
+| v3.1.0 | [#3648](https://github.com/opensearch-project/ml-commons/pull/3648) | Use stream optional enum set from core in MLStatsInput |
+| v3.1.0 | [#3883](https://github.com/opensearch-project/ml-commons/pull/3883) | Change SearchIndexTool arguments parsing logic |
+| v3.1.0 | [#3935](https://github.com/opensearch-project/ml-commons/pull/3935) | Force runtime class path commons-beanutils:1.11.0 to avoid CVE |
 | v2.18.0 | [#3100](https://github.com/opensearch-project/ml-commons/pull/3100) | Gracefully handle error when generative_qa_parameters is not provided |
 | v2.18.0 | [#3057](https://github.com/opensearch-project/ml-commons/pull/3057) | Fix RAG processor NPE when optional parameters not provided |
 | v2.18.0 | [#2985](https://github.com/opensearch-project/ml-commons/pull/2985) | Fix ML inference ingest processor JsonPath return format |
@@ -87,6 +94,8 @@ graph TB
 
 ## References
 
+- [Issue #3834](https://github.com/opensearch-project/ml-commons/issues/3834): SearchIndexTool MCP schema alignment
+- [OpenSearch#17556](https://github.com/opensearch-project/OpenSearch/pull/17556): Core optional EnumSet streaming APIs
 - [Issue #3092](https://github.com/opensearch-project/ml-commons/issues/3092): RAG pipeline error handling
 - [Issue #2983](https://github.com/opensearch-project/ml-commons/issues/2983): RAG processor NPE
 - [Issue #2974](https://github.com/opensearch-project/ml-commons/issues/2974): ML inference processor JsonPath issue
@@ -97,4 +106,5 @@ graph TB
 
 ## Change History
 
+- **v3.1.0** (2025-07-15): Hidden model trusted connector bypass, enhanced deploy/undeploy logging, HTTP client alignment, core EnumSet API integration, SearchIndexTool MCP compatibility, commons-beanutils CVE fix
 - **v2.18.0** (2024-11-05): Multiple bugfixes for RAG pipelines, ML inference processors, connector time fields, model deployment stability, master key race condition, Bedrock BWC, and agent logging

--- a/docs/releases/v3.1.0/features/ml-commons/ml-commons-maintenance.md
+++ b/docs/releases/v3.1.0/features/ml-commons/ml-commons-maintenance.md
@@ -1,0 +1,76 @@
+# ML Commons Maintenance
+
+## Summary
+
+This release includes maintenance updates for the ML Commons plugin in OpenSearch v3.1.0. The changes focus on security improvements for hidden models, enhanced debugging capabilities, dependency upgrades, code refactoring, and CVE fixes.
+
+## Details
+
+### What's New in v3.1.0
+
+#### Security: Hidden Model Trusted Connector Check Bypass
+
+PR [#3838](https://github.com/opensearch-project/ml-commons/pull/3838) excludes hidden models from the trusted connector check. This allows internal/system models to operate without requiring explicit trusted connector configuration, improving the user experience for built-in ML capabilities.
+
+#### Enhanced Deploy/Undeploy Logging
+
+PR [#3825](https://github.com/opensearch-project/ml-commons/pull/3825) adds more detailed logging to model deploy and undeploy flows. This improves debugging capabilities when troubleshooting model deployment issues in production environments.
+
+#### Code Cleanup: Remove libs Folder
+
+PR [#3824](https://github.com/opensearch-project/ml-commons/pull/3824) removes the deprecated `libs` folder from the repository, following up on previous refactoring work to clean up the codebase structure.
+
+#### HTTP Client Version Alignment
+
+PR [#3809](https://github.com/opensearch-project/ml-commons/pull/3809) upgrades the HTTP client to align with OpenSearch core's version. This ensures compatibility and reduces potential conflicts between plugin and core dependencies.
+
+#### Core API Integration: Stream Optional EnumSet
+
+PR [#3648](https://github.com/opensearch-project/ml-commons/pull/3648) refactors `MLStatsInput` to use `StreamInput::readOptionalEnumSet` and `StreamOutput::writeOptionalEnumSet` from OpenSearch core (added in [OpenSearch#17556](https://github.com/opensearch-project/OpenSearch/pull/17556)). This replaces the private helper implementation with the standardized core API, enabling code reuse across plugins.
+
+#### SearchIndexTool Arguments Parsing Fix
+
+PR [#3883](https://github.com/opensearch-project/ml-commons/pull/3883) changes the `SearchIndexTool` arguments parsing logic to align tool schemas between ReAct agents and MCP (Model Context Protocol). The fix allows `SearchIndexTool` to parse parameters both from the `input` key wrapper and directly from the parameters map, enabling consistent tool registration across different agent types.
+
+#### CVE Fix: commons-beanutils Upgrade
+
+PR [#3935](https://github.com/opensearch-project/ml-commons/pull/3935) forces the runtime classpath to use `commons-beanutils:1.11.0` to resolve CVE-48734. This addresses a security vulnerability from transitive dependencies.
+
+### Technical Changes
+
+#### Components Updated
+
+| Component | Change |
+|-----------|--------|
+| Hidden Model Security | Bypass trusted connector check for hidden models |
+| Deploy/Undeploy Flow | Enhanced logging for debugging |
+| MLStatsInput | Use core's optional EnumSet streaming APIs |
+| SearchIndexTool | Flexible argument parsing for agent/MCP compatibility |
+| Dependencies | HTTP client alignment, commons-beanutils CVE fix |
+
+## Limitations
+
+- The SearchIndexTool parsing change maintains backward compatibility but may require schema updates for MCP tool registrations
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3838](https://github.com/opensearch-project/ml-commons/pull/3838) | Exclude trusted connector check for hidden model |
+| [#3825](https://github.com/opensearch-project/ml-commons/pull/3825) | Add more logging to deploy/undeploy flows for better debugging |
+| [#3824](https://github.com/opensearch-project/ml-commons/pull/3824) | Remove libs folder |
+| [#3809](https://github.com/opensearch-project/ml-commons/pull/3809) | Upgrade HTTP client to version align with core |
+| [#3648](https://github.com/opensearch-project/ml-commons/pull/3648) | Use stream optional enum set from core in MLStatsInput |
+| [#3883](https://github.com/opensearch-project/ml-commons/pull/3883) | Change SearchIndexTool arguments parsing logic |
+| [#3935](https://github.com/opensearch-project/ml-commons/pull/3935) | Force runtime class path commons-beanutils:1.11.0 to avoid CVE |
+| [#426](https://github.com/opensearch-project/ml-commons/pull/426) | Bump version to 3.1.0.0 |
+| [#588](https://github.com/opensearch-project/ml-commons/pull/588) | Fix model deploy failure due to ml-commons update |
+
+## References
+
+- [Issue #3834](https://github.com/opensearch-project/ml-commons/issues/3834): SearchIndexTool MCP schema alignment
+- [OpenSearch#17556](https://github.com/opensearch-project/OpenSearch/pull/17556): Core optional EnumSet streaming APIs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/ml-commons-bugfixes.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -66,6 +66,10 @@
 
 - [Lucene Upgrade](features/learning/lucene-upgrade.md) - Update RankerQuery for Lucene 10.2.1 DisiPriorityQueue API change
 
+### ML Commons
+
+- [ML Commons Maintenance](features/ml-commons/ml-commons-maintenance.md) - Hidden model security, enhanced logging, HTTP client alignment, SearchIndexTool MCP compatibility, CVE fixes
+
 ### Notifications
 
 - [Notifications Maintenance](features/notifications/notifications-maintenance.md) - Migrate from javax.mail to jakarta.mail APIs and version increment to 3.1.0-SNAPSHOT


### PR DESCRIPTION
## Summary

This PR adds documentation for ML Commons maintenance updates in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/ml-commons/ml-commons-maintenance.md`
- Feature report updated: `docs/features/ml-commons/ml-commons-bugfixes.md`

### Key Changes in v3.1.0
- Hidden model trusted connector check bypass (#3838)
- Enhanced deploy/undeploy logging for debugging (#3825)
- Remove deprecated libs folder (#3824)
- HTTP client version alignment with core (#3809)
- Core EnumSet streaming API integration (#3648)
- SearchIndexTool MCP schema compatibility (#3883)
- CVE fix for commons-beanutils (#3935)

Closes #889