### PR TITLE
docs: add Query String & Regex Fixes report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -78,6 +78,7 @@
 - [Query Bug Fixes](opensearch/query-bug-fixes.md)
 - [Query Coordinator Context](opensearch/query-coordinator-context.md)
 - [Query Optimization](opensearch/query-optimization.md)
+- [Query String & Regex Queries](opensearch/query-string-regex.md)
 - [Randomness](opensearch/randomness.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)
 - [Replication](opensearch/replication.md)

--- a/docs/features/opensearch/query-string-regex.md
+++ b/docs/features/opensearch/query-string-regex.md
@@ -1,0 +1,167 @@
+# Query String & Regex Queries
+
+## Summary
+
+OpenSearch provides powerful regular expression (regex) support through two query types: `regexp` and `query_string`. These queries allow pattern matching against indexed terms using Lucene's regex engine. The `query_string` query supports regex patterns within a broader query syntax, while `regexp` provides dedicated regex matching on specific fields.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Query Processing"
+        QS[query_string Query]
+        RQ[regexp Query]
+    end
+    
+    subgraph "Query Parsing"
+        QSP[QueryStringQueryParser]
+        RQB[RegexpQueryBuilder]
+    end
+    
+    subgraph "Field Resolution"
+        FM[Field Mapper]
+        FA[Field Alias Resolution]
+    end
+    
+    subgraph "Lucene"
+        LRQ[Lucene RegexpQuery]
+        AUTO[Automaton Engine]
+    end
+    
+    QS --> QSP
+    RQ --> RQB
+    QSP --> FM
+    RQB --> FM
+    FM --> FA
+    FA --> LRQ
+    LRQ --> AUTO
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `QueryStringQueryParser` | Parses query string syntax including regex patterns enclosed in `/pattern/` |
+| `RegexpQueryBuilder` | Builds regexp queries with configurable flags and options |
+| `RegexpFlag` | Enum defining optional regex operators (COMPLEMENT, INTERSECTION, INTERVAL, ANYSTRING) |
+| Field Mapper | Resolves field names including aliases to actual index fields |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `max_determinized_states` | Maximum automaton states for regex complexity | 10000 |
+| `flags` | Optional regex operators to enable | ALL |
+| `case_insensitive` | Enable case-insensitive matching | false |
+| `lenient` | Ignore data type mismatches (query_string only) | false |
+
+### Query Types Comparison
+
+| Feature | `regexp` query | `query_string` query |
+|---------|---------------|---------------------|
+| Pattern matching | Must match entire field value | Can match any part of field |
+| `flags` support | Yes | No |
+| Query type | Term-level (not scored) | Full-text (scored) |
+| Best use case | Strict pattern matching on keyword fields | Flexible search with regex patterns |
+
+### Regex Operators
+
+**Standard Operators** (always available):
+- `.` - Match any single character
+- `?` - Match zero or one of preceding
+- `+` - Match one or more of preceding
+- `*` - Match zero or more of preceding
+- `|` - Logical OR
+- `()` - Grouping
+- `[]` - Character class
+- `{}` - Repetition range
+
+**Optional Operators** (enabled via `flags`):
+- `~` (COMPLEMENT) - Negates following expression (deprecated)
+- `&` (INTERSECTION) - Logical AND
+- `<min-max>` (INTERVAL) - Numeric range matching
+- `@` (ANYSTRING) - Match any string
+
+### Usage Example
+
+#### Basic Regex Query
+
+```json
+GET /logs/_search
+{
+  "query": {
+    "regexp": {
+      "message": {
+        "value": "error[0-9]+",
+        "flags": "ALL"
+      }
+    }
+  }
+}
+```
+
+#### Query String with Regex
+
+```json
+GET /test_index/_search
+{
+  "query": {
+    "query_string": {
+      "query": "title: /w[a-z]nd/"
+    }
+  }
+}
+```
+
+#### Field Alias Support
+
+```json
+PUT /test_index
+{
+  "mappings": {
+    "properties": {
+      "original_field": { "type": "text" },
+      "field_alias": { "type": "alias", "path": "original_field" }
+    }
+  }
+}
+
+GET /test_index/_search
+{
+  "query": {
+    "query_string": {
+      "query": "field_alias: /pattern.*/"
+    }
+  }
+}
+```
+
+## Limitations
+
+- Lucene regex engine does not support `^` (start) and `$` (end) anchors - patterns must match entire terms
+- The COMPLEMENT operator (`~`) is deprecated and will be removed in OpenSearch 4.0 (Lucene 11)
+- Complex regex patterns may exceed `max_determinized_states` limit, causing `TooComplexToDeterminizeException`
+- Regex queries can be resource-intensive; consider using `search.allow_expensive_queries` setting
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18215](https://github.com/opensearch-project/OpenSearch/pull/18215) | Fix regex query from query string query to work with field alias |
+| v3.2.0 | [#18640](https://github.com/opensearch-project/OpenSearch/pull/18640) | Fix backward compatibility regression with COMPLEMENT for Regexp queries |
+| v3.2.0 | [#18883](https://github.com/opensearch-project/OpenSearch/pull/18883) | Propagate TooComplexToDeterminizeException in query_string regex queries |
+
+## References
+
+- [Issue #18214](https://github.com/opensearch-project/OpenSearch/issues/18214): Regex query doesn't support field alias
+- [Issue #18397](https://github.com/opensearch-project/OpenSearch/issues/18397): COMPLEMENT does not work in Regexp queries
+- [Issue #18733](https://github.com/opensearch-project/OpenSearch/issues/18733): query_string behavior using regex when shard failures occur
+- [Query String Documentation](https://docs.opensearch.org/3.0/query-dsl/full-text/query-string/): Official query_string docs
+- [Regular Expression Syntax](https://docs.opensearch.org/3.0/query-dsl/regex-syntax/): Regex syntax reference
+- [Regexp Query Documentation](https://docs.opensearch.org/3.0/query-dsl/term/regexp/): Official regexp query docs
+
+## Change History
+
+- **v3.2.0** (2025): Fixed field alias support for regex in query_string, restored COMPLEMENT flag backward compatibility, fixed TooComplexToDeterminizeException propagation

--- a/docs/releases/v3.2.0/features/opensearch/query-string-regex-fixes.md
+++ b/docs/releases/v3.2.0/features/opensearch/query-string-regex-fixes.md
@@ -1,0 +1,137 @@
+# Query String & Regex Fixes
+
+## Summary
+
+OpenSearch v3.2.0 includes three important bug fixes for query string and regular expression queries. These fixes address issues with field alias support, backward compatibility for the COMPLEMENT operator, and proper error propagation for overly complex regex patterns.
+
+## Details
+
+### What's New in v3.2.0
+
+This release resolves three distinct bugs affecting regex functionality in OpenSearch:
+
+1. **Field Alias Support**: Regex queries within `query_string` now correctly resolve field aliases
+2. **COMPLEMENT Flag Restoration**: The `~` (COMPLEMENT) operator for regexp queries works again after a regression in OpenSearch 3.0
+3. **TooComplexToDeterminizeException Propagation**: Complex regex patterns now properly return 400 errors instead of silently failing
+
+### Technical Changes
+
+#### Fix 1: Regex Query with Field Alias (PR #18215)
+
+The `QueryStringQueryParser.getRegexpQuerySingle()` method was updated to use `currentFieldType.regexpQuery()` instead of delegating to Lucene's `super.getRegexpQuery()`. This ensures field aliases are properly resolved through OpenSearch's field mapper.
+
+**Before**: Regex queries on alias fields returned no results
+**After**: Regex queries correctly resolve aliases to their target fields
+
+```java
+// Changed from:
+return super.getRegexpQuery(field, termStr);
+
+// To:
+termStr = getAnalyzer().normalize(currentFieldType.name(), termStr).utf8ToString();
+return currentFieldType.regexpQuery(termStr, RegExp.ALL, 0, getDeterminizeWorkLimit(), getMultiTermRewriteMethod(), context);
+```
+
+#### Fix 2: COMPLEMENT Flag Backward Compatibility (PR #18640)
+
+The `RegexpQueryBuilder.doToQuery()` method was fixed to preserve the COMPLEMENT flag when sanitizing syntax flags. The issue was introduced in OpenSearch 3.0 when Lucene changed `RegExp.ALL` from `0xffff` to `0xff`, which inadvertently dropped the COMPLEMENT bit (`0x10000`).
+
+```java
+// Changed from:
+int sanitisedSyntaxFlag = syntaxFlagsValue & RegExp.ALL;
+
+// To:
+int sanitisedSyntaxFlag = syntaxFlagsValue & (RegExp.ALL | RegExp.DEPRECATED_COMPLEMENT);
+```
+
+A deprecation warning is now emitted when using the COMPLEMENT operator, as it will be removed in Lucene 11 (OpenSearch 4.0).
+
+#### Fix 3: TooComplexToDeterminizeException Handling (PR #18883)
+
+The `QueryStringQueryParser` was incorrectly swallowing `TooComplexToDeterminizeException` when `lenient` mode was enabled. The fix adds an explicit check to propagate this exception regardless of lenient mode.
+
+```java
+// Changed from:
+if (lenient) {
+    return newLenientFieldQuery(field, e);
+}
+
+// To:
+if (lenient && !(e instanceof TooComplexToDeterminizeException)) {
+    return newLenientFieldQuery(field, e);
+}
+```
+
+**Before**: Complex regex in `query_string` returned HTTP 200 with empty results
+**After**: Complex regex properly returns HTTP 400 with `too_complex_to_determinize_exception`
+
+### Usage Example
+
+#### Field Alias with Regex Query
+
+```json
+PUT /test_index
+{
+  "mappings": {
+    "properties": {
+      "test": { "type": "text" },
+      "test_alias": { "type": "alias", "path": "test" }
+    }
+  }
+}
+
+GET /test_index/_search
+{
+  "query": {
+    "query_string": {
+      "query": "test_alias: /h[a-z].*/"
+    }
+  }
+}
+```
+
+#### COMPLEMENT Operator
+
+```json
+GET /test/_search
+{
+  "query": {
+    "regexp": {
+      "text.keyword": {
+        "value": "a~bc",
+        "flags": "COMPLEMENT"
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- **COMPLEMENT Deprecation**: The `~` operator is deprecated and will be removed in OpenSearch 4.0 (Lucene 11). Consider using character class negation `[^...]` or other query types as alternatives.
+- **Error Handling**: Applications relying on `query_string` with complex regex patterns may now receive 400 errors where they previously received empty results. Update error handling accordingly.
+
+## Limitations
+
+- The COMPLEMENT operator (`~`) is deprecated and scheduled for removal in OpenSearch 4.0
+- Field alias support for regex is only available in OpenSearch 3.2.0 and later
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18215](https://github.com/opensearch-project/OpenSearch/pull/18215) | Fix regex query from query string query to work with field alias |
+| [#18640](https://github.com/opensearch-project/OpenSearch/pull/18640) | Fix backward compatibility regression with COMPLEMENT for Regexp queries |
+| [#18883](https://github.com/opensearch-project/OpenSearch/pull/18883) | Propagate TooComplexToDeterminizeException in query_string regex queries |
+
+## References
+
+- [Issue #18214](https://github.com/opensearch-project/OpenSearch/issues/18214): Regex query doesn't support field alias
+- [Issue #18397](https://github.com/opensearch-project/OpenSearch/issues/18397): COMPLEMENT does not work in Regexp queries
+- [Issue #18733](https://github.com/opensearch-project/OpenSearch/issues/18733): query_string behavior using regex when shard failures occur
+- [Query String Documentation](https://docs.opensearch.org/3.0/query-dsl/full-text/query-string/): Official query_string docs
+- [Regular Expression Syntax](https://docs.opensearch.org/3.0/query-dsl/regex-syntax/): Regex syntax reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/query-string-regex.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -49,3 +49,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Replication Lag Fix](features/opensearch/replication-lag-fix.md) | bugfix | Fix segment replication lag computation using correct epoch timestamps |
 | [Parent-Child Query Fixes](features/opensearch/parent-child-query-fixes.md) | bugfix | Fix QueryBuilderVisitor pattern for HasParentQuery and HasChildQuery |
 | [HTTP/2 & Reactor-Netty Fix](features/opensearch/http2-reactor-netty-fix.md) | bugfix | Fix HTTP/2 communication when reactor-netty-secure transport is enabled |
+| [Query String & Regex Fixes](features/opensearch/query-string-regex-fixes.md) | bugfix | Fix field alias support, COMPLEMENT flag, and TooComplexToDeterminizeException handling |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Query String & Regex Fixes in OpenSearch v3.2.0.

### Bug Fixes Covered

1. **PR #18215**: Fix regex query from query string query to work with field alias
2. **PR #18640**: Fix backward compatibility regression with COMPLEMENT for Regexp queries
3. **PR #18883**: Propagate TooComplexToDeterminizeException in query_string regex queries

### Reports Created

- Release report: `docs/releases/v3.2.0/features/opensearch/query-string-regex-fixes.md`
- Feature report: `docs/features/opensearch/query-string-regex.md`

### Key Changes

- Field aliases now work correctly with regex queries in query_string
- COMPLEMENT (`~`) operator restored for regexp queries (with deprecation warning)
- Complex regex patterns now properly return 400 errors instead of silently failing

Closes #1135