### PR TITLE
docs: add ML Commons Agent Framework report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -240,6 +240,7 @@
 
 ## ml-commons
 
+- [Agent Framework](ml-commons/ml-commons-agent-framework.md)
 - [Batch Ingestion](ml-commons/batch-ingestion.md)
 - [ML Commons Bugfixes](ml-commons/ml-commons-bugfixes.md)
 - [ML Commons CI/CD](ml-commons/ml-commons-ci-cd.md)

--- a/docs/features/ml-commons/ml-commons-agent-framework.md
+++ b/docs/features/ml-commons/ml-commons-agent-framework.md
@@ -1,0 +1,258 @@
+# ML Commons Agent Framework
+
+## Summary
+
+The ML Commons Agent Framework enables building AI-powered agents within OpenSearch that can orchestrate tools, interact with LLMs, and maintain conversational memory. Agents can perform complex tasks by combining multiple tools, executing plans, and reflecting on results to provide intelligent responses.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Agent Framework"
+        subgraph "Agent APIs"
+            REG[Register Agent]
+            UPD[Update Agent]
+            EXEC[Execute Agent]
+            GET[Get Agent]
+            SEARCH[Search Agent]
+            DEL[Delete Agent]
+        end
+        
+        subgraph "MCP APIs"
+            MCP_REG[Register MCP Tools]
+            MCP_UPD[Update MCP Tools]
+            MCP_LIST[List MCP Tools]
+        end
+        
+        subgraph "Agent Types"
+            FLOW[Flow Agent]
+            CONV_FLOW[Conversational Flow Agent]
+            CONV[Conversational Agent]
+            PER[Plan-Execute-Reflect Agent]
+        end
+        
+        subgraph "LLM Integration"
+            LLM[LLM Connector]
+            FC[Function Calling]
+            SSE[SSE Endpoint]
+            LLMI[LLM Interface]
+        end
+        
+        subgraph "Memory"
+            CONV_MEM[Conversation Memory]
+            EXEC_MEM[Executor Memory]
+        end
+        
+        subgraph "Tools"
+            BUILTIN[Built-in Tools]
+            MCP_TOOLS[MCP Tools]
+            CUSTOM[Custom Tools]
+        end
+    end
+    
+    subgraph "External Services"
+        BEDROCK[Amazon Bedrock]
+        OPENAI[OpenAI]
+        OTHER[Other LLM Services]
+    end
+    
+    REG --> FLOW
+    REG --> CONV_FLOW
+    REG --> CONV
+    REG --> PER
+    UPD --> FLOW
+    UPD --> CONV
+    
+    EXEC --> LLM
+    LLM --> FC
+    FC --> LLMI
+    LLMI --> SSE
+    
+    LLM --> BEDROCK
+    LLM --> OPENAI
+    LLM --> OTHER
+    
+    EXEC --> CONV_MEM
+    PER --> EXEC_MEM
+    
+    EXEC --> BUILTIN
+    EXEC --> MCP_TOOLS
+    EXEC --> CUSTOM
+    
+    MCP_REG --> MCP_TOOLS
+    MCP_UPD --> MCP_TOOLS
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    USER[User Query] --> EXEC[Execute Agent]
+    EXEC --> PLAN[Create Plan]
+    PLAN --> TOOL_SELECT[Select Tools]
+    TOOL_SELECT --> TOOL_EXEC[Execute Tools]
+    TOOL_EXEC --> LLM[LLM Processing]
+    LLM --> REFLECT[Reflect on Results]
+    REFLECT --> |Need More| TOOL_SELECT
+    REFLECT --> |Complete| RESPONSE[Generate Response]
+    RESPONSE --> MEMORY[Store in Memory]
+    MEMORY --> USER
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Agent Registry | Stores agent configurations in system index |
+| Agent Executor | Orchestrates agent execution with tool selection and LLM interaction |
+| Memory Manager | Manages conversation and executor memory for context retention |
+| Tool Registry | Manages built-in, MCP, and custom tools |
+| LLM Connector | Connects to external LLM services (Bedrock, OpenAI, etc.) |
+| Function Calling | Native function/tool calling support for compatible LLMs |
+| MCP Server | Model Context Protocol server for tool integration |
+| Metrics Collector | Collects adoption and operational metrics |
+
+### Agent Types
+
+| Type | Description | Use Case |
+|------|-------------|----------|
+| Flow Agent | Sequential tool execution | Simple workflows |
+| Conversational Flow Agent | Flow agent with memory | Multi-turn workflows |
+| Conversational Agent | LLM-driven with memory | General chat assistants |
+| Plan-Execute-Reflect Agent | Planning, execution, and reflection loop | Complex reasoning tasks |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ml_commons.agent_framework.enabled` | Enable agent framework | `true` |
+| `plugins.ml_commons.metrics.enabled` | Enable metrics collection | `true` |
+| `plugins.ml_commons.memory.feature_enabled` | Enable conversation memory | `true` |
+
+### APIs
+
+**Register Agent**
+```
+POST /_plugins/_ml/agents/_register
+```
+
+**Update Agent** (v3.1.0+)
+```
+PUT /_plugins/_ml/agents/{agent_id}
+```
+
+**Execute Agent**
+```
+POST /_plugins/_ml/agents/{agent_id}/_execute
+```
+
+**MCP Tools Management** (v3.1.0+)
+```
+POST /_plugins/_ml/mcp/tools/_update
+GET /_plugins/_ml/mcp/tools/_list
+```
+
+### Usage Example
+
+**Register a conversational agent with function calling:**
+```json
+POST /_plugins/_ml/agents/_register
+{
+  "name": "Search Assistant",
+  "type": "conversational",
+  "description": "An assistant that helps search OpenSearch indices",
+  "llm": {
+    "model_id": "bedrock_claude_model_id",
+    "parameters": {
+      "prompt": "${parameters.question}"
+    }
+  },
+  "memory": {
+    "type": "conversation_index"
+  },
+  "parameters": {
+    "_llm_interface": "bedrock/converse/claude"
+  },
+  "tools": [
+    {
+      "type": "ListIndexTool",
+      "description": "List available indices"
+    },
+    {
+      "type": "SearchIndexTool",
+      "description": "Search documents in an index"
+    },
+    {
+      "type": "IndexMappingTool",
+      "description": "Get index mappings"
+    }
+  ]
+}
+```
+
+**Execute the agent:**
+```json
+POST /_plugins/_ml/agents/{agent_id}/_execute
+{
+  "parameters": {
+    "question": "What indices do I have and what are their mappings?"
+  }
+}
+```
+
+**Update agent configuration:**
+```json
+PUT /_plugins/_ml/agents/{agent_id}
+{
+  "name": "Updated Search Assistant",
+  "description": "Updated description",
+  "tools": [
+    { "type": "ListIndexTool" },
+    { "type": "SearchIndexTool" },
+    { "type": "IndexMappingTool" },
+    { "type": "PPLTool" }
+  ]
+}
+```
+
+## Limitations
+
+- Function calling requires compatible LLM interfaces (Bedrock/Claude, DeepSeek, OpenAI)
+- Simultaneous tool use with handle/supply not yet supported
+- Circuit breaker bypass for agents may impact cluster stability under heavy load
+- Agent execution timeout depends on underlying LLM response time
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#3820](https://github.com/opensearch-project/ml-commons/pull/3820) | Expose Update Agent API |
+| v3.1.0 | [#3874](https://github.com/opensearch-project/ml-commons/pull/3874) | Support persisting MCP tools in system index |
+| v3.1.0 | [#3888](https://github.com/opensearch-project/ml-commons/pull/3888) | Use function calling for existing LLM interfaces |
+| v3.1.0 | [#3891](https://github.com/opensearch-project/ml-commons/pull/3891) | Add custom SSE endpoint for MCP Client |
+| v3.1.0 | [#3884](https://github.com/opensearch-project/ml-commons/pull/3884) | PlanExecuteReflect: Return memory early to track progress |
+| v3.1.0 | [#3810](https://github.com/opensearch-project/ml-commons/pull/3810) | Support customized message endpoint |
+| v3.1.0 | [#3845](https://github.com/opensearch-project/ml-commons/pull/3845) | Add error handling for plan&execute agent |
+| v3.1.0 | [#3661](https://github.com/opensearch-project/ml-commons/pull/3661) | Metrics framework integration with ml-commons |
+| v3.1.0 | [#3862](https://github.com/opensearch-project/ml-commons/pull/3862) | Fix connector private IP validation when executing agent |
+| v3.1.0 | [#3814](https://github.com/opensearch-project/ml-commons/pull/3814) | Exclude circuit breaker for Agent |
+| v3.1.0 | [#3822](https://github.com/opensearch-project/ml-commons/pull/3822) | Fix Python client MCP server connection |
+
+## References
+
+- [Agent APIs Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/api/agent-apis/index/)
+- [Plan-Execute-Reflect Agents](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/agents/plan-execute-reflect/)
+- [ML Commons Cluster Settings](https://docs.opensearch.org/3.0/ml-commons-plugin/cluster-settings/)
+- [Issue #3748](https://github.com/opensearch-project/ml-commons/issues/3748): Update Agent API feature request
+- [Issue #2172](https://github.com/opensearch-project/ml-commons/issues/2172): Original Update Agent API request
+- [Issue #3841](https://github.com/opensearch-project/ml-commons/issues/3841): MCP tools persistence
+- [Issue #3847](https://github.com/opensearch-project/ml-commons/issues/3847): Function calling for LLM interfaces
+- [Issue #3635](https://github.com/opensearch-project/ml-commons/issues/3635): Metrics framework integration
+
+## Change History
+
+- **v3.1.0** (2025-07-15): Update Agent API, MCP tools persistence, function calling for LLM interfaces, custom SSE endpoint, metrics framework integration, PlanExecuteReflect memory tracking, error handling improvements, multiple bug fixes (private IP validation, circuit breaker bypass, Python MCP client)
+- **v3.0.0** (2025-05-13): Plan-Execute-Reflect agent type, MCP server integration
+- **v2.13.0** (2024-03-26): Initial agent framework with flow and conversational agents

--- a/docs/releases/v3.1.0/features/ml-commons/ml-commons-agent-framework.md
+++ b/docs/releases/v3.1.0/features/ml-commons/ml-commons-agent-framework.md
@@ -1,0 +1,214 @@
+# ML Commons Agent Framework
+
+## Summary
+
+OpenSearch v3.1.0 brings significant enhancements and bug fixes to the ML Commons Agent Framework, including new APIs for agent management, MCP (Model Context Protocol) integration improvements, function calling support for LLM interfaces, metrics framework integration, and multiple stability fixes for agent execution.
+
+## Details
+
+### What's New in v3.1.0
+
+This release focuses on three major areas:
+
+1. **Agent Management APIs**: New Update Agent API and MCP tools persistence
+2. **LLM Integration**: Function calling support and custom SSE endpoints for MCP
+3. **Stability & Observability**: Metrics framework integration, error handling improvements, and multiple bug fixes
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Agent Framework v3.1.0"
+        REG[Register Agent API]
+        UPD[Update Agent API]
+        EXEC[Execute Agent API]
+        MCP_REG[MCP Tools Register]
+        MCP_UPD[MCP Tools Update]
+        MCP_LIST[MCP Tools List]
+    end
+    
+    subgraph "LLM Integration"
+        FC[Function Calling]
+        SSE[Custom SSE Endpoint]
+        LLMI[LLM Interface]
+    end
+    
+    subgraph "Agent Types"
+        CONV[Conversational Agent]
+        FLOW[Flow Agent]
+        PER[Plan-Execute-Reflect]
+    end
+    
+    subgraph "Observability"
+        METRICS[Metrics Framework]
+        MEMORY[Memory Tracking]
+    end
+    
+    REG --> EXEC
+    UPD --> EXEC
+    EXEC --> CONV
+    EXEC --> FLOW
+    EXEC --> PER
+    
+    MCP_REG --> MCP_UPD
+    MCP_UPD --> MCP_LIST
+    
+    EXEC --> FC
+    FC --> LLMI
+    LLMI --> SSE
+    
+    EXEC --> METRICS
+    EXEC --> MEMORY
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| Update Agent API | `PUT /_plugins/_ml/agents/{agent_id}` - Modify existing agents without re-registration |
+| MCP Tools Persistence | Store MCP tools in system index with update and list APIs |
+| Function Calling | Native function calling support for Bedrock/Claude, DeepSeek, and OpenAI interfaces |
+| Custom SSE Endpoint | Configurable Server-Sent Events endpoint for MCP client connections |
+| Metrics Framework | Integration with OpenSearch metrics framework for adoption and operational metrics |
+
+#### New APIs
+
+**Update Agent API**
+```
+PUT /_plugins/_ml/agents/{agent_id}
+{
+  "name": "updated_agent_name",
+  "description": "updated description",
+  "llm": {
+    "model_id": "model_id"
+  },
+  "tools": [...]
+}
+```
+
+**MCP Tools Update API**
+```
+POST /_plugins/_ml/mcp/tools/_update
+{
+  "tools": [
+    {
+      "type": "PPLTool",
+      "name": "My_PPLTool",
+      "description": "Tool description",
+      "parameters": {...},
+      "attributes": {
+        "input_schema": {...}
+      }
+    }
+  ]
+}
+```
+
+**MCP Tools List API**
+```
+GET /_plugins/_ml/mcp/tools/_list
+```
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ml_commons.metrics.enabled` | Enable/disable metrics collection | `true` |
+| `_llm_interface` | LLM interface for function calling (e.g., `bedrock/converse/claude`) | - |
+
+### Usage Example
+
+**Creating an agent with function calling:**
+```json
+POST /_plugins/_ml/agents/_register
+{
+  "name": "Function Calling Agent",
+  "type": "conversational",
+  "llm": {
+    "model_id": "bedrock_model_id",
+    "parameters": {
+      "prompt": "${parameters.question}"
+    }
+  },
+  "memory": {
+    "type": "conversation_index"
+  },
+  "parameters": {
+    "_llm_interface": "bedrock/converse/claude"
+  },
+  "tools": [
+    { "type": "ListIndexTool" },
+    { "type": "SearchIndexTool" },
+    { "type": "IndexMappingTool" }
+  ]
+}
+```
+
+### Bug Fixes
+
+| Issue | Fix |
+|-------|-----|
+| Private IP validation | Fixed connector private IP validation when executing agent without remote model |
+| Inline connector name | Connector name no longer required for inline model connectors |
+| AIConnectorHelper tutorial | Fixed domain_name fetching in tutorial |
+| Nested object JSON parsing | Fixed JSON parsing for nested objects during update query step |
+| Valid character handling | Added `/` as a valid character in tool parameters |
+| Guava NoClassDefFoundError | Quick fix for Guava class loading issue |
+| Python MCP client | Fixed Python client connection to MCP server |
+| Circuit breaker bypass | Excluded agent execution from circuit breaker checks |
+| Tenant ID handling | Added tenantId to connector executor for inline connectors |
+
+### Migration Notes
+
+- Existing agents continue to work without modification
+- To use function calling, add `_llm_interface` parameter when registering agents
+- MCP tools can now be persisted and managed via new APIs
+
+## Limitations
+
+- Function calling currently supports Bedrock/Claude, DeepSeek R1, and OpenAI interfaces
+- Simultaneous tool use with handle/supply not yet supported (planned for future release)
+- Circuit breaker bypass for agents may impact cluster stability under heavy load
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3820](https://github.com/opensearch-project/ml-commons/pull/3820) | Expose Update Agent API |
+| [#3874](https://github.com/opensearch-project/ml-commons/pull/3874) | Support persisting MCP tools in system index |
+| [#3888](https://github.com/opensearch-project/ml-commons/pull/3888) | Use function calling for existing LLM interfaces |
+| [#3891](https://github.com/opensearch-project/ml-commons/pull/3891) | Add custom SSE endpoint for MCP Client |
+| [#3884](https://github.com/opensearch-project/ml-commons/pull/3884) | PlanExecuteReflect: Return memory early to track progress |
+| [#3810](https://github.com/opensearch-project/ml-commons/pull/3810) | Support customized message endpoint |
+| [#3845](https://github.com/opensearch-project/ml-commons/pull/3845) | Add error handling for plan&execute agent |
+| [#3661](https://github.com/opensearch-project/ml-commons/pull/3661) | Metrics framework integration with ml-commons |
+| [#3786](https://github.com/opensearch-project/ml-commons/pull/3786) | Add space type mapping for pre-trained embedding models |
+| [#3862](https://github.com/opensearch-project/ml-commons/pull/3862) | Fix connector private IP validation when executing agent |
+| [#3882](https://github.com/opensearch-project/ml-commons/pull/3882) | For inline model connector name isn't required |
+| [#3852](https://github.com/opensearch-project/ml-commons/pull/3852) | Fix AIConnectorHelper tutorial domain_name fetching |
+| [#3856](https://github.com/opensearch-project/ml-commons/pull/3856) | Add JSON parsing for nested objects during update query |
+| [#3854](https://github.com/opensearch-project/ml-commons/pull/3854) | Add `/` as a valid character |
+| [#3844](https://github.com/opensearch-project/ml-commons/pull/3844) | Quick fix for Guava NoClassDefFoundError |
+| [#3822](https://github.com/opensearch-project/ml-commons/pull/3822) | Fix Python client MCP server connection |
+| [#3814](https://github.com/opensearch-project/ml-commons/pull/3814) | Exclude circuit breaker for Agent |
+| [#3837](https://github.com/opensearch-project/ml-commons/pull/3837) | Add tenantId to connector executor for inline connectors |
+
+## References
+
+- [Issue #3748](https://github.com/opensearch-project/ml-commons/issues/3748): Update Agent API feature request
+- [Issue #2172](https://github.com/opensearch-project/ml-commons/issues/2172): Original Update Agent API request
+- [Issue #3816](https://github.com/opensearch-project/ml-commons/issues/3816): Custom SSE endpoint for MCP
+- [Issue #3841](https://github.com/opensearch-project/ml-commons/issues/3841): MCP tools persistence
+- [Issue #3847](https://github.com/opensearch-project/ml-commons/issues/3847): Function calling for LLM interfaces
+- [Issue #3881](https://github.com/opensearch-project/ml-commons/issues/3881): PlanExecuteReflect memory tracking
+- [Issue #3839](https://github.com/opensearch-project/ml-commons/issues/3839): Private IP validation fix
+- [Issue #3635](https://github.com/opensearch-project/ml-commons/issues/3635): Metrics framework integration
+- [Documentation Issue #9865](https://github.com/opensearch-project/documentation-website/issues/9865): Update Agent API documentation
+- [Agent APIs Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/api/agent-apis/index/)
+- [Plan-Execute-Reflect Agents](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/agents/plan-execute-reflect/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/ml-commons/ml-commons-agent-framework.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -84,6 +84,7 @@
 
 ### ML Commons
 
+- [Agent Framework](features/ml-commons/ml-commons-agent-framework.md) - Update Agent API, MCP tools persistence, function calling for LLM interfaces, custom SSE endpoint, metrics framework integration, multiple bug fixes
 - [Connector/Model Validation Bug Fixes](features/ml-commons/connector-model-validation.md) - Input validation for names/descriptions, schema string type preservation, connector retry policy NPE fix, MCP tool memory fix, Bedrock DeepSeek format fix
 - [ML Commons Maintenance](features/ml-commons/ml-commons-maintenance.md) - Hidden model security, enhanced logging, HTTP client alignment, SearchIndexTool MCP compatibility, CVE fixes
 - [MCP (Model Context Protocol)](features/ml-commons/mcp-(model-context-protocol).md) - MCP SDK downgrade to 0.9.0 and unit test coverage


### PR DESCRIPTION
## Summary

This PR adds documentation for the ML Commons Agent Framework enhancements in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/ml-commons/ml-commons-agent-framework.md`
- Feature report: `docs/features/ml-commons/ml-commons-agent-framework.md`

### Key Changes in v3.1.0

**New Features:**
- Update Agent API (`PUT /_plugins/_ml/agents/{agent_id}`)
- MCP tools persistence with update and list APIs
- Function calling support for LLM interfaces (Bedrock/Claude, DeepSeek, OpenAI)
- Custom SSE endpoint for MCP client connections
- Metrics framework integration for adoption and operational metrics
- PlanExecuteReflect memory tracking improvements

**Bug Fixes:**
- Connector private IP validation when executing agent without remote model
- Inline connector name no longer required
- Python MCP client connection fix
- Circuit breaker bypass for agent execution
- Multiple stability improvements

### PRs Investigated
18 PRs from ml-commons repository covering enhancements and bugfixes.

Closes #849