### PR TITLE
docs: add field-mapping-fixes report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -30,6 +30,7 @@
 - [DocRequest Refactoring](opensearch/docrequest-refactoring.md)
 - [Dynamic Settings](opensearch/dynamic-settings.md)
 - [Field Data Cache](opensearch/field-data-cache.md)
+- [Field Mapping](opensearch/field-mapping.md)
 - [File Cache](opensearch/file-cache.md)
 - [Cluster Permissions](opensearch/cluster-permissions.md)
 - [Flat Object Field](opensearch/flat-object-field.md)

--- a/docs/features/opensearch/field-mapping.md
+++ b/docs/features/opensearch/field-mapping.md
@@ -1,0 +1,159 @@
+# Field Mapping
+
+## Summary
+
+Field mapping in OpenSearch defines how documents and their fields are stored and indexed. This includes support for the `ignore_malformed` parameter, which controls how OpenSearch handles documents containing fields with incorrect data types.
+
+The `ignore_malformed` parameter can be set at both the index level and the field level, with field-level settings taking precedence over index-level settings.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Document Indexing"
+        Doc[Document] --> Parser[Field Parser]
+        Parser --> Validate{Validate Type}
+        Validate -->|Valid| Index[Index Field]
+        Validate -->|Invalid| Check{Check ignore_malformed}
+        Check -->|Field-level set| FieldSetting[Use Field Setting]
+        Check -->|Not set| IndexSetting[Use Index Setting]
+        FieldSetting -->|true| Ignore[Ignore & Add to _ignored]
+        FieldSetting -->|false| Reject[Reject Document]
+        IndexSetting -->|true| Ignore
+        IndexSetting -->|false| Reject
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `FieldMapper` | Base class for all field mappers, provides `ignoreMalformed()` method |
+| `DateFieldMapper` | Handles date field parsing with ignore_malformed support |
+| `IpFieldMapper` | Handles IP address field parsing with ignore_malformed support |
+| `NumberFieldMapper` | Handles numeric field parsing with ignore_malformed support |
+| `ScaledFloatFieldMapper` | Handles scaled float fields with scaling factor |
+| `RangeFieldMapper` | Handles range field types (ip_range, date_range, etc.) |
+| `AbstractGeometryFieldMapper` | Base for geo_point, geo_shape, xy_point, xy_shape |
+| `DerivedFieldMapper` | Handles derived fields with ignore_malformed support |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.mapping.ignore_malformed` | Index-level setting to ignore malformed values | `false` |
+| `ignore_malformed` (field-level) | Field-level setting that overrides index-level | Inherits from index |
+
+### Supported Field Types
+
+The `ignore_malformed` parameter is supported by the following field types:
+
+| Field Type | Description |
+|------------|-------------|
+| `date` | Date and datetime values |
+| `ip` | IPv4 and IPv6 addresses |
+| `integer`, `long`, `short`, `byte` | Integer numeric types |
+| `float`, `double`, `half_float` | Floating-point numeric types |
+| `scaled_float` | Scaled floating-point stored as long |
+| `geo_point` | Geographic point coordinates |
+| `geo_shape` | Geographic shapes |
+| `xy_point` | Cartesian point coordinates |
+| `xy_shape` | Cartesian shapes |
+| `ip_range`, `date_range`, etc. | Range field types |
+| `derived` | Derived fields |
+
+### Usage Example
+
+**Index-level setting with field-level override:**
+```json
+PUT /my-index
+{
+  "settings": {
+    "index.mapping.ignore_malformed": true
+  },
+  "mappings": {
+    "properties": {
+      "timestamp": {
+        "type": "date"
+      },
+      "price": {
+        "type": "scaled_float",
+        "scaling_factor": 100
+      },
+      "strict_id": {
+        "type": "integer",
+        "ignore_malformed": false
+      }
+    }
+  }
+}
+```
+
+**Indexing with malformed data:**
+```json
+// timestamp and price will accept malformed values (index-level: true)
+// strict_id will reject malformed values (field-level: false)
+PUT /my-index/_doc/1
+{
+  "timestamp": "invalid-date",
+  "price": 19.99,
+  "strict_id": 12345
+}
+```
+
+**Querying ignored fields:**
+```json
+GET /my-index/_search
+{
+  "query": {
+    "exists": {
+      "field": "_ignored"
+    }
+  }
+}
+```
+
+### Scaled Float Field Type
+
+The `scaled_float` type stores floating-point values as long integers by multiplying by a scaling factor:
+
+```json
+PUT /products
+{
+  "mappings": {
+    "properties": {
+      "price": {
+        "type": "scaled_float",
+        "scaling_factor": 100
+      }
+    }
+  }
+}
+```
+
+A value of `19.99` with `scaling_factor: 100` is stored as `1999`.
+
+## Limitations
+
+- `ignore_malformed` does not apply to all field types (e.g., `keyword`, `text`)
+- When a field is ignored, it is not searchable but the document is still indexed
+- Ignored fields are tracked in the `_ignored` metadata field
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18706](https://github.com/opensearch-project/OpenSearch/pull/18706) | Fix field-level ignore_malformed override |
+| v3.2.0 | [#18952](https://github.com/opensearch-project/OpenSearch/pull/18952) | Fix scaled_float encodePoint method |
+
+## References
+
+- [Issue #16599](https://github.com/opensearch-project/OpenSearch/issues/16599): Bug report for ignore_malformed override
+- [Numeric field types](https://docs.opensearch.org/3.0/field-types/supported-field-types/numeric/): Official documentation
+- [Mapping parameters](https://docs.opensearch.org/3.0/field-types/mapping-parameters/index/): Mapping parameter reference
+
+## Change History
+
+- **v3.2.0** (2025-08): Fixed field-level `ignore_malformed` to properly override index-level setting; Fixed `scaled_float` `encodePoint` method bug

--- a/docs/releases/v3.2.0/features/opensearch/field-mapping-fixes.md
+++ b/docs/releases/v3.2.0/features/opensearch/field-mapping-fixes.md
@@ -1,0 +1,130 @@
+# Field Mapping Fixes
+
+## Summary
+
+OpenSearch v3.2.0 includes two important bug fixes for field mapping behavior:
+
+1. **Field-level `ignore_malformed` override**: Field-level `ignore_malformed` settings now correctly override index-level settings, fixing a regression introduced in OpenSearch 2.4.
+2. **`scaled_float` encodePoint fix**: Fixed a bug in the `encodePoint` method for `scaled_float` fields that was introduced in PR #18896.
+
+These fixes ensure proper handling of malformed data during indexing and correct point encoding for scaled float range queries.
+
+## Details
+
+### What's New in v3.2.0
+
+#### Fix 1: Field-level `ignore_malformed` Override
+
+Prior to this fix, when both index-level and field-level `ignore_malformed` settings were configured, the index-level setting would always take precedence. This was incorrect behavior - field-level settings should override index-level settings.
+
+**Affected Field Types:**
+
+| Type | Controlling Class |
+|------|-------------------|
+| `ip` | `IpFieldMapper` |
+| `ip_range` | `RangeFieldMapper` |
+| `geo_point` | `AbstractGeometryFieldMapper` |
+| `geo_shape` | `AbstractGeometryFieldMapper` |
+| `xy_point` | `AbstractGeometryFieldMapper` |
+| `xy_shape` | `AbstractGeometryFieldMapper` |
+| numerics | `NumberFieldMapper`, `ScaledFloatFieldMapper` |
+| `derived` | `DerivedFieldMapper` |
+| `date` | `DateFieldMapper` |
+
+**Technical Changes:**
+
+The fix introduces an `ignoreMalformed()` method in the `FieldMapper` base class that allows field mappers to expose their field-level setting. The `parse()` method now checks this field-level setting before falling back to the index-level `IGNORE_MALFORMED_SETTING`.
+
+```java
+private boolean shouldIgnoreMalformed(IndexSettings is) {
+    if (ignoreMalformed() != null) {
+        return ignoreMalformed().value();
+    }
+    if (is == null) {
+        return false;
+    }
+    return IGNORE_MALFORMED_SETTING.get(is.getSettings());
+}
+```
+
+#### Fix 2: `scaled_float` encodePoint Method
+
+A bug was introduced in PR #18896 where the `encodePoint(Object value, boolean roundUp)` method in `ScaledFloatFieldMapper` was not correctly encoding the scaled value. The fix follows the same pattern used in the `termQuery` method.
+
+**Before (buggy):**
+```java
+public byte[] encodePoint(Object value, boolean roundUp) {
+    double doubleValue = parse(value);
+    long scaledValue = Math.round(scale(doubleValue));
+    // ... rounding logic
+    return encodePoint(scaledValue);  // Wrong: called wrong overload
+}
+```
+
+**After (fixed):**
+```java
+public byte[] encodePoint(Object value, boolean roundUp) {
+    long scaledValue = Math.round(scale(value));
+    // ... rounding logic
+    byte[] point = new byte[Long.BYTES];
+    LongPoint.encodeDimension(scaledValue, point, 0);
+    return point;
+}
+```
+
+### Usage Example
+
+**Index with field-level override:**
+```json
+PUT /my-index
+{
+  "settings": {
+    "index.mapping.ignore_malformed": true
+  },
+  "mappings": {
+    "properties": {
+      "number_one": {
+        "type": "byte"
+      },
+      "number_two": {
+        "type": "integer",
+        "ignore_malformed": false
+      }
+    }
+  }
+}
+```
+
+**Expected behavior (v3.2.0+):**
+- `number_one`: Malformed values are ignored (inherits index-level setting)
+- `number_two`: Malformed values cause indexing failure (field-level override)
+
+```json
+// This will FAIL in v3.2.0+ (correct behavior)
+PUT /my-index/_doc/1
+{
+  "number_two": "not_a_number"
+}
+```
+
+## Limitations
+
+- The fix only applies to field types that support `ignore_malformed` (listed above)
+- Versions prior to 3.2.0 (back to 2.4) have the incorrect behavior where index-level settings always take precedence
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18706](https://github.com/opensearch-project/OpenSearch/pull/18706) | Field-level ignore_malformed should override index-level setting |
+| [#18952](https://github.com/opensearch-project/OpenSearch/pull/18952) | Bug fix for `scaled_float` in `encodePoint` method |
+
+## References
+
+- [Issue #16599](https://github.com/opensearch-project/OpenSearch/issues/16599): Original bug report for ignore_malformed override
+- [Numeric field types documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/numeric/): Official docs for scaled_float
+- [Mapping parameters](https://docs.opensearch.org/3.0/field-types/mapping-parameters/index/): Documentation on ignore_malformed
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/field-mapping.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -44,3 +44,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Search Preference & Awareness Fix](features/opensearch/search-preference-awareness-fix.md) | bugfix | Fix custom preference string to ignore awareness attributes for consistent routing |
 | [Settings Management](features/opensearch/settings-management.md) | bugfix | Ignore archived settings on update to unblock settings modifications |
 | [SecureRandom Blocking Fix](features/opensearch/securerandom-blocking-fix.md) | bugfix | Fix startup freeze on low-entropy systems by reverting to non-blocking SecureRandom |
+| [Field Mapping Fixes](features/opensearch/field-mapping-fixes.md) | bugfix | Fix field-level ignore_malformed override and scaled_float encodePoint method |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Field Mapping Fixes in OpenSearch v3.2.0.

### Bug Fixes Documented

1. **Field-level `ignore_malformed` override** (PR #18706)
   - Fixed a regression from OpenSearch 2.4 where field-level `ignore_malformed` settings were not properly overriding index-level settings
   - Affects: date, ip, numeric, geo_point, geo_shape, xy_point, xy_shape, ip_range, derived fields

2. **`scaled_float` encodePoint fix** (PR #18952)
   - Fixed a bug in the `encodePoint` method introduced in PR #18896
   - Ensures correct point encoding for scaled float range queries

### Files Added/Modified

- `docs/releases/v3.2.0/features/opensearch/field-mapping-fixes.md` - Release report
- `docs/features/opensearch/field-mapping.md` - Feature report
- `docs/releases/v3.2.0/index.md` - Updated release index
- `docs/features/index.md` - Updated features index

### Related Issues

- Resolves investigation for GitHub Issue #1141