### PR TITLE
docs: add IndexFieldDataService Async Close report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -29,6 +29,7 @@
 - [Deprecated Code Cleanup](opensearch/deprecated-code-cleanup.md)
 - [DocRequest Refactoring](opensearch/docrequest-refactoring.md)
 - [Dynamic Settings](opensearch/dynamic-settings.md)
+- [Field Data Cache](opensearch/field-data-cache.md)
 - [File Cache](opensearch/file-cache.md)
 - [Cluster Permissions](opensearch/cluster-permissions.md)
 - [Flat Object Field](opensearch/flat-object-field.md)

--- a/docs/features/opensearch/field-data-cache.md
+++ b/docs/features/opensearch/field-data-cache.md
@@ -1,0 +1,116 @@
+# Field Data Cache
+
+## Summary
+
+The Field Data Cache is a node-level cache in OpenSearch that stores field data used for sorting, aggregations, and scripting on text fields. It loads field values into memory for efficient access during search operations. The cache uses a composite key structure and provides mechanisms for cache clearing during index operations.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Node Level"
+        IFC[IndicesFieldDataCache]
+        IFC --> Cache[(Cache Store)]
+    end
+    
+    subgraph "Index Level"
+        IFDS[IndexFieldDataService]
+        IFDS --> IFC
+    end
+    
+    subgraph "Cache Key Structure"
+        Key[Composite Key]
+        Key --> IF[IndexFieldCache]
+        Key --> SID[ShardId]
+        Key --> RCK[IndexReader.CacheKey]
+        IF --> FN[Field Name]
+        IF --> IDX[Index Details]
+    end
+    
+    subgraph "Operations"
+        Load[Load Field Data]
+        Clear[Clear Cache]
+        Invalidate[Invalidate Entry]
+    end
+    
+    IFDS --> Load
+    IFDS --> Clear
+    IFDS --> Invalidate
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Cache Population"
+        Q[Query with Sort/Agg] --> Check{Cache Hit?}
+        Check -->|Yes| Return[Return Cached Data]
+        Check -->|No| Load[Load from Disk]
+        Load --> Store[Store in Cache]
+        Store --> Return
+    end
+    
+    subgraph "Cache Invalidation"
+        Refresh[Index Refresh] --> Inv[Invalidate Stale Keys]
+        Remove[Index Removal] --> Clear[Clear Index Entries]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `IndicesFieldDataCache` | Node-level cache that stores field data across all indices |
+| `IndexFieldDataService` | Index-level service managing field data operations |
+| `IndexFieldCache` | Per-index cache wrapper containing field name and index details |
+| `CircuitBreakerService` | Memory protection to prevent OOM from excessive cache growth |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `indices.fielddata.cache.size` | Maximum size of the field data cache | Unbounded |
+| `indices.breaker.fielddata.limit` | Circuit breaker limit for field data | 40% of JVM heap |
+| `indices.breaker.fielddata.overhead` | Multiplier for field data memory estimation | 1.03 |
+
+### Cache Clearing Scenarios
+
+1. **Index Refresh**: During shard refresh, stale cache entries are invalidated synchronously
+2. **Index Removal**: When an index is deleted, all associated cache entries are cleared
+3. **Manual Clear**: Using the Clear Cache API to explicitly clear field data
+
+### Usage Example
+
+View field data cache usage per node:
+```bash
+GET _cat/fielddata?v
+```
+
+Clear field data cache for specific index:
+```bash
+POST /my-index/_cache/clear?fielddata=true
+```
+
+## Limitations
+
+- Field data cache size is unbounded by default, controlled only by circuit breakers
+- Cache clearing during index removal iterates over all cache keys (inefficient for large caches)
+- No integration with tiered caching (heap + disk) as of v3.2.0
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18888](https://github.com/opensearch-project/OpenSearch/pull/18888) | Close IndexFieldDataService asynchronously |
+
+## References
+
+- [Issue #13862](https://github.com/opensearch-project/OpenSearch/issues/13862): Optimize FieldDataCache removal flow
+- [CAT Field Data API](https://docs.opensearch.org/3.0/api-reference/cat/cat-field-data/): View field data cache memory usage
+- [Clear Cache API](https://docs.opensearch.org/3.0/api-reference/index-apis/clear-index-cache/): Clear index caches including field data
+
+## Change History
+
+- **v3.2.0** (2025-08): Changed `IndexFieldDataService.close()` to clear cache asynchronously, preventing cluster applier thread blocking during index removal

--- a/docs/releases/v3.2.0/features/opensearch/indexfielddataservice-async-close.md
+++ b/docs/releases/v3.2.0/features/opensearch/indexfielddataservice-async-close.md
@@ -1,0 +1,130 @@
+# IndexFieldDataService Async Close
+
+## Summary
+
+This bugfix changes the `IndexFieldDataService.close()` method to clear the field data cache asynchronously instead of synchronously. Previously, when an index was removed, the field data cache cleanup blocked the cluster applier thread, potentially causing data nodes to be removed from the cluster due to lagging when the cache contained many entries.
+
+## Details
+
+### What's New in v3.2.0
+
+The `IndexFieldDataService` now accepts a `ThreadPool` parameter and uses the `GENERIC` thread pool executor to clear the field data cache asynchronously during index removal.
+
+### Technical Changes
+
+#### Problem
+
+When an index is removed, the associated field data cache entries are cleared by iterating over ALL cache keys, regardless of whether they belong to the target index. This operation was performed synchronously on the cluster applier thread (`clusterApplierService#updateTask`).
+
+With large field data caches, this synchronous cleanup could take significant time, preventing the data node from acknowledging cluster state updates. This caused nodes to be removed from the cluster due to "lagging."
+
+CPU profile showing the issue:
+```
+100.4% (501.8ms out of 500ms) cpu usage by thread 'opensearch[...][clusterApplierService#updateTask][T#1]'
+  org.opensearch.indices.fielddata.cache.IndicesFieldDataCache$IndexFieldCache.clear()
+  org.opensearch.index.fielddata.IndexFieldDataService.clear()
+  org.opensearch.index.fielddata.IndexFieldDataService.close()
+  ...
+  org.opensearch.indices.IndicesService.removeIndex()
+  org.opensearch.indices.cluster.IndicesClusterStateService.removeIndices()
+  org.opensearch.cluster.service.ClusterApplierService.applyChanges()
+```
+
+#### Solution
+
+The fix modifies `IndexFieldDataService.close()` to execute cache clearing on a separate thread:
+
+```java
+@Override
+public void close() throws IOException {
+    // Clear the field data cache for this index in an async manner
+    threadPool.executor(ThreadPool.Names.GENERIC).execute(() -> {
+        try {
+            this.clear();
+        } catch (Exception ex) {
+            logger.warn(
+                "Exception occurred while clearing index field data cache for index: {}, exception: {}",
+                indexSettings.getIndex().getName(),
+                ex
+            );
+        }
+    });
+}
+```
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.2.0"
+        A1[Index Removal] --> B1[ClusterApplierService Thread]
+        B1 --> C1[IndexFieldDataService.close]
+        C1 --> D1[Sync Cache Clear]
+        D1 --> E1[Block Until Complete]
+    end
+    
+    subgraph "After v3.2.0"
+        A2[Index Removal] --> B2[ClusterApplierService Thread]
+        B2 --> C2[IndexFieldDataService.close]
+        C2 --> D2[Submit to GENERIC ThreadPool]
+        D2 --> E2[Return Immediately]
+        D2 -.-> F2[Async Cache Clear]
+    end
+```
+
+#### Modified Components
+
+| Component | Change |
+|-----------|--------|
+| `IndexFieldDataService` | Added `ThreadPool` parameter, async close implementation |
+| `IndexService` | Pass `ThreadPool` to `IndexFieldDataService` constructor |
+
+#### Constructor Change
+
+```java
+// Before
+public IndexFieldDataService(
+    IndexSettings indexSettings,
+    IndicesFieldDataCache indicesFieldDataCache,
+    CircuitBreakerService circuitBreakerService,
+    MapperService mapperService
+)
+
+// After
+public IndexFieldDataService(
+    IndexSettings indexSettings,
+    IndicesFieldDataCache indicesFieldDataCache,
+    CircuitBreakerService circuitBreakerService,
+    MapperService mapperService,
+    ThreadPool threadPool  // New parameter
+)
+```
+
+### Usage Example
+
+No user-facing configuration changes are required. The fix is applied automatically when indexes are removed.
+
+### Migration Notes
+
+This is a transparent bugfix. No migration steps are required.
+
+## Limitations
+
+- This fix addresses only the synchronous blocking issue during index removal
+- The underlying inefficiency of iterating over all cache keys remains (planned for future optimization in Issue #13862)
+- Cache clearing errors are logged but do not fail the index removal operation
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18888](https://github.com/opensearch-project/OpenSearch/pull/18888) | Close IndexFieldDataService asynchronously |
+
+## References
+
+- [Issue #13862](https://github.com/opensearch-project/OpenSearch/issues/13862): Optimize FieldDataCache removal flow (parent enhancement issue)
+- [CAT Field Data API](https://docs.opensearch.org/3.0/api-reference/cat/cat-field-data/): API to view field data cache memory usage
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/field-data-cache.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -6,6 +6,12 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 
 ## Release Reports
 
+### OpenSearch
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [IndexFieldDataService Async Close](features/opensearch/indexfielddataservice-async-close.md) | bugfix | Async field data cache clearing to prevent cluster applier thread blocking |
+
 ### OpenSearch Dashboards
 
 | Item | Category | Description |


### PR DESCRIPTION
## Summary

This PR adds documentation for the IndexFieldDataService Async Close bugfix in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/indexfielddataservice-async-close.md`
- Feature report: `docs/features/opensearch/field-data-cache.md`

### Key Changes in v3.2.0
- `IndexFieldDataService.close()` now clears field data cache asynchronously using the GENERIC thread pool
- Prevents cluster applier thread blocking during index removal
- Fixes issue where data nodes could be removed from cluster due to lagging when clearing large field data caches

### Source PR
- [opensearch-project/OpenSearch#18888](https://github.com/opensearch-project/OpenSearch/pull/18888)

### Related Issue
- [opensearch-project/OpenSearch#13862](https://github.com/opensearch-project/OpenSearch/issues/13862): Optimize FieldDataCache removal flow

Closes #1147