### PR TITLE
docs: add Trace Details Page report for v3.2.0

### DIFF
--- a/docs/features/opensearch-dashboards/explore.md
+++ b/docs/features/opensearch-dashboards/explore.md
@@ -10,6 +10,7 @@ Key benefits include:
 - Automatic visualization selection based on data patterns
 - Dashboard integration through embeddable components
 - Extensible tab system for custom result views
+- Trace Details page for deep investigation of distributed traces (v3.2.0)
 
 ## Details
 
@@ -22,6 +23,13 @@ graph TB
             LogsApp[Logs App]
             TracesApp[Traces App]
             MetricsApp[Metrics App]
+        end
+        
+        subgraph "Trace Details Page"
+            TraceView[Trace Details View]
+            GanttChart[Gantt Chart - Vega]
+            ServiceMap[Service Map - React Flow]
+            SpanFlyout[Span Detail Flyout]
         end
         
         subgraph "Core Services"
@@ -71,7 +79,12 @@ graph TB
     
     LogsApp --> StateManager
     TracesApp --> StateManager
+    TracesApp --> TraceView
     MetricsApp --> StateManager
+    
+    TraceView --> GanttChart
+    TraceView --> ServiceMap
+    TraceView --> SpanFlyout
     
     StateManager --> QueryBar
     StateManager --> TabRegistry
@@ -146,6 +159,12 @@ flowchart TB
 | `PatternsTable` | Log patterns analysis table |
 | `FieldSelector` | Field selection sidebar |
 | `DataTable` | Results data table with action bar |
+| `TraceDetails` | Trace details page with span visualization |
+| `GanttChart` | Vega-based Gantt chart for span timeline |
+| `ServiceMap` | React Flow-based interactive service dependency graph |
+| `SpanDetailPanel` | Container for span visualization with view mode switching |
+| `SpanDetailTable` | Flat list view of spans with sorting and filtering |
+| `SpanDetailTableHierarchy` | Tree view showing parent-child span relationships |
 
 ### Configuration
 
@@ -264,11 +283,14 @@ source = opensearch_dashboards_sample_data_ecommerce
 | v3.2.0 | [#9932](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9932) | Histogram UI fix |
 | v3.2.0 | [#9946](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9946) | Tab preservation and cache update |
 | v3.2.0 | [#9972](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9972) | Panels layout adjustment |
+| v3.2.0 | [#10253](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10253) | Trace Details page with Gantt chart and service map |
 
 ## References
 
 - [OpenSearch Dashboards Repository](https://github.com/opensearch-project/OpenSearch-Dashboards)
+- [Issue #9898](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9898): RFC for React Flow library introduction
+- [React Flow Documentation](https://reactflow.dev/): Interactive node-based visualization library
 
 ## Change History
 
-- **v3.2.0** (2026-01-10): Initial implementation with query panel, auto-visualization, multi-flavor support, dashboard embeddable, patterns tab, and chart type switcher
+- **v3.2.0** (2026-01-10): Initial implementation with query panel, auto-visualization, multi-flavor support, dashboard embeddable, patterns tab, chart type switcher, and Trace Details page with Gantt chart and service map visualization

--- a/docs/releases/v3.2.0/features/opensearch-dashboards/trace-details-page.md
+++ b/docs/releases/v3.2.0/features/opensearch-dashboards/trace-details-page.md
@@ -1,0 +1,150 @@
+# Trace Details Page
+
+## Summary
+
+The Trace Details page is a new feature in OpenSearch Dashboards that provides a dedicated interface for viewing and analyzing individual trace journeys within the Explore plugin's Traces flavor. It displays complete metadata, attributes, execution context, and service relationships for specific traces, enabling deep investigation of distributed system behavior.
+
+Key capabilities include:
+- Gantt chart visualization of span timelines using Vega
+- Interactive service map using React Flow and dagre.js for automatic layout
+- Span detail flyout with filtering capabilities
+- Multiple view modes: timeline, span list, and tree view
+- URL-based navigation with trace ID and span ID parameters
+
+## Details
+
+### What's New in v3.2.0
+
+This release introduces the Trace Details page as part of the Explore plugin's Traces flavor. The page is accessible via URL navigation with the following format:
+
+```
+/app/explore/traces/traceDetails#/?_a=(dataSourceId:{id},indexPattern:'{pattern}',spanId:{spanId},traceId:'{traceId}')
+```
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Trace Details Page"
+        TraceView[TraceDetails Component]
+        
+        subgraph "Visualization Components"
+            GanttChart[Gantt Chart - Vega]
+            ServiceMap[Service Map - React Flow]
+            SpanTable[Span Detail Table]
+            TreeView[Span Hierarchy Tree]
+        end
+        
+        subgraph "Data Processing"
+            PPLTransform[PPL to Trace Hits]
+            ColorMapGen[Color Map Generator]
+            GanttAdapter[Gantt Data Adapter]
+        end
+        
+        subgraph "UI Components"
+            TopNav[Top Nav Menu]
+            SpanFlyout[Span Detail Flyout]
+            ViewSwitcher[View Mode Switcher]
+        end
+    end
+    
+    TraceView --> GanttChart
+    TraceView --> ServiceMap
+    TraceView --> SpanTable
+    TraceView --> TreeView
+    
+    PPLTransform --> GanttAdapter
+    GanttAdapter --> GanttChart
+    ColorMapGen --> ServiceMap
+    ColorMapGen --> GanttChart
+    
+    TraceView --> TopNav
+    TraceView --> SpanFlyout
+    TraceView --> ViewSwitcher
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `TraceDetails` | Main page component with trace data fetching and state management |
+| `GanttChart` | Vega-based Gantt chart for span timeline visualization |
+| `ServiceMap` | React Flow-based interactive service dependency graph |
+| `SpanDetailPanel` | Container for span visualization with view mode switching |
+| `SpanDetailTable` | Flat list view of spans with sorting and filtering |
+| `SpanDetailTableHierarchy` | Tree view showing parent-child span relationships |
+| `FlyoutListItem` | Reusable component for span attribute display in flyout |
+| `TraceTopNavMenu` | Top navigation with "View raw trace" action |
+
+#### New Dependencies
+
+| Package | Version | Purpose |
+|---------|---------|---------|
+| `@xyflow/react` | ^12.8.2 | React Flow library for service map visualization |
+| `@dagrejs/dagre` | ^1.1.5 | Automatic graph layout algorithm |
+
+#### Gantt Chart Configuration
+
+| Constant | Value | Description |
+|----------|-------|-------------|
+| `TOP_PADDING` | 20 | Top padding in pixels |
+| `BOTTOM_PADDING` | 20 | Bottom padding in pixels |
+| `MIN_ROW_HEIGHT` | 30 | Minimum height per span row |
+| `MIN_HEIGHT` | 150 | Minimum chart height |
+| `MAX_HEIGHT` | 600 | Maximum chart height |
+
+### Usage Example
+
+Navigate to a trace details page:
+```
+http://localhost:5601/app/explore/traces/traceDetails#/?_a=(dataSourceId:e2681970-5b5b-11f0-84cd-1f27cd4c7d84,indexPattern:'otel-v1-apm-span-*',spanId:a8b6dd34808083b3,traceId:'23a88fa559da1b6c7521658fba2cb82f')
+```
+
+If `spanId` is not provided, the root span or first available span is automatically selected.
+
+### Service Map Features
+
+- **Focus on Service**: Filter view to show only selected service and its direct connections
+- **Metric Visualization**: Request rate, error rate, and duration displayed as color-coded bars
+- **Expandable Cards**: Toggle between compact and detailed service card views
+- **Automatic Layout**: dagre.js provides hierarchical left-to-right layout
+
+### View Modes
+
+| Mode | Description |
+|------|-------------|
+| Timeline | Gantt chart showing span execution timeline |
+| Span List | Flat table with sortable columns |
+| Tree View | Hierarchical view showing parent-child relationships |
+
+### Migration Notes
+
+To enable the Trace Details page:
+1. Enable the Explore plugin (experimental feature)
+2. Navigate to Traces flavor in Explore
+3. Click on a trace to view details
+
+## Limitations
+
+- Requires Explore plugin to be enabled (experimental)
+- Service map performance may degrade with very large numbers of services (50+)
+- React Flow library is experimental in OpenSearch Dashboards core
+- Gantt chart has maximum height of 600px
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10253](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10253) | Trace Details page implementation |
+
+## References
+
+- [Issue #9898](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9898): RFC for React Flow library introduction
+- [React Flow Documentation](https://reactflow.dev/): Interactive node-based visualization library
+- [OpenSearch 3.3 Blog](https://opensearch.org/blog/explore-opensearch-3-3/): Feature announcement
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/explore.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -21,3 +21,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [UI Settings Backward Compatibility](features/opensearch-dashboards/ui-settings-backward-compatibility.md) | feature | Restore backward compatibility for multi-scope UI settings client |
 | [Chart & Visualization Fixes](features/opensearch-dashboards/chart-visualization-fixes.md) | bugfix | Line chart legend display fix, popover toggle fix |
 | [Data Source Selector Scope](features/opensearch-dashboards/data-source-selector-scope.md) | feature | Workspace-aware scope support for data source selector |
+| [Trace Details Page](features/opensearch-dashboards/trace-details-page.md) | feature | Dedicated trace investigation page with Gantt chart and service map |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Trace Details Page feature introduced in OpenSearch Dashboards v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch-dashboards/trace-details-page.md`
- Feature report: Updated `docs/features/opensearch-dashboards/explore.md`

### Key Changes in v3.2.0
- New Trace Details page for deep investigation of distributed traces
- Gantt chart visualization using Vega for span timelines
- Interactive service map using React Flow and dagre.js
- Multiple view modes: timeline, span list, and tree view
- URL-based navigation with trace ID and span ID parameters

### Resources Used
- PR: #10253 (opensearch-project/OpenSearch-Dashboards)
- Issue: #9898 (RFC for React Flow library)
- Blog: https://opensearch.org/blog/explore-opensearch-3-3/