### PR TITLE
docs: add engine-optimization-fixes report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -43,6 +43,7 @@
 - [Derived Source](opensearch/derived-source.md)
 - [Docker Compose v2 Support](opensearch/docker-compose-v2-support.md)
 - [Dynamic Threadpool Resize](opensearch/dynamic-threadpool-resize.md)
+- [Engine Optimization Fixes](opensearch/engine-optimization-fixes.md)
 - [Locale Provider](opensearch/locale-provider.md)
 - [HTTP API](opensearch/http-api.md)
 - [Jackson & Query Limits](opensearch/jackson--query-limits.md)

--- a/docs/features/opensearch/engine-optimization-fixes.md
+++ b/docs/features/opensearch/engine-optimization-fixes.md
@@ -1,0 +1,137 @@
+# Engine Optimization Fixes
+
+## Summary
+
+Engine optimization fixes address performance inconsistencies across different OpenSearch engine types. The primary fix ensures that timestamp sort optimizations (leafSorter) work consistently across `InternalEngine`, `ReadOnlyEngine`, and `NRTReplicationEngine`, providing uniform time-series query performance regardless of shard type or replication strategy.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Engine Types"
+        IE[InternalEngine<br/>Primary Shards]
+        ROE[ReadOnlyEngine<br/>Searchable Snapshots]
+        NRTE[NRTReplicationEngine<br/>Segment Replication]
+    end
+    
+    subgraph "EngineConfig"
+        LS[leafSorter<br/>Comparator&lt;LeafReader&gt;]
+    end
+    
+    subgraph "Lucene"
+        DR[DirectoryReader.open<br/>with leafSorter]
+    end
+    
+    LS --> IE
+    LS --> ROE
+    LS --> NRTE
+    
+    IE --> DR
+    ROE --> DR
+    NRTE --> DR
+    
+    DR --> OPT[Optimized Segment Order<br/>for Time-Series Queries]
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    Query[Time-Series Query<br/>sort: @timestamp desc] --> Coord[Coordinator Node]
+    Coord --> Shard1[Primary Shard<br/>InternalEngine]
+    Coord --> Shard2[Replica Shard<br/>NRTReplicationEngine]
+    Coord --> Shard3[Searchable Snapshot<br/>ReadOnlyEngine]
+    
+    Shard1 --> LS1[leafSorter Applied]
+    Shard2 --> LS2[leafSorter Applied]
+    Shard3 --> LS3[leafSorter Applied]
+    
+    LS1 --> Result[Consistent Fast Results<br/>Early Termination Enabled]
+    LS2 --> Result
+    LS3 --> Result
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `InternalEngine` | Primary engine for read/write shards, has IndexWriter |
+| `ReadOnlyEngine` | Engine for searchable snapshots, read-only access |
+| `NRTReplicationEngine` | Engine for segment replication replicas |
+| `NRTReplicationReaderManager` | Manages DirectoryReader refresh for segment replication |
+| `EngineConfig` | Configuration holder including leafSorter comparator |
+| `leafSorter` | Comparator that orders segments by timestamp for optimization |
+
+### How leafSorter Works
+
+The `leafSorter` is a `Comparator<LeafReader>` that determines the order in which Lucene segments are visited during search. For time-series data sorted by timestamp descending:
+
+1. Segments are ordered by their maximum timestamp value (descending)
+2. When searching with `sort: @timestamp desc`, the most recent segments are searched first
+3. Once enough results are found, remaining segments can be skipped (early termination)
+
+### Configuration
+
+No explicit configuration is required. The leafSorter is automatically configured based on index settings when:
+
+- Index has a timestamp field (typically `@timestamp`)
+- Index sort is configured for timestamp-based ordering
+
+### Usage Example
+
+```json
+// Index with timestamp sort (automatic optimization)
+PUT /logs-2024
+{
+  "settings": {
+    "index": {
+      "sort.field": "@timestamp",
+      "sort.order": "desc"
+    }
+  },
+  "mappings": {
+    "properties": {
+      "@timestamp": { "type": "date" },
+      "message": { "type": "text" }
+    }
+  }
+}
+
+// Query benefits from leafSorter optimization on all engine types
+GET /logs-*/_search
+{
+  "size": 100,
+  "sort": [{ "@timestamp": "desc" }],
+  "query": {
+    "bool": {
+      "filter": [
+        { "range": { "@timestamp": { "gte": "now-1d" } } }
+      ]
+    }
+  }
+}
+```
+
+## Limitations
+
+- Optimization only applies to timestamp-sorted queries matching the index sort order
+- Requires index-level sort configuration for full benefit
+- Early termination depends on query structure and result requirements
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18639](https://github.com/opensearch-project/OpenSearch/pull/18639) | Fix leafSorter optimization for ReadOnlyEngine and NRTReplicationEngine |
+
+## References
+
+- [Issue #17579](https://github.com/opensearch-project/OpenSearch/issues/17579): Original bug report
+- [Segment Replication](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/segment-replication/index/): Segment replication documentation
+- [Searchable Snapshots](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot/): Searchable snapshots documentation
+
+## Change History
+
+- **v3.2.0** (2025-07-23): Fix leafSorter optimization for ReadOnlyEngine and NRTReplicationEngine

--- a/docs/releases/v3.2.0/features/opensearch/engine-optimization-fixes.md
+++ b/docs/releases/v3.2.0/features/opensearch/engine-optimization-fixes.md
@@ -1,0 +1,146 @@
+# Engine Optimization Fixes
+
+## Summary
+
+This bugfix ensures that timestamp sort optimizations (leafSorter) work consistently across all OpenSearch engine types. Previously, the optimization only worked on primary shards using `InternalEngine`, while `ReadOnlyEngine` (searchable snapshots) and `NRTReplicationEngine` (segment replication replicas) did not benefit from this performance enhancement. This fix applies the leafSorter optimization to all engine types, providing consistent time-series query performance across the cluster.
+
+## Details
+
+### What's New in v3.2.0
+
+The fix ensures that `DirectoryReader.open()` calls in `ReadOnlyEngine` and `NRTReplicationEngine` include the `leafSorter` parameter, which was previously only applied in `InternalEngine`.
+
+### Technical Changes
+
+#### Problem Background
+
+OpenSearch applies a sort to the `IndexWriterConfig` so that any `IndexReader` opened from the `IndexWriter` has its segments sorted by descending max timestamp. This optimization enables faster time-series queries by allowing early termination when searching sorted data.
+
+However, this optimization was only implemented in `InternalEngine`, which has an `IndexWriter`. Other engine types (`ReadOnlyEngine` and `NRTReplicationEngine`) don't have an `IndexWriter` since they don't write Lucene indexes directly.
+
+```mermaid
+graph TB
+    subgraph "Before Fix"
+        IE1[InternalEngine<br/>Primary Shards]
+        ROE1[ReadOnlyEngine<br/>Searchable Snapshots]
+        NRTE1[NRTReplicationEngine<br/>Segment Replication]
+        
+        IE1 -->|leafSorter ✓| Fast1[Fast Time-Series Queries]
+        ROE1 -->|No leafSorter| Slow1[Slower Queries]
+        NRTE1 -->|No leafSorter| Slow2[Slower Queries]
+    end
+```
+
+```mermaid
+graph TB
+    subgraph "After Fix"
+        IE2[InternalEngine<br/>Primary Shards]
+        ROE2[ReadOnlyEngine<br/>Searchable Snapshots]
+        NRTE2[NRTReplicationEngine<br/>Segment Replication]
+        
+        IE2 -->|leafSorter ✓| Fast2[Fast Time-Series Queries]
+        ROE2 -->|leafSorter ✓| Fast3[Fast Time-Series Queries]
+        NRTE2 -->|leafSorter ✓| Fast4[Fast Time-Series Queries]
+    end
+```
+
+#### Code Changes
+
+| File | Change |
+|------|--------|
+| `ReadOnlyEngine.java` | Added new `openDirectory()` overload that accepts `leafSorter` parameter |
+| `NoOpEngine.java` | Updated to use new `openDirectory()` with `leafSorter` |
+| `NRTReplicationEngine.java` | Pass `leafSorter` to `DirectoryReader.open()` |
+| `NRTReplicationReaderManager.java` | Accept `EngineConfig` and use `leafSorter` in `refreshIfNeeded()` |
+
+#### Key Implementation Details
+
+1. **ReadOnlyEngine**: New overloaded method passes `leafSorter` to `DirectoryReader.open()`:
+```java
+protected static DirectoryReader openDirectory(
+    Directory directory, 
+    boolean wrapSoftDeletes, 
+    Comparator<LeafReader> leafSorter
+) throws IOException {
+    final DirectoryReader reader = DirectoryReader.open(directory, leafSorter);
+    if (wrapSoftDeletes) {
+        return new SoftDeletesDirectoryReaderWrapper(reader, Lucene.SOFT_DELETES_FIELD);
+    }
+    return reader;
+}
+```
+
+2. **NRTReplicationEngine**: Updated `getDirectoryReader()` to include leafSorter:
+```java
+private DirectoryReader getDirectoryReader() throws IOException {
+    return new SoftDeletesDirectoryReaderWrapper(
+        DirectoryReader.open(store.directory(), engineConfig.getLeafSorter()),
+        Lucene.SOFT_DELETES_FIELD
+    );
+}
+```
+
+3. **NRTReplicationReaderManager**: Now accepts `EngineConfig` and uses `leafSorter` when refreshing:
+```java
+DirectoryReader innerReader = StandardDirectoryReader.open(
+    referenceToRefresh.directory(),
+    currentInfos,
+    subs,
+    engineConfig.getLeafSorter()
+);
+```
+
+### Performance Impact
+
+| Scenario | Before | After |
+|----------|--------|-------|
+| Primary shard time-series query | Optimized | Optimized |
+| Searchable snapshot time-series query | Not optimized | Optimized |
+| Segment replication replica time-series query | Not optimized | Optimized |
+
+### Usage Example
+
+No configuration changes required. The fix is automatically applied when using:
+
+- **Searchable Snapshots**: Queries on searchable snapshot indexes now benefit from timestamp sort optimization
+- **Segment Replication**: Replica shards using segment replication now have consistent query performance with primary shards
+
+```json
+// Time-series query that benefits from this fix
+GET logs-*/_search
+{
+  "size": 10,
+  "sort": [
+    { "@timestamp": { "order": "desc" } }
+  ],
+  "query": {
+    "range": {
+      "@timestamp": {
+        "gte": "now-1h"
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- The optimization applies to timestamp-based sorting only
+- Requires indexes to have the `@timestamp` field or equivalent time field configured for sorting
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18639](https://github.com/opensearch-project/OpenSearch/pull/18639) | Fix leafSorter optimization for ReadOnlyEngine and NRTReplicationEngine |
+
+## References
+
+- [Issue #17579](https://github.com/opensearch-project/OpenSearch/issues/17579): Bug report - Timestamp sort optimizations don't work on searchable snapshot or segrep replicas
+- [PR #7967](https://github.com/opensearch-project/OpenSearch/pull/7967): Original timestamp sort optimization implementation
+- [Segment Replication Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/segment-replication/index/)
+- [Searchable Snapshots Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/engine-optimization-fixes.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -39,3 +39,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [System Ingest Pipeline Fix](features/opensearch/system-ingest-pipeline-fix.md) | bugfix | Fix system ingest pipeline to properly handle index templates |
 | [Azure Repository Fixes](features/opensearch/azure-repository-fixes.md) | bugfix | Fix SOCKS5 proxy authentication for Azure repository |
 | [Profiler Enhancements](features/opensearch/profiler-enhancements.md) | bugfix | Fix concurrent timings in profiler for concurrent segment search |
+| [Engine Optimization Fixes](features/opensearch/engine-optimization-fixes.md) | bugfix | Fix leafSorter optimization for ReadOnlyEngine and NRTReplicationEngine |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Engine Optimization Fixes bugfix in OpenSearch v3.2.0.

### Changes
- Release report: `docs/releases/v3.2.0/features/opensearch/engine-optimization-fixes.md`
- Feature report: `docs/features/opensearch/engine-optimization-fixes.md`
- Updated release index and features index

### Key Points
- Fixes leafSorter optimization for `ReadOnlyEngine` (searchable snapshots) and `NRTReplicationEngine` (segment replication)
- Ensures consistent time-series query performance across all engine types
- Previously, only `InternalEngine` (primary shards) benefited from timestamp sort optimization

### Related
- Closes #1146
- OpenSearch PR: [#18639](https://github.com/opensearch-project/OpenSearch/pull/18639)
- OpenSearch Issue: [#17579](https://github.com/opensearch-project/OpenSearch/issues/17579)