### PR TITLE
docs: add OUI updates report for v3.2.0

### DIFF
--- a/docs/features/opensearch-dashboards/oui.md
+++ b/docs/features/opensearch-dashboards/oui.md
@@ -86,6 +86,8 @@ function MyComponent() {
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#10153](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10153) | Update OUI to 1.20 |
+| v3.2.0 | [#10284](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10284) | Update OUI to 1.21 |
 | v2.18.0 | [#8246](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8246) | Update OUI to 1.13 |
 | v2.18.0 | [#8372](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8372) | Update OUI to 1.14 |
 | v2.18.0 | [#8480](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8480) | Update OUI to 1.15 |
@@ -97,4 +99,5 @@ function MyComponent() {
 
 ## Change History
 
+- **v3.2.0** (2025-07-29): Updated to OUI 1.21 with `preserveTabContent` prop for `EuiTabbedContent` component
 - **v2.18.0** (2024-11-05): Updated to OUI 1.15 with new `$euiSideNavBackgroundColor` variable, font changes from Fira Code to Source Code Pro

--- a/docs/releases/v3.2.0/features/opensearch-dashboards/oui-updates.md
+++ b/docs/releases/v3.2.0/features/opensearch-dashboards/oui-updates.md
@@ -1,0 +1,68 @@
+# OUI (OpenSearch UI) Updates
+
+## Summary
+
+OpenSearch Dashboards v3.2.0 updates the OUI (OpenSearch UI) component library from version 1.19 to 1.21. These updates bring bug fixes, component improvements, and dependency updates to the UI framework.
+
+## Details
+
+### What's New in v3.2.0
+
+This release includes two sequential OUI version updates:
+
+1. **OUI 1.19 → 1.20** (PR #10153): Includes component fixes and snapshot updates for `EuiTabbedContent` with new `preserveTabContent` prop
+2. **OUI 1.20 → 1.21** (PR #10284): Further refinements and bug fixes
+
+### Technical Changes
+
+#### Package Updates
+
+The OUI dependency is updated across multiple package.json files:
+
+| Package | Previous | Updated |
+|---------|----------|---------|
+| Root `package.json` | `@opensearch-project/oui@1.19.0` | `@opensearch-project/oui@1.21.0` |
+| `osd-ui-framework` | `@opensearch-project/oui@1.19.0` | `@opensearch-project/oui@1.21.0` |
+| `osd-ui-shared-deps` | `@opensearch-project/oui@1.19.0` | `@opensearch-project/oui@1.21.0` |
+| Test plugins | `@opensearch-project/oui@1.19.0` | `@opensearch-project/oui@1.21.0` |
+
+#### Component Changes
+
+The update introduces the `preserveTabContent` prop to `EuiTabbedContent` component, affecting several plugins:
+
+- `data` plugin: Shard failure modal
+- `discover` plugin: Doc viewer
+- `explore` plugin: Doc viewer and line visualization options
+- `index_pattern_management` plugin: Scripting help flyout
+
+### Files Changed
+
+| File | Change Type |
+|------|-------------|
+| `package.json` | Version bump |
+| `packages/osd-ui-framework/package.json` | Version bump |
+| `packages/osd-ui-shared-deps/package.json` | Version bump |
+| `yarn.lock` | Dependency resolution |
+| Various `__snapshots__/*.snap` files | Updated component snapshots |
+
+## Limitations
+
+- OUI updates may require snapshot test updates in plugins using affected components
+- The `preserveTabContent` prop defaults to `false`, maintaining backward compatibility
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10153](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10153) | Update oui to 1.20 |
+| [#10284](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10284) | Update oui to 1.21 |
+
+## References
+
+- [OUI 1.20.0 Release](https://github.com/opensearch-project/oui/releases/tag/1.20.0): OUI version 1.20 release notes
+- [OUI 1.21.0 Release](https://github.com/opensearch-project/oui/releases/tag/1.21.0): OUI version 1.21 release notes
+- [OUI Repository](https://github.com/opensearch-project/oui): OpenSearch UI component library
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/oui.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -10,5 +10,6 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 
 | Item | Category | Description |
 |------|----------|-------------|
+| [OUI (OpenSearch UI) Updates](features/opensearch-dashboards/oui-updates.md) | bugfix | Update OUI component library from 1.19 to 1.21 |
 | [Query Editor UI](features/opensearch-dashboards/query-editor-ui.md) | bugfix | Autocomplete fixes, generated query UI improvements, edit button placement |
 | [UI Settings & Dataset Select](features/opensearch-dashboards/ui-settings-dataset-select.md) | bugfix | UI settings client robustness, dataset selector visual updates |


### PR DESCRIPTION
## Summary

This PR adds documentation for the OUI (OpenSearch UI) updates in OpenSearch Dashboards v3.2.0.

### Changes
- Created release report: `docs/releases/v3.2.0/features/opensearch-dashboards/oui-updates.md`
- Updated feature report: `docs/features/opensearch-dashboards/oui.md`
- Updated release index: `docs/releases/v3.2.0/index.md`

### Key Updates in v3.2.0
- OUI updated from 1.19 to 1.21
- New `preserveTabContent` prop for `EuiTabbedContent` component
- Various bug fixes and improvements

### Related PRs
- opensearch-project/OpenSearch-Dashboards#10153: Update oui to 1.20
- opensearch-project/OpenSearch-Dashboards#10284: Update oui to 1.21

Closes #1164