### PR TITLE
docs: add remote store segment warming report for v3.2.0

### DIFF
--- a/docs/releases/v3.2.0/features/opensearch/remote-store-segment-warming.md
+++ b/docs/releases/v3.2.0/features/opensearch/remote-store-segment-warming.md
@@ -1,0 +1,122 @@
+# Remote Store Segment Warming
+
+## Summary
+
+This release adds remote store support to the merged segment warmer feature. When segment merges complete on the primary shard, merged segments are now uploaded to the remote store and replicated to replica shards before the refresh completes. This significantly reduces replication lag in remote-store-enabled clusters by pre-copying merged segments through the remote store rather than waiting for the standard segment replication flow.
+
+## Details
+
+### What's New in v3.2.0
+
+- **Remote Store Integration**: The merged segment warmer now supports remote-store-enabled domains, uploading merged segments to remote storage and notifying replicas to download them
+- **Unified Warmer Implementation**: `LocalMergedSegmentWarmer` and `RemoteStoreMergedSegmentWarmer` have been consolidated into a single `MergedSegmentWarmer` class
+- **Low-Priority Rate Limiting**: Downloads of merged segments use a separate low-priority rate limiter to avoid impacting regular operations
+- **Pending Download Tracking**: Replica shards track pending merged segment downloads to coordinate with the remote store
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Primary Shard"
+        IW[IndexWriter]
+        SM[SegmentMerger]
+        MSW[MergedSegmentWarmer]
+        UP[RemoteStoreUploader]
+    end
+    
+    subgraph "Remote Store"
+        RS[(Remote Segment Store)]
+    end
+    
+    subgraph "Replica Shards"
+        R1[Replica 1]
+        R2[Replica N]
+        PD1[PendingDownloads]
+        PD2[PendingDownloads]
+    end
+    
+    SM -->|merge complete| IW
+    IW -->|warm callback| MSW
+    MSW -->|upload segments| UP
+    UP -->|low priority| RS
+    MSW -->|RemoteStorePublishMergedSegmentRequest| R1
+    MSW -->|RemoteStorePublishMergedSegmentRequest| R2
+    R1 -->|mark pending| PD1
+    R2 -->|mark pending| PD2
+    RS -->|low priority download| R1
+    RS -->|low priority download| R2
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `RemoteStorePublishMergedSegmentAction` | Replication action that uploads merged segments to remote store and publishes checkpoints to replicas |
+| `RemoteStoreMergedSegmentCheckpoint` | Checkpoint containing local-to-remote filename mappings for merged segments |
+| `RemoteStorePublishMergedSegmentRequest` | Request sent to replica shards with merged segment information |
+| `DownloadRateLimiterProvider` | Provides appropriate rate limiter based on whether download is for merged segments |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `max_remote_low_priority_download_bytes_per_sec` | Rate limit for low-priority downloads (merged segments) | `0` (unlimited) |
+
+#### API Changes
+
+New transport action registered:
+- `indices:admin/remote_publish_merged_segment` - Publishes merged segment checkpoint to replica shards
+
+### Usage Example
+
+The feature is automatically enabled when using remote-store-enabled indexes with the merged segment warmer feature flag:
+
+```yaml
+# opensearch.yml
+opensearch.experimental.feature.merged_segment_warmer.enabled: true
+```
+
+Configure low-priority download rate limiting in repository settings:
+
+```json
+PUT _snapshot/my-repo
+{
+  "type": "s3",
+  "settings": {
+    "bucket": "my-bucket",
+    "max_remote_low_priority_download_bytes_per_sec": "100mb"
+  }
+}
+```
+
+### Migration Notes
+
+- Existing remote-store-enabled clusters will automatically benefit from this feature when the feature flag is enabled
+- No configuration changes required for basic functionality
+- Consider configuring `max_remote_low_priority_download_bytes_per_sec` to control bandwidth usage for merged segment downloads
+
+## Limitations
+
+- Requires the experimental feature flag `opensearch.experimental.feature.merged_segment_warmer.enabled`
+- Only applicable to remote-store-enabled indexes with segment replication
+- Failures during the warming process are logged but do not block the merge operation
+- Timeout for merged segment replication is controlled by recovery settings
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18683](https://github.com/opensearch-project/OpenSearch/pull/18683) | Core implementation for warming merged segments in remote-store enabled domains |
+| [#18255](https://github.com/opensearch-project/OpenSearch/pull/18255) | Local merged segment warmer support (prerequisite) |
+
+## References
+
+- [Issue #17528](https://github.com/opensearch-project/OpenSearch/issues/17528): RFC - Introduce Pre-copy Merged Segment into Segment Replication
+- [Issue #18625](https://github.com/opensearch-project/OpenSearch/issues/18625): META - Merged segment pre-copy tracking issue
+- [Remote-backed Storage Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/remote-store/index/): Official docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/segment-warmer.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -63,3 +63,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Numeric Field Skip List](features/opensearch/numeric-field-skip-list.md) | feature | Skip list indexing for numeric field doc values to improve range query performance |
 | [Scripted Metric Aggregation](features/opensearch/scripted-metric-aggregation.md) | feature | Support InternalScriptedMetric in InternalValueCount and InternalAvg reduce methods |
 | [Composite Aggregation Optimization](features/opensearch/composite-aggregation-optimization.md) | feature | Optimize composite aggregations by removing unnecessary object allocations |
+| [Remote Store Segment Warming](features/opensearch/remote-store-segment-warming.md) | feature | Remote store support for merged segment warming to reduce replication lag |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Remote Store Segment Warming feature introduced in OpenSearch v3.2.0.

### Changes

- **Release Report**: `docs/releases/v3.2.0/features/opensearch/remote-store-segment-warming.md`
  - Documents the core implementation for warming merged segments in remote-store enabled domains
  - Includes architecture diagram, new components, and configuration options

- **Feature Report Update**: `docs/features/opensearch/segment-warmer.md`
  - Updated architecture diagram to reflect unified `MergedSegmentWarmer`
  - Added new components (`RemoteStorePublishMergedSegmentAction`, `RemoteStoreMergedSegmentCheckpoint`)
  - Added new configuration option (`max_remote_low_priority_download_bytes_per_sec`)
  - Updated change history with v3.2.0 entry

- **Release Index Update**: `docs/releases/v3.2.0/index.md`
  - Added link to the new release report

### Key Feature Details

The merged segment warmer now supports remote-store-enabled domains:
1. Primary shard uploads merged segments to remote store with low-priority rate limiting
2. Primary sends `RemoteStorePublishMergedSegmentRequest` to replicas with segment metadata
3. Replicas download merged segments from remote store before refresh completes
4. Reduces replication lag by pre-copying segments through remote storage

### Related Issue

Closes #1120