### PR TITLE
docs: add node-duress-caching report for v3.2.0

### DIFF
--- a/docs/features/opensearch/search-backpressure.md
+++ b/docs/features/opensearch/search-backpressure.md
@@ -123,16 +123,19 @@ PUT /_cluster/settings
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#18649](https://github.com/opensearch-project/OpenSearch/pull/18649) | Make node duress values cacheable for NodeDuressTrackers |
 | v3.0.0 | [#10028](https://github.com/opensearch-project/OpenSearch/pull/10028) | Add task completion count in search backpressure stats API |
 | v2.18.0 | [#15501](https://github.com/opensearch-project/OpenSearch/pull/15501) | Add validation for the search backpressure cancellation settings |
 
 ## References
 
+- [Issue #18641](https://github.com/opensearch-project/OpenSearch/issues/18641): Latency regression due to node duress trackers
 - [Issue #8698](https://github.com/opensearch-project/OpenSearch/issues/8698): Add total successful task count in nodeStats API
 - [Issue #15495](https://github.com/opensearch-project/OpenSearch/issues/15495): [BUG] Updating some search backpressure settings crash the cluster
-- [Search Backpressure Documentation](https://docs.opensearch.org/2.18/tuning-your-cluster/availability-and-recovery/search-backpressure/): Official documentation
+- [Search Backpressure Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/search-backpressure/): Official documentation
 
 ## Change History
 
+- **v3.2.0** (2025-07-01): Added time-based caching for node duress values to reduce latency overhead from /proc filesystem reads
 - **v3.0.0** (2025-05-06): Added `completion_count` field to stats API for calculating cancellation percentages
 - **v2.18.0** (2024-11-05): Added validation for `cancellation_rate`, `cancellation_ratio`, and `cancellation_burst` settings to prevent cluster crashes

--- a/docs/releases/v3.2.0/features/opensearch/node-duress-caching.md
+++ b/docs/releases/v3.2.0/features/opensearch/node-duress-caching.md
@@ -1,0 +1,97 @@
+# Node Duress Caching
+
+## Summary
+
+This release introduces time-based caching for node duress values in the Search Backpressure mechanism. Previously, every call to check if a node was under duress required reading CPU and JVM memory utilization from the `/proc` virtual file system, causing significant latency overhead (3x-9x regression) under workload management traffic. The new caching mechanism amortizes this cost by caching duress values for 1 second, dramatically reducing search request latency from 35+ ms to 4-6 ms.
+
+## Details
+
+### What's New in v3.2.0
+
+The `NodeDuressTrackers` class now caches resource duress values using a new `TimeBasedExpiryTracker` utility. Instead of evaluating node duress on every request, the system now:
+
+1. Checks if the cache has expired (default: 1 second)
+2. If expired, refreshes all resource type duress values
+3. Returns cached values for subsequent requests within the expiry window
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.2.0"
+        Request1[Search Request] --> Check1[Check Node Duress]
+        Check1 --> Read1[Read /proc filesystem]
+        Read1 --> Result1[Return Result]
+    end
+    
+    subgraph "After v3.2.0"
+        Request2[Search Request] --> Cache{Cache Expired?}
+        Cache -->|Yes| Refresh[Refresh Cache from /proc]
+        Refresh --> Store[Store in ConcurrentHashMap]
+        Store --> Return2[Return Cached Value]
+        Cache -->|No| Return2
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `TimeBasedExpiryTracker` | A utility class that tracks time-based expiration events with nanosecond precision. Returns `true` when the configured expiry time has elapsed since the last access. |
+| `resourceDuressCache` | A `ConcurrentHashMap<ResourceType, Boolean>` that stores cached duress values for each resource type (CPU, MEMORY). |
+| `nodeDuressCacheExpiryChecker` | A `BooleanSupplier` that determines when the cache should be refreshed. |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Cache expiry time | Time interval for cache refresh | 1 second (1,000,000,000 nanoseconds) |
+
+Note: The cache expiry time is currently hardcoded and not configurable via cluster settings.
+
+### Usage Example
+
+The caching is transparent to users. No configuration changes are required. The performance improvement is automatic when using Search Backpressure or Workload Management features.
+
+```java
+// Internal implementation - cache is checked automatically
+public boolean isResourceInDuress(ResourceType resourceType) {
+    updateCache();  // Only refreshes if cache expired
+    return resourceDuressCache.get(resourceType);
+}
+
+private void updateCache() {
+    if (nodeDuressCacheExpiryChecker.getAsBoolean()) {
+        for (ResourceType resourceType : ResourceType.values())
+            resourceDuressCache.put(resourceType, duressTrackers.get(resourceType).test());
+    }
+}
+```
+
+### Migration Notes
+
+No migration required. This is a transparent performance optimization that maintains backward compatibility.
+
+## Limitations
+
+- Cache expiry time (1 second) is not configurable via cluster settings
+- The `TimeBasedExpiryTracker` is intentionally not completely thread-safe for nanosecond-level precision; minor timing variations are tolerable
+- During the cache window, duress state changes may not be immediately reflected (up to 1 second delay)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18649](https://github.com/opensearch-project/OpenSearch/pull/18649) | Make node duress values cacheable for NodeDuressTrackers |
+
+## References
+
+- [Issue #18641](https://github.com/opensearch-project/OpenSearch/issues/18641): Latency regression due to node duress trackers
+- [Search Backpressure Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/search-backpressure/): Official documentation
+- [Workload Management Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/workload-management/wlm-feature-overview/): Workload management feature overview
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/search-backpressure.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -51,6 +51,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [HTTP/2 & Reactor-Netty Fix](features/opensearch/http2-reactor-netty-fix.md) | bugfix | Fix HTTP/2 communication when reactor-netty-secure transport is enabled |
 | [Query String & Regex Fixes](features/opensearch/query-string-regex-fixes.md) | bugfix | Fix field alias support, COMPLEMENT flag, and TooComplexToDeterminizeException handling |
 | [Aggregation Task Cancellation](features/opensearch/aggregation-task-cancellation.md) | feature | Add task cancellation checks in aggregators to terminate long-running queries |
+| [Node Duress Caching](features/opensearch/node-duress-caching.md) | feature | Time-based caching for node duress values to reduce search latency overhead |
 | [Segment Concurrent Search Optimization](features/opensearch/segment-concurrent-search-optimization.md) | feature | Optimize segment grouping for concurrent search with balanced document distribution |
 | [Dependency Bumps (OpenSearch Core)](features/opensearch/dependency-bumps-opensearch-core.md) | feature | 20 dependency updates including Lucene 10.2.2, Log4j 2.25.1, BouncyCastle, OkHttp 5.1.0 |
 | [Repository Rate Limiters](features/opensearch/repository-rate-limiters.md) | feature | Dynamic rate limiter settings for snapshot/restore operations |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Node Duress Caching feature introduced in OpenSearch v3.2.0.

### Changes
- Created release report: `docs/releases/v3.2.0/features/opensearch/node-duress-caching.md`
- Updated feature report: `docs/features/opensearch/search-backpressure.md`
- Updated release index: `docs/releases/v3.2.0/index.md`

### Feature Overview
The Node Duress Caching feature introduces time-based caching for node duress values in the Search Backpressure mechanism. This optimization reduces search request latency from 35+ ms to 4-6 ms by caching CPU and JVM memory utilization values instead of reading from `/proc` filesystem on every request.

### Related
- Resolves investigation for Issue #1128
- OpenSearch PR: [#18649](https://github.com/opensearch-project/OpenSearch/pull/18649)
- OpenSearch Issue: [#18641](https://github.com/opensearch-project/OpenSearch/issues/18641)