### PR TITLE
docs: add Secure Aux Transport Settings report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -95,6 +95,7 @@
 - [Search Request Stats](opensearch/search-request-stats.md)
 - [Search Scoring](opensearch/search-scoring.md)
 - [Search Shard Routing](opensearch/search-shard-routing.md)
+- [Secure Aux Transport Settings](opensearch/secure-aux-transport-settings.md)
 - [Secure Transport Settings](opensearch/secure-transport-settings.md)
 - [Segment Replication](opensearch/segment-replication.md)
 - [Segment Warmer](opensearch/segment-warmer.md)

--- a/docs/features/opensearch/secure-aux-transport-settings.md
+++ b/docs/features/opensearch/secure-aux-transport-settings.md
@@ -1,0 +1,164 @@
+# Secure Aux Transport Settings
+
+## Summary
+
+The `SecureAuxTransportSettingsProvider` interface enables security plugins to provide SSL/TLS configuration for OpenSearch auxiliary transports. Auxiliary transports are pluggable communication channels (such as gRPC or Arrow Flight) that operate alongside the primary HTTP and transport layers. This interface allows each auxiliary transport to have its own independent security configuration.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Core"
+        A[NetworkModule] --> B[AuxTransport Registry]
+        B --> C[gRPC Transport]
+        B --> D[Arrow Transport]
+        B --> E[Other Aux Transports]
+    end
+    
+    subgraph "Security Plugin"
+        F[OpenSearchSecurityPlugin] --> G[SecureAuxTransportSettingsProvider]
+        G --> H[SSL Context Builder]
+        G --> I[Transport Parameters]
+    end
+    
+    subgraph "Configuration"
+        J["plugins.security.ssl.aux.grpc.*"]
+        K["plugins.security.ssl.aux.arrow.*"]
+        L["plugins.security.ssl.aux.other.*"]
+    end
+    
+    C -->|settingKey| G
+    D -->|settingKey| G
+    E -->|settingKey| G
+    J --> H
+    K --> H
+    L --> H
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Aux Transport Startup] --> B[Request SSL Context]
+    B --> C{Security Plugin Enabled?}
+    C -->|Yes| D[SecureAuxTransportSettingsProvider]
+    C -->|No| E[Use Default SSLContext]
+    D --> F[Load Transport-Specific Config]
+    F --> G[Build SSLContext]
+    G --> H[Return to Transport]
+    E --> H
+    H --> I[Configure Server Channel]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SecureAuxTransportSettingsProvider` | Interface for providing SSL/TLS settings to auxiliary transports |
+| `SecureAuxTransportParameters` | Interface for ALPN configuration (client auth mode, cipher suites) |
+| `SecureNetty4GrpcServerTransport` | Secure gRPC transport implementation using this interface |
+
+### Configuration
+
+Each auxiliary transport has its own configuration namespace under `plugins.security.ssl.aux.<transport-type>`:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.ssl.aux.<type>.enabled` | Enable TLS for this auxiliary transport | `false` |
+| `plugins.security.ssl.aux.<type>.pemcert_filepath` | Path to PEM certificate file | - |
+| `plugins.security.ssl.aux.<type>.pemkey_filepath` | Path to PEM private key file | - |
+| `plugins.security.ssl.aux.<type>.pemtrustedcas_filepath` | Path to trusted CA certificates | - |
+| `plugins.security.ssl.aux.<type>.clientauth_mode` | Client authentication mode (`NONE`, `OPTIONAL`, `REQUIRE`) | `OPTIONAL` |
+
+### Interface Definition
+
+```java
+@ExperimentalApi
+public interface SecureAuxTransportSettingsProvider {
+    /**
+     * Build an SSLContext for the specified auxiliary transport.
+     * @param settings OpenSearch settings
+     * @param auxTransportType Key identifying the transport (e.g., "experimental-secure-transport-grpc")
+     * @return SSLContext for the transport, or empty to use default
+     */
+    default Optional<SSLContext> buildSecureAuxServerTransportContext(
+        Settings settings, String auxTransportType) throws SSLException {
+        return Optional.empty();
+    }
+
+    /**
+     * Get ALPN parameters for the specified auxiliary transport.
+     * @param settings OpenSearch settings
+     * @param auxTransportType Key identifying the transport
+     * @return Transport parameters including client auth mode and cipher suites
+     */
+    default Optional<SecureAuxTransportParameters> parameters(
+        Settings settings, String auxTransportType) throws SSLException {
+        return Optional.empty();
+    }
+
+    @ExperimentalApi
+    interface SecureAuxTransportParameters {
+        Optional<String> clientAuth();
+        Collection<String> cipherSuites();
+    }
+}
+```
+
+### Usage Example
+
+Configure TLS for the gRPC auxiliary transport:
+
+```yaml
+# opensearch.yml
+
+# Enable gRPC auxiliary transport
+aux.transport.types: experimental-secure-transport-grpc
+aux.transport.experimental-secure-transport-grpc.port: '9400-9500'
+
+# Configure TLS for gRPC transport
+plugins.security.ssl.aux.experimental-secure-transport-grpc.enabled: true
+plugins.security.ssl.aux.experimental-secure-transport-grpc.pemcert_filepath: esnode.pem
+plugins.security.ssl.aux.experimental-secure-transport-grpc.pemkey_filepath: esnode-key.pem
+plugins.security.ssl.aux.experimental-secure-transport-grpc.pemtrustedcas_filepath: root-ca.pem
+plugins.security.ssl.aux.experimental-secure-transport-grpc.clientauth_mode: REQUIRE
+```
+
+Test the secure connection:
+
+```bash
+# Test with client certificate (should succeed)
+grpcurl -insecure \
+  -cert config/esnode.pem \
+  -key config/esnode-key.pem \
+  localhost:9400 list
+
+# Test without client certificate (should fail with REQUIRE mode)
+grpcurl -insecure localhost:9400 list
+```
+
+## Limitations
+
+- The interface is marked as `@ExperimentalApi` and may change in future versions
+- Only provides TLS/SSL configuration; no authorization or authentication is enforced
+- Users can configure `clientauth_mode` to allow/disallow certificates, but no permissions are checked
+- Each transport type requires separate configuration; no inheritance from main transport settings
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18616](https://github.com/opensearch-project/OpenSearch/pull/18616) | Update interface to distinguish between aux transport types |
+| v3.2.0 | [security#5375](https://github.com/opensearch-project/security/pull/5375) | TLS support for auxiliary transports in security plugin |
+
+## References
+
+- [Issue #17795](https://github.com/opensearch-project/OpenSearch/issues/17795): Feature request for separation of auxiliary transport SSL configurations
+- [SecureAuxTransportSettingsProvider.java](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/plugins/SecureAuxTransportSettingsProvider.java): Interface source code
+- [gRPC APIs Documentation](https://docs.opensearch.org/3.0/api-reference/grpc-apis/index/): Official gRPC transport documentation
+
+## Change History
+
+- **v3.2.0** (2025-09-16): Updated interface to accept `auxTransportType` string parameter, enabling transport-specific SSL configurations

--- a/docs/releases/v3.2.0/features/opensearch/secure-aux-transport-settings.md
+++ b/docs/releases/v3.2.0/features/opensearch/secure-aux-transport-settings.md
@@ -1,0 +1,110 @@
+# Secure Aux Transport Settings
+
+## Summary
+
+This release updates the `SecureAuxTransportSettingsProvider` interface to distinguish between different auxiliary transport types. The API change allows security plugins to provide transport-specific SSL/TLS configurations for each auxiliary transport (e.g., gRPC, Arrow Flight) rather than using a single shared configuration.
+
+## Details
+
+### What's New in v3.2.0
+
+The `SecureAuxTransportSettingsProvider` interface methods now accept an `auxTransportType` string parameter instead of an `AuxTransport` instance. This enables security plugins to identify which auxiliary transport is requesting security settings and provide transport-specific configurations.
+
+### Technical Changes
+
+#### API Changes
+
+The interface signature changed from:
+
+```java
+// Before v3.2.0
+Optional<SSLContext> buildSecureAuxServerTransportContext(Settings settings, AuxTransport transport);
+Optional<SecureAuxTransportParameters> parameters();
+```
+
+To:
+
+```java
+// v3.2.0
+Optional<SSLContext> buildSecureAuxServerTransportContext(Settings settings, String auxTransportType) throws SSLException;
+Optional<SecureAuxTransportParameters> parameters(Settings settings, String auxTransportType) throws SSLException;
+```
+
+#### Key Changes
+
+| Change | Description |
+|--------|-------------|
+| Parameter type | `AuxTransport transport` → `String auxTransportType` |
+| Settings parameter | Added `Settings settings` to `parameters()` method |
+| Exception handling | Both methods now declare `throws SSLException` |
+| Import removal | Removed dependency on `AuxTransport` class |
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Auxiliary Transports"
+        A[gRPC Transport] -->|"settingKey()"| D
+        B[Arrow Transport] -->|"settingKey()"| D
+        C[Other Aux Transport] -->|"settingKey()"| D
+    end
+    
+    subgraph "Security Plugin"
+        D[SecureAuxTransportSettingsProvider]
+        D -->|auxTransportType| E[Transport-Specific Config]
+        E --> F["plugins.security.ssl.aux.grpc.*"]
+        E --> G["plugins.security.ssl.aux.arrow.*"]
+        E --> H["plugins.security.ssl.aux.other.*"]
+    end
+```
+
+### Usage Example
+
+The gRPC transport now passes its setting key to the security provider:
+
+```java
+// SecureNetty4GrpcServerTransport.java
+private JdkSslContext getSslContext(Settings settings, SecureAuxTransportSettingsProvider provider) throws SSLException {
+    // Pass the transport's setting key instead of the transport instance
+    Optional<SSLContext> sslContext = provider.buildSecureAuxServerTransportContext(settings, this.settingKey());
+    
+    // Get transport-specific parameters
+    SecureAuxTransportParameters params = provider.parameters(settings, this.settingKey())
+        .orElseGet(DefaultParameters::new);
+    
+    // Configure SSL context with transport-specific settings
+    ClientAuth clientAuth = ClientAuth.valueOf(params.clientAuth().orElseThrow().toUpperCase(Locale.ROOT));
+    return new JdkSslContext(sslContext.get(), false, params.cipherSuites(), ...);
+}
+```
+
+### Migration Notes
+
+Plugins implementing `SecureAuxTransportSettingsProvider` must update their implementations:
+
+1. Change `buildSecureAuxServerTransportContext(Settings, AuxTransport)` to `buildSecureAuxServerTransportContext(Settings, String)`
+2. Change `parameters()` to `parameters(Settings, String)`
+3. Use the `auxTransportType` string to determine which transport-specific configuration to return
+4. Add `throws SSLException` to method signatures
+
+## Limitations
+
+- The `SecureAuxTransportSettingsProvider` interface remains marked as `@ExperimentalApi`
+- This is a breaking API change for existing implementations
+- No authorization component is provided; only SSL/TLS configuration is supported
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18616](https://github.com/opensearch-project/OpenSearch/pull/18616) | Update SecureAuxTransportSettingsProvider to distinguish between aux transport types |
+| [security#5375](https://github.com/opensearch-project/security/pull/5375) | TLS support for auxiliary transports (security plugin implementation) |
+
+## References
+
+- [Issue #17795](https://github.com/opensearch-project/OpenSearch/issues/17795): Feature request for separation of auxiliary transport SSL configurations
+- [SecureAuxTransportSettingsProvider.java](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/plugins/SecureAuxTransportSettingsProvider.java): Interface definition
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/secure-aux-transport-settings.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -55,4 +55,5 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Segment Concurrent Search Optimization](features/opensearch/segment-concurrent-search-optimization.md) | feature | Optimize segment grouping for concurrent search with balanced document distribution |
 | [Dependency Bumps (OpenSearch Core)](features/opensearch/dependency-bumps-opensearch-core.md) | feature | 20 dependency updates including Lucene 10.2.2, Log4j 2.25.1, BouncyCastle, OkHttp 5.1.0 |
 | [Repository Rate Limiters](features/opensearch/repository-rate-limiters.md) | feature | Dynamic rate limiter settings for snapshot/restore operations |
+| [Secure Aux Transport Settings](features/opensearch/secure-aux-transport-settings.md) | feature | API update to distinguish between auxiliary transport types for SSL configuration |
 | [Searchable Snapshots & Writeable Warm](features/opensearch/searchable-snapshots-writeable-warm.md) | feature | FS stats for warm nodes based on addressable space; default remote_data_ratio changed to 5 |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Secure Aux Transport Settings feature in OpenSearch v3.2.0.

## Changes

### Release Report
- `docs/releases/v3.2.0/features/opensearch/secure-aux-transport-settings.md`

### Feature Report
- `docs/features/opensearch/secure-aux-transport-settings.md`

## Key Changes in v3.2.0

The `SecureAuxTransportSettingsProvider` interface was updated to:
- Accept `auxTransportType` string parameter instead of `AuxTransport` instance
- Add `Settings` parameter to `parameters()` method
- Enable transport-specific SSL/TLS configurations for each auxiliary transport (gRPC, Arrow, etc.)

## Related

- Closes #1127
- OpenSearch PR: [#18616](https://github.com/opensearch-project/OpenSearch/pull/18616)
- Security PR: [#5375](https://github.com/opensearch-project/security/pull/5375)