### PR TITLE
docs: add parent-child-query-fixes report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -67,6 +67,7 @@
 - [Offline Nodes (Background Tasks)](opensearch/offline-nodes.md)
 - [OpenSearch Core Dependencies](opensearch/opensearch-core-dependencies.md)
 - [Parallel Shard Refresh](opensearch/parallel-shard-refresh.md)
+- [Parent-Child Query](opensearch/parent-child-query.md)
 - [Percentiles Aggregation](opensearch/percentiles-aggregation.md)
 - [Phone Number Analyzer](opensearch/phone-analyzer.md)
 - [Platform Support](opensearch/platform-support.md)

--- a/docs/features/opensearch/parent-child-query.md
+++ b/docs/features/opensearch/parent-child-query.md
@@ -1,0 +1,194 @@
+# Parent-Child Query
+
+## Summary
+
+Parent-child queries in OpenSearch allow you to model hierarchical relationships between documents within the same index using a join field type. The `has_child` query returns parent documents whose child documents match a specific query, while the `has_parent` query returns child documents whose parent documents match a specific query. These queries are essential for modeling one-to-many relationships without denormalization.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Index with Join Field"
+        JF[Join Field Type]
+        JF --> P[Parent Documents]
+        JF --> C[Child Documents]
+        P --> |parent_id| C
+    end
+    
+    subgraph "Query Types"
+        HC[has_child Query]
+        HP[has_parent Query]
+        PID[parent_id Query]
+    end
+    
+    subgraph "Query Processing"
+        QB[QueryBuilder]
+        QB --> |visitor pattern| V[QueryBuilderVisitor]
+        V --> |traverses| SQ[Sub-Queries]
+    end
+    
+    HC --> |finds parents with matching children| P
+    HP --> |finds children with matching parents| C
+    PID --> |finds children by parent ID| C
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `HasChildQueryBuilder` | Builds queries to find parent documents with matching children |
+| `HasParentQueryBuilder` | Builds queries to find child documents with matching parents |
+| `ParentIdQueryBuilder` | Builds queries to find children by parent document ID |
+| `JoinFieldMapper` | Maps the join field type that establishes parent-child relationships |
+| `QueryBuilderVisitor` | Visitor pattern interface for traversing query trees |
+
+### Query Parameters
+
+#### has_child Query
+
+| Parameter | Description | Required |
+|-----------|-------------|----------|
+| `type` | The child type to search | Yes |
+| `query` | Query to run on child documents | Yes |
+| `score_mode` | How to aggregate child scores (none, avg, max, min, sum) | No |
+| `min_children` | Minimum number of matching children required | No |
+| `max_children` | Maximum number of matching children allowed | No |
+| `inner_hits` | Return matching child documents | No |
+
+#### has_parent Query
+
+| Parameter | Description | Required |
+|-----------|-------------|----------|
+| `parent_type` | The parent type to search | Yes |
+| `query` | Query to run on parent documents | Yes |
+| `score` | Whether to use parent score (true/false) | No |
+| `inner_hits` | Return matching parent documents | No |
+
+### Usage Examples
+
+#### Setting up a Join Field
+
+```json
+PUT /my_index
+{
+  "mappings": {
+    "properties": {
+      "my_join_field": {
+        "type": "join",
+        "relations": {
+          "brand": "product"
+        }
+      },
+      "name": { "type": "text" }
+    }
+  }
+}
+```
+
+#### Indexing Parent and Child Documents
+
+```json
+// Index parent document
+PUT /my_index/_doc/1
+{
+  "name": "Brand A",
+  "my_join_field": "brand"
+}
+
+// Index child document
+PUT /my_index/_doc/2?routing=1
+{
+  "name": "Product 1",
+  "my_join_field": {
+    "name": "product",
+    "parent": "1"
+  }
+}
+```
+
+#### has_child Query Example
+
+```json
+GET /my_index/_search
+{
+  "query": {
+    "has_child": {
+      "type": "product",
+      "query": {
+        "match": {
+          "name": "Product 1"
+        }
+      }
+    }
+  }
+}
+```
+
+#### has_parent Query Example
+
+```json
+GET /my_index/_search
+{
+  "query": {
+    "has_parent": {
+      "parent_type": "brand",
+      "query": {
+        "match": {
+          "name": "Brand A"
+        }
+      }
+    }
+  }
+}
+```
+
+#### Neural Search with Parent-Child Query (v3.2.0+)
+
+```json
+GET /my_index/_search
+{
+  "query": {
+    "has_child": {
+      "type": "product",
+      "query": {
+        "neural": {
+          "embedding_field": {
+            "query_text": "search query",
+            "model_id": "model_123"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Parent and child documents must be indexed on the same shard (use routing)
+- Join queries are expensive compared to regular queries
+- Only one join field per index is allowed
+- Parent-child relationships cannot span multiple indices
+- The `search.allow_expensive_queries` setting can disable join queries
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18621](https://github.com/opensearch-project/OpenSearch/pull/18621) | Fix visitor pattern for HasParentQuery and HasChildQuery |
+| v2.16.0 | [#14739](https://github.com/opensearch-project/OpenSearch/pull/14739) | Fix visitor pattern for NestedQueryBuilder |
+| - | [#10110](https://github.com/opensearch-project/OpenSearch/pull/10110) | Original visitor pattern implementation |
+
+## References
+
+- [Has Child Query Documentation](https://docs.opensearch.org/3.0/query-dsl/joining/has-child/): Official has_child query docs
+- [Has Parent Query Documentation](https://docs.opensearch.org/3.0/query-dsl/joining/has-parent/): Official has_parent query docs
+- [Joining Queries Overview](https://docs.opensearch.org/3.0/query-dsl/joining/index/): Overview of all joining queries
+- [Join Field Type](https://docs.opensearch.org/3.0/field-types/supported-field-types/join/): Join field mapping documentation
+- [Inner Hits](https://docs.opensearch.org/3.0/search-plugins/searching-data/inner-hits/): Retrieving nested/child documents
+
+## Change History
+
+- **v3.2.0** (2026-01-10): Fixed QueryBuilderVisitor pattern for HasParentQuery and HasChildQuery to properly traverse sub-queries

--- a/docs/releases/v3.2.0/features/opensearch/parent-child-query-fixes.md
+++ b/docs/releases/v3.2.0/features/opensearch/parent-child-query-fixes.md
@@ -1,0 +1,108 @@
+# Parent-Child Query Fixes
+
+## Summary
+
+This bugfix addresses a missing implementation in the `QueryBuilderVisitor` pattern for `HasParentQueryBuilder` and `HasChildQueryBuilder`. Without this fix, the visitor pattern could not traverse sub-queries within parent-child queries, which prevented features like neural search from properly processing embedding fields in nested join queries.
+
+## Details
+
+### What's New in v3.2.0
+
+The `visit()` method has been implemented for both `HasParentQueryBuilder` and `HasChildQueryBuilder` classes. This allows the visitor pattern to properly traverse and process sub-queries within parent-child join queries.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Query Visitor Pattern"
+        V[QueryBuilderVisitor]
+        V --> |visits| HP[HasParentQueryBuilder]
+        V --> |visits| HC[HasChildQueryBuilder]
+        HP --> |delegates to child visitor| SQ1[Sub-Query]
+        HC --> |delegates to child visitor| SQ2[Sub-Query]
+    end
+    
+    subgraph "Use Case: Neural Search"
+        NS[Neural Search Processor]
+        NS --> |uses visitor| V
+        SQ1 --> |can now process| EMB1[Embedding Fields]
+        SQ2 --> |can now process| EMB2[Embedding Fields]
+    end
+```
+
+#### Code Changes
+
+| File | Change |
+|------|--------|
+| `HasChildQueryBuilder.java` | Added `visit()` method implementation |
+| `HasParentQueryBuilder.java` | Added `visit()` method implementation |
+| `HasChildQueryBuilderTests.java` | Added test for visitor pattern |
+| `HasParentQueryBuilderTests.java` | Added test for visitor pattern |
+
+#### Implementation Details
+
+The fix adds the following `visit()` method to both query builders:
+
+```java
+@Override
+public void visit(QueryBuilderVisitor visitor) {
+    visitor.accept(this);
+    query.visit(visitor.getChildVisitor(BooleanClause.Occur.MUST));
+}
+```
+
+This implementation:
+1. Accepts the current query builder with the visitor
+2. Delegates to the child visitor for the inner query using `MUST` occurrence
+
+### Usage Example
+
+With this fix, neural search can now process embedding fields within parent-child queries:
+
+```json
+{
+  "query": {
+    "has_child": {
+      "type": "child_doc",
+      "query": {
+        "neural": {
+          "embedding_field": {
+            "query_text": "search query",
+            "model_id": "model_123"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+No migration required. This is a transparent bugfix that enables previously broken functionality.
+
+## Limitations
+
+- The fix only addresses the visitor pattern for `HasParentQuery` and `HasChildQuery`
+- Other join queries may still need similar fixes if they have nested sub-queries
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18621](https://github.com/opensearch-project/OpenSearch/pull/18621) | Fix the visit of sub queries for HasParentQuery and HasChildQuery |
+
+## References
+
+- [PR #13837](https://github.com/opensearch-project/OpenSearch/pull/13837): Previous visitor pattern fix (stalled)
+- [PR #14739](https://github.com/opensearch-project/OpenSearch/pull/14739): Fix for NestedQueryBuilder visitor
+- [PR #10110](https://github.com/opensearch-project/OpenSearch/pull/10110): Original visitor pattern implementation
+- [Has Child Query Documentation](https://docs.opensearch.org/3.0/query-dsl/joining/has-child/): Official docs
+- [Has Parent Query Documentation](https://docs.opensearch.org/3.0/query-dsl/joining/has-parent/): Official docs
+- [Joining Queries Documentation](https://docs.opensearch.org/3.0/query-dsl/joining/index/): Overview of joining queries
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/parent-child-query.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -47,3 +47,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Field Mapping Fixes](features/opensearch/field-mapping-fixes.md) | bugfix | Fix field-level ignore_malformed override and scaled_float encodePoint method |
 | [Search Scoring Fixes](features/opensearch/search-scoring-fixes.md) | bugfix | Fix max_score null when sorting by _score with secondary fields |
 | [Replication Lag Fix](features/opensearch/replication-lag-fix.md) | bugfix | Fix segment replication lag computation using correct epoch timestamps |
+| [Parent-Child Query Fixes](features/opensearch/parent-child-query-fixes.md) | bugfix | Fix QueryBuilderVisitor pattern for HasParentQuery and HasChildQuery |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Parent-Child Query Fixes in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/parent-child-query-fixes.md`
- Feature report: `docs/features/opensearch/parent-child-query.md` (new)

### Key Changes in v3.2.0
- Fixed `QueryBuilderVisitor` pattern for `HasParentQueryBuilder` and `HasChildQueryBuilder`
- Enables neural search and other query processors to properly traverse sub-queries within parent-child join queries

### Related PR
- [opensearch-project/OpenSearch#18621](https://github.com/opensearch-project/OpenSearch/pull/18621)