### PR TITLE
docs: add settings-management report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -89,6 +89,7 @@
 - [Search Shard Routing](opensearch/search-shard-routing.md)
 - [Secure Transport Settings](opensearch/secure-transport-settings.md)
 - [Segment Warmer](opensearch/segment-warmer.md)
+- [Settings Management](opensearch/settings-management.md)
 - [Snapshot Restore Enhancements](opensearch/snapshot-restore-enhancements.md)
 - [Star Tree Index](opensearch/star-tree-index.md)
 - [Streaming Indexing](opensearch/streaming-indexing.md)

--- a/docs/features/opensearch/settings-management.md
+++ b/docs/features/opensearch/settings-management.md
@@ -1,0 +1,149 @@
+# Settings Management
+
+## Summary
+
+OpenSearch provides a comprehensive settings management system that allows configuration of cluster-level and index-level settings. Settings can be persistent (survive cluster restarts) or transient (reset on restart). When settings become unknown (e.g., after plugin removal), they are moved to an "archived" namespace to preserve data while preventing conflicts.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Settings Types"
+        PS[Persistent Settings]
+        TS[Transient Settings]
+        AS[Archived Settings]
+    end
+    
+    subgraph "Settings Scope"
+        CS[Cluster Settings]
+        IS[Index Settings]
+    end
+    
+    subgraph "Settings Service"
+        MSS[MetadataUpdateSettingsService]
+        ISS[IndexScopedSettings]
+        CSS[ClusterSettings]
+    end
+    
+    PS --> CS
+    PS --> IS
+    TS --> CS
+    AS --> CS
+    AS --> IS
+    
+    CS --> CSS
+    IS --> ISS
+    CSS --> MSS
+    ISS --> MSS
+```
+
+### Settings Lifecycle
+
+```mermaid
+flowchart TB
+    A[Setting Defined] --> B{Setting Known?}
+    B -->|Yes| C[Apply Setting]
+    B -->|No| D[Archive Setting]
+    D --> E[archived.* namespace]
+    C --> F[Cluster State]
+    E --> F
+    
+    G[Update Request] --> H{Validate Settings}
+    H -->|Valid| I[Apply Update]
+    H -->|Invalid| J[Return Error]
+    I --> F
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ClusterSettings` | Manages cluster-level settings validation and updates |
+| `IndexScopedSettings` | Manages index-level settings validation and updates |
+| `MetadataUpdateSettingsService` | Coordinates settings updates across the cluster |
+| `SettingsModule` | Registers and initializes all settings |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.max_shards_per_node` | Maximum shards per node | 1000 |
+| `cluster.routing.allocation.enable` | Shard allocation mode | `all` |
+
+### Archived Settings
+
+When OpenSearch encounters an unknown setting (e.g., from a removed plugin), it archives the setting by prefixing it with `archived.`. This preserves the setting value while preventing validation errors.
+
+#### Clearing Archived Settings
+
+For cluster settings:
+```bash
+PUT /_cluster/settings
+{
+  "persistent": {
+    "archived.plugins.some_plugin.setting": null
+  }
+}
+```
+
+For index settings (requires closing the index):
+```bash
+POST /my-index/_close
+
+PUT /my-index/_settings
+{
+  "archived.index.some_setting": null
+}
+
+POST /my-index/_open
+```
+
+### Usage Example
+
+```bash
+# Get current cluster settings
+GET /_cluster/settings?include_defaults=true
+
+# Update a persistent setting
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.max_shards_per_node": 500
+  }
+}
+
+# Update a transient setting
+PUT /_cluster/settings
+{
+  "transient": {
+    "cluster.routing.allocation.enable": "primaries"
+  }
+}
+```
+
+## Limitations
+
+- Some settings are not dynamically updateable and require a node restart
+- Archived index settings can only be cleared on closed indices
+- Transient settings are lost on cluster restart
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18885](https://github.com/opensearch-project/OpenSearch/pull/18885) | Ignore archived settings on update |
+| v2.10.0 | [#9019](https://github.com/opensearch-project/OpenSearch/pull/9019) | Add support to clear archived index settings |
+
+## References
+
+- [Issue #8714](https://github.com/opensearch-project/OpenSearch/issues/8714): Unable to change any cluster setting with archived settings
+- [Issue #18515](https://github.com/opensearch-project/OpenSearch/issues/18515): Cannot update cluster settings after upgrading to 3.0.0
+- [Cluster Settings API](https://docs.opensearch.org/3.2/api-reference/cluster-api/cluster-settings/): Official API documentation
+- [Configuring OpenSearch](https://docs.opensearch.org/3.2/install-and-configure/configuring-opensearch/): Configuration guide
+
+## Change History
+
+- **v3.2.0** (2026-01): Fixed issue where archived settings blocked all settings updates
+- **v2.10.0** (2023-08): Added support to clear archived index settings on closed indices

--- a/docs/releases/v3.2.0/features/opensearch/settings-management.md
+++ b/docs/releases/v3.2.0/features/opensearch/settings-management.md
@@ -1,0 +1,81 @@
+# Settings Management
+
+## Summary
+
+This bugfix resolves a critical issue where cluster settings updates would fail if archived settings were present, even when attempting to update unrelated settings. Prior to this fix, users who upgraded from older OpenSearch versions could become completely blocked from modifying any cluster settings.
+
+## Details
+
+### What's New in v3.2.0
+
+OpenSearch now ignores archived settings when validating settings updates. This allows users to modify cluster and index settings without first having to clear archived settings.
+
+### Technical Changes
+
+#### Problem Background
+
+When OpenSearch encounters unknown settings (typically from plugins that were removed or settings that were deprecated), it moves them to an "archived" namespace. For example, `plugins.index_state_management.template_migration.control` becomes `archived.plugins.index_state_management.template_migration.control`.
+
+Before this fix, the settings validation logic would fail on these archived settings when attempting to update any setting, resulting in errors like:
+
+```json
+{
+  "error": {
+    "root_cause": [{
+      "type": "settings_exception",
+      "reason": "unknown setting [archived.plugins.index_state_management.metadata_migration.status] please check that any required plugins are installed, or check the breaking changes documentation for removed settings"
+    }]
+  },
+  "status": 400
+}
+```
+
+#### Solution
+
+The fix modifies `MetadataUpdateSettingsService` to pass `ignoreArchivedSettings: true` when validating settings updates. This allows the validation to skip archived settings while still validating all other settings.
+
+#### Code Changes
+
+| File | Change |
+|------|--------|
+| `MetadataUpdateSettingsService.java` | Added `ignoreArchivedSettings` parameter to `indexScopedSettings.validate()` calls |
+| `ArchivedIndexSettingsIT.java` | Added test to verify unrelated settings can be updated when archived settings are present |
+
+### Usage Example
+
+After this fix, users can update settings normally even with archived settings present:
+
+```bash
+# This now works even if archived settings exist
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.max_shards_per_node": 500
+  }
+}
+```
+
+### Migration Notes
+
+No migration required. This fix is automatically applied when upgrading to v3.2.0.
+
+## Limitations
+
+- Archived settings themselves still cannot be modified on open indices (must close the index first)
+- This fix only addresses the validation blocking issue; archived settings remain in the cluster state until explicitly cleared
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18885](https://github.com/opensearch-project/OpenSearch/pull/18885) | Ignore archived settings on update |
+
+## References
+
+- [Issue #8714](https://github.com/opensearch-project/OpenSearch/issues/8714): Original bug report - Unable to change any cluster setting
+- [Issue #18515](https://github.com/opensearch-project/OpenSearch/issues/18515): Cannot update cluster settings after upgrading to 3.0.0
+- [Cluster Settings API](https://docs.opensearch.org/3.2/api-reference/cluster-api/cluster-settings/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/settings-management.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -41,3 +41,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Profiler Enhancements](features/opensearch/profiler-enhancements.md) | bugfix | Fix concurrent timings in profiler for concurrent segment search |
 | [Engine Optimization Fixes](features/opensearch/engine-optimization-fixes.md) | bugfix | Fix leafSorter optimization for ReadOnlyEngine and NRTReplicationEngine |
 | [Search Preference & Awareness Fix](features/opensearch/search-preference-awareness-fix.md) | bugfix | Fix custom preference string to ignore awareness attributes for consistent routing |
+| [Settings Management](features/opensearch/settings-management.md) | bugfix | Ignore archived settings on update to unblock settings modifications |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Settings Management bugfix in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/settings-management.md`
- Feature report: `docs/features/opensearch/settings-management.md`

### Key Changes in v3.2.0
- Fixed issue where archived settings blocked all cluster/index settings updates
- Users can now modify settings without first clearing archived settings
- Resolves long-standing issues #8714 and #18515

### Resources Used
- PR: [#18885](https://github.com/opensearch-project/OpenSearch/pull/18885)
- Issue: [#8714](https://github.com/opensearch-project/OpenSearch/issues/8714)
- Issue: [#18515](https://github.com/opensearch-project/OpenSearch/issues/18515)
- Docs: [Cluster Settings API](https://docs.opensearch.org/3.2/api-reference/cluster-api/cluster-settings/)