### PR TITLE
docs: add security-cve-fixes report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -147,6 +147,10 @@
 
 - [Security Dashboards Plugin](security-dashboards/security-dashboards-plugin.md)
 
+## remote
+
+- [Security CVE Fixes](remote/security-cve-fixes.md)
+
 ## reporting
 
 - [AUTO Version Management](reporting/auto-version-management.md)

--- a/docs/features/remote/security-cve-fixes.md
+++ b/docs/features/remote/security-cve-fixes.md
@@ -1,0 +1,88 @@
+# Security CVE Fixes
+
+## Summary
+
+The opensearch-remote-metadata-sdk maintains security by addressing Common Vulnerabilities and Exposures (CVEs) in its dependencies. This includes fixes for vulnerabilities in Apache HttpClient and other transitive dependencies that could potentially compromise security.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "opensearch-remote-metadata-sdk"
+        SDK[Remote Metadata SDK]
+        subgraph "Dependencies"
+            HC[httpclient5]
+            HCore[httpcore]
+            HCore2[httpcore5-h2]
+        end
+    end
+    
+    SDK --> HC
+    SDK --> HCore
+    SDK --> HCore2
+    
+    subgraph "Security Layer"
+        Cookie[Cookie Management]
+        Hostname[Hostname Verification]
+    end
+    
+    HC --> Cookie
+    HC --> Hostname
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| httpclient5 | Apache HttpClient 5.x for HTTP communication |
+| httpcore | Apache HttpCore for low-level HTTP transport |
+| httpcore5-h2 | HTTP/2 support for Apache HttpCore 5.x |
+
+### Configuration
+
+The SDK uses Gradle's resolution strategy to enforce secure dependency versions:
+
+```groovy
+configurations.all {
+    resolutionStrategy {
+        force("org.apache.httpcomponents.client5:httpclient5:5.4.4")
+        force("org.apache.httpcomponents:httpcore:5.3.4")
+        force("org.apache.httpcomponents.core5:httpcore5-h2:5.3.4")
+    }
+}
+```
+
+### CVE Details
+
+#### CVE-2025-27820
+
+| Attribute | Value |
+|-----------|-------|
+| Affected Component | Apache HttpClient |
+| Impact | Domain-related checks bypass |
+| Affected Functions | Cookie management, hostname verification |
+| Fixed Version | httpclient5 5.4.4 |
+
+This vulnerability could allow malicious domains to bypass domain-related checks in cookie management and hostname verification, potentially enabling unauthorized activities.
+
+## Limitations
+
+- CVE fixes are applied at the SDK level; downstream consumers should verify their own dependency trees
+- Transitive dependencies may still require independent verification
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#195](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/195) | CVE fix for CVE-2025-27820 |
+
+## References
+
+- [CVE-2025-27820](https://www.sentinelone.com/vulnerability-database/cve-2025-27820/): Apache HttpClient Auth Bypass Vulnerability
+- [opensearch-remote-metadata-sdk](https://github.com/opensearch-project/opensearch-remote-metadata-sdk): SDK repository
+
+## Change History
+
+- **v3.1.0** (2025-06): Fixed CVE-2025-27820 by updating Apache HttpClient dependencies

--- a/docs/releases/v3.1.0/features/remote/security-cve-fixes.md
+++ b/docs/releases/v3.1.0/features/remote/security-cve-fixes.md
@@ -1,0 +1,70 @@
+# Security CVE Fixes
+
+## Summary
+
+This release item addresses CVE-2025-27820, a security vulnerability in Apache HttpClient that could allow malicious domains to bypass domain-related checks in cookie management and hostname verification. The fix updates the httpclient5 and httpcore dependencies to patched versions.
+
+## Details
+
+### What's New in v3.1.0
+
+The opensearch-remote-metadata-sdk now includes a fix for CVE-2025-27820 by forcing updated versions of Apache HttpClient dependencies through Gradle's resolution strategy.
+
+### Technical Changes
+
+#### Vulnerability Details
+
+CVE-2025-27820 is a bug in Apache HttpClient that disables domain-related checks in critical functions like cookie management and hostname verification. This could potentially allow malicious domains to bypass security checks and engage in unauthorized activities.
+
+#### Dependency Updates
+
+| Dependency | Updated Version |
+|------------|-----------------|
+| org.apache.httpcomponents.client5:httpclient5 | 5.4.4 |
+| org.apache.httpcomponents:httpcore | 5.3.4 |
+| org.apache.httpcomponents.core5:httpcore5-h2 | 5.3.4 |
+
+#### Implementation
+
+The fix uses Gradle's `resolutionStrategy` to force the updated dependency versions:
+
+```groovy
+configurations.all {
+    resolutionStrategy {
+        force("org.apache.httpcomponents.client5:httpclient5:5.4.4")
+        force("org.apache.httpcomponents:httpcore:5.3.4")
+        force("org.apache.httpcomponents.core5:httpcore5-h2:5.3.4")
+
+        eachDependency { DependencyResolveDetails details ->
+            if (details.requested.group == 'org.apache.httpcomponents.client5' &&
+                    details.requested.name == 'httpclient5') {
+                details.useVersion "${versions.httpclient5}"
+            }
+        }
+    }
+}
+```
+
+### Migration Notes
+
+No migration steps required. The dependency updates are transparent to users and do not change any APIs or behavior.
+
+## Limitations
+
+- This fix only applies to the opensearch-remote-metadata-sdk component
+- Other OpenSearch components using Apache HttpClient should verify their dependency versions independently
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#195](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/195) | CVE fix for CVE-2025-27820 |
+
+## References
+
+- [CVE-2025-27820](https://www.sentinelone.com/vulnerability-database/cve-2025-27820/): Apache HttpClient Auth Bypass Vulnerability
+- [opensearch-remote-metadata-sdk](https://github.com/opensearch-project/opensearch-remote-metadata-sdk): SDK for remote metadata storage
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/remote/security-cve-fixes.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -104,3 +104,7 @@
 ### Search Relevance
 
 - [Search Relevance Test Data](features/search-relevance/search-relevance-test-data.md) - Add realistic ESCI-based test dataset with 150 queries and matching judgments
+
+### Remote
+
+- [Security CVE Fixes](features/remote/security-cve-fixes.md) - CVE-2025-27820 fix for Apache HttpClient in opensearch-remote-metadata-sdk


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security CVE Fixes release item in v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/remote/security-cve-fixes.md`
- Feature report: `docs/features/remote/security-cve-fixes.md`

### Key Changes in v3.1.0
- Fixed CVE-2025-27820 in opensearch-remote-metadata-sdk
- Updated Apache HttpClient dependencies (httpclient5 5.4.4, httpcore 5.3.4, httpcore5-h2 5.3.4)

### Related Issue
Closes #878