### PR TITLE
docs: add bar-chart-enhancements report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -103,6 +103,7 @@
 
 - [Async Query](opensearch-dashboards/async-query.md)
 - [Banner Plugin](opensearch-dashboards/banner-plugin.md)
+- [Bar Chart Enhancements](opensearch-dashboards/bar-chart-enhancements.md)
 - [CI/CD & Build Fixes](opensearch-dashboards/ci-cd-build-fixes.md)
 - [Chart & Visualization Fixes](opensearch-dashboards/chart-visualization-fixes.md)
 - [Content Management](opensearch-dashboards/content-management.md)

--- a/docs/features/opensearch-dashboards/bar-chart-enhancements.md
+++ b/docs/features/opensearch-dashboards/bar-chart-enhancements.md
@@ -1,0 +1,119 @@
+# Bar Chart Enhancements
+
+## Summary
+
+Bar chart enhancements in OpenSearch Dashboards provide users with flexible control over bar chart appearance. The feature introduces a bar size mode toggle that allows switching between automatic sizing (where Vega optimizes bar dimensions) and manual mode (where users can specify custom bar width and padding values).
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Explore Plugin - Bar Visualization"
+        A[BarVisStyleControls] --> B[BarExclusiveVisOptions]
+        B --> C{barSizeMode}
+        C -->|auto| D[Vega Auto-sizing]
+        C -->|manual| E[Manual Controls]
+        E --> F[barWidth Input]
+        E --> G[barPadding Input]
+    end
+    
+    subgraph "Vega Spec Generation"
+        H[to_expression.ts] --> I[configureBarSizeAndSpacing]
+        I --> J{Check Mode}
+        J -->|auto| K[No size/binSpacing set]
+        J -->|manual| L[Apply custom values]
+    end
+    
+    B --> H
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User selects bar size mode] --> B[BarExclusiveVisOptions]
+    B --> C[onBarSizeModeChange callback]
+    C --> D[Update styleOptions.barSizeMode]
+    D --> E[Trigger re-render]
+    E --> F[createBarSpec / createTimeBarChart]
+    F --> G[configureBarSizeAndSpacing]
+    G --> H{barSizeMode === 'manual'?}
+    H -->|Yes| I[Set size and binSpacing]
+    H -->|No| J[Leave unset for Vega auto]
+    I --> K[Render bar chart]
+    J --> K
+```
+
+### Components
+
+| Component | File | Description |
+|-----------|------|-------------|
+| `BarExclusiveVisOptions` | `bar_exclusive_vis_options.tsx` | UI component with bar size mode toggle and manual inputs |
+| `BarVisStyleControls` | `bar_vis_options.tsx` | Parent component that passes style options |
+| `BarChartStyleControls` | `bar_vis_config.ts` | TypeScript interface defining style properties |
+| `configureBarSizeAndSpacing` | `to_expression.ts` | Utility function for conditional size application |
+
+### Configuration
+
+| Setting | Type | Description | Default | Range |
+|---------|------|-------------|---------|-------|
+| `barSizeMode` | `'auto' \| 'manual'` | Controls bar sizing behavior | `'auto'` | - |
+| `barWidth` | `number` | Bar width multiplier (manual mode only) | `0.7` | 0.1 - 1.0 |
+| `barPadding` | `number` | Bar padding multiplier (manual mode only) | `0.1` | 0 - 0.5 |
+| `showBarBorder` | `boolean` | Whether to show bar borders | `false` | - |
+| `barBorderWidth` | `number` | Border width in pixels | `1` | 1 - 10 |
+| `barBorderColor` | `string` | Border color | - | - |
+
+### Usage Example
+
+```typescript
+// Default configuration (auto mode)
+const defaultBarChartStyles: BarChartStyleControls = {
+  barSizeMode: 'auto',
+  barWidth: 0.7,
+  barPadding: 0.1,
+  showBarBorder: false,
+  barBorderWidth: 1,
+  barBorderColor: '#000000',
+  // ... other properties
+};
+
+// Manual mode with custom values
+const customStyles: Partial<BarChartStyleControls> = {
+  barSizeMode: 'manual',
+  barWidth: 0.5,    // Narrower bars
+  barPadding: 0.2,  // More spacing
+};
+```
+
+### User Interface
+
+The bar size controls appear in the "Bar Settings" accordion within the style options panel:
+
+1. **Bar Size Mode Toggle**: Button group with "Auto" and "Manual" options
+2. **Bar Width Input** (manual mode only): Numeric input with range 0.1-1.0, step 0.1
+3. **Bar Padding Input** (manual mode only): Numeric input with range 0-0.5, step 0.05
+
+## Limitations
+
+- Bar size controls are specific to the Explore plugin's bar chart visualization
+- Width and padding values are multipliers, not direct pixel values
+- Auto mode relies on Vega's default sizing algorithm
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#10152](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10152) | Add Bar Size Control Switch for auto/manual bar sizing |
+
+## References
+
+- [PR #10152](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10152): Initial implementation
+- [Building data visualizations](https://docs.opensearch.org/3.0/dashboards/visualize/viz-index/): OpenSearch visualization documentation
+- [Vega](https://docs.opensearch.org/3.0/dashboards/visualize/vega/): Vega visualization documentation
+
+## Change History
+
+- **v3.2.0**: Initial implementation - Added bar size mode toggle with auto/manual options

--- a/docs/releases/v3.2.0/features/opensearch-dashboards/bar-chart-enhancements.md
+++ b/docs/releases/v3.2.0/features/opensearch-dashboards/bar-chart-enhancements.md
@@ -1,0 +1,94 @@
+# Bar Chart Enhancements
+
+## Summary
+
+This release introduces a "Bar Size Control Switch" to bar chart visualizations in OpenSearch Dashboards. Users can now toggle between "Auto" and "Manual" modes for bar sizing, providing greater flexibility in customizing bar chart appearance.
+
+## Details
+
+### What's New in v3.2.0
+
+A new bar size mode toggle has been added to the bar chart style options panel. This allows users to choose between automatic bar sizing (where Vega determines optimal width and padding) or manual control with custom values.
+
+### Technical Changes
+
+#### User Interface Flow
+
+```mermaid
+graph TB
+    subgraph "Bar Settings Panel"
+        A[Bar Size Mode Toggle] --> B{Mode Selected}
+        B -->|Auto| C[Vega Auto-sizing]
+        B -->|Manual| D[Show Width/Padding Inputs]
+        D --> E[Bar Width Input<br/>0.1 - 1.0]
+        D --> F[Bar Padding Input<br/>0 - 0.5]
+    end
+    C --> G[Rendered Bar Chart]
+    E --> G
+    F --> G
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `barSizeMode` | New style control property with values `'auto'` or `'manual'` |
+| `EuiButtonGroup` | Toggle switch for selecting bar size mode |
+| `configureBarSizeAndSpacing()` | Utility function to conditionally apply size settings |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `barSizeMode` | Controls whether bar sizing is automatic or manual | `'auto'` |
+| `barWidth` | Bar width multiplier (only in manual mode) | `0.7` |
+| `barPadding` | Bar padding multiplier (only in manual mode) | `0.1` |
+
+#### API Changes
+
+The `BarChartStyleControls` interface now includes:
+
+```typescript
+interface BarChartStyleControls {
+  // ... existing properties
+  barSizeMode: 'auto' | 'manual';
+  barWidth: number;
+  barPadding: number;
+  // ...
+}
+```
+
+### Usage Example
+
+1. Navigate to OpenSearch Dashboards Discover page
+2. Run a PPL query to generate data
+3. Open the "Bar Settings" accordion in the style options panel
+4. Select "Auto" for automatic bar sizing, or "Manual" to customize:
+   - **Bar Width**: Value between 0.1 and 1.0 (scaled to actual pixel width)
+   - **Bar Padding**: Value between 0 and 0.5 (scaled to actual spacing)
+
+### Migration Notes
+
+- Existing bar charts will default to "Auto" mode
+- No breaking changes - manual width/padding settings are preserved when switching modes
+
+## Limitations
+
+- Bar size controls are only available in the Explore plugin's bar chart visualization
+- Manual mode settings are scaled values, not direct pixel measurements
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10152](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10152) | Add Bar Size Control Switch for auto/manual bar sizing |
+
+## References
+
+- [PR #10152](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10152): Main implementation
+- [Building data visualizations](https://docs.opensearch.org/3.0/dashboards/visualize/viz-index/): OpenSearch visualization documentation
+- [Vega](https://docs.opensearch.org/3.0/dashboards/visualize/vega/): Vega visualization documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/bar-chart-enhancements.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -22,3 +22,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Chart & Visualization Fixes](features/opensearch-dashboards/chart-visualization-fixes.md) | bugfix | Line chart legend display fix, popover toggle fix |
 | [Data Source Selector Scope](features/opensearch-dashboards/data-source-selector-scope.md) | feature | Workspace-aware scope support for data source selector |
 | [Trace Details Page](features/opensearch-dashboards/trace-details-page.md) | feature | Dedicated trace investigation page with Gantt chart and service map |
+| [Bar Chart Enhancements](features/opensearch-dashboards/bar-chart-enhancements.md) | feature | Bar size control switch for auto/manual bar sizing |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Bar Chart Enhancements feature in OpenSearch Dashboards v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch-dashboards/bar-chart-enhancements.md`
- Feature report: `docs/features/opensearch-dashboards/bar-chart-enhancements.md`

### Key Changes in v3.2.0
- Added bar size mode toggle with "Auto" and "Manual" options
- In Auto mode, Vega automatically determines bar width and padding
- In Manual mode, users can specify custom barWidth (0.1-1.0) and barPadding (0-0.5) values

### Source
- [PR #10152](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10152): Add Bar Size Control Switch

Closes #1154