### PR TITLE
docs: add QAT-Accelerated Zstandard Compression report for v3.1.0

### DIFF
--- a/docs/features/custom-codecs/custom-codecs.md
+++ b/docs/features/custom-codecs/custom-codecs.md
@@ -21,6 +21,7 @@ graph TB
         ZstdNoDictCodec[ZSTD No Dict Codec]
         QatLz4[QAT LZ4 Codec]
         QatDeflate[QAT DEFLATE Codec]
+        QatZstd[QAT ZSTD Codec]
     end
     
     subgraph "Compression Libraries"
@@ -38,11 +39,13 @@ graph TB
     CodecService --> ZstdNoDictCodec
     CodecService --> QatLz4
     CodecService --> QatDeflate
+    CodecService --> QatZstd
     
     ZstdCodec --> ZstdJni
     ZstdNoDictCodec --> ZstdJni
     QatLz4 --> QatJava
     QatDeflate --> QatJava
+    QatZstd --> QatJava
     QatJava --> IntelQAT
 ```
 
@@ -74,6 +77,7 @@ flowchart TB
 | `Lucene101QatCodec` | Base codec for QAT hardware acceleration (Lucene 10.1.0) |
 | `QatLz4101Codec` | Hardware-accelerated LZ4 compression |
 | `QatDeflate101Codec` | Hardware-accelerated DEFLATE compression |
+| `QatZstd101Codec` | Hardware-accelerated ZSTD compression |
 
 #### Backward Compatibility Components
 
@@ -91,6 +95,7 @@ flowchart TB
 | `zstd_no_dict` | Zstandard | No | No | 2.9.0 |
 | `qat_lz4` | LZ4 | N/A | Yes (Intel QAT) | 2.15.0 |
 | `qat_deflate` | DEFLATE | N/A | Yes (Intel QAT) | 2.15.0 |
+| `qat_zstd` | Zstandard | N/A | Yes (Intel QAT) | 3.1.0 |
 
 ### Configuration
 
@@ -145,6 +150,21 @@ PUT /my-index
 }
 ```
 
+#### QAT ZSTD Codec
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "codec": "qat_zstd",
+      "codec.compression_level": 3,
+      "codec.qatmode": "auto"
+    }
+  }
+}
+```
+
 ### Performance Comparison
 
 Benchmark results comparing codecs against the default LZ4 codec (using `nyc_taxi` dataset):
@@ -165,7 +185,7 @@ Benchmark results comparing codecs against the default LZ4 codec (using `nyc_tax
 | Library | Version | Purpose |
 |---------|---------|---------|
 | `com.github.luben:zstd-jni` | 1.5.6-1 | ZSTD compression via JNI |
-| `com.intel.qat:qat-java` | 1.1.1 | Intel QAT hardware acceleration |
+| `com.intel.qat:qat-java` | 2.3.2 | Intel QAT hardware acceleration |
 
 ## Limitations
 
@@ -179,6 +199,7 @@ Benchmark results comparing codecs against the default LZ4 codec (using `nyc_tax
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#238](https://github.com/opensearch-project/custom-codecs/pull/238) | Add QAT-Accelerated Zstandard Compression Support |
 | v3.1.0 | [#255](https://github.com/opensearch-project/custom-codecs/pull/255) | Fix version on BWC test dependency |
 | v3.0.0 | [#228](https://github.com/opensearch-project/custom-codecs/pull/228) | Upgrade to Lucene 10.1.0 and introduce new Codec implementation |
 | v3.0.0 | [#232](https://github.com/opensearch-project/custom-codecs/pull/232) | Bump ZSTD lib version to 1.5.6-1 |
@@ -196,6 +217,7 @@ Benchmark results comparing codecs against the default LZ4 codec (using `nyc_tax
 
 ## Change History
 
+- **v3.1.0** (2025-09-16): Added QAT-accelerated ZSTD codec (`qat_zstd`), upgraded qat-java to 2.3.2
 - **v3.1.0** (2025-09-16): Fixed BWC test dependency version and added java-agent plugin to BWC tests
 - **v3.0.0** (2025-05-06): Upgraded to Lucene 10.1.0 with new codec implementations (Lucene101*), bumped zstd-jni to 1.5.6-1, migrated to Java Agent from SecurityManager
 - **v2.15.0** (2024-06-25): Added QAT hardware-accelerated codecs (`qat_lz4`, `qat_deflate`)

--- a/docs/releases/v3.1.0/features/custom-codecs/qat-accelerated-zstandard-compression.md
+++ b/docs/releases/v3.1.0/features/custom-codecs/qat-accelerated-zstandard-compression.md
@@ -1,0 +1,119 @@
+# QAT-Accelerated Zstandard Compression
+
+## Summary
+
+OpenSearch v3.1.0 adds a new hardware-accelerated compression codec `qat_zstd` to the Custom Codecs plugin. This codec leverages Intel® QuickAssist Technology (QAT) to accelerate Zstandard (ZSTD) compression, combining the excellent compression ratio of ZSTD with hardware acceleration for improved performance.
+
+## Details
+
+### What's New in v3.1.0
+
+This release introduces the `qat_zstd` codec, which provides:
+
+- Hardware-accelerated ZSTD compression using Intel QAT
+- Configurable compression levels (1-6)
+- Automatic fallback to software compression when QAT hardware is unavailable (with `qatmode: auto`)
+- Full integration with existing QAT codec infrastructure
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Custom Codecs Plugin"
+        CodecService[Codec Service]
+        QatLz4[QAT LZ4 Codec]
+        QatDeflate[QAT DEFLATE Codec]
+        QatZstd[QAT ZSTD Codec]
+    end
+    
+    subgraph "QAT Infrastructure"
+        QatCompressionMode[QatCompressionMode]
+        QatZipperFactory[QatZipperFactory]
+        QatZipper[QatZipper]
+    end
+    
+    subgraph "Hardware"
+        IntelQAT[Intel QAT Accelerator]
+        Software[Software Fallback]
+    end
+    
+    CodecService --> QatLz4
+    CodecService --> QatDeflate
+    CodecService --> QatZstd
+    
+    QatZstd --> QatCompressionMode
+    QatCompressionMode --> QatZipperFactory
+    QatZipperFactory --> QatZipper
+    QatZipper --> IntelQAT
+    QatZipper --> Software
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `QatZstd101Codec` | Main codec class for QAT-accelerated ZSTD compression |
+| `Lucene101QatCodec.Mode.QAT_ZSTD` | New mode enum for ZSTD algorithm selection |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.codec` | Set to `qat_zstd` to enable QAT ZSTD compression | N/A |
+| `index.codec.compression_level` | Compression level (1-6) | 3 |
+| `index.codec.qatmode` | `auto` (fallback to software) or `hardware` (QAT only) | `auto` |
+
+### Usage Example
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "codec": "qat_zstd",
+      "codec.compression_level": 3,
+      "codec.qatmode": "auto"
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- Existing indexes using other codecs can be migrated by closing the index, updating the codec setting, and reopening
+- Alternatively, reindex data into a new index with `qat_zstd` codec
+- The `qat_zstd` codec requires Intel 4th/5th Gen Xeon processors with QAT support for hardware acceleration
+- Use `qatmode: auto` for environments where QAT hardware may not be available
+
+### Dependencies
+
+| Library | Version | Change |
+|---------|---------|--------|
+| `com.intel.qat:qat-java` | 2.3.2 | Upgraded from 1.1.1 to support ZSTD algorithm |
+
+## Limitations
+
+- Requires Intel QAT hardware for hardware acceleration (falls back to software with `qatmode: auto`)
+- Cannot be used for k-NN or Security Analytics indexes
+- Compression levels limited to range [1, 6]
+- QAT `hardware` mode will fail if hardware is unavailable
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#238](https://github.com/opensearch-project/custom-codecs/pull/238) | Add QAT-Accelerated Zstandard Compression Support |
+
+## References
+
+- [Custom Codecs Repository](https://github.com/opensearch-project/custom-codecs): Source code
+- [Index Codecs Documentation](https://docs.opensearch.org/3.0/im-plugin/index-codecs/): Official documentation
+- [Intel QAT Overview](https://www.intel.com/content/www/us/en/developer/topic-technology/open/quick-assist-technology/overview.html): Hardware acceleration
+- [qat-java Library](https://github.com/intel/qat-java): Intel QAT Java bindings
+- [Zstandard](https://github.com/facebook/zstd): ZSTD compression algorithm
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/custom-codecs/custom-codecs.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -163,3 +163,4 @@
 ### Custom Codecs
 
 - [Build/Test Infrastructure](features/custom-codecs/test-infrastructure.md) - Fix BWC test dependency version and add java-agent plugin
+- [QAT-Accelerated Zstandard Compression](features/custom-codecs/qat-accelerated-zstandard-compression.md) - New `qat_zstd` codec for hardware-accelerated ZSTD compression using Intel QAT


### PR DESCRIPTION
## Summary

This PR adds documentation for the QAT-Accelerated Zstandard Compression feature introduced in OpenSearch v3.1.0.

## Changes

### Release Report
- Created `docs/releases/v3.1.0/features/custom-codecs/qat-accelerated-zstandard-compression.md`
- Documents the new `qat_zstd` codec that leverages Intel QAT for hardware-accelerated ZSTD compression

### Feature Report Update
- Updated `docs/features/custom-codecs/custom-codecs.md`:
  - Added `QatZstd101Codec` to architecture diagram and components table
  - Added `qat_zstd` to supported codecs table
  - Added usage example for QAT ZSTD codec
  - Updated qat-java dependency version to 2.3.2
  - Added PR #238 to related PRs
  - Added v3.1.0 entry to change history

### Release Index
- Updated `docs/releases/v3.1.0/index.md` to include the new report

## Key Changes in v3.1.0
- New `qat_zstd` codec for hardware-accelerated ZSTD compression
- Upgraded qat-java library from 1.1.1 to 2.3.2 to support ZSTD algorithm
- Configurable compression levels (1-6) and QAT mode (auto/hardware)

## Related Issue
Closes #837