### PR TITLE
docs: add security backend bug fixes report for v3.1.0

### DIFF
--- a/docs/features/security/security-bugfixes.md
+++ b/docs/features/security/security-bugfixes.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-This document tracks security-related bug fixes across OpenSearch Security plugin, Security Analytics plugin, and related components. These fixes address various issues including system index access control, authentication audit logging, configuration detection, SSL settings propagation, and stored field handling.
+This document tracks security-related bug fixes across OpenSearch Security plugin, Security Analytics plugin, Security Dashboards plugin, and related components. These fixes address various issues including system index access control, authentication audit logging, configuration detection, SSL settings propagation, stored field handling, cache synchronization, compliance audit logging, and DLS/FLS filtering.
 
 ## Details
 
@@ -17,11 +17,21 @@ graph TB
         SSL[SSL Dual Mode]
         HASH[HashingStoredFieldVisitor]
         MAP[Index Mappings]
+        CACHE[Security Index Cache]
+        AUDIT[Compliance Audit Log]
+        DLSFLS[DLS/FLS Filter Reader]
+        AUTH[Basic Authenticator]
+    end
+    
+    subgraph "Security Dashboards"
+        PWD[Password Reset UI]
+        PERM[Permissions Dropdown]
     end
     
     subgraph "Security Analytics"
         SA[Security Analytics Plugin]
         FORE[Forecasting Tests]
+        GUAVA[Guava Dependencies]
     end
     
     subgraph "Alerting"
@@ -33,6 +43,8 @@ graph TB
     SSL --> |Settings Propagation| Core
     MAP --> |Index Operations| Core
     HASH --> |Field Handling| Core
+    CACHE --> |Snapshot Restore| Core
+    DLSFLS --> |Field Filtering| Core
 ```
 
 ### Components
@@ -45,6 +57,13 @@ graph TB
 | SSL Dual Mode | Manages SSL/TLS dual mode settings propagation | security |
 | HashingStoredFieldVisitor | Handles stored fields in search operations | security |
 | Index Mappings | Manages index mapping operations for closed indices | security |
+| Security Index Cache | Manages in-memory cache of security index data | security |
+| Compliance Audit Log | Logs diffs for security index write operations | security |
+| DLS/FLS Filter Reader | Handles document and field level security filtering | security |
+| Basic Authenticator | Handles HTTP Basic authentication and logging | security |
+| Password Reset UI | Manages password reset form in dashboards | security-dashboards-plugin |
+| Permissions Dropdown | Static dropdown for cluster/index permissions | security-dashboards-plugin |
+| Guava Dependencies | Runtime dependencies for security analytics | security-analytics |
 | Role Permissions | Manages alerting role permissions | alerting |
 
 ### Configuration
@@ -81,11 +100,22 @@ GET /my-index/_search
 - SSL dual mode changes require companion OpenSearch core changes
 - Some fixes are backports and may have version-specific behavior
 - Demo configuration detection requires SnakeYaml library for nested YAML parsing
+- Cache reload on snapshot restore adds small overhead during restore operations
+- Compliance audit log fix requires proper configuration of `write_log_diffs` and `write_metadata_only` settings
 
 ## Related PRs
 
 | Version | PR | Repository | Description |
 |---------|-----|------------|-------------|
+| v3.1.0 | [#5307](https://github.com/opensearch-project/security/pull/5307) | security | Fix security index stale cache post snapshot restore |
+| v3.1.0 | [#5279](https://github.com/opensearch-project/security/pull/5279) | security | Fix compliance audit log diff computation |
+| v3.1.0 | [#5303](https://github.com/opensearch-project/security/pull/5303) | security | Fix DlsFlsFilterLeafReader PointValues handling |
+| v3.1.0 | [#5377](https://github.com/opensearch-project/security/pull/5377) | security | Conditional invalid auth header logging |
+| v3.1.0 | [#5331](https://github.com/opensearch-project/security/pull/5331) | security | Fix dependabot changelog workflow |
+| v3.1.0 | [#5334](https://github.com/opensearch-project/security/pull/5334) | security | Fix assemble workflow for Jenkins build |
+| v3.1.0 | [#2238](https://github.com/opensearch-project/security-dashboards-plugin/pull/2238) | security-dashboards-plugin | Fix page reload on invalid password |
+| v3.1.0 | [#2253](https://github.com/opensearch-project/security-dashboards-plugin/pull/2253) | security-dashboards-plugin | Add forecasting transport actions to dropdown |
+| v3.1.0 | [#1530](https://github.com/opensearch-project/security-analytics/pull/1530) | security-analytics | Fix guava dependency scope |
 | v2.18.0 | [#4775](https://github.com/opensearch-project/security/pull/4775) | security | Fix admin system index read |
 | v2.18.0 | [#4770](https://github.com/opensearch-project/security/pull/4770) | security | Remove SAML failed login audit |
 | v2.18.0 | [#4798](https://github.com/opensearch-project/security/pull/4798) | security | Handle non-flat YAML settings |
@@ -96,6 +126,9 @@ GET /my-index/_search
 
 ## References
 
+- [Issue #5308](https://github.com/opensearch-project/security/issues/5308): Stale cache post snapshot restore
+- [Issue #5280](https://github.com/opensearch-project/security/issues/5280): Compliance audit log diff computation issue
+- [Issue #2189](https://github.com/opensearch-project/security-dashboards-plugin/issues/2189): Page reload on invalid password
 - [Issue #4608](https://github.com/opensearch-project/security/issues/4608): SAML failed login audit issue
 - [Issue #4735](https://github.com/opensearch-project/security/issues/4735): Demo config nested YAML issue
 - [Issue #4755](https://github.com/opensearch-project/security/issues/4755): Admin system index read issue
@@ -104,4 +137,5 @@ GET /my-index/_search
 
 ## Change History
 
+- **v3.1.0** (2025-06-10): Security backend bug fixes including stale cache post snapshot restore, compliance audit log diff computation, DLS/FLS filter reader corrections, authentication header logging improvements, password reset UI fixes, forecasting permissions, and guava dependency fixes
 - **v2.18.0** (2024-10-29): Multiple security bug fixes including system index protection, SAML audit logging, demo config detection, SSL dual mode propagation, stored field handling, and closed index mappings

--- a/docs/releases/v3.1.0/features/security/security-backend-bug-fixes.md
+++ b/docs/releases/v3.1.0/features/security/security-backend-bug-fixes.md
@@ -1,0 +1,103 @@
+# Security Backend Bug Fixes
+
+## Summary
+
+OpenSearch v3.1.0 includes multiple bug fixes across the security plugin, security-dashboards-plugin, and security-analytics repositories. These fixes address critical issues including stale cache after snapshot restore, compliance audit log diff computation, DLS/FLS filter reader corrections, authentication header logging improvements, and various CI/CD workflow fixes.
+
+## Details
+
+### What's New in v3.1.0
+
+This release addresses several important security-related bugs:
+
+1. **Stale Cache Post Snapshot Restore** - Fixed an issue where the security index cache was not updated after snapshot restore, causing incorrect AuthN/AuthZ decisions
+2. **Compliance Audit Log Diff Computation** - Fixed incorrect diff computation when writing to the security index
+3. **DLS/FLS Filter Reader Corrections** - Fixed issues with PointValues and object-valued attributes in DlsFlsFilterLeafReader
+4. **Authentication Header Logging** - Improved logging to only log invalid authorization headers when HTTP Basic auth challenge is called
+5. **Password Reset UI Improvements** - Fixed page reload issue on invalid password and disabled reset button when fields are empty
+6. **Forecasting Permissions** - Added forecasting transport actions to the static dropdown list
+7. **Dependency Fixes** - Fixed guava dependency issues in security-analytics
+
+### Technical Changes
+
+#### Security Index Cache Fix
+
+```mermaid
+graph TB
+    subgraph "Before Fix"
+        A1[Snapshot Restore] --> B1[Security Index Updated]
+        B1 --> C1[Cache NOT Updated]
+        C1 --> D1[Stale AuthN/AuthZ]
+    end
+    subgraph "After Fix"
+        A2[Snapshot Restore] --> B2[Security Index Updated]
+        B2 --> C2[Index Shard Update Event]
+        C2 --> D2[Cache Reloaded]
+        D2 --> E2[Correct AuthN/AuthZ]
+    end
+```
+
+The fix adds a listener to index shard update events that triggers cache reload when the security index is updated via snapshot restore.
+
+#### Compliance Audit Log Fix
+
+The `ComplianceIndexingOperationListenerImpl` was incorrectly computing diffs when writing to the security index. The `getForUpdate` call was silently failing and returning an empty document, causing every update to appear as a full document creation rather than a partial change.
+
+#### DLS/FLS Filter Reader Corrections
+
+Fixed logic in `DlsFlsFilterLeafReader` related to field mappings based on PointValues and object-valued attributes, ensuring proper document-level and field-level security filtering.
+
+#### Authentication Header Logging
+
+Simplified the logic in the basic authenticator to only log "Invalid Authorization header" when:
+- Request has invalid basic auth header (no header, not basic auth, or corrupted)
+- There is exactly one challenging basic auth authenticator
+- SAML is not configured with `challenge: true`
+
+### Bug Fixes Summary
+
+| Component | Issue | Fix |
+|-----------|-------|-----|
+| Security Plugin | Stale cache after snapshot restore | Added index shard update event listener |
+| Security Plugin | Compliance audit log diff computation | Fixed `getForUpdate` to properly retrieve existing document state |
+| Security Plugin | DLS/FLS PointValues handling | Corrected field mapping logic |
+| Security Plugin | Invalid auth header logging | Conditional logging based on auth configuration |
+| Security Dashboards | Page reload on invalid password | Prevented browser auth interceptor from triggering reload |
+| Security Dashboards | Reset button enabled with empty fields | Disabled button when current/new password is empty |
+| Security Analytics | Guava runtime dependency | Changed from compileOnly to implementation |
+
+### CI/CD Fixes
+
+| PR | Description |
+|----|-------------|
+| [#5331](https://github.com/opensearch-project/security/pull/5331) | Fixed dependabot changelog pull_request workflow by using pull_request_target event |
+| [#5334](https://github.com/opensearch-project/security/pull/5334) | Fixed assemble workflow failure during Jenkins build by excluding sample plugin |
+
+## Limitations
+
+- The cache reload on snapshot restore adds a small overhead during restore operations
+- The compliance audit log fix requires proper configuration of `write_log_diffs` and `write_metadata_only` settings
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#5307](https://github.com/opensearch-project/security/pull/5307) | security | Fixes security index stale cache issue post snapshot restore |
+| [#5279](https://github.com/opensearch-project/security/pull/5279) | security | Fixes issue computing diffs in compliance audit log |
+| [#5303](https://github.com/opensearch-project/security/pull/5303) | security | Corrections in DlsFlsFilterLeafReader regarding PointValues |
+| [#5377](https://github.com/opensearch-project/security/pull/5377) | security | Only log Invalid Authorization header when HTTP Basic auth challenge is called |
+| [#5331](https://github.com/opensearch-project/security/pull/5331) | security | Fixes dependabot broken pull_request workflow |
+| [#5334](https://github.com/opensearch-project/security/pull/5334) | security | Fixes assemble workflow failure during Jenkins build |
+| [#2238](https://github.com/opensearch-project/security-dashboards-plugin/pull/2238) | security-dashboards-plugin | Prevents page reload on invalid current password |
+| [#2253](https://github.com/opensearch-project/security-dashboards-plugin/pull/2253) | security-dashboards-plugin | Adds forecasting transport actions to static dropdown |
+| [#1530](https://github.com/opensearch-project/security-analytics/pull/1530) | security-analytics | Switch guava deps from compileOnly to implementation |
+
+## References
+
+- [Issue #5308](https://github.com/opensearch-project/security/issues/5308): Stale cache post snapshot restore
+- [Issue #5280](https://github.com/opensearch-project/security/issues/5280): Issue computing diffs in compliance audit log
+- [Issue #2189](https://github.com/opensearch-project/security-dashboards-plugin/issues/2189): Page reload on invalid password
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/security-backend.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -48,6 +48,7 @@
 
 ### Security
 
+- [Security Backend Bug Fixes](features/security/security-backend-bug-fixes.md) - Stale cache post snapshot restore, compliance audit log diff, DLS/FLS filter reader, auth header logging, password reset UI, forecasting permissions
 - [Security Dependency Updates](features/security/security-dependency-updates.md) - 24 dependency updates including Bouncy Castle 1.81, Kafka 4.0.0, and CVE-2024-52798 fix
 - [Security Permissions](features/security/security-permissions.md) - Add forecast roles and fix missing cluster:monitor and mapping get permissions
 


### PR DESCRIPTION
## Summary

This PR adds documentation for Security Backend Bug Fixes in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/security/security-backend-bug-fixes.md`
- Feature report updated: `docs/features/security/security-bugfixes.md`

### Key Changes in v3.1.0
- **Stale Cache Post Snapshot Restore** - Fixed security index cache not updating after snapshot restore
- **Compliance Audit Log Diff Computation** - Fixed incorrect diff computation when writing to security index
- **DLS/FLS Filter Reader Corrections** - Fixed PointValues and object-valued attributes handling
- **Authentication Header Logging** - Improved logging for invalid authorization headers
- **Password Reset UI** - Fixed page reload on invalid password and disabled reset button when fields empty
- **Forecasting Permissions** - Added forecasting transport actions to static dropdown
- **Guava Dependencies** - Fixed runtime dependency issues in security-analytics

### PRs Investigated
- security#5307, #5279, #5303, #5377, #5331, #5334
- security-dashboards-plugin#2238, #2253
- security-analytics#1530

Closes #870