### PR TITLE
docs: add composite-aggregation-optimization report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -25,6 +25,7 @@
 - [Cluster Stats API](opensearch/cluster-stats-api.md)
 - [Cluster Manager Metrics](opensearch/cluster-manager-metrics.md)
 - [Code Cleanup](opensearch/code-cleanup.md)
+- [Composite Aggregation](opensearch/composite-aggregation.md)
 - [Composite Directory Factory](opensearch/composite-directory-factory.md)
 - [Concurrent Segment Search](opensearch/concurrent-segment-search.md)
 - [Crypto KMS Plugin](opensearch/crypto-kms-plugin.md)

--- a/docs/features/opensearch/composite-aggregation.md
+++ b/docs/features/opensearch/composite-aggregation.md
@@ -1,0 +1,122 @@
+# Composite Aggregation
+
+## Summary
+
+Composite aggregation is a multi-bucket aggregation that creates composite buckets from different sources. It enables efficient pagination through large result sets by using an `after` parameter, making it ideal for scenarios requiring iteration over all unique combinations of field values.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Composite Aggregation Flow"
+        Query[Search Query] --> CA[CompositeAggregator]
+        CA --> Queue[CompositeValuesCollectorQueue]
+        Queue --> Sources[SingleDimensionValuesSource]
+        Sources --> Buckets[Composite Buckets]
+    end
+    
+    subgraph "Key Components"
+        Queue --> Map[Slot Map]
+        Queue --> DocCounts[Doc Counts Array]
+        Map --> Competitive[addIfCompetitive]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `CompositeAggregator` | Main aggregator that coordinates composite bucket collection |
+| `CompositeValuesCollectorQueue` | Priority queue managing competitive composite keys |
+| `SingleDimensionValuesSource` | Handles value extraction for each dimension |
+| `CompositeValuesSourceConfig` | Configuration for each composite source |
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    Doc[Document] --> Collect[collect method]
+    Collect --> Extract[Extract values from sources]
+    Extract --> Candidate[Create candidate key]
+    Candidate --> Check{Key in queue?}
+    Check -->|Yes| Increment[Increment doc count]
+    Check -->|No| Competitive{Is competitive?}
+    Competitive -->|Yes| Add[Add to queue]
+    Competitive -->|No| Skip[Skip document]
+```
+
+### Configuration
+
+Composite aggregation is configured through the search API:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `sources` | Array of value sources (terms, histogram, date_histogram) | Required |
+| `size` | Number of composite buckets to return | 10 |
+| `after` | Key to paginate after | None |
+
+### Usage Example
+
+```json
+POST /logs/_search
+{
+  "size": 0,
+  "aggs": {
+    "my_buckets": {
+      "composite": {
+        "size": 100,
+        "sources": [
+          { "date": { "date_histogram": { "field": "@timestamp", "calendar_interval": "day" }}},
+          { "product": { "terms": { "field": "product.keyword" }}},
+          { "region": { "terms": { "field": "region.keyword" }}}
+        ]
+      },
+      "aggs": {
+        "avg_price": { "avg": { "field": "price" }}
+      }
+    }
+  }
+}
+```
+
+Pagination using `after`:
+
+```json
+POST /logs/_search
+{
+  "size": 0,
+  "aggs": {
+    "my_buckets": {
+      "composite": {
+        "size": 100,
+        "sources": [...],
+        "after": { "date": 1609459200000, "product": "widget", "region": "us-east" }
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Cannot be used as a sub-aggregation
+- Sources must be deterministic (no script with random values)
+- Memory usage scales with `size` parameter and number of sources
+- Thread safety in concurrent search scenarios requires careful handling
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18531](https://github.com/opensearch-project/OpenSearch/pull/18531) | Optimize by removing unnecessary object allocations |
+
+## References
+
+- [Issue #18440](https://github.com/opensearch-project/OpenSearch/issues/18440): Composite Terms Aggregation Performance Improvement
+- [Bucket Aggregations](https://docs.opensearch.org/3.0/aggregations/bucket/index/): OpenSearch documentation
+
+## Change History
+
+- **v3.2.0**: Performance optimization - reusable Slot object, single-loop initialization, reduced GC pressure

--- a/docs/releases/v3.2.0/features/opensearch/composite-aggregation-optimization.md
+++ b/docs/releases/v3.2.0/features/opensearch/composite-aggregation-optimization.md
@@ -1,0 +1,112 @@
+# Composite Aggregation Optimization
+
+## Summary
+
+This release optimizes composite aggregation performance by eliminating unnecessary object allocations in the hot path. The changes reduce GC pressure and improve throughput for composite terms aggregation queries.
+
+## Details
+
+### What's New in v3.2.0
+
+Performance improvements targeting the `collect()` method in composite aggregations, which profiling showed consumed ~50% of query execution time in the `addIfCompetitive()` path.
+
+### Technical Changes
+
+#### Reusable Slot Object (Flyweight Pattern)
+
+The `CompositeValuesCollectorQueue` now uses a reusable `Slot` instance for map lookups instead of creating new objects:
+
+```java
+// Before: Created new Slot for every lookup
+Integer getCurrentSlot() {
+    return map.get(new Slot(CANDIDATE_SLOT));
+}
+
+// After: Reuses single Slot instance
+private final Slot reusableSlot = new Slot(0);
+
+Integer getCurrentSlot() {
+    reusableSlot.set(CANDIDATE_SLOT);
+    return map.get(reusableSlot);
+}
+```
+
+This is thread-safe because each `LeafCollector` is confined to a single thread.
+
+#### Single-Loop Initialization
+
+Replaced 5 separate stream operations with a single for-loop in `CompositeAggregator`:
+
+```java
+// Before: 5 stream traversals
+this.sourceNames = Arrays.stream(sourceConfigs).map(...).collect(...);
+this.reverseMuls = Arrays.stream(sourceConfigs).mapToInt(...).toArray();
+this.missingOrders = Arrays.stream(sourceConfigs).map(...).toArray(...);
+this.formats = Arrays.stream(sourceConfigs).map(...).collect(...);
+// + separate loop for sources
+
+// After: Single loop
+for (int i = 0; i < numSources; i++) {
+    CompositeValuesSourceConfig sourceConfig = sourceConfigs[i];
+    this.sourceNames.add(sourceConfig.name());
+    this.reverseMuls[i] = sourceConfig.reverseMul();
+    this.missingOrders[i] = sourceConfig.missingOrder();
+    this.formats.add(sourceConfig.format());
+    this.sources[i] = sourceConfig.createValuesSource(...);
+}
+```
+
+#### Additional Optimizations
+
+| Change | Description |
+|--------|-------------|
+| Record class | Converted `Entry` inner class to Java record |
+| Removed boxing | Changed `(long) key` to `key` in `bucketOrdProducer` |
+| Cleaned signatures | Removed unnecessary `throws IOException` from `doPreCollection()` and `doPostCollection()` |
+
+### Performance Impact
+
+- Reduced object allocation in high-frequency `collect()` path
+- Lower GC pressure during composite aggregation execution
+- Most beneficial for queries with 2-3 composite fields (typical use case)
+
+### Usage Example
+
+No API changes. Existing composite aggregation queries automatically benefit:
+
+```json
+POST /logs-*/_search
+{
+  "size": 0,
+  "aggs": {
+    "logs": {
+      "composite": {
+        "sources": [
+          { "timestamp": { "terms": { "field": "@timestamp", "order": "desc" }}},
+          { "status": { "terms": { "field": "status", "order": "asc" }}}
+        ]
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Thread safety relies on single-threaded `LeafCollector` execution
+- Future intra-segment concurrent search may require additional changes (tracked in [#18879](https://github.com/opensearch-project/OpenSearch/pull/18879))
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18531](https://github.com/opensearch-project/OpenSearch/pull/18531) | Optimize Composite Aggregations by removing unnecessary object allocations |
+
+## References
+
+- [Issue #18440](https://github.com/opensearch-project/OpenSearch/issues/18440): Composite Terms Aggregation Performance Improvement
+- [Bucket Aggregations](https://docs.opensearch.org/3.0/aggregations/bucket/index/): OpenSearch documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/composite-aggregation.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -62,3 +62,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Numeric Terms Aggregation Optimization](features/opensearch/numeric-terms-aggregation-optimization.md) | feature | QuickSelect algorithm for large bucket count terms aggregations |
 | [Numeric Field Skip List](features/opensearch/numeric-field-skip-list.md) | feature | Skip list indexing for numeric field doc values to improve range query performance |
 | [Scripted Metric Aggregation](features/opensearch/scripted-metric-aggregation.md) | feature | Support InternalScriptedMetric in InternalValueCount and InternalAvg reduce methods |
+| [Composite Aggregation Optimization](features/opensearch/composite-aggregation-optimization.md) | feature | Optimize composite aggregations by removing unnecessary object allocations |


### PR DESCRIPTION
## Summary

Investigation of Composite Aggregation Optimization for OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/composite-aggregation-optimization.md`
- Feature report: `docs/features/opensearch/composite-aggregation.md`

### Key Changes in v3.2.0
- Reusable Slot object (flyweight pattern) to reduce GC pressure in map lookups
- Single-loop initialization replacing 5 separate stream operations
- Converted Entry inner class to Java record
- Removed unnecessary boxing and exception declarations

### Resources Used
- PR: [#18531](https://github.com/opensearch-project/OpenSearch/pull/18531)
- Issue: [#18440](https://github.com/opensearch-project/OpenSearch/issues/18440)

Closes #1121