### PR TITLE
docs: add ML Skills Text2Spark PPL report for v3.1.0

### DIFF
--- a/docs/features/skills/skills-tools.md
+++ b/docs/features/skills/skills-tools.md
@@ -99,9 +99,9 @@ The WebSearchTool enables agents to search the web and retrieve information. It 
 
 ### PPLTool
 
-The PPLTool translates natural language questions into Piped Processing Language (PPL) queries:
+The PPLTool translates natural language questions into Piped Processing Language (PPL) queries. It supports both OpenSearch and Spark data sources through the `datasourceType` parameter.
 
-**Usage Example:**
+**Usage Example (OpenSearch):**
 ```json
 {
   "type": "PPLTool",
@@ -112,6 +112,21 @@ The PPLTool translates natural language questions into Piped Processing Language
   }
 }
 ```
+
+**Usage Example (Spark/S3):**
+```json
+{
+  "type": "PPLTool",
+  "parameters": {
+    "model_id": "<llm_model_id>",
+    "index": "my-spark-table",
+    "question": "Show me the top 10 records",
+    "type": "s3"
+  }
+}
+```
+
+The `type` parameter (defaults to `Opensearch`) is passed to the LLM model as `datasourceType`, enabling the model to generate appropriate PPL syntax for the target data source.
 
 ### Configuration
 
@@ -130,6 +145,7 @@ The PPLTool translates natural language questions into Piped Processing Language
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#587](https://github.com/opensearch-project/skills/pull/587) | Add data source type parameter to PPLTool for Spark/S3 support |
 | v3.1.0 | [#581](https://github.com/opensearch-project/skills/pull/581) | Fix fields bug in PPL tool (multi-field mapping support) |
 | v3.1.0 | [#575](https://github.com/opensearch-project/skills/pull/575) | Fix conflict in dependency versions |
 | v3.0.0 | [#547](https://github.com/opensearch-project/skills/pull/547) | Add WebSearchTool |
@@ -151,6 +167,6 @@ The PPLTool translates natural language questions into Piped Processing Language
 
 ## Change History
 
-- **v3.1.0** (2025-05-06): Fixed PPLTool fields bug to properly expose multi-field mappings (e.g., `a.keyword`) to LLM for aggregation queries; fixed httpclient5 dependency version conflict in build.gradle, applied Spotless code formatting to WebSearchTool
+- **v3.1.0** (2025-05-06): Added data source type parameter (`datasourceType`) to PPLTool for Spark/S3 data source support; fixed PPLTool fields bug to properly expose multi-field mappings (e.g., `a.keyword`) to LLM for aggregation queries; fixed httpclient5 dependency version conflict in build.gradle, applied Spotless code formatting to WebSearchTool
 - **v3.0.0** (2025-02-25): Added WebSearchTool, fixed PPLTool empty list bug, updated dependencies, enhanced developer guide
 - **v2.18.0** (2024-11-12): Added LogPatternTool for log pattern analysis, added customizable prompt support for CreateAnomalyDetectorTool

--- a/docs/releases/v3.1.0/features/skills/ml-skills-text2spark-ppl.md
+++ b/docs/releases/v3.1.0/features/skills/ml-skills-text2spark-ppl.md
@@ -1,0 +1,107 @@
+# ML Skills Text2Spark PPL
+
+## Summary
+
+This release adds data source type information to the PPL tool's request body when communicating with the target model endpoint. The enhancement enables the LLM model to understand the data source context (e.g., OpenSearch vs Spark) and generate appropriate PPL queries accordingly.
+
+## Details
+
+### What's New in v3.1.0
+
+The PPLTool now includes a `datasourceType` parameter in the request sent to the LLM model. This allows the model to differentiate between OpenSearch and Spark data sources and generate PPL queries with the correct syntax and functions for each platform.
+
+### Technical Changes
+
+#### Code Change
+
+The change modifies how the PPLTool constructs the input data for the remote inference request:
+
+**Before:**
+```java
+RemoteInferenceInputDataSet inputDataSet = RemoteInferenceInputDataSet
+    .builder()
+    .parameters(Collections.singletonMap("prompt", prompt))
+    .build();
+```
+
+**After:**
+```java
+RemoteInferenceInputDataSet inputDataSet = RemoteInferenceInputDataSet
+    .builder()
+    .parameters(Map.of("prompt", prompt, "datasourceType", parameters.getOrDefault("type", "Opensearch")))
+    .build();
+```
+
+#### New Parameter
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `datasourceType` | Indicates the type of data source being queried | `Opensearch` |
+
+The `datasourceType` value is extracted from the `type` parameter in the tool's input parameters. If not specified, it defaults to `"Opensearch"`.
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[User Query] --> B[PPLTool]
+    B --> C{Data Source Type?}
+    C -->|OpenSearch| D[prompt + datasourceType=Opensearch]
+    C -->|Spark/S3| E[prompt + datasourceType=s3]
+    D --> F[LLM Model]
+    E --> F
+    F --> G[Generated PPL Query]
+```
+
+### Usage Example
+
+When using the PPLTool with a Spark data source:
+
+```json
+{
+  "type": "PPLTool",
+  "parameters": {
+    "model_id": "<llm_model_id>",
+    "index": "my-spark-table",
+    "question": "Show me the top 10 records",
+    "type": "s3"
+  }
+}
+```
+
+The LLM model receives:
+```json
+{
+  "prompt": "...",
+  "datasourceType": "s3"
+}
+```
+
+This enables the model to generate Spark-compatible PPL syntax when needed.
+
+### Backward Compatibility
+
+This change is backward compatible:
+- The `datasourceType` parameter defaults to `"Opensearch"` if not specified
+- Existing PPLTool configurations continue to work without modification
+- Models that don't use the `datasourceType` parameter can ignore it
+
+## Limitations
+
+- The model must be trained or prompted to understand and utilize the `datasourceType` parameter
+- Only two data source types are currently supported: `Opensearch` (default) and `s3` (Spark)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#587](https://github.com/opensearch-project/skills/pull/587) | Add data source type in the request body from PPL tool to model endpoint |
+
+## References
+
+- [PPL Tool Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/tools/ppl-tool/): Official PPL tool reference
+- [Skills Repository](https://github.com/opensearch-project/skills): Source code
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/skills/skills-tools.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -40,6 +40,7 @@
 ### Skills
 
 - [ML Skills](features/skills/ml-skills.md) - Fix httpclient5 dependency version conflict and apply Spotless formatting
+- [ML Skills Text2Spark PPL](features/skills/ml-skills-text2spark-ppl.md) - Add data source type parameter to PPLTool for Spark/S3 support
 - [Skills PPL Tool Fixes](features/skills/skills-ppl-tool-fixes.md) - Fix fields bug to expose multi-field mappings for aggregation queries
 
 ### Reporting


### PR DESCRIPTION
## Summary

This PR adds documentation for the ML Skills Text2Spark PPL feature in OpenSearch v3.1.0.

## Changes

### Release Report
- Created `docs/releases/v3.1.0/features/skills/ml-skills-text2spark-ppl.md`
- Documents the addition of `datasourceType` parameter to PPLTool for Spark/S3 data source support

### Feature Report Update
- Updated `docs/features/skills/skills-tools.md`
- Added documentation for the new `type` parameter in PPLTool
- Added PR #587 to Related PRs table
- Updated Change History

### Release Index
- Added link to the new release report in `docs/releases/v3.1.0/index.md`

## Related Issue
Closes #844

## Key Changes in v3.1.0
- PPLTool now includes `datasourceType` parameter in LLM requests
- Enables model to generate appropriate PPL syntax for OpenSearch vs Spark data sources
- Backward compatible - defaults to `Opensearch` if not specified

## PR Reference
- [opensearch-project/skills#587](https://github.com/opensearch-project/skills/pull/587)