### PR TITLE
docs: add Dashboards CVE Fixes report for v3.2.0

### DIFF
--- a/docs/features/opensearch-dashboards/security-cve-fixes.md
+++ b/docs/features/opensearch-dashboards/security-cve-fixes.md
@@ -19,6 +19,7 @@ graph TB
             PTR[path-to-regexp<br/>URL Routing]
             MM[micromatch<br/>Glob Matching]
             DNS[dns-sync<br/>DNS Resolution]
+            TARFS[tar-fs<br/>Archive Extraction]
         end
     end
     OSD --> AXIOS
@@ -27,6 +28,7 @@ graph TB
     OSD --> PTR
     OSD --> MM
     OSD --> DNS
+    OSD --> TARFS
 ```
 
 ### Components
@@ -39,11 +41,13 @@ graph TB
 | path-to-regexp | URL path matching for routing | ReDoS vulnerabilities |
 | micromatch | Glob pattern matching | ReDoS vulnerabilities |
 | dns-sync | Synchronous DNS resolution | Command injection |
+| tar-fs | Filesystem bindings for tar archives | Path traversal |
 
 ### CVE Summary
 
 | CVE | Package | Description | Severity |
 |-----|---------|-------------|----------|
+| CVE-2025-48387 | tar-fs | Path traversal during tar extraction | High |
 | CVE-2017-16100 | dns-sync | Command injection via DNS lookup | Critical |
 | CVE-2024-39338 | axios | Server-Side Request Forgery | High |
 | CVE-2024-45296 | path-to-regexp | Regular Expression DoS | High |
@@ -73,6 +77,7 @@ The OpenSearch Dashboards team follows a proactive security update process:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#10225](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10225) | [CVE-2025-48387] tar-fs 2.1.2 → 2.1.3, 3.0.8 → 3.1.0 |
 | v2.18.0 | [#7811](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7811) | [CVE-2017-16100] dns-sync patched version |
 | v2.18.0 | [#8026](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8026) | micromatch 4.0.7 → 4.0.8 |
 | v2.18.0 | [#8197](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8197) | [CVE-2024-45296] path-to-regexp updates |
@@ -82,6 +87,7 @@ The OpenSearch Dashboards team follows a proactive security update process:
 
 ## References
 
+- [CVE-2025-48387](https://nvd.nist.gov/vuln/detail/CVE-2025-48387): tar-fs path traversal
 - [CVE-2017-16100](https://nvd.nist.gov/vuln/detail/CVE-2017-16100): dns-sync command injection
 - [CVE-2024-39338](https://nvd.nist.gov/vuln/detail/CVE-2024-39338): axios SSRF vulnerability
 - [CVE-2024-45296](https://nvd.nist.gov/vuln/detail/CVE-2024-45296): path-to-regexp ReDoS
@@ -90,4 +96,5 @@ The OpenSearch Dashboards team follows a proactive security update process:
 
 ## Change History
 
+- **v3.2.0** (2026-01-10): Fixed CVE-2025-48387; bumped tar-fs 2.1.2 → 2.1.3, 3.0.8 → 3.1.0
 - **v2.18.0** (2024-11-05): Fixed CVE-2017-16100, CVE-2024-39338, CVE-2024-45296, CVE-2024-45801, CVE-2024-48948; bumped micromatch

--- a/docs/releases/v3.2.0/features/opensearch-dashboards/dashboards-cve-fixes.md
+++ b/docs/releases/v3.2.0/features/opensearch-dashboards/dashboards-cve-fixes.md
@@ -1,0 +1,77 @@
+# Dashboards CVE Fixes
+
+## Summary
+
+OpenSearch Dashboards v3.2.0 addresses CVE-2025-48387, a high-severity vulnerability in the `tar-fs` package. This security fix updates `tar-fs` from versions 2.1.2 and 3.0.8 to patched versions 2.1.3 and 3.1.0 respectively, preventing potential path traversal attacks during tar archive extraction.
+
+## Details
+
+### What's New in v3.2.0
+
+This release fixes a critical security vulnerability that could allow an attacker to write files outside the intended extraction directory when processing specially crafted tar archives.
+
+### Technical Changes
+
+#### Vulnerability Details
+
+| CVE | Package | Severity | CVSS Score | Attack Vector |
+|-----|---------|----------|------------|---------------|
+| CVE-2025-48387 | tar-fs | High | 7.5 | Network |
+
+The vulnerability affects the `tar-fs` package, which provides filesystem bindings for `tar-stream`. Prior to the fix, a malicious tarball could write files outside the specified extraction directory, potentially leading to arbitrary file overwrites.
+
+#### Dependency Updates
+
+| Package | Previous Version | Fixed Version | Location |
+|---------|-----------------|---------------|----------|
+| tar-fs | 2.1.2 | 2.1.3 | @osd/opensearch, @osd/test |
+| tar-fs | 3.0.8 | 3.1.0 | puppeteer (transitive) |
+| puppeteer | 24.4.0 | 24.14.0 | Root package |
+
+#### Affected Components
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        OSD[OSD Application]
+        subgraph "Affected Packages"
+            OPENSEARCH[@osd/opensearch]
+            TEST[@osd/test]
+            PUPPETEER[puppeteer]
+        end
+        subgraph "Vulnerable Dependency"
+            TARFS[tar-fs<br/>Path Traversal Fix]
+        end
+    end
+    OSD --> OPENSEARCH
+    OSD --> TEST
+    OSD --> PUPPETEER
+    OPENSEARCH --> TARFS
+    TEST --> TARFS
+    PUPPETEER --> TARFS
+```
+
+### Migration Notes
+
+No migration steps required. The fix is a transparent dependency update that does not change any APIs or behavior.
+
+## Limitations
+
+- The vulnerability only affects scenarios where untrusted tar archives are extracted
+- Development and testing workflows using `@osd/opensearch` and `@osd/test` packages were potentially affected
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10225](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10225) | [CVE-2025-48387] Bump tar-fs from 2.1.2 to 2.1.3 and from 3.0.8 to 3.1.0 |
+
+## References
+
+- [Issue #9841](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9841): CVE-2025-48387 detection report
+- [CVE-2025-48387](https://nvd.nist.gov/vuln/detail/CVE-2025-48387): NVD vulnerability details
+- [GHSA-8cj5-5rvv-wf4v](https://github.com/advisories/GHSA-8cj5-5rvv-wf4v): GitHub Security Advisory
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/security-cve-fixes.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -23,3 +23,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Data Source Selector Scope](features/opensearch-dashboards/data-source-selector-scope.md) | feature | Workspace-aware scope support for data source selector |
 | [Trace Details Page](features/opensearch-dashboards/trace-details-page.md) | feature | Dedicated trace investigation page with Gantt chart and service map |
 | [Bar Chart Enhancements](features/opensearch-dashboards/bar-chart-enhancements.md) | feature | Bar size control switch for auto/manual bar sizing |
+| [Dashboards CVE Fixes](features/opensearch-dashboards/dashboards-cve-fixes.md) | deprecation | [CVE-2025-48387] tar-fs security update |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dashboards CVE Fixes release item in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch-dashboards/dashboards-cve-fixes.md`
- Feature report: `docs/features/opensearch-dashboards/security-cve-fixes.md` (updated)

### Key Changes in v3.2.0
- Fixed CVE-2025-48387 (High severity) - path traversal vulnerability in tar-fs
- Updated tar-fs from 2.1.2 to 2.1.3 and from 3.0.8 to 3.1.0
- Updated puppeteer from 24.4.0 to 24.14.0

### Resources Used
- PR: [#10225](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10225)
- Issue: [#9841](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9841)

Closes #1152