### PR TITLE
docs: add Geospatial Ip2Geo Fixes report for v3.1.0

### DIFF
--- a/docs/features/geospatial/ip2geo.md
+++ b/docs/features/geospatial/ip2geo.md
@@ -1,0 +1,202 @@
+# IP2Geo Processor
+
+## Summary
+
+The IP2Geo processor is an ingest processor that adds geographical location information to documents based on IPv4 or IPv6 addresses. It uses IP geolocation (GeoIP) data from external endpoints and maintains the mapping in system indexes for efficient lookup during data ingestion.
+
+The processor is part of the `opensearch-geospatial` plugin and requires a datasource configuration that defines where to download GeoIP data and how frequently to update it.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Ingest Pipeline"
+        A[Document with IP] --> B[IP2Geo Processor]
+    end
+    
+    subgraph "Geospatial Plugin"
+        B --> C[Ip2GeoCachedDao]
+        C --> D{Cache Hit?}
+        D -->|Yes| E[Return Cached Data]
+        D -->|No| F[GeoIpDataDao]
+        F --> G[System Index]
+        G --> F
+        F --> H[Cache Result]
+        H --> E
+    end
+    
+    subgraph "External"
+        I[GeoIP Endpoint] -->|Periodic Update| J[Datasource]
+        J --> G
+    end
+    
+    E --> K[Enriched Document]
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Setup Phase"
+        A1[Create Datasource] --> B1[Download GeoIP Data]
+        B1 --> C1[Index to System Index]
+        C1 --> D1[Cache Metadata]
+    end
+    
+    subgraph "Ingestion Phase"
+        A2[Ingest Document] --> B2[Extract IP Field]
+        B2 --> C2[Lookup in Cache/Index]
+        C2 --> D2[Add Geo Fields]
+        D2 --> E2[Continue Pipeline]
+    end
+    
+    subgraph "Update Phase"
+        A3[Scheduled Update] --> B3[Check Endpoint]
+        B3 --> C3[Download New Data]
+        C3 --> D3[Update System Index]
+        D3 --> E3[Invalidate Cache]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `Ip2GeoProcessor` | Ingest processor that performs IP-to-geo conversion |
+| `Ip2GeoCachedDao` | Caches datasource metadata and GeoIP lookup results |
+| `GeoIpDataDao` | Retrieves GeoIP data from system indexes |
+| `DatasourceDao` | Manages datasource configurations |
+| `DatasourceMetadata` | Stores datasource state, index name, and expiration |
+
+### Configuration
+
+#### Cluster Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.geospatial.ip2geo.datasource.endpoint` | Default endpoint for creating datasource | `https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json` |
+| `plugins.geospatial.ip2geo.datasource.update_interval_in_days` | Default update interval | 3 |
+| `plugins.geospatial.ip2geo.datasource.batch_size` | Max documents per bulk request during datasource creation | 10,000 |
+| `plugins.geospatial.ip2geo.processor.cache_size` | Max cached results per node | 1,000 |
+| `plugins.geospatial.ip2geo.timeout` | Timeout for endpoint and cluster responses | 30s |
+
+#### Datasource Options
+
+| Option | Required | Default | Description |
+|--------|----------|---------|-------------|
+| `endpoint` | No | GeoLite2 City manifest | URL to download GeoIP data |
+| `update_interval_in_days` | No | 3 | Update frequency (minimum: 1) |
+
+#### Processor Parameters
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `datasource` | Yes | - | Datasource name for geo lookup |
+| `field` | Yes | - | Field containing IP address |
+| `target_field` | No | `ip2geo` | Field for geo information |
+| `properties` | No | All fields | Properties to add from datasource |
+| `ignore_missing` | No | `false` | Ignore missing field |
+
+### Usage Example
+
+#### Create Datasource
+
+```bash
+PUT /_plugins/geospatial/ip2geo/datasource/my-datasource
+{
+    "endpoint": "https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json",
+    "update_interval_in_days": 3
+}
+```
+
+#### Create Pipeline
+
+```bash
+PUT /_ingest/pipeline/geoip-pipeline
+{
+    "description": "Add geo information from IP address",
+    "processors": [
+        {
+            "ip2geo": {
+                "field": "client_ip",
+                "datasource": "my-datasource",
+                "target_field": "geo",
+                "properties": ["city_name", "country_name", "location"]
+            }
+        }
+    ]
+}
+```
+
+#### Ingest Document
+
+```bash
+PUT /my-index/_doc/1?pipeline=geoip-pipeline
+{
+    "client_ip": "172.0.0.1"
+}
+```
+
+#### Result
+
+```json
+{
+    "client_ip": "172.0.0.1",
+    "geo": {
+        "city_name": "Calera",
+        "country_name": "United States",
+        "location": "33.1063,-86.7583"
+    }
+}
+```
+
+### Available GeoIP Endpoints
+
+OpenSearch provides GeoLite2 databases from MaxMind (CC BY-SA 4.0 license):
+
+| Database | Endpoint |
+|----------|----------|
+| GeoLite2 City | `https://geoip.maps.opensearch.org/v1/geolite2-city/manifest.json` |
+| GeoLite2 Country | `https://geoip.maps.opensearch.org/v1/geolite2-country/manifest.json` |
+| GeoLite2 ASN | `https://geoip.maps.opensearch.org/v1/geolite2-asn/manifest.json` |
+
+### Available Fields
+
+Fields available depend on the datasource. GeoLite2 City provides:
+
+- `country_iso_code`
+- `country_name`
+- `continent_name`
+- `region_iso_code`
+- `region_name`
+- `city_name`
+- `time_zone`
+- `location`
+
+## Limitations
+
+- GeoIP data must be updated within 30 days or lookups return `"error":"ip2geo_data_expired"`
+- Search performance is impacted as the processor queries system indexes
+- For optimal performance, nodes should have both ingest and data roles to avoid internode calls
+- Cache is shared across all IP2Geo processors on each node
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#761](https://github.com/opensearch-project/geospatial/pull/761) | Reset datasource metadata on update failure |
+| v3.1.0 | [#766](https://github.com/opensearch-project/geospatial/pull/766) | Cache refresh and retry on errors |
+| v2.10.0 | - | Initial implementation |
+
+## References
+
+- [IP2Geo Documentation](https://docs.opensearch.org/3.0/ingest-pipelines/processors/ip2geo/): Official processor documentation
+- [MaxMind GeoLite2](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data): GeoIP data source
+- [Geospatial Plugin](https://github.com/opensearch-project/geospatial): Source repository
+
+## Change History
+
+- **v3.1.0** (2026-01-10): Bug fixes for cache synchronization - reset metadata on failure, add retry logic with cache refresh
+- **v2.10.0**: Initial implementation of IP2Geo processor

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -209,6 +209,7 @@
 ## geospatial
 
 - [Geospatial Plugin](geospatial/geospatial-plugin.md)
+- [IP2Geo Processor](geospatial/ip2geo.md)
 
 ## multi-plugin
 

--- a/docs/releases/v3.1.0/features/geospatial/geospatial-ip2geo-fixes.md
+++ b/docs/releases/v3.1.0/features/geospatial/geospatial-ip2geo-fixes.md
@@ -1,0 +1,129 @@
+# Geospatial Ip2Geo Fixes
+
+## Summary
+
+This release includes two bug fixes for the IP2Geo processor in the geospatial plugin. These fixes address cache synchronization issues between primary and replica shards, improving reliability when datasource metadata updates fail or when cache becomes stale.
+
+## Details
+
+### What's New in v3.1.0
+
+Two bug fixes improve the resilience of the IP2Geo cache mechanism:
+
+1. **Metadata Reset on Failure** (PR #761): When datasource metadata updates fail in `postIndex` or `postDelete` operations, the cache is now reset to force a refresh from the primary index shard.
+
+2. **Cache Refresh with Retry** (PR #766): When operations encounter errors, the system now refreshes the IP2Geo cache and retries once before failing.
+
+### Technical Changes
+
+#### Problem Addressed
+
+The IP2Geo processor caches datasource metadata locally on each node. When updates succeed on the primary shard but fail to propagate to replica shards, the cache can become stale. Even after replica recovery from the primary shard, the cache update logic was not triggered, leaving outdated metadata in the cache.
+
+#### Solution Architecture
+
+```mermaid
+graph TB
+    subgraph "Before Fix"
+        A1[Primary Shard Update] --> B1[Replica Update Fails]
+        B1 --> C1[Cache Stale]
+        C1 --> D1[Incorrect GeoIP Data]
+    end
+    
+    subgraph "After Fix"
+        A2[Primary Shard Update] --> B2[Replica Update Fails]
+        B2 --> C2[Reset Metadata Cache]
+        C2 --> D2[Force Refresh from Primary]
+        D2 --> E2[Correct GeoIP Data]
+    end
+```
+
+#### Key Changes in Ip2GeoCachedDao
+
+| Method | Change | Purpose |
+|--------|--------|---------|
+| `postIndex(ShardId, Index, Exception)` | New override | Reset cache on indexing exception |
+| `postIndex(ShardId, Index, IndexResult)` | Enhanced | Reset cache on failure result, add logging |
+| `postDelete(ShardId, Delete, Exception)` | New override | Reset cache on delete exception |
+| `postDelete(ShardId, Delete, DeleteResult)` | Enhanced | Reset cache on failure result, add logging |
+| `clearMetadata()` | New method | Reset all datasource metadata |
+| `refreshDatasource(String)` | New method | Refresh specific datasource from index |
+| `getGeoData(String, String, String)` | New signature | Added datasourceName parameter for retry logic |
+
+#### Retry Logic Flow
+
+```mermaid
+flowchart TB
+    A[getGeoData Request] --> B{Cache Hit?}
+    B -->|Yes| C[Return Cached Data]
+    B -->|No| D[Fetch from Index]
+    D --> E{Success?}
+    E -->|Yes| F[Cache & Return]
+    E -->|No| G[Refresh Datasource]
+    G --> H[Retry Fetch]
+    H --> I{Success?}
+    I -->|Yes| J[Cache & Return]
+    I -->|No| K[Throw Exception]
+```
+
+#### Thread Safety Improvement
+
+The `getMetadata()` method was updated to use a local variable pattern to prevent null pointer exceptions when another thread clears the metadata during access:
+
+```java
+// Before: Direct field access could return null unexpectedly
+if (metadata != null) {
+    return metadata;
+}
+
+// After: Local variable ensures non-null return
+Map<String, DatasourceMetadata> currentMetadata = metadata;
+if (currentMetadata != null) {
+    return currentMetadata;
+}
+```
+
+### Usage Example
+
+No configuration changes required. The fixes are automatic improvements to the existing IP2Geo processor behavior.
+
+```json
+PUT /_ingest/pipeline/my-pipeline
+{
+  "processors": [
+    {
+      "ip2geo": {
+        "field": "client_ip",
+        "datasource": "my-datasource",
+        "target_field": "geo"
+      }
+    }
+  ]
+}
+```
+
+### Migration Notes
+
+- No migration required
+- Existing pipelines automatically benefit from improved reliability
+- The `getGeoData` method signature changed internally (added `datasourceName` parameter), but this is an internal API
+
+## Limitations
+
+- Retry logic adds one additional attempt, which may slightly increase latency on first failure
+- Cache reset affects all datasources on the node, not just the failing one
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#761](https://github.com/opensearch-project/geospatial/pull/761) | Reset datasource metadata when failed to update it in postIndex and postDelete |
+| [#766](https://github.com/opensearch-project/geospatial/pull/766) | Refresh the Ip2Geo cache and retry one more time when we run into an issue |
+
+## References
+
+- [IP2Geo Documentation](https://docs.opensearch.org/3.0/ingest-pipelines/processors/ip2geo/): Official IP2Geo processor documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/geospatial/ip2geo.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -127,3 +127,7 @@
 ### Remote
 
 - [Security CVE Fixes](features/remote/security-cve-fixes.md) - CVE-2025-27820 fix for Apache HttpClient in opensearch-remote-metadata-sdk
+
+### Geospatial
+
+- [Geospatial Ip2Geo Fixes](features/geospatial/geospatial-ip2geo-fixes.md) - Cache synchronization fixes for IP2Geo processor with metadata reset and retry logic


### PR DESCRIPTION
## Summary

This PR adds documentation for the Geospatial Ip2Geo Fixes in OpenSearch v3.1.0.

## Changes

### Release Report
- `docs/releases/v3.1.0/features/geospatial/geospatial-ip2geo-fixes.md`

### Feature Report
- `docs/features/geospatial/ip2geo.md` (new)

### Index Updates
- Updated `docs/releases/v3.1.0/index.md`
- Updated `docs/features/index.md`

## Key Findings

Two bug fixes improve the resilience of the IP2Geo cache mechanism:

1. **PR #761**: Reset datasource metadata when updates fail in `postIndex` and `postDelete` operations to force refresh from primary shard
2. **PR #766**: Refresh IP2Geo cache and retry once when operations encounter errors

These fixes address cache synchronization issues between primary and replica shards.

## Related Issue

Closes #864