### PR TITLE
docs: add neural-search-compatibility report for v3.1.0

### DIFF
--- a/docs/features/neural-search/neural-search-compatibility.md
+++ b/docs/features/neural-search/neural-search-compatibility.md
@@ -111,8 +111,8 @@ Supported BWC versions: 2.9.0 through 2.20.0-SNAPSHOT
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#1245](https://github.com/opensearch-project/neural-search/pull/1245) | OpenSearch 3.0 beta compatibility |
 | v3.0.0 | [#1141](https://github.com/opensearch-project/neural-search/pull/1141) | OpenSearch 3.0 compatibility |
-| v3.0.0 | [#1245](https://github.com/opensearch-project/neural-search/pull/1245) | OpenSearch 3.0 beta compatibility |
 | v3.0.0 | [#502](https://github.com/opensearch-project/neural-search/pull/502) | Code guidelines |
 
 ## References
@@ -124,6 +124,8 @@ Supported BWC versions: 2.9.0 through 2.20.0-SNAPSHOT
 
 ## Change History
 
+- **v3.1.0** (2025-05-06): Build configuration update for OpenSearch 3.0 beta compatibility
+  - Updated version qualifiers from alpha1 to beta1
 - **v3.0.0** (2025-05-06): Major compatibility update for Lucene 10 and OpenSearch 3.0
   - Updated all Lucene API calls to use accessor methods
   - Migrated Client import to transport package

--- a/docs/releases/v3.1.0/features/neural-search/neural-search-compatibility.md
+++ b/docs/releases/v3.1.0/features/neural-search/neural-search-compatibility.md
@@ -1,0 +1,59 @@
+# Neural Search Compatibility
+
+## Summary
+
+This release item updates the neural-search plugin for OpenSearch 3.0 beta compatibility. The change updates version qualifiers in the build configuration from `alpha1` to `beta1`, ensuring the plugin builds correctly against the OpenSearch 3.0 beta release.
+
+## Details
+
+### What's New in v3.1.0
+
+This is a maintenance/infrastructure change that updates the neural-search plugin's build configuration to target OpenSearch 3.0 beta1 instead of alpha1.
+
+### Technical Changes
+
+#### Build Configuration Update
+
+The `build.gradle` file was updated to change the version qualifiers:
+
+```groovy
+// Before
+opensearch_version = System.getProperty("opensearch.version", "3.0.0-alpha1-SNAPSHOT")
+buildVersionQualifier = System.getProperty("build.version_qualifier", "alpha1")
+
+// After
+opensearch_version = System.getProperty("opensearch.version", "3.0.0-beta1-SNAPSHOT")
+buildVersionQualifier = System.getProperty("build.version_qualifier", "beta1")
+```
+
+#### Files Changed
+
+| File | Changes |
+|------|---------|
+| `build.gradle` | Version qualifier update (alpha1 → beta1) |
+| `CHANGELOG.md` | Added entry for this PR |
+
+### Migration Notes
+
+No migration required. This is a build infrastructure change that does not affect runtime behavior or APIs.
+
+## Limitations
+
+- This change is specific to the 3.0 beta release cycle
+- No functional changes to neural search capabilities
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1245](https://github.com/opensearch-project/neural-search/pull/1245) | Update neural-search for OpenSearch 3.0 beta compatibility |
+
+## References
+
+- [Issue #225](https://github.com/opensearch-project/neural-search/issues/225): Release version 3.0.0
+- [Issue #3747](https://github.com/opensearch-project/opensearch-build/issues/3747): Release version 3.0.0 (build)
+- [Neural Search Documentation](https://docs.opensearch.org/3.1/vector-search/ai-search/neural-sparse-search/): Official docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/neural-search/neural-search-compatibility.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -61,6 +61,7 @@
 ### Neural Search
 
 - [Lucene Upgrade](features/neural-search/lucene-upgrade.md) - Update hybrid query implementation for Lucene 10.2.1 API compatibility
+- [Neural Search Compatibility](features/neural-search/neural-search-compatibility.md) - Update neural-search for OpenSearch 3.0 beta compatibility
 
 ### Learning to Rank
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Neural Search Compatibility bugfix in v3.1.0.

### Changes
- Created release report: `docs/releases/v3.1.0/features/neural-search/neural-search-compatibility.md`
- Updated feature report: `docs/features/neural-search/neural-search-compatibility.md`
- Updated release index: `docs/releases/v3.1.0/index.md`

### Key Findings
- PR #1245 updates the neural-search plugin build configuration for OpenSearch 3.0 beta compatibility
- Changes version qualifiers from `alpha1` to `beta1` in `build.gradle`
- Infrastructure/maintenance change with no functional impact

Related Issue: #877