### PR TITLE
docs: add dashboard-assistant-ci-fixes report for v3.1.0

### DIFF
--- a/docs/features/dashboards-assistant/ci-configuration.md
+++ b/docs/features/dashboards-assistant/ci-configuration.md
@@ -1,0 +1,85 @@
+# Dashboard Assistant CI Configuration
+
+## Summary
+
+The dashboards-assistant plugin uses a babel configuration for Jest testing that aligns with OpenSearch Dashboards core. This configuration ensures proper module resolution during test execution, particularly for path aliases used across the codebase.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Test Environment"
+        Jest[Jest Test Runner]
+        Babel[Babel Transpiler]
+        PathAlias[Path Alias Plugin]
+    end
+    
+    subgraph "OSD Core"
+        BabelPreset["@osd/babel-preset"]
+        PathAliasFunc["path_alias function"]
+    end
+    
+    Jest --> Babel
+    Babel --> PathAlias
+    PathAlias --> PathAliasFunc
+    BabelPreset --> PathAliasFunc
+```
+
+### Configuration
+
+The `babel.config.js` file configures babel for the test environment:
+
+| Setting | Description | Value |
+|---------|-------------|-------|
+| `@babel/preset-env` | JavaScript transpilation | Node current |
+| `@babel/preset-react` | React JSX support | Default |
+| `@babel/preset-typescript` | TypeScript support | Default |
+| `pathAliasPlugin` | Module path resolution | From `@osd/babel-preset` |
+
+### Usage Example
+
+```javascript
+// babel.config.js
+const pathAliasPlugin = require('@osd/babel-preset/path_alias');
+
+module.exports = function (api) {
+  if (api.env('test')) {
+    return {
+      presets: [
+        require('@babel/preset-env', {
+          useBuiltIns: false,
+          targets: {
+            node: 'current',
+          },
+        }),
+        require('@babel/preset-react'),
+        require('@babel/preset-typescript'),
+      ],
+      plugins: [pathAliasPlugin({})],
+    };
+  }
+  return {};
+};
+```
+
+## Limitations
+
+- Configuration only applies to test environment (`api.env('test')`)
+- Requires `@osd/babel-preset` package from OpenSearch Dashboards core
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#580](https://github.com/opensearch-project/dashboards-assistant/pull/580) | Fix failed CI due to path alias |
+
+## References
+
+- [PR #580](https://github.com/opensearch-project/dashboards-assistant/pull/580): CI fix implementation
+- [PR #9831](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9831): Path alias extraction in OSD core
+
+## Change History
+
+- **v3.1.0** (2025-06-03): Added path alias plugin to babel configuration for CI compatibility

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -297,6 +297,7 @@
 ## dashboards-assistant
 
 - [AI Assistant / Chatbot](dashboards-assistant/ai-assistant-chatbot.md)
+- [CI Configuration](dashboards-assistant/ci-configuration.md)
 - [Text to Visualization (t2viz)](dashboards-assistant/text-to-visualization.md)
 
 ## k-nn

--- a/docs/releases/v3.1.0/features/dashboards-assistant/dashboard-assistant-ci-fixes.md
+++ b/docs/releases/v3.1.0/features/dashboards-assistant/dashboard-assistant-ci-fixes.md
@@ -1,0 +1,69 @@
+# Dashboard Assistant CI Fixes
+
+## Summary
+
+This release fixes CI failures in the dashboards-assistant plugin caused by path alias changes introduced in OpenSearch Dashboards core. The fix ensures Jest tests can properly resolve module imports using the new path alias babel configuration.
+
+## Details
+
+### What's New in v3.1.0
+
+The CI pipeline was failing because OpenSearch Dashboards core introduced a path alias babel configuration in PR #9831. This change required plugins to update their babel configuration to use the new reusable path alias plugin.
+
+### Technical Changes
+
+#### Root Cause
+
+OpenSearch Dashboards core extracted the path alias babel configuration into a reusable function (`@osd/babel-preset/path_alias`) to allow plugins to share the same module resolution behavior during testing.
+
+#### Fix Applied
+
+The `babel.config.js` file was updated to:
+1. Import the `pathAliasPlugin` from `@osd/babel-preset/path_alias`
+2. Add the plugin to the babel configuration for test environments
+
+```javascript
+const pathAliasPlugin = require('@osd/babel-preset/path_alias');
+
+module.exports = function (api) {
+  if (api.env('test')) {
+    return {
+      presets: [
+        require('@babel/preset-env', { ... }),
+        require('@babel/preset-react'),
+        require('@babel/preset-typescript'),
+      ],
+      plugins: [pathAliasPlugin({})],
+    };
+  }
+  return {};
+};
+```
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `babel.config.js` | Added path alias plugin import and configuration |
+| `CHANGELOG.md` | Added entry under Infrastructure section |
+
+## Limitations
+
+- This fix only affects the test environment configuration
+- No runtime behavior changes
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#580](https://github.com/opensearch-project/dashboards-assistant/pull/580) | Fix failed CI due to path alias |
+| [#9831](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9831) | Extract path alias babel config to reusable function (OSD core) |
+
+## References
+
+- [PR #580](https://github.com/opensearch-project/dashboards-assistant/pull/580): Main fix implementation
+- [PR #9831](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9831): Root cause - path alias extraction in OSD core
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-assistant/ci-configuration.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -89,6 +89,10 @@
 
 - [Flow Framework Dependencies](features/flow-framework/flow-framework-dependencies.md) - Conditional DynamoDB client dependency and data summary with log pattern agent template
 
+### Dashboards Assistant
+
+- [Dashboard Assistant CI Fixes](features/dashboards-assistant/dashboard-assistant-ci-fixes.md) - Fix CI failures due to path alias babel configuration changes
+
 ### Multi-Plugin
 
 - [Testing Library Updates](features/multi-plugin/testing-library-updates.md) - Update @testing-library/user-event to v14.4.3 in anomaly-detection and index-management dashboards plugins


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dashboard Assistant CI Fixes in v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/dashboards-assistant/dashboard-assistant-ci-fixes.md`
- Feature report: `docs/features/dashboards-assistant/ci-configuration.md`

### Key Changes in v3.1.0
- Fixed CI failures caused by path alias babel configuration changes in OpenSearch Dashboards core
- Added `pathAliasPlugin` from `@osd/babel-preset/path_alias` to babel configuration

### Resources Used
- PR: opensearch-project/dashboards-assistant#580
- Related: opensearch-project/OpenSearch-Dashboards#9831

Closes #881