### PR TITLE
docs: add test-infrastructure report for v3.1.0

### DIFF
--- a/docs/features/custom-codecs/custom-codecs.md
+++ b/docs/features/custom-codecs/custom-codecs.md
@@ -179,6 +179,7 @@ Benchmark results comparing codecs against the default LZ4 codec (using `nyc_tax
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#255](https://github.com/opensearch-project/custom-codecs/pull/255) | Fix version on BWC test dependency |
 | v3.0.0 | [#228](https://github.com/opensearch-project/custom-codecs/pull/228) | Upgrade to Lucene 10.1.0 and introduce new Codec implementation |
 | v3.0.0 | [#232](https://github.com/opensearch-project/custom-codecs/pull/232) | Bump ZSTD lib version to 1.5.6-1 |
 | v3.0.0 | [#235](https://github.com/opensearch-project/custom-codecs/pull/235) | Fix build due to phasing off SecurityManager in favor of Java Agent |
@@ -195,6 +196,7 @@ Benchmark results comparing codecs against the default LZ4 codec (using `nyc_tax
 
 ## Change History
 
+- **v3.1.0** (2025-09-16): Fixed BWC test dependency version and added java-agent plugin to BWC tests
 - **v3.0.0** (2025-05-06): Upgraded to Lucene 10.1.0 with new codec implementations (Lucene101*), bumped zstd-jni to 1.5.6-1, migrated to Java Agent from SecurityManager
 - **v2.15.0** (2024-06-25): Added QAT hardware-accelerated codecs (`qat_lz4`, `qat_deflate`)
 - **v2.9.0** (2023-07-24): Initial implementation of ZSTD codecs (`zstd`, `zstd_no_dict`)

--- a/docs/releases/v3.1.0/features/custom-codecs/test-infrastructure.md
+++ b/docs/releases/v3.1.0/features/custom-codecs/test-infrastructure.md
@@ -1,0 +1,66 @@
+# Build/Test Infrastructure
+
+## Summary
+
+This bugfix updates the backward compatibility (BWC) test infrastructure in the custom-codecs plugin to align with OpenSearch v3.1.0. The change ensures BWC tests use the correct OpenSearch version dependency and includes the required Java agent plugin for compatibility with the SecurityManager replacement.
+
+## Details
+
+### What's New in v3.1.0
+
+The BWC test configuration was updated to:
+1. Update the default OpenSearch version from `3.0.0-alpha1-SNAPSHOT` to `3.1.0-SNAPSHOT`
+2. Add the `opensearch.java-agent` plugin required for Java 21+ compatibility
+
+### Technical Changes
+
+#### Configuration Updates
+
+| Setting | Before | After |
+|---------|--------|-------|
+| `opensearch_version` | `3.0.0-alpha1-SNAPSHOT` | `3.1.0-SNAPSHOT` |
+| `opensearch.java-agent` plugin | Not applied | Applied |
+
+#### Build Configuration
+
+The `bwc-test/build.gradle` file was modified:
+
+```groovy
+apply plugin: 'opensearch.build'
+apply plugin: 'opensearch.java-agent'  // Added for Java 21+ support
+apply plugin: 'opensearch.rest-test'
+apply plugin: 'java'
+```
+
+```groovy
+buildscript {
+    ext {
+        opensearch_version = System.getProperty("opensearch.version", "3.1.0-SNAPSHOT")
+        opensearch_group = "org.opensearch"
+    }
+}
+```
+
+### Migration Notes
+
+No migration required. This is an internal build infrastructure change that does not affect plugin functionality or user-facing APIs.
+
+## Limitations
+
+- BWC tests require the appropriate plugin artifacts to be available in the `src/test/resources/` directory for the versions being tested
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#255](https://github.com/opensearch-project/custom-codecs/pull/255) | Fix version on bwc test dependency |
+| [#256](https://github.com/opensearch-project/custom-codecs/pull/256) | Backport to 3.1 branch |
+
+## References
+
+- [PR #255](https://github.com/opensearch-project/custom-codecs/pull/255): Main implementation
+- [custom-codecs repository](https://github.com/opensearch-project/custom-codecs): OpenSearch custom Lucene codecs plugin
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/custom-codecs/custom-codecs.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -132,3 +132,7 @@
 ### Geospatial
 
 - [Geospatial Ip2Geo Fixes](features/geospatial/geospatial-ip2geo-fixes.md) - Cache synchronization fixes for IP2Geo processor with metadata reset and retry logic
+
+### Custom Codecs
+
+- [Build/Test Infrastructure](features/custom-codecs/test-infrastructure.md) - Fix BWC test dependency version and add java-agent plugin


### PR DESCRIPTION
## Summary

Add release report for Build/Test Infrastructure bugfix in custom-codecs plugin for v3.1.0.

## Changes

- Created release report: `docs/releases/v3.1.0/features/custom-codecs/test-infrastructure.md`
- Updated feature report: `docs/features/custom-codecs/custom-codecs.md`
- Updated release index: `docs/releases/v3.1.0/index.md`

## Related Issue

Closes #862

## Key Changes in v3.1.0

- Fixed BWC test dependency version from `3.0.0-alpha1-SNAPSHOT` to `3.1.0-SNAPSHOT`
- Added `opensearch.java-agent` plugin to BWC tests for Java 21+ compatibility

## Resources Used

- PR: [opensearch-project/custom-codecs#255](https://github.com/opensearch-project/custom-codecs/pull/255)