### PR TITLE
docs: add security-ci-cd report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -148,6 +148,7 @@
 - [Security Plugin Dependencies](security/security-plugin-dependencies.md)
 - [Security Role Mapping](security/security-role-mapping.md)
 - [Security Testing Framework](security/security-testing-framework.md)
+- [Security CI/CD](security/security-ci-cd.md)
 - [JWT Authentication](security/jwt-authentication.md)
 
 ## security-dashboards

--- a/docs/features/security/security-ci-cd.md
+++ b/docs/features/security/security-ci-cd.md
@@ -1,0 +1,115 @@
+# Security CI/CD
+
+## Summary
+
+The OpenSearch Security plugin includes automated CI/CD workflows for changelog management and dependency updates. These GitHub Actions workflows enforce changelog updates on every pull request and automate housekeeping tasks for Dependabot PRs, improving release note quality and reducing manual maintenance burden.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "CI/CD Workflows"
+        subgraph "Changelog Verification"
+            PR[Pull Request] --> CV[Changelog Verifier]
+            CV -->|Check| CL[CHANGELOG.md]
+            CV -->|Pass| Ready[Ready to Merge]
+            CV -->|Fail| Block[Block Merge]
+            Label[skip-changelog label] --> Ready
+        end
+        
+        subgraph "Dependabot Automation"
+            DP[Dependabot PR] --> Token[GitHub App Token]
+            Token --> SHA[Update Gradle SHAs]
+            SHA --> Spotless[Run Spotless]
+            Spotless --> Helper[Changelog Helper]
+            Helper --> Commit[Auto-commit]
+        end
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `changelog_verifier.yml` | GitHub Actions workflow that enforces changelog updates on PRs |
+| `dependabot_pr.yml` | GitHub Actions workflow that automates Dependabot PR housekeeping |
+| `CHANGELOG.md` | Changelog file following Keep a Changelog format |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `skipLabels` | Labels that bypass changelog verification | `autocut, skip-changelog` |
+| `version` | Target changelog section for Dependabot entries | `Unreleased 3.x` |
+
+### Changelog Verifier Workflow
+
+```yaml
+name: "Changelog Verifier"
+on:
+  pull_request:
+    types: [opened, edited, review_requested, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+jobs:
+  verify-changelog:
+    if: github.repository == 'opensearch-project/security'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dangoslen/changelog-enforcer@v3
+        with:
+          skipLabels: "autocut, skip-changelog"
+```
+
+### Dependabot PR Workflow
+
+The Dependabot workflow automates three tasks:
+
+1. **Update Gradle SHAs** - Runs `./gradlew updateSHAs` to update dependency checksums
+2. **Spotless Formatting** - Runs `./gradlew spotlessApply` for consistent code formatting
+3. **Changelog Update** - Adds dependency update entries to the changelog
+
+### Usage Example
+
+#### Adding a Changelog Entry
+
+```markdown
+## [Unreleased 3.x]
+### Added
+- New feature description ([#1234](https://github.com/opensearch-project/security/pull/1234))
+
+### Changed
+- Change description ([#1234](https://github.com/opensearch-project/security/pull/1234))
+
+### Dependencies
+- Bump `library_name` from X.Y.Z to A.B.C ([#1234](https://github.com/opensearch-project/security/pull/1234))
+
+### Fixed
+- Bug fix description ([#1234](https://github.com/opensearch-project/security/pull/1234))
+```
+
+## Limitations
+
+- Changelog verifier only runs for the `opensearch-project/security` repository
+- Dependabot workflow requires GitHub App credentials configured as repository secrets
+- Dependabot changelog helper targets a specific version section ("Unreleased 3.x")
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#5318](https://github.com/opensearch-project/security/pull/5318) | Add workflow for changelog verification |
+
+## References
+
+- [Issue #5095](https://github.com/opensearch-project/security/issues/5095): Original feature request
+- [Keep a Changelog](https://keepachangelog.com/en/1.0.0/): Changelog format specification
+- [changelog-enforcer](https://github.com/dangoslen/changelog-enforcer): GitHub Action for enforcing changelog updates
+- [dependabot-changelog-helper](https://github.com/dangoslen/dependabot-changelog-helper): GitHub Action for Dependabot changelog automation
+- [Geospatial PR #238](https://github.com/opensearch-project/geospatial/pull/238): Reference implementation in another OpenSearch repository
+
+## Change History
+
+- **v3.1.0** (2025-05-12): Initial implementation with changelog verifier and Dependabot PR workflows

--- a/docs/releases/v3.1.0/features/security/security-ci-cd.md
+++ b/docs/releases/v3.1.0/features/security/security-ci-cd.md
@@ -1,0 +1,114 @@
+# Security CI/CD
+
+## Summary
+
+This release introduces automated changelog verification and Dependabot integration workflows to the OpenSearch Security plugin. These GitHub Actions workflows enforce changelog updates on every PR and automate dependency update housekeeping tasks, improving release note quality and reducing manual maintenance burden.
+
+## Details
+
+### What's New in v3.1.0
+
+The Security plugin now includes two new GitHub Actions workflows:
+
+1. **Changelog Verifier** - Enforces changelog updates on every pull request
+2. **Dependabot PR Handler** - Automates SHA updates, formatting, and changelog entries for dependency PRs
+
+### Technical Changes
+
+#### Workflow Architecture
+
+```mermaid
+graph TB
+    subgraph "PR Workflow"
+        PR[Pull Request] --> CV[Changelog Verifier]
+        CV -->|Pass| Merge[Ready to Merge]
+        CV -->|Fail| Block[Block Merge]
+        CV -->|skip-changelog label| Merge
+    end
+    
+    subgraph "Dependabot Workflow"
+        DP[Dependabot PR] --> SHA[Update Gradle SHAs]
+        SHA --> Spotless[Run Spotless]
+        Spotless --> CL[Update Changelog]
+        CL --> Commit[Auto-commit Changes]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `.github/workflows/changelog_verifier.yml` | Enforces changelog updates using [changelog-enforcer](https://github.com/dangoslen/changelog-enforcer) |
+| `.github/workflows/dependabot_pr.yml` | Automates Dependabot PR housekeeping with SHA updates, Spotless formatting, and changelog entries |
+| `CHANGELOG.md` | New changelog file following [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format |
+| `CONTRIBUTING.md` | Updated with changelog contribution guidelines |
+
+#### Changelog Verifier Workflow
+
+Triggers on PR events: `opened`, `edited`, `review_requested`, `synchronize`, `reopened`, `ready_for_review`, `labeled`, `unlabeled`
+
+Key features:
+- Uses `dangoslen/changelog-enforcer@v3` action
+- Skips verification for PRs with `autocut` or `skip-changelog` labels
+- Only runs for `opensearch-project/security` repository
+
+#### Dependabot PR Workflow
+
+Automates three tasks for Dependabot PRs:
+1. **Update Gradle SHAs** - Runs `./gradlew updateSHAs` to update dependency checksums
+2. **Spotless Formatting** - Runs `./gradlew spotlessApply` for code formatting
+3. **Changelog Update** - Uses `dangoslen/dependabot-changelog-helper@v4` to add entries under "Unreleased 3.x"
+
+Uses GitHub App token for authentication to enable auto-commits.
+
+### Usage Example
+
+#### Adding a Changelog Entry
+
+```markdown
+## [Unreleased 3.x]
+### Added
+- Your new feature description ([#PR_NUMBER](https://github.com/opensearch-project/security/pull/PR_NUMBER))
+
+### Changed
+- Your change description ([#PR_NUMBER](https://github.com/opensearch-project/security/pull/PR_NUMBER))
+
+### Fixed
+- Your bug fix description ([#PR_NUMBER](https://github.com/opensearch-project/security/pull/PR_NUMBER))
+```
+
+#### Skipping Changelog Verification
+
+For PRs that don't require changelog entries (tests, documentation, refactoring):
+1. Add the `skip-changelog` label to the PR
+2. The changelog verifier will pass automatically
+
+### Migration Notes
+
+Contributors to the Security plugin must now:
+1. Update `CHANGELOG.md` with every PR (unless using `skip-changelog` label)
+2. Follow the [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) format
+3. Reference the PR number in changelog entries
+
+## Limitations
+
+- Changelog verifier only runs for the `opensearch-project/security` repository
+- Dependabot workflow requires GitHub App credentials (`APP_ID`, `APP_PRIVATE_KEY` secrets)
+- Dependabot changelog helper targets "Unreleased 3.x" section specifically
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5318](https://github.com/opensearch-project/security/pull/5318) | Add workflow for changelog verification |
+
+## References
+
+- [Issue #5095](https://github.com/opensearch-project/security/issues/5095): Add a CHANGELOG to assemble release notes as PRs are merged
+- [Keep a Changelog](https://keepachangelog.com/en/1.0.0/): Changelog format specification
+- [changelog-enforcer](https://github.com/dangoslen/changelog-enforcer): GitHub Action for enforcing changelog updates
+- [dependabot-changelog-helper](https://github.com/dangoslen/dependabot-changelog-helper): GitHub Action for Dependabot changelog automation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/security-ci-cd.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -57,6 +57,7 @@
 - [Security Permissions](features/security/security-permissions.md) - Add forecast roles and fix missing cluster:monitor and mapping get permissions
 - [Security Testing Framework](features/security/security-testing-framework.md) - Use extendedPlugins in integrationTest framework for sample resource plugin testing
 - [Security JWT Enhancements](features/security/security-jwt-enhancements.md) - Support for extracting backend roles from nested JWT claims
+- [Security CI/CD](features/security/security-ci-cd.md) - Changelog verification workflow and Dependabot PR automation
 
 ### Query Insights
 


### PR DESCRIPTION
## Summary\n\nAdd documentation for Security CI/CD feature in OpenSearch v3.1.0.\n\n### Reports Created\n- Release report: `docs/releases/v3.1.0/features/security/security-ci-cd.md`\n- Feature report: `docs/features/security/security-ci-cd.md`\n\n### Key Changes in v3.1.0\n- Changelog verification workflow using `changelog-enforcer` GitHub Action\n- Dependabot PR automation workflow for SHA updates, Spotless formatting, and changelog entries\n- New CHANGELOG.md file following Keep a Changelog format\n- Updated CONTRIBUTING.md with changelog guidelines\n\n### Related Issue\n- Closes #854\n\n### Source PR\n- [opensearch-project/security#5318](https://github.com/opensearch-project/security/pull/5318)"