### PR TITLE
docs: add securerandom-blocking-fix report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -76,6 +76,7 @@
 - [Query Bug Fixes](opensearch/query-bug-fixes.md)
 - [Query Coordinator Context](opensearch/query-coordinator-context.md)
 - [Query Optimization](opensearch/query-optimization.md)
+- [Randomness](opensearch/randomness.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)
 - [Replication](opensearch/replication.md)
 - [Remote Store](opensearch/remote-store.md)

--- a/docs/features/opensearch/randomness.md
+++ b/docs/features/opensearch/randomness.md
@@ -1,0 +1,111 @@
+# Randomness
+
+## Summary
+
+The `Randomness` class provides factory methods for producing reproducible and secure sources of randomness in OpenSearch. It handles both test environments (reproducible random) and production environments (secure random), with special support for FIPS-compliant cryptographic random number generation.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Randomness Factory"
+        R[Randomness.get]
+        RS[Randomness.createSecure]
+    end
+    
+    subgraph "Test Environment"
+        RC[RandomizedContext]
+        TS[tests.seed property]
+    end
+    
+    subgraph "Production Environment"
+        TLR[ThreadLocalRandom]
+        SR[SecureRandom]
+    end
+    
+    subgraph "FIPS Mode"
+        BC[BouncyCastle FIPS]
+        DRBG[FipsDRBG.SHA512_HMAC]
+    end
+    
+    R -->|tests running| RC
+    R -->|production| TLR
+    RS -->|FIPS mode| BC
+    BC --> DRBG
+    RS -->|non-FIPS| SR
+    TS --> RC
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `Randomness.get()` | Returns reproducible Random in tests, ThreadLocalRandom in production |
+| `Randomness.get(Settings, Setting)` | Returns seeded Random from settings, or default |
+| `Randomness.createSecure()` | Returns SecureRandom appropriate for the runtime environment |
+| `Randomness.shuffle(List)` | Shuffles a list using the appropriate Random source |
+
+### Configuration
+
+The class uses reflection to detect the runtime environment:
+
+| Environment | Detection Method | Random Source |
+|-------------|-----------------|---------------|
+| Test | `RandomizedContext` class present | `RandomizedContext.getRandom()` |
+| Production | No test context | `ThreadLocalRandom.current()` |
+| FIPS | `CryptoServicesRegistrar.isInApprovedOnlyMode()` | `FipsDRBG.SHA512_HMAC` |
+| Non-FIPS | Default | `new SecureRandom()` |
+
+### SecureRandom Implementation Details
+
+```mermaid
+flowchart TB
+    Start[createSecure called] --> CheckFIPS{FIPS mode?}
+    CheckFIPS -->|Yes| CreateDRBG[Create FipsDRBG.SHA512_HMAC]
+    CheckFIPS -->|No| CreateSR[new SecureRandom]
+    CreateDRBG --> Return[Return SecureRandom]
+    CreateSR --> Return
+    CheckFIPS -->|Exception| Fallback[SecureRandom.getInstanceStrong]
+    Fallback --> Return
+```
+
+### Usage Example
+
+```java
+// Get a random source (reproducible in tests)
+Random random = Randomness.get();
+
+// Get a seeded random from settings
+Random seededRandom = Randomness.get(settings, NODE_ID_SEED_SETTING);
+
+// Get a secure random for cryptographic operations
+SecureRandom secureRandom = Randomness.createSecure();
+
+// Shuffle a list
+List<String> items = new ArrayList<>(Arrays.asList("a", "b", "c"));
+Randomness.shuffle(items);
+```
+
+## Limitations
+
+- The fallback path uses `SecureRandom.getInstanceStrong()` which may block on low-entropy systems
+- FIPS mode requires BouncyCastle FIPS provider on the classpath
+- Test reproducibility requires the `tests.seed` system property to be set
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18758](https://github.com/opensearch-project/OpenSearch/pull/18758) | Use `new SecureRandom()` to avoid blocking |
+
+## References
+
+- [Issue #18729](https://github.com/opensearch-project/OpenSearch/issues/18729): OpenSearch 3.1.0 freezes when running on AlmaLinux 8
+- [Java SecureRandom Documentation](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/security/SecureRandom.html)
+- [BouncyCastle FIPS Documentation](https://www.bouncycastle.org/fips-java/)
+
+## Change History
+
+- **v3.2.0** (2025-07-16): Fixed blocking issue by reverting to `new SecureRandom()` in non-FIPS mode

--- a/docs/releases/v3.2.0/features/opensearch/securerandom-blocking-fix.md
+++ b/docs/releases/v3.2.0/features/opensearch/securerandom-blocking-fix.md
@@ -1,0 +1,103 @@
+# SecureRandom Blocking Fix
+
+## Summary
+
+This bugfix reverts the `SecureRandom` instantiation method from `SecureRandom.getInstanceStrong()` back to `new SecureRandom()` in non-FIPS mode. The previous change caused OpenSearch to freeze on systems with low entropy (particularly older Linux kernels like 4.18.x), as `getInstanceStrong()` blocks when the system entropy pool is exhausted.
+
+## Details
+
+### What's New in v3.2.0
+
+The `Randomness.createSecure()` method was modified to use `new SecureRandom()` instead of `SecureRandom.getInstanceStrong()` for the non-FIPS code path. This prevents blocking behavior on systems with limited entropy sources.
+
+### Technical Changes
+
+#### Root Cause
+
+The issue stemmed from a previous change that switched from `new SecureRandom()` to `SecureRandom.getInstanceStrong()`. On Linux systems:
+
+- `SecureRandom.getInstanceStrong()` typically uses `/dev/random`
+- `/dev/random` blocks when the entropy pool is depleted
+- Older kernels (4.18.x, used in AlmaLinux 8) have smaller entropy pools
+- This caused OpenSearch to freeze during startup
+
+#### Code Change
+
+```java
+// Before (blocking)
+return SecureRandom.getInstanceStrong();
+
+// After (non-blocking)
+return new SecureRandom();
+```
+
+The fix is applied in `server/src/main/java/org/opensearch/common/Randomness.java`:
+
+```java
+public static SecureRandom createSecure() {
+    try {
+        // FIPS mode handling (unchanged)
+        var registrarClass = Class.forName("org.bouncycastle.crypto.CryptoServicesRegistrar");
+        var isApprovedOnlyMethod = registrarClass.getMethod("isInApprovedOnlyMode");
+        var approvedOnly = (Boolean) isApprovedOnlyMethod.invoke(null);
+
+        if (approvedOnly) {
+            // FIPS-compliant DRBG implementation
+            // ... (unchanged)
+        }
+
+        // Non-FIPS: Use new SecureRandom() to avoid blocking
+        return new SecureRandom();
+    } catch (ReflectiveOperationException | GeneralSecurityException e) {
+        try {
+            return SecureRandom.getInstanceStrong();
+        } catch (NoSuchAlgorithmException ex) {
+            throw new SecurityException("Failed to instantiate SecureRandom: " + e.getMessage(), e);
+        }
+    }
+}
+```
+
+#### Behavior by Mode
+
+| Mode | Implementation | Blocking Behavior |
+|------|---------------|-------------------|
+| FIPS | `FipsDRBG.SHA512_HMAC` via BouncyCastle | Non-blocking |
+| Non-FIPS | `new SecureRandom()` | Non-blocking |
+| Fallback | `SecureRandom.getInstanceStrong()` | May block |
+
+### Affected Systems
+
+Systems most likely to experience the blocking issue:
+- AlmaLinux 8 (kernel 4.18.x)
+- RHEL 8 / CentOS 8
+- Other distributions with older kernels
+- Virtual machines with limited entropy sources
+- Containers without access to hardware RNG
+
+### Workarounds (for older versions)
+
+If upgrading is not immediately possible:
+1. Upgrade to kernel 5.x or later
+2. Install `haveged` or `rng-tools` to increase entropy
+3. Use hardware RNG if available
+
+## Limitations
+
+- The fallback path still uses `getInstanceStrong()` and may block if BouncyCastle reflection fails
+- FIPS mode behavior is unchanged and uses BouncyCastle DRBG
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18758](https://github.com/opensearch-project/OpenSearch/pull/18758) | Use `new SecureRandom()` to avoid blocking |
+
+## References
+
+- [Issue #18729](https://github.com/opensearch-project/OpenSearch/issues/18729): OpenSearch 3.1.0 freezes when running on AlmaLinux 8
+- [OpenSearch Forum Discussion](https://forum.opensearch.org/t/docker-image-3-1-1-doesnt-seem-to-work/24875): Original bug report and investigation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/randomness.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -42,3 +42,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Engine Optimization Fixes](features/opensearch/engine-optimization-fixes.md) | bugfix | Fix leafSorter optimization for ReadOnlyEngine and NRTReplicationEngine |
 | [Search Preference & Awareness Fix](features/opensearch/search-preference-awareness-fix.md) | bugfix | Fix custom preference string to ignore awareness attributes for consistent routing |
 | [Settings Management](features/opensearch/settings-management.md) | bugfix | Ignore archived settings on update to unblock settings modifications |
+| [SecureRandom Blocking Fix](features/opensearch/securerandom-blocking-fix.md) | bugfix | Fix startup freeze on low-entropy systems by reverting to non-blocking SecureRandom |


### PR DESCRIPTION
## Summary

This PR adds documentation for the SecureRandom blocking fix in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/securerandom-blocking-fix.md`
- Feature report: `docs/features/opensearch/randomness.md` (new)

### Key Changes in v3.2.0
- Reverted `SecureRandom.getInstanceStrong()` to `new SecureRandom()` in non-FIPS mode
- Fixes startup freeze on systems with low entropy (AlmaLinux 8, older kernels)

### Related
- Resolves investigation for Issue #1143
- OpenSearch PR: [#18758](https://github.com/opensearch-project/OpenSearch/pull/18758)
- OpenSearch Issue: [#18729](https://github.com/opensearch-project/OpenSearch/issues/18729)