### PR TITLE
docs: add observability-bug-fixes report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -263,6 +263,7 @@
 
 - [Observability Integrations](observability/observability-integrations.md)
 - [Release Maintenance](observability/release-maintenance.md)
+- [Trace Analytics Bug Fixes](observability/trace-analytics-bug-fixes.md)
 
 ## performance-analyzer
 

--- a/docs/features/observability/trace-analytics-bug-fixes.md
+++ b/docs/features/observability/trace-analytics-bug-fixes.md
@@ -1,0 +1,100 @@
+# Trace Analytics Bug Fixes
+
+## Summary
+
+This feature tracks bug fixes for the Trace Analytics functionality in OpenSearch Dashboards Observability plugin, including time filter processing for Jaeger trace data and visualization warning handling for integrations.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Trace Analytics"
+        TP[Time Picker] --> TF[Time Filter Processing]
+        TF --> |Jaeger Mode| JP[Jaeger Processor]
+        TF --> |Data Prepper Mode| DP[Data Prepper Processor]
+        JP --> DSL[DSL Query Builder]
+        DP --> DSL
+        DSL --> OS[OpenSearch]
+    end
+    
+    subgraph "Integrations"
+        NFW[NFW Integration] --> MV[Materialized View]
+        MV --> Vega[Vega Visualization]
+        Vega --> Dashboard[Dashboard Panel]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `processTimeStamp()` | Converts time picker values to appropriate format for Jaeger (microseconds) or Data Prepper |
+| `dateMath.parse()` | OpenSearch date math parser with optional `roundUp` for end times |
+| Vega Configuration | Visualization config supporting `hideWarnings` option |
+| NFW MV SQL | Materialized view creation SQL with `COALESCE()` defaults |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `kibana.hideWarnings` | Suppress Vega visualization warnings | `false` |
+| `roundUp` (dateMath) | Round parsed time to end of period | `false` |
+
+### Time Processing Flow
+
+```mermaid
+flowchart LR
+    A[Time Picker Value] --> B{Is End Time?}
+    B -->|Yes| C[dateMath.parse with roundUp: true]
+    B -->|No| D[dateMath.parse]
+    C --> E[Convert to Microseconds]
+    D --> E
+    E --> F[DSL Query]
+```
+
+### Usage Example
+
+**Jaeger Time Filter** (automatic):
+```typescript
+// Start time - rounds down to beginning of period
+processTimeStamp('now/d', 'jaeger', false)
+
+// End time - rounds up to end of period  
+processTimeStamp('now/d', 'jaeger', true)
+```
+
+**Vega Warning Suppression**:
+```json
+{
+  "$schema": "https://vega.github.io/schema/vega-lite/v5.json",
+  "config": {
+    "kibana": {
+      "hideWarnings": true
+    }
+  }
+}
+```
+
+## Limitations
+
+- Jaeger time fix only applies to Jaeger mode trace analytics
+- NFW default values are placeholders indicating missing data
+- Warning suppression hides all Vega warnings, not just empty data warnings
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#2460](https://github.com/opensearch-project/dashboards-observability/pull/2460) | Fix Jaeger end time processing |
+| v3.1.0 | [#2452](https://github.com/opensearch-project/dashboards-observability/pull/2452) | NFW Integration Vega Vis Warning Msg Fix |
+
+## References
+
+- [Analyzing Jaeger trace data](https://docs.opensearch.org/3.1/observing-your-data/trace/trace-analytics-jaeger/): Official Jaeger trace analytics documentation
+- [Trace Analytics](https://docs.opensearch.org/3.1/observing-your-data/trace/index/): Trace Analytics overview
+
+## Change History
+
+- **v3.1.0** (2025-06-13): Fix Jaeger end time processing for "Today/This month/This year/This day" time picker options; Fix NFW integration Vega visualization warnings with empty MV indexes

--- a/docs/releases/v3.1.0/features/observability/observability-bug-fixes.md
+++ b/docs/releases/v3.1.0/features/observability/observability-bug-fixes.md
@@ -1,0 +1,104 @@
+# Observability Bug Fixes
+
+## Summary
+
+This release includes two bug fixes for the OpenSearch Dashboards Observability plugin: a fix for Jaeger trace analytics end time processing that caused empty results with certain time picker options, and a fix for Network Firewall (NFW) integration Vega visualization warnings when materialized view indexes are empty.
+
+## Details
+
+### What's New in v3.1.0
+
+Two bug fixes improve the reliability of trace analytics and NFW integration dashboards.
+
+### Technical Changes
+
+#### Jaeger End Time Processing Fix
+
+The Trace Analytics plugin issues DSL queries when Jaeger requests are made. The time filter processing was not correctly handling end times for certain time picker options.
+
+**Problem**: When using time picker options like "Today", "This year", "This month", or "This day", the start and end times could resolve to the same value, resulting in no data being returned.
+
+**Solution**: Added `roundUp: true` option to `dateMath.parse()` for end time processing, ensuring end times are rounded up to the end of the period.
+
+| Component | Change |
+|-----------|--------|
+| `helper_functions.tsx` | Added `isEndTime` parameter to `processTimeStamp()` function |
+| `dashboard_content.tsx` | Pass `true` for end time in `processTimeStamp()` calls |
+| `services_content.tsx` | Pass `true` for end time in `processTimeStamp()` calls |
+| `service_view.tsx` | Pass `true` for end time in `processTimeStamp()` calls |
+| `traces_content.tsx` | Pass `true` for end time in `processTimeStamp()` calls |
+| `trace_view.tsx` | Pass `true` for end time in `processTimeStamp()` calls |
+
+**Code Change**:
+```typescript
+// Before
+export function processTimeStamp(time: string, mode: TraceAnalyticsMode) {
+  if (mode === 'jaeger') {
+    const timeMoment = dateMath.parse(time)!;
+    return timeMoment.unix() * 1000000;
+  }
+  return time;
+}
+
+// After
+export function processTimeStamp(time: string, mode: TraceAnalyticsMode, isEndTime = false) {
+  if (mode === 'jaeger') {
+    const timeMoment = isEndTime ? dateMath.parse(time, { roundUp: true })! : dateMath.parse(time)!;
+    return timeMoment.unix() * 1000000;
+  }
+  return time;
+}
+```
+
+#### NFW Integration Vega Visualization Warning Fix
+
+The Network Firewall integration dashboards displayed warning messages when the materialized view (MV) index was empty.
+
+**Solution**: 
+1. Added `hideWarnings: true` to Vega panel configurations to suppress warnings
+2. Assigned default values using `COALESCE()` to all NFW MV index fields
+3. Rearranged visualization panels for better readability at low resolutions (e.g., CloudWatch console iframe embedding)
+
+**Configuration Change**:
+```json
+{
+  "kibana": {
+    "hideWarnings": true
+  }
+}
+```
+
+**SQL Changes**: Added `COALESCE()` with default values for all fields:
+```sql
+COALESCE(CAST(firewall_name AS STRING), 'UNKNOWN_FIREWALL') AS `firewall_name`,
+COALESCE(CAST(event.src_ip AS STRING), '-') AS `event_src_ip`,
+COALESCE(CAST(event.src_port AS INTEGER), -1) AS `event_src_port`,
+-- ... additional fields with defaults
+```
+
+### Usage Example
+
+The Jaeger time filter fix is automatic. Users selecting "Today", "This month", "This year", or "This day" in the time picker will now see correct trace data.
+
+For NFW integration, the warning messages are now hidden and empty indexes display default placeholder values instead of errors.
+
+## Limitations
+
+- The Jaeger fix only affects Jaeger mode; Data Prepper mode time handling remains unchanged
+- NFW integration default values are placeholders and should be interpreted as "no data available"
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2460](https://github.com/opensearch-project/dashboards-observability/pull/2460) | Fix Jaeger end time processing |
+| [#2452](https://github.com/opensearch-project/dashboards-observability/pull/2452) | NFW Integration Vega Vis Warning Msg Fix |
+
+## References
+
+- [Analyzing Jaeger trace data](https://docs.opensearch.org/3.1/observing-your-data/trace/trace-analytics-jaeger/): Official documentation for Jaeger trace analytics
+- [Trace Analytics](https://docs.opensearch.org/3.1/observing-your-data/trace/index/): Trace Analytics overview
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/observability/trace-analytics-bug-fixes.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -60,6 +60,7 @@
 ### Observability
 
 - [Observability Release Maintenance](features/observability/observability-release-maintenance.md) - Version increments, release notes, and bug fixes for trace analytics
+- [Observability Bug Fixes](features/observability/observability-bug-fixes.md) - Jaeger end time processing fix and NFW integration Vega warning fix
 
 ### Neural Search
 


### PR DESCRIPTION
## Summary

This PR adds documentation for observability bug fixes in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/observability/observability-bug-fixes.md`
- Feature report: `docs/features/observability/trace-analytics-bug-fixes.md`

### Key Changes in v3.1.0

1. **Jaeger End Time Processing Fix** (PR #2460)
   - Fixed time filter processing for Jaeger trace analytics
   - Added `roundUp: true` option for end time parsing
   - Resolves issue where \"Today\", \"This month\", \"This year\", \"This day\" time picker options returned no results

2. **NFW Integration Vega Warning Fix** (PR #2452)
   - Added `hideWarnings: true` to Vega panel configurations
   - Added `COALESCE()` defaults for all NFW MV index fields
   - Improved panel layout for low-resolution displays

### Resources Used
- PR: [#2460](https://github.com/opensearch-project/dashboards-observability/pull/2460)
- PR: [#2452](https://github.com/opensearch-project/dashboards-observability/pull/2452)
- Docs: [Analyzing Jaeger trace data](https://docs.opensearch.org/3.1/observing-your-data/trace/trace-analytics-jaeger/)

Closes #868"