### PR TITLE
docs: add search-relevance-dashboards-fixes report for v3.1.0

### DIFF
--- a/docs/features/dashboards-search-relevance/search-comparison.md
+++ b/docs/features/dashboards-search-relevance/search-comparison.md
@@ -142,6 +142,7 @@ Query 2 - Boosted field:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#542](https://github.com/opensearch-project/dashboards-search-relevance/pull/542) | Fix schema validation in POST Query Sets endpoint |
 | v2.17.0 | [#427](https://github.com/opensearch-project/dashboards-search-relevance/pull/427) | Add compare queries card to search use case overview page |
 | v2.14.0 | [#383](https://github.com/opensearch-project/dashboards-search-relevance/pull/383) | Multi-datasource support for Search-relevance |
 | v2.14.0 | [#352](https://github.com/opensearch-project/dashboards-search-relevance/pull/352) | Add ability to select a search pipeline in comparison tool |
@@ -154,6 +155,7 @@ Query 2 - Boosted field:
 
 ## Change History
 
+- **v3.1.0** (2025-06-11): Fixed schema validation in POST Query Sets endpoint - added missing `querySetSize` parameter
 - **v2.17.0** (2024-09-17): Added Compare Queries card to Search use case overview page via Content Management integration
 - **v2.14.0** (2024-05-02): Added multi-datasource support and search pipeline selection
 - **v2.11.0** (2023-10-16): Fixed ace editor theme consistency for dark mode

--- a/docs/releases/v3.1.0/features/dashboards-search-relevance/search-relevance-dashboards-fixes.md
+++ b/docs/releases/v3.1.0/features/dashboards-search-relevance/search-relevance-dashboards-fixes.md
@@ -1,0 +1,77 @@
+# Search Relevance Dashboards Fixes
+
+## Summary
+
+This bugfix addresses a schema validation error in the Search Relevance Workbench that prevented users from creating query sets using sampling methods (pptss, random, topn). The POST Query Sets endpoint was missing the `querySetSize` parameter in its schema validation specification, causing a "Bad Request" error when users attempted to create query sets through the frontend.
+
+## Details
+
+### What's New in v3.1.0
+
+Fixed the schema validation for the POST Query Sets endpoint by adding the missing `querySetSize` parameter to the request body validation schema.
+
+### Technical Changes
+
+#### Bug Description
+
+When creating a query set in the Search Relevance Workbench frontend using sampling methods (`pptss`, `random`, `topn`), users encountered a 400 Bad Request error:
+
+```
+error: "Bad Request"
+message: "[request body.querySetSize]: definition for this key is missing"
+statusCode: 400
+```
+
+The root cause was that the server-side route validation schema for the POST `/api/relevancy/query_sets` endpoint did not include the `querySetSize` field, even though the frontend was sending this parameter in the request body.
+
+#### Code Change
+
+The fix adds `querySetSize` to the schema validation in `server/routes/search_relevance_route_service.ts`:
+
+```typescript
+router.post(
+  {
+    path: ServiceEndpoints.QuerySets,
+    validate: {
+      body: schema.object({
+        name: schema.string(),
+        description: schema.string(),
+        sampling: schema.string(),
+        querySetSize: schema.number(),  // Added in this fix
+      }),
+    },
+  },
+  backendAction('POST', BackendEndpoints.QuerySets)
+);
+```
+
+### Affected Components
+
+| Component | Description |
+|-----------|-------------|
+| `search_relevance_route_service.ts` | Server-side route definitions with schema validation |
+| POST Query Sets endpoint | API endpoint for creating query sets with sampling methods |
+
+### Impact
+
+- Users can now successfully create query sets using all sampling methods (pptss, random, topn) through the Search Relevance Workbench UI
+- No migration required - this is a pure bugfix with no breaking changes
+
+## Limitations
+
+- This fix only addresses the schema validation issue; the underlying query set creation functionality was already working correctly on the backend
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#542](https://github.com/opensearch-project/dashboards-search-relevance/pull/542) | Fix schema validation in POST Query Sets endpoint |
+
+## References
+
+- [Issue #541](https://github.com/opensearch-project/dashboards-search-relevance/issues/541): [BUG] Creating a query set with sampling methods throws an error
+- [Blog: Taking your first steps towards search relevance](https://opensearch.org/blog/taking-your-first-steps-towards-search-relevance/): Introduction to Search Relevance Workbench
+
+## Related Feature Report
+
+- [Search Comparison feature documentation](../../../../features/dashboards-search-relevance/search-comparison.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -79,3 +79,7 @@
 ### Job Scheduler
 
 - [Job Scheduler Maintenance](features/job-scheduler/job-scheduler-maintenance.md) - Remove Guava dependency to reduce jar hell and version increment to 3.1.0
+
+### Dashboards Search Relevance
+
+- [Search Relevance Dashboards Fixes](features/dashboards-search-relevance/search-relevance-dashboards-fixes.md) - Fix schema validation in POST Query Sets endpoint


### PR DESCRIPTION
## Summary

This PR adds documentation for the Search Relevance Dashboards bugfix in v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/dashboards-search-relevance/search-relevance-dashboards-fixes.md`
- Feature report updated: `docs/features/dashboards-search-relevance/search-comparison.md`

### Key Changes in v3.1.0
- Fixed schema validation in POST Query Sets endpoint by adding missing `querySetSize` parameter
- Users can now create query sets using sampling methods (pptss, random, topn) without errors

### Resources Used
- PR: opensearch-project/dashboards-search-relevance#542
- Issue: opensearch-project/dashboards-search-relevance#541