### PR TITLE
docs: add skills-ppl-tool-fixes report for v3.1.0

### DIFF
--- a/docs/features/skills/skills-tools.md
+++ b/docs/features/skills/skills-tools.md
@@ -130,6 +130,7 @@ The PPLTool translates natural language questions into Piped Processing Language
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#581](https://github.com/opensearch-project/skills/pull/581) | Fix fields bug in PPL tool (multi-field mapping support) |
 | v3.1.0 | [#575](https://github.com/opensearch-project/skills/pull/575) | Fix conflict in dependency versions |
 | v3.0.0 | [#547](https://github.com/opensearch-project/skills/pull/547) | Add WebSearchTool |
 | v3.0.0 | [#541](https://github.com/opensearch-project/skills/pull/541) | Fix PPLTool empty list bug |
@@ -150,6 +151,6 @@ The PPLTool translates natural language questions into Piped Processing Language
 
 ## Change History
 
-- **v3.1.0** (2025-05-06): Fixed httpclient5 dependency version conflict in build.gradle, applied Spotless code formatting to WebSearchTool
+- **v3.1.0** (2025-05-06): Fixed PPLTool fields bug to properly expose multi-field mappings (e.g., `a.keyword`) to LLM for aggregation queries; fixed httpclient5 dependency version conflict in build.gradle, applied Spotless code formatting to WebSearchTool
 - **v3.0.0** (2025-02-25): Added WebSearchTool, fixed PPLTool empty list bug, updated dependencies, enhanced developer guide
 - **v2.18.0** (2024-11-12): Added LogPatternTool for log pattern analysis, added customizable prompt support for CreateAnomalyDetectorTool

--- a/docs/releases/v3.1.0/features/skills/skills-ppl-tool-fixes.md
+++ b/docs/releases/v3.1.0/features/skills/skills-ppl-tool-fixes.md
@@ -1,0 +1,75 @@
+# Skills PPL Tool Fixes
+
+## Summary
+
+This bugfix addresses an issue in the PPLTool where multi-field mappings (such as `text` fields with a `keyword` sub-field) were not being properly exposed to the LLM model. The fix enables the model to use sub-fields like `a.keyword` for aggregations on text fields, which is required since PPL/DSL does not allow aggregations directly on text fields.
+
+## Details
+
+### What's New in v3.1.0
+
+The PPLTool now correctly extracts and exposes multi-field mappings to the LLM model. This allows the model to generate valid PPL queries that use keyword sub-fields for aggregation operations.
+
+### Technical Changes
+
+#### Bug Fix
+
+The fix is a single-line change in `PPLTool.java` that modifies the `extractFieldNamesTypes` call to include multi-field mappings:
+
+```java
+// Before (v3.0.0)
+ToolHelper.extractFieldNamesTypes(mappingSource, fieldsToType, "", false);
+
+// After (v3.1.0)
+ToolHelper.extractFieldNamesTypes(mappingSource, fieldsToType, "", true);
+```
+
+The fourth parameter (`includeFields`) controls whether the `fields` property in mappings is traversed to extract sub-fields.
+
+#### Affected Scenario
+
+For index mappings like:
+```json
+{
+  "a": {
+    "type": "text",
+    "fields": {
+      "keyword": {"type": "keyword"}
+    }
+  }
+}
+```
+
+- **Before**: Only `a` (text) was exposed to the model
+- **After**: Both `a` (text) and `a.keyword` (keyword) are exposed
+
+This enables the LLM to generate correct PPL queries for aggregations:
+```ppl
+source=my_index | stats count() by a.keyword
+```
+
+### Impact
+
+- Improves PPL query generation accuracy for indexes with multi-field mappings
+- Enables aggregation queries on text fields via their keyword sub-fields
+- No configuration changes required
+
+## Limitations
+
+- The fix only affects the `constructTableInfo` method used for OpenSearch indexes
+- S3/Spark data sources use a separate code path (`constructTableInfoByPPLResultForSpark`) which was not affected
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#581](https://github.com/opensearch-project/skills/pull/581) | Fix fields bug in PPL tool |
+
+## References
+
+- [PPL Tool Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/tools/ppl-tool/): Official PPL tool documentation
+- [Multi-field Mappings](https://docs.opensearch.org/3.0/field-types/mapping-parameters/fields/): OpenSearch fields mapping parameter
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/skills/skills-tools.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -40,6 +40,7 @@
 ### Skills
 
 - [ML Skills](features/skills/ml-skills.md) - Fix httpclient5 dependency version conflict and apply Spotless formatting
+- [Skills PPL Tool Fixes](features/skills/skills-ppl-tool-fixes.md) - Fix fields bug to expose multi-field mappings for aggregation queries
 
 ### Reporting
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Skills PPL Tool bug fix in v3.1.0.

### Changes

- **Release report**: `docs/releases/v3.1.0/features/skills/skills-ppl-tool-fixes.md`
  - Documents the fix for multi-field mapping support in PPLTool
  - Explains the technical change (enabling `includeFields` parameter)
  - Describes the impact on aggregation queries

- **Feature report update**: `docs/features/skills/skills-tools.md`
  - Added PR #581 to Related PRs table
  - Updated Change History with the bug fix

- **Release index update**: `docs/releases/v3.1.0/index.md`
  - Added link to the new release report

### Related Issue

Closes #871

### Key Changes in v3.1.0

- Fixed PPLTool to properly expose multi-field mappings (e.g., `a.keyword`) to LLM
- Enables correct PPL query generation for aggregations on text fields via keyword sub-fields