### PR TITLE
docs: add PlanExecuteReflect Agent report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -233,6 +233,7 @@
 - [ML Commons Test Fixes](ml-commons/ml-commons-test-fixes.md)
 - [ML Config API](ml-commons/ml-config-api.md)
 - [ML Inference Processor](ml-commons/ml-inference-processor.md)
+- [PlanExecuteReflect Agent](ml-commons/planexecutereflect-agent.md)
 - [Query Assist](ml-commons/query-assist.md)
 
 ## ml-commons-dashboards

--- a/docs/features/ml-commons/planexecutereflect-agent.md
+++ b/docs/features/ml-commons/planexecutereflect-agent.md
@@ -1,0 +1,132 @@
+# PlanExecuteReflect Agent
+
+## Summary
+
+The PlanExecuteReflect Agent is an experimental agent type in OpenSearch ML Commons designed to solve complex tasks through iterative reasoning and step-by-step execution. It uses a "plan-execute-reflect" pattern where one LLM (the planner) creates and updates a plan, while another LLM (or the same one) executes individual steps using a built-in conversational agent.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "PlanExecuteReflect Agent"
+        User[User Query] --> Planner[Planner LLM]
+        Planner --> Plan[Step-by-Step Plan]
+        Plan --> Executor[Executor Agent]
+        Executor --> Tools[Available Tools]
+        Tools --> Result[Step Result]
+        Result --> Reflect[Re-evaluation]
+        Reflect --> |Adjust Plan| Planner
+        Reflect --> |Complete| Final[Final Result]
+    end
+    
+    subgraph "Memory"
+        Memory[(Conversation Index)]
+    end
+    
+    Executor --> Memory
+    Final --> Memory
+```
+
+### Workflow
+
+The agent operates in three phases:
+
+1. **Planning**: The planner LLM generates an initial step-by-step plan using available tools
+2. **Execution**: Each step is executed sequentially using the conversational agent and tools
+3. **Re-evaluation**: After each step, the planner LLM re-evaluates and can adjust the plan dynamically
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `MLPlanExecuteAndReflectAgentRunner` | Main agent runner that orchestrates the plan-execute-reflect loop |
+| `Planner LLM` | LLM responsible for creating and updating the execution plan |
+| `Executor Agent` | Built-in conversational agent that executes individual steps |
+| `ConversationIndexMemory` | Persists execution history including questions, intermediate results, and outputs |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `type` | Agent type | `plan_execute_and_reflect` |
+| `_llm_interface` | LLM interface identifier | Required |
+| `planner_prompt_template` | Template for planner prompts | Built-in default |
+| `reflect_prompt_template` | Template for reflection prompts | Built-in default |
+| `executor_system_prompt` | System prompt for executor agent | Built-in default |
+| `memory.type` | Memory type for conversation persistence | `conversation_index` |
+
+### Supported LLMs
+
+The agent provides built-in function calling interfaces for:
+
+- Anthropic Claude 3.7 on Amazon Bedrock (`bedrock/converse/claude`)
+- OpenAI GPT-4o (`openai/v1/chat/completions`)
+- DeepSeek-R1 on Amazon Bedrock (`bedrock/converse/deepseek_r1`)
+
+### Usage Example
+
+```json
+POST /_plugins/_ml/agents/_register
+{
+  "name": "My Plan Execute Reflect Agent",
+  "type": "plan_execute_and_reflect",
+  "description": "Agent for dynamic task planning and reasoning",
+  "llm": {
+    "model_id": "YOUR_LLM_MODEL_ID",
+    "parameters": {
+      "prompt": "${parameters.question}"
+    }
+  },
+  "memory": {
+    "type": "conversation_index"
+  },
+  "parameters": {
+    "_llm_interface": "bedrock/converse/claude"
+  },
+  "tools": [
+    { "type": "ListIndexTool" },
+    { "type": "SearchIndexTool" },
+    { "type": "IndexMappingTool" }
+  ]
+}
+```
+
+Execute the agent:
+
+```json
+POST /_plugins/_ml/agents/{agent_id}/_execute
+{
+  "parameters": {
+    "question": "How many documents are in my index?"
+  }
+}
+```
+
+## Limitations
+
+- Experimental feature - not recommended for production use
+- Re-evaluation currently only occurs after each step completion
+- Requires thorough tool descriptions for optimal LLM decision-making
+- DeepSeek-R1 on Bedrock requires custom `executor_system_prompt` due to lack of native function calling
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#3778](https://github.com/opensearch-project/ml-commons/pull/3778) | Adding test cases for PlanExecuteReflect Agent |
+| v3.0.0 | [#3716](https://github.com/opensearch-project/ml-commons/pull/3716) | Initial PlanExecuteReflect Agent implementation |
+
+## References
+
+- [Issue #3750](https://github.com/opensearch-project/ml-commons/issues/3750): Test coverage request
+- [Issue #3745](https://github.com/opensearch-project/ml-commons/issues/3745): Feature tracking issue
+- [Plan-execute-reflect agents documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/agents/plan-execute-reflect/)
+- [Register Agent API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/agent-apis/register-agent/)
+- [Building a plan-execute-reflect agent tutorial](https://docs.opensearch.org/3.0/tutorials/gen-ai/agents/build-plan-execute-reflect-agent/)
+
+## Change History
+
+- **v3.1.0** (2026-01-10): Added comprehensive unit test and integration test coverage
+- **v3.0.0**: Initial experimental release of PlanExecuteReflect Agent

--- a/docs/releases/v3.1.0/features/ml-commons/planexecutereflect-agent.md
+++ b/docs/releases/v3.1.0/features/ml-commons/planexecutereflect-agent.md
@@ -1,0 +1,103 @@
+# PlanExecuteReflect Agent Test Coverage
+
+## Summary
+
+This release item adds comprehensive unit test and integration test coverage for the PlanExecuteReflect Agent in ML Commons. The PlanExecuteReflect Agent was released as an experimental feature in OpenSearch 3.0-beta but lacked adequate test coverage. This bugfix addresses that gap by adding test cases for the agent runner and related utility methods.
+
+## Details
+
+### What's New in v3.1.0
+
+This PR improves code quality by adding test coverage for the `MLPlanExecuteAndReflectAgentRunner` class and related agent utilities. The changes ensure the experimental PlanExecuteReflect Agent feature has proper test validation.
+
+### Technical Changes
+
+#### Modified Components
+
+| Component | Description |
+|-----------|-------------|
+| `MLPlanExecuteAndReflectAgentRunner` | Changed method visibility from `private` to package-private with `@VisibleForTesting` annotation to enable unit testing |
+| `AgentUtilsTest` | Added 243 lines of new test cases for agent utility methods |
+| `MLPlanExecuteAndReflectAgentRunnerTest` | New test class with 547 lines covering agent runner functionality |
+| `ConnectorUtilsTest` | Added 49 lines of tests for remote inference input data escaping |
+| `RegisterAgentTransportActionTests` | Added 88 lines of tests for agent registration with/without executor agent ID |
+
+#### New Test Coverage
+
+The following methods now have test coverage:
+
+- `setupPromptParameters()` - Tests prompt parameter initialization
+- `usePlannerPromptTemplate()` - Tests planner prompt template usage
+- `useReflectPromptTemplate()` - Tests reflection prompt template usage
+- `usePlannerWithHistoryPromptTemplate()` - Tests planner with history template
+- `populatePrompt()` - Tests prompt population with parameters
+- `parseLLMOutput()` - Tests LLM output parsing including error cases
+- `extractJsonFromMarkdown()` - Tests JSON extraction from markdown code blocks
+- `addToolsToPrompt()` - Tests tool description injection into prompts
+- `addSteps()` - Tests step list formatting
+- `saveAndReturnFinalResult()` - Tests final result persistence and response
+- `createModelTensors()` - Tests model tensor creation
+
+#### Visibility Changes
+
+Methods in `MLPlanExecuteAndReflectAgentRunner` were changed from `private` to package-private with `@VisibleForTesting` annotation:
+
+```java
+@VisibleForTesting
+void setupPromptParameters(Map<String, String> params) { ... }
+
+@VisibleForTesting
+void usePlannerPromptTemplate(Map<String, String> params) { ... }
+
+@VisibleForTesting
+Map<String, String> parseLLMOutput(Map<String, String> allParams, ModelTensorOutput modelTensorOutput) { ... }
+```
+
+### Usage Example
+
+The test cases validate agent execution scenarios:
+
+```java
+@Test
+public void testBasicExecution() {
+    MLAgent mlAgent = createMLAgentWithTools();
+    
+    // Setup LLM response for planning phase
+    doAnswer(invocation -> {
+        ActionListener<Object> listener = invocation.getArgument(2);
+        ModelTensor modelTensor = ModelTensor.builder()
+            .dataAsMap(ImmutableMap.of("response", 
+                "{\"steps\":[\"step1\"], \"result\":\"final result\"}"))
+            .build();
+        // ... mock setup
+        listener.onResponse(mlTaskResponse);
+        return null;
+    }).when(client).execute(eq(MLPredictionTaskAction.INSTANCE), any(), any());
+    
+    mlPlanExecuteAndReflectAgentRunner.run(mlAgent, params, agentActionListener);
+    
+    verify(agentActionListener).onResponse(objectCaptor.capture());
+    // Assertions...
+}
+```
+
+## Limitations
+
+- This is a code quality improvement only; no functional changes to the PlanExecuteReflect Agent
+- The PlanExecuteReflect Agent remains an experimental feature
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3778](https://github.com/opensearch-project/ml-commons/pull/3778) | Adding test cases for PlanExecuteReflect Agent |
+
+## References
+
+- [Issue #3750](https://github.com/opensearch-project/ml-commons/issues/3750): Original feature request for test coverage
+- [PR #3716](https://github.com/opensearch-project/ml-commons/pull/3716): Related PlanExecuteReflect Agent implementation
+- [Plan-execute-reflect agents documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/agents/plan-execute-reflect/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/planexecutereflect-agent.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -69,6 +69,7 @@
 ### ML Commons
 
 - [ML Commons Maintenance](features/ml-commons/ml-commons-maintenance.md) - Hidden model security, enhanced logging, HTTP client alignment, SearchIndexTool MCP compatibility, CVE fixes
+- [PlanExecuteReflect Agent](features/ml-commons/planexecutereflect-agent.md) - Test coverage for PlanExecuteReflect Agent runner and utilities
 
 ### Notifications
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the PlanExecuteReflect Agent test coverage improvement in OpenSearch v3.1.0.

## Changes

### Release Report
- `docs/releases/v3.1.0/features/ml-commons/planexecutereflect-agent.md`
  - Documents the test coverage additions for MLPlanExecuteAndReflectAgentRunner
  - Details the visibility changes for testability
  - Lists all new test methods added

### Feature Report
- `docs/features/ml-commons/planexecutereflect-agent.md`
  - Comprehensive documentation of the PlanExecuteReflect Agent feature
  - Architecture diagram showing the plan-execute-reflect workflow
  - Configuration options and supported LLMs
  - Usage examples

### Index Updates
- Updated `docs/releases/v3.1.0/index.md` to include the new release report
- Updated `docs/features/index.md` to include the new feature report

## Related Issue
Closes #888

## References
- [PR #3778](https://github.com/opensearch-project/ml-commons/pull/3778): Adding test cases for PlanExecuteReflect Agent
- [Issue #3750](https://github.com/opensearch-project/ml-commons/issues/3750): Original feature request