### PR TITLE
docs: add flow-framework-improvements report for v3.1.0

### DIFF
--- a/docs/features/flow-framework/flow-framework.md
+++ b/docs/features/flow-framework/flow-framework.md
@@ -190,6 +190,9 @@ POST /_plugins/_flow_framework/workflow/<id>/_deprovision
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#1151](https://github.com/opensearch-project/flow-framework/pull/1151) | Fixing llm field processing in RegisterAgentStep |
+| v3.1.0 | [#1154](https://github.com/opensearch-project/flow-framework/pull/1154) | Include exception type in WorkflowState error field even if no cause |
+| v3.1.0 | [#1155](https://github.com/opensearch-project/flow-framework/pull/1155) | Pass llm spec params to builder |
 | v3.1.0 | [#1141](https://github.com/opensearch-project/flow-framework/pull/1141) | Conditionally include ddb-client dependency only if env variable set |
 | v3.1.0 | [#1137](https://github.com/opensearch-project/flow-framework/pull/1137) | Add data summary with log pattern agent template |
 | v3.0.0 | [#1026](https://github.com/opensearch-project/flow-framework/pull/1026) | Fix breaking changes for 3.0.0 release |
@@ -213,6 +216,9 @@ POST /_plugins/_flow_framework/workflow/<id>/_deprovision
 - [Workflow Tutorial](https://docs.opensearch.org/3.0/automating-configurations/workflow-tutorial/)
 - [Workflow APIs](https://docs.opensearch.org/3.0/automating-configurations/api/index/)
 - [Workflow Template Security](https://docs.opensearch.org/3.0/automating-configurations/workflow-security/)
+- [Register Agent API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/agent-apis/register-agent/)
+- [Flow Agents](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/agents/flow/)
+- [Issue #1153](https://github.com/opensearch-project/flow-framework/issues/1153): Workflow state error messages don't include FFE/WSE types
 - [Issue #1095](https://github.com/opensearch-project/flow-framework/issues/1095): Config parser tenant_id handling
 - [Issue #1097](https://github.com/opensearch-project/flow-framework/issues/1097): Action listener completion
 - [Issue #1106](https://github.com/opensearch-project/flow-framework/issues/1106): Reprovision timeout response
@@ -223,7 +229,7 @@ POST /_plugins/_flow_framework/workflow/<id>/_deprovision
 
 ## Change History
 
-- **v3.1.0** (2025-07-15): Conditional DynamoDB client dependency inclusion via environment variable; New data summary with log pattern agent template for query assist
+- **v3.1.0** (2025-07-15): Bug fixes for RegisterAgentStep LLM field processing, exception type in WorkflowState error messages, and LLM spec parameter passing; Conditional DynamoDB client dependency inclusion via environment variable; New data summary with log pattern agent template for query assist
 - **v3.0.0** (2025-05-06): OpenSearch 3.0 compatibility fixes, per-tenant provisioning throttling, REST status code corrections, config parser fix for tenant_id, synchronous provisioning action listener fix, reprovision timeout response fix, ToolStep attributes field, text-to-visualization templates
 - **v2.18.0** (2024-11-05): Added optional config field to tool step for static tool parameters; Incremental resource removal during deprovisioning for better reliability; Removed Painless scripts for workflow state updates with optimistic locking; Fixed template update location in ReprovisionWorkflowTransportAction
 - **v2.17.0** (2024-10-01): Initial Reprovision API implementation supporting updates to search pipelines, ingest pipelines, and index settings

--- a/docs/releases/v3.1.0/features/flow-framework/flow-framework-improvements.md
+++ b/docs/releases/v3.1.0/features/flow-framework/flow-framework-improvements.md
@@ -1,0 +1,122 @@
+# Flow Framework Improvements
+
+## Summary
+
+This release includes three bug fixes for the Flow Framework plugin that improve the RegisterAgentStep functionality and error handling in workflow provisioning. The fixes address issues with LLM field processing, exception type reporting in workflow state errors, and LLM spec parameter passing.
+
+## Details
+
+### What's New in v3.1.0
+
+Three bug fixes improve the reliability and usability of Flow Framework:
+
+1. **LLM Field Processing Fix**: Corrected how the `llm` field is parsed in RegisterAgentStep when a model ID is provided
+2. **Exception Type in Error Messages**: WorkflowState error field now consistently includes the exception type even when there's no cause
+3. **LLM Spec Parameters Fix**: LLM spec parameters are now properly passed to the LLMSpec builder in RegisterAgentStep
+
+### Technical Changes
+
+#### RegisterAgentStep LLM Field Processing (PR #1151)
+
+The RegisterAgentStep now correctly handles the `llm` field as a nested JSON object instead of flat parameters:
+
+**Before (broken):**
+```json
+{
+  "llm.model_id": "xyz",
+  "llm.parameters": {
+    "max_iteration": "5"
+  }
+}
+```
+
+**After (fixed):**
+```json
+{
+  "llm": {
+    "model_id": "xyz",
+    "parameters": {
+      "max_iteration": "5",
+      "stop_when_no_tool_found": "true"
+    }
+  }
+}
+```
+
+Key changes in `RegisterAgentStep.java`:
+- Added `LLM` constant to `CommonValue.java` for the llm field
+- Updated `WorkflowNode.java` to include `llm` in `MAP_FIELDS` set for proper parsing
+- Refactored LLM field processing to parse as a JSON map using `XContentHelper.convertToMap()`
+- Added validation for LLM parameters map (must be string-to-string)
+
+#### Exception Type in WorkflowState Error (PR #1154)
+
+Fixed inconsistent error message formatting in `ProvisionWorkflowTransportAction.java`:
+
+**Before:**
+- With cause: `"RuntimeException during step step_1, restStatus: INTERNAL_SERVER_ERROR"`
+- Without cause: `"Error message during step step_1, restStatus: BAD_REQUEST"` (missing exception type)
+
+**After:**
+- Both cases now include exception type: `"WorkflowStepException during step step_1, Simulated failure, restStatus: BAD_REQUEST"`
+
+The fix ensures the exception class name is always prepended to the error message for consistent debugging.
+
+#### LLM Spec Parameters Passing (PR #1155)
+
+Fixed a bug where LLM spec parameters were validated but not actually passed to the LLMSpec builder:
+
+```java
+// Before: Parameters validated but not used
+if (llmParams != null) {
+    validateLLMParametersMap(llmParams);
+}
+
+// After: Parameters validated AND added to builder
+if (llmParams != null) {
+    validateLLMParametersMap(llmParams);
+    llmParameters.putAll((Map<String, String>) llmParams);
+}
+```
+
+### Usage Example
+
+```json
+{
+  "name": "my-agent",
+  "type": "flow",
+  "llm": {
+    "model_id": "<model_id>",
+    "parameters": {
+      "max_iteration": "5",
+      "system_instruction": "You are a helpful assistant.",
+      "prompt": "${parameters.question}"
+    }
+  },
+  "tools": [...]
+}
+```
+
+## Limitations
+
+- LLM parameters must be a string-to-string map; non-string values will cause validation errors
+- These fixes are also backported to v2.19.3
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1151](https://github.com/opensearch-project/flow-framework/pull/1151) | Fixing llm field processing in RegisterAgentStep |
+| [#1154](https://github.com/opensearch-project/flow-framework/pull/1154) | Include exception type in WorkflowState error field even if no cause |
+| [#1155](https://github.com/opensearch-project/flow-framework/pull/1155) | Pass llm spec params to builder |
+
+## References
+
+- [Issue #1153](https://github.com/opensearch-project/flow-framework/issues/1153): Workflow state error messages don't include FFE/WSE types
+- [Register Agent API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/agent-apis/register-agent/): Official documentation for agent registration
+- [Flow Agents](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/agents/flow/): Flow agent documentation
+- [Workflow Steps](https://docs.opensearch.org/3.0/automating-configurations/workflow-steps/): Workflow step reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/flow-framework/flow-framework.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -96,6 +96,7 @@
 ### Flow Framework
 
 - [Flow Framework Dependencies](features/flow-framework/flow-framework-dependencies.md) - Conditional DynamoDB client dependency and data summary with log pattern agent template
+- [Flow Framework Improvements](features/flow-framework/flow-framework-improvements.md) - Bug fixes for RegisterAgentStep LLM field processing, exception type in error messages, and LLM spec parameter passing
 
 ### Index Management
 


### PR DESCRIPTION
## Summary

This PR adds documentation for Flow Framework bug fixes in v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/flow-framework/flow-framework-improvements.md`
- Feature report: `docs/features/flow-framework/flow-framework.md` (updated)

### Key Changes in v3.1.0
- **PR #1151**: Fixed LLM field processing in RegisterAgentStep - now correctly handles nested `llm` JSON object instead of flat parameters
- **PR #1154**: WorkflowState error field now consistently includes exception type even when there's no cause
- **PR #1155**: LLM spec parameters are now properly passed to the LLMSpec builder

### Resources Used
- PR: #1151, #1154, #1155
- Issue: #1153
- Docs: https://docs.opensearch.org/3.0/ml-commons-plugin/api/agent-apis/register-agent/

Closes #863