### PR TITLE
docs: add Static Banner Plugin report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -102,6 +102,7 @@
 ## opensearch-dashboards
 
 - [Async Query](opensearch-dashboards/async-query.md)
+- [Banner Plugin](opensearch-dashboards/banner-plugin.md)
 - [CI/CD & Build Fixes](opensearch-dashboards/ci-cd-build-fixes.md)
 - [Chart & Visualization Fixes](opensearch-dashboards/chart-visualization-fixes.md)
 - [Content Management](opensearch-dashboards/content-management.md)

--- a/docs/features/opensearch-dashboards/banner-plugin.md
+++ b/docs/features/opensearch-dashboards/banner-plugin.md
@@ -1,0 +1,161 @@
+# Banner Plugin
+
+## Summary
+
+The Banner Plugin provides a global, configurable header banner system for OpenSearch Dashboards. It enables administrators to display important announcements, notifications, or alerts to all users across the dashboard interface. Unlike the existing core banner service (OverlayBannersService), this plugin is dedicated to persistent top-of-page announcements with styling, markdown support, and dismissal capabilities.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph Configuration
+        YML[opensearch_dashboards.yml]
+    end
+    
+    subgraph Server["Server Side"]
+        ServerPlugin[BannerPlugin Server]
+        ConfigSchema[Config Schema]
+    end
+    
+    subgraph Browser["Browser Side"]
+        ClientPlugin[BannerPlugin Client]
+        BannerService[BannerService]
+        GlobalBanner[GlobalBanner Component]
+        LinkRenderer[LinkRenderer]
+    end
+    
+    subgraph Core["OSD Core"]
+        Header[Header Component]
+        BannerContainer["#pluginGlobalBanner"]
+        InjectedMetadata[InjectedMetadata]
+    end
+    
+    YML --> ConfigSchema
+    ConfigSchema --> ServerPlugin
+    ServerPlugin -->|exposeToBrowser| InjectedMetadata
+    InjectedMetadata --> ClientPlugin
+    ClientPlugin --> BannerService
+    BannerService --> GlobalBanner
+    GlobalBanner --> LinkRenderer
+    Header -->|conditionally renders| BannerContainer
+    GlobalBanner -->|mounts to| BannerContainer
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[YAML Config] --> B[Server Plugin]
+    B --> C[Browser Config]
+    C --> D[BannerService]
+    D --> E[BehaviorSubject]
+    E --> F[GlobalBanner]
+    F --> G[EuiCallOut]
+    G --> H[User Sees Banner]
+    H -->|Dismiss| I[Update State]
+    I --> E
+```
+
+### Components
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| `BannerPlugin` (server) | `src/plugins/banner/server/plugin.ts` | Reads configuration and exposes to browser |
+| `BannerPlugin` (public) | `src/plugins/banner/public/plugin.ts` | Initializes service and renders banner |
+| `BannerService` | `src/plugins/banner/public/services/banner_service.ts` | Manages banner state with RxJS |
+| `GlobalBanner` | `src/plugins/banner/public/components/global_banner.tsx` | Main React component |
+| `LinkRenderer` | `src/plugins/banner/public/components/link_renderer.tsx` | Markdown link renderer |
+| `render_banner` | `src/plugins/banner/public/services/render_banner.ts` | DOM mounting utilities |
+
+### Configuration
+
+| Setting | Type | Description | Default |
+|---------|------|-------------|---------|
+| `banner.enabled` | boolean | Enable/disable the banner plugin | `false` |
+| `banner.text` | string | Banner message (supports Markdown) | Default announcement |
+| `banner.color` | enum | `primary`, `success`, `warning` | `primary` |
+| `banner.iconType` | string | EUI icon type | `iInCircle` |
+| `banner.isVisible` | boolean | Initial visibility | `true` |
+| `banner.useMarkdown` | boolean | Enable Markdown rendering | `true` |
+
+### Usage Example
+
+```yaml
+# opensearch_dashboards.yml
+
+# Enable the banner
+banner.enabled: true
+
+# Configure banner content
+banner.text: |
+  **Important:** System maintenance scheduled for Saturday 2AM-4AM UTC.
+  [View details](https://status.example.com)
+banner.color: warning
+banner.iconType: alert
+banner.isVisible: true
+banner.useMarkdown: true
+```
+
+### CSS Variables
+
+The plugin uses CSS variables for dynamic layout adjustment:
+
+```scss
+:root {
+  --global-banner-height: 0;
+}
+
+#pluginGlobalBanner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1100;
+  min-height: var(--global-banner-height);
+}
+
+.expandedHeader {
+  top: var(--global-banner-height) !important;
+}
+
+.primaryHeader:not(.newTopNavHeader) {
+  top: calc(var(--global-banner-height) + $euiSizeXL + $euiSizeM) !important;
+}
+```
+
+### Why a Separate Plugin?
+
+The Banner Plugin was created as a standalone plugin rather than extending the existing `OverlayBannersService` for several reasons:
+
+1. **Separation of Concerns**: The core banner service is tightly coupled with existing layout logic
+2. **Widespread Usage**: Modifying the core service could cause regressions in dependent plugins
+3. **Scope Differences**: Global banners need persistence and server-side configuration
+4. **Ownership**: Independent lifecycle improves maintainability and versioning
+
+## Limitations
+
+- Static configuration only (no runtime API to update banner)
+- No server-side dynamic content fetching
+- No role-based visibility
+- No scheduled banners
+- No Advanced Settings UI for customization
+- Single banner only (no stacking)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#9989](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9989) | Initial implementation with feature flag |
+| v3.2.0 | [#10251](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10251) | Fix font size and center alignment |
+| v3.2.0 | [#10254](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10254) | Reset lighthouse baseline |
+
+## References
+
+- [Issue #9861](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9861): RFC - OpenSearch Dashboards Banner Plugin
+- [Issue #9990](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9990): Meta issue tracking banner plugin development
+
+## Change History
+
+- **v3.2.0** (2026-01-10): Initial implementation with static banner, feature flag, markdown support, and dismissal functionality

--- a/docs/releases/v3.2.0/features/opensearch-dashboards/static-banner-plugin.md
+++ b/docs/releases/v3.2.0/features/opensearch-dashboards/static-banner-plugin.md
@@ -1,0 +1,129 @@
+# Static Banner Plugin
+
+## Summary
+
+OpenSearch Dashboards v3.2.0 introduces a new Banner Plugin that displays a global, configurable header banner for important announcements or notifications. The plugin is disabled by default and can be enabled via configuration, providing administrators with a non-intrusive way to communicate with users across all dashboard pages.
+
+## Details
+
+### What's New in v3.2.0
+
+This release introduces the initial implementation of the Banner Plugin with the following capabilities:
+
+- Global banner displayed at the top of all OpenSearch Dashboards pages
+- Feature flag to enable/disable the banner (`banner.enabled`)
+- Markdown support for rich text content including links
+- Configurable banner color (primary, success, warning)
+- Configurable icon type
+- Dismissible by users
+- Smooth CSS transitions when showing/hiding
+- Dynamic layout adjustment to prevent content overlap
+
+### Technical Changes
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph Server
+        Config[opensearch_dashboards.yml]
+        ServerPlugin[Banner Server Plugin]
+    end
+    
+    subgraph Browser
+        ClientPlugin[Banner Client Plugin]
+        BannerService[BannerService]
+        GlobalBanner[GlobalBanner Component]
+        Header[Header Component]
+    end
+    
+    Config --> ServerPlugin
+    ServerPlugin -->|exposeToBrowser| ClientPlugin
+    ClientPlugin --> BannerService
+    BannerService --> GlobalBanner
+    Header -->|renders| BannerContainer[#pluginGlobalBanner]
+    GlobalBanner -->|mounts to| BannerContainer
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `BannerPlugin` (server) | Server-side plugin that reads configuration and exposes it to browser |
+| `BannerPlugin` (public) | Client-side plugin that initializes banner service and renders component |
+| `BannerService` | Manages banner state using RxJS BehaviorSubject |
+| `GlobalBanner` | React component that renders the EuiCallOut banner |
+| `LinkRenderer` | Custom markdown renderer for links (opens in new tab) |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `banner.enabled` | Enable/disable the banner plugin | `false` |
+| `banner.text` | Banner message text (supports Markdown) | Default announcement text |
+| `banner.color` | Banner color: `primary`, `success`, `warning` | `primary` |
+| `banner.iconType` | EUI icon type for the banner | `iInCircle` |
+| `banner.isVisible` | Initial visibility state | `true` |
+| `banner.useMarkdown` | Enable Markdown rendering | `true` |
+
+### Usage Example
+
+Enable the banner in `opensearch_dashboards.yml`:
+
+```yaml
+# Enable the banner plugin
+banner.enabled: true
+
+# Customize banner content (optional)
+banner.text: "System maintenance scheduled for Saturday. [Learn more](https://example.com)"
+banner.color: warning
+banner.iconType: alert
+```
+
+### CSS Implementation
+
+The plugin uses a CSS variable (`--global-banner-height`) to dynamically adjust the layout:
+
+```css
+:root {
+  --global-banner-height: 0;
+}
+
+#pluginGlobalBanner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1100;
+}
+
+.expandedHeader {
+  top: var(--global-banner-height) !important;
+}
+```
+
+A ResizeObserver monitors the banner's actual height and updates the CSS variable accordingly.
+
+## Limitations
+
+- Banner content is static (configured via YAML only in this release)
+- No server-side dynamic content fetching yet
+- No role-based visibility or scheduled banners
+- No Advanced Settings UI for customization (planned for future releases)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9989](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9989) | Add static banner plugin and feature flag |
+| [#10251](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10251) | Fix font size and center alignment for banner text |
+| [#10254](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10254) | Reset lighthouse baseline limit for dashboard and discover |
+
+## References
+
+- [Issue #9861](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9861): RFC - OpenSearch Dashboards Banner Plugin
+- [Issue #9990](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9990): Meta issue tracking banner plugin development
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/banner-plugin.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -10,6 +10,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 
 | Item | Category | Description |
 |------|----------|-------------|
+| [Static Banner Plugin](features/opensearch-dashboards/static-banner-plugin.md) | feature | Global configurable header banner for announcements |
 | [Discover Plugin Fixes](features/opensearch-dashboards/discover-plugin-fixes.md) | bugfix | Fix empty page when no index patterns, add Cypress tests |
 | [OUI (OpenSearch UI) Updates](features/opensearch-dashboards/oui-updates.md) | bugfix | Update OUI component library from 1.19 to 1.21 |
 | [Query Editor UI](features/opensearch-dashboards/query-editor-ui.md) | bugfix | Autocomplete fixes, generated query UI improvements, edit button placement |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Static Banner Plugin feature introduced in OpenSearch Dashboards v3.2.0.

## Reports Created

- **Release report**: `docs/releases/v3.2.0/features/opensearch-dashboards/static-banner-plugin.md`
- **Feature report**: `docs/features/opensearch-dashboards/banner-plugin.md`

## Key Changes in v3.2.0

- New Banner Plugin for displaying global header announcements
- Feature flag (`banner.enabled`) to enable/disable the plugin
- Markdown support for rich text content
- Configurable banner color, icon, and visibility
- Dismissible by users
- Dynamic CSS layout adjustment to prevent content overlap

## Related PRs

- [#9989](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9989): Add static banner plugin and feature flag
- [#10251](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10251): Fix font size and center alignment
- [#10254](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10254): Reset lighthouse baseline

## Related Issue

Closes #1161