### PR TITLE
docs: add security-cache-management report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -139,6 +139,7 @@
 - [Correlation Alerts](security/correlation-alerts.md)
 - [Security Auth Enhancements](security/security-auth-enhancements.md)
 - [Security Bugfixes](security/security-bugfixes.md)
+- [Security Cache Management](security/security-cache-management.md)
 - [Security Configuration](security/security-configuration.md)
 - [Security Debugging](security/security-debugging.md)
 - [Security Permissions](security/security-permissions.md)

--- a/docs/features/security/security-cache-management.md
+++ b/docs/features/security/security-cache-management.md
@@ -1,0 +1,190 @@
+# Security Cache Management
+
+## Summary
+
+The OpenSearch Security plugin provides authentication caching to improve performance by temporarily storing user objects returned from authentication backends. This feature allows administrators to manage the authentication cache through REST APIs, including flushing the entire cache or invalidating entries for specific users. Dynamic configuration of cache TTL is also supported, enabling runtime adjustments without cluster restarts.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Authentication Flow"
+        REQ[Request] --> AUTH[Authentication]
+        AUTH --> CHECK{Cache Hit?}
+        CHECK -->|Yes| CACHED[Return Cached User]
+        CHECK -->|No| BACKEND[Authentication Backend]
+        BACKEND --> STORE[Store in Cache]
+        STORE --> CACHED
+    end
+    
+    subgraph "Cache Components"
+        UC[User Cache<br/>AuthCredentials → User]
+        RIC[REST Impersonation Cache<br/>Username → User]
+        RRC[REST Role Cache<br/>User → Roles]
+    end
+    
+    subgraph "Cache Management"
+        FLUSH[Flush All Cache]
+        FLUSHUSER[Flush User Cache]
+        TTL[Dynamic TTL Update]
+    end
+    
+    AUTH --> UC
+    AUTH --> RIC
+    AUTH --> RRC
+    
+    FLUSH --> UC
+    FLUSH --> RIC
+    FLUSH --> RRC
+    
+    FLUSHUSER --> UC
+    FLUSHUSER --> RIC
+    FLUSHUSER --> RRC
+    
+    TTL -.->|Recreate| UC
+    TTL -.->|Recreate| RIC
+    TTL -.->|Recreate| RRC
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Cache Invalidation"
+        A[Admin Request] --> B{Endpoint}
+        B -->|/cache| C[Invalidate All]
+        B -->|/cache/user/{name}| D[Invalidate User]
+        C --> E[Clear All Caches]
+        D --> F[Filter by Username]
+        F --> G[Invalidate Matching Entries]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `BackendRegistry` | Central registry managing authentication backends and caches |
+| `FlushCacheApiAction` | REST handler for cache management endpoints |
+| `ConfigUpdateAction` | Transport action for propagating cache updates across nodes |
+| `SecuritySettings` | Cluster settings definitions including dynamic TTL |
+
+### Configuration
+
+| Setting | Description | Default | Dynamic |
+|---------|-------------|---------|---------|
+| `plugins.security.cache.ttl_minutes` | Time-to-live for cached authentication entries in minutes | 60 | Yes (v3.1.0+) |
+
+### Cache Types
+
+The Security plugin maintains three separate caches:
+
+1. **User Cache**: Maps `AuthCredentials` to `User` objects for standard REST authentication
+2. **REST Impersonation Cache**: Maps usernames to `User` objects for impersonation scenarios
+3. **REST Role Cache**: Maps `User` objects to their resolved backend roles
+
+### API Endpoints
+
+#### Flush All Cache
+
+Invalidates all entries in all security caches.
+
+```
+DELETE /_plugins/_security/api/cache
+```
+
+**Response:**
+```json
+{
+  "message": "Cache flushed successfully."
+}
+```
+
+#### Flush User Cache (v3.1.0+)
+
+Invalidates cache entries for a specific user across all cache types.
+
+```
+DELETE /_plugins/_security/api/cache/user/{username}
+```
+
+**Response:**
+```json
+{
+  "message": "Cache invalidated for user: {username}"
+}
+```
+
+#### Dynamic TTL Update (v3.1.0+)
+
+Update cache TTL at runtime via cluster settings API.
+
+```
+PUT /_cluster/settings
+{
+  "transient": {
+    "plugins.security.cache.ttl_minutes": "120"
+  }
+}
+```
+
+### Usage Example
+
+```bash
+# Check current cache TTL via health endpoint
+curl -X GET "https://localhost:9200/_plugins/_security/health" \
+  --cert admin.pem --key admin-key.pem --cacert root-ca.pem
+
+# Flush cache for specific user after role change
+curl -X DELETE "https://localhost:9200/_plugins/_security/api/cache/user/john_doe" \
+  -H "Content-Type: application/json" \
+  --cert admin.pem --key admin-key.pem --cacert root-ca.pem
+
+# Flush entire cache
+curl -X DELETE "https://localhost:9200/_plugins/_security/api/cache" \
+  -H "Content-Type: application/json" \
+  --cert admin.pem --key admin-key.pem --cacert root-ca.pem
+
+# Update cache TTL dynamically
+curl -X PUT "https://localhost:9200/_cluster/settings" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "transient": {
+      "plugins.security.cache.ttl_minutes": "1440"
+    }
+  }' \
+  --cert admin.pem --key admin-key.pem --cacert root-ca.pem
+```
+
+### Use Cases
+
+1. **LDAP Role Changes**: When a user's backend roles change in LDAP, invalidate their cache entry to pick up new permissions immediately
+2. **User Deactivation**: Immediately revoke access by invalidating a specific user's cache
+3. **Performance Tuning**: Adjust cache TTL based on authentication backend load and security requirements
+4. **Troubleshooting**: Clear cache to diagnose authentication issues
+
+## Limitations
+
+- Cache invalidation requires admin TLS certificate authentication
+- User-specific invalidation does not validate user existence
+- Dynamic TTL changes are transient (not persisted across restarts)
+- Changing TTL recreates all caches, causing temporary cache misses
+- Disabling cache (`ttl_minutes: 0`) increases load on authentication backends
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#5337](https://github.com/opensearch-project/security/pull/5337) | Add flush cache endpoint for individual user |
+| v3.1.0 | [#5324](https://github.com/opensearch-project/security/pull/5324) | Register cluster settings listener for dynamic TTL |
+
+## References
+
+- [Issue #2829](https://github.com/opensearch-project/security/issues/2829): Feature request for per-user cache invalidation
+- [Security Settings Documentation](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/security-settings/): Official security configuration
+
+## Change History
+
+- **v3.1.0** (2026-01): Added selective user cache invalidation endpoint and dynamic TTL configuration

--- a/docs/releases/v3.1.0/features/security/security-cache-management.md
+++ b/docs/releases/v3.1.0/features/security/security-cache-management.md
@@ -1,0 +1,152 @@
+# Security Cache Management
+
+## Summary
+
+OpenSearch v3.1.0 introduces enhanced security cache management capabilities, allowing administrators to invalidate authentication cache entries for individual users and dynamically update cache TTL settings without restarting the cluster. These improvements address the inefficiency of global cache invalidation when only specific user entries become stale, particularly useful for LDAP environments where user backend roles may change.
+
+## Details
+
+### What's New in v3.1.0
+
+This release adds two key enhancements to security cache management:
+
+1. **Selective User Cache Invalidation**: A new REST endpoint to flush cache entries for individual users
+2. **Dynamic Cache TTL Configuration**: The `plugins.security.cache.ttl_minutes` setting can now be updated dynamically via cluster settings API
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Security Cache Management"
+        API[REST API]
+        BR[BackendRegistry]
+        UC[User Cache]
+        RIC[REST Impersonation Cache]
+        RRC[REST Role Cache]
+    end
+    
+    subgraph "New Endpoints"
+        FC[DELETE /cache]
+        FU[DELETE /cache/user/{username}]
+    end
+    
+    subgraph "Dynamic Settings"
+        CS[Cluster Settings API]
+        TTL[TTL Setting Listener]
+    end
+    
+    FC --> API
+    FU --> API
+    API --> BR
+    BR --> UC
+    BR --> RIC
+    BR --> RRC
+    
+    CS --> TTL
+    TTL --> BR
+    BR -.->|Recreate| UC
+    BR -.->|Recreate| RIC
+    BR -.->|Recreate| RRC
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `FlushCacheApiAction` | Extended REST handler supporting user-specific cache invalidation |
+| `BackendRegistry.invalidateUserCache()` | New method for selective cache invalidation by username |
+| `SecuritySettings.CACHE_TTL_SETTING` | Dynamic cluster setting for cache TTL |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.cache.ttl_minutes` | Authentication cache TTL (now dynamic) | 60 |
+
+#### API Changes
+
+**New Endpoint: Flush Individual User Cache**
+
+```
+DELETE /_plugins/_security/api/cache/user/{username}
+```
+
+Response:
+```json
+{
+  "message": "Cache invalidated for user: {username}"
+}
+```
+
+**Existing Endpoint: Flush All Cache (unchanged)**
+
+```
+DELETE /_plugins/_security/api/cache
+```
+
+Response:
+```json
+{
+  "message": "Cache flushed successfully."
+}
+```
+
+**Dynamic TTL Update via Cluster Settings**
+
+```
+PUT /_cluster/settings
+{
+  "transient": {
+    "plugins.security.cache.ttl_minutes": "1440"
+  }
+}
+```
+
+### Usage Example
+
+```bash
+# Invalidate cache for a specific user after LDAP role change
+curl -X DELETE "https://localhost:9200/_plugins/_security/api/cache/user/john_doe" \
+  -H "Content-Type: application/json" \
+  --cert admin.pem --key admin-key.pem --cacert root-ca.pem
+
+# Update cache TTL dynamically (24 hours)
+curl -X PUT "https://localhost:9200/_cluster/settings" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "transient": {
+      "plugins.security.cache.ttl_minutes": "1440"
+    }
+  }' \
+  --cert admin.pem --key admin-key.pem --cacert root-ca.pem
+```
+
+### Migration Notes
+
+- The new user-specific cache invalidation endpoint requires admin privileges
+- Dynamic TTL changes via cluster settings are transient and do not persist across restarts
+- For permanent TTL changes, update `opensearch.yml` with `plugins.security.cache.ttl_minutes`
+
+## Limitations
+
+- User-specific cache invalidation requires knowing the exact username
+- Dynamic TTL changes recreate all caches, temporarily affecting performance
+- The endpoint does not validate if the user exists before invalidation
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5337](https://github.com/opensearch-project/security/pull/5337) | Add flush cache endpoint for individual user |
+| [#5324](https://github.com/opensearch-project/security/pull/5324) | Register cluster settings listener for `plugins.security.cache.ttl_minutes` |
+
+## References
+
+- [Issue #2829](https://github.com/opensearch-project/security/issues/2829): Feature request for per-user cache invalidation
+- [Security Settings Documentation](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/security-settings/): Official security configuration docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/security-cache-management.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -49,6 +49,7 @@
 ### Security
 
 - [Security Backend Bug Fixes](features/security/security-backend-bug-fixes.md) - Stale cache post snapshot restore, compliance audit log diff, DLS/FLS filter reader, auth header logging, password reset UI, forecasting permissions
+- [Security Cache Management](features/security/security-cache-management.md) - Selective user cache invalidation endpoint and dynamic cache TTL configuration
 - [Security Debugging](features/security/security-debugging.md) - Enhanced error messages for "Security not initialized" with cluster manager status
 - [Security Dependency Updates](features/security/security-dependency-updates.md) - 24 dependency updates including Bouncy Castle 1.81, Kafka 4.0.0, and CVE-2024-52798 fix
 - [Security Performance Improvements](features/security/security-performance-improvements.md) - Immutable User object with serialization caching for reduced inter-node communication overhead


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security Cache Management enhancement in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/security/security-cache-management.md`
- Feature report: `docs/features/security/security-cache-management.md`

### Key Changes in v3.1.0
- **Selective User Cache Invalidation**: New REST endpoint `DELETE /_plugins/_security/api/cache/user/{username}` to flush cache entries for individual users
- **Dynamic Cache TTL Configuration**: The `plugins.security.cache.ttl_minutes` setting can now be updated dynamically via cluster settings API

### Related PRs
- [opensearch-project/security#5337](https://github.com/opensearch-project/security/pull/5337): Add flush cache endpoint for individual user
- [opensearch-project/security#5324](https://github.com/opensearch-project/security/pull/5324): Register cluster settings listener for `plugins.security.cache.ttl_minutes`

### Related Issue
- Closes #855