### PR TITLE
docs: add Neural Search Enhancements report for v3.1.0

### DIFF
--- a/docs/features/neural-search/neural-sparse-search.md
+++ b/docs/features/neural-search/neural-sparse-search.md
@@ -171,11 +171,13 @@ GET /my-sparse-index/_search
 - Analyzer must be configured in index settings (for analyzer-based queries)
 - Token weights in analyzer mode must be encoded as 4-byte floats in payload attribute
 - Two-phase optimization requires search pipeline configuration
+- Cannot specify both `model_id` and `analyzer` in the same query (v3.1.0+)
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#1359](https://github.com/opensearch-project/neural-search/pull/1359) | Validate model_id and analyzer mutual exclusivity |
 | v3.0.0 | [#1088](https://github.com/opensearch-project/neural-search/pull/1088) | Implement analyzer-based neural sparse query |
 | v2.11.0 | - | Initial neural sparse query implementation |
 
@@ -188,5 +190,6 @@ GET /my-sparse-index/_search
 
 ## Change History
 
+- **v3.1.0**: Added validation to prevent specifying both model_id and analyzer simultaneously
 - **v3.0.0** (2025-03-11): Added analyzer-based neural sparse query support, enabling tokenization without ML Commons models
 - **v2.11.0**: Initial implementation of neural sparse query with model-based and raw token support

--- a/docs/features/neural-search/text-chunking.md
+++ b/docs/features/neural-search/text-chunking.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Text chunking is an ingest processor in the neural-search plugin that splits long documents into shorter passages for improved semantic search and embedding generation. It supports multiple chunking algorithms including fixed token length and delimiter-based splitting, with configurable parameters for token limits, overlap, and handling of missing fields.
+Text chunking is an ingest processor in the neural-search plugin that splits long documents into shorter passages for improved semantic search and embedding generation. It supports multiple chunking algorithms including fixed token length, delimiter-based splitting, and fixed character length, with configurable parameters for token/character limits, overlap, and handling of missing fields.
 
 ## Details
 
@@ -15,8 +15,10 @@ graph TB
         TCP --> ALGO{Algorithm}
         ALGO -->|fixed_token_length| FTL[Fixed Token Length Chunker]
         ALGO -->|delimiter| DEL[Delimiter Chunker]
+        ALGO -->|fixed_char_length| FCL[Fixed Char Length Chunker]
         FTL --> OUT[Chunked Passages]
         DEL --> OUT
+        FCL --> OUT
     end
     subgraph "Downstream Processing"
         OUT --> EMB[Text Embedding Processor]
@@ -37,12 +39,15 @@ flowchart TB
     G --> H[Split by Token Limit]
     H --> I[Apply Overlap]
     F -->|delimiter| J[Split by Delimiter]
-    I --> K[Output Passages]
-    J --> K
-    D --> L[Pass Through]
-    E --> K
-    K --> M[Output Document]
+    F -->|fixed_char_length| K[Split by Character Count]
+    K --> L[Apply Overlap]
+    I --> M[Output Passages]
+    J --> M
     L --> M
+    D --> N[Pass Through]
+    E --> M
+    M --> O[Output Document]
+    N --> O
 ```
 
 ### Components
@@ -53,6 +58,7 @@ flowchart TB
 | `TextChunkingProcessorFactory` | Factory for creating processor instances from pipeline configuration |
 | `FixedTokenLengthChunker` | Splits text into passages of specified token count with optional overlap |
 | `DelimiterChunker` | Splits text on specified delimiter strings |
+| `FixedCharLengthChunker` | Splits text into passages of specified character count with optional overlap |
 
 ### Configuration
 
@@ -78,6 +84,14 @@ flowchart TB
 | Setting | Description | Default |
 |---------|-------------|---------|
 | `delimiter` | String delimiter for splitting | `\n\n` |
+| `max_chunk_limit` | Maximum number of chunks allowed | `100` |
+
+#### Fixed Character Length Algorithm Parameters
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `char_limit` | Maximum characters per chunk | `2048` |
+| `overlap_rate` | Overlap percentage between chunks (0-0.5) | `0` |
 | `max_chunk_limit` | Maximum number of chunks allowed | `100` |
 
 ### Usage Example
@@ -129,24 +143,53 @@ Multiple text chunking processors can be chained for complex splitting strategie
 }
 ```
 
+### Fixed Character Length Example
+
+The `fixed_char_length` algorithm is especially beneficial for languages that do not use spaces to separate words, such as Chinese, Japanese, Thai, and Khmer:
+
+```json
+PUT _ingest/pipeline/char-chunking-pipeline
+{
+  "processors": [
+    {
+      "text_chunking": {
+        "algorithm": {
+          "fixed_char_length": {
+            "char_limit": 500,
+            "overlap_rate": 0.2
+          }
+        },
+        "field_map": {
+          "content": "content_chunks"
+        }
+      }
+    }
+  ]
+}
+```
+
 ## Limitations
 
 - The default `token_limit` of 384 is optimized for OpenSearch pretrained models with 512 token input limits
 - `max_chunk_limit` throws an exception if exceeded; set to `-1` to disable
 - Nested field paths must use JSON object notation, not dot notation
+- The `fixed_char_length` algorithm's `overlap_rate` is limited to 0-0.5 range
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#1342](https://github.com/opensearch-project/neural-search/pull/1342) | Add FixedCharLengthChunker for character length-based chunking |
 | v2.18.0 | [#907](https://github.com/opensearch-project/neural-search/pull/907) | Add ignore_missing field to text chunking processors |
 
 ## References
 
 - [Issue #906](https://github.com/opensearch-project/neural-search/issues/906): Feature request for ignore_missing field
+- [Issue #1261](https://github.com/opensearch-project/neural-search/issues/1261): Proposal for RecursiveCharacterTextSplitter
 - [Text Chunking Processor Documentation](https://docs.opensearch.org/latest/ingest-pipelines/processors/text-chunking/): Official documentation
 - [Text Chunking Guide](https://docs.opensearch.org/latest/search-plugins/text-chunking/): Usage guide for semantic search
 
 ## Change History
 
+- **v3.1.0**: Added `fixed_char_length` algorithm for character-based chunking, beneficial for non-space-delimited languages
 - **v2.18.0** (2024-10-29): Added `ignore_missing` parameter to skip missing fields during processing

--- a/docs/releases/v3.1.0/features/neural-search/neural-search-enhancements.md
+++ b/docs/releases/v3.1.0/features/neural-search/neural-search-enhancements.md
@@ -1,0 +1,135 @@
+# Neural Search Enhancements
+
+## Summary
+
+OpenSearch v3.1.0 introduces significant enhancements to the neural-search plugin, including analyzer-based neural sparse queries for lightweight tokenization without ML model inference, a new character-based text chunking algorithm for non-space-delimited languages, and improved validation for neural sparse query parameters.
+
+## Details
+
+### What's New in v3.1.0
+
+This release adds three key improvements to neural search capabilities:
+
+1. **Analyzer-based Neural Sparse Query**: Enables neural sparse search using Lucene analyzers instead of ML models for query tokenization
+2. **FixedCharLengthChunker**: New text chunking algorithm that splits text by character count rather than tokens
+3. **Model ID and Analyzer Validation**: Prevents configuration conflicts by validating that both parameters aren't provided simultaneously
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Neural Sparse Query Flow"
+        QT[Query Text] --> NSQ[NeuralSparseQueryBuilder]
+        NSQ --> CHECK{Tokenization Method?}
+        CHECK -->|model_id| ML[ML Model Inference]
+        CHECK -->|analyzer| ANA[Lucene Analyzer]
+        CHECK -->|neither| DEF[Default: bert-uncased]
+        ML --> TOKENS[Query Tokens]
+        ANA --> TOKENS
+        DEF --> TOKENS
+        TOKENS --> SEARCH[Sparse Vector Search]
+    end
+    
+    subgraph "Text Chunking"
+        DOC[Document] --> TCP[TextChunkingProcessor]
+        TCP --> ALGO{Algorithm}
+        ALGO -->|fixed_token_length| FTL[Token-based]
+        ALGO -->|delimiter| DEL[Delimiter-based]
+        ALGO -->|fixed_char_length| FCL[Character-based]
+        FTL --> OUT[Chunked Passages]
+        DEL --> OUT
+        FCL --> OUT
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `NeuralSparseQueryBuilder.analyzer` | New field to specify Lucene analyzer for query tokenization |
+| `NeuralSparseQueryTwoPhaseInfo` | Encapsulates two-phase execution state for neural sparse queries |
+| `FixedCharLengthChunker` | Chunker implementation that splits text by character count |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `analyzer` (neural_sparse query) | Lucene analyzer name for tokenization | `bert-uncased` |
+| `char_limit` (fixed_char_length) | Maximum characters per chunk | `2048` |
+| `overlap_rate` (fixed_char_length) | Overlap percentage between chunks (0-0.5) | `0.0` |
+
+### Usage Example
+
+#### Analyzer-based Neural Sparse Query
+
+```json
+GET my-nlp-index/_search
+{
+  "query": {
+    "neural_sparse": {
+      "passage_embedding": {
+        "query_text": "Hello world",
+        "analyzer": "standard"
+      }
+    }
+  }
+}
+```
+
+#### Fixed Character Length Chunking
+
+```json
+PUT _ingest/pipeline/char-chunking-pipeline
+{
+  "processors": [
+    {
+      "text_chunking": {
+        "algorithm": {
+          "fixed_char_length": {
+            "char_limit": 500,
+            "overlap_rate": 0.2
+          }
+        },
+        "field_map": {
+          "content": "content_chunks"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Migration Notes
+
+- If using neural sparse queries without specifying `model_id` or `analyzer`, the default `bert-uncased` analyzer is now used automatically on clusters running v3.0+
+- Cannot specify both `model_id` and `analyzer` in the same query - choose one tokenization method
+- The `neural_query_enricher` processor can set default model IDs, which may conflict with analyzer settings
+
+## Limitations
+
+- Analyzer-based queries require the analyzer to be available in the index settings
+- The `bert-uncased` default analyzer is only available on clusters running OpenSearch 3.0+
+- `fixed_char_length` chunker `overlap_rate` is limited to 0-0.5 range
+- Token weights from analyzers must be encoded as 4-byte floats in the payload attribute
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1088](https://github.com/opensearch-project/neural-search/pull/1088) | Implement analyzer-based neural sparse query |
+| [#1342](https://github.com/opensearch-project/neural-search/pull/1342) | Add FixedCharLengthChunker for character length-based chunking |
+| [#1359](https://github.com/opensearch-project/neural-search/pull/1359) | Validate model_id and analyzer mutual exclusivity |
+
+## References
+
+- [Issue #1052](https://github.com/opensearch-project/neural-search/issues/1052): RFC for analyzer-based neural sparse query
+- [Issue #1261](https://github.com/opensearch-project/neural-search/issues/1261): Proposal for RecursiveCharacterTextSplitter
+- [Neural Sparse Query Documentation](https://docs.opensearch.org/3.0/query-dsl/specialized/neural-sparse/): Official docs
+- [Text Chunking Processor Documentation](https://docs.opensearch.org/3.0/ingest-pipelines/processors/text-chunking/): Official docs
+
+## Related Feature Report
+
+- [Text Chunking](../../../../features/neural-search/text-chunking.md)
+- [Neural Sparse Search](../../../../features/neural-search/neural-sparse-search.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -79,6 +79,7 @@
 - [Lucene Upgrade](features/neural-search/lucene-upgrade.md) - Update hybrid query implementation for Lucene 10.2.1 API compatibility
 - [Neural Search Bug Fixes](features/neural-search/neural-search-bug-fixes.md) - 7 bug fixes for hybrid query validation, semantic field handling, radial search serialization, stats API, and stability
 - [Neural Search Compatibility](features/neural-search/neural-search-compatibility.md) - Update neural-search for OpenSearch 3.0 beta compatibility
+- [Neural Search Enhancements](features/neural-search/neural-search-enhancements.md) - Analyzer-based neural sparse query, FixedCharLengthChunker, and model_id/analyzer validation
 - [Neural Search Stats](features/neural-search/neural-search-stats.md) - Comprehensive stats API for monitoring ingest processors, search processors, hybrid queries, and semantic highlighting
 
 ### Learning to Rank


### PR DESCRIPTION
## Summary

This PR adds documentation for Neural Search Enhancements in OpenSearch v3.1.0.

### Changes

**Release Report Created:**
- `docs/releases/v3.1.0/features/neural-search/neural-search-enhancements.md`

**Feature Reports Updated:**
- `docs/features/neural-search/text-chunking.md` - Added FixedCharLengthChunker algorithm
- `docs/features/neural-search/neural-sparse-search.md` - Added v3.1.0 validation enhancement

### Key Features Documented

1. **Analyzer-based Neural Sparse Query** (PR #1088)
   - Enables neural sparse search using Lucene analyzers instead of ML models
   - Default analyzer: `bert-uncased`
   - Reduces dependency on ML Commons for doc-only mode

2. **FixedCharLengthChunker** (PR #1342)
   - New text chunking algorithm based on character count
   - Beneficial for non-space-delimited languages (Chinese, Japanese, Thai, Khmer)
   - Parameters: `char_limit` (default: 2048), `overlap_rate` (0-0.5)

3. **Model ID and Analyzer Validation** (PR #1359)
   - Prevents configuration conflicts by validating mutual exclusivity
   - Clear error message when both parameters are provided

### Related Issue
Closes #841