### PR TITLE
docs: add security-role-mapping report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -144,6 +144,7 @@
 - [Security Permissions](security/security-permissions.md)
 - [Security Plugin](security/security-plugin.md)
 - [Security Plugin Dependencies](security/security-plugin-dependencies.md)
+- [Security Role Mapping](security/security-role-mapping.md)
 
 ## security-dashboards
 

--- a/docs/features/security/security-role-mapping.md
+++ b/docs/features/security/security-role-mapping.md
@@ -1,0 +1,145 @@
+# Security Role Mapping
+
+## Summary
+
+Security Role Mapping in OpenSearch allows administrators to map backend roles (from external authentication systems like LDAP, SAML, or OpenID Connect) to OpenSearch security roles. This mapping determines what permissions users have based on their external identity attributes. The ThreadContext stores user information including mapped roles, which plugins can access to make authorization decisions.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph "Authentication"
+        A[User Login] --> B[Authentication Backend]
+        B --> C[Backend Roles]
+    end
+    
+    subgraph "Role Mapping"
+        C --> D[ConfigModel]
+        D --> E[roles_mapping.yml / REST API]
+        E --> F[Mapped Security Roles]
+    end
+    
+    subgraph "Privileges Evaluation"
+        F --> G[PrivilegesEvaluator]
+        G --> H[setUserInfoInThreadContext]
+        H --> I[ThreadContext]
+    end
+    
+    subgraph "Plugin Access"
+        I --> J[Anomaly Detection]
+        I --> K[Alerting]
+        I --> L[Other Plugins]
+    end
+```
+
+### Data Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant AuthBackend as Auth Backend
+    participant ConfigModel
+    participant PrivEval as PrivilegesEvaluator
+    participant ThreadCtx as ThreadContext
+    participant Plugin
+    
+    User->>AuthBackend: Authenticate
+    AuthBackend->>User: User object with backend roles
+    User->>ConfigModel: Resolve role mappings
+    ConfigModel->>PrivEval: Return mapped roles
+    PrivEval->>ThreadCtx: setUserInfoInThreadContext(user, mappedRoles)
+    Plugin->>ThreadCtx: Get user info
+    ThreadCtx->>Plugin: username|backend_roles|mapped_roles|tenant
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `PrivilegesEvaluator` | Evaluates user privileges and sets user info in ThreadContext |
+| `ConfigModel` | Resolves backend roles to security roles using role mappings |
+| `ThreadContext` | Stores user information accessible to plugins |
+| `roles_mapping.yml` | Configuration file for static role mappings |
+| `User` | Immutable object containing user identity and backend roles |
+
+### Configuration
+
+Role mappings can be configured in `roles_mapping.yml`:
+
+```yaml
+all_access:
+  reserved: false
+  backend_roles:
+    - "admin"
+  users:
+    - "admin"
+    
+readall:
+  reserved: false
+  backend_roles:
+    - "readall"
+```
+
+Or via the REST API:
+
+```bash
+PUT _plugins/_security/api/rolesmapping/all_access
+{
+  "backend_roles": ["admin"],
+  "users": ["admin"]
+}
+```
+
+### ThreadContext User Info Format
+
+The user information stored in ThreadContext follows this format:
+
+```
+username|backend_roles|mapped_roles|requested_tenant
+```
+
+Example:
+```
+john|ldap_admin,ldap_users|all_access,readall|global_tenant
+```
+
+### Usage Example
+
+Plugins can access user information from ThreadContext:
+
+```java
+String userInfo = threadContext.getTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT);
+if (userInfo != null) {
+    String[] parts = userInfo.split("\\|");
+    String username = parts[0];
+    String[] backendRoles = parts[1].split(",");
+    String[] mappedRoles = parts[2].split(",");
+    String tenant = parts.length > 3 ? parts[3] : null;
+}
+```
+
+## Limitations
+
+- Role mappings are resolved at authentication time; changes to mappings require re-authentication
+- The ThreadContext user info format uses pipe (`|`) as delimiter; values containing pipes must be escaped
+- Backend roles from external systems must match exactly (case-sensitive) with role mapping configuration
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#5369](https://github.com/opensearch-project/security/pull/5369) | Fix: Include mapped roles when setting userInfo in ThreadContext |
+| v3.1.0 | [#5212](https://github.com/opensearch-project/security/pull/5212) | Performance: Immutable user object |
+
+## References
+
+- [Defining users and roles](https://docs.opensearch.org/3.0/security/access-control/users-roles/): Official documentation
+- [Security settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/security-settings/): Configuration options including `plugins.security.roles_mapping_resolution`
+- [PR #5369](https://github.com/opensearch-project/security/pull/5369): ThreadContext mapped roles fix
+- [PR #5212](https://github.com/opensearch-project/security/pull/5212): Immutable user object implementation
+
+## Change History
+
+- **v3.1.0** (2026-01-10): Fix mapped roles not being included in ThreadContext userInfo after immutable User object change

--- a/docs/releases/v3.1.0/features/security/security-role-mapping.md
+++ b/docs/releases/v3.1.0/features/security/security-role-mapping.md
@@ -1,0 +1,85 @@
+# Security Role Mapping
+
+## Summary
+
+This enhancement fixes an issue where mapped roles were not being included when setting user information in the ThreadContext. After PR #5212 made the User object immutable, the code that temporarily added mapped roles before setting userInfo was inadvertently removed. This fix ensures that plugins like Anomaly Detection and SAP that rely on the ThreadContext user information can correctly access the user's mapped security roles.
+
+## Details
+
+### What's New in v3.1.0
+
+The `setUserInfoInThreadContext` method now explicitly receives and uses the mapped roles instead of relying on `user.getSecurityRoles()`, which no longer contains the dynamically mapped roles after the User object became immutable.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+flowchart TB
+    subgraph "Before Fix"
+        A1[User Object] --> B1[getSecurityRoles]
+        B1 --> C1[ThreadContext userInfo]
+        C1 -.->|Missing mapped roles| D1[Plugins]
+    end
+    
+    subgraph "After Fix"
+        A2[User Object] --> B2[PrivilegesEvaluator]
+        B2 --> C2[mappedRoles from ConfigModel]
+        C2 --> D2[setUserInfoInThreadContext]
+        D2 --> E2[ThreadContext userInfo]
+        E2 -->|Complete role info| F2[Plugins]
+    end
+```
+
+#### Code Changes
+
+| Component | Change |
+|-----------|--------|
+| `PrivilegesEvaluator.java` | Modified `setUserInfoInThreadContext` to accept `Set<String> mappedRoles` parameter |
+| `PrivilegesEvaluator.java` | Updated call site to pass `mappedRoles` from the evaluation context |
+
+#### Method Signature Change
+
+```java
+// Before
+private void setUserInfoInThreadContext(User user)
+
+// After  
+private void setUserInfoInThreadContext(User user, Set<String> mappedRoles)
+```
+
+### Usage Example
+
+The ThreadContext user info format remains unchanged:
+
+```
+username|backend_roles|mapped_roles|requested_tenant
+```
+
+Where `mapped_roles` now correctly contains the roles resolved through `roles_mapping.yml` or the REST API, rather than only the roles stored directly on the User object.
+
+### Migration Notes
+
+No migration required. This is a bug fix that restores expected behavior for plugins relying on ThreadContext user information.
+
+## Limitations
+
+- This fix specifically addresses the regression introduced by the immutable User object change in PR #5212
+- The underlying role mapping configuration and resolution logic remains unchanged
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5369](https://github.com/opensearch-project/security/pull/5369) | Include mapped roles when setting userInfo in ThreadContext |
+| [#5212](https://github.com/opensearch-project/security/pull/5212) | Immutable user object (introduced the regression) |
+
+## References
+
+- [PR #5369](https://github.com/opensearch-project/security/pull/5369): Main implementation
+- [PR #5212](https://github.com/opensearch-project/security/pull/5212): Related immutable user object change
+- [Defining users and roles](https://docs.opensearch.org/3.0/security/access-control/users-roles/): Official documentation on role mapping
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/security/security-role-mapping.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -51,6 +51,7 @@
 - [Security Backend Bug Fixes](features/security/security-backend-bug-fixes.md) - Stale cache post snapshot restore, compliance audit log diff, DLS/FLS filter reader, auth header logging, password reset UI, forecasting permissions
 - [Security Debugging](features/security/security-debugging.md) - Enhanced error messages for "Security not initialized" with cluster manager status
 - [Security Dependency Updates](features/security/security-dependency-updates.md) - 24 dependency updates including Bouncy Castle 1.81, Kafka 4.0.0, and CVE-2024-52798 fix
+- [Security Role Mapping](features/security/security-role-mapping.md) - Fix mapped roles not included in ThreadContext userInfo after immutable User object change
 - [Security Permissions](features/security/security-permissions.md) - Add forecast roles and fix missing cluster:monitor and mapping get permissions
 
 ### Query Insights


### PR DESCRIPTION
## Summary

Add documentation for Security Role Mapping enhancement in v3.1.0.

### Changes
- **Release report**: `docs/releases/v3.1.0/features/security/security-role-mapping.md`
- **Feature report**: `docs/features/security/security-role-mapping.md`
- Updated release and feature indexes

### Related Issue
Closes #859

### Key Findings
This enhancement fixes an issue where mapped roles were not being included when setting user information in the ThreadContext. After PR #5212 made the User object immutable, the code that temporarily added mapped roles before setting userInfo was inadvertently removed.

The fix in PR #5369 ensures that plugins like Anomaly Detection and SAP that rely on the ThreadContext user information can correctly access the user's mapped security roles.