### PR TITLE
docs: add derived source report for v3.2.0

### DIFF
--- a/docs/features/opensearch/derived-source.md
+++ b/docs/features/opensearch/derived-source.md
@@ -60,13 +60,17 @@ flowchart LR
 | `SortedSetDocValuesFetcher` | Fetches string values from sorted set doc values (keyword, IP fields) |
 | `StoredFieldFetcher` | Fetches values from stored fields using `SingleFieldsVisitor` |
 | `FieldValueType` | Enum with values `DOC_VALUES` and `STORED` indicating storage preference |
+| `DerivedSourceDirectoryReader` | FilterDirectoryReader that wraps readers to support derived source (v3.2.0+) |
+| `DerivedSourceLeafReader` | LeafReader wrapper providing access to derived source (v3.2.0+) |
+| `DerivedSourceStoredFieldsReader` | StoredFieldsReader that injects `_source` field by deriving it dynamically (v3.2.0+) |
+| `TranslogOperationHelper` | Helper class for comparing translog operations with derived source support (v3.2.0+) |
 
 ### Configuration
 
 | Setting | Description | Default |
 |---------|-------------|---------|
 | `index.derived_source.enabled` | Enable derived source for the index | `false` |
-| `index.derived_source.translog.enabled` | Enable derived source for translog operations | `true` |
+| `index.derived_source.translog.enabled` | Enable derived source for translog operations (dynamic, v3.2.0+) | Same as `index.derived_source.enabled` |
 
 ### Supported Field Types
 
@@ -148,6 +152,7 @@ Search latency may increase by 10-100% depending on the number of documents retr
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#18565](https://github.com/opensearch-project/OpenSearch/pull/18565) | Add integration of derived source feature across various paths like get/search/recovery |
 | v3.1.0 | [#17759](https://github.com/opensearch-project/OpenSearch/pull/17759) | Adding support for derive source feature and implementing it for various type of field mappers |
 
 ## References
@@ -160,4 +165,5 @@ Search latency may increase by 10-100% depending on the number of documents retr
 
 ## Change History
 
+- **v3.2.0** (2026-01-10): Integration across get/search/recovery paths - Added DerivedSourceDirectoryReader, DerivedSourceLeafReader, DerivedSourceStoredFieldsReader, TranslogOperationHelper; Added dynamic `index.derived_source.translog.enabled` setting; Fixed flaky test issues from reverted PR #18054; Added Star-Tree mapper compatibility
 - **v3.1.0** (2026-01-10): Initial implementation - Added derive source support for basic field types including Date, Number, Boolean, IP, Keyword, Text, Geo Point, Constant Keyword, Scaled Float, and Wildcard

--- a/docs/releases/v3.2.0/features/opensearch/derived-source.md
+++ b/docs/releases/v3.2.0/features/opensearch/derived-source.md
@@ -1,0 +1,117 @@
+# Derived Source Integration
+
+## Summary
+
+OpenSearch v3.2.0 completes the integration of the derived source feature across all critical paths including get, search, and recovery operations. This release fixes flaky test issues from the reverted PR #18054 and adds comprehensive support for translog-based operations, ensuring derived source works reliably in production environments.
+
+## Details
+
+### What's New in v3.2.0
+
+This release integrates derived source functionality across various operational paths:
+
+1. **Get/Search Path Integration**: Documents can now be retrieved with dynamically reconstructed `_source` from doc_values and stored fields during search and get operations
+2. **Recovery Path Support**: Derived source now works correctly during shard recovery, including both Lucene-based and translog-based recovery
+3. **Translog Operation Support**: Added `TranslogOperationHelper` class to properly handle derived source comparison during translog operations
+4. **Star-Tree Mapper Compatibility**: Overridden derived source validation for StarTreeMapper to skip star-tree fields (not part of ingested documents)
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "v3.2.0 Integration"
+        A[Document Request] --> B{Operation Type}
+        B -->|Get| C[TranslogLeafReader]
+        B -->|Search| D[DerivedSourceDirectoryReader]
+        B -->|Recovery| E[TranslogOperationHelper]
+        
+        C --> F{Derived Source Enabled?}
+        D --> F
+        E --> F
+        
+        F -->|Yes| G[Create In-Memory Index]
+        G --> H[RootObjectMapper.deriveSource]
+        H --> I[Reconstructed Document]
+        
+        F -->|No| J[Read Original _source]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `DerivedSourceDirectoryReader` | FilterDirectoryReader that wraps readers to support derived source |
+| `DerivedSourceLeafReader` | LeafReader wrapper providing access to derived source |
+| `DerivedSourceStoredFieldsReader` | StoredFieldsReader that injects `_source` field by deriving it dynamically |
+| `TranslogOperationHelper` | Helper class for comparing translog operations with derived source support |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.derived_source.translog.enabled` | Enable/disable derived source for translog reads (dynamic setting) | Same as `index.derived_source.enabled` |
+
+### Usage Example
+
+```json
+PUT sample-index
+{
+  "settings": {
+    "index": {
+      "derived_source": {
+        "enabled": true,
+        "translog": {
+          "enabled": false
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "name": { "type": "keyword" },
+      "value": { "type": "integer" },
+      "timestamp": { "type": "date" }
+    }
+  }
+}
+```
+
+To avoid performance impact on translog-based recovery, you can disable derived source for translog while keeping it enabled for the main index:
+
+```json
+PUT sample-index/_settings
+{
+  "index.derived_source.translog.enabled": false
+}
+```
+
+### Migration Notes
+
+- The `index.derived_source.translog.enabled` setting can be dynamically updated after index creation
+- When `translog.enabled` is `false`, real-time get operations return the original `_source` format until documents are flushed to segments
+- After flush, documents will always return derived source format regardless of translog setting
+
+## Limitations
+
+- **Translog-based recovery performance**: Operation-based recovery can be slower when derived source is enabled for translog, as documents must be re-indexed in memory to reconstruct the source
+- **Source format differences**: When `translog.enabled` is `false`, the `_source` format may differ between translog reads (original format) and segment reads (derived format)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18565](https://github.com/opensearch-project/OpenSearch/pull/18565) | Add integration of derived source feature across various paths like get/search/recovery |
+
+## References
+
+- [Issue #17073](https://github.com/opensearch-project/OpenSearch/issues/17073): Add support for deriving source field in FieldMapper
+- [Issue #9568](https://github.com/opensearch-project/OpenSearch/issues/9568): Optimizing Data Storage and Retrieval for Time Series data
+- [Documentation: Derived source](https://docs.opensearch.org/3.2/field-types/metadata-fields/source/#derived-source)
+- [Blog: Save up to 2x on storage with derived source](https://opensearch.org/blog/save-up-to-2x-on-storage-with-derived-source/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/derived-source.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -10,6 +10,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 
 | Item | Category | Description |
 |------|----------|-------------|
+| [Derived Source Integration](features/opensearch/derived-source.md) | feature | Integration of derived source feature across get/search/recovery paths |
 | [IndexFieldDataService Async Close](features/opensearch/indexfielddataservice-async-close.md) | bugfix | Async field data cache clearing to prevent cluster applier thread blocking |
 | [Staggered Merge Optimization](features/opensearch/staggered-merge-optimization.md) | bugfix | Replace CPU load average with AverageTracker classes, adjust default thresholds |
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Derived Source feature integration in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/derived-source.md`
- Feature report: `docs/features/opensearch/derived-source.md` (updated)

### Key Changes in v3.2.0
- Integration of derived source across get/search/recovery paths
- Added DerivedSourceDirectoryReader, DerivedSourceLeafReader, DerivedSourceStoredFieldsReader components
- Added TranslogOperationHelper for translog operation comparison
- Added dynamic `index.derived_source.translog.enabled` setting
- Fixed flaky test issues from reverted PR #18054
- Added Star-Tree mapper compatibility

### Resources Used
- PR: #18565
- Issue: #17073, #9568
- Docs: https://docs.opensearch.org/3.2/field-types/metadata-fields/source/#derived-source
- Blog: https://opensearch.org/blog/save-up-to-2x-on-storage-with-derived-source/

Closes #1122