### PR TITLE
docs: add k-NN Vector Search Improvements report for v3.1.0

### DIFF
--- a/docs/features/k-nn/vector-search-k-nn.md
+++ b/docs/features/k-nn/vector-search-k-nn.md
@@ -212,6 +212,12 @@ PUT /_cluster/settings
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#2735](https://github.com/opensearch-project/k-NN/pull/2735) | Integrate LuceneOnFaiss memory-optimized search into KNNWeight |
+| v3.1.0 | [#2709](https://github.com/opensearch-project/k-NN/pull/2709) | Add rescore to Lucene Vector Search Query |
+| v3.1.0 | [#2750](https://github.com/opensearch-project/k-NN/pull/2750) | Update rescore context for 4X Compression |
+| v3.1.0 | [#2704](https://github.com/opensearch-project/k-NN/pull/2704) | Apply mask operation in preindex to optimize derived source |
+| v3.1.0 | [#2351](https://github.com/opensearch-project/k-NN/pull/2351) | Remove redundant type conversions for script scoring with binary vectors |
+| v3.1.0 | [#2727](https://github.com/opensearch-project/k-NN/pull/2727) | Refactor Knn Search Results to use TopDocs |
 | v3.0.0 | [#2564](https://github.com/opensearch-project/k-NN/pull/2564) | Breaking changes - remove deprecated settings |
 | v2.18.0 | [#2195](https://github.com/opensearch-project/k-NN/pull/2195) | Fix lucene codec after lucene version bumped to 9.12 |
 | v2.18.0 | [#2133](https://github.com/opensearch-project/k-NN/pull/2133) | Optimize KNNVectorValues creation for non-quantization cases |
@@ -239,6 +245,8 @@ PUT /_cluster/settings
 - [k-NN API Reference](https://docs.opensearch.org/3.0/vector-search/api/knn/): API documentation
 - [Approximate k-NN Search](https://docs.opensearch.org/3.0/vector-search/vector-search-techniques/approximate-knn/): ANN search guide
 - [Efficient k-NN Filtering](https://docs.opensearch.org/3.0/vector-search/filter-search-knn/efficient-knn-filtering/): Filtering guide
+- [Memory-optimized vectors](https://docs.opensearch.org/3.0/field-types/supported-field-types/knn-memory-optimized/): Compression and rescoring guide
+- [Issue #1827](https://github.com/opensearch-project/k-NN/issues/1827): Remove double converting for script scoring with binary vector
 - [Issue #2263](https://github.com/opensearch-project/k-NN/issues/2263): Node-level circuit breaker request
 - [Issue #2265](https://github.com/opensearch-project/k-NN/issues/2265): Concurrency optimizations request
 - [Issue #2465](https://github.com/opensearch-project/k-NN/issues/2465): Remote Native Index Build design
@@ -253,6 +261,7 @@ PUT /_cluster/settings
 
 ## Change History
 
+- **v3.1.0** (2025-07-15): Memory-optimized search (LuceneOnFaiss) integration into KNNWeight with layered architecture; rescore support for Lucene engine; 4x compression rescore context optimization; derived source indexing optimization; script scoring performance improvement for binary vectors; TopDocs refactoring for search results
 - **v3.0.0** (2025-05-06): Breaking changes removing deprecated index settings; node-level circuit breakers; filter function in KNNQueryBuilder; concurrency optimizations for graph loading; Remote Native Index Build foundation
 - **v2.18.0** (2024-11-05): Lucene 9.12 codec compatibility (KNN9120Codec); force merge performance optimization for non-quantization cases (~20% improvement); removed deprecated benchmarks folder; code refactoring improvements
 - **v2.17.0** (2024-09-17): Memory overflow fix for cache behavior; improved filter handling for non-existent fields; script_fields context support; field name validation for snapshots; graph merge stats fix; binary vector IVF training fix; Windows build improvements

--- a/docs/releases/v3.1.0/features/k-nn/k-nn-vector-search-improvements.md
+++ b/docs/releases/v3.1.0/features/k-nn/k-nn-vector-search-improvements.md
@@ -1,0 +1,146 @@
+# k-NN Vector Search Improvements
+
+## Summary
+
+OpenSearch v3.1.0 introduces significant improvements to k-NN vector search, including memory-optimized search for Faiss binary indexes, rescore support for Lucene engine, performance optimizations for derived source indexing, and internal refactoring for better alignment with Lucene's TopDocs interface. These changes improve search accuracy, reduce memory consumption, and enhance overall system performance.
+
+## Details
+
+### What's New in v3.1.0
+
+#### Memory-Optimized Search for Faiss Binary Index (LuceneOnFaiss)
+
+PR [#2735](https://github.com/opensearch-project/k-NN/pull/2735) integrates memory-optimized search (LuceneOnFaiss) into KNNWeight, enabling transparent switching to optimized search algorithms while preserving consistent user experience.
+
+Key changes:
+- **Layered KNNWeight architecture**: Common logic in base class with `DefaultKNNWeight` and `MemoryOptimizedKNNWeight` subclasses
+- **Extended compression support**: Now supports binary + disk mode compressions (32x, 16x, 8x)
+- **Nested document support**: Custom KnnCollector and parent ID grouper for nested queries
+- **Removed Lucene query dependency**: LuceneOnFaiss no longer relies on Lucene queries, fixing issues with options like `index.knn.advanced.approximate_threshold`
+
+#### Rescore Support for Lucene Engine
+
+PR [#2709](https://github.com/opensearch-project/k-NN/pull/2709) adds `RescoreKnnVectorQuery` to support rescoring after executing approximate k-NN search with the Lucene engine, bringing feature parity with Faiss.
+
+PR [#2750](https://github.com/opensearch-project/k-NN/pull/2750) updates the rescore context for 4x compression to use 1x oversampling factor, optimizing the balance between recall and performance.
+
+#### Derived Source Optimization
+
+PR [#2704](https://github.com/opensearch-project/k-NN/pull/2704) optimizes CPU and memory usage by applying mask operations in the preindex listener rather than the codec writer. Benchmark results on 10M vectors show significant reduction in resource utilization by avoiding redundant map deserialization.
+
+#### Script Scoring Performance
+
+PR [#2351](https://github.com/opensearch-project/k-NN/pull/2351) removes redundant type conversions (byte[] → float[] → byte[]) for script scoring with binary vectors using Hamming space, reducing query latency.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "KNNWeight Hierarchy (v3.1.0)"
+        KW[KNNWeight Base] --> DKW[DefaultKNNWeight]
+        KW --> MOKW[MemoryOptimizedKNNWeight]
+        
+        DKW --> LS[Lucene Search]
+        DKW --> FS[Faiss Search]
+        
+        MOKW --> LOF[LuceneOnFaiss]
+        LOF --> BQ[Binary Quantization]
+        LOF --> DM[Disk Mode]
+    end
+    
+    subgraph "Rescore Flow"
+        ANN[ANN Search] --> OS[Oversample k*factor]
+        OS --> FP[Full Precision Rescore]
+        FP --> TK[Top K Results]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `RescoreKnnVectorQuery` | Query wrapper for rescoring ANN results with full precision vectors |
+| `MemoryOptimizedKNNWeight` | KNNWeight subclass for memory-optimized search path |
+| `DefaultKNNWeight` | KNNWeight subclass for standard search path |
+
+#### Configuration Updates
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `rescore.oversample_factor` | Oversampling factor for 4x compression | `1.0` (updated from previous default) |
+
+### Usage Example
+
+#### Rescore with Lucene Engine
+
+```json
+GET /my-knn-index/_search
+{
+  "size": 10,
+  "query": {
+    "knn": {
+      "my_vector": {
+        "vector": [0.1, 0.2, 0.3, ...],
+        "k": 10,
+        "rescore": {
+          "oversample_factor": 2.0
+        }
+      }
+    }
+  }
+}
+```
+
+#### Binary Vector with Hamming Space (Optimized)
+
+```json
+PUT /binary-index
+{
+  "settings": {
+    "index.knn": true
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 128,
+        "data_type": "binary",
+        "space_type": "hamming",
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss"
+        }
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Memory-optimized search is only supported for Faiss engine with binary and disk mode compressions
+- Rescore is only supported for `faiss` and `lucene` engines (not `nmslib`)
+- The derived source optimization requires the preindex listener to be called before writeField
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2735](https://github.com/opensearch-project/k-NN/pull/2735) | Integrate LuceneOnFaiss memory-optimized search into KNNWeight |
+| [#2709](https://github.com/opensearch-project/k-NN/pull/2709) | Add rescore to Lucene Vector Search Query |
+| [#2750](https://github.com/opensearch-project/k-NN/pull/2750) | Update rescore context for 4X Compression |
+| [#2704](https://github.com/opensearch-project/k-NN/pull/2704) | Apply mask operation in preindex to optimize derived source |
+| [#2351](https://github.com/opensearch-project/k-NN/pull/2351) | Remove redundant type conversions for script scoring with binary vectors |
+| [#2727](https://github.com/opensearch-project/k-NN/pull/2727) | Refactor Knn Search Results to use TopDocs |
+
+## References
+
+- [Issue #1827](https://github.com/opensearch-project/k-NN/issues/1827): Remove double converting for script scoring with binary vector
+- [Memory-optimized vectors documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/knn-memory-optimized/): Official docs on compression and rescoring
+- [k-NN query documentation](https://docs.opensearch.org/3.0/query-dsl/specialized/k-nn/index/): k-NN query reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/k-nn/vector-search-k-nn.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -128,6 +128,7 @@
 
 - [k-NN Bug Fixes](features/k-nn/k-nn-bug-fixes.md) - 9 bug fixes for quantization cache, rescoring, thread safety, nested queries, memory cache race conditions, backward compatibility
 - [k-NN Testing Infrastructure](features/k-nn/k-nn-testing-infrastructure.md) - Enable all integration tests with remote index builder and fix MockNode constructor compatibility
+- [k-NN Vector Search Improvements](features/k-nn/k-nn-vector-search-improvements.md) - Memory-optimized search for Faiss binary indexes, Lucene rescore support, derived source optimization, script scoring performance
 - [Remote Vector Index Build](features/k-nn/remote-vector-index-build.md) - GA preparation with tuned buffer sizes, segment size upper bound, renamed settings, metrics fixes
 
 ### Search Relevance


### PR DESCRIPTION
## Summary

This PR adds documentation for k-NN Vector Search Improvements in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/k-nn/k-nn-vector-search-improvements.md`
- Feature report: `docs/features/k-nn/vector-search-k-nn.md` (updated)

### Key Changes in v3.1.0

1. **Memory-Optimized Search (LuceneOnFaiss)** - PR #2735
   - Layered KNNWeight architecture with DefaultKNNWeight and MemoryOptimizedKNNWeight
   - Extended compression support (32x, 16x, 8x)
   - Nested document support with custom KnnCollector

2. **Rescore Support for Lucene Engine** - PR #2709, #2750
   - RescoreKnnVectorQuery for rescoring ANN results
   - Updated 4x compression rescore context to 1x oversampling factor

3. **Derived Source Optimization** - PR #2704
   - Mask operation in preindex listener reduces CPU/memory usage

4. **Script Scoring Performance** - PR #2351
   - Removed redundant type conversions for binary vectors with Hamming space

5. **TopDocs Refactoring** - PR #2727
   - Search results now use TopDocs for better Lucene alignment

### Related Issue
Closes #845