### PR TITLE
docs: add discover-plugin-fixes report for v3.2.0

### DIFF
--- a/docs/features/opensearch-dashboards/discover.md
+++ b/docs/features/opensearch-dashboards/discover.md
@@ -142,6 +142,8 @@ Requires ML agent configuration:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#10345](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10345) | Fix empty page when no index patterns exist |
+| v3.2.0 | [#10315](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10315) | Add cypress tests for discover visualization |
 | v2.18.0 | [#8186](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8186) | Add data summary panel in discover |
 | v2.18.0 | [#8214](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8214) | Add cache time and refresh button to dataset selector |
 | v2.18.0 | [#8651](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8651) | Update the appearance of Discover |
@@ -163,4 +165,5 @@ Requires ML agent configuration:
 
 ## Change History
 
+- **v3.2.0** (2025-08-05): Fixed empty page issue when no index patterns exist, added Cypress tests for discover visualization
 - **v2.18.0** (2024-11-05): Added AI-powered data summary panel, updated visual appearance, cache management in dataset selector, and 14 bug fixes for stability and usability

--- a/docs/releases/v3.2.0/features/opensearch-dashboards/discover-plugin-fixes.md
+++ b/docs/releases/v3.2.0/features/opensearch-dashboards/discover-plugin-fixes.md
@@ -1,0 +1,90 @@
+# Discover Plugin Fixes
+
+## Summary
+
+This release includes two bug fixes for the Discover plugin in OpenSearch Dashboards: a critical fix for the empty page issue when no index patterns exist, and new Cypress tests for discover visualization functionality.
+
+## Details
+
+### What's New in v3.2.0
+
+Two improvements to the Discover plugin:
+
+1. **Empty Page Fix**: Fixed an issue where the Discover plugin showed an empty page instead of the "no index patterns" UI when users had no index patterns configured
+2. **Cypress Tests**: Added comprehensive Cypress tests for discover visualization functionality
+
+### Technical Changes
+
+#### Bug Fix: Empty Page Issue
+
+The root cause was in the data-explorer's `metadata_slice.ts`. When no index patterns exist, `data.indexPatterns.getDefault()` threw an error instead of returning undefined. This error occurred during the preload phase, preventing the application from loading and stopping the discover plugin from showing the `DiscoverNoIndexPatterns` component.
+
+**Before (problematic code):**
+```typescript
+const defaultIndexPattern = isQueryEnhancementEnabled
+  ? undefined
+  : await data.indexPatterns.getDefault();
+```
+
+**After (fixed code):**
+```typescript
+let defaultIndexPattern;
+if (!isQueryEnhancementEnabled) {
+  try {
+    defaultIndexPattern = await data.indexPatterns.getDefault();
+  } catch (error) {
+    defaultIndexPattern = undefined;
+  }
+} else {
+  defaultIndexPattern = undefined;
+}
+```
+
+The fix wraps the `getDefault()` call in a try-catch block, allowing the application to continue with `undefined` instead of crashing. This ensures the discover plugin can properly render the `DiscoverNoIndexPatterns` component.
+
+#### New Cypress Tests
+
+Added comprehensive Cypress tests for discover visualization:
+
+| Test | Description |
+|------|-------------|
+| Saved search in dashboards | Tests loading saved searches into dashboards |
+| Time range updates | Verifies changing time range updates saved search results |
+| Visualization rule matching | Tests metric, line, bar, scatter, heatmap, and facet visualizations |
+| Chart type switching | Tests switching between chart types and table view |
+
+**Key test improvements:**
+- Added `data-test-subj` attributes to UI components for better test targeting
+- Tests cover PPL queries with various aggregation patterns
+- Validates correct axis assignments for different visualization types
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `src/plugins/data_explorer/public/utils/state_management/metadata_slice.ts` | Added try-catch for getDefault() |
+| `cypress/.../saved_search_in_dashboards.spec.js` | Rewrote saved search tests |
+| `cypress/.../rule_matching_vis.spec.js` | Added visualization tests |
+| `src/plugins/dashboard/.../show_add_panel_popover.tsx` | Added test-subj attribute |
+| `src/plugins/explore/.../chart_type_selector.tsx` | Added test-subj attributes |
+| `src/plugins/explore/.../axes_selector.tsx` | Added test-subj attribute |
+
+## Limitations
+
+- The fix only addresses the case where `getDefault()` throws an error; other index pattern loading issues may still occur
+- Cypress tests require workspace and data source setup
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10345](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10345) | Fix: Discover plugin shows empty page instead of no-index-patterns UI |
+| [#10315](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10315) | Add cypress tests for discover visualization |
+
+## References
+
+- [Index patterns documentation](https://docs.opensearch.org/3.2/dashboards/management/index-patterns/): Official docs on index patterns
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/discover.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -10,6 +10,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 
 | Item | Category | Description |
 |------|----------|-------------|
+| [Discover Plugin Fixes](features/opensearch-dashboards/discover-plugin-fixes.md) | bugfix | Fix empty page when no index patterns, add Cypress tests |
 | [OUI (OpenSearch UI) Updates](features/opensearch-dashboards/oui-updates.md) | bugfix | Update OUI component library from 1.19 to 1.21 |
 | [Query Editor UI](features/opensearch-dashboards/query-editor-ui.md) | bugfix | Autocomplete fixes, generated query UI improvements, edit button placement |
 | [UI Settings & Dataset Select](features/opensearch-dashboards/ui-settings-dataset-select.md) | bugfix | UI settings client robustness, dataset selector visual updates |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Discover Plugin Fixes in OpenSearch Dashboards v3.2.0.

### Changes
- Created release report: `docs/releases/v3.2.0/features/opensearch-dashboards/discover-plugin-fixes.md`
- Updated feature report: `docs/features/opensearch-dashboards/discover.md`
- Updated release index: `docs/releases/v3.2.0/index.md`

### Key Fixes Documented
1. **Empty Page Fix (PR #10345)**: Fixed issue where Discover showed empty page instead of no-index-patterns UI when no index patterns exist
2. **Cypress Tests (PR #10315)**: Added comprehensive Cypress tests for discover visualization functionality

Closes #1162