### PR TITLE
docs: add segment concurrent search optimization report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -26,6 +26,7 @@
 - [Cluster Manager Metrics](opensearch/cluster-manager-metrics.md)
 - [Code Cleanup](opensearch/code-cleanup.md)
 - [Composite Directory Factory](opensearch/composite-directory-factory.md)
+- [Concurrent Segment Search](opensearch/concurrent-segment-search.md)
 - [Crypto KMS Plugin](opensearch/crypto-kms-plugin.md)
 - [Deprecated Code Cleanup](opensearch/deprecated-code-cleanup.md)
 - [DocRequest Refactoring](opensearch/docrequest-refactoring.md)

--- a/docs/releases/v3.2.0/features/opensearch/segment-concurrent-search-optimization.md
+++ b/docs/releases/v3.2.0/features/opensearch/segment-concurrent-search-optimization.md
@@ -1,0 +1,105 @@
+# Segment Concurrent Search Optimization
+
+## Summary
+
+This release optimizes the segment grouping algorithm for concurrent segment search, improving load balancing across search slices. The new algorithm ensures documents are distributed more evenly across groups, reducing the maximum-minimum document difference between slices and improving search latency for parallel segment searches.
+
+## Details
+
+### What's New in v3.2.0
+
+The segment concurrent search feature now uses an optimized grouping algorithm that replaces the previous round-robin distribution approach with a priority queue-based algorithm that balances document counts across slices.
+
+### Technical Changes
+
+#### Algorithm Change
+
+The previous round-robin approach could lead to significant imbalance in document counts across groups. For example, with segments containing [10, 8, 7, 6, 5, 4] documents and a slice size of 4:
+
+**Previous (Round-Robin) Grouping:**
+- group0: 10, 5 (15 docs)
+- group1: 8, 4 (12 docs)
+- group2: 7 (7 docs)
+- group3: 6 (6 docs)
+- Max-min difference: 9 documents
+
+**New (Optimized) Grouping:**
+- group0: 10 (10 docs)
+- group1: 8 (8 docs)
+- group2: 7, 4 (11 docs)
+- group3: 6, 5 (11 docs)
+- Max-min difference: 3 documents
+
+#### Implementation Details
+
+The `MaxTargetSliceSupplier` class now uses a `PriorityQueue` to track the document count sum for each group:
+
+```java
+PriorityQueue<Group> groupQueue = new PriorityQueue<>();
+for (int i = 0; i < targetSliceCount; i++) {
+    groupQueue.offer(new Group(i));
+}
+
+for (int i = 0; i < sortedLeaves.size(); ++i) {
+    Group minGroup = groupQueue.poll();
+    groupedLeaves.get(minGroup.index).add(
+        IndexSearcher.LeafReaderContextPartition.createForEntireSegment(sortedLeaves.get(i))
+    );
+    minGroup.sum += sortedLeaves.get(i).reader().maxDoc();
+    groupQueue.offer(minGroup);
+}
+```
+
+The algorithm:
+1. Sorts segments by document count in descending order
+2. Maintains a priority queue of groups ordered by total document count
+3. Assigns each segment to the group with the smallest current document sum
+4. Updates the group's sum and reinserts into the priority queue
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `Group` | Inner class tracking group index and document sum, implementing `Comparable` for priority queue ordering |
+
+### Usage Example
+
+Concurrent segment search is enabled at the cluster or index level:
+
+```json
+PUT _cluster/settings
+{
+   "persistent": {
+      "search.concurrent_segment_search.mode": "all"
+   }
+}
+```
+
+The optimization is applied automatically when concurrent segment search is enabled. No additional configuration is required.
+
+### Performance Impact
+
+The optimized grouping algorithm provides:
+- More balanced workload distribution across search threads
+- Reduced tail latency for concurrent segment searches
+- Better resource utilization when segments have varying document counts
+
+## Limitations
+
+- The optimization is most effective when segments have significantly different document counts
+- For segments with similar document counts, the improvement may be minimal
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18451](https://github.com/opensearch-project/OpenSearch/pull/18451) | Optimize grouping for segment concurrent search by ensuring that documents within each group are as equal as possible |
+
+## References
+
+- [Concurrent Segment Search Documentation](https://docs.opensearch.org/3.0/search-plugins/concurrent-segment-search/): Official documentation
+- [Issue #7358](https://github.com/opensearch-project/OpenSearch/issues/7358): Original issue discussing slice computation mechanisms
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/concurrent-segment-search.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -51,4 +51,5 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [HTTP/2 & Reactor-Netty Fix](features/opensearch/http2-reactor-netty-fix.md) | bugfix | Fix HTTP/2 communication when reactor-netty-secure transport is enabled |
 | [Query String & Regex Fixes](features/opensearch/query-string-regex-fixes.md) | bugfix | Fix field alias support, COMPLEMENT flag, and TooComplexToDeterminizeException handling |
 | [Aggregation Task Cancellation](features/opensearch/aggregation-task-cancellation.md) | feature | Add task cancellation checks in aggregators to terminate long-running queries |
+| [Segment Concurrent Search Optimization](features/opensearch/segment-concurrent-search-optimization.md) | feature | Optimize segment grouping for concurrent search with balanced document distribution |
 | [Dependency Bumps (OpenSearch Core)](features/opensearch/dependency-bumps-opensearch-core.md) | feature | 20 dependency updates including Lucene 10.2.2, Log4j 2.25.1, BouncyCastle, OkHttp 5.1.0 |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Segment Concurrent Search Optimization feature in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/segment-concurrent-search-optimization.md`
- Feature report: `docs/features/opensearch/concurrent-segment-search.md` (new)

### Key Changes in v3.2.0
- Optimized segment grouping algorithm using priority queue for better load balancing
- Replaced round-robin distribution with document count-aware grouping
- Reduces max-min document difference between slices for improved search latency

### Resources Used
- PR: [#18451](https://github.com/opensearch-project/OpenSearch/pull/18451)
- Docs: https://docs.opensearch.org/3.0/search-plugins/concurrent-segment-search/

Closes #1131