### PR TITLE
docs: add Resource Access Control Framework report for v3.1.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -151,6 +151,7 @@
 - [Security Testing Framework](security/security-testing-framework.md)
 - [Security CI/CD](security/security-ci-cd.md)
 - [JWT Authentication](security/jwt-authentication.md)
+- [Resource Access Control Framework](security/resource-access-control-framework.md)
 
 ## security-dashboards
 

--- a/docs/features/security/resource-access-control-framework.md
+++ b/docs/features/security/resource-access-control-framework.md
@@ -1,0 +1,235 @@
+# Resource Access Control Framework
+
+## Summary
+
+The Resource Access Control Framework provides centralized, fine-grained access management for plugin-defined resources in OpenSearch. It enables document-level authorization for higher-level objects such as ML models, anomaly detectors, and reports, allowing resource owners to share their resources with specific users, roles, or backend roles while maintaining security and auditability.
+
+This framework replaces the legacy backend-role-based access model (`filter_by_backend_role`) with an owner-controlled sharing model, providing more granular control over who can access specific resources.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph User["User / OpenSearch Dashboards"]
+        U[User Request]
+    end
+    
+    subgraph Plugin["Resource Plugin"]
+        PL[Plugin REST API]
+        RSE[ResourceSharingExtension]
+        RSC[ResourceSharingClient]
+    end
+    
+    subgraph Security["Security Plugin"]
+        SF[Security Filter]
+        RAE[ResourceAccessEvaluator]
+        MAP[Index→SharingIndex Mapping]
+        RSH[ResourceSharingIndexHandler]
+        RIL[ResourceIndexListener]
+    end
+    
+    subgraph Data["System Indices - Per Plugin"]
+        RIDX1[(Resource Index A)]
+        RSIDX1[(Sharing Index A)]
+        RIDX2[(Resource Index B)]
+        RSIDX2[(Sharing Index B)]
+    end
+    
+    U -->|CRUD Request| PL
+    PL --> SF
+    SF --> RAE
+    RAE --> MAP
+    MAP -->|resolve| RSIDX1
+    MAP -->|resolve| RSIDX2
+    
+    PL --> RIDX1
+    PL --> RIDX2
+    
+    RSE -.->|registers on startup| Security
+    RSC -->|share/revoke/verify| RSH
+    RSH --> RSIDX1
+    RSH --> RSIDX2
+    
+    RIL -->|listens to| RIDX1
+    RIL -->|listens to| RIDX2
+    RIL -->|creates/deletes| RSIDX1
+    RIL -->|creates/deletes| RSIDX2
+```
+
+### Data Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Plugin as Resource Plugin
+    participant SecFilter as Security Filter
+    participant RAE as ResourceAccessEvaluator
+    participant Map as Index→SharingIndex Mapping
+    participant RSIDX as Backing Sharing Index
+
+    User->>Plugin: Request (e.g., GET /resource/{id})
+    Plugin->>SecFilter: Routed through security
+    SecFilter->>RAE: Evaluate (user, roles, backend_roles, action)
+    RAE->>Map: Resolve sharing index for resource_type
+    Map-->>RAE: sharing_index_name
+    RAE->>RSIDX: Fetch sharing doc by resource_id
+    RSIDX-->>RAE: share_with + created_by
+    RAE->>RAE: Check required access level
+    alt Allowed
+        RAE-->>SecFilter: ALLOW
+        SecFilter-->>Plugin: Proceed
+        Plugin-->>User: 200 OK
+    else Denied
+        RAE-->>SecFilter: DENY
+        SecFilter-->>Plugin: 403 Forbidden
+        Plugin-->>User: 403
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `opensearch-security-spi` | Service Provider Interface package for plugins to implement resource sharing |
+| `ResourceSharingExtension` | Interface that plugins implement to declare themselves as resource plugins |
+| `ResourceProvider` | Record containing resource class name and index name |
+| `ResourceSharingClient` | Client interface for plugins to perform access control operations |
+| `ResourceAccessEvaluator` | Evaluates access permissions automatically via Security Filter |
+| `ResourceSharingIndexHandler` | Manages CRUD operations on per-resource sharing indices |
+| `ResourceIndexListener` | IndexingOperationListener that maintains sharing metadata on resource changes |
+| `ResourcePluginInfo` | Tracks registered resource sharing extensions |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.experimental.resource_sharing.enabled` | Enable/disable resource sharing feature | `false` |
+| `plugins.security.system_indices.enabled` | Enable system index protection (required) | `true` |
+
+### Data Model
+
+Each resource index has a backing sharing index with naming convention: `{resourceIndex}-sharing`
+
+**Sharing Document Structure:**
+
+```json
+{
+  "resource_id": "resource-123",
+  "created_by": {
+    "user": "owner_username"
+  },
+  "share_with": {
+    "READ_ONLY": {
+      "users": ["user1", "user2"],
+      "roles": ["viewer_role"],
+      "backend_roles": ["data_analyst"]
+    },
+    "READ_WRITE": {
+      "users": ["admin_user"],
+      "roles": ["editor_role"],
+      "backend_roles": ["content_manager"]
+    }
+  }
+}
+```
+
+### Access Scopes
+
+| Scope | Description | Example |
+|-------|-------------|---------|
+| Private | No `share_with` entry - only owner and super-admins can access | `"share_with": {}` |
+| Restricted | Specific users/roles/backend_roles listed | `"share_with": {"READ_ONLY": {"users": ["alice"]}}` |
+| Public | Wildcard `*` grants access to all | `"share_with": {"READ_ONLY": {"users": ["*"]}}` |
+
+### Java APIs
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `verifyResourceAccess` | `void verifyResourceAccess(String resourceId, String resourceIndex, ActionListener<Boolean> listener)` | Check if current user has access |
+| `share` | `void share(String resourceId, String resourceIndex, Recipients recipients, ActionListener<ResourceSharing> listener)` | Grant access to specified entities |
+| `revoke` | `void revoke(String resourceId, String resourceIndex, Recipients entitiesToRevoke, ActionListener<ResourceSharing> listener)` | Remove access from specified entities |
+| `getAccessibleResourceIds` | `void getAccessibleResourceIds(String resourceIndex, ActionListener<Set<String>> listener)` | Get all accessible resource IDs |
+
+### Usage Example
+
+**1. Implement ResourceSharingExtension:**
+
+```java
+public class SampleResourceExtension implements ResourceSharingExtension {
+    @Override
+    public Set<ResourceProvider> getResourceProviders() {
+        return Set.of(new ResourceProvider(
+            SampleResource.class.getCanonicalName(), 
+            RESOURCE_INDEX_NAME
+        ));
+    }
+
+    @Override
+    public void assignResourceSharingClient(ResourceSharingClient client) {
+        ResourceSharingClientAccessor.getInstance()
+            .setResourceSharingClient(client);
+    }
+}
+```
+
+**2. Register via SPI:**
+
+Create file: `src/main/resources/META-INF/services/org.opensearch.security.spi.ResourceSharingExtension`
+
+```
+org.opensearch.sample.SampleResourceExtension
+```
+
+**3. Add dependency in build.gradle:**
+
+```gradle
+compileOnly group: 'org.opensearch', name:'opensearch-security-spi', version:"${opensearch_build}"
+
+opensearchplugin {
+    extendedPlugins = ['opensearch-security;optional=true']
+}
+```
+
+**4. Use client for access control:**
+
+```java
+ResourceSharingClient client = ResourceSharingClientAccessor.getInstance()
+    .getResourceSharingClient();
+
+client.share(
+    resourceId,
+    RESOURCE_INDEX_NAME,
+    new Recipients(List.of("user1"), List.of("role1"), List.of()),
+    ActionListener.wrap(
+        sharing -> log.info("Shared: {}", sharing),
+        e -> log.error("Failed to share", e)
+    )
+);
+```
+
+## Limitations
+
+- Feature is marked as **experimental** and disabled by default
+- Only resource owners and super-admins can share/revoke access
+- No pattern matching for users/roles/backend_roles - each must be individually specified
+- Resources must be stored in system indices with system index protection enabled
+- Currently supports single action group (`default`) - multiple action groups planned for future
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.1.0 | [#5281](https://github.com/opensearch-project/security/pull/5281) | Introduces Centralized Resource Access Control Framework |
+| v3.1.0 | [#5358](https://github.com/opensearch-project/security/pull/5358) | Store resource sharing info in 1:1 backing indices |
+
+## References
+
+- [Issue #4500](https://github.com/opensearch-project/security/issues/4500): Resource Permissions and Sharing proposal
+- [Blog: Introducing resource sharing](https://opensearch.org/blog/introducing-resource-sharing-a-new-access-control-model-for-opensearch/): Official announcement
+- [RESOURCE_ACCESS_CONTROL_FOR_PLUGINS.md](https://github.com/opensearch-project/security/blob/main/RESOURCE_ACCESS_CONTROL_FOR_PLUGINS.md): Developer guide
+
+## Change History
+
+- **v3.1.0** (2025): Initial implementation with centralized SPI, 1:1 backing sharing indices, and automatic access evaluation

--- a/docs/releases/v3.1.0/features/security/resource-access-control-framework.md
+++ b/docs/releases/v3.1.0/features/security/resource-access-control-framework.md
@@ -1,0 +1,181 @@
+# Resource Access Control Framework
+
+## Summary
+
+OpenSearch v3.1.0 introduces the **Resource Access Control Framework**, a centralized mechanism for managing fine-grained access control to plugin-defined resources. This framework enables document-level authorization for resources such as ML models, anomaly detectors, and reports, replacing the legacy backend-role-based access model with owner-controlled sharing capabilities.
+
+## Details
+
+### What's New in v3.1.0
+
+The Resource Access Control Framework provides:
+
+- **Centralized Resource Sharing SPI**: A new Service Provider Interface (`opensearch-security-spi`) that plugins can implement to declare themselves as resource plugins
+- **1:1 Backing Sharing Indices**: Each resource index now has a dedicated sharing index (e.g., `.plugins-ml-model-group` → `.plugins-ml-model-group-sharing`)
+- **Automatic Access Evaluation**: The `ResourceAccessEvaluator` automatically evaluates access permissions via the Security Filter
+- **Owner-Controlled Sharing**: Resource owners can share and revoke access to their resources with specific users, roles, or backend roles
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph User["User / Dashboards"]
+        U[User Request]
+    end
+    
+    subgraph Plugin["Resource Plugin"]
+        PL[Plugin API]
+        RSE[ResourceSharingExtension]
+    end
+    
+    subgraph Security["Security Plugin"]
+        SF[Security Filter]
+        RAE[ResourceAccessEvaluator]
+        MAP[Index→SharingIndex Mapping]
+        RSH[ResourceSharingIndexHandler]
+    end
+    
+    subgraph Data["System Indices"]
+        RIDX[(Resource Index)]
+        RSIDX[(Sharing Index)]
+    end
+    
+    U --> PL
+    PL --> SF
+    SF --> RAE
+    RAE --> MAP
+    MAP --> RSIDX
+    PL --> RIDX
+    RSE -.->|registers| Security
+    RSH --> RSIDX
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `opensearch-security-spi` | Service Provider Interface for plugins to implement resource sharing |
+| `ResourceSharingExtension` | Interface that plugins implement to declare resource types |
+| `ResourceSharingClient` | Client API for plugins to perform access control operations |
+| `ResourceAccessEvaluator` | Automatic access evaluation via Security Filter |
+| `ResourceSharingIndexHandler` | Manages per-resource sharing indices |
+| `ResourceIndexListener` | Listens for resource CRUD operations to maintain sharing metadata |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.experimental.resource_sharing.enabled` | Enable/disable resource sharing feature | `false` |
+
+#### API Changes
+
+The framework introduces Java APIs for plugins:
+
+| Method | Description |
+|--------|-------------|
+| `verifyResourceAccess()` | Check if current user has access to a resource |
+| `share()` | Grant access to a resource for specified users/roles/backend_roles |
+| `revoke()` | Remove access permissions for specified entities |
+| `getAccessibleResourceIds()` | Retrieve IDs of all resources the current user can access |
+
+### Data Model
+
+Resource sharing information is stored in backing indices with the following structure:
+
+```json
+{
+  "resource_id": "resource-123",
+  "created_by": {
+    "user": "owner_username"
+  },
+  "share_with": {
+    "READ_ONLY": {
+      "users": ["user1", "user2"],
+      "roles": ["viewer_role"],
+      "backend_roles": ["data_analyst"]
+    },
+    "READ_WRITE": {
+      "users": ["admin_user"],
+      "roles": ["editor_role"],
+      "backend_roles": ["content_manager"]
+    }
+  }
+}
+```
+
+### Access Scopes
+
+Resources can have three access scopes:
+
+- **Private**: No `share_with` entry exists - only owner and super-admins can access
+- **Restricted**: `share_with` contains specific users/roles/backend_roles
+- **Public**: `share_with` contains wildcard `*` for users/roles/backend_roles
+
+### Usage Example
+
+Plugin implementation to use the framework:
+
+```java
+// 1. Implement ResourceSharingExtension
+public class SampleResourceExtension implements ResourceSharingExtension {
+    @Override
+    public Set<ResourceProvider> getResourceProviders() {
+        return Set.of(new ResourceProvider(
+            SampleResource.class.getCanonicalName(), 
+            RESOURCE_INDEX_NAME
+        ));
+    }
+
+    @Override
+    public void assignResourceSharingClient(ResourceSharingClient client) {
+        ResourceSharingClientAccessor.getInstance()
+            .setResourceSharingClient(client);
+    }
+}
+
+// 2. Register in META-INF/services
+// src/main/resources/META-INF/services/org.opensearch.security.spi.ResourceSharingExtension
+// org.opensearch.sample.SampleResourceExtension
+
+// 3. Use the client for access control
+resourceSharingClient.share(
+    resourceId,
+    RESOURCE_INDEX_NAME,
+    shareWithRecipients,
+    ActionListener.wrap(sharing -> {
+        // Handle success
+    }, listener::onFailure)
+);
+```
+
+### Migration Notes
+
+- Enable the feature flag: `plugins.security.experimental.resource_sharing.enabled: true`
+- System index protection must be enabled: `plugins.security.system_indices.enabled: true`
+- Plugins must declare `compileOnly` dependency on `opensearch-security-spi`
+- Plugins must extend `opensearch-security` with optional flag
+
+## Limitations
+
+- Feature is marked as **experimental** and disabled by default
+- Only resource owners and super-admins can share/revoke access
+- No pattern matching for users/roles/backend_roles - each must be individually specified
+- Resources must be stored in system indices with system index protection enabled
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5281](https://github.com/opensearch-project/security/pull/5281) | Introduces Centralized Resource Access Control Framework |
+| [#5358](https://github.com/opensearch-project/security/pull/5358) | Store resource sharing info in indices that map 1-to-1 with resource index |
+
+## References
+
+- [Issue #4500](https://github.com/opensearch-project/security/issues/4500): Resource Permissions and Sharing proposal
+- [Blog: Introducing resource sharing](https://opensearch.org/blog/introducing-resource-sharing-a-new-access-control-model-for-opensearch/): Official announcement blog
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/security/resource-access-control-framework.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -49,6 +49,7 @@
 
 ### Security
 
+- [Resource Access Control Framework](features/security/resource-access-control-framework.md) - Centralized resource sharing SPI with 1:1 backing indices and automatic access evaluation
 - [Security Backend Bug Fixes](features/security/security-backend-bug-fixes.md) - Stale cache post snapshot restore, compliance audit log diff, DLS/FLS filter reader, auth header logging, password reset UI, forecasting permissions
 - [Security Cache Management](features/security/security-cache-management.md) - Selective user cache invalidation endpoint and dynamic cache TTL configuration
 - [Security Debugging](features/security/security-debugging.md) - Enhanced error messages for "Security not initialized" with cluster manager status


### PR DESCRIPTION
## Summary

This PR adds documentation for the **Resource Access Control Framework** feature introduced in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/security/resource-access-control-framework.md`
- Feature report: `docs/features/security/resource-access-control-framework.md`

### Key Changes in v3.1.0
- Centralized Resource Sharing SPI (`opensearch-security-spi`) for plugins to implement resource sharing
- 1:1 backing sharing indices per resource index (e.g., `.plugins-ml-model-group` → `.plugins-ml-model-group-sharing`)
- Automatic access evaluation via `ResourceAccessEvaluator` in Security Filter
- Owner-controlled sharing with users, roles, and backend roles

### Resources Used
- PR: #5281 (Centralized Resource Access Control Framework)
- PR: #5358 (Store resource sharing info in 1:1 backing indices)
- Issue: #4500 (Resource Permissions and Sharing proposal)
- Blog: https://opensearch.org/blog/introducing-resource-sharing-a-new-access-control-model-for-opensearch/

Closes #843