### PR TITLE
docs: add numeric-terms-aggregation-optimization report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -66,6 +66,7 @@
 - [Node Join/Leave](opensearch/node-join-leave.md)
 - [Nodes Info API](opensearch/nodes-info-api.md)
 - [Node Roles Configuration](opensearch/node-roles-configuration.md)
+- [Numeric Terms Aggregation Optimization](opensearch/numeric-terms-aggregation-optimization.md)
 - [Offline Nodes (Background Tasks)](opensearch/offline-nodes.md)
 - [OpenSearch Core Dependencies](opensearch/opensearch-core-dependencies.md)
 - [Parallel Shard Refresh](opensearch/parallel-shard-refresh.md)

--- a/docs/features/opensearch/numeric-terms-aggregation-optimization.md
+++ b/docs/features/opensearch/numeric-terms-aggregation-optimization.md
@@ -1,0 +1,154 @@
+# Numeric Terms Aggregation Optimization
+
+## Summary
+
+Numeric terms aggregation optimization improves the performance of bucket aggregations by dynamically selecting the most efficient algorithm for top-N bucket selection based on the ratio between requested bucket size and total bucket count. This feature uses quickselect algorithm instead of priority queue when appropriate, reducing computational overhead for large bucket requests.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "NumericTermsAggregator"
+        A[buildAggregations] --> B[BucketSelectionStrategy.determine]
+        B --> C{Strategy Selection}
+        C -->|Small N| D[PRIORITY_QUEUE]
+        C -->|Large N| E[QUICK_SELECT_OR_SELECT_ALL]
+        D --> F[PriorityQueue Top-N]
+        E --> G{Bucket Count Check}
+        G -->|validBuckets > size| H[ArrayUtil.select QuickSelect]
+        G -->|validBuckets <= size| I[Return All Buckets]
+        F --> J[SelectionResult]
+        H --> J
+        I --> J
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Search Request] --> B[NumericTermsAggregator]
+    B --> C[Collect Buckets per Shard]
+    C --> D[Determine Selection Strategy]
+    D --> E[Execute Strategy]
+    E --> F[Return Top Buckets to Coordinator]
+    F --> G[Merge Results]
+    G --> H[Final Aggregation Response]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `BucketSelectionStrategy` | Enum with PRIORITY_QUEUE and QUICK_SELECT_OR_SELECT_ALL strategies |
+| `SelectionInput<B>` | Generic input container for strategy execution parameters |
+| `SelectionResult<B>` | Result container with topBuckets, otherDocCount, and actualStrategyUsed |
+| `BucketDocCountFunction` | Functional interface for bucket document count retrieval |
+| `BucketUpdateFunction<B>` | Functional interface for bucket updates |
+| `BucketArrayBuilder<B>` | Functional interface for bucket array construction |
+| `PriorityQueueBuilder<B>` | Functional interface for priority queue construction |
+
+### Configuration
+
+| Setting | Description | Default | Range |
+|---------|-------------|---------|-------|
+| `search.aggregation.bucket_selection_strategy_factor` | Multiplier to determine strategy threshold. Priority queue used when `size * factor < bucketsInOrd`. | `5` | 0-10 |
+
+### Strategy Selection Algorithm
+
+```java
+// Pseudocode for strategy determination
+if (size * factor < bucketsInOrd || isKeyOrder(order) || partiallyBuiltBucketComparator == null) {
+    return PRIORITY_QUEUE;
+} else {
+    return QUICK_SELECT_OR_SELECT_ALL;
+}
+```
+
+**Strategy conditions:**
+
+| Condition | Strategy | Reason |
+|-----------|----------|--------|
+| `size * factor < bucketsInOrd` | PRIORITY_QUEUE | Small top-N relative to total buckets |
+| `isKeyOrder(order)` | PRIORITY_QUEUE | Key ordering requires sorted output |
+| `partiallyBuiltBucketComparator == null` | PRIORITY_QUEUE | Significant terms aggregation |
+| Otherwise | QUICK_SELECT_OR_SELECT_ALL | Large top-N benefits from quickselect |
+
+### Usage Example
+
+```json
+// Standard terms aggregation - optimization applied automatically
+GET /logs/_search
+{
+  "size": 0,
+  "aggs": {
+    "status_codes": {
+      "terms": {
+        "field": "status_code",
+        "size": 100
+      }
+    }
+  }
+}
+```
+
+```yaml
+# Cluster setting to adjust strategy factor
+PUT /_cluster/settings
+{
+  "persistent": {
+    "search.aggregation.bucket_selection_strategy_factor": 5
+  }
+}
+```
+
+### Debug Information
+
+The selected strategy is exposed in profiling output:
+
+```json
+{
+  "profile": {
+    "shards": [{
+      "aggregations": [{
+        "debug": {
+          "result_strategy": "long_terms",
+          "total_buckets": 1000,
+          "result_selection_strategy": "quick_select"
+        }
+      }]
+    }]
+  }
+}
+```
+
+Possible values for `result_selection_strategy`:
+- `priority_queue`: Traditional PriorityQueue-based selection
+- `quick_select`: QuickSelect algorithm for top-N
+- `select_all`: All valid buckets returned (no selection needed)
+
+## Limitations
+
+- Only applies to numeric field types in terms aggregations
+- Does not optimize significant terms aggregations
+- Does not apply when ordering by key (requires sorted output)
+- Factor setting is cluster-wide, affecting all numeric terms aggregations
+- Memory overhead for QUICK_SELECT_OR_SELECT_ALL is O(bucketsInOrd) vs O(size) for PRIORITY_QUEUE
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18702](https://github.com/opensearch-project/OpenSearch/pull/18702) | Initial implementation with quickselect optimization |
+
+## References
+
+- [Issue #18703](https://github.com/opensearch-project/OpenSearch/issues/18703): Original performance optimization request
+- [Terms Aggregation Documentation](https://docs.opensearch.org/3.2/aggregations/bucket/terms/): Official terms aggregation docs
+- [Lucene ArrayUtil.select](https://lucene.apache.org/core/9_0_0/core/org/apache/lucene/util/ArrayUtil.html): QuickSelect implementation
+
+## Change History
+
+- **v3.2.0** (2025-08-07): Initial implementation with configurable bucket selection strategy factor

--- a/docs/releases/v3.2.0/features/opensearch/numeric-terms-aggregation-optimization.md
+++ b/docs/releases/v3.2.0/features/opensearch/numeric-terms-aggregation-optimization.md
@@ -1,0 +1,124 @@
+# Numeric Terms Aggregation Optimization
+
+## Summary
+
+This release introduces a performance optimization for numeric terms aggregations when dealing with large bucket counts. The optimization uses quickselect algorithm instead of priority queue for top-N bucket selection when the requested size is close to or exceeds the total bucket count, significantly improving aggregation performance.
+
+## Details
+
+### What's New in v3.2.0
+
+The optimization addresses inefficiency in bucket aggregations where data nodes send top-N buckets to the coordinator. When the requested top-N bucket count is close to or exceeds the maximum bucket ordinal, using a PriorityQueue becomes inefficient or redundant.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Bucket Selection Strategy"
+        A[NumericTermsAggregator] --> B{Determine Strategy}
+        B -->|size * factor < bucketsInOrd| C[PRIORITY_QUEUE]
+        B -->|size * factor >= bucketsInOrd| D[QUICK_SELECT_OR_SELECT_ALL]
+        D --> E{validBuckets > size?}
+        E -->|Yes| F[QuickSelect Top-N]
+        E -->|No| G[Return All Buckets]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `BucketSelectionStrategy` | Enum defining bucket selection strategies (PRIORITY_QUEUE, QUICK_SELECT_OR_SELECT_ALL) |
+| `SelectionInput` | Input parameters for strategy execution |
+| `SelectionResult` | Result container with selected buckets and metadata |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `search.aggregation.bucket_selection_strategy_factor` | Factor to determine when to switch from priority queue to quickselect. When `size * factor < bucketsInOrd`, priority queue is used; otherwise quickselect. | `5` |
+
+The setting is:
+- Dynamic (can be changed at runtime)
+- Node-scoped
+- Valid range: 0-10 (0 always uses priority queue)
+
+### Strategy Selection Logic
+
+The strategy is determined based on:
+
+1. **PRIORITY_QUEUE**: Used when:
+   - `size * factor < bucketsInOrd` (requested size is small relative to total buckets)
+   - Order is by key (isKeyOrder)
+   - Significant terms aggregation (partiallyBuiltBucketComparator is null)
+
+2. **QUICK_SELECT_OR_SELECT_ALL**: Used when:
+   - `size * factor >= bucketsInOrd` (requested size is large relative to total buckets)
+   - Uses Lucene's `ArrayUtil.select()` for quickselect algorithm
+   - Returns all buckets if valid bucket count <= requested size
+
+### Usage Example
+
+```json
+// Terms aggregation with large bucket request
+GET /my_index/_search
+{
+  "size": 0,
+  "aggs": {
+    "numeric_terms": {
+      "terms": {
+        "field": "numeric_field",
+        "size": 1000
+      }
+    }
+  }
+}
+```
+
+The optimization is automatic and transparent to users. Debug information is available via the profile API:
+
+```json
+{
+  "profile": {
+    "shards": [{
+      "aggregations": [{
+        "debug": {
+          "result_selection_strategy": "quick_select"
+        }
+      }]
+    }]
+  }
+}
+```
+
+### Performance Impact
+
+Benchmark results show significant improvements when the requested bucket size is close to or exceeds 20% of total buckets:
+
+- **Priority Queue**: Optimal for small top-N requests (< 20% of total buckets)
+- **QuickSelect**: Better performance for larger top-N requests (>= 20% of total buckets)
+- **Select All**: Most efficient when all buckets are needed
+
+## Limitations
+
+- Only applies to `NumericTermsAggregator` (numeric field types)
+- Does not apply to significant terms aggregations
+- Does not apply when ordering by key
+- The factor setting affects all numeric terms aggregations cluster-wide
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18702](https://github.com/opensearch-project/OpenSearch/pull/18702) | Optimization in Numeric Terms Aggregation query for Large Bucket Counts |
+
+## References
+
+- [Issue #18703](https://github.com/opensearch-project/OpenSearch/issues/18703): Performance optimization request
+- [Terms Aggregation Documentation](https://docs.opensearch.org/3.2/aggregations/bucket/terms/): Official docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/numeric-terms-aggregation-optimization.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -58,3 +58,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Secure Aux Transport Settings](features/opensearch/secure-aux-transport-settings.md) | feature | API update to distinguish between auxiliary transport types for SSL configuration |
 | [Searchable Snapshots & Writeable Warm](features/opensearch/searchable-snapshots-writeable-warm.md) | feature | FS stats for warm nodes based on addressable space; default remote_data_ratio changed to 5 |
 | [Subject Interface Update](features/opensearch/subject-interface-update.md) | feature | Update Subject interface to use CheckedRunnable instead of Callable |
+| [Numeric Terms Aggregation Optimization](features/opensearch/numeric-terms-aggregation-optimization.md) | feature | QuickSelect algorithm for large bucket count terms aggregations |


### PR DESCRIPTION
## Summary

Add release and feature reports for Numeric Terms Aggregation Optimization in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/numeric-terms-aggregation-optimization.md`
- Feature report: `docs/features/opensearch/numeric-terms-aggregation-optimization.md`

### Key Changes in v3.2.0
- New `BucketSelectionStrategy` enum with PRIORITY_QUEUE and QUICK_SELECT_OR_SELECT_ALL strategies
- Configurable `search.aggregation.bucket_selection_strategy_factor` setting (default: 5)
- QuickSelect algorithm for top-N bucket selection when requested size is large relative to total buckets
- Debug information exposed via profile API (`result_selection_strategy` field)

### Resources Used
- PR: #18702 (opensearch-project/OpenSearch)
- Issue: #18703 (opensearch-project/OpenSearch)
- Docs: https://docs.opensearch.org/3.2/aggregations/bucket/terms/

Closes #1125