### PR TITLE
docs: add security-debugging report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -140,6 +140,7 @@
 - [Security Auth Enhancements](security/security-auth-enhancements.md)
 - [Security Bugfixes](security/security-bugfixes.md)
 - [Security Configuration](security/security-configuration.md)
+- [Security Debugging](security/security-debugging.md)
 - [Security Permissions](security/security-permissions.md)
 - [Security Plugin](security/security-plugin.md)
 - [Security Plugin Dependencies](security/security-plugin-dependencies.md)

--- a/docs/features/security/security-debugging.md
+++ b/docs/features/security/security-debugging.md
@@ -1,0 +1,124 @@
+# Security Debugging
+
+## Summary
+
+Security Debugging provides enhanced error messages and diagnostic information when the OpenSearch Security plugin fails to initialize. This feature helps administrators quickly identify and resolve common security initialization issues by providing contextual information about the underlying cause of failures.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Security Initialization Check"
+        A[Incoming Request] --> B[SecurityFilter / BackendRegistry]
+        B --> C{isInitialized?}
+        C -->|No| D[ClusterInfoHolder]
+        D --> E{hasClusterManager?}
+        E -->|No| F["Error + 'Cluster manager not present'"]
+        E -->|Yes| G["Error: Security not initialized"]
+        C -->|Yes| H[Continue Processing]
+    end
+    
+    subgraph "ClusterInfoHolder"
+        I[ClusterStateListener] --> J[Track Cluster State]
+        J --> K[nodes]
+        K --> L[getClusterManagerNode]
+    end
+    
+    D --> I
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[ClusterChangedEvent] --> B[ClusterInfoHolder]
+    B --> C[Store DiscoveryNodes]
+    D[Security Check] --> E{Initialized?}
+    E -->|No| F[Query ClusterInfoHolder]
+    F --> G[hasClusterManager]
+    G --> H[Build Error Message]
+    H --> I[Return to Client]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ClusterInfoHolder` | Tracks cluster state including node information and cluster manager presence |
+| `BackendRegistry` | Handles authentication and checks security initialization status |
+| `SecurityFilter` | Action filter that validates security state before processing requests |
+| `PrivilegesEvaluator` | Evaluates user privileges and includes diagnostic info in exceptions |
+| `DynamicConfigFactory` | Manages dynamic security configuration with enhanced debug logging |
+
+### Key Methods
+
+| Method | Class | Description |
+|--------|-------|-------------|
+| `hasClusterManager()` | `ClusterInfoHolder` | Returns `true` if a cluster manager node is present in the cluster |
+| `authenticate()` | `BackendRegistry` | Enhanced to include cluster manager status in error responses |
+| `apply()` | `SecurityFilter` | Enhanced to include diagnostic info when security is not initialized |
+| `createContext()` | `PrivilegesEvaluator` | Throws exception with cluster manager status if not initialized |
+| `evaluate()` | `PrivilegesEvaluator` | Throws exception with cluster manager status if not initialized |
+
+### Configuration
+
+No additional configuration is required. The enhanced error messages are automatically included when security initialization fails.
+
+### Usage Example
+
+**Scenario: Cluster without a cluster manager**
+
+```yaml
+# opensearch.yml - Node configured without cluster manager role
+node.roles: [data, ingest]
+```
+
+**API Request:**
+```bash
+curl -X GET "https://localhost:9200/my-index/_search" \
+  -H 'Content-Type: application/json' \
+  -u admin:admin \
+  --insecure
+```
+
+**Response (v3.1.0+):**
+```
+OpenSearch Security is not initialized. Cluster manager not present
+```
+
+**Log Output:**
+```
+ERROR [...] OpenSearch Security not initialized. Cluster manager not present (you may need to run securityadmin)
+```
+
+### Common Causes of Security Not Initialized
+
+| Cause | Error Message | Resolution |
+|-------|---------------|------------|
+| No cluster manager | "Cluster manager not present" | Ensure at least one node has `cluster_manager` or `master` role |
+| Security index not created | Base message only | Run `securityadmin.sh` to initialize security index |
+| Network partition | May show cluster manager missing | Check network connectivity between nodes |
+
+## Limitations
+
+- Currently only detects missing cluster manager as a diagnostic cause
+- Other causes (network issues, disk space, etc.) are not yet detected
+- Debug logging requires appropriate log level configuration
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#5370](https://github.com/opensearch-project/security/pull/5370) | Adds details for debugging Security not initialized error |
+
+## References
+
+- [PR #5370](https://github.com/opensearch-project/security/pull/5370): Initial implementation
+- [Security Settings Documentation](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/security-settings/): OpenSearch security configuration
+- [About Security](https://docs.opensearch.org/3.0/security/): Security plugin overview
+
+## Change History
+
+- **v3.1.0** (2025-06-10): Initial implementation - Added cluster manager presence check to security initialization error messages

--- a/docs/releases/v3.1.0/features/security/security-debugging.md
+++ b/docs/releases/v3.1.0/features/security/security-debugging.md
@@ -1,0 +1,97 @@
+# Security Debugging
+
+## Summary
+
+This enhancement improves the debugging experience when encountering the "OpenSearch Security not initialized" error. Previously, this generic error message provided no context about the underlying cause. In v3.1.0, the error message now includes additional details about potential causes, starting with cluster manager availability status.
+
+## Details
+
+### What's New in v3.1.0
+
+The security plugin now provides more informative error messages when security initialization fails. When the security index cannot be created during node bootup and API calls are made, users now receive contextual information about why initialization may have failed.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Error Detection Flow"
+        A[API Request] --> B{Security Initialized?}
+        B -->|No| C[ClusterInfoHolder]
+        C --> D{Has Cluster Manager?}
+        D -->|No| E["Error: Security not initialized. Cluster manager not present"]
+        D -->|Yes| F["Error: Security not initialized"]
+        B -->|Yes| G[Process Request]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ClusterInfoHolder.hasClusterManager()` | New method to check if a cluster manager node is present |
+| `ClusterInfoHolder.CLUSTER_MANAGER_NOT_PRESENT` | Constant for the "Cluster manager not present" message |
+
+#### Modified Components
+
+| Component | Change |
+|-----------|--------|
+| `BackendRegistry` | Now accepts `ClusterInfoHolder` to check cluster manager status during authentication |
+| `SecurityFilter` | Enhanced to include cluster manager status in error messages for action filter failures |
+| `PrivilegesEvaluator` | Updated `createContext()` and `evaluate()` methods to include cluster manager status in exceptions |
+| `DynamicConfigFactory` | Added debug logging when config update notifications are dispatched |
+
+### Usage Example
+
+**Before v3.1.0:**
+```bash
+curl -X GET "https://localhost:9200/my-index/_search" -u admin:admin --insecure
+
+# Response:
+OpenSearch Security is not initialized
+```
+
+**After v3.1.0:**
+```bash
+curl -X GET "https://localhost:9200/my-index/_search" -u admin:admin --insecure
+
+# Response (when cluster manager is missing):
+OpenSearch Security is not initialized. Cluster manager not present
+```
+
+### How to Reproduce the Scenario
+
+To test this enhanced error message, configure a node without the cluster manager role:
+
+```yaml
+# opensearch.yml
+node.roles: [data, ingest]  # No master/cluster_manager role
+```
+
+When making API calls to this node before a cluster manager is elected, you'll see the enhanced error message.
+
+### Migration Notes
+
+No migration required. This is a backward-compatible enhancement that only affects error message content.
+
+## Limitations
+
+- Currently only detects missing cluster manager as a cause
+- Future enhancements may add detection for other common causes of initialization failure
+- The enhancement focuses on REST API and transport layer errors
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5370](https://github.com/opensearch-project/security/pull/5370) | Adds details for debugging Security not initialized error |
+
+## References
+
+- [PR #5370](https://github.com/opensearch-project/security/pull/5370): Main implementation
+- [Security Settings Documentation](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/security-settings/): OpenSearch security configuration
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/security-debugging.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -49,6 +49,7 @@
 ### Security
 
 - [Security Backend Bug Fixes](features/security/security-backend-bug-fixes.md) - Stale cache post snapshot restore, compliance audit log diff, DLS/FLS filter reader, auth header logging, password reset UI, forecasting permissions
+- [Security Debugging](features/security/security-debugging.md) - Enhanced error messages for "Security not initialized" with cluster manager status
 - [Security Dependency Updates](features/security/security-dependency-updates.md) - 24 dependency updates including Bouncy Castle 1.81, Kafka 4.0.0, and CVE-2024-52798 fix
 - [Security Permissions](features/security/security-permissions.md) - Add forecast roles and fix missing cluster:monitor and mapping get permissions
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security Debugging enhancement in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/security/security-debugging.md`
- Feature report: `docs/features/security/security-debugging.md`

### Key Changes in v3.1.0
- Enhanced "OpenSearch Security not initialized" error messages with cluster manager status
- Added `ClusterInfoHolder.hasClusterManager()` method to detect missing cluster manager
- Updated `BackendRegistry`, `SecurityFilter`, and `PrivilegesEvaluator` to include diagnostic info

### Resources Used
- PR: [opensearch-project/security#5370](https://github.com/opensearch-project/security/pull/5370)
- Docs: [Security Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/security-settings/)

Closes #860