### PR TITLE
docs: add query-editor-ui report for v3.2.0

### DIFF
--- a/docs/features/opensearch-dashboards/query-editor.md
+++ b/docs/features/opensearch-dashboards/query-editor.md
@@ -128,6 +128,9 @@ The footer bar displays:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#9960](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9960) | Fix autocomplete for new query panel |
+| v3.2.0 | [#10259](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10259) | Change query editor UI - edit button placement |
+| v3.2.0 | [#10337](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10337) | Change generated query UI - scrollable display |
 | v2.18.0 | [#8565](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8565) | Adds editor footer to single line editor on focus |
 | v2.18.0 | [#8045](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8045) | Fix order of query editor extensions not working |
 | v2.18.0 | [#8087](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8087) | PPL Autocomplete functions, fields, & table suggestion |
@@ -139,4 +142,5 @@ The footer bar displays:
 
 ## Change History
 
+- **v3.2.0**: Fixed autocomplete stale query issue, improved Tab/Enter key handling for suggestions, made generated query scrollable, refined "Replace query" button placement
 - **v2.18.0** (2024-11-05): Added footer bar to single-line editor, fixed query editor extension ordering, improved PPL autocomplete

--- a/docs/releases/v3.2.0/features/opensearch-dashboards/query-editor-ui.md
+++ b/docs/releases/v3.2.0/features/opensearch-dashboards/query-editor-ui.md
@@ -1,0 +1,106 @@
+# Query Editor UI
+
+## Summary
+
+OpenSearch Dashboards v3.2.0 includes several UI/UX improvements to the Query Editor in the Explore plugin. These changes improve the autocomplete behavior, generated query display, and "Edit query" button placement for a better user experience.
+
+## Details
+
+### What's New in v3.2.0
+
+Three bugfixes improve the Query Editor experience:
+
+1. **Autocomplete fixes**: Fixed stale query data being passed to the autocomplete service, improved Tab and Enter key handling for suggestion selection
+2. **Generated query UI**: Made the generated query display scrollable with a max height instead of using ellipsis truncation
+3. **Edit query button placement**: Moved the "Edit query" button closer to the generated PPL query and changed it from a button to a badge, then refined to use `EuiButtonEmpty` with "Replace query" label
+
+### Technical Changes
+
+#### Autocomplete Improvements (PR #9960)
+
+The autocomplete system had issues with stale query data and keyboard handling:
+
+| Issue | Fix |
+|-------|-----|
+| Stale query passed to autocomplete | Use `model.getValue()` instead of `localQuery` state |
+| Tab selection not triggering next autocomplete | Added Tab key handler to accept suggestion and retrigger |
+| Enter key behavior inconsistent | Added Enter key handler to check suggestion widget visibility |
+
+Key code changes in `resuable_editor.tsx`:
+```typescript
+// Tab key: accept suggestion and trigger next autocomplete
+editor.addCommand(monaco.KeyCode.Tab, () => {
+  editor.trigger('keyboard', 'acceptSelectedSuggestion', {});
+  setTimeout(() => {
+    editor.trigger('keyboard', 'editor.action.triggerSuggest', {});
+  }, 100);
+});
+
+// Enter key: accept suggestion if visible, otherwise run query
+editor.addCommand(monaco.KeyCode.Enter, () => {
+  const suggestWidgetVisible = contextKeyService?.getContextKeyValue('suggestWidgetVisible');
+  if (suggestWidgetVisible) {
+    editor.trigger('keyboard', 'acceptSelectedSuggestion', {});
+    setTimeout(() => {
+      editor.trigger('keyboard', 'editor.action.triggerSuggest', {});
+    }, 100);
+  } else {
+    onRun(editor.getValue());
+    onEdit();
+  }
+});
+```
+
+Also enabled `tabCompletion: 'on'` in editor configuration.
+
+#### Generated Query UI (PR #10337)
+
+Changed the generated query display from ellipsis truncation to scrollable:
+
+| Before | After |
+|--------|-------|
+| Single line with ellipsis | Scrollable with max height |
+| `text-overflow: ellipsis` | `max-height: calc($ouiSize * 3)` |
+| `white-space: nowrap` | `overflow-y: auto` |
+
+The button was also changed from `EuiBadge` to `EuiButtonEmpty` with icon changed from `editorCodeBlock` to `sortUp`, and label changed from "Edit query" to "Replace query".
+
+#### Edit Query Button Placement (PR #10259)
+
+Moved the "Edit query" button to be adjacent to the generated query text:
+
+- Changed from `EuiButtonEmpty` to `EuiBadge` (later reverted in PR #10337)
+- Added `filter: brightness(0.65)` to prompt icon for better visibility
+- Simplified CSS by removing separate right section wrapper
+
+### Usage Example
+
+The Query Editor in Explore now provides smoother autocomplete interaction:
+
+1. Type a query in the editor
+2. Press Tab to accept a suggestion and immediately see next suggestions
+3. Press Enter within suggestion widget to accept and continue
+4. Press Enter outside suggestion widget to execute the query
+5. View the full generated PPL query in a scrollable area
+6. Click "Replace query" to copy the generated query to the editor
+
+## Limitations
+
+- The 100ms delay for retriggering suggestions is a workaround and may feel slightly delayed
+- The max height for generated query is fixed at `3 * $ouiSize`
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9960](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9960) | Fix autocomplete for new query panel |
+| [#10259](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10259) | Change query editor UI - edit button placement |
+| [#10337](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10337) | Change generated query UI - scrollable display |
+
+## References
+
+- [Query Editor Feature](../../../features/opensearch-dashboards/query-editor.md): Full feature documentation
+
+## Related Feature Report
+
+- [Query Editor](../../../features/opensearch-dashboards/query-editor.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -1,0 +1,13 @@
+# OpenSearch v3.2.0 Release
+
+## Overview
+
+This page indexes all investigated release items for OpenSearch v3.2.0.
+
+## Release Reports
+
+### OpenSearch Dashboards
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Query Editor UI](features/opensearch-dashboards/query-editor-ui.md) | bugfix | Autocomplete fixes, generated query UI improvements, edit button placement |


### PR DESCRIPTION
## Summary

Adds release report for Query Editor UI bugfixes in OpenSearch Dashboards v3.2.0.

## Changes

### Release Report
- `docs/releases/v3.2.0/features/opensearch-dashboards/query-editor-ui.md`
- `docs/releases/v3.2.0/index.md`

### Feature Report Update
- `docs/features/opensearch-dashboards/query-editor.md` - Added v3.2.0 PRs and change history

## Key Findings

Three bugfixes improve the Query Editor experience in the Explore plugin:

1. **PR #9960**: Fixed autocomplete stale query issue, improved Tab/Enter key handling
2. **PR #10259**: Moved "Edit query" button closer to generated query
3. **PR #10337**: Made generated query display scrollable instead of ellipsis truncation

Closes #1167