### PR TITLE
docs: add MCP (Model Context Protocol) report for v3.1.0

### DIFF
--- a/docs/features/ml-commons/ml-commons-mcp.md
+++ b/docs/features/ml-commons/ml-commons-mcp.md
@@ -266,6 +266,8 @@ POST /_plugins/_ml/models/_register
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#3787](https://github.com/opensearch-project/ml-commons/pull/3787) | Add Unit Tests for MCP feature |
+| v3.1.0 | [#3821](https://github.com/opensearch-project/ml-commons/pull/3821) | Downgrade MCP version to 0.9 |
 | v3.0.0 | [#3721](https://github.com/opensearch-project/ml-commons/pull/3721) | Onboard MCP - MCP connector support |
 | v3.0.0 | [#3781](https://github.com/opensearch-project/ml-commons/pull/3781) | Support MCP server in OpenSearch |
 | v3.0.0 | [#3803](https://github.com/opensearch-project/ml-commons/pull/3803) | Support MCP session management |
@@ -304,4 +306,5 @@ POST /_plugins/_ml/models/_register
 
 ## Change History
 
+- **v3.1.0** (2025-07-15): MCP SDK downgrade to 0.9.0 for compatibility, added comprehensive unit tests for MCP components
 - **v3.0.0** (2025-05-06): Initial implementation of MCP support (client and server), Plan-Execute-Reflect agent, function calling, async execution, and sentence highlighting QA models

--- a/docs/releases/v3.1.0/features/ml-commons/mcp-(model-context-protocol).md
+++ b/docs/releases/v3.1.0/features/ml-commons/mcp-(model-context-protocol).md
@@ -1,0 +1,109 @@
+# MCP (Model Context Protocol)
+
+## Summary
+
+This release includes bugfixes for the MCP (Model Context Protocol) feature in ml-commons. The changes include adding comprehensive unit tests for MCP components and downgrading the MCP SDK version from 0.10.0-SNAPSHOT to 0.9.0 for improved compatibility with MCP servers.
+
+## Details
+
+### What's New in v3.1.0
+
+This release focuses on stability and compatibility improvements for the MCP feature:
+
+1. **Unit Test Coverage**: Added comprehensive unit tests for MCP components to improve code quality and reliability
+2. **MCP SDK Version Downgrade**: Changed from custom 0.10.0-SNAPSHOT JAR to official 0.9.0 release for better compatibility
+
+### Technical Changes
+
+#### MCP SDK Version Change
+
+The MCP SDK dependency was changed from a custom snapshot JAR to the official release:
+
+```gradle
+// Before (v3.0.0)
+api files('libs/mcp-0.10.0-SNAPSHOT.jar')
+
+// After (v3.1.0)
+api('io.modelcontextprotocol.sdk:mcp:0.9.0')
+```
+
+This change:
+- Uses the official MCP SDK 0.9.0 release instead of a custom snapshot
+- Improves compatibility with MCP servers
+- Includes backported custom headers support from 0.10
+
+#### Content-Type Header Removal
+
+Removed redundant `Content-Type: application/json` header from `McpConnectorExecutor` since the MCP client adds it by default:
+
+```java
+// Removed from McpConnectorExecutor.java
+builder.header("Content-Type", "application/json");
+```
+
+#### Reactor Core Version Pinning
+
+Added explicit version pinning for reactor-core to ensure compatibility:
+
+```gradle
+resolutionStrategy.force 'io.projectreactor:reactor-core:3.7.0'
+```
+
+#### New Unit Tests
+
+Added comprehensive test coverage for MCP components:
+
+| Test Class | Description |
+|------------|-------------|
+| `McpConnectorTest` | Tests for MCP connector serialization, encryption, decryption, URL validation, and updates |
+| `McpConnectorExecutorTest` | Tests for MCP tool spec retrieval and error handling |
+| `McpSseToolTests` | Tests for MCP SSE tool execution, validation, and factory methods |
+| `AgentUtilsTest` (extended) | Tests for `getMcpToolSpecs()` including connector handling, tool filtering, and multi-connector merging |
+
+### Usage Example
+
+No changes to the MCP usage API. The MCP connector and server continue to work as documented:
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "External MCP Server",
+  "description": "Connect to external MCP server",
+  "version": "1",
+  "protocol": "mcp_sse",
+  "url": "http://mcp-server:8080",
+  "headers": {
+    "Authorization": "Bearer ${credential.api_key}"
+  },
+  "credential": {
+    "api_key": "your-api-key"
+  }
+}
+```
+
+### Migration Notes
+
+No migration required. The SDK version change is backward compatible.
+
+## Limitations
+
+- MCP remains an experimental feature
+- MCP server requires `transport-reactor-netty4` plugin to be enabled
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3787](https://github.com/opensearch-project/ml-commons/pull/3787) | Add Unit Tests for MCP feature |
+| [#3821](https://github.com/opensearch-project/ml-commons/pull/3821) | Downgrade MCP version to 0.9 |
+
+## References
+
+- [Issue #3743](https://github.com/opensearch-project/ml-commons/issues/3743): Add test cases for MCP experimental feature
+- [Using MCP Tools Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/mcp/index/)
+- [Connecting to External MCP Server](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/mcp/mcp-connector/)
+- [Introducing MCP in OpenSearch Blog](https://opensearch.org/blog/introducing-mcp-in-opensearch/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/ml-commons-mcp.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -69,6 +69,7 @@
 ### ML Commons
 
 - [ML Commons Maintenance](features/ml-commons/ml-commons-maintenance.md) - Hidden model security, enhanced logging, HTTP client alignment, SearchIndexTool MCP compatibility, CVE fixes
+- [MCP (Model Context Protocol)](features/ml-commons/mcp-(model-context-protocol).md) - MCP SDK downgrade to 0.9.0 and unit test coverage
 - [PlanExecuteReflect Agent](features/ml-commons/planexecutereflect-agent.md) - Test coverage for PlanExecuteReflect Agent runner and utilities
 
 ### Notifications


### PR DESCRIPTION
## Summary

This PR adds documentation for the MCP (Model Context Protocol) bugfixes in OpenSearch v3.1.0.

## Changes

### Release Report
- Created `docs/releases/v3.1.0/features/ml-commons/mcp-(model-context-protocol).md`
- Documents MCP SDK downgrade from 0.10.0-SNAPSHOT to 0.9.0
- Documents unit test additions for MCP components

### Feature Report Update
- Updated `docs/features/ml-commons/ml-commons-mcp.md`
- Added v3.1.0 PRs to Related PRs table
- Added v3.1.0 entry to Change History

### Release Index Update
- Added MCP bugfix entry to `docs/releases/v3.1.0/index.md`

## Related PRs
- [ml-commons#3787](https://github.com/opensearch-project/ml-commons/pull/3787) - Add Unit Tests for MCP feature
- [ml-commons#3821](https://github.com/opensearch-project/ml-commons/pull/3821) - Downgrade MCP version to 0.9

## Related Issue
Closes #887