### PR TITLE
docs: add Azure Repository Fixes report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -19,6 +19,7 @@
 - [Async Shard Batch Fetch](opensearch/async-shard-batch-fetch.md)
 - [Async Shard Fetch Metrics](opensearch/async-shard-fetch-metrics.md)
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
+- [Azure Repository](opensearch/azure-repository.md)
 - [Bulk API](opensearch/bulk-api.md)
 - [Cluster Stats API](opensearch/cluster-stats-api.md)
 - [Cluster Manager Metrics](opensearch/cluster-manager-metrics.md)

--- a/docs/features/opensearch/azure-repository.md
+++ b/docs/features/opensearch/azure-repository.md
@@ -1,0 +1,149 @@
+# Azure Repository Plugin
+
+## Summary
+
+The Azure Repository plugin (`repository-azure`) enables OpenSearch to use Microsoft Azure Blob Storage as a backend for snapshot and restore operations. It supports various authentication methods including storage account keys, shared access signatures (SAS), and managed identity token credentials. The plugin also supports proxy configurations including HTTP and SOCKS5 proxies with authentication.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph OpenSearch Cluster
+        OS[OpenSearch Node]
+        ARS[AzureStorageService]
+        AR[AzureRepository]
+    end
+    
+    subgraph Configuration
+        KS[Keystore]
+        YML[opensearch.yml]
+    end
+    
+    subgraph Network
+        PROXY[Proxy Server]
+    end
+    
+    subgraph Azure
+        BLOB[Azure Blob Storage]
+        CONTAINER[Storage Container]
+    end
+    
+    OS --> AR
+    AR --> ARS
+    KS --> ARS
+    YML --> ARS
+    ARS --> PROXY
+    PROXY --> BLOB
+    ARS -.-> BLOB
+    BLOB --> CONTAINER
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `AzureStorageService` | Core service managing Azure Blob Storage client connections |
+| `AzureRepository` | Repository implementation for snapshot/restore operations |
+| `ProxySettings` | Configuration for HTTP/SOCKS5 proxy connections |
+| `AzureStorageSettings` | Storage account and authentication settings |
+
+### Configuration
+
+#### Authentication Settings
+
+| Setting | Description | Required |
+|---------|-------------|----------|
+| `azure.client.{client}.account` | Azure Storage account name | Yes |
+| `azure.client.{client}.key` | Storage account key | One of key/sas_token/token_credential |
+| `azure.client.{client}.sas_token` | Shared access signature token | One of key/sas_token/token_credential |
+| `azure.client.{client}.token_credential_type` | Token credential type (e.g., `managed_identity`) | One of key/sas_token/token_credential |
+
+#### Proxy Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `azure.client.{client}.proxy.type` | Proxy type: `http`, `https`, `socks4`, `socks5` | - |
+| `azure.client.{client}.proxy.host` | Proxy server hostname | - |
+| `azure.client.{client}.proxy.port` | Proxy server port | - |
+| `azure.client.{client}.proxy.username` | Proxy authentication username (keystore) | - |
+| `azure.client.{client}.proxy.password` | Proxy authentication password (keystore) | - |
+
+#### Timeout Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `azure.client.{client}.connect_timeout` | Connection timeout | - |
+| `azure.client.{client}.read_timeout` | Read timeout | - |
+| `azure.client.{client}.write_timeout` | Write timeout | - |
+| `azure.client.{client}.response_timeout` | Response timeout | - |
+
+### Usage Example
+
+#### Installation
+
+```bash
+./bin/opensearch-plugin install repository-azure
+```
+
+#### Configure Authentication
+
+```bash
+# Add storage account name
+./bin/opensearch-keystore add azure.client.default.account
+
+# Add storage account key
+./bin/opensearch-keystore add azure.client.default.key
+```
+
+#### Register Repository
+
+```json
+PUT /_snapshot/my-azure-repository
+{
+  "type": "azure",
+  "settings": {
+    "client": "default",
+    "container": "my-snapshot-container",
+    "base_path": "snapshots"
+  }
+}
+```
+
+#### Configure SOCKS5 Proxy with Authentication
+
+```yaml
+# opensearch.yml
+azure.client.default.proxy.type: socks5
+azure.client.default.proxy.host: proxy.example.com
+azure.client.default.proxy.port: 1080
+```
+
+```bash
+# Add proxy credentials to keystore
+./bin/opensearch-keystore add azure.client.default.proxy.username
+./bin/opensearch-keystore add azure.client.default.proxy.password
+```
+
+## Limitations
+
+- Token credential authentication only supports managed identity (as of v2.15+)
+- When using token credentials, they take precedence over storage account keys or SAS tokens
+- SOCKS5 proxy authentication requires credentials to be stored in the OpenSearch keystore
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18904](https://github.com/opensearch-project/OpenSearch/pull/18904) | Fix socks5 user password settings for Azure repo |
+
+## References
+
+- [OpenSearch Snapshot and Restore Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/)
+- [Azure Blob Storage Introduction](https://learn.microsoft.com/en-us/azure/storage/common/storage-introduction)
+- [Azure SDK ProxyOptions](https://learn.microsoft.com/en-us/java/api/com.azure.core.http.proxyoptions)
+
+## Change History
+
+- **v3.2.0** (2025-08-05): Fixed SOCKS5 proxy authentication - credentials now properly set via ProxyOptions.setCredentials() instead of JDK Authenticator

--- a/docs/releases/v3.2.0/features/opensearch/azure-repository-fixes.md
+++ b/docs/releases/v3.2.0/features/opensearch/azure-repository-fixes.md
@@ -1,0 +1,96 @@
+# Azure Repository Fixes
+
+## Summary
+
+This bugfix resolves an issue with SOCKS5 proxy authentication settings (username and password) for the Azure repository plugin. Previously, SOCKS5 credentials were incorrectly configured using the JDK `Authenticator` class, but the Azure SDK client requires these credentials to be set through the `ProxyOptions` class.
+
+## Details
+
+### What's New in v3.2.0
+
+The fix corrects the proxy authentication mechanism for Azure Blob Storage connections when using SOCKS5 proxies with username/password authentication.
+
+### Technical Changes
+
+#### Problem
+
+When configuring a SOCKS5 proxy with authentication for the Azure repository plugin, the credentials were being set using Java's `Authenticator.setDefault()` method:
+
+```java
+// Previous incorrect implementation
+Authenticator.setDefault(new Authenticator() {
+    @Override
+    protected PasswordAuthentication getPasswordAuthentication() {
+        return new PasswordAuthentication(
+            proxySettings.getUsername(), 
+            proxySettings.getPassword().toCharArray()
+        );
+    }
+});
+clientBuilder.proxy(new ProxyOptions(proxySettings.getType().toProxyType(), proxySettings.getAddress()));
+```
+
+This approach doesn't work with the Azure SDK because the Azure client uses its own `ProxyOptions` class for proxy configuration, which has a dedicated method for setting credentials.
+
+#### Solution
+
+The fix properly configures proxy credentials through the Azure SDK's `ProxyOptions.setCredentials()` method:
+
+```java
+// Fixed implementation
+final ProxyOptions proxyOptions = new ProxyOptions(
+    proxySettings.getType().toProxyType(), 
+    proxySettings.getAddress()
+);
+if (proxySettings.isAuthenticated()) {
+    proxyOptions.setCredentials(proxySettings.getUsername(), proxySettings.getPassword());
+}
+clientBuilder.proxy(proxyOptions);
+```
+
+#### Changed Files
+
+| File | Change |
+|------|--------|
+| `AzureStorageService.java` | Removed JDK Authenticator usage, added ProxyOptions.setCredentials() |
+
+### Usage Example
+
+To configure a SOCKS5 proxy with authentication for Azure repository:
+
+```yaml
+# opensearch.yml
+azure.client.default.proxy.type: socks5
+azure.client.default.proxy.host: proxy.example.com
+azure.client.default.proxy.port: 1080
+```
+
+```bash
+# Add proxy credentials to keystore
+./bin/opensearch-keystore add azure.client.default.proxy.username
+./bin/opensearch-keystore add azure.client.default.proxy.password
+```
+
+### Migration Notes
+
+No migration required. This is a transparent bugfix that corrects the behavior of existing proxy authentication settings.
+
+## Limitations
+
+- This fix specifically addresses SOCKS5 proxy authentication
+- HTTP/HTTPS proxy authentication was not affected by this issue
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18904](https://github.com/opensearch-project/OpenSearch/pull/18904) | Fix socks5 user password settings for Azure repo |
+
+## References
+
+- [Azure Repository Plugin Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/)
+- [Azure SDK ProxyOptions](https://learn.microsoft.com/en-us/java/api/com.azure.core.http.proxyoptions)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/azure-repository.md)

--- a/docs/releases/v3.2.0/features/opensearch/system-ingest-pipeline-fix.md
+++ b/docs/releases/v3.2.0/features/opensearch/system-ingest-pipeline-fix.md
@@ -1,0 +1,90 @@
+# System Ingest Pipeline Fix
+
+## Summary
+
+This bugfix resolves an issue where the system ingest pipeline was not triggered when an index request was forwarded from a non-ingest node to an ingest node. The fix ensures that the `isPipelineResolved` flag is reset before attempting to resolve the system ingest pipeline again on the ingest node.
+
+## Details
+
+### What's New in v3.2.0
+
+Fixed a bug where system ingest pipelines were silently skipped when:
+1. An index request arrives at a non-ingest node (e.g., a dedicated master node)
+2. The non-ingest node resolves the pipeline and marks `isPipelineResolved = true`
+3. The request is forwarded to an ingest node
+4. The ingest node's cache doesn't have the system pipeline
+5. The ingest node skips pipeline resolution because `isPipelineResolved` is already `true`
+
+### Technical Changes
+
+#### Root Cause
+
+The `IngestService.getPipeline()` method checks the `SystemIngestPipelineCache` for cached pipelines. When the cache is empty (e.g., on a fresh ingest node), it should re-resolve the system pipeline. However, the code was checking `indexRequest.isPipelineResolved()` before attempting resolution, causing it to skip the resolution step entirely.
+
+#### Fix Implementation
+
+The fix resets `isPipelineResolved` to `false` before calling `resolveSystemIngestPipeline()`:
+
+```java
+// In IngestService.getPipeline()
+if (indexPipeline == null) {
+    // reset isPipelineResolved as false so that we can resolve it again
+    indexRequest.isPipelineResolved(false);
+    resolveSystemIngestPipeline(actionRequest, indexRequest, state.metadata());
+    // ...
+}
+```
+
+#### Affected Code
+
+| File | Change |
+|------|--------|
+| `IngestService.java` | Reset `isPipelineResolved` flag before re-resolving system pipeline |
+| `IngestServiceTests.java` | Added test for cache miss scenario with forwarded requests |
+
+### Scenario
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Master as Master Node<br/>(non-ingest)
+    participant Data as Data Node<br/>(ingest)
+    participant Cache as SystemIngestPipelineCache
+    
+    Client->>Master: Index Request
+    Master->>Master: Resolve Pipeline<br/>isPipelineResolved = true
+    Master->>Data: Forward Request
+    Data->>Cache: Get System Pipeline
+    Cache-->>Data: null (cache miss)
+    Note over Data: Before Fix: Skip resolution<br/>After Fix: Reset flag & resolve
+    Data->>Data: resolveSystemIngestPipeline()
+    Data->>Data: Execute Pipeline
+    Data-->>Client: Success
+```
+
+### Impact
+
+Without this fix, documents indexed through non-ingest nodes would not have system ingest processors applied, leading to:
+- Missing auto-generated embeddings for semantic fields
+- Inconsistent data depending on which node received the request
+- Silent failures with no error messages
+
+## Limitations
+
+- This fix addresses the specific case of request forwarding between nodes
+- The underlying cache invalidation behavior remains unchanged
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18911](https://github.com/opensearch-project/OpenSearch/pull/18911) | Reset isPipelineResolved to false to resolve the system ingest pipeline again |
+
+## References
+
+- [Issue #18909](https://github.com/opensearch-project/OpenSearch/issues/18909): System ingest pipeline not triggered when request is from a non-ingest node
+- [Blog: Making ingestion smarter](https://opensearch.org/blog/making-ingestion-smarter-system-ingest-pipelines-in-opensearch/): System ingest pipeline overview
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/system-ingest-pipeline.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -24,3 +24,10 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Trace Details Page](features/opensearch-dashboards/trace-details-page.md) | feature | Dedicated trace investigation page with Gantt chart and service map |
 | [Bar Chart Enhancements](features/opensearch-dashboards/bar-chart-enhancements.md) | feature | Bar size control switch for auto/manual bar sizing |
 | [Dashboards CVE Fixes](features/opensearch-dashboards/dashboards-cve-fixes.md) | deprecation | [CVE-2025-48387] tar-fs security update |
+
+### OpenSearch
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [System Ingest Pipeline Fix](features/opensearch/system-ingest-pipeline-fix.md) | bugfix | Fix system ingest pipeline to properly handle index templates |
+| [Azure Repository Fixes](features/opensearch/azure-repository-fixes.md) | bugfix | Fix SOCKS5 proxy authentication for Azure repository |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Azure Repository Fixes bugfix in OpenSearch v3.2.0.

### Changes

- **Release Report**: `docs/releases/v3.2.0/features/opensearch/azure-repository-fixes.md`
  - Documents the fix for SOCKS5 proxy authentication settings
  - Explains the technical change from JDK Authenticator to ProxyOptions.setCredentials()

- **Feature Report**: `docs/features/opensearch/azure-repository.md`
  - Comprehensive documentation for the Azure Repository plugin
  - Covers authentication methods, proxy configuration, and usage examples

### Related Issue

Closes #1150

### PR Investigated

- [opensearch-project/OpenSearch#18904](https://github.com/opensearch-project/OpenSearch/pull/18904): Fix socks5 user password settings for Azure repo