### PR TITLE
docs: add Rule-based Auto Tagging Fix report for v3.2.0

### DIFF
--- a/docs/features/opensearch/workload-management.md
+++ b/docs/features/opensearch/workload-management.md
@@ -252,6 +252,7 @@ GET _list/wlm_stats?size=50&sort=node_id&order=asc&next_token=<encrypted_token>
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#18628](https://github.com/opensearch-project/OpenSearch/pull/18628) | Fix delete rule event consumption for wildcard index based rules |
 | v3.1.0 | [#17638](https://github.com/opensearch-project/OpenSearch/pull/17638) | Add paginated wlm/stats API |
 | v3.1.0 | [#17336](https://github.com/opensearch-project/OpenSearch/pull/17336) | Add Get Rule API for auto-tagging |
 | v3.1.0 | [#17791](https://github.com/opensearch-project/OpenSearch/pull/17791) | Add WLM ActionFilter for automatic tagging |
@@ -280,5 +281,6 @@ GET _list/wlm_stats?size=50&sort=node_id&order=asc&next_token=<encrypted_token>
 
 ## Change History
 
+- **v3.2.0** (2026-01-10): Fixed delete rule event consumption for wildcard index based rules in `InMemoryRuleProcessingService`
 - **v3.1.0** (2026-01-10): Added rule-based auto-tagging with full CRUD API (`/_rules/workload_group`), WLM ActionFilter for automatic request tagging, refresh-based rule synchronization, and paginated `/_list/wlm_stats` API
 - **v2.18.0** (2024-10-22): Initial implementation with QueryGroup CRUD APIs, Stats API, resource cancellation framework, resiliency orchestrator, persistence, and enhanced rejection logic

--- a/docs/releases/v3.2.0/features/opensearch/rule-based-auto-tagging-fix.md
+++ b/docs/releases/v3.2.0/features/opensearch/rule-based-auto-tagging-fix.md
@@ -1,0 +1,93 @@
+# Rule-based Auto Tagging Fix
+
+## Summary
+
+This bugfix resolves an issue where delete rule events were not properly consumed for wildcard-based index pattern rules in the `InMemoryRuleProcessingService`. When a rule with a wildcard pattern (e.g., `test-*`) was deleted, the in-memory data structure was not correctly updated because the wildcard character was not stripped during the remove operation.
+
+## Details
+
+### What's New in v3.2.0
+
+This release fixes a bug in the rule-based auto-tagging feature where deleting rules with wildcard index patterns did not properly remove them from the in-memory data structure.
+
+### Technical Changes
+
+#### Bug Description
+
+The rule-based auto-tagging feature stores rules in an in-memory trie data structure for efficient pattern matching. When adding a rule, the wildcard character (`*`) is stripped from the pattern before storing (e.g., `test-*` becomes `test-`). However, the remove operation was not applying the same transformation, causing delete events for wildcard-based rules to fail silently.
+
+#### Root Cause
+
+In `InMemoryRuleProcessingService.removeOperation()`, the code was calling:
+```java
+valueStore.remove(value);
+```
+
+This did not strip the wildcard, so when trying to remove `test-*`, it looked for a key that didn't exist in the trie (since it was stored as `test-`).
+
+#### Fix Applied
+
+The fix ensures the wildcard is stripped during removal, matching the behavior of the add operation:
+
+```java
+// Before (broken)
+valueStore.remove(value);
+
+// After (fixed)
+valueStore.remove(value.replace(WILDCARD, ""));
+```
+
+#### Code Change
+
+```java
+private void removeOperation(Map.Entry<Attribute, Set<String>> attributeEntry, Rule rule) {
+    AttributeValueStore<String, String> valueStore = 
+        attributeValueStoreFactory.getAttributeValueStore(attributeEntry.getKey());
+    for (String value : attributeEntry.getValue()) {
+        valueStore.remove(value.replace(WILDCARD, ""), rule.getFeatureValue());
+    }
+}
+```
+
+### Usage Example
+
+```bash
+# Create a rule with wildcard pattern
+PUT _rules/workload_group
+{
+  "description": "Route test indexes",
+  "index_pattern": ["test-*"],
+  "workload_group": "<workload_group_id>"
+}
+
+# Delete the rule - now correctly removes from in-memory store
+DELETE _rules/workload_group/<rule_id>
+
+# Subsequent searches to test-* indexes will no longer be auto-tagged
+# (previously, the rule would remain in memory until node restart)
+```
+
+### Migration Notes
+
+- No migration required
+- The fix is automatically applied after upgrading to v3.2.0
+- Existing rules with wildcard patterns will be correctly handled on delete
+
+## Limitations
+
+- This fix only affects the delete operation for wildcard-based rules
+- Rules without wildcards were not affected by this bug
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18628](https://github.com/opensearch-project/OpenSearch/pull/18628) | Fix delete rule event consumption for wildcard index based rules |
+
+## References
+
+- [Rule Lifecycle API Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/rule-based-autotagging/rule-lifecycle-api/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/workload-management.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -29,5 +29,6 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 
 | Item | Category | Description |
 |------|----------|-------------|
+| [Rule-based Auto Tagging Fix](features/opensearch/rule-based-auto-tagging-fix.md) | bugfix | Fix delete rule event consumption for wildcard index based rules |
 | [System Ingest Pipeline Fix](features/opensearch/system-ingest-pipeline-fix.md) | bugfix | Fix system ingest pipeline to properly handle index templates |
 | [Azure Repository Fixes](features/opensearch/azure-repository-fixes.md) | bugfix | Fix SOCKS5 proxy authentication for Azure repository |


### PR DESCRIPTION
## Summary

This PR adds the release report for the Rule-based Auto Tagging bugfix in v3.2.0.

### Changes
- Created release report: `docs/releases/v3.2.0/features/opensearch/rule-based-auto-tagging-fix.md`
- Updated feature report: `docs/features/opensearch/workload-management.md` (added v3.2.0 to change history and related PRs)
- Updated release index: `docs/releases/v3.2.0/index.md`

### Bug Fixed
PR [#18628](https://github.com/opensearch-project/OpenSearch/pull/18628) fixes an issue where delete rule events were not properly consumed for wildcard-based index pattern rules in `InMemoryRuleProcessingService`. The wildcard character was not being stripped during the remove operation, causing delete events for wildcard-based rules to fail silently.

Closes #1149