### PR TITLE
docs: add neural-search-bug-fixes report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -4,6 +4,7 @@
 
 - [Batch Ingestion](neural-search/batch-ingestion.md)
 - [Hybrid Query](neural-search/hybrid-query.md)
+- [Neural Search Bug Fixes](neural-search/neural-search-bug-fixes.md)
 - [Neural Search Compatibility](neural-search/neural-search-compatibility.md)
 - [Neural Search Rescore](neural-search/neural-search-rescore.md)
 - [Neural Search Reranking](neural-search/neural-search-reranking.md)

--- a/docs/features/neural-search/neural-search-bug-fixes.md
+++ b/docs/features/neural-search/neural-search-bug-fixes.md
@@ -1,0 +1,167 @@
+# Neural Search Bug Fixes
+
+## Summary
+
+This document tracks bug fixes and stability improvements in the OpenSearch Neural Search plugin. Neural Search enables semantic search capabilities through vector embeddings, hybrid queries combining lexical and semantic search, and neural sparse search. These fixes ensure reliable operation across various deployment scenarios including multi-node clusters, rolling upgrades, and complex query patterns.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Neural Search Plugin"
+        NQ[Neural Query]
+        HQ[Hybrid Query]
+        NSQ[Neural Sparse Query]
+        Stats[Stats API]
+    end
+    
+    subgraph "Query Processing"
+        Parser[Query Parser]
+        Validator[Query Validator]
+        Rewriter[Query Rewriter]
+    end
+    
+    subgraph "Dependencies"
+        KNN[k-NN Plugin]
+        ML[ML Commons]
+    end
+    
+    NQ --> Parser
+    HQ --> Parser
+    NSQ --> Parser
+    Parser --> Validator
+    Validator --> Rewriter
+    Rewriter --> KNN
+    Rewriter --> ML
+    Stats --> Validator
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Hybrid Query Parser | Parses and validates hybrid queries, prevents nesting |
+| Neural Query Builder | Builds neural queries with semantic field support |
+| Stats REST Action | Handles stats API requests with validation |
+| Semantic Field Collector | Collects semantic fields from mappings |
+| Radial Search Handler | Handles min_score/max_distance queries |
+
+### Bug Fix Categories
+
+#### Query Validation
+
+| Fix | Version | Description |
+|-----|---------|-------------|
+| Nested hybrid query validation | v3.1.0 | Prevents hybrid queries from being nested within other hybrid queries |
+| Semantic field validation | v3.1.0 | Ensures validation runs when semantic field info is available |
+
+#### Serialization & Multi-Node
+
+| Fix | Version | Description |
+|-----|---------|-------------|
+| Radial search serialization | v3.1.0 | Fixes k-NN parameter serialization in multi-node clusters |
+| Stats BWC compatibility | v3.1.0 | Filters stats based on cluster version during rolling upgrades |
+
+#### Query Rewriting
+
+| Fix | Version | Description |
+|-----|---------|-------------|
+| Model inference trigger | v3.1.0 | Correctly checks semantic field for search analyzer |
+| Token source precedence | v3.1.0 | Query settings override semantic field settings |
+| Analyzer selection | v3.1.0 | Uses semantic field analyzer when query doesn't specify one |
+
+#### Stability
+
+| Fix | Version | Description |
+|-----|---------|-------------|
+| Stack overflow prevention | v3.1.0 | Uses iterative approach for semantic field collection |
+| Score handling | v3.1.0 | Returns null score for single shard with non-score sorting |
+
+### Configuration
+
+No new configuration options were added. These are internal bug fixes.
+
+### Usage Examples
+
+#### Valid Hybrid Query
+```json
+{
+  "query": {
+    "hybrid": {
+      "queries": [
+        {
+          "neural": {
+            "passage_embedding": {
+              "query_text": "semantic search",
+              "model_id": "model_id",
+              "k": 10
+            }
+          }
+        },
+        {
+          "match": {
+            "text": "keyword search"
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+#### Neural Query with Radial Search (Fixed in v3.1.0)
+```json
+{
+  "query": {
+    "neural": {
+      "embedding_field": {
+        "query_text": "search query",
+        "model_id": "model_id",
+        "min_score": 0.5
+      }
+    }
+  }
+}
+```
+
+#### Stats API with Validation (Fixed in v3.1.0)
+```bash
+# Returns 400 with suggestion for invalid stat name
+GET /_plugins/_neural/stats/invalid_stat
+
+# Valid stat names
+GET /_plugins/_neural/stats/text_embedding_executions
+```
+
+## Limitations
+
+- Multi-node radial search tests require manual verification until automated multi-node CI is available
+- Stats BWC fix is a workaround; full solution requires OpenSearch core changes
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#1277](https://github.com/opensearch-project/neural-search/pull/1277) | Fix score value as null for single shard sorting |
+| v3.1.0 | [#1291](https://github.com/opensearch-project/neural-search/pull/1291) | Return bad request for invalid stat parameters |
+| v3.1.0 | [#1305](https://github.com/opensearch-project/neural-search/pull/1305) | Add validation for nested hybrid query |
+| v3.1.0 | [#1357](https://github.com/opensearch-project/neural-search/pull/1357) | Use stack for semantic field collection |
+| v3.1.0 | [#1373](https://github.com/opensearch-project/neural-search/pull/1373) | Filter stats based on cluster version |
+| v3.1.0 | [#1393](https://github.com/opensearch-project/neural-search/pull/1393) | Fix radial search serialization |
+| v3.1.0 | [#1396](https://github.com/opensearch-project/neural-search/pull/1396) | Fix neural query with semantic field |
+
+## References
+
+- [Issue #1108](https://github.com/opensearch-project/neural-search/issues/1108): Nested hybrid query bug
+- [Issue #1274](https://github.com/opensearch-project/neural-search/issues/1274): Hybrid search sort score corruption
+- [Issue #1368](https://github.com/opensearch-project/neural-search/issues/1368): Stats BWC test failure
+- [Issue #1392](https://github.com/opensearch-project/neural-search/issues/1392): Radial search fails on 3.0
+- [Neural Search Documentation](https://docs.opensearch.org/3.0/vector-search/ai-search/neural-sparse-search/)
+- [Neural Query DSL](https://docs.opensearch.org/3.0/query-dsl/specialized/neural/)
+- [Neural Search API](https://docs.opensearch.org/3.0/vector-search/api/neural/)
+
+## Change History
+
+- **v3.1.0** (2026-01-10): Added 7 bug fixes for hybrid query validation, semantic field handling, radial search serialization, stats API, and stability improvements

--- a/docs/releases/v3.1.0/features/neural-search/neural-search-bug-fixes.md
+++ b/docs/releases/v3.1.0/features/neural-search/neural-search-bug-fixes.md
@@ -1,0 +1,123 @@
+# Neural Search Bug Fixes
+
+## Summary
+
+OpenSearch v3.1.0 includes seven bug fixes for the Neural Search plugin, addressing issues across hybrid queries, neural queries with semantic fields, radial search in multi-node clusters, Stats API validation, and internal stability improvements. These fixes improve reliability and correctness for neural search operations.
+
+## Details
+
+### What's New in v3.1.0
+
+This release addresses multiple bug categories in the Neural Search plugin:
+
+1. **Hybrid Query Validation** - Prevents invalid nested hybrid queries
+2. **Neural Query with Semantic Fields** - Fixes validation, model inference, and analyzer handling
+3. **Radial Search Serialization** - Fixes multi-node cluster compatibility
+4. **Stats API Improvements** - Better error handling and BWC compatibility
+5. **Stack Overflow Prevention** - Uses iterative approach for semantic field collection
+6. **Score Handling** - Fixes null score values for single shard sorting
+
+### Technical Changes
+
+#### Hybrid Query Nesting Validation
+
+Previously, hybrid queries could be nested within other hybrid queries, leading to undefined behavior. The fix adds validation during query parsing to reject nested hybrid queries with a clear error message.
+
+```json
+// This invalid query now returns an error
+{
+  "query": {
+    "hybrid": {
+      "queries": [
+        {
+          "hybrid": {  // ERROR: hybrid query cannot be nested
+            "queries": [...]
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Error response:
+```
+hybrid query cannot be nested in another hybrid query
+```
+
+#### Neural Query with Semantic Field Fixes
+
+Five issues were addressed in neural query handling with semantic fields:
+
+| Issue | Description | Fix |
+|-------|-------------|-----|
+| Missing validation | Validation bypassed when semantic field info available | Ensure validation runs regardless of rewrite path |
+| Incorrect model inference | Search analyzer in semantic field triggered model inference | Check semantic field settings for analyzer |
+| Token source precedence | Confusing priority between query and field settings | Clear precedence: query settings override field settings |
+| Incorrect analyzer | Null analyzer used when only defined in semantic field | Use semantic field analyzer when query doesn't specify one |
+| Incorrect tests | Tests verified against wrong analyzer | Fixed tests to verify against correct analyzer |
+
+#### Radial Search Multi-Node Fix
+
+Neural radial search queries with `min_score` or `max_distance` failed in multi-node clusters with the error:
+```
+[knn] requires exactly one of k, distance or score to be set
+```
+
+The fix delegates serialization/deserialization to the k-NN plugin, avoiding version checking conflicts between neural-search and k-NN plugins.
+
+#### Stats API Improvements
+
+Two fixes improve the Stats API:
+
+1. **Invalid stat name handling**: Returns 400 Bad Request with helpful suggestions instead of silently logging
+```json
+GET /_plugins/_neural/stats/text_embedding
+{
+  "error": {
+    "type": "illegal_argument_exception",
+    "reason": "request contains unrecognized stat: [text_embedding] -> did you mean [text_embedding_executions]?"
+  },
+  "status": 400
+}
+```
+
+2. **BWC compatibility**: Filters stats based on minimum cluster version during rolling upgrades to prevent enum ordinal reading errors
+
+#### Stack Overflow Prevention
+
+Changed semantic field collection from recursive to iterative approach using a stack data structure, preventing stack overflow errors with deeply nested field structures.
+
+#### Single Shard Score Fix
+
+Fixed score values showing as `null` for single shard indices when sorting by non-score fields. The fix aligns behavior with standard OpenSearch, returning `null` for `_score` when sort field is not score.
+
+## Limitations
+
+- Multi-node integration tests for radial search require manual verification (automated multi-node test CI in progress)
+- Stats API BWC fix is a workaround; full fix requires OpenSearch core changes for enum reading
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1277](https://github.com/opensearch-project/neural-search/pull/1277) | Fix score value as null for single shard when sorting |
+| [#1291](https://github.com/opensearch-project/neural-search/pull/1291) | Return bad request for invalid stat parameters in stats API |
+| [#1305](https://github.com/opensearch-project/neural-search/pull/1305) | Add validation for invalid nested hybrid query |
+| [#1357](https://github.com/opensearch-project/neural-search/pull/1357) | Use stack to collect semantic fields to avoid stack overflow |
+| [#1373](https://github.com/opensearch-project/neural-search/pull/1373) | Filter requested stats based on minimum cluster version |
+| [#1393](https://github.com/opensearch-project/neural-search/pull/1393) | Fix neural radial search serialization in multi-node clusters |
+| [#1396](https://github.com/opensearch-project/neural-search/pull/1396) | Fix bugs for neural query with semantic field using sparse model |
+
+## References
+
+- [Issue #1108](https://github.com/opensearch-project/neural-search/issues/1108): Nested hybrid query bug report
+- [Issue #1274](https://github.com/opensearch-project/neural-search/issues/1274): Hybrid search with sort corrupts scores
+- [Issue #1368](https://github.com/opensearch-project/neural-search/issues/1368): Stats BWC test failure
+- [Issue #1392](https://github.com/opensearch-project/neural-search/issues/1392): Neural query with min_score/max_distance fails on 3.0
+- [Neural Search Documentation](https://docs.opensearch.org/3.0/vector-search/ai-search/neural-sparse-search/)
+- [Neural Query DSL](https://docs.opensearch.org/3.0/query-dsl/specialized/neural/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/neural-search/neural-search-bug-fixes.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -65,6 +65,7 @@
 ### Neural Search
 
 - [Lucene Upgrade](features/neural-search/lucene-upgrade.md) - Update hybrid query implementation for Lucene 10.2.1 API compatibility
+- [Neural Search Bug Fixes](features/neural-search/neural-search-bug-fixes.md) - 7 bug fixes for hybrid query validation, semantic field handling, radial search serialization, stats API, and stability
 - [Neural Search Compatibility](features/neural-search/neural-search-compatibility.md) - Update neural-search for OpenSearch 3.0 beta compatibility
 
 ### Learning to Rank


### PR DESCRIPTION
## Summary

Add release and feature reports for Neural Search Bug Fixes in v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/neural-search/neural-search-bug-fixes.md`
- Feature report: `docs/features/neural-search/neural-search-bug-fixes.md`

### Key Changes in v3.1.0
- Hybrid query nesting validation - prevents invalid nested hybrid queries
- Neural query with semantic field fixes - validation, model inference, analyzer handling
- Radial search serialization fix for multi-node clusters
- Stats API improvements - better error handling and BWC compatibility
- Stack overflow prevention using iterative approach
- Single shard score handling fix

### PRs Covered
- #1277: Fix score value as null for single shard sorting
- #1291: Return bad request for invalid stat parameters
- #1305: Add validation for nested hybrid query
- #1357: Use stack for semantic field collection
- #1373: Filter stats based on cluster version
- #1393: Fix radial search serialization
- #1396: Fix neural query with semantic field

Closes #867