### PR TITLE
docs: add SQL/PPL Bug Fixes report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -197,6 +197,7 @@
 - [SQL PIT Refactor](sql/sql-pit-refactor.md)
 - [SQL Plugin Maintenance](sql/sql-plugin-maintenance.md)
 - [SQL Query Fixes](sql/sql-query-fixes.md)
+- [SQL/PPL Bug Fixes](sql/sql-ppl-bug-fixes.md)
 - [SQL/PPL Engine](sql/sql-ppl-engine.md)
 - [SQL/PPL Breaking Changes](sql/sql-ppl-breaking-changes.md)
 

--- a/docs/features/sql/sql-ppl-bug-fixes.md
+++ b/docs/features/sql/sql-ppl-bug-fixes.md
@@ -1,0 +1,135 @@
+# SQL/PPL Bug Fixes
+
+## Summary
+
+This document tracks bug fixes and stability improvements for the OpenSearch SQL/PPL plugin. The SQL plugin enables querying OpenSearch data using familiar SQL syntax, while PPL (Piped Processing Language) provides a pipe-based query language for data exploration and analysis.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "SQL/PPL Plugin"
+        Parser[Query Parser]
+        V2[V2 Engine]
+        Calcite[Calcite Engine]
+        Pushdown[Filter Pushdown]
+        Functions[Function Library]
+    end
+    
+    subgraph "OpenSearch"
+        Index[Index Storage]
+        DSL[Query DSL]
+    end
+    
+    Parser --> V2
+    Parser --> Calcite
+    V2 --> Pushdown
+    Calcite --> Pushdown
+    V2 --> Functions
+    Calcite --> Functions
+    Pushdown --> DSL
+    DSL --> Index
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Query Parser | Parses SQL and PPL queries into AST |
+| V2 Engine | Legacy query execution engine |
+| Calcite Engine | Apache Calcite-based query engine (newer) |
+| Filter Pushdown | Optimizes queries by pushing filters to OpenSearch |
+| Function Library | Built-in SQL/PPL functions |
+
+### Key Bug Fix Categories
+
+#### Query Execution
+
+- Long IN-lists causing StackOverflowError - fixed by using balanced tree for OR operations
+- NPE in aggregate queries - fixed by adding trimmed project before aggregate
+- Limit with offset exceeding maxResultWindow - prevented by checking bounds before pushdown
+- query.size_limit affecting intermediate results - fixed to only affect final results
+
+#### Function Behavior
+
+- `ATAN(x, y)` two-parameter form support in Calcite engine
+- `CONV(x, a, b)` type conversion correctness
+- `UNIX_TIMESTAMP` precision with timestamp strings
+
+#### Field and Type Handling
+
+- Alias type with nested field path support
+- Script filter with struct type fields
+- Filter pushdown with nested text fields
+- Ambiguous column names in JOIN operations
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.sql.query.size_limit` | Maximum result size for queries | 200 |
+| `max_result_window` | Maximum from + size for pagination | 10000 |
+
+### Usage Example
+
+```sql
+-- SQL query with IN clause
+SELECT * FROM my_index WHERE status IN ('active', 'pending', 'completed')
+
+-- PPL query with JOIN
+source=orders | join left=o right=c on o.customer_id=c.id customers | fields o.order_id, c.name
+
+-- Using ATAN function
+SELECT ATAN(y_coord, x_coord) as angle FROM coordinates
+
+-- UNIX_TIMESTAMP with precision
+SELECT UNIX_TIMESTAMP('2025-01-10 12:30:45.123') as ts FROM my_index
+```
+
+## Limitations
+
+- Script filter pushdown disabled for struct type fields in v2 engine
+- Calcite engine does not support script pushdown
+- Alias fields pointing to text type require using original field's keyword for filters
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#3693](https://github.com/opensearch-project/sql/pull/3693) | Fix error when pushing down script filter with struct field |
+| v3.1.0 | [#3674](https://github.com/opensearch-project/sql/pull/3674) | Fix alias type referring to nested field |
+| v3.1.0 | [#3660](https://github.com/opensearch-project/sql/pull/3660) | Fix: Long IN-lists causes crash |
+| v3.1.0 | [#3621](https://github.com/opensearch-project/sql/pull/3621) | Add a trimmed project before aggregate to avoid NPE in Calcite |
+| v3.1.0 | [#3760](https://github.com/opensearch-project/sql/pull/3760) | Fix field not found issue in join output when column names are ambiguous |
+| v3.1.0 | [#3748](https://github.com/opensearch-project/sql/pull/3748) | Fix: correct ATAN(x, y) and CONV(x, a, b) functions bug |
+| v3.1.0 | [#3679](https://github.com/opensearch-project/sql/pull/3679) | Return double with correct precision for UNIX_TIMESTAMP |
+| v3.1.0 | [#3713](https://github.com/opensearch-project/sql/pull/3713) | Prevent push down limit with offset reach maxResultWindow |
+| v3.1.0 | [#3645](https://github.com/opensearch-project/sql/pull/3645) | Fix pushing down filter with nested field of the text type |
+| v3.1.0 | [#3623](https://github.com/opensearch-project/sql/pull/3623) | Make query.size_limit only affect the final results |
+| v3.1.0 | [#3553](https://github.com/opensearch-project/sql/pull/3553) | Revert stream pattern method in V2 and implement SIMPLE_PATTERN |
+| v3.1.0 | [#2617](https://github.com/opensearch-project/sql/pull/2617) | Remove the duplicated timestamp row in data type mapping table |
+| v3.1.0 | [#3576](https://github.com/opensearch-project/sql/pull/3576) | Migrate existing UDFs to PPLFuncImpTable |
+| v3.1.0 | [#3715](https://github.com/opensearch-project/sql/pull/3715) | Modified workflow: Grammar Files & Async Query Core |
+| v3.1.0 | [#3656](https://github.com/opensearch-project/sql/pull/3656) | Update PPL Limitation Docs |
+| v3.1.0 | [#3649](https://github.com/opensearch-project/sql/pull/3649) | Create a new directory org/opensearch/direct-query/ |
+| v3.1.0 | [#3622](https://github.com/opensearch-project/sql/pull/3622) | Add a TPC-H PPL query suite |
+
+## References
+
+- [SQL and PPL Documentation](https://docs.opensearch.org/3.1/search-plugins/sql/index/)
+- [SQL and PPL API](https://docs.opensearch.org/3.1/search-plugins/sql/sql-ppl-api/)
+- [PPL Documentation](https://docs.opensearch.org/3.1/search-plugins/sql/ppl/index/)
+- [Issue #1469](https://github.com/opensearch-project/sql/issues/1469): Long IN-lists causes crash
+- [Issue #3312](https://github.com/opensearch-project/sql/issues/3312): Script filter with struct field error
+- [Issue #3646](https://github.com/opensearch-project/sql/issues/3646): Alias type referring to nested field
+- [Issue #3566](https://github.com/opensearch-project/sql/issues/3566): NPE in Calcite aggregate
+- [Issue #3617](https://github.com/opensearch-project/sql/issues/3617): Field not found in join output
+- [Issue #3672](https://github.com/opensearch-project/sql/issues/3672): ATAN and CONV function bugs
+- [Issue #3611](https://github.com/opensearch-project/sql/issues/3611): UNIX_TIMESTAMP precision
+- [Issue #3102](https://github.com/opensearch-project/sql/issues/3102): Limit with offset exceeds maxResultWindow
+
+## Change History
+
+- **v3.1.0** (2025-06): 17 bug fixes including long IN-list crash, function fixes (ATAN, CONV, UNIX_TIMESTAMP), field handling improvements, and Calcite engine stability

--- a/docs/releases/v3.1.0/features/sql/sql-ppl-bug-fixes.md
+++ b/docs/releases/v3.1.0/features/sql/sql-ppl-bug-fixes.md
@@ -1,0 +1,110 @@
+# SQL/PPL Bug Fixes
+
+## Summary
+
+OpenSearch v3.1.0 includes 17 bug fixes for the SQL/PPL plugin, addressing issues in query execution, function behavior, filter pushdown, and Calcite engine compatibility. Key fixes resolve crashes with long IN-lists, incorrect function results for `ATAN`, `CONV`, and `UNIX_TIMESTAMP`, and field resolution issues in JOIN operations.
+
+## Details
+
+### What's New in v3.1.0
+
+This release focuses on stability and correctness improvements across both the legacy v2 engine and the new Calcite-based engine.
+
+### Technical Changes
+
+#### Query Execution Fixes
+
+| Issue | Fix | PR |
+|-------|-----|-----|
+| Long IN-lists cause StackOverflowError | Rewrite `or` tree as balanced tree for logarithmic recursion | [#3660](https://github.com/opensearch-project/sql/pull/3660) |
+| NPE in Calcite aggregate queries | Add trimmed project before aggregate | [#3621](https://github.com/opensearch-project/sql/pull/3621) |
+| Limit with offset exceeds maxResultWindow | Prevent pushdown when startFrom reaches maxResultWindow | [#3713](https://github.com/opensearch-project/sql/pull/3713) |
+| query.size_limit affects intermediate results | Make size_limit only affect final results | [#3623](https://github.com/opensearch-project/sql/pull/3623) |
+
+#### Function Fixes
+
+| Function | Issue | Fix | PR |
+|----------|-------|-----|-----|
+| `ATAN(x, y)` | Two-parameter form not supported in v3 | Add two-parameter support in Calcite engine | [#3748](https://github.com/opensearch-project/sql/pull/3748) |
+| `CONV(x, a, b)` | Incorrect type conversion | Fix type conversion logic | [#3748](https://github.com/opensearch-project/sql/pull/3748) |
+| `UNIX_TIMESTAMP` | Incorrect precision with timestamp strings | Reorder signatures to prioritize timestamp coercion | [#3679](https://github.com/opensearch-project/sql/pull/3679) |
+
+#### Field and Type Handling Fixes
+
+| Issue | Fix | PR |
+|-------|-----|-----|
+| Alias type referring to nested field fails | Support alias type with nested field path | [#3674](https://github.com/opensearch-project/sql/pull/3674) |
+| Script filter with struct field throws error | Prevent pushdown for struct type fields | [#3693](https://github.com/opensearch-project/sql/pull/3693) |
+| Filter with nested text field fails | Use original field's keyword for text type | [#3645](https://github.com/opensearch-project/sql/pull/3645) |
+| Ambiguous column names in JOIN output | Rename duplicated columns with alias/table prefix | [#3760](https://github.com/opensearch-project/sql/pull/3760) |
+
+#### Infrastructure and Maintenance
+
+| Change | PR |
+|--------|-----|
+| Migrate UDFs to PPLFuncImpTable | [#3576](https://github.com/opensearch-project/sql/pull/3576) |
+| Revert stream pattern method, implement SIMPLE_PATTERN | [#3553](https://github.com/opensearch-project/sql/pull/3553) |
+| Remove duplicated timestamp row in data type mapping | [#2617](https://github.com/opensearch-project/sql/pull/2617) |
+| Update PPL Limitation Docs | [#3656](https://github.com/opensearch-project/sql/pull/3656) |
+| Create org/opensearch/direct-query/ directory | [#3649](https://github.com/opensearch-project/sql/pull/3649) |
+| Add TPC-H PPL query suite | [#3622](https://github.com/opensearch-project/sql/pull/3622) |
+| Modified workflow: Grammar Files & Async Query Core | [#3715](https://github.com/opensearch-project/sql/pull/3715) |
+
+### Usage Example
+
+```sql
+-- Long IN-list now works without StackOverflowError
+SELECT * FROM my_index WHERE id IN (1, 2, 3, ... /* hundreds of values */)
+
+-- ATAN with two parameters now supported
+SELECT ATAN(1, 2) FROM my_index
+
+-- UNIX_TIMESTAMP returns correct precision
+SELECT UNIX_TIMESTAMP('2025-01-10 12:30:45.123') FROM my_index
+
+-- JOIN with ambiguous columns now properly qualified
+source=table1 | join left=t1 right=t2 on t1.id=t2.id table2 | fields t1.id, t2.id
+```
+
+## Limitations
+
+- Script filter pushdown is disabled for struct type fields in v2 engine (Calcite engine doesn't support script pushdown)
+- Alias fields pointing to text type require using the original field's keyword for filter operations
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3693](https://github.com/opensearch-project/sql/pull/3693) | Fix error when pushing down script filter with struct field |
+| [#3674](https://github.com/opensearch-project/sql/pull/3674) | Fix alias type referring to nested field |
+| [#3660](https://github.com/opensearch-project/sql/pull/3660) | Fix: Long IN-lists causes crash |
+| [#3621](https://github.com/opensearch-project/sql/pull/3621) | Add a trimmed project before aggregate to avoid NPE in Calcite |
+| [#3760](https://github.com/opensearch-project/sql/pull/3760) | Fix field not found issue in join output when column names are ambiguous |
+| [#3748](https://github.com/opensearch-project/sql/pull/3748) | Fix: correct ATAN(x, y) and CONV(x, a, b) functions bug |
+| [#3679](https://github.com/opensearch-project/sql/pull/3679) | Return double with correct precision for UNIX_TIMESTAMP |
+| [#3713](https://github.com/opensearch-project/sql/pull/3713) | Prevent push down limit with offset reach maxResultWindow |
+| [#3645](https://github.com/opensearch-project/sql/pull/3645) | Fix pushing down filter with nested field of the text type |
+| [#3623](https://github.com/opensearch-project/sql/pull/3623) | Make query.size_limit only affect the final results |
+| [#3553](https://github.com/opensearch-project/sql/pull/3553) | Revert stream pattern method in V2 and implement SIMPLE_PATTERN |
+| [#2617](https://github.com/opensearch-project/sql/pull/2617) | Remove the duplicated timestamp row in data type mapping table |
+| [#3576](https://github.com/opensearch-project/sql/pull/3576) | Migrate existing UDFs to PPLFuncImpTable |
+| [#3715](https://github.com/opensearch-project/sql/pull/3715) | Modified workflow: Grammar Files & Async Query Core |
+| [#3656](https://github.com/opensearch-project/sql/pull/3656) | Update PPL Limitation Docs |
+| [#3649](https://github.com/opensearch-project/sql/pull/3649) | Create a new directory org/opensearch/direct-query/ |
+| [#3622](https://github.com/opensearch-project/sql/pull/3622) | Add a TPC-H PPL query suite |
+
+## References
+
+- [Issue #1469](https://github.com/opensearch-project/sql/issues/1469): Long IN-lists causes crash
+- [Issue #3312](https://github.com/opensearch-project/sql/issues/3312): Script filter with struct field error
+- [Issue #3646](https://github.com/opensearch-project/sql/issues/3646): Alias type referring to nested field
+- [Issue #3566](https://github.com/opensearch-project/sql/issues/3566): NPE in Calcite aggregate
+- [Issue #3617](https://github.com/opensearch-project/sql/issues/3617): Field not found in join output
+- [Issue #3672](https://github.com/opensearch-project/sql/issues/3672): ATAN and CONV function bugs
+- [Issue #3611](https://github.com/opensearch-project/sql/issues/3611): UNIX_TIMESTAMP precision
+- [Issue #3102](https://github.com/opensearch-project/sql/issues/3102): Limit with offset exceeds maxResultWindow
+- [SQL and PPL Documentation](https://docs.opensearch.org/3.1/search-plugins/sql/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/sql/sql-ppl-bug-fixes.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -107,6 +107,10 @@
 
 - [Search Relevance Test Data](features/search-relevance/search-relevance-test-data.md) - Add realistic ESCI-based test dataset with 150 queries and matching judgments
 
+### SQL
+
+- [SQL/PPL Bug Fixes](features/sql/sql-ppl-bug-fixes.md) - 17 bug fixes including long IN-list crash, function fixes (ATAN, CONV, UNIX_TIMESTAMP), field handling, and Calcite engine stability
+
 ### Remote
 
 - [Security CVE Fixes](features/remote/security-cve-fixes.md) - CVE-2025-27820 fix for Apache HttpClient in opensearch-remote-metadata-sdk


### PR DESCRIPTION
## Summary

Add release and feature reports for SQL/PPL Bug Fixes in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/sql/sql-ppl-bug-fixes.md`
- Feature report: `docs/features/sql/sql-ppl-bug-fixes.md`

### Key Changes in v3.1.0
- 17 bug fixes for SQL/PPL plugin
- Fix long IN-lists causing StackOverflowError (balanced tree for OR operations)
- Fix ATAN(x, y) two-parameter support in Calcite engine
- Fix CONV(x, a, b) type conversion
- Fix UNIX_TIMESTAMP precision with timestamp strings
- Fix alias type referring to nested field
- Fix script filter with struct type fields
- Fix ambiguous column names in JOIN output
- Fix NPE in Calcite aggregate queries
- Fix limit with offset exceeding maxResultWindow

### Related Issue
Closes #875