### PR TITLE
docs: add Neural Search Stats report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -8,6 +8,7 @@
 - [Neural Search Compatibility](neural-search/neural-search-compatibility.md)
 - [Neural Search Rescore](neural-search/neural-search-rescore.md)
 - [Neural Search Reranking](neural-search/neural-search-reranking.md)
+- [Neural Search Stats](neural-search/neural-search-stats.md)
 - [Neural Sparse Search](neural-search/neural-sparse-search.md)
 - [Semantic Field](neural-search/semantic-field.md)
 - [Text Chunking](neural-search/text-chunking.md)

--- a/docs/features/neural-search/neural-search-stats.md
+++ b/docs/features/neural-search/neural-search-stats.md
@@ -1,0 +1,231 @@
+# Neural Search Stats
+
+## Summary
+
+The Neural Search Stats API provides comprehensive monitoring capabilities for the Neural Search plugin in OpenSearch. It exposes cluster-level and node-level statistics for tracking the usage and performance of semantic search, hybrid search, and AI-powered ingest processors.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Neural Search Stats API"
+        Endpoint[GET /_plugins/_neural/stats]
+        PathParams[Path Parameters<br/>nodes, stats]
+        QueryParams[Query Parameters<br/>include_metadata<br/>flat_stat_paths<br/>include_individual_nodes<br/>include_all_nodes<br/>include_info]
+    end
+    
+    subgraph "Response Structure"
+        Info[info<br/>Cluster-level stats]
+        AllNodes[all_nodes<br/>Aggregated node stats]
+        Nodes[nodes<br/>Per-node stats]
+    end
+    
+    subgraph "Stat Types"
+        InfoString[info_string<br/>Version info]
+        InfoCounter[info_counter<br/>Processor counts]
+        EventCounter[timestamped_event_counter<br/>Execution counts]
+    end
+    
+    subgraph "Tracked Components"
+        IngestProc[Ingest Processors]
+        SearchProc[Search Processors]
+        QueryStats[Query Statistics]
+        HighlightStats[Semantic Highlighting]
+    end
+    
+    Endpoint --> PathParams
+    Endpoint --> QueryParams
+    Endpoint --> Info
+    Endpoint --> AllNodes
+    Endpoint --> Nodes
+    
+    Info --> InfoString
+    Info --> InfoCounter
+    AllNodes --> EventCounter
+    Nodes --> EventCounter
+    
+    IngestProc --> EventCounter
+    SearchProc --> EventCounter
+    QueryStats --> EventCounter
+    HighlightStats --> EventCounter
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Data Collection"
+        Ingest[Ingest Pipeline<br/>Execution]
+        Search[Search Pipeline<br/>Execution]
+        Query[Query<br/>Execution]
+    end
+    
+    subgraph "Stats Aggregation"
+        NodeStats[Node-level<br/>Statistics]
+        ClusterStats[Cluster-level<br/>Aggregation]
+    end
+    
+    subgraph "API Response"
+        Response[Stats API<br/>Response]
+    end
+    
+    Ingest --> NodeStats
+    Search --> NodeStats
+    Query --> NodeStats
+    NodeStats --> ClusterStats
+    NodeStats --> Response
+    ClusterStats --> Response
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Stats API Endpoint | REST endpoint at `/_plugins/_neural/stats` for retrieving statistics |
+| Info Stats | Cluster-wide information including version and processor counts |
+| Node Stats | Per-node execution counters for processors and queries |
+| All Nodes Stats | Aggregated statistics across all nodes in the cluster |
+| Event Counter | Timestamped counter tracking executions with trailing interval support |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.neural_search.stats_enabled` | Enable/disable statistics collection | `false` |
+
+### API Parameters
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `nodes` | Path | Filter by node ID(s), comma-separated | All nodes |
+| `stats` | Path | Filter by stat name(s), comma-separated | All stats |
+| `include_metadata` | Query | Include stat type metadata | `false` |
+| `flat_stat_paths` | Query | Flatten JSON response structure | `false` |
+| `include_individual_nodes` | Query | Include per-node statistics | `true` |
+| `include_all_nodes` | Query | Include aggregated cluster statistics | `true` |
+| `include_info` | Query | Include cluster-level info statistics | `true` |
+
+### Available Statistics
+
+#### Ingest Processor Stats
+
+| Statistic | Type | Description |
+|-----------|------|-------------|
+| `text_embedding_processors_in_pipelines` | Info | Count of text embedding processors in pipelines |
+| `text_embedding_executions` | Event | Text embedding processor execution count |
+| `text_chunking_processors` | Info | Count of text chunking processors |
+| `text_chunking_executions` | Event | Text chunking processor execution count |
+| `text_chunking_delimiter_processors` | Info | Count of delimiter-based chunking processors |
+| `text_chunking_delimiter_executions` | Event | Delimiter chunking execution count |
+| `text_chunking_fixed_length_processors` | Info | Count of fixed-length chunking processors |
+| `text_chunking_fixed_length_executions` | Event | Fixed-length chunking execution count |
+| `sparse_encoding_processors` | Info | Count of sparse encoding processors |
+| `sparse_encoding_executions` | Event | Sparse encoding execution count |
+| `text_image_embedding_processors` | Info | Count of text-image embedding processors |
+| `text_image_embedding_executions` | Event | Text-image embedding execution count |
+| `skip_existing_processors` | Info | Count of processors with skip_existing enabled |
+| `skip_existing_executions` | Event | Executions with skip_existing flag |
+
+#### Search Processor Stats
+
+| Statistic | Type | Description |
+|-----------|------|-------------|
+| `normalization_processors` | Info | Count of score-based normalization processors |
+| `normalization_processor_executions` | Event | Score-based normalization execution count |
+| `rank_based_normalization_processors` | Info | Count of RRF normalization processors |
+| `rank_based_normalization_processor_executions` | Event | RRF normalization execution count |
+| `comb_arithmetic_processors` | Info | Arithmetic combination processor count |
+| `comb_arithmetic_executions` | Event | Arithmetic combination execution count |
+| `comb_geometric_processors` | Info | Geometric combination processor count |
+| `comb_geometric_executions` | Event | Geometric combination execution count |
+| `comb_harmonic_processors` | Info | Harmonic combination processor count |
+| `comb_harmonic_executions` | Event | Harmonic combination execution count |
+| `comb_rrf_processors` | Info | RRF combination processor count |
+| `comb_rrf_executions` | Event | RRF combination execution count |
+| `norm_l2_processors` | Info | L2 normalization processor count |
+| `norm_l2_executions` | Event | L2 normalization execution count |
+| `norm_minmax_processors` | Info | Min-max normalization processor count |
+| `norm_minmax_executions` | Event | Min-max normalization execution count |
+| `norm_zscore_processors` | Info | Z-score normalization processor count |
+| `norm_zscore_executions` | Event | Z-score normalization execution count |
+| `neural_query_enricher_processors` | Info | Neural query enricher processor count |
+| `neural_query_enricher_executions` | Event | Neural query enricher execution count |
+| `neural_sparse_two_phase_processors` | Info | Neural sparse two-phase processor count |
+| `neural_sparse_two_phase_executions` | Event | Neural sparse two-phase execution count |
+| `rerank_ml_processors` | Info | ML reranker processor count |
+| `rerank_ml_executions` | Event | ML reranker execution count |
+| `rerank_by_field_processors` | Info | By-field reranker processor count |
+| `rerank_by_field_executions` | Event | By-field reranker execution count |
+
+#### Query Stats
+
+| Statistic | Type | Description |
+|-----------|------|-------------|
+| `hybrid_query_requests` | Event | Total hybrid query request count |
+| `hybrid_query_with_filter_requests` | Event | Hybrid queries with filter count |
+| `hybrid_query_with_inner_hits_requests` | Event | Hybrid queries with inner hits count |
+| `hybrid_query_with_pagination_requests` | Event | Hybrid queries with pagination count |
+
+#### Semantic Highlighting Stats
+
+| Statistic | Type | Description |
+|-----------|------|-------------|
+| `semantic_highlighting_request_count` | Event | Semantic highlighting request count |
+
+### Usage Example
+
+Enable statistics collection:
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "plugins.neural_search.stats_enabled": "true"
+  }
+}
+```
+
+Retrieve all statistics:
+```bash
+GET /_plugins/_neural/stats
+```
+
+Retrieve specific statistics with metadata:
+```bash
+GET /_plugins/_neural/stats/text_embedding_executions,hybrid_query_requests?include_metadata=true
+```
+
+Retrieve aggregated stats only (exclude per-node breakdown):
+```bash
+GET /_plugins/_neural/stats?include_individual_nodes=false
+```
+
+## Limitations
+
+- Statistics collection is disabled by default for performance reasons
+- All statistics reset when collection is disabled or node restarts
+- Metadata fields (`trailing_interval_value`, `minutes_since_last_event`) only available when `include_metadata=true`
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#1308](https://github.com/opensearch-project/neural-search/pull/1308) | Add stats for text chunking processor algorithms |
+| v3.1.0 | [#1327](https://github.com/opensearch-project/neural-search/pull/1327) | Add stats tracking for semantic highlighting |
+| v3.1.0 | [#1332](https://github.com/opensearch-project/neural-search/pull/1332) | Add stats for text embedding processor with skip_existing flag |
+| v3.1.0 | [#1326](https://github.com/opensearch-project/neural-search/pull/1326) | Add stats for score/rank based normalization and hybrid query |
+| v3.1.0 | [#1343](https://github.com/opensearch-project/neural-search/pull/1343) | Add stats for neural query enricher, sparse encoding, reranker |
+| v3.1.0 | [#1360](https://github.com/opensearch-project/neural-search/pull/1360) | Add include_individual_nodes, include_all_nodes, include_info params |
+| v3.1.0 | [#1378](https://github.com/opensearch-project/neural-search/pull/1378) | Combine skip_existing flag stats into single stat |
+
+## References
+
+- [Neural Search Stats API Documentation](https://docs.opensearch.org/3.0/vector-search/api/neural/)
+- [Issue #1146](https://github.com/opensearch-project/neural-search/issues/1146): Stats for normalization processor
+- [Issue #1104](https://github.com/opensearch-project/neural-search/issues/1104): Stats API parameters
+- [Issue #1182](https://github.com/opensearch-project/neural-search/issues/1182): Semantic highlighting stats
+
+## Change History
+
+- **v3.1.0** (2026-01-10): Comprehensive stats coverage for all Neural Search components including text chunking, text embedding, hybrid query, normalization processors, semantic highlighting, and API parameter enhancements

--- a/docs/releases/v3.1.0/features/neural-search/neural-search-stats.md
+++ b/docs/releases/v3.1.0/features/neural-search/neural-search-stats.md
@@ -1,0 +1,190 @@
+# Neural Search Stats
+
+## Summary
+
+OpenSearch v3.1.0 introduces comprehensive statistics tracking for the Neural Search plugin. The Stats API provides cluster-level and node-level metrics for monitoring semantic and hybrid search features, including ingest processors, search processors, and query execution.
+
+## Details
+
+### What's New in v3.1.0
+
+This release adds extensive statistics coverage across all Neural Search components:
+
+- **Text Chunking Processor Stats**: Track executions and processor counts for delimiter and fixed-length chunking algorithms
+- **Text Embedding Processor Stats**: Monitor embedding processor executions with `skip_existing` flag tracking
+- **Hybrid Query Stats**: Track hybrid query requests including filter, inner hits, and pagination usage
+- **Normalization Processor Stats**: Monitor score-based and rank-based normalization with algorithm-specific metrics
+- **Semantic Highlighting Stats**: Track semantic highlighting request counts
+- **Additional Processor Stats**: Coverage for sparse encoding, neural query enricher, reranker, and text-image embedding processors
+- **API Enhancements**: New query parameters for flexible stats retrieval
+
+### Technical Changes
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph "Stats API"
+        API[/_plugins/_neural/stats]
+        Params[Query Parameters]
+    end
+    
+    subgraph "Stats Categories"
+        Info[Info Stats<br/>Cluster-level]
+        AllNodes[All Nodes Stats<br/>Aggregated]
+        Nodes[Node Stats<br/>Per-node]
+    end
+    
+    subgraph "Tracked Components"
+        Ingest[Ingest Processors]
+        Search[Search Processors]
+        Query[Query Stats]
+        Highlight[Semantic Highlighting]
+    end
+    
+    API --> Info
+    API --> AllNodes
+    API --> Nodes
+    Params --> API
+    
+    Info --> Ingest
+    AllNodes --> Ingest
+    AllNodes --> Search
+    AllNodes --> Query
+    AllNodes --> Highlight
+    Nodes --> Ingest
+    Nodes --> Search
+    Nodes --> Query
+    Nodes --> Highlight
+```
+
+#### New Statistics
+
+| Category | Statistic | Description |
+|----------|-----------|-------------|
+| Ingest | `text_chunking_executions` | Total text chunking processor executions |
+| Ingest | `text_chunking_delimiter_executions` | Delimiter-based chunking executions |
+| Ingest | `text_chunking_fixed_length_executions` | Fixed-length chunking executions |
+| Ingest | `text_embedding_executions` | Text embedding processor executions |
+| Ingest | `sparse_encoding_executions` | Sparse encoding processor executions |
+| Ingest | `text_image_embedding_executions` | Text-image embedding executions |
+| Ingest | `skip_existing_executions` | Executions with skip_existing flag |
+| Search | `normalization_processor_executions` | Score-based normalization executions |
+| Search | `rank_based_normalization_processor_executions` | RRF normalization executions |
+| Search | `comb_arithmetic_executions` | Arithmetic combination executions |
+| Search | `comb_geometric_executions` | Geometric combination executions |
+| Search | `comb_harmonic_executions` | Harmonic combination executions |
+| Search | `comb_rrf_executions` | RRF combination executions |
+| Search | `norm_l2_executions` | L2 normalization executions |
+| Search | `norm_minmax_executions` | Min-max normalization executions |
+| Search | `norm_zscore_executions` | Z-score normalization executions |
+| Search | `neural_query_enricher_executions` | Neural query enricher executions |
+| Search | `neural_sparse_two_phase_executions` | Neural sparse two-phase executions |
+| Search | `rerank_ml_executions` | ML reranker executions |
+| Search | `rerank_by_field_executions` | By-field reranker executions |
+| Query | `hybrid_query_requests` | Total hybrid query requests |
+| Query | `hybrid_query_with_filter_requests` | Hybrid queries with filters |
+| Query | `hybrid_query_with_inner_hits_requests` | Hybrid queries with inner hits |
+| Query | `hybrid_query_with_pagination_requests` | Hybrid queries with pagination |
+| Highlight | `semantic_highlighting_request_count` | Semantic highlighting requests |
+
+#### New API Parameters
+
+| Parameter | Default | Description |
+|-----------|---------|-------------|
+| `include_individual_nodes` | `true` | Include per-node statistics |
+| `include_all_nodes` | `true` | Include aggregated cluster statistics |
+| `include_info` | `true` | Include cluster-level info statistics |
+
+### Usage Example
+
+Enable statistics collection:
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "plugins.neural_search.stats_enabled": "true"
+  }
+}
+```
+
+Retrieve stats with selective output:
+```bash
+GET /_plugins/_neural/stats?include_individual_nodes=false
+```
+
+Example response:
+```json
+{
+  "_nodes": { "total": 1, "successful": 1, "failed": 0 },
+  "cluster_name": "integTest",
+  "info": {
+    "cluster_version": "3.1.0",
+    "processors": {
+      "search": {
+        "hybrid": {
+          "normalization_processors": 0,
+          "rank_based_normalization_processors": 0
+        }
+      },
+      "ingest": {
+        "text_chunking_processors": 0,
+        "text_embedding_processors_in_pipelines": 0,
+        "sparse_encoding_processors": 0
+      }
+    }
+  },
+  "all_nodes": {
+    "query": {
+      "hybrid": {
+        "hybrid_query_requests": 0,
+        "hybrid_query_with_filter_requests": 0
+      }
+    },
+    "semantic_highlighting": {
+      "semantic_highlighting_request_count": 0
+    },
+    "processors": {
+      "search": {
+        "hybrid": {
+          "normalization_processor_executions": 0,
+          "comb_arithmetic_executions": 0
+        }
+      },
+      "ingest": {
+        "text_embedding_executions": 0,
+        "text_chunking_executions": 0
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Statistics collection is disabled by default and must be enabled via cluster settings
+- When disabled, all values reset and new statistics are not collected
+- Statistics are reset on node restart
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1308](https://github.com/opensearch-project/neural-search/pull/1308) | Add stats for text chunking processor algorithms |
+| [#1327](https://github.com/opensearch-project/neural-search/pull/1327) | Add stats tracking for semantic highlighting |
+| [#1332](https://github.com/opensearch-project/neural-search/pull/1332) | Add stats for text embedding processor with skip_existing flag |
+| [#1326](https://github.com/opensearch-project/neural-search/pull/1326) | Add stats for score/rank based normalization and hybrid query |
+| [#1343](https://github.com/opensearch-project/neural-search/pull/1343) | Add stats for neural query enricher, sparse encoding, reranker, text-image embedding |
+| [#1360](https://github.com/opensearch-project/neural-search/pull/1360) | Add `include_individual_nodes`, `include_all_nodes`, `include_info` params |
+| [#1378](https://github.com/opensearch-project/neural-search/pull/1378) | Combine skip_existing flag stats into single stat |
+
+## References
+
+- [Neural Search Stats API Documentation](https://docs.opensearch.org/3.0/vector-search/api/neural/)
+- [Issue #1146](https://github.com/opensearch-project/neural-search/issues/1146): Stats for normalization processor
+- [Issue #1104](https://github.com/opensearch-project/neural-search/issues/1104): Stats API parameters
+- [Issue #1182](https://github.com/opensearch-project/neural-search/issues/1182): Semantic highlighting stats
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/neural-search/neural-search-stats.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -76,6 +76,7 @@
 - [Lucene Upgrade](features/neural-search/lucene-upgrade.md) - Update hybrid query implementation for Lucene 10.2.1 API compatibility
 - [Neural Search Bug Fixes](features/neural-search/neural-search-bug-fixes.md) - 7 bug fixes for hybrid query validation, semantic field handling, radial search serialization, stats API, and stability
 - [Neural Search Compatibility](features/neural-search/neural-search-compatibility.md) - Update neural-search for OpenSearch 3.0 beta compatibility
+- [Neural Search Stats](features/neural-search/neural-search-stats.md) - Comprehensive stats API for monitoring ingest processors, search processors, hybrid queries, and semantic highlighting
 
 ### Learning to Rank
 


### PR DESCRIPTION
## Summary

Add comprehensive documentation for Neural Search Stats feature in v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/neural-search/neural-search-stats.md`
- Feature report: `docs/features/neural-search/neural-search-stats.md`

### Key Changes in v3.1.0
- Text chunking processor stats (delimiter and fixed-length algorithms)
- Text embedding processor stats with skip_existing flag tracking
- Hybrid query stats (filter, inner hits, pagination)
- Normalization processor stats (score-based and rank-based)
- Semantic highlighting stats
- Additional processor stats (sparse encoding, neural query enricher, reranker, text-image embedding)
- New API parameters: `include_individual_nodes`, `include_all_nodes`, `include_info`

### Related PRs
- #1308: Text chunking processor stats
- #1327: Semantic highlighting stats
- #1332: Text embedding processor stats
- #1326: Normalization and hybrid query stats
- #1343: Additional processor stats
- #1360: API parameter enhancements
- #1378: Skip existing flag consolidation

Closes #850