### PR TITLE
docs: add UI Settings & Dataset Select report for v3.2.0

### DIFF
--- a/docs/features/opensearch-dashboards/dashboards-ui-ux-fixes.md
+++ b/docs/features/opensearch-dashboards/dashboards-ui-ux-fixes.md
@@ -100,6 +100,7 @@ graph TB
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#10344](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10344) | Dataset selector UI visual improvements |
 | v3.0.0 | [#9514](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9514) | Make nav icon style compatible with sidecar |
 | v2.18.0 | [#8227](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8227) | Change page title to h1 with xs size for accessibility |
 | v3.0.0 | [#9516](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9516) | Fix data frame null or undefined object conversion error |
@@ -141,5 +142,6 @@ graph TB
 
 ## Change History
 
+- **v3.2.0** (2026-01-10): Dataset selector visual improvements (bold text, improved layout)
 - **v3.0.0** (2025-05-06): Initial collection of UI/UX fixes including navigation, query editor, data source, and Discover improvements
 - **v2.18.0** (2024-11-05): Sidebar tooltips, initial page fixes, dev tools nav group removal, overlay positioning, Chrome 129 workaround, OUI breakpoints, HeaderControl rendering, responsive design fixes, page title semantic improvements (h1 + xs size)

--- a/docs/features/opensearch-dashboards/experimental-features.md
+++ b/docs/features/opensearch-dashboards/experimental-features.md
@@ -160,6 +160,7 @@ curl -X POST 'http://localhost:5601/api/opensearch-dashboards/settings?scope=use
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#9927](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9927) | Make UI setting client more robust when setting key does not exist |
 | v2.18.0 | [#7953](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7953) | Initial implementation of user level settings |
 
 ## References
@@ -170,4 +171,5 @@ curl -X POST 'http://localhost:5601/api/opensearch-dashboards/settings?scope=use
 
 ## Change History
 
+- **v3.2.0** (2026-01-10): Improved UiSettingsClient robustness for non-existent setting keys
 - **v2.18.0** (2024-10-22): Initial implementation with user settings page, scoped uiSettings, and UserUISettingsClientWrapper

--- a/docs/releases/v3.2.0/features/opensearch-dashboards/ui-settings-dataset-select.md
+++ b/docs/releases/v3.2.0/features/opensearch-dashboards/ui-settings-dataset-select.md
@@ -1,0 +1,99 @@
+# UI Settings & Dataset Select
+
+## Summary
+
+This release includes two bug fixes for OpenSearch Dashboards: improved robustness of the UI settings client when handling non-existent setting keys, and visual updates to the dataset selector component in the Explore feature.
+
+## Details
+
+### What's New in v3.2.0
+
+#### UI Settings Client Robustness (PR #9927)
+
+The `UiSettingsClient` has been made more robust to handle cases where a non-existent setting key is passed. Previously, accessing undefined keys could cause errors; now the client handles these cases gracefully.
+
+**Key Changes:**
+- `validateScope()` now defaults to an empty object when the key doesn't exist in cache
+- `getUserProvidedWithScope()` uses optional chaining for the type property
+- Removed unused `scope` parameter from `mergeSettingsIntoCache()` method
+- Added unit tests to verify no errors are thrown for non-existent keys
+
+```typescript
+// Before: Could throw error if key doesn't exist
+private validateScope(key: string, scope: UiSettingScope) {
+  const definition = this.cache[key]; // undefined if key doesn't exist
+  // ...
+}
+
+// After: Gracefully handles missing keys
+private validateScope(key: string, scope: UiSettingScope) {
+  const definition = this.cache[key] || {}; // Defaults to empty object
+  // ...
+}
+```
+
+#### Dataset Selector UI Update (PR #10344)
+
+The dataset selector component in the Explore feature received visual improvements for better layout and readability.
+
+**Visual Changes:**
+- Removed fixed width constraints (was 300px)
+- Added bold font weight to dataset title text
+- Improved text wrapper alignment with flexbox
+- Simplified icon styling by removing separate icon class
+- Set max-width to 275px for text overflow handling
+
+```scss
+// Updated styles
+.datasetSelect {
+  &__textWrapper {
+    align-items: center;
+    margin-inline-end: $euiSizeXS;
+    gap: $euiSizeXS;
+  }
+
+  &__text {
+    text-align: left;
+    white-space: nowrap;
+    font-weight: $euiFontWeightBold;
+    flex: 1;
+    max-width: 275px;
+    text-overflow: ellipsis;
+    height: $euiSizeL;
+    line-height: $euiSizeL;
+    overflow: hidden;
+  }
+}
+```
+
+### Technical Changes
+
+#### Modified Components
+
+| Component | File | Change |
+|-----------|------|--------|
+| UiSettingsClient | `src/core/public/ui_settings/ui_settings_client.ts` | Added null-safe access patterns |
+| DatasetSelect | `src/plugins/data/public/ui/dataset_select/dataset_select.tsx` | Updated CSS class names |
+| Dataset Select Styles | `src/plugins/data/public/ui/dataset_select/_dataset_select.scss` | Improved layout styles |
+
+## Limitations
+
+- The UI settings client fix only addresses the public (browser-side) client; server-side behavior remains unchanged
+- Dataset selector visual changes are specific to the Explore feature
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9927](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9927) | Make UI setting client more robust when the setting key does not exist |
+| [#10344](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10344) | UI update for dataset select |
+
+## References
+
+- [PR #9927](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9927): UI settings client robustness fix
+- [PR #10344](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10344): Dataset selector UI update
+
+## Related Feature Reports
+
+- [Discover](../../../features/opensearch-dashboards/discover.md): Dataset selector is part of the Discover/Explore feature
+- [Dashboards UI/UX Fixes](../../../features/opensearch-dashboards/dashboards-ui-ux-fixes.md): Related UI improvements

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -11,3 +11,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | Item | Category | Description |
 |------|----------|-------------|
 | [Query Editor UI](features/opensearch-dashboards/query-editor-ui.md) | bugfix | Autocomplete fixes, generated query UI improvements, edit button placement |
+| [UI Settings & Dataset Select](features/opensearch-dashboards/ui-settings-dataset-select.md) | bugfix | UI settings client robustness, dataset selector visual updates |


### PR DESCRIPTION
## Summary

This PR adds documentation for the UI Settings & Dataset Select bugfixes in OpenSearch Dashboards v3.2.0.

### Changes

**Release Report Created:**
- `docs/releases/v3.2.0/features/opensearch-dashboards/ui-settings-dataset-select.md`

**Feature Reports Updated:**
- `docs/features/opensearch-dashboards/dashboards-ui-ux-fixes.md` - Added v3.2.0 dataset selector UI changes
- `docs/features/opensearch-dashboards/experimental-features.md` - Added v3.2.0 UI settings client robustness fix

### PRs Investigated

| PR | Description |
|----|-------------|
| [#9927](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9927) | Make UI setting client more robust when the setting key does not exist |
| [#10344](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10344) | UI update for dataset select |

### Key Findings

1. **UI Settings Client Robustness**: The `UiSettingsClient` now gracefully handles non-existent setting keys by defaulting to empty objects and using optional chaining.

2. **Dataset Selector Visual Updates**: The dataset selector in the Explore feature received styling improvements including bold text, improved flexbox layout, and better text overflow handling.

Closes #1166