### PR TITLE
docs: add Alerting Improvements report for v3.1.0

### DIFF
--- a/docs/features/alerting/alerting.md
+++ b/docs/features/alerting/alerting.md
@@ -155,6 +155,15 @@ POST _plugins/_alerting/monitors
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.1.0 | [#1850](https://github.com/opensearch-project/alerting/pull/1850) | Timebox doc level monitor execution |
+| v3.1.0 | [#1854](https://github.com/opensearch-project/alerting/pull/1854) | Prevent dry run execution of doc level monitor with index pattern |
+| v3.1.0 | [#1856](https://github.com/opensearch-project/alerting/pull/1856) | Use transport service timeout instead of custom impl |
+| v3.1.0 | [#1860](https://github.com/opensearch-project/alerting/pull/1860) | Publish list of findings instead of individual ones |
+| v3.1.0 | [#829](https://github.com/opensearch-project/common-utils/pull/829) | Validate index patterns not allowed in doc level monitor |
+| v3.1.0 | [#832](https://github.com/opensearch-project/common-utils/pull/832) | Update PublishFindingsRequest to use list of findings |
+| v3.1.0 | [#835](https://github.com/opensearch-project/common-utils/pull/835) | Fix isDocLevelMonitor check for threat intel monitor |
+| v3.1.0 | [#1248](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1248) | Add alert insight to alerts card on overview page |
+| v3.1.0 | [#1256](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1256) | Add error handling for extract log pattern |
 | v3.0.0 | [#1780](https://github.com/opensearch-project/alerting/pull/1780) | Fix bucket selector aggregation writeable name |
 | v3.0.0 | [#1823](https://github.com/opensearch-project/alerting/pull/1823) | Fix build due to phasing off SecurityManager |
 | v3.0.0 | [#1824](https://github.com/opensearch-project/alerting/pull/1824) | Use java-agent Gradle plugin |
@@ -190,11 +199,14 @@ POST _plugins/_alerting/monitors
 - [Composite Monitors](https://docs.opensearch.org/3.0/observing-your-data/alerting/composite-monitors/): Composite monitor documentation
 - [Alerting Security](https://docs.opensearch.org/3.0/observing-your-data/alerting/security/): Security configuration for alerting
 - [Notifications Plugin](https://docs.opensearch.org/3.0/observing-your-data/notifications/index/): Notifications integration
+- [Issue #1853](https://github.com/opensearch-project/alerting/issues/1853): Timebox doc level monitor to avoid duplicate executions
+- [Issue #1859](https://github.com/opensearch-project/alerting/issues/1859): Change publish findings to accept a list of findings
 - [Issue #1617](https://github.com/opensearch-project/alerting/issues/1617): Distribution build issue
 - [Issue #671](https://github.com/opensearch-project/alerting-dashboards-plugin/issues/671): Trigger name validation issue
 
 ## Change History
 
+- **v3.1.0** (2025): Doc-level monitor timeboxing (3-4 min execution limit), batch findings publishing for improved performance, index pattern validation for doc-level monitors, threat intel monitor check fix, alert insight on dashboard overview page, log pattern extraction error handling
 - **v3.0.0** (2025): Bug fixes for bucket selector aggregation, Java Agent migration, and dashboard subfield selection
 - **v2.18.0** (2024-11-05): Doc-level monitor improvements including dynamic query index deletion (`delete_query_index_in_every_run` flag), query index lifecycle optimization, bucket-level monitor performance optimization for time-series indices, dashboard UX fit-and-finish updates, MDS compatibility fixes
 - **v2.17.0** (2024-09-17): Monitor lock renewal fix, distribution build fixes, workspace navigation fix, trigger name validation fix, alerts card rendering fix, cypress and unit test fixes

--- a/docs/releases/v3.1.0/features/alerting/alerting-improvements.md
+++ b/docs/releases/v3.1.0/features/alerting/alerting-improvements.md
@@ -1,0 +1,152 @@
+# Alerting Improvements
+
+## Summary
+
+OpenSearch v3.1.0 includes several improvements to the Alerting plugin focused on doc-level monitor stability, performance optimization, and dashboard enhancements. Key changes include timeboxing doc-level monitor execution to prevent duplicate job runs, batch publishing of findings for improved performance, index pattern validation for doc-level monitors, and alert insight integration in the dashboards overview page.
+
+## Details
+
+### What's New in v3.1.0
+
+#### Doc-Level Monitor Execution Timeboxing
+
+Doc-level monitor fan-out operations can now be timeboxed to prevent execution from running beyond the job scheduler lock lease expiry, which previously caused duplicate job executions.
+
+- Execution timeboxed to 3-4 minutes
+- Uses `TransportService`'s built-in timeout via `TransportOptions` instead of custom implementation
+- Prevents duplicate monitor executions when fan-out takes too long
+
+#### Batch Findings Publishing
+
+Findings are now published in batches instead of individually, significantly reducing transport thread contention.
+
+- `PublishFindingsRequest` updated to accept a list of findings
+- Reduces deadlocks and contention on transport threadpool
+- Improves performance when monitors generate many findings
+
+#### Index Pattern Validation
+
+Doc-level monitors now validate that index patterns are not allowed during create/update operations.
+
+- Prevents configuration errors with index patterns in doc-level monitors
+- Validation added in both alerting plugin and common-utils
+
+#### Threat Intel Monitor Check Fix
+
+Fixed the `isDocLevelMonitor` check to properly account for threat intel monitors.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Doc-Level Monitor Execution"
+        Monitor[Doc-Level Monitor]
+        Fanout[Fan-out Action]
+        Timeout[TransportService Timeout]
+        Findings[Findings]
+    end
+    
+    subgraph "Findings Publishing"
+        BatchPublish[Batch Publish]
+        SecurityAnalytics[Security Analytics]
+    end
+    
+    Monitor --> Fanout
+    Fanout --> Timeout
+    Timeout -->|3-4 min limit| Findings
+    Findings --> BatchPublish
+    BatchPublish --> SecurityAnalytics
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| Timebox Execution | Limits doc-level monitor execution to prevent lock expiry issues |
+| Batch Findings Publisher | Publishes findings in batches for improved performance |
+| Index Pattern Validator | Validates index patterns are not used in doc-level monitors |
+
+### Usage Example
+
+Doc-level monitors now automatically benefit from timeboxed execution. No configuration changes are required.
+
+```json
+POST _plugins/_alerting/monitors
+{
+  "type": "monitor",
+  "name": "doc-level-monitor",
+  "monitor_type": "doc_level_monitor",
+  "enabled": true,
+  "schedule": {
+    "period": {
+      "interval": 5,
+      "unit": "MINUTES"
+    }
+  },
+  "inputs": [{
+    "doc_level_input": {
+      "description": "Monitor for specific documents",
+      "indices": ["logs-*"],
+      "queries": [{
+        "id": "query1",
+        "name": "error-query",
+        "query": "level:ERROR",
+        "tags": ["error"]
+      }]
+    }
+  }],
+  "triggers": [{
+    "name": "error-trigger",
+    "severity": "1",
+    "condition": {
+      "script": {
+        "source": "true",
+        "lang": "painless"
+      }
+    },
+    "actions": []
+  }]
+}
+```
+
+### Dashboard Enhancements
+
+#### Alert Insight on Overview Page
+
+Alert insight component has been refactored and added to the alerts card on the overview page, providing quick visibility into alert status.
+
+#### Error Handling for Log Pattern Extraction
+
+Added error handling for log pattern extraction in alert insights, gracefully ignoring errors when patterns cannot be extracted.
+
+## Limitations
+
+- Timeboxed execution may cause monitors to complete before processing all documents in very large datasets
+- Batch findings publishing requires corresponding updates in Security Analytics for correlation processing
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#1850](https://github.com/opensearch-project/alerting/pull/1850) | alerting | Timebox doc level monitor execution |
+| [#1854](https://github.com/opensearch-project/alerting/pull/1854) | alerting | Prevent dry run execution of doc level monitor with index pattern |
+| [#1856](https://github.com/opensearch-project/alerting/pull/1856) | alerting | Use transport service timeout instead of custom impl |
+| [#1860](https://github.com/opensearch-project/alerting/pull/1860) | alerting | Publish list of findings instead of individual ones |
+| [#829](https://github.com/opensearch-project/common-utils/pull/829) | common-utils | Validate index patterns not allowed in doc level monitor |
+| [#832](https://github.com/opensearch-project/common-utils/pull/832) | common-utils | Update PublishFindingsRequest to use list of findings |
+| [#835](https://github.com/opensearch-project/common-utils/pull/835) | common-utils | Fix isDocLevelMonitor check for threat intel monitor |
+| [#1248](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1248) | alerting-dashboards-plugin | Add alert insight to alerts card on overview page |
+| [#1256](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1256) | alerting-dashboards-plugin | Add error handling for extract log pattern |
+
+## References
+
+- [Issue #1853](https://github.com/opensearch-project/alerting/issues/1853): Timebox doc level monitor to avoid duplicate executions
+- [Issue #1859](https://github.com/opensearch-project/alerting/issues/1859): Change publish findings to accept a list of findings
+- [Alerting Documentation](https://docs.opensearch.org/3.0/observing-your-data/alerting/index/): Official alerting documentation
+- [Per Document Monitors](https://docs.opensearch.org/3.0/observing-your-data/alerting/per-document-monitors/): Per-document monitor documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/alerting/alerting.md)

--- a/docs/releases/v3.1.0/index.md
+++ b/docs/releases/v3.1.0/index.md
@@ -168,3 +168,7 @@
 ### Anomaly Detection
 
 - [Anomaly Detection Forecasting](features/anomaly-detection/anomaly-detection-forecasting.md) - Bug fixes for forecasting task state handling, date format compatibility, cold-start/window delay refinements, UI validation and error display improvements
+
+### Alerting
+
+- [Alerting Improvements](features/alerting/alerting-improvements.md) - Doc-level monitor timeboxing, batch findings publishing, index pattern validation, threat intel monitor fix, dashboard alert insights


### PR DESCRIPTION
## Summary

This PR adds documentation for Alerting Improvements in OpenSearch v3.1.0.

### Reports Created
- Release report: `docs/releases/v3.1.0/features/alerting/alerting-improvements.md`
- Feature report: `docs/features/alerting/alerting.md` (updated)

### Key Changes in v3.1.0
- Doc-level monitor execution timeboxing (3-4 min limit) to prevent duplicate job runs
- Batch findings publishing for improved performance (reduces transport thread contention)
- Index pattern validation for doc-level monitors
- Fix isDocLevelMonitor check for threat intel monitors
- Alert insight integration on dashboard overview page
- Error handling for log pattern extraction

### PRs Investigated
- alerting: #1850, #1854, #1856, #1860
- common-utils: #829, #832, #835
- alerting-dashboards-plugin: #1248, #1256

### Related Issues
- [Issue #1853](https://github.com/opensearch-project/alerting/issues/1853): Timebox doc level monitor
- [Issue #1859](https://github.com/opensearch-project/alerting/issues/1859): Batch findings publishing