### PR TITLE
docs: add HTTP/2 & Reactor-Netty fix report for v3.2.0

### DIFF
--- a/docs/features/opensearch/streaming-indexing.md
+++ b/docs/features/opensearch/streaming-indexing.md
@@ -123,10 +123,11 @@ Each batch returns a separate JSON response:
 
 | Version | PR | Description |
 |---------|-----|-------------|
-| v2.15.0 | [#13772](https://github.com/opensearch-project/OpenSearch/pull/13772) | Enhance RestAction with request/response streaming support |
-| v2.17.0 | [#15381](https://github.com/opensearch-project/OpenSearch/pull/15381) | Introduce bulk HTTP API streaming flavor |
-| v2.18.0 | [#16158](https://github.com/opensearch-project/OpenSearch/pull/16158) | Fix streaming bulk request hangs |
+| v3.2.0 | [#18599](https://github.com/opensearch-project/OpenSearch/pull/18599) | Fix HTTP/2 communication when reactor-netty is enabled |
 | v2.18.0 | [#16337](https://github.com/opensearch-project/OpenSearch/pull/16337) | Fix intermittent newline termination failures |
+| v2.18.0 | [#16158](https://github.com/opensearch-project/OpenSearch/pull/16158) | Fix streaming bulk request hangs |
+| v2.17.0 | [#15381](https://github.com/opensearch-project/OpenSearch/pull/15381) | Introduce bulk HTTP API streaming flavor |
+| v2.15.0 | [#13772](https://github.com/opensearch-project/OpenSearch/pull/13772) | Enhance RestAction with request/response streaming support |
 
 ## References
 
@@ -137,6 +138,7 @@ Each batch returns a separate JSON response:
 
 ## Change History
 
+- **v3.2.0** (2025-07-15): Fix HTTP/2 communication when reactor-netty-secure is enabled
 - **v2.18.0** (2024-11-05): Bug fixes for request hangs and newline termination errors
 - **v2.17.0** (2024-09-17): Initial release of Streaming Bulk API
 - **v2.15.0** (2024-06-25): RestAction streaming support foundation

--- a/docs/releases/v3.2.0/features/opensearch/http2-reactor-netty-fix.md
+++ b/docs/releases/v3.2.0/features/opensearch/http2-reactor-netty-fix.md
@@ -1,0 +1,126 @@
+# HTTP/2 & Reactor-Netty Fix
+
+## Summary
+
+This bugfix resolves an issue where HTTP/2 communication failed when using the `reactor-netty4-secure` HTTP transport. Clients attempting to communicate via HTTP/2 received errors indicating the server did not properly support the protocol, while HTTP/1.1 connections worked correctly.
+
+## Details
+
+### What's New in v3.2.0
+
+The fix addresses the root cause of HTTP/2 communication failures in the Reactor Netty transport by properly configuring SSL/TLS context with ALPN (Application-Layer Protocol Negotiation) support.
+
+### Technical Changes
+
+#### Problem Analysis
+
+When `http.type: reactor-netty4-secure` was configured, the server would:
+1. Accept HTTP/2 during ALPN negotiation
+2. Fail to send proper HTTP/2 SETTINGS frame
+3. Cause clients to receive: "Remote peer returned unexpected data while we expected SETTINGS frame"
+
+The issue was in how the SSL context was being constructed - it used a custom `SslContext` wrapper that didn't properly support HTTP/2 protocol negotiation.
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before Fix"
+        A1[Client] -->|ALPN: h2, http/1.1| B1[Server]
+        B1 -->|Accept h2| C1[Custom SslContext Wrapper]
+        C1 -->|Missing ALPN Config| D1[HTTP/2 Failure]
+    end
+    subgraph "After Fix"
+        A2[Client] -->|ALPN: h2, http/1.1| B2[Server]
+        B2 -->|Accept h2| C2[Native SslContextBuilder]
+        C2 -->|Proper ALPN Config| D2[HTTP/2 Success]
+    end
+```
+
+#### Code Changes
+
+The fix replaces the custom `SslContext` wrapper with Netty's native `SslContextBuilder`:
+
+| Component | Change |
+|-----------|--------|
+| `ReactorNetty4HttpServerTransport` | Use `SslContextBuilder.forServer()` instead of custom wrapper |
+| `SecureHttpTransportSettingsProvider` | New `parameters()` method for SSL configuration |
+| `SslUtils` | Made `DEFAULT_SSL_PROTOCOLS` public |
+
+#### New Configuration Interface
+
+The fix introduces `SecureHttpTransportParameters` interface:
+
+| Method | Description |
+|--------|-------------|
+| `keyManagerFactory()` | Returns KeyManagerFactory for server certificates |
+| `trustManagerFactory()` | Returns TrustManagerFactory for client verification |
+| `protocols()` | Returns supported TLS protocols |
+| `cipherSuites()` | Returns allowed cipher suites |
+| `sslProvider()` | Returns SSL provider (JDK or OpenSSL) |
+| `clientAuth()` | Returns client authentication mode |
+
+#### ALPN Configuration
+
+The fix properly configures ALPN for HTTP/2:
+
+```java
+new ApplicationProtocolConfig(
+    ApplicationProtocolConfig.Protocol.ALPN,
+    ApplicationProtocolConfig.SelectorFailureBehavior.NO_ADVERTISE,
+    ApplicationProtocolConfig.SelectedListenerFailureBehavior.ACCEPT,
+    ApplicationProtocolNames.HTTP_2,
+    ApplicationProtocolNames.HTTP_1_1
+)
+```
+
+### Additional Fix: URI Length Validation
+
+The PR also adds URI length validation for HTTP/2 requests, as Reactor Netty doesn't respect `maxInitialLineLength` for HTTP/2:
+
+```java
+if (request.uri().length() > maxInitialLineLength.bytesAsInt()) {
+    return response.status(HttpResponseStatus.REQUEST_URI_TOO_LONG).send();
+}
+```
+
+### Usage Example
+
+```yaml
+# opensearch.yml
+http.type: reactor-netty4-secure
+```
+
+```bash
+# HTTP/2 now works correctly
+curl -XGET https://localhost:9200/_cat/nodes -u admin:admin --insecure -v
+
+# Output shows successful HTTP/2 communication:
+# * ALPN: server accepted h2
+# * using HTTP/2
+# [successful response]
+```
+
+### Migration Notes
+
+No migration required. The fix is backward compatible and automatically applies when using `reactor-netty4-secure` transport.
+
+## Limitations
+
+- The `transport-reactor-netty4` plugin remains experimental
+- Requires proper SSL/TLS certificate configuration via security plugin
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18599](https://github.com/opensearch-project/OpenSearch/pull/18599) | Fix HTTP/2 communication when reactor-netty is enabled |
+
+## References
+
+- [Issue #18559](https://github.com/opensearch-project/OpenSearch/issues/18559): Bug report for HTTP/2 failure
+- [Network Settings Documentation](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/network-settings/): Transport configuration
+
+## Related Feature Report
+
+- [Streaming Indexing](../../../features/opensearch/streaming-indexing.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -48,3 +48,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Search Scoring Fixes](features/opensearch/search-scoring-fixes.md) | bugfix | Fix max_score null when sorting by _score with secondary fields |
 | [Replication Lag Fix](features/opensearch/replication-lag-fix.md) | bugfix | Fix segment replication lag computation using correct epoch timestamps |
 | [Parent-Child Query Fixes](features/opensearch/parent-child-query-fixes.md) | bugfix | Fix QueryBuilderVisitor pattern for HasParentQuery and HasChildQuery |
+| [HTTP/2 & Reactor-Netty Fix](features/opensearch/http2-reactor-netty-fix.md) | bugfix | Fix HTTP/2 communication when reactor-netty-secure transport is enabled |


### PR DESCRIPTION
## Summary

This PR adds documentation for the HTTP/2 & Reactor-Netty bugfix in OpenSearch v3.2.0.

### Issue Investigated
- GitHub Issue: #1137

### Bug Fixed
When `http.type: reactor-netty4-secure` was configured, HTTP/2 communication failed with "Remote peer returned unexpected data while we expected SETTINGS frame" error. HTTP/1.1 worked correctly.

### Root Cause
The SSL context was using a custom wrapper that didn't properly configure ALPN (Application-Layer Protocol Negotiation) for HTTP/2.

### Fix
PR #18599 replaces the custom SslContext wrapper with Netty's native SslContextBuilder, properly configuring ALPN for HTTP/2 support.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/http2-reactor-netty-fix.md`
- Feature report updated: `docs/features/opensearch/streaming-indexing.md`

### References
- [PR #18599](https://github.com/opensearch-project/OpenSearch/pull/18599)
- [Issue #18559](https://github.com/opensearch-project/OpenSearch/issues/18559)