### PR TITLE
docs: add repository-rate-limiters report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -85,6 +85,7 @@
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)
 - [Replication](opensearch/replication.md)
 - [Remote Store](opensearch/remote-store.md)
+- [Repository Rate Limiters](opensearch/repository-rate-limiters.md)
 - [RestHandler.Wrapper](opensearch/resthandler-wrapper.md)
 - [Remote Store Metrics](opensearch/remote-store-metrics.md)
 - [S3 Repository](opensearch/s3-repository.md)

--- a/docs/features/opensearch/repository-rate-limiters.md
+++ b/docs/features/opensearch/repository-rate-limiters.md
@@ -1,0 +1,132 @@
+# Repository Rate Limiters
+
+## Summary
+
+Repository rate limiters control the throughput of snapshot and restore operations in OpenSearch. These settings allow operators to limit I/O bandwidth consumption during backup and recovery operations, preventing snapshot operations from overwhelming cluster resources. Starting from v3.2.0, these rate limiter settings can be dynamically adjusted without recreating the repository.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Snapshot Repository"
+        Repo[BlobStoreRepository]
+        Repo --> SRL[snapshotRateLimiter]
+        Repo --> RRL[restoreRateLimiter]
+        Repo --> RURL[remoteUploadRateLimiter]
+        Repo --> RULPL[remoteUploadLowPriorityRateLimiter]
+        Repo --> RDRL[remoteDownloadRateLimiter]
+    end
+    
+    subgraph "Operations"
+        Snap[Snapshot Operation] --> SRL
+        Restore[Restore Operation] --> RRL
+        Upload[Remote Upload] --> RURL
+        LowUpload[Low Priority Upload] --> RULPL
+        Download[Remote Download] --> RDRL
+    end
+    
+    subgraph "Dynamic Update"
+        API[PUT /_snapshot/repo] --> RS[RepositoriesService]
+        RS --> Check{Reloadable?}
+        Check -->|Yes| Update[Update Rate Limiters]
+        Check -->|No| Recreate[Recreate Repository]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Rate Limiting Flow"
+        Data[Data Stream] --> RL[RateLimiter]
+        RL --> Pause{Rate Exceeded?}
+        Pause -->|Yes| Wait[Wait/Throttle]
+        Pause -->|No| Write[Write to Storage]
+        Wait --> Write
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `BlobStoreRepository` | Base repository class managing rate limiters |
+| `RateLimiter.SimpleRateLimiter` | Lucene rate limiter implementation |
+| `RELOADABLE_SETTINGS` | Set of dynamically updatable setting keys |
+| `isReloadableSettings()` | Method to check if settings can be hot-reloaded |
+| `RepositoriesService` | Service handling repository registration and updates |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `max_snapshot_bytes_per_sec` | Maximum rate for snapshot creation | `40mb` |
+| `max_restore_bytes_per_sec` | Maximum rate for snapshot restore | `0` (unlimited) |
+| `max_remote_upload_bytes_per_sec` | Maximum rate for remote store uploads | `0` (unlimited) |
+| `max_remote_low_priority_upload_bytes_per_sec` | Maximum rate for low-priority remote uploads | `0` (unlimited) |
+| `max_remote_download_bytes_per_sec` | Maximum rate for remote store downloads | `0` (unlimited) |
+
+### Usage Example
+
+```json
+// Create repository with rate limits
+PUT /_snapshot/my-repository
+{
+  "type": "fs",
+  "settings": {
+    "location": "/mnt/snapshots",
+    "max_snapshot_bytes_per_sec": "100mb",
+    "max_restore_bytes_per_sec": "200mb"
+  }
+}
+
+// Dynamically update rate limits (v3.2.0+)
+PUT /_snapshot/my-repository
+{
+  "type": "fs",
+  "settings": {
+    "max_snapshot_bytes_per_sec": "50mb",
+    "max_restore_bytes_per_sec": "100mb"
+  }
+}
+```
+
+For S3 repositories:
+
+```json
+PUT /_snapshot/s3-repository
+{
+  "type": "s3",
+  "settings": {
+    "bucket": "my-bucket",
+    "base_path": "snapshots",
+    "max_snapshot_bytes_per_sec": "40mb",
+    "max_restore_bytes_per_sec": "40mb"
+  }
+}
+```
+
+## Limitations
+
+- Rate limiting applies per-node, not cluster-wide
+- Setting value to `0` disables rate limiting (unlimited throughput)
+- Only the five rate limiter settings are dynamically reloadable; other repository settings require recreation
+- Rate changes affect ongoing operations immediately
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18069](https://github.com/opensearch-project/OpenSearch/pull/18069) | Making multi rate limiters in repository dynamic |
+
+## References
+
+- [Issue #17488](https://github.com/opensearch-project/OpenSearch/issues/17488): Feature request for dynamic snapshot rate settings
+- [Register Snapshot Repository API](https://docs.opensearch.org/3.0/api-reference/snapshots/create-repository/): Official documentation
+- [Take and Restore Snapshots](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/): Snapshot operations guide
+
+## Change History
+
+- **v3.2.0** (2025-07-01): Made rate limiter settings dynamically reloadable without repository recreation

--- a/docs/releases/v3.2.0/features/opensearch/repository-rate-limiters.md
+++ b/docs/releases/v3.2.0/features/opensearch/repository-rate-limiters.md
@@ -1,0 +1,102 @@
+# Repository Rate Limiters
+
+## Summary
+
+This release makes snapshot and restore rate limiter settings dynamically adjustable without recreating the repository. Previously, changing `max_snapshot_bytes_per_sec` or `max_restore_bytes_per_sec` required deleting and recreating the repository. Now these settings can be updated on-the-fly, allowing operators to adjust throughput based on I/O resource availability.
+
+## Details
+
+### What's New in v3.2.0
+
+The following rate limiter settings are now dynamically reloadable:
+
+- `max_snapshot_bytes_per_sec` - Controls snapshot creation rate
+- `max_restore_bytes_per_sec` - Controls snapshot restore rate
+- `max_remote_upload_bytes_per_sec` - Controls remote store upload rate
+- `max_remote_low_priority_upload_bytes_per_sec` - Controls low-priority remote uploads
+- `max_remote_download_bytes_per_sec` - Controls remote store download rate
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Repository Update Flow"
+        API[PUT /_snapshot/repo] --> RS[RepositoriesService]
+        RS --> Check{isReloadableSettings?}
+        Check -->|Yes| Reload[Reload Rate Limiters]
+        Check -->|No| Recreate[Recreate Repository]
+        Reload --> Update[Update RateLimiter instances]
+        Recreate --> New[Create New Repository]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `RELOADABLE_SETTINGS` | Set of setting keys that can be updated without repository recreation |
+| `isReloadableSettings()` | Method in `Repository` interface to check if settings change is reloadable |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `max_snapshot_bytes_per_sec` | Maximum rate for snapshot creation | `40mb` |
+| `max_restore_bytes_per_sec` | Maximum rate for snapshot restore | `0` (unlimited) |
+| `max_remote_upload_bytes_per_sec` | Maximum rate for remote store uploads | `0` (unlimited) |
+| `max_remote_low_priority_upload_bytes_per_sec` | Maximum rate for low-priority remote uploads | `0` (unlimited) |
+| `max_remote_download_bytes_per_sec` | Maximum rate for remote store downloads | `0` (unlimited) |
+
+### Usage Example
+
+```json
+// Create repository with initial rate limits
+PUT /_snapshot/my-fs-repository/
+{
+  "type": "fs",
+  "settings": {
+    "location": "/path/to/snapshots",
+    "max_restore_bytes_per_sec": "100mb",
+    "max_snapshot_bytes_per_sec": "100mb"
+  }
+}
+
+// Dynamically adjust rate limits (no repository recreation needed)
+PUT /_snapshot/my-fs-repository/
+{
+  "type": "fs",
+  "settings": {
+    "max_restore_bytes_per_sec": "50mb",
+    "max_snapshot_bytes_per_sec": "50mb"
+  }
+}
+```
+
+### Migration Notes
+
+- No migration required - existing repositories automatically support dynamic rate limiting
+- Only rate limiter settings can be changed dynamically; other settings (e.g., `location`, `io_buffer_size`) still require repository recreation
+- Rate changes take effect immediately on ongoing snapshot/restore operations
+
+## Limitations
+
+- Only the five rate limiter settings listed above are dynamically reloadable
+- Changing non-reloadable settings (e.g., `chunk_size`, `io_buffer_size`) alongside rate limiters will trigger a full repository recreation
+- The repository must not be in use (no active snapshot/restore operations) when changing non-reloadable settings
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18069](https://github.com/opensearch-project/OpenSearch/pull/18069) | Making multi rate limiters in repository dynamic |
+
+## References
+
+- [Issue #17488](https://github.com/opensearch-project/OpenSearch/issues/17488): Feature request for dynamic snapshot rate settings
+- [Register Snapshot Repository API](https://docs.opensearch.org/3.0/api-reference/snapshots/create-repository/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/repository-rate-limiters.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -53,3 +53,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Aggregation Task Cancellation](features/opensearch/aggregation-task-cancellation.md) | feature | Add task cancellation checks in aggregators to terminate long-running queries |
 | [Segment Concurrent Search Optimization](features/opensearch/segment-concurrent-search-optimization.md) | feature | Optimize segment grouping for concurrent search with balanced document distribution |
 | [Dependency Bumps (OpenSearch Core)](features/opensearch/dependency-bumps-opensearch-core.md) | feature | 20 dependency updates including Lucene 10.2.2, Log4j 2.25.1, BouncyCastle, OkHttp 5.1.0 |
+| [Repository Rate Limiters](features/opensearch/repository-rate-limiters.md) | feature | Dynamic rate limiter settings for snapshot/restore operations |


### PR DESCRIPTION
## Summary

Add documentation for the Repository Rate Limiters feature in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/repository-rate-limiters.md`
- Feature report: `docs/features/opensearch/repository-rate-limiters.md`

### Key Changes in v3.2.0
- Made snapshot/restore rate limiter settings dynamically reloadable
- Five rate limiter settings can now be updated without repository recreation:
  - `max_snapshot_bytes_per_sec`
  - `max_restore_bytes_per_sec`
  - `max_remote_upload_bytes_per_sec`
  - `max_remote_low_priority_upload_bytes_per_sec`
  - `max_remote_download_bytes_per_sec`

### Resources Used
- PR: [opensearch-project/OpenSearch#18069](https://github.com/opensearch-project/OpenSearch/pull/18069)
- Issue: [opensearch-project/OpenSearch#17488](https://github.com/opensearch-project/OpenSearch/issues/17488)
- Docs: https://docs.opensearch.org/3.0/api-reference/snapshots/create-repository/

Closes #1130