### PR TITLE
docs: add Chart & Visualization Fixes report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -103,6 +103,7 @@
 
 - [Async Query](opensearch-dashboards/async-query.md)
 - [CI/CD & Build Fixes](opensearch-dashboards/ci-cd-build-fixes.md)
+- [Chart & Visualization Fixes](opensearch-dashboards/chart-visualization-fixes.md)
 - [Content Management](opensearch-dashboards/content-management.md)
 - [Cross-Cluster Search](opensearch-dashboards/cross-cluster-search.md)
 - [Dashboards CI/CD & Documentation](opensearch-dashboards/dashboards-ci-cd-documentation.md)

--- a/docs/features/opensearch-dashboards/chart-visualization-fixes.md
+++ b/docs/features/opensearch-dashboards/chart-visualization-fixes.md
@@ -1,0 +1,85 @@
+# Chart & Visualization Fixes
+
+## Summary
+
+OpenSearch Dashboards includes various bug fixes for chart and visualization components to improve user experience. This feature tracks fixes related to chart rendering, legend display, and interactive UI elements like popovers.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        subgraph "Explore Plugin"
+            LINE[Line Chart Visualization]
+            OPTS[LineVisStyleControls]
+            LEG[Legend Component]
+        end
+        
+        subgraph "Workspace Plugin"
+            DSA[DataSourceAssociation]
+            POP[Popover Component]
+            BTN[Associate Button]
+        end
+    end
+    
+    LINE --> OPTS
+    OPTS --> LEG
+    DSA --> POP
+    BTN --> POP
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| LineVisStyleControls | Controls for line chart visualization styling including legend visibility |
+| Legend Component | Displays series labels for multi-series charts |
+| DataSourceAssociation | UI component for associating data sources with workspaces |
+| Popover Component | Dropdown panel triggered by button click |
+
+### Key Fixes
+
+#### Line Chart Legend Display
+
+The line chart visualization determines whether to show a legend based on the data structure:
+- **Show legend**: When there are multiple metrics or categorical breakdowns
+- **Hide legend**: When there's a single metric over a single date dimension (redundant)
+
+The logic correctly identifies simple time-series charts where a legend adds no value.
+
+#### Popover Toggle Behavior
+
+Interactive popovers should follow standard toggle behavior:
+- First click: Open popover
+- Second click on same button: Close popover
+- Click outside: Close popover
+
+This ensures consistent UX across the application.
+
+### Configuration
+
+No configuration options are available for these fixes. They apply automatically to the affected components.
+
+## Limitations
+
+- Legend visibility logic is specific to the Explore plugin's line chart
+- Popover fix applies only to the workspace data source association component
+- Other popover implementations may have similar issues that need separate fixes
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#9911](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9911) | Disable legend for line chart when it is 1 metric and 1 date |
+| v3.2.0 | [#9993](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9993) | Fix popover not close if double click |
+
+## References
+
+- [PR #9911](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9911): Line chart legend fix implementation
+- [PR #9993](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9993): Popover toggle fix implementation
+
+## Change History
+
+- **v3.2.0** (2026-01-10): Initial fixes for line chart legend display and popover toggle behavior

--- a/docs/releases/v3.2.0/features/opensearch-dashboards/chart-visualization-fixes.md
+++ b/docs/releases/v3.2.0/features/opensearch-dashboards/chart-visualization-fixes.md
@@ -1,0 +1,65 @@
+# Chart & Visualization Fixes
+
+## Summary
+
+This release includes two bug fixes for chart and visualization components in OpenSearch Dashboards: fixing the line chart legend display logic and resolving a popover toggle issue in the data source association UI.
+
+## Details
+
+### What's New in v3.2.0
+
+#### Line Chart Legend Fix
+
+The line chart visualization in the Explore plugin had incorrect logic for determining when to hide the legend. Previously, the legend was hidden when there was 1 metric, 0 categorical columns, and 0 date columns. This was incorrect because a typical time-series line chart has 1 metric and 1 date column.
+
+**Before (incorrect)**:
+```typescript
+const notShowLegend =
+    numericalColumns.length === 1 && categoricalColumns.length === 0 && dateColumns.length === 0;
+```
+
+**After (correct)**:
+```typescript
+const notShowLegend =
+    numericalColumns.length === 1 && categoricalColumns.length === 0 && dateColumns.length === 1;
+```
+
+The legend is now correctly hidden only when displaying a simple time-series chart with a single metric over time, where showing a legend would be redundant.
+
+#### Popover Toggle Fix
+
+The "Associate data sources" button in the Data Sources page had a bug where clicking the button twice would not close the popover. The popover would remain open and could not be dismissed by clicking outside.
+
+**Before**: The button always called `setIsOpen(true)`, so clicking it again had no effect.
+
+**After**: The button now toggles the state with `setIsOpen((prevState) => !prevState)`, allowing users to close the popover by clicking the button again.
+
+### Technical Changes
+
+#### Modified Components
+
+| Component | File | Change |
+|-----------|------|--------|
+| LineVisStyleControls | `src/plugins/explore/public/components/visualizations/line/line_vis_options.tsx` | Fixed legend visibility condition |
+| DataSourceAssociation | `src/plugins/workspace/public/components/data_source_association/data_source_association.tsx` | Changed popover open to toggle |
+
+## Limitations
+
+- The line chart legend fix is specific to the Explore plugin's line visualization
+- The popover fix is specific to the workspace data source association component
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9911](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9911) | Disable legend for line chart when it is 1 metric and 1 date |
+| [#9993](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9993) | Fix popover not close if double click |
+
+## References
+
+- [PR #9911](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9911): Line chart legend fix
+- [PR #9993](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9993): Popover toggle fix
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/chart-visualization-fixes.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -13,3 +13,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [OUI (OpenSearch UI) Updates](features/opensearch-dashboards/oui-updates.md) | bugfix | Update OUI component library from 1.19 to 1.21 |
 | [Query Editor UI](features/opensearch-dashboards/query-editor-ui.md) | bugfix | Autocomplete fixes, generated query UI improvements, edit button placement |
 | [UI Settings & Dataset Select](features/opensearch-dashboards/ui-settings-dataset-select.md) | bugfix | UI settings client robustness, dataset selector visual updates |
+| [Chart & Visualization Fixes](features/opensearch-dashboards/chart-visualization-fixes.md) | bugfix | Line chart legend display fix, popover toggle fix |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Chart & Visualization Fixes release item in OpenSearch Dashboards v3.2.0.

## Changes

### Release Report
- `docs/releases/v3.2.0/features/opensearch-dashboards/chart-visualization-fixes.md`

### Feature Report
- `docs/features/opensearch-dashboards/chart-visualization-fixes.md`

## Key Fixes Documented

1. **Line Chart Legend Fix (PR #9911)**: Fixed incorrect logic that hid the legend when there was 1 metric and 0 date columns. Now correctly hides legend only when there's 1 metric and 1 date column (simple time-series).

2. **Popover Toggle Fix (PR #9993)**: Fixed the "Associate data sources" button in the Data Sources page to properly toggle the popover open/closed instead of always opening it.

## Related Issue

Closes #1163