### PR TITLE
docs: add Profiler Enhancements report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -69,6 +69,7 @@
 - [Platform Support](opensearch/platform-support.md)
 - [Plugin Installation](opensearch/plugin-installation.md)
 - [Plugin Testing Framework](opensearch/plugin-testing-framework.md)
+- [Profiler](opensearch/profiler.md)
 - [Pull-based Ingestion](opensearch/pull-based-ingestion.md)
 - [Query Bug Fixes](opensearch/query-bug-fixes.md)
 - [Query Coordinator Context](opensearch/query-coordinator-context.md)

--- a/docs/features/opensearch/profiler.md
+++ b/docs/features/opensearch/profiler.md
@@ -1,0 +1,178 @@
+# Query Profiler
+
+## Summary
+
+The Query Profiler (Profile API) provides detailed timing information about the execution of individual components of a search request. It helps debug slow queries and understand how to improve search performance by breaking down query execution into measurable components.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Search Request"
+        SR[Search Request with profile=true]
+    end
+    
+    subgraph "Query Execution"
+        QE[Query Execution]
+        CW[Create Weight]
+        BS[Build Scorer]
+        SC[Score Documents]
+        CO[Collectors]
+    end
+    
+    subgraph "Profiling Layer"
+        QPB[QueryProfileBreakdown]
+        CQPB[ConcurrentQueryProfileBreakdown]
+        PT[Profile Timers]
+    end
+    
+    subgraph "Output"
+        PR[Profile Results]
+        BD[Breakdown Map]
+        CT[Collector Times]
+        AT[Aggregation Times]
+    end
+    
+    SR --> QE
+    QE --> CW
+    CW --> BS
+    BS --> SC
+    SC --> CO
+    
+    QE --> QPB
+    QE --> CQPB
+    QPB --> PT
+    CQPB --> PT
+    
+    PT --> PR
+    PR --> BD
+    PR --> CT
+    PR --> AT
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Input
+        Q[Query with profile:true]
+    end
+    
+    subgraph Execution
+        W[Weight Creation]
+        S[Scorer Building]
+        D[Document Scoring]
+        C[Collection]
+    end
+    
+    subgraph Timing
+        T1[create_weight]
+        T2[build_scorer]
+        T3[next_doc/advance]
+        T4[score]
+    end
+    
+    subgraph Output
+        R[Profile Response]
+    end
+    
+    Q --> W --> S --> D --> C
+    W --> T1
+    S --> T2
+    D --> T3
+    D --> T4
+    T1 & T2 & T3 & T4 --> R
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `QueryProfileBreakdown` | Tracks timing for non-concurrent query execution |
+| `ConcurrentQueryProfileBreakdown` | Tracks timing for concurrent segment search with slice-level statistics |
+| `ProfileTimer` | Low-level timer for measuring individual operations |
+| `ProfileCollector` | Wraps collectors to measure collection time |
+
+### Configuration
+
+The Profile API is enabled per-request using the `profile` parameter:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `profile` | Enable profiling for the request | `false` |
+| `human` | Return human-readable time values | `false` |
+
+### Usage Example
+
+```json
+GET /myindex/_search
+{
+  "profile": true,
+  "query": {
+    "match": { "title": "opensearch" }
+  }
+}
+```
+
+Response includes breakdown timing:
+
+```json
+{
+  "profile": {
+    "shards": [{
+      "searches": [{
+        "query": [{
+          "type": "TermQuery",
+          "description": "title:opensearch",
+          "time_in_nanos": 123456,
+          "breakdown": {
+            "create_weight": 10000,
+            "create_weight_count": 1,
+            "build_scorer": 50000,
+            "build_scorer_count": 2,
+            "next_doc": 30000,
+            "next_doc_count": 100,
+            "score": 20000,
+            "score_count": 100
+          }
+        }]
+      }]
+    }]
+  }
+}
+```
+
+### Concurrent Segment Search Support
+
+When concurrent segment search is enabled, the profiler provides additional slice-level statistics:
+
+| Field | Description |
+|-------|-------------|
+| `max_slice_time_in_nanos` | Maximum time across all slices |
+| `min_slice_time_in_nanos` | Minimum time across all slices |
+| `avg_slice_time_in_nanos` | Average time across all slices |
+| `slice_count` | Number of slices executed |
+
+## Limitations
+
+- Profiling adds overhead to search operations
+- Does not measure network latency
+- Does not measure fetch phase time
+- Does not measure queue wait time
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18540](https://github.com/opensearch-project/OpenSearch/pull/18540) | Fix concurrent timings in profiler |
+
+## References
+
+- [Profile API Documentation](https://docs.opensearch.org/3.0/api-reference/search-apis/profile/): Official API reference
+- [Concurrent Segment Search](https://docs.opensearch.org/3.0/search-plugins/concurrent-segment-search/): Related feature
+
+## Change History
+
+- **v3.2.0** (2025-06-21): Fixed incorrect timing values for concurrent segment search when timers have zero invocations

--- a/docs/releases/v3.2.0/features/opensearch/profiler-enhancements.md
+++ b/docs/releases/v3.2.0/features/opensearch/profiler-enhancements.md
@@ -1,0 +1,106 @@
+# Profiler Enhancements
+
+## Summary
+
+This release fixes a bug in the Profile API where timing values were incorrectly displayed when using concurrent segment search. The profiler was showing extremely large values (representing start times instead of durations) for timing types that were never invoked on certain slices.
+
+## Details
+
+### What's New in v3.2.0
+
+Fixed incorrect timing calculations in `ConcurrentQueryProfileBreakdown` when concurrent segment search is enabled. The bug caused timing types with zero invocations to display incorrect values in the profile output.
+
+### Technical Changes
+
+#### Bug Description
+
+When running queries with the `profile` flag and concurrent segment search enabled, certain timing values in the breakdown were incorrectly large. For example:
+
+```json
+"next_doc": 221024744949916,
+"advance": 221024744964625,
+"score": 221024744964166
+```
+
+These values should have been `0` since the timers were never invoked.
+
+#### Root Cause
+
+The issue occurred in `ConcurrentQueryProfileBreakdown.buildQueryBreakdownMap()` at line 342. When computing min/max start/end times across slices for a timing type:
+
+1. A timer for a particular slice had `count = 0` (never invoked)
+2. The code still tried to use that slice's timing data
+3. When the minimum start time was computed, a slice with `count = 0` had `startTime = 0`
+4. This `0` became the minimum, making the duration calculation `endTime - 0 = endTime` (the raw nanosecond timestamp)
+
+#### Fix Applied
+
+The fix adds a check to skip slices where the timer was never invoked (`count = 0`) when computing start/end times:
+
+```java
+// only modify the start/end time of the TimingType if the slice used the timer
+if (sliceBreakdownTypeCount > 0L) {
+    // query start/end time for a TimingType is min/max of start/end time across slices
+    queryTimingTypeEndTime = Math.max(
+        queryTimingTypeEndTime,
+        sliceBreakdown.getValue().getOrDefault(sliceEndTimeForTimingType, Long.MIN_VALUE)
+    );
+    queryTimingTypeStartTime = Math.min(
+        queryTimingTypeStartTime,
+        sliceBreakdown.getValue().getOrDefault(sliceStartTimeForTimingType, Long.MAX_VALUE)
+    );
+    queryTimingTypeCount += sliceBreakdownTypeCount;
+}
+```
+
+Additionally, the final duration calculation now returns `0` when no invocations occurred:
+
+```java
+queryBreakdownMap.put(timingTypeKey, (queryTimingTypeCount > 0L) ? queryTimingTypeEndTime - queryTimingTypeStartTime : 0L);
+```
+
+### Usage Example
+
+After the fix, profiling with concurrent segment search returns correct values:
+
+```bash
+# Enable concurrent segment search
+curl -XPUT "http://localhost:9200/myindex/_settings" -H 'Content-Type: application/json' -d'
+{
+    "index.search.concurrent_segment_search.mode": "all"
+}
+'
+
+# Run profiled query
+curl -XGET "http://localhost:9200/myindex/_search" -H 'Content-Type: application/json' -d'
+{
+  "profile": true,
+  "query": {
+    "match": { "field": "value" }
+  }
+}
+'
+```
+
+Timing types that were never invoked now correctly show `0` instead of large incorrect values.
+
+## Limitations
+
+- This fix only affects concurrent segment search profiling
+- Non-concurrent search profiling was not affected by this bug
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18540](https://github.com/opensearch-project/OpenSearch/pull/18540) | Fix concurrent timings in profiler |
+
+## References
+
+- [Issue #18534](https://github.com/opensearch-project/OpenSearch/issues/18534): Bug report - Profile timings incorrect for concurrent segments
+- [Profile API Documentation](https://docs.opensearch.org/3.0/api-reference/search-apis/profile/): Official documentation
+- [Concurrent Segment Search](https://docs.opensearch.org/3.0/search-plugins/concurrent-segment-search/): Feature documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/profiler.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -32,3 +32,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Rule-based Auto Tagging Fix](features/opensearch/rule-based-auto-tagging-fix.md) | bugfix | Fix delete rule event consumption for wildcard index based rules |
 | [System Ingest Pipeline Fix](features/opensearch/system-ingest-pipeline-fix.md) | bugfix | Fix system ingest pipeline to properly handle index templates |
 | [Azure Repository Fixes](features/opensearch/azure-repository-fixes.md) | bugfix | Fix SOCKS5 proxy authentication for Azure repository |
+| [Profiler Enhancements](features/opensearch/profiler-enhancements.md) | bugfix | Fix concurrent timings in profiler for concurrent segment search |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Profiler Enhancements bugfix in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/profiler-enhancements.md`
- Feature report: `docs/features/opensearch/profiler.md` (new)

### Key Changes in v3.2.0
- Fixed incorrect timing values in Profile API when using concurrent segment search
- Timers with zero invocations now correctly show `0` instead of large incorrect values (raw nanosecond timestamps)

### Related
- Resolves investigation for Issue #1148
- OpenSearch PR: [#18540](https://github.com/opensearch-project/OpenSearch/pull/18540)
- OpenSearch Issue: [#18534](https://github.com/opensearch-project/OpenSearch/issues/18534)