### PR TITLE
docs: add data-source-selector-scope report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -117,6 +117,7 @@
 - [Data Connections](opensearch-dashboards/data-connections.md)
 - [Data Importer](opensearch-dashboards/data-importer.md)
 - [Data Source Permissions](opensearch-dashboards/data-source-permissions.md)
+- [Data Source Selector](opensearch-dashboards/data-source-selector.md)
 - [Dependency Updates](opensearch-dashboards/dependency-updates.md)
 - [Dev Tools](opensearch-dashboards/dev-tools.md)
 - [Discover](opensearch-dashboards/discover.md)

--- a/docs/features/opensearch-dashboards/data-source-selector.md
+++ b/docs/features/opensearch-dashboards/data-source-selector.md
@@ -1,0 +1,150 @@
+# Data Source Selector
+
+## Summary
+
+The Data Source Selector is a UI component in OpenSearch Dashboards that allows users to select and manage data sources for their queries and visualizations. It provides a consistent interface across different plugins and supports workspace-aware scope handling to ensure users see the appropriate default data source based on their current context.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Data Source Management Plugin"
+        DSM[DataSourceMenu]
+        DSS[DataSourceSelectable]
+        DSV[DataSourceView]
+        DSMS[DataSourceMultiSelectable]
+        DSAV[DataSourceAggregatedView]
+        DSSelector[DataSourceSelector]
+    end
+    
+    subgraph "Core Services"
+        WS[Workspaces Service]
+        UIS[UiSettings Service]
+        SO[SavedObjects Client]
+        NOT[Notifications]
+    end
+    
+    subgraph "Scope Handling"
+        SC[Scope Detection]
+        WSS[Workspace Scope]
+        GS[Global Scope]
+    end
+    
+    DSM --> DSS
+    DSM --> DSV
+    DSM --> DSMS
+    DSM --> DSAV
+    
+    DSM --> SC
+    SC --> WS
+    SC -->|WORKSPACE| WSS
+    SC -->|GLOBAL| GS
+    
+    DSS --> UIS
+    DSS --> SO
+    DSS --> NOT
+    
+    DSSelector --> WS
+    DSSelector --> UIS
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User Opens Plugin] --> B{In Workspace?}
+    B -->|Yes| C[Use WORKSPACE Scope]
+    B -->|No| D[Use GLOBAL Scope]
+    C --> E[Get Workspace Default Data Source]
+    D --> F[Get Global Default Data Source]
+    E --> G[Render Data Source Selector]
+    F --> G
+    G --> H[User Selects Data Source]
+    H --> I[Callback with Selection]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `DataSourceMenu` | Main entry point that renders the appropriate selector type based on configuration |
+| `DataSourceSelectable` | Dropdown selector for choosing a single data source |
+| `DataSourceView` | Read-only view of the currently selected data source |
+| `DataSourceMultiSelectable` | Multi-select component for choosing multiple data sources |
+| `DataSourceAggregatedView` | Aggregated view showing multiple data sources |
+| `DataSourceSelector` | Legacy selector component (deprecated in favor of DataSourceMenu) |
+| `DataSourceDropDownHeader` | Header component for the dropdown menu |
+| `NoDataSource` | Empty state component when no data sources are available |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `defaultDataSource` | The default data source ID | `null` |
+| `hideLocalCluster` | Whether to hide the local cluster option | `false` |
+| `data_source.enabled` | Enable multi-data-source feature | `false` |
+
+### Usage Example
+
+Using the data source menu in a plugin:
+
+```tsx
+import { DataSourceManagementPluginSetup } from 'src/plugins/data_source_management/public';
+
+// Get the DataSourceMenu component
+const DataSourceMenu = dataSourceManagement.ui.getDataSourceMenu<DataSourceSelectableConfig>();
+
+// Render the component
+<DataSourceMenu
+  componentType={DataSourceComponentType.DataSourceSelectable}
+  componentConfig={{
+    fullWidth: true,
+    savedObjects: savedObjectsClient,
+    notifications: notifications,
+    onSelectedDataSources: (dataSources) => {
+      console.log('Selected:', dataSources);
+    },
+    activeOption: selectedDataSource ? [selectedDataSource] : undefined,
+    dataSourceFilter: (ds) => ds.attributes.auth.type !== AuthType.NoAuth,
+  }}
+/>
+```
+
+Using the aggregated view:
+
+```tsx
+<DataSourceMenu
+  componentType={DataSourceComponentType.DataSourceAggregatedView}
+  componentConfig={{
+    fullWidth: false,
+    savedObjects: savedObjectsClient,
+    notifications: notifications,
+    displayAllCompatibleDataSources: true,
+    activeDataSourceIds: ['ds1', 'ds2'],
+  }}
+/>
+```
+
+## Limitations
+
+- The scope is determined at component mount time; dynamic workspace switching requires component remounting
+- The legacy `DataSourceSelector` component requires manual scope handling
+- Data source filtering is applied client-side after fetching all data sources
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#9832](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9832) | Support scope in data source selector |
+
+## References
+
+- [Workspace Documentation](https://docs.opensearch.org/3.0/dashboards/workspace/workspace/): Official workspace documentation
+- [Data Sources Documentation](https://docs.opensearch.org/3.0/dashboards/management/data-sources/): Data source management guide
+- [Manage Workspaces](https://docs.opensearch.org/3.0/dashboards/workspace/manage-workspace/): Workspace management including data source associations
+
+## Change History
+
+- **v3.2.0** (2026-01-10): Added workspace-aware scope support for default data source retrieval

--- a/docs/releases/v3.2.0/features/opensearch-dashboards/data-source-selector-scope.md
+++ b/docs/releases/v3.2.0/features/opensearch-dashboards/data-source-selector-scope.md
@@ -1,0 +1,144 @@
+# Data Source Selector Scope
+
+## Summary
+
+This release adds scope support to the data source selector component in OpenSearch Dashboards. The data source selector now automatically determines the appropriate UI settings scope (workspace or global) based on the current workspace context, ensuring that default data source settings are correctly retrieved for the user's current environment.
+
+## Details
+
+### What's New in v3.2.0
+
+The data source selector components now support workspace-aware scope handling for UI settings. When a user is working within a workspace, the selector uses workspace-scoped settings; otherwise, it falls back to global settings.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Data Source Menu"
+        DSM[DataSourceMenu]
+        DSS[DataSourceSelectable]
+        DSV[DataSourceView]
+        DSMS[DataSourceMultiSelectable]
+        DSAV[DataSourceAggregatedView]
+    end
+    
+    subgraph "Scope Detection"
+        WS[Workspaces Service]
+        SC[Scope Determination]
+    end
+    
+    subgraph "UI Settings"
+        UIS[UiSettingsClient]
+        WSS[Workspace Scope]
+        GS[Global Scope]
+    end
+    
+    DSM --> SC
+    SC --> WS
+    WS -->|currentWorkspaceId| SC
+    SC -->|WORKSPACE| WSS
+    SC -->|GLOBAL| GS
+    WSS --> UIS
+    GS --> UIS
+    
+    DSM --> DSS
+    DSM --> DSV
+    DSM --> DSMS
+    DSM --> DSAV
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `getWorkspaces` | Utility function to access the workspaces service |
+| `setWorkspaces` | Setter function to initialize the workspaces service reference |
+
+#### API Changes
+
+The `DataSourceMenuProps` interface has been updated:
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `scope` | `UiSettingScope` | Yes | The UI settings scope (WORKSPACE or GLOBAL) |
+| `onManageDataSource` | `() => void` | No | Callback for managing data sources (now optional) |
+
+The `getDefaultDataSourceId` function signature has been updated:
+
+```typescript
+// Before
+getDefaultDataSourceId(uiSettings?: IUiSettingsClient): Promise<string | undefined>
+
+// After
+getDefaultDataSourceId(uiSettings?: IUiSettingsClient, scope: UiSettingScope): Promise<string | undefined>
+```
+
+#### Scope Determination Logic
+
+```typescript
+const currentWorkspaceId = workspaces.currentWorkspaceId$.getValue();
+const scope: UiSettingScope = !!currentWorkspaceId
+  ? UiSettingScope.WORKSPACE
+  : UiSettingScope.GLOBAL;
+```
+
+### Usage Example
+
+The data source menu automatically determines scope based on workspace context:
+
+```tsx
+// In DataSourceMenu component
+const workspaces = getWorkspaces();
+const currentWorkspaceId = workspaces.currentWorkspaceId$.getValue();
+const scope: UiSettingScope = !!currentWorkspaceId
+  ? UiSettingScope.WORKSPACE
+  : UiSettingScope.GLOBAL;
+
+// Scope is passed to child components
+<DataSourceSelectable
+  scope={scope}
+  // ... other props
+/>
+```
+
+For plugins using the data source menu directly:
+
+```tsx
+// The scope is automatically determined internally
+<DataSourceMenu
+  componentType={DataSourceComponentType.DataSourceSelectable}
+  componentConfig={{
+    savedObjects: client,
+    notifications,
+    onSelectedDataSources: handleSelection,
+  }}
+/>
+```
+
+### Migration Notes
+
+- The `onManageDataSource` prop is now optional in `DataSourceSelectableConfig`
+- Plugins using `createDataSourceMenu` do not need to pass `scope`, `uiSettings`, `hideLocalCluster`, or `application` props as these are handled internally
+- The `getDefaultDataSourceId` utility now requires a `scope` parameter
+
+## Limitations
+
+- The scope is determined at component mount time; dynamic workspace switching requires component remounting
+- Direct usage of `DataSourceSelector` (legacy component) requires manual scope handling via `getWorkspaces()`
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9832](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9832) | Support scope in data source selector |
+
+## References
+
+- [Workspace Documentation](https://docs.opensearch.org/3.0/dashboards/workspace/workspace/): Official workspace documentation
+- [Data Sources Documentation](https://docs.opensearch.org/3.0/dashboards/management/data-sources/): Data source management guide
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/data-source-selector.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -19,3 +19,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [UI Settings & Dataset Select](features/opensearch-dashboards/ui-settings-dataset-select.md) | bugfix | UI settings client robustness, dataset selector visual updates |
 | [UI Settings Backward Compatibility](features/opensearch-dashboards/ui-settings-backward-compatibility.md) | feature | Restore backward compatibility for multi-scope UI settings client |
 | [Chart & Visualization Fixes](features/opensearch-dashboards/chart-visualization-fixes.md) | bugfix | Line chart legend display fix, popover toggle fix |
+| [Data Source Selector Scope](features/opensearch-dashboards/data-source-selector-scope.md) | feature | Workspace-aware scope support for data source selector |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Data Source Selector Scope feature introduced in OpenSearch Dashboards v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch-dashboards/data-source-selector-scope.md`
- Feature report: `docs/features/opensearch-dashboards/data-source-selector.md` (new)

### Key Changes in v3.2.0
- Added workspace-aware scope support for data source selector components
- The data source selector now automatically determines the appropriate UI settings scope (workspace or global) based on the current workspace context
- Updated `getDefaultDataSourceId` function to accept a scope parameter
- Made `onManageDataSource` prop optional in `DataSourceSelectableConfig`

### Resources Used
- PR: [#9832](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9832)
- Docs: [Workspace Documentation](https://docs.opensearch.org/3.0/dashboards/workspace/workspace/)
- Docs: [Data Sources Documentation](https://docs.opensearch.org/3.0/dashboards/management/data-sources/)

Closes #1157