### PR TITLE
docs: add numeric-field-skip-list report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -67,6 +67,7 @@
 - [Nodes Info API](opensearch/nodes-info-api.md)
 - [Node Roles Configuration](opensearch/node-roles-configuration.md)
 - [Numeric Terms Aggregation Optimization](opensearch/numeric-terms-aggregation-optimization.md)
+- [Numeric Field Skip List](opensearch/numeric-field-skip-list.md)
 - [Offline Nodes (Background Tasks)](opensearch/offline-nodes.md)
 - [OpenSearch Core Dependencies](opensearch/opensearch-core-dependencies.md)
 - [Parallel Shard Refresh](opensearch/parallel-shard-refresh.md)

--- a/docs/features/opensearch/numeric-field-skip-list.md
+++ b/docs/features/opensearch/numeric-field-skip-list.md
@@ -1,0 +1,197 @@
+# Numeric Field Skip List
+
+## Summary
+
+The Numeric Field Skip List feature enables skip list indexing on doc values for numeric fields in OpenSearch. When enabled via the `skip_list` mapping parameter, this optimization allows the query engine to efficiently skip over document ranges that don't match query criteria, significantly improving performance for range queries and aggregations on numeric fields.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Query Execution"
+        Q[Range Query] --> E{Skip List Enabled?}
+        E -->|Yes| S[Skip Index Lookup]
+        E -->|No| F[Full Doc Values Scan]
+        S --> R[Skip Non-matching Ranges]
+        R --> M[Match Documents]
+        F --> M
+    end
+    
+    subgraph "Index Structure"
+        DV[Doc Values]
+        SI[Skip Index]
+        DV --> SI
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Indexing"
+        V[Numeric Value] --> FM[Field Mapper]
+        FM --> C{skip_list?}
+        C -->|true| IF[SortedNumericDocValuesField.indexedField]
+        C -->|false| NF[new SortedNumericDocValuesField]
+        IF --> DV[Doc Values + Skip Index]
+        NF --> DV2[Doc Values Only]
+    end
+    
+    subgraph "Querying"
+        RQ[Range Query] --> QE[Query Engine]
+        QE --> SI{Has Skip Index?}
+        SI -->|Yes| SK[Skip Non-matching Blocks]
+        SI -->|No| SC[Sequential Scan]
+        SK --> RS[Results]
+        SC --> RS
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `NumberFieldMapper.Builder.skiplist` | New parameter in field mapper builder |
+| `NumberType.createFields()` | Extended with `skiplist` parameter |
+| `SortedNumericDocValuesField.indexedField()` | Lucene method for creating indexed doc values |
+| `DocValuesSkipIndexType.RANGE` | Skip index type used when skip_list is enabled |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `skip_list` | Boolean value that enables skip list indexing for doc values. Only effective when `doc_values` is also `true`. | `false` |
+
+### Supported Field Types
+
+| Field Type | Support | Notes |
+|------------|---------|-------|
+| `byte` | ✓ | Via INTEGER type |
+| `short` | ✓ | Via INTEGER type |
+| `integer` | ✓ | Direct support |
+| `long` | ✓ | Direct support |
+| `float` | ✓ | Direct support |
+| `double` | ✓ | Direct support |
+| `half_float` | ✓ | Direct support |
+| `unsigned_long` | ✓ | Direct support |
+| `scaled_float` | ✓ | Via LONG type (skip_list hardcoded to false) |
+| `token_count` | ✓ | Via INTEGER type (skip_list hardcoded to false) |
+
+### Usage Example
+
+Create an index with skip list enabled:
+
+```json
+PUT /products
+{
+  "mappings": {
+    "properties": {
+      "price": {
+        "type": "double",
+        "skip_list": true
+      },
+      "stock_quantity": {
+        "type": "integer",
+        "skip_list": true
+      },
+      "rating": {
+        "type": "float",
+        "skip_list": true
+      }
+    }
+  }
+}
+```
+
+Index documents:
+
+```json
+POST /products/_bulk
+{"index": {"_id": "1"}}
+{"price": 29.99, "stock_quantity": 150, "rating": 4.5}
+{"index": {"_id": "2"}}
+{"price": 49.99, "stock_quantity": 75, "rating": 4.8}
+{"index": {"_id": "3"}}
+{"price": 19.99, "stock_quantity": 200, "rating": 4.2}
+```
+
+Range queries benefit from skip list optimization:
+
+```json
+GET /products/_search
+{
+  "query": {
+    "bool": {
+      "filter": [
+        {
+          "range": {
+            "price": {
+              "gte": 20.00,
+              "lte": 40.00
+            }
+          }
+        },
+        {
+          "range": {
+            "stock_quantity": {
+              "gte": 100
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+Aggregations also benefit:
+
+```json
+GET /products/_search
+{
+  "size": 0,
+  "aggs": {
+    "price_ranges": {
+      "range": {
+        "field": "price",
+        "ranges": [
+          { "to": 25 },
+          { "from": 25, "to": 50 },
+          { "from": 50 }
+        ]
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Increases index size due to additional skip index data structure
+- Only effective when `doc_values` is enabled (default is `true`)
+- Performance benefits are most noticeable for:
+  - Range queries on high-cardinality fields
+  - Aggregations with range-based filtering
+  - Analytics workloads with numeric filtering
+- Some field types (`scaled_float`, `token_count`, `size`) have skip_list hardcoded to `false`
+- Requires reindexing to enable on existing fields
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18889](https://github.com/opensearch-project/OpenSearch/pull/18889) | Add skip_list parameter to Numeric Field Mappers (default false) |
+
+## References
+
+- [Issue #17965](https://github.com/opensearch-project/OpenSearch/issues/17965): [SparseIndex] Modify FieldMappers to enable SkipList
+- [PR #18066](https://github.com/opensearch-project/OpenSearch/pull/18066): Previous implementation (replaced by #18889)
+- [Documentation PR #10560](https://github.com/opensearch-project/documentation-website/pull/10560): Add skip_list parameter documentation
+- [Numeric field types documentation](https://docs.opensearch.org/latest/field-types/supported-field-types/numeric/)
+- [OpenSearch 3.2 Release Blog](https://opensearch.org/blog/introducing-opensearch-3-2-next-generation-search-and-anayltics-with-enchanced-ai-capabilities/)
+
+## Change History
+
+- **v3.2.0** (2025-08-19): Initial implementation - Added `skip_list` parameter to all numeric field mappers

--- a/docs/releases/v3.2.0/features/opensearch/numeric-field-skip-list.md
+++ b/docs/releases/v3.2.0/features/opensearch/numeric-field-skip-list.md
@@ -1,0 +1,132 @@
+# Numeric Field Skip List
+
+## Summary
+
+OpenSearch 3.2.0 introduces a new `skip_list` parameter for numeric field mappers that enables skip list indexing on doc values. When enabled, this feature allows the query engine to skip over document ranges that don't match query criteria, significantly improving performance for range queries and aggregations on numeric fields.
+
+## Details
+
+### What's New in v3.2.0
+
+The `skip_list` parameter is a new boolean mapping option for all numeric field types. When set to `true` and `doc_values` is also enabled, OpenSearch creates indexed doc values using Lucene's `SortedNumericDocValuesField.indexedField()` method instead of the standard `SortedNumericDocValuesField` constructor. This enables the skip list data structure that allows efficient range-based document filtering.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Indexing with skip_list=false (Default)"
+        A1[Numeric Value] --> B1[SortedNumericDocValuesField]
+        B1 --> C1[Doc Values Only]
+    end
+    
+    subgraph "Indexing with skip_list=true"
+        A2[Numeric Value] --> B2[SortedNumericDocValuesField.indexedField]
+        B2 --> C2[Doc Values + Skip Index]
+        C2 --> D2[DocValuesSkipIndexType.RANGE]
+    end
+```
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `skip_list` | Boolean value that enables skip list indexing for doc values. Requires `doc_values: true` to have effect. | `false` |
+
+#### Supported Field Types
+
+The `skip_list` parameter is supported on all numeric field types:
+
+| Field Type | Support |
+|------------|---------|
+| `byte` | ✓ |
+| `short` | ✓ |
+| `integer` | ✓ |
+| `long` | ✓ |
+| `float` | ✓ |
+| `double` | ✓ |
+| `half_float` | ✓ |
+| `unsigned_long` | ✓ |
+| `scaled_float` | ✓ (via LONG type) |
+| `token_count` | ✓ (via INTEGER type) |
+
+### Usage Example
+
+Create an index with skip list enabled on a numeric field:
+
+```json
+PUT /testindex_skiplist
+{
+  "mappings": {
+    "properties": {
+      "price": {
+        "type": "double",
+        "skip_list": true
+      },
+      "quantity": {
+        "type": "integer",
+        "skip_list": true
+      }
+    }
+  }
+}
+```
+
+Index documents:
+
+```json
+PUT testindex_skiplist/_doc/1
+{
+  "price": 19.99,
+  "quantity": 100
+}
+```
+
+Range queries on these fields will benefit from skip list optimization:
+
+```json
+GET testindex_skiplist/_search
+{
+  "query": {
+    "range": {
+      "price": {
+        "gte": 10.00,
+        "lte": 50.00
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- This is a new optional parameter with no impact on existing indexes
+- To enable skip list on existing fields, you must reindex the data
+- The parameter only takes effect when `doc_values` is also `true`
+- Backward compatible: older versions will ignore the parameter
+
+## Limitations
+
+- Skip list indexing increases index size due to additional skip index data structure
+- Only effective when `doc_values` is enabled (default is `true`)
+- Performance benefits are most noticeable for range queries and aggregations on fields with high cardinality
+- The `scaled_float`, `token_count`, and `size` field mappers pass `false` for skip_list internally
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18889](https://github.com/opensearch-project/OpenSearch/pull/18889) | Add skip_list parameter to Numeric Field Mappers (default false) |
+| [#10560](https://github.com/opensearch-project/documentation-website/pull/10560) | Documentation: Add skip_list parameter to numeric field type |
+
+## References
+
+- [Issue #17965](https://github.com/opensearch-project/OpenSearch/issues/17965): [SparseIndex] Modify FieldMappers to enable SkipList
+- [PR #18066](https://github.com/opensearch-project/OpenSearch/pull/18066): Previous implementation (replaced by #18889)
+- [Numeric field types documentation](https://docs.opensearch.org/latest/field-types/supported-field-types/numeric/)
+- [OpenSearch 3.2 Release Blog](https://opensearch.org/blog/introducing-opensearch-3-2-next-generation-search-and-anayltics-with-enchanced-ai-capabilities/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/numeric-field-skip-list.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -59,3 +59,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Searchable Snapshots & Writeable Warm](features/opensearch/searchable-snapshots-writeable-warm.md) | feature | FS stats for warm nodes based on addressable space; default remote_data_ratio changed to 5 |
 | [Subject Interface Update](features/opensearch/subject-interface-update.md) | feature | Update Subject interface to use CheckedRunnable instead of Callable |
 | [Numeric Terms Aggregation Optimization](features/opensearch/numeric-terms-aggregation-optimization.md) | feature | QuickSelect algorithm for large bucket count terms aggregations |
+| [Numeric Field Skip List](features/opensearch/numeric-field-skip-list.md) | feature | Skip list indexing for numeric field doc values to improve range query performance |


### PR DESCRIPTION
## Summary

Add investigation report for Numeric Field Skip List feature introduced in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/numeric-field-skip-list.md`
- Feature report: `docs/features/opensearch/numeric-field-skip-list.md`

### Key Changes in v3.2.0
- New `skip_list` boolean parameter for all numeric field mappers
- Enables skip list indexing on doc values for improved range query performance
- Supports all numeric types: byte, short, integer, long, float, double, half_float, unsigned_long
- Default is `false` for backward compatibility

### Resources Used
- PR: [#18889](https://github.com/opensearch-project/OpenSearch/pull/18889)
- Issue: [#17965](https://github.com/opensearch-project/OpenSearch/issues/17965)
- Docs PR: [#10560](https://github.com/opensearch-project/documentation-website/pull/10560)
- Blog: [OpenSearch 3.2 Release](https://opensearch.org/blog/introducing-opensearch-3-2-next-generation-search-and-anayltics-with-enchanced-ai-capabilities/)

Closes #1124