### PR TITLE
docs: add job-scheduler-changelog report for v3.1.0

### DIFF
--- a/docs/features/job-scheduler/job-scheduler.md
+++ b/docs/features/job-scheduler/job-scheduler.md
@@ -164,6 +164,7 @@ Job Scheduler supports two schedule formats:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#778](https://github.com/opensearch-project/job-scheduler/pull/778) | Add CHANGELOG and changelog_verifier workflow |
 | v3.1.0 | [#766](https://github.com/opensearch-project/job-scheduler/pull/766) | Increment version to 3.1.0-SNAPSHOT |
 | v3.1.0 | [#773](https://github.com/opensearch-project/job-scheduler/pull/773) | Remove guava dependency |
 | v3.0.0 | [#702](https://github.com/opensearch-project/job-scheduler/pull/702) | Enable custom start commands and options to resolve GHA issues |
@@ -177,15 +178,17 @@ Job Scheduler supports two schedule formats:
 - [Job Scheduler GitHub Repository](https://github.com/opensearch-project/job-scheduler)
 - [Official Documentation](https://docs.opensearch.org/3.1/monitoring-your-cluster/job-scheduler/index/)
 - [Sample Extension Plugin](https://github.com/opensearch-project/job-scheduler/tree/main/sample-extension-plugin)
+- [Issue #777](https://github.com/opensearch-project/job-scheduler/issues/777): Add a CHANGELOG to assemble release notes as PRs are merged
 - [Issue #18113](https://github.com/opensearch-project/OpenSearch/issues/18113): Remove Guava from plugins
 - [Issue #698](https://github.com/opensearch-project/job-scheduler/issues/698): GitHub Action Deprecation
 - [Issue #715](https://github.com/opensearch-project/job-scheduler/issues/715): Release 3.0 Breaking Changes
 - [Issue #14984](https://github.com/opensearch-project/OpenSearch/issues/14984): CreateIndexRequest.mapping() bug with v1 templates
 - [Issue #4439](https://github.com/opensearch-project/security/issues/4439): RFC - Strengthen System Index Protection in the Plugin Ecosystem
+- [Keep a Changelog](https://keepachangelog.com/en/1.0.0/): Changelog format specification
 
 ## Change History
 
-- **v3.1.0** (2025): Removed Guava dependency to reduce jar hell and dependency conflicts in extending plugins
+- **v3.1.0** (2025): Added CHANGELOG and changelog_verifier workflow for iterative release note assembly; Removed Guava dependency to reduce jar hell and dependency conflicts in extending plugins
 - **v3.0.0** (2025): CI/CD improvements, JPMS compatibility fixes, conditional demo certificate downloads
 - **v2.18.0** (2024-11-05): Return LockService from createComponents for Guice injection, enabling shared lock service across plugins
 - **v2.17.0** (2024-09-17): Fixed system index compatibility with v1 templates in LockService and JobDetailsService

--- a/docs/releases/v3.1.0/features/job-scheduler/job-scheduler-changelog.md
+++ b/docs/releases/v3.1.0/features/job-scheduler/job-scheduler-changelog.md
@@ -1,0 +1,98 @@
+# Job Scheduler Changelog
+
+## Summary
+
+This release adds a CHANGELOG file and changelog_verifier GitHub Actions workflow to the Job Scheduler plugin. This enables iterative release note assembly as PRs are merged and integrates with Dependabot for automatic changelog entry updates when dependencies are bumped.
+
+## Details
+
+### What's New in v3.1.0
+
+The Job Scheduler plugin now includes:
+
+1. **CHANGELOG file**: A structured changelog following the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format
+2. **Changelog Verifier workflow**: A GitHub Actions workflow that enforces changelog updates on every pull request
+
+### Technical Changes
+
+#### New Files
+
+| File | Description |
+|------|-------------|
+| `CHANGELOG.md` | Structured changelog with sections for Added, Changed, Dependencies, Deprecated, Removed, Fixed, and Security |
+| `.github/workflows/changelog_verifier.yml` | GitHub Actions workflow using `dangoslen/changelog-enforcer@v3` |
+
+#### Changelog Structure
+
+The CHANGELOG follows semantic versioning and includes these sections:
+
+```markdown
+## [Unreleased 3.x]
+### Added
+### Changed
+### Dependencies
+### Deprecated
+### Removed
+### Fixed
+### Security
+```
+
+#### Workflow Configuration
+
+```yaml
+name: "Changelog Verifier"
+on:
+  pull_request:
+    types: [opened, edited, reopened]
+
+jobs:
+  verify-changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dangoslen/changelog-enforcer@v3
+        with:
+          skipLabels: "autocut, skip-changelog"
+```
+
+### Usage Example
+
+When contributing to Job Scheduler, add an entry to the appropriate section in CHANGELOG.md:
+
+```markdown
+### Added
+- Add new feature X ([#123](https://github.com/opensearch-project/job-scheduler/pull/123))
+
+### Dependencies
+- Bump dependency Y from 1.0 to 2.0 ([#124](https://github.com/opensearch-project/job-scheduler/pull/124))
+```
+
+PRs with `autocut` or `skip-changelog` labels bypass the changelog requirement.
+
+### Benefits
+
+- **Iterative release notes**: Changes are documented as they're merged, reducing release preparation overhead
+- **Dependabot integration**: Dependabot can automatically update changelog entries when bumping the same dependency multiple times
+- **Consistent format**: Enforced structure ensures uniform release notes across versions
+
+## Limitations
+
+- The workflow condition references `security-dashboards-plugin` repository instead of `job-scheduler` (copy-paste issue from template)
+- PRs must include changelog entries unless labeled with `autocut` or `skip-changelog`
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#778](https://github.com/opensearch-project/job-scheduler/pull/778) | Add a CHANGELOG and changelog_verifier workflow |
+
+## References
+
+- [Issue #777](https://github.com/opensearch-project/job-scheduler/issues/777): Add a CHANGELOG to assemble release notes as PRs are merged
+- [Keep a Changelog](https://keepachangelog.com/en/1.0.0/): Changelog format specification
+- [Geospatial PR #238](https://github.com/opensearch-project/geospatial/pull/238): Reference implementation in geospatial repo
+- [OpenSearch PR #17262](https://github.com/opensearch-project/OpenSearch/pull/17262): Example of Dependabot changelog integration
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/job-scheduler/job-scheduler.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -79,6 +79,7 @@
 ### Job Scheduler
 
 - [Job Scheduler Maintenance](features/job-scheduler/job-scheduler-maintenance.md) - Remove Guava dependency to reduce jar hell and version increment to 3.1.0
+- [Job Scheduler Changelog](features/job-scheduler/job-scheduler-changelog.md) - Add CHANGELOG and changelog_verifier workflow for iterative release notes
 
 ### Dashboards Search Relevance
 


### PR DESCRIPTION
## Summary

Add documentation for Job Scheduler Changelog feature in v3.1.0.

### Changes
- Created release report: `docs/releases/v3.1.0/features/job-scheduler/job-scheduler-changelog.md`
- Updated feature report: `docs/features/job-scheduler/job-scheduler.md`
- Updated release index: `docs/releases/v3.1.0/index.md`

### Key Changes in v3.1.0
- Added CHANGELOG file following Keep a Changelog format
- Added changelog_verifier GitHub Actions workflow using `dangoslen/changelog-enforcer@v3`
- Enables iterative release note assembly as PRs are merged
- Integrates with Dependabot for automatic changelog entry updates

### Related
- Closes #884
- PR: opensearch-project/job-scheduler#778
- Issue: opensearch-project/job-scheduler#777