### PR TITLE
docs: add replication-lag-fix report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -91,6 +91,7 @@
 - [Search Scoring](opensearch/search-scoring.md)
 - [Search Shard Routing](opensearch/search-shard-routing.md)
 - [Secure Transport Settings](opensearch/secure-transport-settings.md)
+- [Segment Replication](opensearch/segment-replication.md)
 - [Segment Warmer](opensearch/segment-warmer.md)
 - [Settings Management](opensearch/settings-management.md)
 - [Snapshot Restore Enhancements](opensearch/snapshot-restore-enhancements.md)

--- a/docs/features/opensearch/segment-replication.md
+++ b/docs/features/opensearch/segment-replication.md
@@ -1,0 +1,137 @@
+# Segment Replication
+
+## Summary
+
+Segment replication is an alternative replication strategy in OpenSearch that copies Lucene segment files directly from primary shards to replica shards, instead of re-indexing documents on each replica. This approach significantly improves indexing throughput (up to 40% higher) and reduces CPU/memory utilization on replica nodes, at the cost of increased network bandwidth usage. Segment replication is particularly beneficial for write-heavy workloads with lower search requirements.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Primary Shard"
+        PS[Primary Shard]
+        IDX[Indexing]
+        SEG[Segment Files]
+        CP[Checkpoint]
+        IDX --> SEG
+        SEG --> CP
+    end
+    
+    subgraph "Segment Replicator"
+        SR[SegmentReplicator]
+        RCS[ReplicationCheckpointStats]
+        SR --> RCS
+    end
+    
+    subgraph "Replica Shards"
+        RS1[Replica 1]
+        RS2[Replica 2]
+    end
+    
+    CP --> |Checkpoint Notification| SR
+    SR --> |Copy Segments| RS1
+    SR --> |Copy Segments| RS2
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Primary Refresh] --> B[Create Checkpoint]
+    B --> C[Notify Replicas]
+    C --> D[SegmentReplicator.startReplication]
+    D --> E[Fetch Segment Files]
+    E --> F[Apply to Replica]
+    F --> G[Update Checkpoint Stats]
+    G --> H[Prune Old Checkpoints]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SegmentReplicator` | Manages segment replication events on replicas, tracks checkpoint stats |
+| `ReplicationCheckpoint` | Represents a point-in-time state of segments on primary shard |
+| `ReplicationCheckpointStats` | Tracks bytes behind and timestamp for each checkpoint |
+| `SegmentReplicationTarget` | Orchestrates a single replication event |
+| `SegmentReplicationSource` | Source for fetching segment files (node-to-node or remote store) |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.replication.type` | Replication type: `SEGMENT` or `DOCUMENT` | `DOCUMENT` |
+| `cluster.indices.replication.strategy` | Default replication type for new indexes | `DOCUMENT` |
+| `cluster.index.restrict.replication.type` | Enforce cluster-level replication type | `false` |
+| `segrep.pressure.enabled` | Enable segment replication backpressure | `false` |
+| `cluster.routing.allocation.balance.prefer_primary` | Balance primary shards across nodes | `false` |
+
+### Replication Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `max_bytes_behind` | Maximum bytes replica is behind primary |
+| `total_bytes_behind` | Total bytes behind across all replicas |
+| `max_replication_lag` | Maximum time (ms) replica is behind primary |
+
+### Usage Example
+
+Create an index with segment replication:
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "replication.type": "SEGMENT",
+      "number_of_replicas": 1
+    }
+  }
+}
+```
+
+Enable recommended settings for segment replication:
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.routing.allocation.balance.prefer_primary": true,
+    "segrep.pressure.enabled": true
+  }
+}
+```
+
+Check segment replication status:
+
+```
+GET _cat/segment_replication?v
+```
+
+## Limitations
+
+- Requires reindexing to enable on existing indexes
+- Does not support `refresh=wait_for` or `refresh=true` policies
+- Cross-cluster replication does not use segment replication
+- Increased network bandwidth usage on primary shards (node-to-node mode)
+- Get/MultiGet/TermVector operations route to primary for strong reads
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18602](https://github.com/opensearch-project/OpenSearch/pull/18602) | Fix bugs in replication lag computation |
+
+## References
+
+- [Segment Replication Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/segment-replication/index/): Official documentation
+- [Segment Replication Backpressure](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/segment-replication/backpressure/): Backpressure mechanism
+- [CAT Segment Replication API](https://docs.opensearch.org/3.0/api-reference/cat/cat-segment-replication/): API for viewing metrics
+- [Issue #18437](https://github.com/opensearch-project/OpenSearch/issues/18437): Bug report for lag metric issue
+- [Segment Replication Blog](https://opensearch.org/blog/segment-replication/): Introduction blog post
+
+## Change History
+
+- **v3.2.0** (2025-07-01): Fixed replication lag computation to use epoch-based timestamps and corrected checkpoint pruning logic

--- a/docs/releases/v3.2.0/features/opensearch/replication-lag-fix.md
+++ b/docs/releases/v3.2.0/features/opensearch/replication-lag-fix.md
@@ -1,0 +1,101 @@
+# Replication Lag Fix
+
+## Summary
+
+This release fixes bugs in segment replication lag computation that caused incorrect lag metrics to be reported. The fix addresses two issues: using the correct epoch reference point for timestamp calculations and fixing the checkpoint pruning logic to properly remove synced checkpoints from tracking.
+
+## Details
+
+### What's New in v3.2.0
+
+This bugfix corrects the segment replication lag metric (`segments.segment_replication.max_replication_lag`) which was reporting incorrect values—sometimes showing lag in days when the actual lag was minimal.
+
+### Technical Changes
+
+#### Bug 1: Incorrect Timestamp Reference
+
+The original implementation used `System.nanoTime()` for timestamp calculations, which provides a monotonic clock without a fixed epoch reference. This caused incorrect lag calculations when comparing timestamps across different time references.
+
+**Before:**
+```java
+long replicationLag = bytesBehind > 0L
+    ? TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - lowestEntry.getValue().getTimestamp())
+    : 0;
+```
+
+**After:**
+```java
+long replicationLag = bytesBehind > 0L
+    ? Duration.ofNanos(DateUtils.toLong(Instant.now()) - lowestEntry.getValue().getTimestamp()).toMillis()
+    : 0;
+```
+
+The fix uses `DateUtils.toLong(Instant.now())` which provides a consistent epoch-based timestamp, ensuring accurate lag calculations.
+
+#### Bug 2: Incorrect Checkpoint Pruning
+
+The checkpoint pruning logic used `<` instead of `<=`, which kept the last synced checkpoint in tracking. This caused incorrect lag calculations when new checkpoints arrived.
+
+**Before:**
+```java
+existingCheckpointStats.keySet().removeIf(key -> key < segmentInfoVersion);
+```
+
+**After:**
+```java
+existingCheckpointStats.keySet().removeIf(key -> key <= segmentInfoVersion);
+```
+
+### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Segment Replication Stats"
+        PC[Primary Checkpoint] --> |timestamp| RCS[ReplicationCheckpointStats]
+        RCS --> |bytesBehind, timestamp| Stats[ReplicationStats]
+    end
+    
+    subgraph "Lag Calculation (Fixed)"
+        NOW[Instant.now] --> |DateUtils.toLong| EPOCH[Epoch Timestamp]
+        EPOCH --> |subtract oldest checkpoint| LAG[Replication Lag]
+    end
+    
+    subgraph "Pruning (Fixed)"
+        SYNC[Replica Sync Complete] --> |remove key <= version| PRUNE[Prune Checkpoints]
+    end
+```
+
+### Modified Components
+
+| Component | File | Change |
+|-----------|------|--------|
+| `SegmentReplicator` | `SegmentReplicator.java` | Fixed lag calculation using `DateUtils.toLong(Instant.now())` |
+| `SegmentReplicator` | `SegmentReplicator.java` | Fixed pruning logic to use `<=` instead of `<` |
+| `ReplicationCheckpoint` | `ReplicationCheckpoint.java` | Updated timestamp creation to use `DateUtils.toLong(Instant.now())` |
+
+### Impact
+
+- **Accuracy**: Replication lag metrics now correctly reflect the actual time difference between primary and replica shards
+- **Monitoring**: Users can now rely on `max_replication_lag` metric for accurate monitoring and alerting
+- **Consistency**: Lag values properly correlate with `bytes_behind` metrics
+
+## Limitations
+
+- This fix only affects segment replication; document replication uses different mechanisms
+- Historical lag data collected before this fix may be inaccurate
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18602](https://github.com/opensearch-project/OpenSearch/pull/18602) | Fix bugs in replication lag computation |
+
+## References
+
+- [Issue #18437](https://github.com/opensearch-project/OpenSearch/issues/18437): Bug report for incorrect segment replication lag metric
+- [Segment Replication Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/segment-replication/index/): Official segment replication docs
+- [CAT Segment Replication API](https://docs.opensearch.org/3.0/api-reference/cat/cat-segment-replication/): API for viewing segment replication metrics
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/segment-replication.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -46,3 +46,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [SecureRandom Blocking Fix](features/opensearch/securerandom-blocking-fix.md) | bugfix | Fix startup freeze on low-entropy systems by reverting to non-blocking SecureRandom |
 | [Field Mapping Fixes](features/opensearch/field-mapping-fixes.md) | bugfix | Fix field-level ignore_malformed override and scaled_float encodePoint method |
 | [Search Scoring Fixes](features/opensearch/search-scoring-fixes.md) | bugfix | Fix max_score null when sorting by _score with secondary fields |
+| [Replication Lag Fix](features/opensearch/replication-lag-fix.md) | bugfix | Fix segment replication lag computation using correct epoch timestamps |


### PR DESCRIPTION
## Summary

This PR adds documentation for the replication lag fix in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/replication-lag-fix.md`
- Feature report: `docs/features/opensearch/segment-replication.md` (new)

### Key Changes in v3.2.0
- Fixed replication lag computation to use epoch-based timestamps (`DateUtils.toLong(Instant.now())`) instead of `System.nanoTime()`
- Fixed checkpoint pruning logic to use `<=` instead of `<` for proper cleanup

### Resources Used
- PR: #18602 (opensearch-project/OpenSearch)
- Issue: #18437 (opensearch-project/OpenSearch)
- Docs: https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/segment-replication/index/