### PR TITLE
docs: add Search Preference & Awareness Fix report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -86,6 +86,7 @@
 - [Search API Enhancements](opensearch/search-api-enhancements.md)
 - [Search Pipeline](opensearch/search-pipeline.md)
 - [Search Request Stats](opensearch/search-request-stats.md)
+- [Search Shard Routing](opensearch/search-shard-routing.md)
 - [Secure Transport Settings](opensearch/secure-transport-settings.md)
 - [Segment Warmer](opensearch/segment-warmer.md)
 - [Snapshot Restore Enhancements](opensearch/snapshot-restore-enhancements.md)

--- a/docs/features/opensearch/search-shard-routing.md
+++ b/docs/features/opensearch/search-shard-routing.md
@@ -1,0 +1,150 @@
+# Search Shard Routing
+
+## Summary
+
+Search shard routing controls how OpenSearch distributes search requests across primary and replica shards. It provides mechanisms for adaptive replica selection, custom routing preferences, and awareness-based routing to optimize search performance and ensure consistent query behavior.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Search Request Flow"
+        A[Client Search Request] --> B[Coordinating Node]
+        B --> C{Routing Decision}
+        C -->|Adaptive Selection| D[Best Performing Node]
+        C -->|Custom Preference| E[Deterministic Shard]
+        C -->|Awareness Routing| F[Same-Zone Shard]
+        D --> G[Execute Search]
+        E --> G
+        F --> G
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Search Request] --> B{Has Preference?}
+    B -->|No| C{Adaptive Selection Enabled?}
+    B -->|Yes| D{Preference Type}
+    C -->|Yes| E[Rank by Response Time]
+    C -->|No| F[Random Selection]
+    D -->|_primary| G[Primary Shard Only]
+    D -->|_local| H[Local Node Shard]
+    D -->|_shards| I[Specific Shards]
+    D -->|Custom String| J[Hash-Based Selection]
+    E --> K[Execute on Best Node]
+    F --> K
+    G --> K
+    H --> K
+    I --> K
+    J --> K
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `OperationRouting` | Core class handling shard routing decisions |
+| `IndexShardRoutingTable` | Manages shard routing information for an index |
+| `Preference` | Enum defining available preference types |
+| `ResponseCollectorService` | Collects node response metrics for adaptive selection |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.routing.use_adaptive_replica_selection` | Enable adaptive replica selection | `true` |
+| `cluster.search.ignore_awareness_attributes` | Ignore awareness attributes for routing | `true` |
+| `cluster.routing.weighted.default_weight` | Default weight for weighted routing | `1.0` |
+| `cluster.routing.weighted.fail_open` | Enable fail-open for weighted routing | `true` |
+| `cluster.routing.weighted.strict` | Enable strict weighted shard routing | `true` |
+
+### Preference Types
+
+| Preference | Description |
+|------------|-------------|
+| `_primary` | Execute only on primary shards |
+| `_primary_first` | Prefer primary, fallback to replica |
+| `_replica` | Execute only on replica shards |
+| `_replica_first` | Prefer replica, fallback to primary |
+| `_local` | Execute on local node if possible |
+| `_only_nodes:<ids>` | Execute only on specified nodes |
+| `_prefer_nodes:<ids>` | Prefer specified nodes |
+| `_shards:<ids>` | Execute on specific shards |
+| `<custom_string>` | Deterministic routing based on hash |
+
+### Usage Example
+
+```bash
+# Use custom preference for consistent routing
+GET /my-index/_search?preference=user_session_abc
+{
+  "query": {
+    "match": {
+      "title": "opensearch"
+    }
+  }
+}
+
+# Route to primary shards only
+GET /my-index/_search?preference=_primary
+{
+  "query": {
+    "match_all": {}
+  }
+}
+
+# Route to local node
+GET /my-index/_search?preference=_local
+{
+  "query": {
+    "match_all": {}
+  }
+}
+```
+
+### Custom Routing During Indexing
+
+```bash
+# Index with custom routing value
+POST /my-index/_doc/1?routing=user1
+{
+  "name": "John Doe",
+  "age": 30
+}
+
+# Search with same routing for efficiency
+GET /my-index/_search?routing=user1
+{
+  "query": {
+    "match": {
+      "name": "John Doe"
+    }
+  }
+}
+```
+
+## Limitations
+
+- Custom routing can cause hot spots if routing values are not evenly distributed
+- Data skew may occur with unbalanced routing values
+- `_only_nodes` and `_prefer_nodes` preferences are restricted when strict weighted routing is enabled
+- Awareness-based routing may increase latency if preferred shards are overloaded
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18848](https://github.com/opensearch-project/OpenSearch/pull/18848) | Fix: Ignore awareness attributes when custom preference is set |
+
+## References
+
+- [Issue #18817](https://github.com/opensearch-project/OpenSearch/issues/18817): Bug report for custom preference with awareness attributes
+- [Search Shard Routing Documentation](https://docs.opensearch.org/3.0/search-plugins/searching-data/search-shard-routing/): Official documentation
+
+## Change History
+
+- **v3.2.0** (2025-08-01): Fixed custom string preference to ignore awareness attributes for consistent routing

--- a/docs/releases/v3.2.0/features/opensearch/search-preference-awareness-fix.md
+++ b/docs/releases/v3.2.0/features/opensearch/search-preference-awareness-fix.md
@@ -1,0 +1,100 @@
+# Search Preference & Awareness Fix
+
+## Summary
+
+This bugfix resolves an issue where custom string preferences in search requests did not produce consistent shard routing when awareness attributes were enabled on the cluster. Previously, the coordinating node's awareness attribute would take precedence over the custom preference string, causing inconsistent routing behavior.
+
+## Details
+
+### What's New in v3.2.0
+
+The fix modifies the `OperationRouting` class to ignore awareness attributes when a custom string preference is provided with a search request. This ensures that custom preference strings now behave consistently, regardless of which node acts as the coordinator.
+
+### Technical Changes
+
+#### Problem Background
+
+When awareness attributes (e.g., `rack`, `zone`) are configured on a cluster:
+1. The coordinating node would prefer shards sharing its own awareness attribute
+2. Custom preference strings were only applied *after* this attribute-based filtering
+3. Different coordinators with different attributes would route the same preference string to different shards
+
+```mermaid
+graph TB
+    subgraph "Before Fix"
+        A[Search Request<br/>preference=my_pref] --> B{Coordinator Node}
+        B --> C[Filter by Awareness Attribute]
+        C --> D[Apply Custom Preference]
+        D --> E[Inconsistent Shard Selection]
+    end
+```
+
+#### Solution
+
+The fix changes the behavior so that custom string preferences bypass awareness attribute filtering entirely, matching the behavior of other preference types like `_primary`, `_local`, etc.
+
+```mermaid
+graph TB
+    subgraph "After Fix"
+        A[Search Request<br/>preference=my_pref] --> B{Coordinator Node}
+        B --> C[Apply Custom Preference Directly]
+        C --> D[Consistent Shard Selection]
+    end
+```
+
+#### Code Change
+
+In `OperationRouting.java`, the `preferenceActiveShardIterator` method was simplified:
+
+```java
+// Before: Custom preference still considered awareness attributes
+} else if (ignoreAwarenessAttributes()) {
+    return indexShard.activeInitializingShardsIt(routingHash);
+} else {
+    return indexShard.preferAttributesActiveInitializingShardsIt(awarenessAttributes, nodes, routingHash);
+}
+
+// After: Custom preference always ignores awareness attributes
+} else {
+    return indexShard.activeInitializingShardsIt(routingHash);
+}
+```
+
+### Usage Example
+
+Custom preference strings now work consistently:
+
+```bash
+# This will always route to the same shard replica, regardless of coordinator
+GET /my-index/_search?preference=user_session_123
+{
+  "query": {
+    "match_all": {}
+  }
+}
+```
+
+### Migration Notes
+
+No migration required. This is a behavioral fix that makes custom preference strings work as expected. Existing queries using custom preference strings will now route consistently.
+
+## Limitations
+
+- This fix only affects custom string preferences (e.g., `preference=my_custom_string`)
+- Other preference types (`_primary`, `_local`, `_shards`, etc.) already bypassed awareness attributes
+- Weighted routing still takes precedence when configured with strict mode
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18848](https://github.com/opensearch-project/OpenSearch/pull/18848) | Ignore awareness attributes when custom preference is set |
+
+## References
+
+- [Issue #18817](https://github.com/opensearch-project/OpenSearch/issues/18817): Bug report - Custom string preference with awareness attributes does not produce consistent routing
+- [Search Shard Routing Documentation](https://docs.opensearch.org/3.0/search-plugins/searching-data/search-shard-routing/): Official documentation on search shard routing
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/search-shard-routing.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -40,3 +40,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Azure Repository Fixes](features/opensearch/azure-repository-fixes.md) | bugfix | Fix SOCKS5 proxy authentication for Azure repository |
 | [Profiler Enhancements](features/opensearch/profiler-enhancements.md) | bugfix | Fix concurrent timings in profiler for concurrent segment search |
 | [Engine Optimization Fixes](features/opensearch/engine-optimization-fixes.md) | bugfix | Fix leafSorter optimization for ReadOnlyEngine and NRTReplicationEngine |
+| [Search Preference & Awareness Fix](features/opensearch/search-preference-awareness-fix.md) | bugfix | Fix custom preference string to ignore awareness attributes for consistent routing |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Search Preference & Awareness bugfix in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/search-preference-awareness-fix.md`
- Feature report: `docs/features/opensearch/search-shard-routing.md` (new)

### Key Changes in v3.2.0
- Fixed custom string preference to ignore awareness attributes for consistent shard routing
- Previously, awareness attributes took precedence over custom preference strings, causing inconsistent routing

### Resources Used
- PR: [#18848](https://github.com/opensearch-project/OpenSearch/pull/18848)
- Issue: [#18817](https://github.com/opensearch-project/OpenSearch/issues/18817)
- Docs: [Search Shard Routing](https://docs.opensearch.org/3.0/search-plugins/searching-data/search-shard-routing/)

Closes #1145