### PR TITLE
docs: add subject-interface-update report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -104,6 +104,7 @@
 - [Star Tree Index](opensearch/star-tree-index.md)
 - [Streaming Indexing](opensearch/streaming-indexing.md)
 - [Stream Input/Output](opensearch/stream-inputoutput.md)
+- [Subject Interface](opensearch/subject-interface.md)
 - [System Ingest Pipeline](opensearch/system-ingest-pipeline.md)
 - [Task Management](opensearch/task-management.md)
 - [Test Fixes](opensearch/test-fixes.md)

--- a/docs/features/opensearch/subject-interface.md
+++ b/docs/features/opensearch/subject-interface.md
@@ -1,0 +1,125 @@
+# Subject Interface
+
+## Summary
+
+The `Subject` interface is a core component of OpenSearch's identity framework. It represents an individual, process, or device that causes information to flow among objects or changes the system state. The interface provides a `runAs` method that allows code to execute in the context of a specific subject, enabling secure operations with proper identity context.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph Identity Framework
+        Subject[Subject Interface]
+        PluginSubject[PluginSubject]
+        NoopPluginSubject[NoopPluginSubject]
+        ShiroPluginSubject[ShiroPluginSubject]
+    end
+    
+    subgraph Implementations
+        Subject --> PluginSubject
+        PluginSubject --> NoopPluginSubject
+        PluginSubject --> ShiroPluginSubject
+    end
+    
+    subgraph Usage
+        Plugin[Plugin Code]
+        ThreadContext[ThreadContext]
+    end
+    
+    Plugin --> Subject
+    NoopPluginSubject --> ThreadContext
+    ShiroPluginSubject --> ThreadContext
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `Subject` | Core interface defining identity operations |
+| `PluginSubject` | Extension of Subject for plugin-specific identity |
+| `NoopPluginSubject` | Default implementation that stashes thread context |
+| `ShiroPluginSubject` | Apache Shiro-based implementation |
+| `CheckedRunnable` | Functional interface for runnable code with checked exceptions |
+
+### Configuration
+
+The Subject interface is part of the experimental identity framework. No specific configuration is required for basic usage.
+
+### API
+
+#### Subject Interface
+
+```java
+@ExperimentalApi
+public interface Subject {
+    /**
+     * Get the application-wide uniquely identifying principal
+     */
+    Principal getPrincipal();
+
+    /**
+     * runAs allows the caller to run a CheckedRunnable as this subject
+     */
+    default <E extends Exception> void runAs(CheckedRunnable<E> r) throws E {
+        r.run();
+    }
+}
+```
+
+### Usage Example
+
+```java
+// Execute code in the context of a subject
+subject.runAs(() -> {
+    // Code here runs with the subject's identity context
+    // ThreadContext is stashed, allowing privileged operations
+    performPrivilegedOperation();
+});
+```
+
+### Integration with IdentityAwarePlugin
+
+Plugins implementing `IdentityAwarePlugin` receive a `PluginSubject` during initialization:
+
+```java
+public class MyPlugin implements IdentityAwarePlugin {
+    private PluginSubject pluginSubject;
+    
+    @Override
+    public void initializeIdentity(PluginSubject subject) {
+        this.pluginSubject = subject;
+    }
+    
+    public void doPrivilegedWork() {
+        pluginSubject.runAs(() -> {
+            // Perform operations with plugin identity
+        });
+    }
+}
+```
+
+## Limitations
+
+- The Subject interface is marked as `@ExperimentalApi` and may change in future versions
+- Custom implementations must properly handle thread context stashing
+- The `runAs` method does not return a value (changed in v3.2.0)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18570](https://github.com/opensearch-project/OpenSearch/pull/18570) | Update Subject interface to use CheckedRunnable |
+| v3.0.0 | [#14630](https://github.com/opensearch-project/OpenSearch/pull/14630) | Add runAs to Subject interface and introduce IdentityAwarePlugin |
+
+## References
+
+- [PR #18570](https://github.com/opensearch-project/OpenSearch/pull/18570): Subject interface update
+- [PR #14630](https://github.com/opensearch-project/OpenSearch/pull/14630): Original Subject.runAs implementation
+- [Security Issue #4439](https://github.com/opensearch-project/security/issues/4439): Related security feature request
+
+## Change History
+
+- **v3.2.0** (2026-01-10): Updated `runAs` method to use `CheckedRunnable` instead of `Callable`, changed return type from `T` to `void`, and added `@PublicApi` annotation to `CheckedRunnable`
+- **v3.0.0** (2024-08-28): Initial implementation - added `runAs` method to Subject interface and introduced `IdentityAwarePlugin` extension point

--- a/docs/releases/v3.2.0/features/opensearch/subject-interface-update.md
+++ b/docs/releases/v3.2.0/features/opensearch/subject-interface-update.md
@@ -1,0 +1,92 @@
+# Subject Interface Update
+
+## Summary
+
+This release item updates the `Subject` interface's `runAs` method to use `CheckedRunnable` instead of `Callable`. This is a code cleanup that improves the API by removing an unused return value and providing more specific exception handling.
+
+## Details
+
+### What's New in v3.2.0
+
+The `Subject.runAs()` method signature has been changed from:
+
+```java
+<T> T runAs(Callable<T> callable) throws Exception
+```
+
+to:
+
+```java
+<E extends Exception> void runAs(CheckedRunnable<E> r) throws E
+```
+
+### Technical Changes
+
+#### API Changes
+
+| Before | After |
+|--------|-------|
+| `Callable<T>` parameter | `CheckedRunnable<E>` parameter |
+| Returns `T` | Returns `void` |
+| Throws generic `Exception` | Throws specific exception type `E` |
+
+#### Rationale
+
+1. **Unused return value**: The return value from `Callable.call()` was never used in practice
+2. **Better exception handling**: `CheckedRunnable<E>` allows callers to specify the exact exception type, avoiding generic `Exception` propagation
+3. **Cleaner API**: The `void` return type better reflects the actual usage pattern
+
+#### Updated Components
+
+| Component | Description |
+|-----------|-------------|
+| `Subject` interface | Core identity interface with updated `runAs` method |
+| `NoopPluginSubject` | Noop implementation updated to use `CheckedRunnable` |
+| `ShiroPluginSubject` | Shiro implementation updated to use `CheckedRunnable` |
+| `CheckedRunnable` | Promoted to `@PublicApi(since = "3.2.0")` |
+
+### Usage Example
+
+Before (v3.1.0 and earlier):
+```java
+subject.runAs(() -> {
+    // perform action
+    return null;  // unused return value
+});
+```
+
+After (v3.2.0):
+```java
+subject.runAs(() -> {
+    // perform action
+});
+```
+
+### Migration Notes
+
+If you have custom `Subject` implementations or use `Subject.runAs()`:
+
+1. Update `runAs` method signature to accept `CheckedRunnable<E>` instead of `Callable<T>`
+2. Change return type from `T` to `void`
+3. Remove any `return` statements from lambda expressions passed to `runAs`
+
+## Limitations
+
+- This is a breaking API change for custom `Subject` implementations
+- Existing code using the return value (though unlikely) will need modification
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18570](https://github.com/opensearch-project/OpenSearch/pull/18570) | Update Subject interface to use CheckedRunnable |
+| [#14630](https://github.com/opensearch-project/OpenSearch/pull/14630) | Original PR that introduced `runAs` to Subject interface |
+
+## References
+
+- [PR #18570](https://github.com/opensearch-project/OpenSearch/pull/18570): Main implementation
+- [PR #14630](https://github.com/opensearch-project/OpenSearch/pull/14630): Related - Add runAs to Subject interface and introduce IdentityAwarePlugin extension point
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/subject-interface.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -57,3 +57,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Repository Rate Limiters](features/opensearch/repository-rate-limiters.md) | feature | Dynamic rate limiter settings for snapshot/restore operations |
 | [Secure Aux Transport Settings](features/opensearch/secure-aux-transport-settings.md) | feature | API update to distinguish between auxiliary transport types for SSL configuration |
 | [Searchable Snapshots & Writeable Warm](features/opensearch/searchable-snapshots-writeable-warm.md) | feature | FS stats for warm nodes based on addressable space; default remote_data_ratio changed to 5 |
+| [Subject Interface Update](features/opensearch/subject-interface-update.md) | feature | Update Subject interface to use CheckedRunnable instead of Callable |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Subject Interface Update feature in OpenSearch v3.2.0.

### Changes
- **Release Report**: `docs/releases/v3.2.0/features/opensearch/subject-interface-update.md`
  - Documents the API change from `Callable<T>` to `CheckedRunnable<E>`
  - Explains the rationale (unused return value, better exception handling)
  - Provides migration notes for custom implementations

- **Feature Report**: `docs/features/opensearch/subject-interface.md`
  - Comprehensive documentation of the Subject interface
  - Architecture diagram showing identity framework components
  - Usage examples and integration patterns
  - Change history tracking both v3.0.0 and v3.2.0 changes

### Related
- Closes #1126
- PR: [opensearch-project/OpenSearch#18570](https://github.com/opensearch-project/OpenSearch/pull/18570)