### PR TITLE
docs: add search-scoring-fixes report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -88,6 +88,7 @@
 - [Search API Enhancements](opensearch/search-api-enhancements.md)
 - [Search Pipeline](opensearch/search-pipeline.md)
 - [Search Request Stats](opensearch/search-request-stats.md)
+- [Search Scoring](opensearch/search-scoring.md)
 - [Search Shard Routing](opensearch/search-shard-routing.md)
 - [Secure Transport Settings](opensearch/secure-transport-settings.md)
 - [Segment Warmer](opensearch/segment-warmer.md)

--- a/docs/features/opensearch/search-scoring.md
+++ b/docs/features/opensearch/search-scoring.md
@@ -1,0 +1,184 @@
+# Search Scoring
+
+## Summary
+
+Search scoring in OpenSearch determines how documents are ranked in search results based on relevance. The `max_score` field in search responses indicates the highest relevance score among all matching documents. OpenSearch supports various sorting options including sorting by `_score` (relevance), field values, or combinations thereof. The scoring system integrates with Lucene's collector framework to efficiently compute and return scores.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Search Request"
+        Query[Query]
+        Sort[Sort Configuration]
+    end
+    
+    subgraph "Query Phase"
+        QP[QueryPhase]
+        TDC[TopDocsCollectorContext]
+        MSC[MaxScoreCollector]
+    end
+    
+    subgraph "Collectors"
+        TSDCM[TopScoreDocCollectorManager]
+        TFDCM[TopFieldDocCollectorManager]
+    end
+    
+    subgraph "Results"
+        TD[TopDocs]
+        MS[max_score]
+    end
+    
+    Query --> QP
+    Sort --> QP
+    QP --> TDC
+    TDC --> TSDCM
+    TDC --> TFDCM
+    TDC --> MSC
+    TSDCM --> TD
+    TFDCM --> TD
+    MSC --> MS
+    TD --> MS
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Search Request] --> B{Has Sort?}
+    B -->|No| C[TopScoreDocCollectorManager]
+    B -->|Yes| D{Primary Sort = _score?}
+    D -->|Yes, DESC| E[Extract max_score from first doc]
+    D -->|No or ASC| F{track_scores enabled?}
+    F -->|Yes| G[MaxScoreCollector]
+    F -->|No| H[max_score = NaN]
+    C --> I[max_score from top doc]
+    E --> J[Return TopDocsAndMaxScore]
+    G --> J
+    H --> J
+    I --> J
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `TopDocsCollectorContext` | Manages collector creation and max_score computation |
+| `TopScoreDocCollectorManager` | Collects top documents sorted by score |
+| `TopFieldDocCollectorManager` | Collects top documents sorted by field values |
+| `MaxScoreCollector` | Dedicated collector for tracking maximum score |
+| `TopDocsAndMaxScore` | Container for top docs and max_score result |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `track_scores` | Track scores when sorting by field | `false` |
+| `track_total_hits` | Track total hit count | `10000` |
+
+### max_score Behavior
+
+The `max_score` field in search results follows these rules:
+
+| Scenario | max_score Value |
+|----------|-----------------|
+| No sort (default relevance) | Highest score from results |
+| Sort by `_score` DESC only | Highest score from results |
+| Sort by `_score` DESC + other fields | Highest score from first result (v3.2.0+) |
+| Sort by `_score` ASC | `null` |
+| Sort by field (not score) | `null` (unless `track_scores: true`) |
+| Sort by field with `track_scores: true` | Highest score from all results |
+
+### Usage Example
+
+```json
+// Basic search - max_score automatically computed
+GET /my-index/_search
+{
+  "query": {
+    "match": { "content": "opensearch" }
+  }
+}
+
+// Sort by score with secondary sort - max_score computed (v3.2.0+)
+GET /my-index/_search
+{
+  "query": {
+    "match": { "content": "opensearch" }
+  },
+  "sort": [
+    { "_score": { "order": "desc" } },
+    { "timestamp": { "order": "desc" } }
+  ]
+}
+
+// Sort by field with score tracking
+GET /my-index/_search
+{
+  "query": {
+    "match": { "content": "opensearch" }
+  },
+  "sort": [
+    { "timestamp": { "order": "desc" } }
+  ],
+  "track_scores": true
+}
+```
+
+### Response Structure
+
+```json
+{
+  "took": 10,
+  "timed_out": false,
+  "_shards": {
+    "total": 5,
+    "successful": 5,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 1000,
+      "relation": "eq"
+    },
+    "max_score": 5.234,
+    "hits": [
+      {
+        "_index": "my-index",
+        "_id": "1",
+        "_score": 5.234,
+        "_source": { ... }
+      }
+    ]
+  }
+}
+```
+
+## Limitations
+
+- `max_score` computation adds overhead when `track_scores` is enabled with field sorting
+- Ascending score sort does not compute `max_score` (returns `null`)
+- `max_score` reflects only the scores of returned documents, not all matching documents
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18715](https://github.com/opensearch-project/OpenSearch/pull/18715) | Fix max_score is null when sorting on score firstly |
+| v3.2.0 | [#18802](https://github.com/opensearch-project/OpenSearch/pull/18802) | Use ScoreDoc instead of FieldDoc for TopScoreDocCollectorManager |
+| v3.1.0 | [#18395](https://github.com/opensearch-project/OpenSearch/pull/18395) | Replace deprecated TopScoreDocCollectorManager construction |
+
+## References
+
+- [Issue #18714](https://github.com/opensearch-project/OpenSearch/issues/18714): Bug report for max_score null issue
+- [Search API Documentation](https://docs.opensearch.org/3.2/api-reference/search-apis/search/): Official search API docs
+- [Sort Results Documentation](https://docs.opensearch.org/3.2/search-plugins/searching-data/sort/): Sorting documentation
+- [Lucene PR #450](https://github.com/apache/lucene/pull/450): Related Lucene API change
+
+## Change History
+
+- **v3.2.0** (2025-07): Fixed max_score null when sorting by _score with secondary fields; Use ScoreDoc for TopScoreDocCollectorManager
+- **v3.1.0** (2025-04): Updated deprecated TopScoreDocCollectorManager construction

--- a/docs/releases/v3.2.0/features/opensearch/search-scoring-fixes.md
+++ b/docs/releases/v3.2.0/features/opensearch/search-scoring-fixes.md
@@ -1,0 +1,164 @@
+# Search Scoring Fixes
+
+## Summary
+
+This release fixes two bugs related to search result scoring in OpenSearch. The first fix ensures that `max_score` is properly populated in search results when `_score` is used as the primary sort field with additional secondary sort fields. The second fix improves code correctness by using `ScoreDoc` instead of `FieldDoc` when creating `TopScoreDocCollectorManager`, avoiding unnecessary type conversions.
+
+## Details
+
+### What's New in v3.2.0
+
+#### Fix: max_score is null when sorting on score firstly
+
+Prior to this fix, when using `_score` as the primary sort field combined with other secondary sort fields (e.g., `@timestamp`), the `max_score` field in search results would incorrectly return `null`. This was inconsistent with the behavior when sorting only by `_score`, which correctly returned the maximum score.
+
+**Before the fix:**
+```json
+GET /logs/_search
+{
+  "query": { "match": { "request": "english/images" } },
+  "sort": [
+    { "_score": { "order": "desc" } },
+    { "@timestamp": { "order": "desc" } }
+  ]
+}
+
+// Response had max_score: null (incorrect)
+{
+  "hits": {
+    "total": { "value": 10000, "relation": "gte" },
+    "max_score": null,
+    "hits": [...]
+  }
+}
+```
+
+**After the fix:**
+```json
+// Response now correctly shows max_score
+{
+  "hits": {
+    "total": { "value": 10000, "relation": "gte" },
+    "max_score": 0.47368687,
+    "hits": [...]
+  }
+}
+```
+
+#### Fix: Use ScoreDoc instead of FieldDoc for TopScoreDocCollectorManager
+
+When sorting by `_score` with `search_after` pagination, the code was incorrectly using `FieldDoc` when constructing `TopScoreDocCollectorManager`. This has been corrected to use `ScoreDoc` directly, aligning with the Lucene API changes from [apache/lucene#450](https://github.com/apache/lucene/pull/450).
+
+### Technical Changes
+
+#### Modified Components
+
+| Component | Description |
+|-----------|-------------|
+| `TopDocsCollectorContext` | Core class handling top docs collection and max_score calculation |
+
+#### Code Changes
+
+The fix modifies `TopDocsCollectorContext.java` in two key areas:
+
+1. **SimpleTopDocsCollectorContext constructor**: Added logic to extract `max_score` from the first `FieldDoc` when `_score` is the primary sort field:
+
+```java
+} else if (SortField.FIELD_SCORE.equals(sortAndFormats.sort.getSort()[0])) {
+    maxScoreSupplier = () -> {
+        TopDocs topDocs = topDocsSupplier.get();
+        if (topDocs.scoreDocs.length == 0) {
+            return Float.NaN;
+        } else {
+            FieldDoc fieldDoc = (FieldDoc) topDocs.scoreDocs[0];
+            return (float) fieldDoc.fields[0];
+        }
+    };
+}
+```
+
+2. **newTopDocs method**: Updated to handle `max_score` extraction when sorting by score:
+
+```java
+if (Float.isNaN(maxScore) && newTopDocs.scoreDocs.length > 0) {
+    float maxScoreFromDoc = maxScore;
+    if (sortAndFormats == null) {
+        maxScoreFromDoc = newTopDocs.scoreDocs[0].score;
+    } else if (SortField.FIELD_SCORE.equals(sortAndFormats.sort.getSort()[0])) {
+        maxScoreFromDoc = (float) ((FieldDoc) newTopDocs.scoreDocs[0]).fields[0];
+    }
+    return new TopDocsAndMaxScore(newTopDocs, maxScoreFromDoc);
+}
+```
+
+3. **TopScoreDocCollectorManager creation**: Simplified to use `ScoreDoc` directly:
+
+```java
+if (searchAfter != null) {
+    return new TopScoreDocCollectorManager(numHits, searchAfter, hitCountThreshold);
+}
+```
+
+### Usage Example
+
+```json
+// Search with _score as primary sort and secondary sort field
+GET /my-index/_search
+{
+  "query": {
+    "match": {
+      "content": "opensearch"
+    }
+  },
+  "sort": [
+    { "_score": { "order": "desc" } },
+    { "timestamp": { "order": "desc" } }
+  ]
+}
+
+// Response now correctly includes max_score
+{
+  "took": 10,
+  "hits": {
+    "total": { "value": 100, "relation": "eq" },
+    "max_score": 5.234,
+    "hits": [
+      {
+        "_index": "my-index",
+        "_id": "1",
+        "_score": 5.234,
+        "sort": [5.234, 1704067200000]
+      }
+    ]
+  }
+}
+```
+
+### Behavior Notes
+
+- `max_score` is only populated when `_score` is the **primary** (first) sort field in **descending** order
+- When `_score` is sorted in ascending order, `max_score` remains `null` (expected behavior)
+- The fix works correctly with both standard and concurrent segment search modes
+
+## Limitations
+
+- `max_score` is only computed when `_score` is the first sort field with descending order
+- Ascending score sort (`"order": "asc"`) will still return `max_score: null`
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18715](https://github.com/opensearch-project/OpenSearch/pull/18715) | Fix max_score is null when sorting on score firstly |
+| [#18802](https://github.com/opensearch-project/OpenSearch/pull/18802) | Use ScoreDoc instead of FieldDoc when creating TopScoreDocCollectorManager |
+
+## References
+
+- [Issue #18714](https://github.com/opensearch-project/OpenSearch/issues/18714): Bug report for max_score null issue
+- [Lucene PR #450](https://github.com/apache/lucene/pull/450): Related Lucene API change
+- [Search API Documentation](https://docs.opensearch.org/3.2/api-reference/search-apis/search/): Official search API docs
+- [Sort Results Documentation](https://docs.opensearch.org/3.2/search-plugins/searching-data/sort/): Sorting documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/search-scoring.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -45,3 +45,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Settings Management](features/opensearch/settings-management.md) | bugfix | Ignore archived settings on update to unblock settings modifications |
 | [SecureRandom Blocking Fix](features/opensearch/securerandom-blocking-fix.md) | bugfix | Fix startup freeze on low-entropy systems by reverting to non-blocking SecureRandom |
 | [Field Mapping Fixes](features/opensearch/field-mapping-fixes.md) | bugfix | Fix field-level ignore_malformed override and scaled_float encodePoint method |
+| [Search Scoring Fixes](features/opensearch/search-scoring-fixes.md) | bugfix | Fix max_score null when sorting by _score with secondary fields |


### PR DESCRIPTION
## Summary

This PR adds documentation for search scoring fixes in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/search-scoring-fixes.md`
- Feature report: `docs/features/opensearch/search-scoring.md` (new)

### Key Changes in v3.2.0

1. **Fix max_score null when sorting by _score with secondary fields** ([#18715](https://github.com/opensearch-project/OpenSearch/pull/18715))
   - Previously, `max_score` was incorrectly `null` when using `_score` as primary sort with additional secondary sort fields
   - Now correctly returns the maximum score from the first result

2. **Use ScoreDoc instead of FieldDoc for TopScoreDocCollectorManager** ([#18802](https://github.com/opensearch-project/OpenSearch/pull/18802))
   - Code cleanup to use correct type when creating collector manager
   - Aligns with Lucene API changes

### Related Issue
Resolves investigation for GitHub Issue #1140