### PR TITLE
docs: add scripted-metric-aggregation report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -96,6 +96,7 @@
 - [Search Pipeline](opensearch/search-pipeline.md)
 - [Search Request Stats](opensearch/search-request-stats.md)
 - [Search Scoring](opensearch/search-scoring.md)
+- [Scripted Metric Aggregation](opensearch/scripted-metric-aggregation.md)
 - [Search Shard Routing](opensearch/search-shard-routing.md)
 - [Secure Aux Transport Settings](opensearch/secure-aux-transport-settings.md)
 - [Secure Transport Settings](opensearch/secure-transport-settings.md)

--- a/docs/features/opensearch/scripted-metric-aggregation.md
+++ b/docs/features/opensearch/scripted-metric-aggregation.md
@@ -1,0 +1,132 @@
+# Scripted Metric Aggregation
+
+## Summary
+
+Scripted metric aggregation is a multi-value metric aggregation that returns metrics calculated from user-defined scripts. It provides flexibility for custom aggregation logic through four script stages: init, map, combine, and reduce. In v3.2.0, support was added for using scripted metric aggregations when reducing `InternalValueCount` and `InternalAvg` aggregations, enabling seamless searches across rollup and raw indices.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Scripted Metric Aggregation Flow"
+        A[Search Request] --> B[init_script]
+        B --> C[map_script per shard]
+        C --> D[combine_script per shard]
+        D --> E[reduce_script on coordinator]
+        E --> F[Final Result]
+    end
+    
+    subgraph "Rollup Integration"
+        G[Rollup Index] --> H[InternalScriptedMetric]
+        I[Raw Index] --> J[InternalAvg/InternalValueCount]
+        H --> K[reduce method]
+        J --> K
+        K --> L[Combined Result]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `InternalScriptedMetric` | Internal representation of scripted metric aggregation results |
+| `ScriptedAvg` | Helper class containing sum and count for average calculations |
+| `InternalAvg` | Average aggregation with scripted metric support in reduce |
+| `InternalValueCount` | Value count aggregation with scripted metric support in reduce |
+
+### Script Stages
+
+| Stage | Description | Scope |
+|-------|-------------|-------|
+| `init_script` | Sets initial state before document collection | Once per shard |
+| `map_script` | Processes each document and updates state | Per document |
+| `combine_script` | Aggregates state from each shard | Per shard |
+| `reduce_script` | Combines results from all shards | Coordinator node |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `init_script` | Script to initialize state | Optional |
+| `map_script` | Script to process documents | Required |
+| `combine_script` | Script to combine shard results | Required |
+| `reduce_script` | Script to reduce all results | Required |
+
+### Usage Example
+
+Basic scripted metric aggregation:
+
+```json
+GET my_index/_search
+{
+  "size": 0,
+  "aggs": {
+    "responses.counts": {
+      "scripted_metric": {
+        "init_script": "state.responses = ['error':0L,'success':0L,'other':0L]",
+        "map_script": """
+          def code = doc['response.keyword'].value;
+          if (code.startsWith('5') || code.startsWith('4')) {
+            state.responses.error += 1;
+          } else if(code.startsWith('2')) {
+            state.responses.success += 1;
+          } else {
+            state.responses.other += 1;
+          }
+        """,
+        "combine_script": "state.responses",
+        "reduce_script": """
+          def counts = ['error': 0L, 'success': 0L, 'other': 0L];
+          for (responses in states) {
+            counts.error += responses['error'];
+            counts.success += responses['success'];
+            counts.other += responses['other'];
+          }
+          return counts;
+        """
+      }
+    }
+  }
+}
+```
+
+Searching across rollup and raw indices (enabled in v3.2.0):
+
+```json
+GET rollup_index,raw_index/_search
+{
+  "size": 0,
+  "aggs": {
+    "avg_value": {
+      "avg": {
+        "field": "numeric_field"
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Scripts must be written in Painless scripting language
+- The `reduce_script` has access to a `states` variable containing combined results from all shards
+- When using with rollup indices, the scripted metric result must match expected formats (`ScriptedAvg` for avg, numeric for value_count)
+- Invalid scripted metric results throw `IllegalArgumentException` with descriptive error messages
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18411](https://github.com/opensearch-project/OpenSearch/pull/18411) | Supporting Scripted Metric Aggregation when reducing aggregations in InternalValueCount and InternalAvg |
+
+## References
+
+- [Scripted Metric Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/metric/scripted-metric/): Official documentation
+- [Index Rollups Documentation](https://docs.opensearch.org/3.0/im-plugin/index-rollups/index/): Rollup feature documentation
+- [Index Management PR #1268](https://github.com/opensearch-project/index-management/pull/1268): Original rollup and raw indices search support
+
+## Change History
+
+- **v3.2.0** (2025-08-06): Added support for `InternalScriptedMetric` in `InternalValueCount` and `InternalAvg` reduce methods, enabling searches across rollup and raw indices

--- a/docs/releases/v3.2.0/features/opensearch/scripted-metric-aggregation.md
+++ b/docs/releases/v3.2.0/features/opensearch/scripted-metric-aggregation.md
@@ -1,0 +1,99 @@
+# Scripted Metric Aggregation Support in Reducing Aggregations
+
+## Summary
+
+This release adds support for `InternalScriptedMetric` when reducing `InternalValueCount` and `InternalAvg` aggregations. This fix resolves a `ClassCastException` that occurred when searching rollup and raw indices together, where rollup indices use scripted metric aggregations internally.
+
+## Details
+
+### What's New in v3.2.0
+
+The Index Management plugin introduced support for searching rollup and raw indices together in a previous release. However, a bug was discovered where a `ClassCastException` occurred when trying to reduce `InternalValueCount` and `InternalAvg` aggregations because both used `InternalScriptedMetric` in their aggregation builder for rollup indices.
+
+This PR fixes the issue by adding support for `InternalScriptedMetric` in the reduce methods of both aggregation types.
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ScriptedAvg` | New class to represent scripted average calculations containing sum and count values |
+
+#### Modified Components
+
+| Component | Change |
+|-----------|--------|
+| `InternalAvg.reduce()` | Now handles `InternalScriptedMetric` aggregations by extracting `ScriptedAvg` objects |
+| `InternalValueCount.reduce()` | Now handles `InternalScriptedMetric` aggregations by extracting numeric values |
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Aggregation Reduction"
+        A[Search Request] --> B{Index Type?}
+        B -->|Raw Index| C[InternalAvg/InternalValueCount]
+        B -->|Rollup Index| D[InternalScriptedMetric]
+        C --> E[reduce method]
+        D --> E
+        E --> F{Aggregation Type?}
+        F -->|InternalAvg| G[Extract sum/count from ScriptedAvg]
+        F -->|InternalValueCount| H[Extract numeric value]
+        F -->|InternalScriptedMetric| I[Handle scripted metric]
+        G --> J[Combined Result]
+        H --> J
+        I --> J
+    end
+```
+
+### Usage Example
+
+When searching across both rollup and raw indices with avg or value_count aggregations:
+
+```json
+GET rollup_index,raw_index/_search
+{
+  "size": 0,
+  "aggs": {
+    "avg_field": {
+      "avg": {
+        "field": "numeric_field"
+      }
+    },
+    "count_field": {
+      "value_count": {
+        "field": "numeric_field"
+      }
+    }
+  }
+}
+```
+
+The aggregation now correctly combines results from both index types without throwing a `ClassCastException`.
+
+### Migration Notes
+
+No migration required. This is a bug fix that enables previously failing queries to work correctly.
+
+## Limitations
+
+- The `ScriptedAvg` class expects a specific format from the scripted metric aggregation result
+- Invalid scripted metric results will throw an `IllegalArgumentException` with a descriptive error message
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18411](https://github.com/opensearch-project/OpenSearch/pull/18411) | Supporting Scripted Metric Aggregation when reducing aggregations in InternalValueCount and InternalAvg |
+
+## References
+
+- [PR #18288](https://github.com/opensearch-project/OpenSearch/pull/18288): Related PR (closed without merge)
+- [Index Management PR #1268](https://github.com/opensearch-project/index-management/pull/1268): Original rollup and raw indices search support
+- [Scripted Metric Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/metric/scripted-metric/): Official docs
+- [Index Rollups Documentation](https://docs.opensearch.org/3.0/im-plugin/index-rollups/index/): Rollup feature docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/scripted-metric-aggregation.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -60,3 +60,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Subject Interface Update](features/opensearch/subject-interface-update.md) | feature | Update Subject interface to use CheckedRunnable instead of Callable |
 | [Numeric Terms Aggregation Optimization](features/opensearch/numeric-terms-aggregation-optimization.md) | feature | QuickSelect algorithm for large bucket count terms aggregations |
 | [Numeric Field Skip List](features/opensearch/numeric-field-skip-list.md) | feature | Skip list indexing for numeric field doc values to improve range query performance |
+| [Scripted Metric Aggregation](features/opensearch/scripted-metric-aggregation.md) | feature | Support InternalScriptedMetric in InternalValueCount and InternalAvg reduce methods |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Scripted Metric Aggregation support in reducing aggregations feature introduced in OpenSearch v3.2.0.

## Changes

### Release Report
- `docs/releases/v3.2.0/features/opensearch/scripted-metric-aggregation.md`

### Feature Report
- `docs/features/opensearch/scripted-metric-aggregation.md`

## Key Changes in v3.2.0

- Added support for `InternalScriptedMetric` in `InternalValueCount` and `InternalAvg` reduce methods
- Introduced new `ScriptedAvg` class to represent scripted average calculations
- Fixes `ClassCastException` when searching rollup and raw indices together

## Related Issue
Closes #1123