### PR TITLE
docs: add Security Testing Framework report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -146,6 +146,7 @@
 - [Security Plugin](security/security-plugin.md)
 - [Security Plugin Dependencies](security/security-plugin-dependencies.md)
 - [Security Role Mapping](security/security-role-mapping.md)
+- [Security Testing Framework](security/security-testing-framework.md)
 
 ## security-dashboards
 

--- a/docs/features/security/security-testing-framework.md
+++ b/docs/features/security/security-testing-framework.md
@@ -1,0 +1,142 @@
+# Security Testing Framework
+
+## Summary
+
+The Security Testing Framework provides integration test infrastructure for the OpenSearch Security plugin, enabling comprehensive testing of security features including resource access control, plugin extensions, and the sample-resource-plugin. It leverages OpenSearch's Plugin Testing Framework to support `ExtensiblePlugin` patterns in integration tests.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Test Infrastructure"
+        TC[Test Class] --> LC[LocalCluster]
+        LC --> MN[MockNode]
+        MN --> SP[Security Plugin]
+        MN --> SRP[Sample Resource Plugin]
+    end
+    
+    subgraph "Plugin Extension"
+        SP -->|ExtensiblePlugin| RSE[ResourceSharingExtension]
+        SRP -->|implements| RSE
+        SRP -->|extendedPlugins| SP
+    end
+    
+    subgraph "Resource Sharing"
+        RSE --> RSI[Resource Sharing Index]
+        RSI --> RS[ResourceSharing]
+        RS --> SW[ShareWith]
+        SW --> SWAG[SharedWithActionGroup]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Test creates resource] --> B[Security plugin intercepts]
+    B --> C[Create ResourceSharing entry]
+    C --> D[Store in .opensearch_resource_sharing]
+    D --> E[Test shares resource]
+    E --> F[Fetch ResourceSharing doc]
+    F --> G[Update sharing in memory]
+    G --> H[Write back to index]
+    H --> I[Verify access control]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `LocalCluster` | Test cluster builder supporting PluginInfo configuration |
+| `SampleResourcePlugin` | Example plugin demonstrating resource access control |
+| `ResourceSharing` | Model for resource sharing configuration with docId tracking |
+| `ShareWith` | Container for access level configurations |
+| `SharedWithActionGroup` | Access control configuration per action group |
+| `ActionGroupRecipients` | Recipients (users, roles, backend_roles) for an action group |
+| `ResourceSharingIndexHandler` | Handles CRUD operations on resource sharing index |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `extendedPlugins` | List of plugins this plugin extends (in PluginInfo) | Empty list |
+| `.opensearch_resource_sharing` | System index storing resource sharing entries | Auto-created |
+
+### Usage Example
+
+```java
+// Define test cluster with Security plugin and extending plugin
+@ClassRule
+public static LocalCluster cluster = new LocalCluster.Builder()
+    .clusterManager(ClusterManager.SINGLENODE)
+    .plugin(PainlessModulePlugin.class)
+    .plugin(
+        new PluginInfo(
+            SampleResourcePlugin.class.getName(),
+            "classpath plugin",
+            "NA",
+            Version.CURRENT,
+            "1.8",
+            SampleResourcePlugin.class.getName(),
+            null,
+            List.of(OpenSearchSecurityPlugin.class.getName()),
+            false
+        )
+    )
+    .anonymousAuth(true)
+    .authc(AUTHC_HTTPBASIC_INTERNAL)
+    .users(USER_ADMIN, SHARED_WITH_USER)
+    .build();
+
+// Test resource creation and sharing
+@Test
+public void testCreateAndShareResource() throws Exception {
+    // Create resource
+    try (TestRestClient client = cluster.getRestClient(USER_ADMIN)) {
+        String resource = """
+            {"name": "test-resource"}
+            """;
+        HttpResponse response = client.postJson(SAMPLE_RESOURCE_CREATE_ENDPOINT, resource);
+        response.assertStatusCode(HttpStatus.SC_OK);
+        String resourceId = response.getTextFromJsonBody("/message").split(":")[1].trim();
+        
+        // Share with another user
+        String sharePayload = shareWithPayload("read_access", SHARED_WITH_USER);
+        response = client.postJson(SAMPLE_RESOURCE_SHARE_ENDPOINT + "/" + resourceId, sharePayload);
+        response.assertStatusCode(HttpStatus.SC_OK);
+    }
+    
+    // Verify shared user can access
+    try (TestRestClient client = cluster.getRestClient(SHARED_WITH_USER)) {
+        HttpResponse response = client.get(SAMPLE_RESOURCE_GET_ENDPOINT + "/" + resourceId);
+        response.assertStatusCode(HttpStatus.SC_OK);
+    }
+}
+```
+
+## Limitations
+
+- Requires OpenSearch core v3.1.0+ with Plugin Testing Framework enhancements
+- Test plugins must be on the classpath
+- Extensions require `META-INF/services` files for ServiceLoader discovery
+- Resource sharing tests require the Security plugin to be properly configured
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#5322](https://github.com/opensearch-project/security/pull/5322) | Use extendedPlugins in integrationTest framework |
+| v3.1.0 | [#16908](https://github.com/opensearch-project/OpenSearch/pull/16908) | Core Plugin Testing Framework enhancement |
+
+## References
+
+- [PR #5322](https://github.com/opensearch-project/security/pull/5322): Security plugin test framework update
+- [PR #16908](https://github.com/opensearch-project/OpenSearch/pull/16908): Core Plugin Testing Framework
+- [Security Plugin Documentation](https://docs.opensearch.org/3.1/security/index/): OpenSearch Security plugin docs
+- [Plugin Testing Framework](../opensearch/plugin-testing-framework.md): Core testing framework feature
+
+## Change History
+
+- **v3.1.0** (2025-05-13): Use extendedPlugins in integrationTest framework for sample resource plugin testing, refactor resource sharing to use in-memory updates

--- a/docs/releases/v3.1.0/features/security/security-testing-framework.md
+++ b/docs/releases/v3.1.0/features/security/security-testing-framework.md
@@ -1,0 +1,122 @@
+# Security Testing Framework
+
+## Summary
+
+This release item updates the Security plugin's integration test framework to use the `extendedPlugins` mechanism introduced in OpenSearch core PR #16908. This replaces the previous workaround for testing the sample-resource-plugin, enabling proper plugin extension loading in integration tests. Additionally, the resource sharing flow was refactored to modify sharing info in memory instead of using Painless scripts.
+
+## Details
+
+### What's New in v3.1.0
+
+The Security plugin's sample-resource-plugin integration tests now leverage the core OpenSearch Plugin Testing Framework's `extendedPlugins` support. This change:
+
+1. Removes manual workarounds for loading plugin extensions in tests
+2. Enables proper `ExtensiblePlugin` and extension relationships via `PluginInfo`
+3. Refactors resource sharing to use in-memory modifications instead of Painless scripts
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.1.0"
+        A1[Test] --> B1[Manual Resource Sharing Entry]
+        B1 --> C1[Painless Script Update]
+        C1 --> D1[Resource Sharing Index]
+    end
+    
+    subgraph "After v3.1.0"
+        A2[Test] --> B2[PluginInfo with extendedPlugins]
+        B2 --> C2[Automatic Extension Loading]
+        C2 --> D2[In-Memory Sharing Update]
+        D2 --> E2[Direct Index Write]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ResourceSharing.docId` | New field to track document ID for in-memory updates |
+| `ResourceSharing.share()` | New method to modify sharing info in memory |
+| `ShareWith.accessLevels()` | Helper to get all access levels from share configuration |
+| `ShareWith.atAccessLevel()` | Helper to get sharing config at specific access level |
+| `SharedWithActionGroup.share()` | Method to merge sharing targets |
+
+#### API Changes
+
+The `ResourceSharing` class now includes:
+
+```java
+// New field for document tracking
+private String docId;
+
+// New methods for in-memory sharing
+public void share(String accessLevel, SharedWithActionGroup target) {
+    if (shareWith == null) {
+        shareWith = new ShareWith(Set.of(target));
+    } else {
+        SharedWithActionGroup sharedWith = shareWith.atAccessLevel(accessLevel);
+        sharedWith.share(target);
+    }
+}
+```
+
+### Usage Example
+
+```java
+// Integration test using extendedPlugins
+@ClassRule
+public static LocalCluster cluster = new LocalCluster.Builder()
+    .clusterManager(ClusterManager.SINGLENODE)
+    .plugin(PainlessModulePlugin.class)
+    .plugin(
+        new PluginInfo(
+            SampleResourcePlugin.class.getName(),
+            "classpath plugin",
+            "NA",
+            Version.CURRENT,
+            "1.8",
+            SampleResourcePlugin.class.getName(),
+            null,
+            List.of(OpenSearchSecurityPlugin.class.getName()),  // extendedPlugins
+            false
+        )
+    )
+    .anonymousAuth(true)
+    .authc(AUTHC_HTTPBASIC_INTERNAL)
+    .users(USER_ADMIN, SHARED_WITH_USER)
+    .build();
+```
+
+### Migration Notes
+
+For plugin developers using the Security plugin's test framework:
+
+1. Replace manual resource-sharing index entries with proper `PluginInfo` configuration
+2. Use `extendedPlugins` list to declare plugin extension relationships
+3. Remove `ResourceSharingClientAccessor` manual setup - extensions are now loaded automatically
+
+## Limitations
+
+- Requires OpenSearch core v3.1.0+ with PR #16908 merged
+- Only applicable to integration tests using the Security plugin's test framework
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5322](https://github.com/opensearch-project/security/pull/5322) | Use extendedPlugins in integrationTest framework for sample resource plugin testing |
+| [#16908](https://github.com/opensearch-project/OpenSearch/pull/16908) | Enable testing for ExtensiblePlugins using classpath plugins (core dependency) |
+
+## References
+
+- [PR #5322](https://github.com/opensearch-project/security/pull/5322): Main implementation
+- [PR #16908](https://github.com/opensearch-project/OpenSearch/pull/16908): Core Plugin Testing Framework enhancement
+- [Security Plugin Documentation](https://docs.opensearch.org/3.1/security/index/): OpenSearch Security plugin docs
+
+## Related Feature Report
+
+- [Plugin Testing Framework](../../../features/opensearch/plugin-testing-framework.md)
+- [Security Testing Framework](../../../features/security/security-testing-framework.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -54,6 +54,7 @@
 - [Security Performance Improvements](features/security/security-performance-improvements.md) - Immutable User object with serialization caching for reduced inter-node communication overhead
 - [Security Role Mapping](features/security/security-role-mapping.md) - Fix mapped roles not included in ThreadContext userInfo after immutable User object change
 - [Security Permissions](features/security/security-permissions.md) - Add forecast roles and fix missing cluster:monitor and mapping get permissions
+- [Security Testing Framework](features/security/security-testing-framework.md) - Use extendedPlugins in integrationTest framework for sample resource plugin testing
 
 ### Query Insights
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security Testing Framework enhancement in v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/security/security-testing-framework.md`
- Feature report: `docs/features/security/security-testing-framework.md`

### Key Changes in v3.1.0
- Security plugin's sample-resource-plugin integration tests now use `extendedPlugins` mechanism from OpenSearch core PR #16908
- Removes manual workarounds for loading plugin extensions in tests
- Refactors resource sharing to use in-memory modifications instead of Painless scripts

### Source PR
- [opensearch-project/security#5322](https://github.com/opensearch-project/security/pull/5322): Use extendedPlugins in integrationTest framework for sample resource plugin testing

### Related
- [opensearch-project/OpenSearch#16908](https://github.com/opensearch-project/OpenSearch/pull/16908): Core Plugin Testing Framework enhancement

Closes #857