### PR TITLE
docs: add UI Settings Backward Compatibility report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -136,6 +136,7 @@
 - [Saved Query UX](opensearch-dashboards/saved-query-ux.md)
 - [Security CVE Fixes](opensearch-dashboards/security-cve-fixes.md)
 - [TSVB Visualization](opensearch-dashboards/tsvb-visualization.md)
+- [UI Settings](opensearch-dashboards/ui-settings.md)
 - [Vended Dashboard Progress](opensearch-dashboards/vended-dashboard-progress.md)
 - [Workspace](opensearch-dashboards/workspace.md)
 

--- a/docs/features/opensearch-dashboards/ui-settings.md
+++ b/docs/features/opensearch-dashboards/ui-settings.md
@@ -1,0 +1,141 @@
+# UI Settings
+
+## Summary
+
+UI Settings in OpenSearch Dashboards provides a centralized configuration system for managing user preferences and application settings. The system supports multiple scopes (global, workspace, user, dashboard admin) allowing settings to be applied at different levels with a defined priority hierarchy.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Client Layer"
+        A[Browser/Plugin] --> B[UI Settings Client API]
+    end
+    
+    subgraph "Server Layer"
+        B --> C[UI Settings Service]
+        C --> D{Scope Router}
+        D --> E[Global Settings]
+        D --> F[Workspace Settings]
+        D --> G[User Settings]
+        D --> H[Admin Settings]
+    end
+    
+    subgraph "Storage Layer"
+        E --> I[config SavedObject]
+        F --> J[workspace.uiSettings]
+        G --> K[user config]
+        H --> L[admin config]
+    end
+    
+    subgraph "Wrappers"
+        M[WorkspaceUiSettingsClientWrapper] --> C
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Get Setting] --> B{Has Scope?}
+    B -->|Yes| C[Read from specific scope]
+    B -->|No| D[Merge all scopes]
+    D --> E[Apply priority: User > Workspace > Global]
+    E --> F[Return merged value]
+    
+    G[Set Setting] --> H{Has Scope?}
+    H -->|Yes| I[Write to specific scope]
+    H -->|No| J{Single scope defined?}
+    J -->|Yes| K[Write to defined scope]
+    J -->|No| L{Multi-scope?}
+    L -->|Yes| M[Default to global + warn]
+    L -->|No| N[Write to global]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `UiSettingsClient` | Core client for reading/writing UI settings |
+| `UiSettingsService` | Server-side service managing settings lifecycle |
+| `WorkspaceUiSettingsClientWrapper` | Wrapper handling workspace-scoped settings |
+| `UiSettingScope` | Enum defining available scopes: GLOBAL, WORKSPACE, USER, DASHBOARD_ADMIN |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `scope` | Defines which scopes a setting supports | `undefined` (global) |
+| `value` | Default value for the setting | Setting-specific |
+| `requiresPageReload` | Whether changing requires page reload | `false` |
+
+### Scope Priority
+
+When reading settings without specifying a scope, values are merged with the following priority (highest to lowest):
+
+1. **User** - User-specific preferences
+2. **Workspace** - Workspace-level settings
+3. **Global** - System-wide defaults
+
+### Usage Example
+
+```typescript
+// Register a multi-scope setting
+uiSettings.register({
+  defaultDataSource: {
+    name: 'Default Data Source',
+    value: '',
+    description: 'The default data source for queries',
+    scope: [UiSettingScope.GLOBAL, UiSettingScope.WORKSPACE],
+    category: ['general'],
+  },
+});
+
+// Read with scope
+const workspaceDefault = await uiSettings.getWithScope(
+  'defaultDataSource',
+  UiSettingScope.WORKSPACE
+);
+
+// Write with scope
+await uiSettings.setWithScope(
+  'defaultDataSource',
+  'my-data-source-id',
+  UiSettingScope.WORKSPACE
+);
+
+// Read merged value (applies priority)
+const effectiveDefault = await uiSettings.get('defaultDataSource');
+```
+
+### API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/api/opensearch-dashboards/settings` | GET | Get all settings (merged) |
+| `/api/opensearch-dashboards/settings` | POST | Update settings |
+| `/api/opensearch-dashboards/settings/{key}` | GET | Get specific setting |
+
+## Limitations
+
+- Settings with multiple scopes require explicit scope specification for writes (deprecated fallback to global in v3.2.0)
+- Workspace-scoped settings require workspace context to be active
+- User-scoped settings require authentication
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#9854](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9854) | Backward compatibility for UI setting client |
+| v3.2.0 | [#9726](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9726) | Multi-scope UI settings support |
+
+## References
+
+- [Issue #7821](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7821): Original feature request for workspace-scoped UI settings
+
+## Change History
+
+- **v3.2.0** (2026-01-10): Added backward compatibility for multi-scope settings, deprecation warnings for legacy API usage
+- **v3.1.0**: Initial multi-scope UI settings support with workspace integration

--- a/docs/releases/v3.2.0/features/opensearch-dashboards/ui-settings-backward-compatibility.md
+++ b/docs/releases/v3.2.0/features/opensearch-dashboards/ui-settings-backward-compatibility.md
@@ -1,0 +1,103 @@
+# UI Settings Backward Compatibility
+
+## Summary
+
+This release item restores backward compatibility for the UI settings client in OpenSearch Dashboards. A previous change ([#9726](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9726)) introduced multi-scope UI settings support but inadvertently created a breaking change for the `uiSettingClient` and the `/api/opensearch-dashboards/settings` router. This fix ensures existing code continues to work while adding deprecation warnings to guide developers toward the new API patterns.
+
+## Details
+
+### What's New in v3.2.0
+
+The backward compatibility fix addresses the breaking change introduced by multi-scope UI settings:
+
+1. **Multi-scope settings without explicit scope**: Previously threw an error; now defaults to global scope (or first available scope) with a deprecation warning
+2. **Workspace settings via global scope**: Previously failed; now routes to workspace settings when inside a workspace context with a deprecation warning
+3. **Deprecation logging**: Warns developers about deprecated usage patterns that will be removed in the next major release
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "UI Settings Client"
+        A[setMany/set API] --> B{Has explicit scope?}
+        B -->|Yes| C[Route to specified scope]
+        B -->|No| D{Multi-scope setting?}
+        D -->|Yes| E[Default to global scope + warn]
+        D -->|No| F[Route based on setting metadata]
+    end
+    
+    subgraph "Workspace Wrapper"
+        G[Update Request] --> H{In workspace context?}
+        H -->|Yes| I{Config ID = version?}
+        I -->|Yes| J[Route to workspace + warn]
+        I -->|No| K[Normal processing]
+        H -->|No| L[Global settings update]
+    end
+```
+
+#### Modified Components
+
+| Component | File | Description |
+|-----------|------|-------------|
+| UiSettingsClient | `src/core/server/ui_settings/ui_settings_client.ts` | Modified `groupChanges()` to handle multi-scope settings gracefully |
+| WorkspaceUiSettingsClientWrapper | `src/plugins/workspace/server/saved_objects/workspace_ui_settings_client_wrapper.ts` | Added backward compatibility for workspace settings updates |
+| WorkspacePlugin | `src/plugins/workspace/server/plugin.ts` | Wired up UI settings client for scope detection |
+
+#### Behavior Changes
+
+| Scenario | Before (Breaking) | After (Compatible) |
+|----------|-------------------|-------------------|
+| Update multi-scope setting without scope | Error: "Unable to update, has multiple scopes" | Defaults to global scope + deprecation warning |
+| Update workspace setting via global config ID | Failed silently or error | Routes to workspace settings + deprecation warning |
+
+### Usage Example
+
+```bash
+# This call now works with a deprecation warning
+# (previously would throw an error for multi-scope settings like defaultDataSource)
+curl 'http://localhost:5601/api/opensearch-dashboards/settings' \
+  -H 'Content-Type: application/json' \
+  -H 'osd-xsrf: osd-fetch' \
+  --data-raw '{"changes":{"defaultDataSource":"my-data-source-id"}}'
+```
+
+Server log output:
+```
+[warn] Deprecation warning: The setting "defaultDataSource" has multiple scopes. Please specify a scope when updating it.
+```
+
+### Migration Notes
+
+Developers should update their code to explicitly specify scopes when updating multi-scope settings:
+
+```typescript
+// Deprecated (will be removed in next major version)
+uiSettings.set('defaultDataSource', 'my-ds-id');
+
+// Recommended
+uiSettings.setWithScope('defaultDataSource', 'my-ds-id', UiSettingScope.GLOBAL);
+// or
+uiSettings.setWithScope('defaultDataSource', 'my-ds-id', UiSettingScope.WORKSPACE);
+```
+
+## Limitations
+
+- Deprecation warnings are logged but the deprecated behavior will be removed in the next major release
+- Settings with multiple scopes that don't include `global` will default to the first scope in the array
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9854](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9854) | Keep backward compatibility for UI setting client |
+| [#9726](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9726) | Original multi-scope UI settings implementation (introduced breaking change) |
+
+## References
+
+- [Issue #7821](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7821): Original feature request for workspace-scoped UI settings
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/ui-settings.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -17,4 +17,5 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [OUI (OpenSearch UI) Updates](features/opensearch-dashboards/oui-updates.md) | bugfix | Update OUI component library from 1.19 to 1.21 |
 | [Query Editor UI](features/opensearch-dashboards/query-editor-ui.md) | bugfix | Autocomplete fixes, generated query UI improvements, edit button placement |
 | [UI Settings & Dataset Select](features/opensearch-dashboards/ui-settings-dataset-select.md) | bugfix | UI settings client robustness, dataset selector visual updates |
+| [UI Settings Backward Compatibility](features/opensearch-dashboards/ui-settings-backward-compatibility.md) | feature | Restore backward compatibility for multi-scope UI settings client |
 | [Chart & Visualization Fixes](features/opensearch-dashboards/chart-visualization-fixes.md) | bugfix | Line chart legend display fix, popover toggle fix |


### PR DESCRIPTION
## Summary

This PR adds documentation for the UI Settings Backward Compatibility feature in OpenSearch Dashboards v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch-dashboards/ui-settings-backward-compatibility.md`
- Feature report: `docs/features/opensearch-dashboards/ui-settings.md` (new)

### Key Changes in v3.2.0
- Restores backward compatibility for multi-scope UI settings client
- Adds deprecation warnings for legacy API usage patterns
- Ensures existing code continues to work while guiding developers toward new API patterns

### Resources Used
- PR: [#9854](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9854)
- Related PR: [#9726](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9726)
- Issue: [#7821](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7821)

Closes #1158