### PR TITLE
docs: add ML Commons Connector/Model Validation bug fixes report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -236,6 +236,7 @@
 - [ML Commons CI/CD](ml-commons/ml-commons-ci-cd.md)
 - [ML Commons Configuration](ml-commons/ml-commons-configuration.md)
 - [ML Commons Connector](ml-commons/ml-commons-connector.md)
+- [ML Commons Connector and Model Validation](ml-commons/connector-model-validation.md)
 - [ML Commons Connector Blueprints](ml-commons/ml-commons-blueprints.md)
 - [ML Commons MCP (Model Context Protocol)](ml-commons/ml-commons-mcp.md)
 - [ML Commons Memory Metadata](ml-commons/ml-commons-memory-metadata.md)

--- a/docs/features/ml-commons/connector-model-validation.md
+++ b/docs/features/ml-commons/connector-model-validation.md
@@ -1,0 +1,179 @@
+# ML Commons Connector and Model Validation
+
+## Summary
+
+ML Commons provides validation mechanisms for connectors and models to ensure data integrity, security, and proper API behavior. This includes input validation for names and descriptions, schema validation for model interfaces, connector configuration validation, and proper error handling for edge cases.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "API Request Layer"
+        A[Create/Update Request]
+    end
+    
+    subgraph "Validation Layer"
+        B[Input Validation]
+        C[Schema Validation]
+        D[Connector Validation]
+    end
+    
+    subgraph "Processing Layer"
+        E[Model Registration]
+        F[Connector Creation]
+        G[Model Update]
+    end
+    
+    subgraph "Storage Layer"
+        H[ML Model Index]
+        I[Connector Index]
+    end
+    
+    A --> B
+    B --> C
+    C --> D
+    D --> E
+    D --> F
+    D --> G
+    E --> H
+    F --> I
+    G --> H
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `FieldDescriptor` | Describes field validation requirements including value and required flag |
+| `StringUtils.validateFields()` | Validates multiple fields against safe character patterns |
+| `StringUtils.isSafeText()` | Checks if input contains only allowed characters |
+| `MLNodeUtils.processRemoteInferenceInputDataSetParametersValue()` | Processes input parameters while respecting schema-defined types |
+| `UpdateModelTransportAction` | Handles model updates with connector validation |
+| `TransportMcpToolsRemoveOnNodesAction` | Manages MCP tool registration/removal with memory synchronization |
+
+### Input Validation
+
+#### Safe Character Pattern
+
+The validation framework allows the following characters in name and description fields:
+
+- Letters (Unicode `\p{L}`)
+- Numbers (Unicode `\p{N}`)
+- Whitespace
+- Basic punctuation: `. , ! ? ( ) : @ - _ ' "`
+
+Characters explicitly blocked include: `< > / \ & + = ; | *`
+
+#### Validation Flow
+
+```mermaid
+flowchart TB
+    A[Receive Request] --> B{Field Required?}
+    B -->|Yes| C{Value Present?}
+    B -->|No| D{Value Present?}
+    C -->|No| E[Return Error: Required]
+    C -->|Yes| F{Matches Safe Pattern?}
+    D -->|No| G[Pass Validation]
+    D -->|Yes| H{Matches Safe Pattern?}
+    F -->|No| I[Return Error: Invalid Characters]
+    F -->|Yes| G
+    H -->|No| I
+    H -->|Yes| G
+```
+
+### Schema Validation
+
+The schema validation system ensures that model interface parameters are validated correctly:
+
+1. **Type Preservation**: String values defined in schema remain as strings even if they look like numbers
+2. **JSON Conversion**: Only converts string values to JSON objects/arrays when schema doesn't define them as strings
+3. **Error Messages**: Provides clear validation error messages with schema and instance details
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Safe input pattern | Regex for allowed characters | `^[\p{L}\p{N}\s.,!?():@\-_'"]*$` |
+| Required field validation | Checks for null/blank values | Enabled |
+| Schema type checking | Respects schema-defined types | Enabled |
+
+### Usage Example
+
+#### Creating a Connector with Valid Input
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "My Bedrock Connector",
+  "description": "Connector for Amazon Bedrock models",
+  "version": "1",
+  "protocol": "aws_sigv4",
+  "parameters": {
+    "service_name": "bedrock",
+    "region": "us-west-2"
+  },
+  "actions": [
+    {
+      "action_type": "PREDICT",
+      "method": "POST",
+      "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/invoke"
+    }
+  ]
+}
+```
+
+#### Model Interface with String Type
+
+```json
+{
+  "interface": {
+    "input": {
+      "type": "object",
+      "properties": {
+        "parameters": {
+          "type": "object",
+          "properties": {
+            "inputText": {
+              "type": "string"
+            }
+          },
+          "required": ["inputText"]
+        }
+      }
+    }
+  }
+}
+```
+
+With this schema, a prediction request with `"inputText": "5.11"` will correctly preserve the string type.
+
+## Limitations
+
+- Input validation character set is fixed and cannot be customized per-deployment
+- Schema validation requires explicit type definitions in model interface
+- Connector retry policy updates require inline connectors (not standalone connector_id references)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#3805](https://github.com/opensearch-project/ml-commons/pull/3805) | Add validation for name and description for model, model group, and connector resources |
+| v3.1.0 | [#3761](https://github.com/opensearch-project/ml-commons/pull/3761) | Don't convert schema-defined strings to other types during validation |
+| v3.1.0 | [#3909](https://github.com/opensearch-project/ml-commons/pull/3909) | Fixed NPE for connector retrying policy |
+| v3.1.0 | [#3931](https://github.com/opensearch-project/ml-commons/pull/3931) | Fix tool not found in MCP memory issue |
+| v3.1.0 | [#3933](https://github.com/opensearch-project/ml-commons/pull/3933) | Fix: Ensure proper format for Bedrock DeepSeek tool result |
+
+## References
+
+- [Issue #3639](https://github.com/opensearch-project/ml-commons/issues/3639): Enhance Input Validation for UpdateModel and UpdateModelGroup APIs
+- [Issue #3758](https://github.com/opensearch-project/ml-commons/issues/3758): Model interface validation failed when there is integer within text
+- [Issue #3906](https://github.com/opensearch-project/ml-commons/issues/3906): Gracefully handle error when user attempts to update retry_policy
+- [Update Model API Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/api/model-apis/update-model/)
+- [Update Connector API Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/api/connector-apis/update-connector/)
+- [Connector Blueprints Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/blueprints/)
+
+## Change History
+
+- **v3.1.0** (2025-06): Added input validation for name/description fields, fixed schema string type preservation, fixed connector retry policy NPE, fixed MCP tool memory synchronization, fixed Bedrock DeepSeek tool result format

--- a/docs/releases/v3.1.0/features/ml-commons/connector-model-validation.md
+++ b/docs/releases/v3.1.0/features/ml-commons/connector-model-validation.md
@@ -1,0 +1,165 @@
+# ML Commons Connector/Model Validation Bug Fixes
+
+## Summary
+
+OpenSearch v3.1.0 includes several important bug fixes for ML Commons connector and model validation. These fixes address issues with input validation for model groups and connectors, schema validation for string parameters, connector retry policy handling, MCP tool memory management, and Bedrock DeepSeek function calling format.
+
+## Details
+
+### What's New in v3.1.0
+
+This release addresses five key validation and error handling issues in ML Commons:
+
+1. **Input Validation for Name and Description Fields** - Added stricter validation to prevent script injection in model, model group, and connector name/description fields
+2. **Schema String Type Preservation** - Fixed validation that incorrectly converted schema-defined strings to numbers
+3. **Connector Retry Policy NPE Fix** - Graceful error handling when updating retry policy for models without inline connectors
+4. **MCP Tool Memory Management** - Fixed tool registration/removal synchronization in MCP server memory
+5. **Bedrock DeepSeek Tool Result Format** - Corrected JSON format for function calling results
+
+### Technical Changes
+
+#### Input Validation Enhancement
+
+A new validation framework was added to prevent potentially malicious input in model and connector APIs:
+
+| Component | Validation Added |
+|-----------|------------------|
+| `MLCreateConnectorRequest` | Name (required), Description (optional) |
+| `MLUpdateConnectorRequest` | Name (optional), Description (optional) |
+| `MLUpdateModelRequest` | Name (optional), Description (optional) |
+| `MLRegisterModelGroupRequest` | Name (required), Description (optional) |
+| `MLUpdateModelGroupRequest` | Name (optional), Description (optional) |
+| `MLRegisterModelRequest` | Name (required), Description (optional) |
+
+New utility classes:
+- `FieldDescriptor` - Describes field validation requirements (value, required flag)
+- `StringUtils.validateFields()` - Validates fields against safe character pattern
+
+Allowed characters: letters, numbers, whitespace, and basic punctuation (.,!?():@-_'")
+
+#### Schema Validation Fix
+
+The `processRemoteInferenceInputDataSetParametersValue()` method was updated to check the schema before converting string values:
+
+```java
+// Before: Converted all parseable strings to JSON
+JsonNode parsedValue = mapper.readTree(textValue);
+
+// After: Only convert if schema doesn't define field as string type
+if (value.isTextual() && !isStringTypeInSchema(parametersSchema, key)) {
+    JsonNode parsedValue = mapper.readTree(value.asText());
+    parametersNode.set(key, parsedValue);
+}
+```
+
+This prevents strings like `"5.11"` from being incorrectly converted to numbers when the schema defines the field as a string type.
+
+#### Connector Retry Policy NPE Fix
+
+Added null check before updating connector settings:
+
+```java
+if (connector == null) {
+    wrappedListener.onFailure(
+        new OpenSearchStatusException(
+            "Cannot update connector settings for this model. " +
+            "The model was created with a connector_id and does not have an inline connector.",
+            RestStatus.BAD_REQUEST
+        )
+    );
+    return;
+}
+```
+
+#### MCP Tool Memory Synchronization
+
+Fixed the tool removal flow to properly clean up the in-memory tool map:
+
+```java
+// Before: Tool removed from MCP server but not from memory map
+.subscribe();
+
+// After: Remove from memory map on successful removal
+.doOnSuccess(x -> McpAsyncServerHolder.IN_MEMORY_MCP_TOOLS.remove(toolName))
+.subscribe();
+```
+
+#### Bedrock DeepSeek Tool Result Format
+
+Fixed the tool result format for Bedrock DeepSeek R1 function calling:
+
+```java
+// Before: Nested object structure
+toolMessage.getContent().add(Map.of("text", Map.of(TOOL_CALL_ID, toolUseId, TOOL_RESULT, result)));
+
+// After: JSON escaped string
+String textJson = StringUtils.toJson(Map.of(TOOL_CALL_ID, toolUseId, TOOL_RESULT, result));
+toolMessage.getContent().add(Map.of("text", textJson));
+```
+
+### Usage Example
+
+#### Input Validation Error Response
+
+When attempting to create a connector with invalid characters:
+
+```json
+PUT /_plugins/_ml/connectors/_create
+{
+  "name": "<script>alert(1)</script>",
+  "description": "Test connector"
+}
+```
+
+Response:
+```json
+{
+  "error": {
+    "type": "action_request_validation_exception",
+    "reason": "Validation Failed: 1: Model connector name can only contain letters, numbers, whitespace, and basic punctuation (.,!?():@-_'\");"
+  },
+  "status": 400
+}
+```
+
+#### Schema Validation with String Numbers
+
+With proper schema definition, string values containing numbers are preserved:
+
+```json
+POST /_plugins/_ml/models/{model_id}/_predict
+{
+  "parameters": {
+    "inputText": "5.11"
+  }
+}
+```
+
+With schema defining `inputText` as string type, the value `"5.11"` is correctly passed as a string rather than being converted to the number `5.11`.
+
+## Limitations
+
+- Input validation uses a fixed character set; special characters outside the allowed set will be rejected
+- The schema validation fix requires the model interface to properly define string types for parameters that should remain as strings
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3805](https://github.com/opensearch-project/ml-commons/pull/3805) | Add validation for name and description for model, model group, and connector resources |
+| [#3761](https://github.com/opensearch-project/ml-commons/pull/3761) | Don't convert schema-defined strings to other types during validation |
+| [#3909](https://github.com/opensearch-project/ml-commons/pull/3909) | Fixed NPE for connector retrying policy |
+| [#3931](https://github.com/opensearch-project/ml-commons/pull/3931) | Fix tool not found in MCP memory issue |
+| [#3933](https://github.com/opensearch-project/ml-commons/pull/3933) | Fix: Ensure proper format for Bedrock DeepSeek tool result |
+
+## References
+
+- [Issue #3639](https://github.com/opensearch-project/ml-commons/issues/3639): Enhance Input Validation for UpdateModel and UpdateModelGroup APIs
+- [Issue #3758](https://github.com/opensearch-project/ml-commons/issues/3758): Model interface validation failed when there is integer within text
+- [Issue #3906](https://github.com/opensearch-project/ml-commons/issues/3906): Gracefully handle error when user attempts to update retry_policy for a model that doesn't use inline connector
+- [Update Model API Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/api/model-apis/update-model/)
+- [Update Connector API Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/api/connector-apis/update-connector/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/connector-model-validation.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -74,6 +74,7 @@
 
 ### ML Commons
 
+- [Connector/Model Validation Bug Fixes](features/ml-commons/connector-model-validation.md) - Input validation for names/descriptions, schema string type preservation, connector retry policy NPE fix, MCP tool memory fix, Bedrock DeepSeek format fix
 - [ML Commons Maintenance](features/ml-commons/ml-commons-maintenance.md) - Hidden model security, enhanced logging, HTTP client alignment, SearchIndexTool MCP compatibility, CVE fixes
 - [MCP (Model Context Protocol)](features/ml-commons/mcp-(model-context-protocol).md) - MCP SDK downgrade to 0.9.0 and unit test coverage
 - [PlanExecuteReflect Agent](features/ml-commons/planexecutereflect-agent.md) - Test coverage for PlanExecuteReflect Agent runner and utilities


### PR DESCRIPTION
## Summary

This PR adds documentation for ML Commons Connector/Model Validation bug fixes in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/ml-commons/connector-model-validation.md`
- Feature report: `docs/features/ml-commons/connector-model-validation.md`

### Key Changes in v3.1.0

1. **Input Validation for Name and Description Fields** (PR #3805)
   - Added stricter validation to prevent script injection in model, model group, and connector name/description fields
   - New `FieldDescriptor` class and `StringUtils.validateFields()` utility

2. **Schema String Type Preservation** (PR #3761)
   - Fixed validation that incorrectly converted schema-defined strings to numbers
   - Strings like "5.11" now correctly remain as strings when schema defines them as string type

3. **Connector Retry Policy NPE Fix** (PR #3909)
   - Graceful error handling when updating retry policy for models without inline connectors

4. **MCP Tool Memory Management** (PR #3931)
   - Fixed tool registration/removal synchronization in MCP server memory

5. **Bedrock DeepSeek Tool Result Format** (PR #3933)
   - Corrected JSON format for function calling results

### Related Issues
- Resolves investigation for Issue #866