### PR TITLE
docs: add Security JWT Enhancements report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -147,6 +147,7 @@
 - [Security Plugin Dependencies](security/security-plugin-dependencies.md)
 - [Security Role Mapping](security/security-role-mapping.md)
 - [Security Testing Framework](security/security-testing-framework.md)
+- [JWT Authentication](security/jwt-authentication.md)
 
 ## security-dashboards
 

--- a/docs/features/security/jwt-authentication.md
+++ b/docs/features/security/jwt-authentication.md
@@ -1,0 +1,146 @@
+# JWT Authentication
+
+## Summary
+
+JWT (JSON Web Token) authentication in OpenSearch Security allows users to authenticate using signed tokens issued by an identity provider. JWTs are self-contained tokens that carry user identity and role information, enabling single sign-on (SSO) scenarios. The Security plugin validates JWT signatures and extracts user credentials and backend roles from token claims.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Authentication Flow"
+        A[Client] -->|JWT Token| B[OpenSearch]
+        B --> C[Security Plugin]
+        C --> D[JWT Authenticator]
+        D --> E{Validate Signature}
+        E -->|Valid| F[Extract Claims]
+        E -->|Invalid| G[Reject]
+        F --> H[Extract Subject]
+        F --> I[Extract Roles]
+        H --> J[Create AuthCredentials]
+        I --> J
+        J --> K[Grant Access]
+    end
+    
+    subgraph "JWT Structure"
+        L[Header] --> M[Algorithm]
+        N[Payload] --> O[Subject]
+        N --> P[Roles]
+        N --> Q[Nested Claims]
+        R[Signature] --> S[Verification]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[JWT Token] --> B[Base64 Decode]
+    B --> C[Parse Header]
+    B --> D[Parse Payload]
+    B --> E[Verify Signature]
+    D --> F[Extract subject_key]
+    D --> G[Extract roles_key]
+    F --> H[Username]
+    G --> I[Backend Roles]
+    H --> J[AuthCredentials]
+    I --> J
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `AbstractHTTPJwtAuthenticator` | Base class providing common JWT authentication logic |
+| `HTTPJwtAuthenticator` | Standard JWT authenticator for HTTP requests |
+| `HTTPJwtKeyByOpenIdConnectAuthenticator` | JWT authenticator using OIDC JWKS endpoint for key retrieval |
+| `JwtVerifier` | Validates JWT signatures using configured keys |
+| `KeyProvider` | Interface for providing signing keys |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `signing_key` | Base64-encoded signing key(s) for signature verification | Required |
+| `jwt_header` | HTTP header containing the JWT token | `Authorization` |
+| `jwt_url_parameter` | URL parameter name for JWT (alternative to header) | `null` |
+| `subject_key` | Claim path for extracting username | `sub` (subject claim) |
+| `roles_key` | Claim path for extracting backend roles (supports nested paths) | `null` |
+| `required_audience` | Required audience claim value(s) | `null` |
+| `required_issuer` | Required issuer claim value | `null` |
+| `jwt_clock_skew_tolerance_seconds` | Clock skew tolerance for token validation | `30` |
+
+### Usage Example
+
+**Basic JWT Configuration:**
+```yaml
+jwt_auth_domain:
+  http_enabled: true
+  transport_enabled: true
+  order: 0
+  http_authenticator:
+    type: jwt
+    challenge: false
+    config:
+      signing_key: "base64 encoded HMAC key or PEM public key"
+      jwt_header: "Authorization"
+      subject_key: "preferred_username"
+      roles_key: "roles"
+      required_issuer: "https://idp.example.com"
+      required_audience: "opensearch"
+  authentication_backend:
+    type: noop
+```
+
+**Nested Roles Configuration (v3.1.0+):**
+```yaml
+jwt_auth_domain:
+  http_enabled: true
+  http_authenticator:
+    type: jwt
+    config:
+      signing_key: "..."
+      roles_key:
+        - "attributes"
+        - "roles"
+```
+
+**Example JWT Payload:**
+```json
+{
+  "sub": "user@example.com",
+  "preferred_username": "jdoe",
+  "iss": "https://idp.example.com",
+  "aud": "opensearch",
+  "exp": 1700000000,
+  "iat": 1699996400,
+  "attributes": {
+    "roles": "admin,developer"
+  }
+}
+```
+
+## Limitations
+
+- JWT tokens must be signed; unsigned tokens are rejected
+- Only symmetric (HMAC) and asymmetric (RSA, ECDSA) algorithms are supported
+- Token expiration is enforced; expired tokens are rejected
+- Nested claim paths require all intermediate keys to be JSON objects
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#5355](https://github.com/opensearch-project/security/pull/5355) | Handle roles in nested claim for JWT auth backends |
+
+## References
+
+- [Issue #5343](https://github.com/opensearch-project/security/issues/5343): Support roles in nested JWT claims
+- [JWT Authentication Documentation](https://docs.opensearch.org/3.0/security/authentication-backends/jwt/): Official docs
+- [OpenID Connect Documentation](https://docs.opensearch.org/3.0/security/authentication-backends/openid-connect/): OIDC integration
+
+## Change History
+
+- **v3.1.0** (2025-06-06): Added support for nested claim paths in `roles_key` configuration

--- a/docs/releases/v3.1.0/features/security/security-jwt-enhancements.md
+++ b/docs/releases/v3.1.0/features/security/security-jwt-enhancements.md
@@ -1,0 +1,112 @@
+# Security JWT Enhancements
+
+## Summary
+
+OpenSearch v3.1.0 enhances JWT authentication by adding support for extracting backend roles from nested claims within JWT payloads. Previously, the `roles_key` configuration only supported top-level claims. This enhancement allows administrators to configure a path to roles stored in nested JSON structures, improving compatibility with identity providers that use complex JWT claim structures.
+
+## Details
+
+### What's New in v3.1.0
+
+The `roles_key` configuration parameter for JWT authentication backends now accepts a list of strings to specify a path through nested JSON objects to reach the roles claim.
+
+### Technical Changes
+
+#### Configuration Change
+
+The `roles_key` setting now supports two formats:
+
+| Format | Example | Description |
+|--------|---------|-------------|
+| Simple (existing) | `roles_key: "roles"` | Extracts roles from top-level claim |
+| Nested (new) | `roles_key: ["attributes", "roles"]` | Traverses nested objects to extract roles |
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "JWT Payload"
+        A[JWT Token] --> B[Claims]
+        B --> C[Top-level claims]
+        B --> D[Nested claims]
+        D --> E["attributes.roles"]
+    end
+    
+    subgraph "Role Extraction"
+        F[roles_key config] --> G{Is List?}
+        G -->|Single value| H[Direct lookup]
+        G -->|List| I[Nested traversal]
+        H --> J[Extract roles]
+        I --> J
+    end
+```
+
+#### Implementation Details
+
+The following classes were modified to support nested claim traversal:
+
+| Component | Description |
+|-----------|-------------|
+| `AbstractHTTPJwtAuthenticator` | Base class for JWT authenticators - updated `extractRoles()` method |
+| `HTTPJwtAuthenticator` | HTTP JWT authenticator - updated role extraction logic |
+
+The `extractRoles()` method now iterates through the `roles_key` list, traversing nested Map objects until reaching the final key containing the roles value.
+
+### Usage Example
+
+**JWT Payload with nested roles:**
+```json
+{
+  "sub": "user@example.com",
+  "attributes": {
+    "roles": "admin,developer"
+  }
+}
+```
+
+**Configuration in config.yml:**
+```yaml
+jwt_auth_domain:
+  http_enabled: true
+  transport_enabled: true
+  order: 0
+  http_authenticator:
+    type: jwt
+    challenge: false
+    config:
+      signing_key: "base64 encoded key"
+      jwt_header: "Authorization"
+      subject_key: null
+      roles_key:
+        - "attributes"
+        - "roles"
+  authentication_backend:
+    type: noop
+```
+
+### Migration Notes
+
+- Existing configurations using a single string for `roles_key` continue to work without changes
+- To use nested claims, change `roles_key` from a string to a list of strings representing the path
+- The feature works with all JWT-backed authentication backends (JWT, OpenID Connect)
+
+## Limitations
+
+- The nested path must consist of JSON objects (Maps) at each level except the final value
+- If any intermediate key is missing or not a Map, role extraction fails gracefully with an empty role set
+- The final value must be either a comma-separated string or a Collection of strings
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5355](https://github.com/opensearch-project/security/pull/5355) | Handle roles in nested claim for JWT auth backends |
+
+## References
+
+- [Issue #5343](https://github.com/opensearch-project/security/issues/5343): Original feature request
+- [JWT Authentication Documentation](https://docs.opensearch.org/3.0/security/authentication-backends/jwt/): Official JWT configuration docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/jwt-authentication.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -55,6 +55,7 @@
 - [Security Role Mapping](features/security/security-role-mapping.md) - Fix mapped roles not included in ThreadContext userInfo after immutable User object change
 - [Security Permissions](features/security/security-permissions.md) - Add forecast roles and fix missing cluster:monitor and mapping get permissions
 - [Security Testing Framework](features/security/security-testing-framework.md) - Use extendedPlugins in integrationTest framework for sample resource plugin testing
+- [Security JWT Enhancements](features/security/security-jwt-enhancements.md) - Support for extracting backend roles from nested JWT claims
 
 ### Query Insights
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security JWT Enhancements feature in OpenSearch v3.1.0.

### Changes
- **Release Report**: `docs/releases/v3.1.0/features/security/security-jwt-enhancements.md`
  - Documents the new nested claim support for `roles_key` configuration
  - Includes configuration examples and migration notes
  
- **Feature Report**: `docs/features/security/jwt-authentication.md`
  - Comprehensive documentation of JWT authentication in OpenSearch Security
  - Architecture diagrams and component descriptions
  - Configuration reference and usage examples

### Key Feature
OpenSearch v3.1.0 enhances JWT authentication by allowing `roles_key` to accept a list of strings for traversing nested JSON structures in JWT payloads.

### Related
- Resolves investigation for Issue #856
- PR: opensearch-project/security#5355
- Issue: opensearch-project/security#5343