### PR TITLE
docs: add Vended Dashboard Progress report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -136,6 +136,7 @@
 - [Saved Query UX](opensearch-dashboards/saved-query-ux.md)
 - [Security CVE Fixes](opensearch-dashboards/security-cve-fixes.md)
 - [TSVB Visualization](opensearch-dashboards/tsvb-visualization.md)
+- [Vended Dashboard Progress](opensearch-dashboards/vended-dashboard-progress.md)
 - [Workspace](opensearch-dashboards/workspace.md)
 
 ## security

--- a/docs/features/opensearch-dashboards/vended-dashboard-progress.md
+++ b/docs/features/opensearch-dashboards/vended-dashboard-progress.md
@@ -1,0 +1,175 @@
+# Vended Dashboard Progress
+
+## Summary
+
+Vended Dashboard Progress provides real-time visibility into data synchronization status for dashboards backed by direct query data sources like Amazon S3. The feature displays a progress banner showing sync status, last refresh time, and scheduled refresh intervals. Users can manually trigger data synchronization or monitor automatic background refresh jobs managed by Apache Spark.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        subgraph "Data Source Management Plugin"
+            Banner[DashboardDirectQuerySyncBanner]
+            Utils[direct_query_sync_utils]
+            Progress[sync_progress]
+            Hook[useDirectQuery Hook]
+        end
+    end
+    
+    subgraph "OpenSearch"
+        DSL[DSL Mapping API]
+        Meta[Index Metadata]
+        Scheduler[Async Query Scheduler]
+    end
+    
+    subgraph "External Systems"
+        Spark[Apache Spark / EMR]
+        S3[Amazon S3]
+    end
+    
+    Banner -->|Poll every 10s| Utils
+    Utils -->|GET mapping| DSL
+    DSL -->|Read _meta| Meta
+    Banner -->|Manual sync| Hook
+    Hook -->|POST query| Scheduler
+    Scheduler -->|Execute| Spark
+    Spark -->|Read data| S3
+    Spark -->|Update index| Meta
+    Progress -->|Convert state| Banner
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Dashboard Load] --> B{Is Vended Dashboard?}
+    B -->|No| C[No Banner]
+    B -->|Yes| D[Render Sync Banner]
+    D --> E[Start Polling Loop]
+    E --> F[Fetch Sync Info]
+    F --> G[Extract Index State]
+    G --> H{Calculate Progress}
+    H -->|In Progress| I[Show Progress Bar]
+    H -->|Complete| J{Was Loading?}
+    J -->|Yes| K[Reload Page]
+    J -->|No| L[Show Idle State]
+    I --> M[Wait 10s]
+    L --> M
+    M --> F
+```
+
+### Components
+
+| Component | File | Description |
+|-----------|------|-------------|
+| `DashboardDirectQuerySyncBanner` | `direct_query_sync_banner.tsx` | Main React component displaying sync status |
+| `fetchDirectQuerySyncInfo` | `direct_query_sync_utils.ts` | Fetches dashboard metadata and index mapping |
+| `asSyncProgress` | `sync_progress.tsx` | Converts index state to progress percentage |
+| `useDirectQuery` | `direct_query_hook.ts` | Hook for executing direct queries |
+| `ExternalIndexState` | `types.tsx` | Enum defining Flint index states |
+| `DirectQueryLoadingStatus` | `types.tsx` | Enum defining query execution states |
+
+### Configuration
+
+| Setting | Description | Default | Configurable |
+|---------|-------------|---------|--------------|
+| `SYNC_INFO_POLLING_INTERVAL_MS` | Polling interval for index state | 10000ms | No (hardcoded) |
+| `auto_refresh` | Enable automatic index refresh | false | Yes (via SQL) |
+| `refresh_interval` | Time between auto-refresh operations | - | Yes (via SQL) |
+| `scheduler_mode` | Internal or external scheduler | external | Yes (via SQL) |
+
+### Index State Machine
+
+The feature integrates with the Flint Index State Machine:
+
+```mermaid
+stateDiagram-v2
+    [*] --> creating: CREATE INDEX
+    creating --> active: Success
+    creating --> [*]: Failure
+    active --> refreshing: REFRESH
+    active --> cancelling: CANCEL
+    refreshing --> active: Success
+    refreshing --> recovering: Failure
+    recovering --> active: Recovery Success
+    recovering --> [*]: Recovery Failure
+    cancelling --> [*]: Cancelled
+```
+
+### Progress Calculation
+
+Progress is calculated based on two sources:
+
+1. **Query Status** (takes precedence when active):
+   - `submitted`: 0%
+   - `scheduled`: 25%
+   - `waiting`: 50%
+   - `running`: 75%
+   - `success`/`failed`/`canceled`: Terminal (triggers reload if was loading)
+
+2. **Index State** (used when no query is running):
+   - `creating`: 30%
+   - `active` (no lastRefreshTime): 30%
+   - `active` (with lastRefreshTime): Complete
+   - `refreshing`: 60%
+   - `recovering`: 60%
+   - `cancelling`: 90%
+
+### Usage Example
+
+```sql
+-- Create a materialized view with auto-refresh
+CREATE MATERIALIZED VIEW my_dashboard_mv
+AS SELECT * FROM s3_datasource.database.table
+WITH (
+    auto_refresh = true,
+    refresh_interval = '15 minutes',
+    scheduler_mode = 'external'
+);
+```
+
+The sync banner automatically appears on dashboards using this materialized view:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ Data scheduled to sync every 15 minutes. Last synced: 10:30 AM │
+│ [Sync data]                                                     │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+During sync:
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ ⟳ Data sync is in progress (60% complete).                     │
+│   The dashboard will reload on completion.                      │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Limitations
+
+- Polling interval is fixed at 10 seconds and not user-configurable
+- Progress percentages are approximations based on state machine stages
+- Requires compatible opensearch-spark version for index state reporting
+- Only works with direct query data sources (S3, Prometheus)
+- Banner only appears when dashboard contains visualizations from vended data sources
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#9862](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9862) | Implement polling for index state in Vended Dashboard progress |
+
+## References
+
+- [Scheduled Query Acceleration](https://docs.opensearch.org/3.0/dashboards/management/scheduled-query-acceleration/): Official documentation
+- [Flint Index State Machine](https://github.com/opensearch-project/opensearch-spark/blob/main/docs/index.md#index-state-transition): State transition documentation
+- [opensearch-spark #1195](https://github.com/opensearch-project/opensearch-spark/pull/1195): Index state reporting support
+- [Optimizing query performance using OpenSearch indexing](https://docs.opensearch.org/3.0/dashboards/management/accelerate-external-data/): Query acceleration overview
+
+## Change History
+
+- **v3.2.0** (2025-06-13): Added polling for external index state detection, enabling progress tracking for background auto-refresh jobs

--- a/docs/releases/v3.2.0/features/opensearch-dashboards/vended-dashboard-progress.md
+++ b/docs/releases/v3.2.0/features/opensearch-dashboards/vended-dashboard-progress.md
@@ -1,0 +1,122 @@
+# Vended Dashboard Progress
+
+## Summary
+
+This release adds polling-based index state detection for Vended Dashboards, enabling automatic progress tracking for background data synchronization jobs. Previously, progress was only tracked for queries initiated within OpenSearch Dashboards. Now, the system can detect and display progress for auto-refresh jobs running in the background via Apache Spark, providing users with real-time visibility into data synchronization status.
+
+## Details
+
+### What's New in v3.2.0
+
+The Vended Dashboard progress banner now polls for external index state changes at 10-second intervals. This enables detection of data sync operations that were started outside of the current Dashboards session, such as scheduled auto-refresh jobs managed by Apache Spark.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        Banner[Sync Banner Component]
+        Hook[Direct Query Hook]
+        Utils[Sync Utils]
+    end
+    
+    subgraph "External Systems"
+        Spark[Apache Spark]
+        S3[Amazon S3]
+    end
+    
+    subgraph "OpenSearch"
+        Index[Flint Index]
+        Meta[Index Metadata]
+    end
+    
+    Banner -->|10s polling| Utils
+    Utils -->|Fetch state| Meta
+    Banner -->|Manual sync| Hook
+    Hook -->|Execute query| Spark
+    Spark -->|Update| Index
+    Spark -->|Read| S3
+    Index -->|Store| Meta
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `sync_progress.tsx` | New module for converting index states to progress percentages |
+| `ExternalIndexState` enum | Defines Flint index state machine states (creating, active, refreshing, recovering, cancelling) |
+| `SyncProgress` type | Union type representing sync progress status |
+| `asSyncProgress()` | Function to convert index state and query status to progress |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `SYNC_INFO_POLLING_INTERVAL_MS` | Interval for polling index state | 10000 (10 seconds) |
+
+#### State Machine Integration
+
+The feature integrates with the Flint Index State Machine from opensearch-spark:
+
+| Index State | Progress % | Description |
+|-------------|------------|-------------|
+| `creating` | 30% | Index is being created |
+| `active` (no refresh) | 30% | Index activated but initial refresh pending |
+| `active` (with refresh) | Complete | Index is ready and has been refreshed |
+| `refreshing` | 60% | Data refresh in progress |
+| `recovering` | 60% | Index recovering from error |
+| `cancelling` | 90% | Cancellation in progress |
+
+Query status takes precedence over index state when a query is actively running:
+
+| Query Status | Progress % |
+|--------------|------------|
+| `submitted` | 0% |
+| `scheduled` | 25% |
+| `waiting` | 50% |
+| `running` | 75% |
+
+### Usage Example
+
+The Vended Dashboard banner automatically appears when viewing a dashboard backed by a direct query data source (e.g., Amazon S3). The banner shows:
+
+1. **Idle state**: Last sync time and scheduled refresh interval with "Sync data" link
+2. **In-progress state**: Progress percentage with loading spinner and auto-reload on completion
+
+```typescript
+// Progress calculation example
+const progress = asSyncProgress(
+  syncInfo.indexState,      // e.g., 'refreshing'
+  queryStatus,              // e.g., DirectQueryLoadingStatus.INITIAL
+  Boolean(syncInfo.lastRefreshTime)
+);
+// Returns: { in_progress: true, percentage: 60 }
+```
+
+### Migration Notes
+
+No migration required. The feature is automatically enabled when viewing Vended Dashboards. The polling only runs when the sync banner is rendered, so there is no performance impact on other dashboards.
+
+## Limitations
+
+- Requires opensearch-spark PR #1195 for full functionality (index state reporting)
+- Polling interval is fixed at 10 seconds (not configurable via UI)
+- Progress percentages are approximations based on state machine stages
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9862](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9862) | Implement polling for index state in Vended Dashboard progress |
+
+## References
+
+- [opensearch-spark #1195](https://github.com/opensearch-project/opensearch-spark/pull/1195): Index state reporting support
+- [Flint Index State Machine](https://github.com/opensearch-project/opensearch-spark/blob/main/docs/index.md#index-state-transition): State transition documentation
+- [Scheduled Query Acceleration](https://docs.opensearch.org/3.0/dashboards/management/scheduled-query-acceleration/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/vended-dashboard-progress.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -10,6 +10,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 
 | Item | Category | Description |
 |------|----------|-------------|
+| [Vended Dashboard Progress](features/opensearch-dashboards/vended-dashboard-progress.md) | feature | Polling-based index state detection for background data sync progress |
 | [Explore UI Enhancements](features/opensearch-dashboards/explore-ui-enhancements.md) | feature | New Explore plugin with auto-visualization, multi-flavor support, and dashboard embeddable |
 | [Static Banner Plugin](features/opensearch-dashboards/static-banner-plugin.md) | feature | Global configurable header banner for announcements |
 | [Discover Plugin Fixes](features/opensearch-dashboards/discover-plugin-fixes.md) | bugfix | Fix empty page when no index patterns, add Cypress tests |


### PR DESCRIPTION
## Summary

Adds documentation for the Vended Dashboard Progress feature in OpenSearch Dashboards v3.2.0.

### Changes

- **Release Report**: `docs/releases/v3.2.0/features/opensearch-dashboards/vended-dashboard-progress.md`
- **Feature Report**: `docs/features/opensearch-dashboards/vended-dashboard-progress.md`
- Updated release index and features index

### Feature Overview

This release adds polling-based index state detection for Vended Dashboards, enabling automatic progress tracking for background data synchronization jobs managed by Apache Spark. The sync banner now polls for external index state changes at 10-second intervals.

### Key Changes in v3.2.0

- New `ExternalIndexState` enum for Flint index state machine states
- New `sync_progress.tsx` module for progress calculation
- 10-second polling interval for index state detection
- Automatic page reload when sync completes

### Related Issue

Closes #1159