### PR TITLE
docs: add global-banner-support report for v3.2.0

### DIFF
--- a/docs/features/opensearch-dashboards/banner-plugin.md
+++ b/docs/features/opensearch-dashboards/banner-plugin.md
@@ -71,16 +71,34 @@ flowchart LR
 
 ### Configuration
 
+#### YAML Configuration (opensearch_dashboards.yml)
+
 | Setting | Type | Description | Default |
 |---------|------|-------------|---------|
 | `banner.enabled` | boolean | Enable/disable the banner plugin | `false` |
-| `banner.text` | string | Banner message (supports Markdown) | Default announcement |
-| `banner.color` | enum | `primary`, `success`, `warning` | `primary` |
+| `banner.content` | string | Banner message (supports Markdown) | Default announcement |
+| `banner.color` | enum | `primary`, `warning`, `danger` | `primary` |
 | `banner.iconType` | string | EUI icon type | `iInCircle` |
 | `banner.isVisible` | boolean | Initial visibility | `true` |
 | `banner.useMarkdown` | boolean | Enable Markdown rendering | `true` |
 
+#### UI Settings (Advanced Settings)
+
+As of v3.2.0, banner settings can be configured via the Advanced Settings UI:
+
+| Setting | Type | Description | Default |
+|---------|------|-------------|---------|
+| `banner:active` | boolean | Controls banner visibility | `true` |
+| `banner:content` | markdown | Banner message content | `''` |
+| `banner:color` | select | Color scheme: `primary`, `warning`, `danger` | `primary` |
+| `banner:iconType` | select | Icon type for the banner | `iInCircle` |
+| `banner:useMarkdown` | boolean | Enable Markdown rendering | `true` |
+
+UI Settings take precedence over YAML configuration values.
+
 ### Usage Example
+
+#### YAML Configuration
 
 ```yaml
 # opensearch_dashboards.yml
@@ -89,7 +107,7 @@ flowchart LR
 banner.enabled: true
 
 # Configure banner content
-banner.text: |
+banner.content: |
   **Important:** System maintenance scheduled for Saturday 2AM-4AM UTC.
   [View details](https://status.example.com)
 banner.color: warning
@@ -97,6 +115,18 @@ banner.iconType: alert
 banner.isVisible: true
 banner.useMarkdown: true
 ```
+
+#### UI Settings Configuration (v3.2.0+)
+
+1. Navigate to **Dashboards Management** > **Advanced Settings**
+2. Search for `banner:` to find banner settings
+3. Configure the following settings:
+   - `banner:active`: Enable/disable the banner
+   - `banner:content`: Enter your banner message (Markdown supported)
+   - `banner:color`: Select color scheme
+   - `banner:iconType`: Choose an icon
+   - `banner:useMarkdown`: Enable/disable Markdown rendering
+4. Save changes - banner updates after page reload
 
 ### CSS Variables
 
@@ -136,17 +166,17 @@ The Banner Plugin was created as a standalone plugin rather than extending the e
 
 ## Limitations
 
-- Static configuration only (no runtime API to update banner)
 - No server-side dynamic content fetching
 - No role-based visibility
 - No scheduled banners
-- No Advanced Settings UI for customization
 - Single banner only (no stacking)
+- UI Settings changes require page reload (v3.2.0)
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#10264](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10264) | Add global banner support via UI settings with live updates |
 | v3.2.0 | [#9989](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9989) | Initial implementation with feature flag |
 | v3.2.0 | [#10251](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10251) | Fix font size and center alignment |
 | v3.2.0 | [#10254](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10254) | Reset lighthouse baseline |
@@ -158,4 +188,5 @@ The Banner Plugin was created as a standalone plugin rather than extending the e
 
 ## Change History
 
+- **v3.2.0** (2026-01-10): Added UI Settings support for dynamic banner configuration via Advanced Settings
 - **v3.2.0** (2026-01-10): Initial implementation with static banner, feature flag, markdown support, and dismissal functionality

--- a/docs/releases/v3.2.0/features/opensearch-dashboards/global-banner-support.md
+++ b/docs/releases/v3.2.0/features/opensearch-dashboards/global-banner-support.md
@@ -1,0 +1,142 @@
+# Global Banner Support via UI Settings
+
+## Summary
+
+OpenSearch Dashboards v3.2.0 enhances the Banner Plugin with UI Settings integration, enabling administrators to configure and update the global banner dynamically through the Advanced Settings interface without requiring server restarts. Changes take effect in real-time, providing a more flexible and user-friendly banner management experience.
+
+## Details
+
+### What's New in v3.2.0
+
+This release adds UI Settings support to the Banner Plugin, allowing banner configuration through the Dashboards Management interface:
+
+- Server-side registration of banner settings as UI Settings
+- Client-side subscription to setting changes for live updates
+- Real-time banner updates without page reload
+- YAML configuration values used as default values for UI Settings
+- New banner settings category in Advanced Settings
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph Configuration
+        YML[opensearch_dashboards.yml]
+        UISettings[UI Settings / Advanced Settings]
+    end
+    
+    subgraph Server["Server Side"]
+        ServerPlugin[BannerPlugin Server]
+        UISettingsReg[UI Settings Registration]
+        GetConfigRoute[/api/_plugins/_banner/content]
+    end
+    
+    subgraph Browser["Browser Side"]
+        ClientPlugin[BannerPlugin Client]
+        GlobalBanner[GlobalBanner Component]
+    end
+    
+    YML -->|default values| UISettingsReg
+    UISettings -->|user overrides| UISettingsReg
+    UISettingsReg --> ServerPlugin
+    ServerPlugin --> GetConfigRoute
+    GetConfigRoute -->|reads from UI Settings| ClientPlugin
+    ClientPlugin --> GlobalBanner
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ui_settings.ts` | Defines banner UI settings with schema validation |
+| `getDefaultBannerSettings()` | Returns UI settings configuration for banner |
+
+#### New Configuration (UI Settings)
+
+| Setting | Type | Description | Default |
+|---------|------|-------------|---------|
+| `banner:active` | boolean | Controls banner visibility | `true` |
+| `banner:content` | markdown | Banner message content | `''` |
+| `banner:color` | select | Color scheme: `primary`, `warning`, `danger` | `primary` |
+| `banner:iconType` | select | Icon: `iInCircle`, `help`, `alert`, `warning`, `check`, `bell` | `iInCircle` |
+| `banner:useMarkdown` | boolean | Enable Markdown rendering | `true` |
+
+### Usage Example
+
+1. Navigate to **Dashboards Management** > **Advanced Settings**
+2. Search for `banner:` to find banner settings
+3. Modify settings:
+
+```
+banner:active = true
+banner:content = **Maintenance Notice:** System upgrade scheduled for Saturday 2AM UTC
+banner:color = warning
+banner:iconType = alert
+banner:useMarkdown = true
+```
+
+4. Save changes - banner updates immediately
+
+### Configuration Priority
+
+Settings are resolved in the following order:
+1. User-modified UI Settings (highest priority)
+2. YAML configuration values (used as defaults)
+3. Built-in defaults (lowest priority)
+
+```yaml
+# opensearch_dashboards.yml - sets default values
+banner.enabled: true
+banner.content: "Default announcement"
+banner.color: primary
+```
+
+### API Changes
+
+The `/api/_plugins/_banner/content` endpoint now reads from UI Settings instead of directly from YAML configuration:
+
+```typescript
+// Server reads from UI Settings client
+const uiSettingsClient = context.core.uiSettings.client;
+const settings = await uiSettingsClient.getAll();
+
+const config: BannerConfig = {
+  content: settings['banner:content'],
+  color: settings['banner:color'],
+  iconType: settings['banner:iconType'],
+  isVisible: Boolean(settings['banner:active']),
+  useMarkdown: Boolean(settings['banner:useMarkdown']),
+  size: settings['banner:size'],
+};
+```
+
+### Migration Notes
+
+- Existing YAML configurations continue to work as default values
+- UI Settings overrides take precedence over YAML values
+- No breaking changes to existing deployments
+- Page reload required after changing settings (indicated in UI)
+
+## Limitations
+
+- Settings require page reload to take effect (`requiresPageReload: true`)
+- No `banner:size` setting exposed in UI (uses default)
+- Settings are global (no per-workspace or per-user configuration)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10264](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10264) | Add global banner support via UI settings with live updates |
+
+## References
+
+- [Issue #9861](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9861): RFC - OpenSearch Dashboards Banner Plugin
+- [Issue #9990](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9990): Meta issue tracking banner plugin development
+- [Advanced Settings Documentation](https://docs.opensearch.org/3.0/dashboards/management/advanced-settings/): OpenSearch Dashboards Advanced Settings
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/banner-plugin.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -13,6 +13,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Vended Dashboard Progress](features/opensearch-dashboards/vended-dashboard-progress.md) | feature | Polling-based index state detection for background data sync progress |
 | [Explore UI Enhancements](features/opensearch-dashboards/explore-ui-enhancements.md) | feature | New Explore plugin with auto-visualization, multi-flavor support, and dashboard embeddable |
 | [Static Banner Plugin](features/opensearch-dashboards/static-banner-plugin.md) | feature | Global configurable header banner for announcements |
+| [Global Banner Support](features/opensearch-dashboards/global-banner-support.md) | feature | UI Settings integration for dynamic banner configuration |
 | [Discover Plugin Fixes](features/opensearch-dashboards/discover-plugin-fixes.md) | bugfix | Fix empty page when no index patterns, add Cypress tests |
 | [OUI (OpenSearch UI) Updates](features/opensearch-dashboards/oui-updates.md) | bugfix | Update OUI component library from 1.19 to 1.21 |
 | [Query Editor UI](features/opensearch-dashboards/query-editor-ui.md) | bugfix | Autocomplete fixes, generated query UI improvements, edit button placement |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Global Banner Support via UI Settings feature in OpenSearch Dashboards v3.2.0.

### Changes
- Created release report: `docs/releases/v3.2.0/features/opensearch-dashboards/global-banner-support.md`
- Updated feature report: `docs/features/opensearch-dashboards/banner-plugin.md`
- Updated release index: `docs/releases/v3.2.0/index.md`

### Key Feature
PR [#10264](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10264) adds UI Settings integration to the Banner Plugin, enabling:
- Dynamic banner configuration via Advanced Settings UI
- Real-time updates without server restart
- New settings: `banner:active`, `banner:content`, `banner:color`, `banner:iconType`, `banner:useMarkdown`

Closes #1156