### PR TITLE
docs: add version-bumps-and-release-maintenance report for v3.1.0

### DIFF
--- a/docs/features/multi-plugin/version-bumps-release-notes.md
+++ b/docs/features/multi-plugin/version-bumps-release-notes.md
@@ -63,6 +63,22 @@ release-notes/
 
 | Version | PR | Repository | Description |
 |---------|-----|------------|-------------|
+| v3.1.0 | [#1837](https://github.com/opensearch-project/alerting/pull/1837) | alerting | Auto-increment to 3.1.0-SNAPSHOT |
+| v3.1.0 | [#1249](https://github.com/opensearch-project/alerting/pull/1249) | alerting | Upgrade Java to 21 for binary CI |
+| v3.1.0 | [#1251](https://github.com/opensearch-project/alerting/pull/1251) | alerting | Increment to 3.1.0.0 |
+| v3.1.0 | [#726](https://github.com/opensearch-project/asynchronous-search/pull/726) | asynchronous-search | Increment to 3.1.0 |
+| v3.1.0 | [#820](https://github.com/opensearch-project/common-utils/pull/820) | common-utils | Auto-increment to 3.1.0-SNAPSHOT |
+| v3.1.0 | [#735](https://github.com/opensearch-project/dashboards-notifications/pull/735) | dashboards-notifications | Increment to 3.1.0.0 |
+| v3.1.0 | [#357](https://github.com/opensearch-project/notifications/pull/357) | notifications | Increment to 3.1.0.0 |
+| v3.1.0 | [#579](https://github.com/opensearch-project/reporting/pull/579) | reporting | Increment to 3.1.0.0 |
+| v3.1.0 | [#587](https://github.com/opensearch-project/reporting/pull/587) | reporting | Adding release notes for 3.1.0 |
+| v3.1.0 | [#534](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/534) | index-management-dashboards | Increment to 3.1.0.0 |
+| v3.1.0 | [#1414](https://github.com/opensearch-project/index-management/pull/1414) | index-management | Auto-increment to 3.1.0-SNAPSHOT |
+| v3.1.0 | [#1313](https://github.com/opensearch-project/index-management/pull/1313) | index-management | Increment to 3.1.0.0 |
+| v3.1.0 | [#572](https://github.com/opensearch-project/ml-commons/pull/572) | ml-commons | Bump version to 3.1.0.0 |
+| v3.1.0 | [#2451](https://github.com/opensearch-project/observability/pull/2451) | observability | Workflows - Version bump to 3.1.0 |
+| v3.1.0 | [#3671](https://github.com/opensearch-project/sql/pull/3671) | sql | Bump setuptools to 78.1.1 |
+| v3.1.0 | [#18039](https://github.com/opensearch-project/OpenSearch/pull/18039) | OpenSearch | Bump Core main branch to 3.0.0 |
 | v3.0.0 | [#1843](https://github.com/opensearch-project/alerting/pull/1843) | alerting | Added 3.0 release notes |
 | v3.0.0 | [#775](https://github.com/opensearch-project/common-utils/pull/775) | common-utils | Update shadow plugin and bump to 3.0.0.0-alpha1 |
 | v3.0.0 | [#1384](https://github.com/opensearch-project/index-management/pull/1384) | index-management | Bump Version to 3.0.0-alpha1 |
@@ -86,6 +102,7 @@ release-notes/
 
 ## Change History
 
+- **v3.1.0** (2026-01-10): Version bumps across 11 repositories (alerting, asynchronous-search, common-utils, dashboards-notifications, notifications, reporting, index-management-dashboards, index-management, ml-commons, observability, sql, OpenSearch core)
 - **v3.0.0** (2025-05-06): Version bumps and release notes across 9 repositories (alerting, common-utils, index-management, notifications, security, sql, and dashboard plugins)
 - **v2.18.0** (2024-11-05): Release notes across 5 repositories (alerting, common-utils, notifications, query-insights, security)
 - **v2.17.0** (2024-09-17): Version bumps and release notes across 12 repositories (alerting, anomaly-detection, asynchronous-search, common-utils, dashboards-notifications, index-management, job-scheduler, ml-commons, notifications, query-insights, security, sql)

--- a/docs/releases/v3.1.0/features/multi-plugin/version-bumps-and-release-maintenance.md
+++ b/docs/releases/v3.1.0/features/multi-plugin/version-bumps-and-release-maintenance.md
@@ -1,0 +1,76 @@
+# Version Bumps and Release Maintenance
+
+## Summary
+
+This release item covers version increments and release maintenance activities across 11 OpenSearch repositories for the v3.1.0 release cycle. These changes prepare the codebase for the 3.1.0 release by updating version numbers, adding release notes, and performing necessary CI/build updates.
+
+## Details
+
+### What's New in v3.1.0
+
+Version bump PRs were merged across multiple repositories to increment versions from 3.0.x to 3.1.0-SNAPSHOT or 3.1.0.0, preparing for the v3.1.0 release.
+
+### Technical Changes
+
+#### Repositories Updated
+
+| Repository | PR | Change Type |
+|------------|-----|-------------|
+| alerting | [#1837](https://github.com/opensearch-project/alerting/pull/1837) | Auto-increment to 3.1.0-SNAPSHOT |
+| alerting | [#1249](https://github.com/opensearch-project/alerting/pull/1249) | Upgrade Java to 21 for binary CI |
+| alerting | [#1251](https://github.com/opensearch-project/alerting/pull/1251) | Increment to 3.1.0.0 |
+| asynchronous-search | [#726](https://github.com/opensearch-project/asynchronous-search/pull/726) | Increment to 3.1.0 |
+| common-utils | [#820](https://github.com/opensearch-project/common-utils/pull/820) | Auto-increment to 3.1.0-SNAPSHOT |
+| notifications-dashboards | [#735](https://github.com/opensearch-project/dashboards-notifications/pull/735) | Increment to 3.1.0.0 |
+| notifications | [#357](https://github.com/opensearch-project/notifications/pull/357) | Increment to 3.1.0.0 |
+| reporting | [#579](https://github.com/opensearch-project/reporting/pull/579) | Increment to 3.1.0.0 |
+| reporting | [#587](https://github.com/opensearch-project/reporting/pull/587) | Adding release notes for 3.1.0 |
+| index-management-dashboards | [#534](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/534) | Increment to 3.1.0.0 |
+| index-management | [#1414](https://github.com/opensearch-project/index-management/pull/1414) | Auto-increment to 3.1.0-SNAPSHOT |
+| index-management | [#1313](https://github.com/opensearch-project/index-management/pull/1313) | Increment to 3.1.0.0 |
+| ml-commons | [#572](https://github.com/opensearch-project/ml-commons/pull/572) | Bump version to 3.1.0.0 |
+| observability | [#2451](https://github.com/opensearch-project/observability/pull/2451) | Workflows - Version bump to 3.1.0 |
+| sql | [#3671](https://github.com/opensearch-project/sql/pull/3671) | Bump setuptools to 78.1.1 |
+| OpenSearch | [#18039](https://github.com/opensearch-project/OpenSearch/pull/18039) | Bump Core main branch to 3.0.0 |
+
+#### Version Numbering Convention
+
+OpenSearch plugins follow a versioning scheme where:
+- Core OpenSearch uses semantic versioning (e.g., 3.1.0)
+- Plugins use four-part versioning (e.g., 3.1.0.0) where the fourth digit allows for plugin-specific patches
+- SNAPSHOT versions indicate development builds
+
+### Usage Example
+
+Version bumps are typically automated or follow a standard pattern:
+
+```gradle
+// build.gradle example
+opensearch_version = System.getProperty("opensearch.version", "3.1.0-SNAPSHOT")
+```
+
+### Migration Notes
+
+No migration required. Version bumps are internal maintenance changes that don't affect user-facing functionality.
+
+## Limitations
+
+- Version bump PRs are routine maintenance and don't introduce new features
+- Some repositories may have additional version-specific changes bundled with the bump
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18039](https://github.com/opensearch-project/OpenSearch/pull/18039) | Bump OpenSearch Core main branch to 3.0.0 |
+| [#1837](https://github.com/opensearch-project/alerting/pull/1837) | Auto-increment alerting to 3.1.0-SNAPSHOT |
+| [#1414](https://github.com/opensearch-project/index-management/pull/1414) | Auto-increment index-management to 3.1.0-SNAPSHOT |
+| [#820](https://github.com/opensearch-project/common-utils/pull/820) | Auto-increment common-utils to 3.1.0-SNAPSHOT |
+
+## References
+
+- [Issue #3747](https://github.com/opensearch-project/opensearch-build/issues/3747): OpenSearch build version tracking
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/multi-plugin/version-bumps-release-maintenance.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -98,6 +98,7 @@
 ### Multi-Plugin
 
 - [Testing Library Updates](features/multi-plugin/testing-library-updates.md) - Update @testing-library/user-event to v14.4.3 in anomaly-detection and index-management dashboards plugins
+- [Version Bumps and Release Maintenance](features/multi-plugin/version-bumps-and-release-maintenance.md) - Version increments across 11 repositories for v3.1.0 release cycle
 
 ### k-NN
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Version Bumps and Release Maintenance release item for OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/multi-plugin/version-bumps-and-release-maintenance.md`
- Feature report: Updated `docs/features/multi-plugin/version-bumps-release-notes.md`

### Key Changes in v3.1.0
- Version increments across 11 repositories (alerting, asynchronous-search, common-utils, dashboards-notifications, notifications, reporting, index-management-dashboards, index-management, ml-commons, observability, sql, OpenSearch core)
- Java 21 upgrade for alerting binary CI
- Release notes for reporting 3.1.0
- Setuptools bump for sql plugin

### Related Issue
Closes #874