### PR TITLE
docs: add search-relevance-test-data report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -165,6 +165,10 @@
 - [Documentation Maintenance](dashboards-search-relevance/documentation-maintenance.md)
 - [Search Comparison](dashboards-search-relevance/search-comparison.md)
 
+## search-relevance
+
+- [Search Relevance Workbench](search-relevance/search-relevance-workbench.md)
+
 ## dashboards-flow-framework
 
 - [AI Search Flows](dashboards-flow-framework/ai-search-flows.md)

--- a/docs/features/search-relevance/search-relevance-workbench.md
+++ b/docs/features/search-relevance/search-relevance-workbench.md
@@ -1,0 +1,164 @@
+# Search Relevance Workbench
+
+## Summary
+
+Search Relevance Workbench is an experimental toolkit in OpenSearch that helps search relevance engineers and business users improve search result quality through experimentation. It provides tools for comparing search configurations, evaluating search quality with metrics, and optimizing hybrid search queries.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        UI[Search Relevance UI]
+    end
+    
+    subgraph "Search Relevance Plugin"
+        API[REST API]
+        QS[Query Sets]
+        SC[Search Configurations]
+        JL[Judgment Lists]
+        EXP[Experiments]
+    end
+    
+    subgraph "OpenSearch Indexes"
+        QSI[Query Set Index]
+        SCI[Search Config Index]
+        JLI[Judgment Index]
+        EXPI[Experiment Index]
+        ECI[Ecommerce Index]
+    end
+    
+    UI --> API
+    API --> QS
+    API --> SC
+    API --> JL
+    API --> EXP
+    
+    QS --> QSI
+    SC --> SCI
+    JL --> JLI
+    EXP --> EXPI
+    EXP --> ECI
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Query Sets | Collections of queries used for search evaluation experiments |
+| Search Configurations | Query patterns defining how searches are executed |
+| Judgment Lists | Relevance ratings for query-document pairs |
+| Experiments | Evaluation runs comparing search configurations |
+
+### Experiment Types
+
+| Type | Description |
+|------|-------------|
+| Pairwise Comparison | Compare results of two search configurations side-by-side |
+| Pointwise Evaluation | Evaluate search quality using metrics and judgment lists |
+| Hybrid Search Optimization | Find optimal parameters for hybrid search queries |
+
+### Configuration
+
+Enable the Search Relevance Workbench backend:
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "plugins.search_relevance.workbench_enabled": true
+  }
+}
+```
+
+### API Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `PUT _plugins/_search_relevance/query_sets` | Create a query set |
+| `PUT _plugins/_search_relevance/search_configurations` | Create a search configuration |
+| `PUT _plugins/_search_relevance/judgments` | Import judgments |
+| `POST _plugins/_search_relevance/experiments` | Create and run an experiment |
+| `GET _plugins/_search_relevance/experiments/{id}` | Get experiment results |
+
+### Usage Example
+
+Create a query set:
+```json
+PUT _plugins/_search_relevance/query_sets
+{
+  "name": "Product Queries",
+  "description": "Common product search queries",
+  "sampling": "manual",
+  "querySetQueries": [
+    { "queryText": "laptop" },
+    { "queryText": "wireless headphones" }
+  ]
+}
+```
+
+Create a search configuration:
+```json
+PUT _plugins/_search_relevance/search_configurations
+{
+  "name": "baseline_config",
+  "query": "{\"query\":{\"multi_match\":{\"query\":\"%SearchText%\",\"fields\":[\"title\",\"description\"]}}}",
+  "index": "ecommerce"
+}
+```
+
+Run a comparison experiment:
+```json
+POST _plugins/_search_relevance/experiments
+{
+  "querySetId": "<query_set_id>",
+  "searchConfigurationList": ["<config_1_id>", "<config_2_id>"],
+  "size": 10,
+  "type": "PAIRWISE_COMPARISON"
+}
+```
+
+### Metrics
+
+The workbench calculates several comparison metrics:
+
+| Metric | Description |
+|--------|-------------|
+| Jaccard | Overlap between result sets |
+| RBO50 | Rank-Biased Overlap at 50% weight |
+| RBO90 | Rank-Biased Overlap at 90% weight |
+| Frequency Weighted | Weighted frequency of result overlap |
+
+### Test Data
+
+The plugin includes test data based on Amazon's ESCI (Shopping Queries Dataset):
+
+- **Product catalog**: E-commerce products with images
+- **Query set**: 150 queries from the ESCI ranking task
+- **Judgments**: Relevance ratings for query-document pairs
+
+## Limitations
+
+- Experimental feature - not recommended for production use
+- Requires both frontend (Dashboards) and backend plugins to be enabled
+- Dynamic field mappings may require increased `total_fields.limit` setting
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#70](https://github.com/opensearch-project/search-relevance/pull/70) | Add realistic ESCI-based test dataset |
+
+## References
+
+- [Search Relevance Workbench Documentation](https://docs.opensearch.org/3.1/search-plugins/search-relevance/using-search-relevance-workbench/)
+- [Search Relevance Plugin Repository](https://github.com/opensearch-project/search-relevance)
+- [Dashboards Search Relevance Repository](https://github.com/opensearch-project/dashboards-search-relevance)
+- [ESCI Dataset](https://github.com/amazon-science/esci-data): Amazon Shopping Queries Dataset
+- [Taking your first steps towards search relevance](https://opensearch.org/blog/taking-your-first-steps-towards-search-relevance/): Blog post
+
+## Change History
+
+- **v3.1.0** (2025-06-06): Added realistic ESCI-based test dataset with 150 queries and matching judgments

--- a/docs/releases/v3.1.0/features/search-relevance/search-relevance-test-data.md
+++ b/docs/releases/v3.1.0/features/search-relevance/search-relevance-test-data.md
@@ -1,0 +1,104 @@
+# Search Relevance Test Data
+
+## Summary
+
+This release adds a realistic test dataset based on Amazon's ESCI (Shopping Queries Dataset) to the Search Relevance Workbench. The dataset includes product data with images, 150 queries with matching judgments, enabling comprehensive demonstration and testing of search relevance evaluation capabilities.
+
+## Details
+
+### What's New in v3.1.0
+
+PR [#70](https://github.com/opensearch-project/search-relevance/pull/70) introduces a complete test dataset sourced from the ESCI benchmark dataset, providing:
+
+- **Product data**: E-commerce product catalog with images for all products
+- **Query set**: 150 queries from the ESCI ranking task (`esci_us_queryset.json`)
+- **Judgments**: Matching relevance judgments for query-document pairs (`esci_us_judgments.json`)
+
+### Technical Changes
+
+#### New Data Files
+
+| File | Description | Records |
+|------|-------------|---------|
+| `esci_us_queryset.json` | Query set with 150 queries from ESCI | 150 queries |
+| `esci_us_judgments.json` | Relevance judgments for query-document pairs | ~7000 judgments |
+| `esci_us_opensearch-2025-06-06.json` | Product data (downloaded from S3) | Full catalog |
+
+#### Demo Script Updates
+
+The `demo.sh` and `demo_hybrid_optimizer.sh` scripts were updated to:
+
+1. Download the new ESCI-based product data from S3
+2. Process data in chunks (50,000 lines per chunk) for reliable bulk indexing
+3. Upload ESCI query sets and judgments to Search Relevance Workbench
+4. Increase field mapping limits for SRW indexes to handle dynamic fields
+
+#### Data Source
+
+The test data is derived from Amazon's ESCI (Shopping Queries Dataset):
+
+```
+@article{reddy2022shopping,
+  title={Shopping Queries Dataset: A Large-Scale {ESCI} Benchmark for Improving Product Search},
+  author={Chandan K. Reddy and Lluís Màrquez and Fran Valero and Nikhil Rao and Hugo Zaragoza and Sambaran Bandyopadhyay and Arnab Biswas and Anlu Xing and Karthik Subbian},
+  year={2022},
+  eprint={2206.06588},
+  archivePrefix={arXiv}
+}
+```
+
+### Usage Example
+
+The demo script automatically sets up the test data:
+
+```bash
+cd search-relevance/src/test/scripts
+./demo.sh
+```
+
+This will:
+1. Download the ESCI product data from S3
+2. Create and populate the `ecommerce` index
+3. Upload the ESCI query set and judgments
+4. Configure Search Relevance Workbench for experimentation
+
+Query set format:
+```json
+{
+  "name": "ESCI Queries",
+  "description": "Queries from the ESCI ranking task",
+  "sampling": "manual",
+  "querySetQueries": [
+    { "queryText": "laptop" },
+    { "queryText": "red shoes" },
+    { "queryText": "in-ear headphones" }
+  ]
+}
+```
+
+### Migration Notes
+
+Users running the demo scripts should note:
+- The data file has changed from `transformed_esci_1.json` to `esci_us_opensearch-2025-06-06.json`
+- Data is now downloaded from a new S3 location: `https://o19s-public-datasets.s3.amazonaws.com/esci_us_opensearch-2025-06-06.json`
+
+## Limitations
+
+- The test dataset is a subset of the full ESCI dataset, optimized for demonstration purposes
+- Product images are hosted externally and require internet connectivity
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#70](https://github.com/opensearch-project/search-relevance/pull/70) | Use realistic dataset based on ESCI |
+
+## References
+
+- [ESCI Dataset](https://github.com/amazon-science/esci-data): Amazon Shopping Queries Dataset
+- [Search Relevance Workbench Documentation](https://docs.opensearch.org/3.1/search-plugins/search-relevance/using-search-relevance-workbench/)
+- [Taking your first steps towards search relevance](https://opensearch.org/blog/taking-your-first-steps-towards-search-relevance/): Blog post demonstrating SRW with ESCI data
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/search-relevance/search-relevance-workbench.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -100,3 +100,7 @@
 ### k-NN
 
 - [k-NN Testing Infrastructure](features/k-nn/k-nn-testing-infrastructure.md) - Enable all integration tests with remote index builder and fix MockNode constructor compatibility
+
+### Search Relevance
+
+- [Search Relevance Test Data](features/search-relevance/search-relevance-test-data.md) - Add realistic ESCI-based test dataset with 150 queries and matching judgments


### PR DESCRIPTION
## Summary

Add release and feature reports for Search Relevance Test Data (v3.1.0).

### Reports Created
- Release report: `docs/releases/v3.1.0/features/search-relevance/search-relevance-test-data.md`
- Feature report: `docs/features/search-relevance/search-relevance-workbench.md` (created)

### Key Changes in v3.1.0
- Added realistic ESCI-based test dataset with 150 queries and matching judgments
- Updated demo scripts to use new data format with chunked bulk indexing
- Product data with images for all products

### Resources Used
- PR: opensearch-project/search-relevance#70
- Docs: https://docs.opensearch.org/3.1/search-plugins/search-relevance/using-search-relevance-workbench/
- Blog: https://opensearch.org/blog/taking-your-first-steps-towards-search-relevance/

Closes #879