### PR TITLE
docs: add job-scheduler-maintenance report for v3.1.0

### DIFF
--- a/docs/features/job-scheduler/job-scheduler.md
+++ b/docs/features/job-scheduler/job-scheduler.md
@@ -164,6 +164,8 @@ Job Scheduler supports two schedule formats:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#766](https://github.com/opensearch-project/job-scheduler/pull/766) | Increment version to 3.1.0-SNAPSHOT |
+| v3.1.0 | [#773](https://github.com/opensearch-project/job-scheduler/pull/773) | Remove guava dependency |
 | v3.0.0 | [#702](https://github.com/opensearch-project/job-scheduler/pull/702) | Enable custom start commands and options to resolve GHA issues |
 | v3.0.0 | [#730](https://github.com/opensearch-project/job-scheduler/pull/730) | Fix JS compile issues caused by OpenSearch JPMS Refactoring |
 | v3.0.0 | [#737](https://github.com/opensearch-project/job-scheduler/pull/737) | Only download demo certs when integTest run with -Dsecurity.enabled=true |
@@ -173,8 +175,9 @@ Job Scheduler supports two schedule formats:
 ## References
 
 - [Job Scheduler GitHub Repository](https://github.com/opensearch-project/job-scheduler)
-- [Official Documentation](https://docs.opensearch.org/3.0/monitoring-your-cluster/job-scheduler/index/)
+- [Official Documentation](https://docs.opensearch.org/3.1/monitoring-your-cluster/job-scheduler/index/)
 - [Sample Extension Plugin](https://github.com/opensearch-project/job-scheduler/tree/main/sample-extension-plugin)
+- [Issue #18113](https://github.com/opensearch-project/OpenSearch/issues/18113): Remove Guava from plugins
 - [Issue #698](https://github.com/opensearch-project/job-scheduler/issues/698): GitHub Action Deprecation
 - [Issue #715](https://github.com/opensearch-project/job-scheduler/issues/715): Release 3.0 Breaking Changes
 - [Issue #14984](https://github.com/opensearch-project/OpenSearch/issues/14984): CreateIndexRequest.mapping() bug with v1 templates
@@ -182,6 +185,7 @@ Job Scheduler supports two schedule formats:
 
 ## Change History
 
+- **v3.1.0** (2025): Removed Guava dependency to reduce jar hell and dependency conflicts in extending plugins
 - **v3.0.0** (2025): CI/CD improvements, JPMS compatibility fixes, conditional demo certificate downloads
 - **v2.18.0** (2024-11-05): Return LockService from createComponents for Guice injection, enabling shared lock service across plugins
 - **v2.17.0** (2024-09-17): Fixed system index compatibility with v1 templates in LockService and JobDetailsService

--- a/docs/releases/v3.1.0/features/job-scheduler/job-scheduler-maintenance.md
+++ b/docs/releases/v3.1.0/features/job-scheduler/job-scheduler-maintenance.md
@@ -1,0 +1,86 @@
+# Job Scheduler Maintenance
+
+## Summary
+
+OpenSearch v3.1.0 includes maintenance updates for the Job Scheduler plugin, focusing on version increment and removal of the Guava dependency. The Guava removal reduces potential jar hell and dependency conflicts for plugins that extend Job Scheduler, such as SQL, ML Commons, and others.
+
+## Details
+
+### What's New in v3.1.0
+
+This release contains two maintenance changes:
+
+1. **Version Increment**: Updated plugin version to 3.1.0-SNAPSHOT for the new release cycle
+2. **Guava Dependency Removal**: Removed Google Guava library dependency to prevent jar hell issues
+
+### Technical Changes
+
+#### Guava Dependency Removal
+
+The Guava library was removed from Job Scheduler to address dependency conflicts that occurred in extending plugins. This change:
+
+- Removes `com.google.guava:guava` dependency from `build.gradle`
+- Removes `com.google.guava:failureaccess` dependency
+- Removes `com.google.googlejavaformat:google-java-format` dependency (which had Guava exclusion)
+- Replaces `ImmutableList.of()` and `ImmutableMap.of()` with Java's native `List.of()` and `Map.of()`
+
+#### Files Changed
+
+| File | Change |
+|------|--------|
+| `build.gradle` | Removed Guava dependencies and resolution strategy |
+| `JobSchedulerPlugin.java` | Replaced `ImmutableList` with `List.of()` |
+| `RestGetJobDetailsAction.java` | Replaced `ImmutableList` with `List.of()` |
+| `RestGetLockAction.java` | Replaced `ImmutableList` with `List.of()` |
+| `RestReleaseLockAction.java` | Replaced `ImmutableList` with `List.of()` |
+| Test files | Replaced `ImmutableMap` with `Map.of()` |
+
+#### Code Changes
+
+Before (using Guava):
+```java
+import com.google.common.collect.ImmutableList;
+
+@Override
+public List<Route> routes() {
+    return ImmutableList.of(
+        new Route(GET, String.format(Locale.ROOT, "%s/%s", JS_BASE_URI, "_lock"))
+    );
+}
+```
+
+After (using Java standard library):
+```java
+@Override
+public List<Route> routes() {
+    return List.of(
+        new Route(GET, String.format(Locale.ROOT, "%s/%s", JS_BASE_URI, "_lock"))
+    );
+}
+```
+
+### Migration Notes
+
+This is a transparent change for users. Plugin developers extending Job Scheduler will benefit from reduced dependency conflicts without any code changes required.
+
+## Limitations
+
+- No functional changes in this release
+- This is a maintenance-only release for Job Scheduler
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#766](https://github.com/opensearch-project/job-scheduler/pull/766) | Increment version to 3.1.0-SNAPSHOT |
+| [#773](https://github.com/opensearch-project/job-scheduler/pull/773) | Remove guava dependency |
+
+## References
+
+- [Issue #18113](https://github.com/opensearch-project/OpenSearch/issues/18113): Remove Guava from plugins
+- [v3.1.0 Release Notes](https://github.com/opensearch-project/job-scheduler/blob/main/release-notes/opensearch-job-scheduler.release-notes-3.1.0.0.md)
+- [Job Scheduler Documentation](https://docs.opensearch.org/3.1/monitoring-your-cluster/job-scheduler/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/job-scheduler/job-scheduler.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -75,3 +75,7 @@
 ### Notifications
 
 - [Notifications Maintenance](features/notifications/notifications-maintenance.md) - Migrate from javax.mail to jakarta.mail APIs and version increment to 3.1.0-SNAPSHOT
+
+### Job Scheduler
+
+- [Job Scheduler Maintenance](features/job-scheduler/job-scheduler-maintenance.md) - Remove Guava dependency to reduce jar hell and version increment to 3.1.0


### PR DESCRIPTION
## Summary

This PR adds the release report for Job Scheduler Maintenance in OpenSearch v3.1.0.

### Changes in v3.1.0

- **Version Increment**: Updated plugin version to 3.1.0-SNAPSHOT
- **Guava Dependency Removal**: Removed Google Guava library to reduce jar hell and dependency conflicts in extending plugins (SQL, ML Commons, etc.)

### Reports Created

- Release report: `docs/releases/v3.1.0/features/job-scheduler/job-scheduler-maintenance.md`
- Feature report: `docs/features/job-scheduler/job-scheduler.md` (updated)

### Related PRs

- [#766](https://github.com/opensearch-project/job-scheduler/pull/766): Increment version to 3.1.0-SNAPSHOT
- [#773](https://github.com/opensearch-project/job-scheduler/pull/773): Remove guava dependency

### Related Issue

- Closes #886