### PR TITLE
docs: add Security Dashboards UI Fixes report for v3.1.0

### DIFF
--- a/docs/features/dashboards-assistant/dashboards-assistant.md
+++ b/docs/features/dashboards-assistant/dashboards-assistant.md
@@ -1,0 +1,101 @@
+# Dashboards Assistant
+
+## Summary
+
+The OpenSearch Dashboards Assistant is a plugin that enables users to interact with an AI assistant through chat or various OpenSearch Dashboards pages. It provides natural language query capabilities, in-context insights, and visualization generation features.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        subgraph "Dashboards Assistant Plugin"
+            ChatUI[Chat UI]
+            IncontextInsight[In-context Insight]
+            NLQVis[NLQ Visualization]
+            ConversationService[Conversation Service]
+            ConversationLoadService[Conversation Load Service]
+        end
+        
+        subgraph "Services"
+            HTTP[HTTP Service]
+            Overlays[Overlays Service]
+            Sidecar[Sidecar Service]
+        end
+    end
+    
+    subgraph "Backend"
+        AssistantAPI[Assistant API]
+        SummaryAPI[Summary API]
+        InsightAPI[Insight API]
+    end
+    
+    ChatUI --> ConversationService
+    ChatUI --> ConversationLoadService
+    IncontextInsight --> SummaryAPI
+    IncontextInsight --> InsightAPI
+    NLQVis --> AssistantAPI
+    ConversationService --> HTTP
+    ConversationLoadService --> HTTP
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Chat UI | Main chat interface for interacting with the AI assistant |
+| In-context Insight | Provides AI-generated insights and summaries for alerts and other data |
+| NLQ Visualization | Natural language query visualization embeddable |
+| Conversation Service | Manages conversation history and pagination |
+| Conversation Load Service | Handles loading individual conversations and latest conversation ID |
+
+### Key Features
+
+#### Chat Interface
+- Sidecar-based chat panel
+- Conversation history management
+- Real-time message streaming
+- Conversation persistence
+
+#### In-context Insights
+- AI-generated summaries for alerts
+- RAG-based insights with context
+- Lazy loading of insights (triggered on user action)
+
+#### NLQ Visualization
+- Natural language to visualization conversion
+- Embeddable visualization component
+- Integration with dashboards
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `assistant.chat.enabled` | Enable/disable chat functionality | `true` |
+| `assistant.incontextInsight.enabled` | Enable/disable in-context insights | `true` |
+
+## Limitations
+
+- NLQ Visualization is not available from the "Create new" dropdown menu (by design)
+- Insights API calls are deferred until user explicitly requests them
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#579](https://github.com/opensearch-project/dashboards-assistant/pull/579) | Fix unnecessary embeddable in create new dropdown |
+| v3.1.0 | [#548](https://github.com/opensearch-project/dashboards-assistant/pull/548) | Log error body or message instead of the entire error object |
+| v3.1.0 | [#520](https://github.com/opensearch-project/dashboards-assistant/pull/520) | Fix http request for insights to be triggered only after view insights button is clicked |
+| v3.1.0 | [#569](https://github.com/opensearch-project/dashboards-assistant/pull/569) | Fix chat page conversation loading state |
+
+## References
+
+- [dashboards-assistant repository](https://github.com/opensearch-project/dashboards-assistant)
+- [Text to Visualization](text-to-visualization.md)
+- [AI Assistant Chatbot](ai-assistant-chatbot.md)
+
+## Change History
+
+- **v3.1.0** (2026-01-10): Bug fixes for UI behavior, error logging, insights request timing, and conversation loading state

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -311,6 +311,7 @@
 
 - [AI Assistant / Chatbot](dashboards-assistant/ai-assistant-chatbot.md)
 - [CI Configuration](dashboards-assistant/ci-configuration.md)
+- [Dashboards Assistant](dashboards-assistant/dashboards-assistant.md)
 - [Text to Visualization (t2viz)](dashboards-assistant/text-to-visualization.md)
 
 ## k-nn

--- a/docs/releases/v3.1.0/features/dashboards-assistant/security-dashboards-ui-fixes.md
+++ b/docs/releases/v3.1.0/features/dashboards-assistant/security-dashboards-ui-fixes.md
@@ -1,0 +1,92 @@
+# Security Dashboards UI Fixes
+
+## Summary
+
+This release includes four bug fixes for the OpenSearch Dashboards Assistant plugin that improve UI behavior, error logging, and performance. The fixes address issues with unnecessary embeddable options in dropdown menus, improved error logging, optimized HTTP request timing for insights, and better conversation loading state management.
+
+## Details
+
+### What's New in v3.1.0
+
+This release focuses on improving the user experience and code quality of the Dashboards Assistant plugin through targeted bug fixes.
+
+### Technical Changes
+
+#### Fix Unnecessary Embeddable in Create New Dropdown (PR #579)
+
+The "Visualization with natural language" option was incorrectly appearing in the "Create new" dropdown menu. This fix adds a `canCreateNew()` method to `NLQVisualizationEmbeddableFactory` that returns `false`, preventing the option from appearing in the dropdown.
+
+**Changed Files:**
+- `public/components/visualization/embeddable/nlq_vis_embeddable_factory.ts`
+
+```typescript
+public canCreateNew() {
+  return false;
+}
+```
+
+#### Improved Error Logging (PR #548)
+
+Error logging was previously outputting entire error objects, which could be verbose and difficult to parse. This fix modifies the error handler to log only the error body or message.
+
+**Changed Files:**
+- `server/routes/error_handler.ts`
+
+```typescript
+// Before
+logger.error('Error occurred', e);
+
+// After
+logger.error('Error occurred', e.body || e.message);
+```
+
+#### Optimized Insights HTTP Request Timing (PR #520)
+
+Previously, the HTTP request for insights was triggered immediately after the summary request, even if the user didn't intend to view insights. This fix defers the insights API call until the user explicitly clicks the "View insights" button.
+
+**Changed Files:**
+- `public/components/incontext_insight/generate_popover_body.tsx`
+
+Key changes:
+- Extracted `getInsightParams()` helper function for reuse
+- Added `handleInsightClick()` function that triggers insight generation only on button click
+- Removed automatic insight generation from the summary response handler
+
+#### Fixed Chat Page Conversation Loading State (PR #569)
+
+The chat page was showing a loading screen during history page loading when switching conversations. This fix introduces a standalone `ConversationLoadService` with its own status observable to separate conversation loading from history page loading.
+
+**Changed Files:**
+- `public/services/conversation_load_service.ts`
+- `public/chat_header_button.tsx`
+- `public/tabs/chat/chat_page.tsx`
+
+Key changes:
+- Added `getLatestConversationId()` method to `ConversationLoadService`
+- Created separate `latestIdStatus$` observable for tracking conversation ID loading
+- Refactored `loadLatestConversation()` to use the new service method
+
+### Usage Example
+
+No configuration changes are required. These fixes are automatically applied when upgrading to v3.1.0.
+
+## Limitations
+
+- The NLQ visualization embeddable is still available through other means (e.g., from within the assistant chat), just not from the "Create new" dropdown.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#579](https://github.com/opensearch-project/dashboards-assistant/pull/579) | Fix unnecessary embeddable in create new dropdown |
+| [#548](https://github.com/opensearch-project/dashboards-assistant/pull/548) | Log error body or message instead of the entire error object |
+| [#520](https://github.com/opensearch-project/dashboards-assistant/pull/520) | Fix http request for insights to be triggered only after view insights button is clicked |
+| [#569](https://github.com/opensearch-project/dashboards-assistant/pull/569) | Fix chat page conversation loading state |
+
+## References
+
+- [dashboards-assistant repository](https://github.com/opensearch-project/dashboards-assistant)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-assistant/dashboards-assistant.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -105,6 +105,7 @@
 ### Dashboards Assistant
 
 - [Dashboard Assistant CI Fixes](features/dashboards-assistant/dashboard-assistant-ci-fixes.md) - Fix CI failures due to path alias babel configuration changes
+- [Security Dashboards UI Fixes](features/dashboards-assistant/security-dashboards-ui-fixes.md) - Bug fixes for embeddable dropdown, error logging, insights request timing, and conversation loading state
 
 ### Multi-Plugin
 


### PR DESCRIPTION
## Overview

This PR adds documentation for the Security Dashboards UI Fixes release item in OpenSearch v3.1.0.

## Reports Created

- Release report: `docs/releases/v3.1.0/features/dashboards-assistant/security-dashboards-ui-fixes.md`
- Feature report: `docs/features/dashboards-assistant/dashboards-assistant.md` (created)

## Summary

This release item includes 4 bug fixes for the OpenSearch Dashboards Assistant plugin:

1. **Fix unnecessary embeddable in create new dropdown** (PR #579)
   - Removed "Visualization with natural language" from the "Create new" dropdown menu

2. **Log error body or message instead of the entire error object** (PR #548)
   - Improved error logging to output only the error body or message

3. **Fix http request for insights to be triggered only after view insights button is clicked** (PR #520)
   - Deferred insights API call until user explicitly clicks "View insights"

4. **Fix chat page conversation loading state** (PR #569)
   - Introduced standalone ConversationLoadService to separate conversation loading from history page loading

## Key Changes in v3.1.0

- Improved UI behavior by hiding NLQ visualization from create new dropdown
- Better error logging for debugging
- Optimized network requests by lazy-loading insights
- Fixed loading state issues in chat page

## Resources Used

- PR: [#579](https://github.com/opensearch-project/dashboards-assistant/pull/579)
- PR: [#548](https://github.com/opensearch-project/dashboards-assistant/pull/548)
- PR: [#520](https://github.com/opensearch-project/dashboards-assistant/pull/520)
- PR: [#569](https://github.com/opensearch-project/dashboards-assistant/pull/569)

Closes #861