### PR TITLE
docs: add Streaming Transport & Aggregation report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -107,6 +107,7 @@
 - [Snapshot Restore Enhancements](opensearch/snapshot-restore-enhancements.md)
 - [Star Tree Index](opensearch/star-tree-index.md)
 - [Streaming Indexing](opensearch/streaming-indexing.md)
+- [Streaming Transport & Aggregation](opensearch/streaming-transport-aggregation.md)
 - [Stream Input/Output](opensearch/stream-inputoutput.md)
 - [Subject Interface](opensearch/subject-interface.md)
 - [System Ingest Pipeline](opensearch/system-ingest-pipeline.md)

--- a/docs/features/opensearch/streaming-transport-aggregation.md
+++ b/docs/features/opensearch/streaming-transport-aggregation.md
@@ -1,0 +1,176 @@
+# Streaming Transport & Aggregation
+
+## Summary
+
+Streaming Transport & Aggregation is a memory-efficient approach to aggregation processing in OpenSearch. Instead of accumulating all partial aggregation results on data nodes before sending them to the coordinator, this feature streams partial results per segment immediately. This redistributes memory load from data nodes to coordinator nodes, improving cluster stability and enabling better resource utilization for high-cardinality aggregation workloads.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph Legend["Legend"]
+        direction LR
+        NewComp["New Component"]
+        OldComp["Existing Component"]
+        style NewComp fill:#bbf,stroke:#333
+        style OldComp fill:#bfb,stroke:#333
+    end
+    
+    subgraph Coordinator["Coordinator Node"]
+        EP[Execution Planner]
+        SC[Stream Consumer]
+        SM[Stream Merger]
+    end
+    
+    subgraph DN1["Data Node 1"]
+        S1[Searcher]
+        A1[Aggregator]
+        SP1[Stream Producer]
+    end
+    
+    subgraph DN2["Data Node 2"]
+        S2[Searcher]
+        A2[Aggregator]
+        SP2[Stream Producer]
+    end
+    
+    Query[Aggregation Query] --> EP
+    EP -->|shard request| S1
+    EP -->|shard request| S2
+    S1 --> A1
+    A1 -->|per-segment results| SP1
+    SP1 --> SC
+    S2 --> A2
+    A2 -->|per-segment results| SP2
+    SP2 --> SC
+    SC --> SM
+    SM --> Result[Final Result]
+    
+    class EP,SC,SM,SP1,SP2 new
+    class S1,A1,S2,A2 old
+    classDef new fill:#bbf,stroke:#333
+    classDef old fill:#bfb,stroke:#333
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph Client["Client"]
+        REQ[Search Request with stream=true]
+    end
+    
+    subgraph Coord["Coordinator"]
+        ROUTE[Route to Shards]
+        CONSUME[Stream Consumer]
+        MERGE[Incremental Merge]
+        FINAL[Final Reduce]
+    end
+    
+    subgraph Data["Data Node"]
+        SEARCH[Search Segments]
+        AGG[Per-Segment Aggregation]
+        STREAM[Stream Results]
+    end
+    
+    REQ --> ROUTE
+    ROUTE --> SEARCH
+    SEARCH --> AGG
+    AGG --> STREAM
+    STREAM -->|partial results| CONSUME
+    CONSUME --> MERGE
+    MERGE -->|all segments done| FINAL
+    FINAL --> Response[Search Response]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `StreamTransportService` | Transport service handling streaming requests with connection management |
+| `StreamSearchTransportService` | Search-specific streaming transport for query/fetch phases |
+| `StreamTransportResponseHandler` | Interface for handling streaming responses with `handleStreamResponse()` |
+| `StreamQueryPhaseResultConsumer` | Consumes and merges streaming aggregation results |
+| `StreamSearchQueryThenFetchAsyncAction` | Coordinates streaming search execution across shards |
+| `StreamStringTermsAggregator` | Per-segment terms aggregator that resets after each batch |
+| `StreamSearchChannelListener` | Sends streaming responses back to coordinator |
+| `StreamSearchActionListener` | Handles intermediate and final streaming responses |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `transport.stream.request_timeout` | Timeout for streaming transport requests | 5 minutes |
+| `opensearch.experimental.feature.transport.stream.enabled` | Feature flag to enable stream transport | false |
+
+### Usage Example
+
+Enable the feature flag in `opensearch.yml`:
+
+```yaml
+opensearch.experimental.feature.transport.stream.enabled: true
+```
+
+Use the `stream` parameter in search requests:
+
+```bash
+GET /my-index/_search?stream=true
+{
+  "size": 0,
+  "aggs": {
+    "categories": {
+      "terms": {
+        "field": "category.keyword"
+      },
+      "aggs": {
+        "max_price": {
+          "max": { "field": "price" }
+        }
+      }
+    }
+  }
+}
+```
+
+Java client usage:
+
+```java
+// Using streaming search
+SearchRequestBuilder builder = client.prepareStreamSearch("my-index")
+    .addAggregation(
+        AggregationBuilders.terms("categories")
+            .field("category.keyword")
+            .subAggregation(AggregationBuilders.max("max_price").field("price"))
+    )
+    .setSize(0);
+
+SearchResponse response = builder.execute().actionGet();
+```
+
+## Limitations
+
+- Currently supports only `terms` bucket aggregation and `max` metric aggregation
+- Requires the Arrow Flight RPC plugin for stream transport implementation
+- Feature is experimental and behind a feature flag
+- Does not support concurrent segment search mode
+- Only `QUERY_THEN_FETCH` search type is supported
+- Pre-filter (can_match) phase is not supported in streaming mode
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18722](https://github.com/opensearch-project/OpenSearch/pull/18722) | APIs for stream transport and stream-based search action |
+| v3.2.0 | [#18874](https://github.com/opensearch-project/OpenSearch/pull/18874) | Streaming aggregation implementation |
+
+## References
+
+- [RFC #16774](https://github.com/opensearch-project/OpenSearch/issues/16774): Streaming Aggregation - A Memory-Efficient Approach
+- [RFC #18425](https://github.com/opensearch-project/OpenSearch/issues/18425): Alternate Stream Transport in OpenSearch
+- [Apache Arrow Flight](https://arrow.apache.org/blog/2019/10/13/introducing-arrow-flight/): Underlying transport technology
+
+## Change History
+
+- **v3.2.0** (2025-08): Initial implementation with stream transport framework and streaming terms aggregation with max sub-aggregation support

--- a/docs/releases/v3.2.0/features/opensearch/streaming-transport-aggregation.md
+++ b/docs/releases/v3.2.0/features/opensearch/streaming-transport-aggregation.md
@@ -1,0 +1,124 @@
+# Streaming Transport & Aggregation
+
+## Summary
+
+OpenSearch v3.2.0 introduces a new streaming transport framework and streaming aggregation capability. This feature enables memory-efficient aggregation processing by streaming partial results from data nodes to coordinator nodes, reducing memory pressure on data nodes and improving cluster stability for high-cardinality aggregation workloads.
+
+## Details
+
+### What's New in v3.2.0
+
+This release introduces two major components:
+
+1. **Stream Transport Framework**: A new transport layer that supports streaming responses, enabling multiple response batches for a single request
+2. **Streaming Aggregation**: Per-segment aggregation results streamed to the coordinator, shifting memory load from data nodes to coordinator nodes
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph Coordinator["Coordinator Node"]
+        EP[Execution Planner]
+        SC[Stream Consumer]
+        SM[Stream Merger]
+    end
+    subgraph DN1["Data Node 1"]
+        S1[Searcher]
+        A1[Aggregator]
+        SP1[Stream Producer]
+    end
+    subgraph DN2["Data Node 2"]
+        S2[Searcher]
+        A2[Aggregator]
+        SP2[Stream Producer]
+    end
+    
+    Query[Aggregation Query] --> EP
+    EP -->|shard request| S1
+    EP -->|shard request| S2
+    S1 --> A1
+    A1 -->|per-segment results| SP1
+    SP1 --> SC
+    S2 --> A2
+    A2 -->|per-segment results| SP2
+    SP2 --> SC
+    SC --> SM
+    SM --> Result[Final Result]
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `StreamTransportService` | Transport service for streaming requests with configurable timeout |
+| `StreamSearchTransportService` | Search-specific streaming transport handling query/fetch phases |
+| `StreamTransportResponseHandler` | Handler interface for processing streaming responses |
+| `StreamQueryPhaseResultConsumer` | Consumes streaming aggregation results and merges them |
+| `StreamSearchQueryThenFetchAsyncAction` | Async action coordinating streaming search execution |
+| `StreamStringTermsAggregator` | Per-segment terms aggregator for streaming mode |
+| `StreamSearchChannelListener` | Listener for sending streaming responses back to coordinator |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `transport.stream.request_timeout` | Timeout for streaming transport requests | 5 minutes |
+| `opensearch.experimental.feature.transport.stream.enabled` | Feature flag to enable stream transport | false |
+
+#### API Changes
+
+New `stream` query parameter for search REST endpoint:
+
+```bash
+GET /index/_search?stream=true
+{
+  "size": 0,
+  "aggs": {
+    "my_terms": {
+      "terms": { "field": "category" }
+    }
+  }
+}
+```
+
+### Usage Example
+
+```java
+// Client-side: Using streaming search
+SearchRequestBuilder builder = client.prepareStreamSearch("index")
+    .addAggregation(AggregationBuilders.terms("agg1").field("field1"))
+    .setSize(0);
+SearchResponse response = builder.execute().actionGet();
+```
+
+### Migration Notes
+
+1. Enable the feature flag: `opensearch.experimental.feature.transport.stream.enabled=true`
+2. Install the `arrow-flight-rpc` plugin for the underlying stream transport implementation
+3. The feature is experimental and behind a feature flag - not recommended for production use yet
+
+## Limitations
+
+- Currently supports only `terms` bucket aggregation and `max` metric aggregation
+- Requires the Arrow Flight RPC plugin to be installed
+- Feature is experimental and behind a feature flag
+- Does not support concurrent segment search mode with streaming
+- Only `QUERY_THEN_FETCH` search type is supported for streaming
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18722](https://github.com/opensearch-project/OpenSearch/pull/18722) | APIs for stream transport and stream-based search action |
+| [#18874](https://github.com/opensearch-project/OpenSearch/pull/18874) | Streaming aggregation implementation |
+
+## References
+
+- [RFC #16774](https://github.com/opensearch-project/OpenSearch/issues/16774): Streaming Aggregation - A Memory-Efficient Approach
+- [RFC #18425](https://github.com/opensearch-project/OpenSearch/issues/18425): Alternate Stream Transport in OpenSearch
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/streaming-transport-aggregation.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -64,3 +64,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Scripted Metric Aggregation](features/opensearch/scripted-metric-aggregation.md) | feature | Support InternalScriptedMetric in InternalValueCount and InternalAvg reduce methods |
 | [Composite Aggregation Optimization](features/opensearch/composite-aggregation-optimization.md) | feature | Optimize composite aggregations by removing unnecessary object allocations |
 | [Remote Store Segment Warming](features/opensearch/remote-store-segment-warming.md) | feature | Remote store support for merged segment warming to reduce replication lag |
+| [Streaming Transport & Aggregation](features/opensearch/streaming-transport-aggregation.md) | feature | Stream transport framework and streaming aggregation for memory-efficient high-cardinality aggregations |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Streaming Transport & Aggregation feature introduced in OpenSearch v3.2.0.

## Reports Created

- Release report: `docs/releases/v3.2.0/features/opensearch/streaming-transport-aggregation.md`
- Feature report: `docs/features/opensearch/streaming-transport-aggregation.md`

## Key Changes in v3.2.0

- New stream transport framework enabling streaming responses for transport requests
- Streaming aggregation that sends per-segment partial results to coordinator
- Memory-efficient approach for high-cardinality aggregation workloads
- Currently supports terms bucket aggregation and max metric aggregation

## Related PRs

- [#18722](https://github.com/opensearch-project/OpenSearch/pull/18722): APIs for stream transport and stream-based search action
- [#18874](https://github.com/opensearch-project/OpenSearch/pull/18874): Streaming aggregation implementation

## Related RFCs

- [#16774](https://github.com/opensearch-project/OpenSearch/issues/16774): Streaming Aggregation - A Memory-Efficient Approach
- [#18425](https://github.com/opensearch-project/OpenSearch/issues/18425): Alternate Stream Transport in OpenSearch

Closes #1119