### PR TITLE
docs: add aggregation task cancellation report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -16,6 +16,7 @@
 ## opensearch
 
 - [Approximation Framework](opensearch/approximation-framework.md)
+- [Aggregation Task Cancellation](opensearch/aggregation-task-cancellation.md)
 - [Async Shard Batch Fetch](opensearch/async-shard-batch-fetch.md)
 - [Async Shard Fetch Metrics](opensearch/async-shard-fetch-metrics.md)
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)

--- a/docs/features/opensearch/aggregation-task-cancellation.md
+++ b/docs/features/opensearch/aggregation-task-cancellation.md
@@ -1,0 +1,161 @@
+# Aggregation Task Cancellation
+
+## Summary
+
+Aggregation Task Cancellation enables OpenSearch to properly terminate long-running aggregation queries when they exceed resource thresholds or are manually cancelled. This feature addresses a critical gap where deeply nested aggregations could run indefinitely, consuming excessive memory and potentially causing Out of Memory errors on data nodes.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Aggregation Framework"
+        A[AggregatorBase] --> B[checkCancelled]
+        B --> C{context.isCancelled?}
+        C -->|Yes| D[TaskCancelledException]
+        C -->|No| E[Continue]
+    end
+    
+    subgraph "Bucket Aggregators"
+        F[BucketsAggregator] --> A
+        G[TermsAggregator] --> F
+        H[HistogramAggregator] --> F
+        I[RangeAggregator] --> F
+        J[CompositeAggregator] --> F
+    end
+    
+    subgraph "Cancellation Sources"
+        K[Search Backpressure] --> L[SearchContext]
+        M[Task Cancel API] --> L
+        N[Query Timeout] --> L
+        L --> C
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Search Request] --> B[Create SearchContext]
+    B --> C[Build Aggregators]
+    C --> D[Collect Documents]
+    D --> E[Build Aggregations]
+    
+    subgraph "Cancellation Checkpoints"
+        E --> F{Check Cancelled}
+        F -->|No| G[Build Sub-Aggregations]
+        G --> H{Check Cancelled}
+        H -->|No| I[Process Buckets]
+        I --> J{Check Cancelled}
+        J -->|No| K[Return Results]
+        
+        F -->|Yes| L[Throw Exception]
+        H -->|Yes| L
+        J -->|Yes| L
+    end
+    
+    L --> M[Return Error Response]
+    K --> N[Return Aggregation Results]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `AggregatorBase.checkCancelled()` | Protected method that checks `SearchContext.isCancelled()` and throws `TaskCancelledException` |
+| `BucketsAggregator` | Base class for bucket aggregations with cancellation checks in `buildSubAggsForBuckets()` |
+| `SearchContext` | Holds the cancellation state for the search request |
+| `TaskCancelledException` | Exception thrown when a cancelled task attempts to continue |
+
+### Configuration
+
+Aggregation task cancellation works with existing search backpressure settings:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `search_backpressure.mode` | Backpressure mode: `monitor_only`, `enforced`, `disabled` | `monitor_only` |
+| `search_backpressure.search_task.elapsed_time_millis_threshold` | Max elapsed time before cancellation | 45,000 |
+| `search_backpressure.search_task.cpu_time_millis_threshold` | Max CPU time before cancellation | 30,000 |
+| `search_backpressure.search_shard_task.elapsed_time_millis_threshold` | Max elapsed time for shard tasks | 30,000 |
+
+### Usage Example
+
+Enable enforced search backpressure to automatically cancel long-running aggregations:
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "search_backpressure": {
+      "mode": "enforced"
+    }
+  }
+}
+```
+
+Example of a problematic query that will now be properly cancelled:
+
+```json
+POST /my-index/_search
+{
+  "size": 0,
+  "aggs": {
+    "level1": {
+      "terms": {
+        "field": "category",
+        "size": 500000
+      },
+      "aggs": {
+        "level2": {
+          "terms": {
+            "field": "subcategory",
+            "size": 500000
+          },
+          "aggs": {
+            "level3": {
+              "date_histogram": {
+                "field": "timestamp",
+                "interval": "1m"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+When cancelled, the response will include:
+
+```json
+{
+  "error": {
+    "type": "task_cancelled_exception",
+    "reason": "The query has been cancelled"
+  }
+}
+```
+
+## Limitations
+
+- Cancellation checks are implemented in the **query phase** only
+- The fetch phase (result transformation) does not yet support cancellation
+- Very fast aggregations may complete before cancellation can take effect
+- Cancellation is checked at bucket boundaries, not during individual document collection
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18426](https://github.com/opensearch-project/OpenSearch/pull/18426) | Add task cancellation check in aggregation code paths |
+
+## References
+
+- [Issue #15413](https://github.com/opensearch-project/OpenSearch/issues/15413): Original bug report describing the problem with non-terminable nested aggregations
+- [Search Backpressure Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/search-backpressure/): Official documentation on configuring search backpressure
+
+## Change History
+
+- **v3.2.0** (2025-06-11): Initial implementation - Added cancellation checks in aggregation code paths during query phase

--- a/docs/releases/v3.2.0/features/opensearch/aggregation-task-cancellation.md
+++ b/docs/releases/v3.2.0/features/opensearch/aggregation-task-cancellation.md
@@ -1,0 +1,113 @@
+# Aggregation Task Cancellation
+
+## Summary
+
+OpenSearch v3.2.0 adds task cancellation checks in aggregation code paths, enabling long-running aggregation queries to be properly cancelled when requested. This addresses a critical issue where deeply nested aggregations could not be terminated, potentially causing Out of Memory errors on data nodes.
+
+## Details
+
+### What's New in v3.2.0
+
+This release introduces cancellation checkpoints throughout the aggregation framework, allowing the search backpressure mechanism and manual task cancellation to effectively terminate resource-intensive aggregation queries during the query phase.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Search Request Flow"
+        A[Search Request] --> B[Query Phase]
+        B --> C[Aggregation Building]
+        C --> D{Cancellation Check}
+        D -->|Not Cancelled| E[Continue Processing]
+        D -->|Cancelled| F[TaskCancelledException]
+        E --> G[Build Sub-Aggregations]
+        G --> D
+    end
+    
+    subgraph "Cancellation Triggers"
+        H[Search Backpressure] --> I[Mark Task Cancelled]
+        J[Manual Cancel API] --> I
+        K[Timeout] --> I
+        I --> D
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `AggregatorBase.checkCancelled()` | New protected method that checks if the search context is cancelled and throws `TaskCancelledException` |
+| Cancellation checkpoints | Strategic placement of `checkCancelled()` calls in aggregation building methods |
+
+#### Modified Aggregators
+
+The following aggregator classes now include cancellation checks:
+
+| Aggregator Type | Files Modified |
+|-----------------|----------------|
+| Bucket Aggregators | `BucketsAggregator.java` |
+| Terms Aggregators | `GlobalOrdinalsStringTermsAggregator.java`, `MapStringTermsAggregator.java`, `NumericTermsAggregator.java`, `MultiTermsAggregator.java` |
+| Rare Terms | `LongRareTermsAggregator.java`, `StringRareTermsAggregator.java` |
+| Histogram | `AbstractHistogramAggregator.java`, `AutoDateHistogramAggregator.java`, `DateRangeHistogramAggregator.java`, `VariableWidthHistogramAggregator.java` |
+| Range | `RangeAggregator.java` |
+| Filter | `FiltersAggregator.java`, `AdjacencyMatrixAggregator.java` |
+| Composite | `CompositeAggregator.java` |
+
+### Usage Example
+
+The cancellation mechanism works automatically with existing search backpressure settings:
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "search_backpressure": {
+      "mode": "enforced",
+      "search_task": {
+        "elapsed_time_millis_threshold": 30000,
+        "cpu_time_millis_threshold": 15000
+      }
+    }
+  }
+}
+```
+
+When a query exceeds thresholds, the aggregation will now properly terminate:
+
+```json
+{
+  "error": {
+    "type": "task_cancelled_exception",
+    "reason": "The query has been cancelled"
+  }
+}
+```
+
+### Migration Notes
+
+- No configuration changes required
+- Existing search backpressure settings will now effectively cancel aggregation queries
+- Manual task cancellation via `_tasks/{task_id}/_cancel` API now works for aggregations
+
+## Limitations
+
+- Cancellation checks are added during the **query phase** only
+- The fetch phase (where `InternalAggregation` results are transformed) does not yet have cancellation checks
+- A follow-up PR is planned to add cancellation checks in the fetch phase
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18426](https://github.com/opensearch-project/OpenSearch/pull/18426) | Add task cancellation check in aggregation code paths |
+
+## References
+
+- [Issue #15413](https://github.com/opensearch-project/OpenSearch/issues/15413): Original bug report - Deeply nested aggregations are not terminable
+- [Search Backpressure Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/search-backpressure/): Official documentation on search backpressure
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/aggregation-task-cancellation.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -50,3 +50,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Parent-Child Query Fixes](features/opensearch/parent-child-query-fixes.md) | bugfix | Fix QueryBuilderVisitor pattern for HasParentQuery and HasChildQuery |
 | [HTTP/2 & Reactor-Netty Fix](features/opensearch/http2-reactor-netty-fix.md) | bugfix | Fix HTTP/2 communication when reactor-netty-secure transport is enabled |
 | [Query String & Regex Fixes](features/opensearch/query-string-regex-fixes.md) | bugfix | Fix field alias support, COMPLEMENT flag, and TooComplexToDeterminizeException handling |
+| [Aggregation Task Cancellation](features/opensearch/aggregation-task-cancellation.md) | feature | Add task cancellation checks in aggregators to terminate long-running queries |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Aggregation Task Cancellation feature introduced in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/aggregation-task-cancellation.md`
- Feature report: `docs/features/opensearch/aggregation-task-cancellation.md`

### Key Changes in v3.2.0
- Added `checkCancelled()` method to `AggregatorBase` class
- Integrated cancellation checks in bucket aggregators, terms aggregators, histogram aggregators, range aggregators, and composite aggregators
- Enables search backpressure and manual task cancellation to properly terminate long-running aggregation queries

### Related
- Resolves investigation for Issue #1133
- Based on [PR #18426](https://github.com/opensearch-project/OpenSearch/pull/18426)