### PR TITLE
docs: add Combined Fields Query report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -25,6 +25,7 @@
 - [Cluster Stats API](opensearch/cluster-stats-api.md)
 - [Cluster Manager Metrics](opensearch/cluster-manager-metrics.md)
 - [Code Cleanup](opensearch/code-cleanup.md)
+- [Combined Fields Query](opensearch/combined-fields-query.md)
 - [Composite Aggregation](opensearch/composite-aggregation.md)
 - [Composite Directory Factory](opensearch/composite-directory-factory.md)
 - [Concurrent Segment Search](opensearch/concurrent-segment-search.md)

--- a/docs/features/opensearch/combined-fields-query.md
+++ b/docs/features/opensearch/combined-fields-query.md
@@ -1,0 +1,168 @@
+# Combined Fields Query
+
+## Summary
+
+The Combined Fields Query is a full-text search query type that treats multiple text fields as a single combined field for scoring purposes. It uses Lucene's `CombinedFieldQuery` to implement the BM25F (BM25 for multi-field documents) scoring algorithm, providing more accurate relevance ranking when searching across multiple related text fields such as title, body, and summary.
+
+This query is particularly useful when you want to search across multiple fields that conceptually represent the same content (e.g., a document's title and body) and want the scoring to reflect how well the query matches the document as a whole, rather than scoring each field independently.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Query Execution Flow"
+        A[User Query] --> B[combined_fields Query DSL]
+        B --> C[CombinedFieldsQueryBuilder]
+        C --> D{Field Validation}
+        D -->|Valid Text Fields| E{Analyzer Validation}
+        D -->|Invalid Field Type| F[IllegalArgumentException]
+        E -->|Same Analyzer| G[Build Query]
+        E -->|Different Analyzers| H[IllegalArgumentException]
+        G --> I[Lucene CombinedFieldQuery]
+    end
+    
+    subgraph "BM25F Scoring"
+        I --> J[Combine Document Frequencies]
+        J --> K[Apply Field Weights]
+        K --> L[Calculate BM25F Score]
+        L --> M[Return Ranked Results]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph Input
+        Q[Query Text] --> A[Analyzer]
+        F[Fields + Weights] --> V[Validator]
+    end
+    
+    subgraph Processing
+        A --> T[Tokenized Terms]
+        V --> MF[Mapped Fields]
+        T --> CFQ[CombinedFieldQuery Builder]
+        MF --> CFQ
+    end
+    
+    subgraph Scoring
+        CFQ --> TF[Combined Term Frequency]
+        CFQ --> DF[Shared Document Frequency]
+        TF --> BM25F[BM25F Score]
+        DF --> BM25F
+    end
+    
+    subgraph Output
+        BM25F --> R[Ranked Results]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `CombinedFieldsQueryBuilder` | Main query builder class that handles query construction, validation, and serialization |
+| `Builder` (inner class) | Extends Lucene's `QueryBuilder` to create `CombinedFieldQuery` instances with BM25F scoring |
+| `CombinedFieldQuery` (Lucene) | Underlying Lucene query that implements the BM25F scoring algorithm |
+
+### Configuration
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `query` | String | The search text to be analyzed and matched against the specified fields | Required |
+| `fields` | Array | List of text field names with optional boost values (e.g., `["title^3", "content^1.5", "summary"]`) | Required |
+| `operator` | String | Boolean operator for combining terms: `AND` (all terms must match) or `OR` (any term can match) | `OR` |
+| `minimum_should_match` | String | Minimum number of optional clauses that must match. Supports absolute numbers (`"2"`), percentages (`"75%"`), and complex expressions (`"2<75%"`) | None |
+| `boost` | Float | Query-level boost factor applied to the entire query score | `1.0` |
+| `_name` | String | Optional query name for identification in search responses | None |
+
+### Usage Examples
+
+#### Basic Usage
+
+```json
+GET articles/_search
+{
+  "query": {
+    "combined_fields": {
+      "query": "machine learning algorithms",
+      "fields": ["title", "abstract", "content"]
+    }
+  }
+}
+```
+
+#### With Field Boosting
+
+```json
+GET articles/_search
+{
+  "query": {
+    "combined_fields": {
+      "query": "distributed systems",
+      "fields": ["title^3", "abstract^2", "content"],
+      "operator": "AND"
+    }
+  }
+}
+```
+
+#### With Minimum Should Match
+
+```json
+GET articles/_search
+{
+  "query": {
+    "combined_fields": {
+      "query": "natural language processing techniques",
+      "fields": ["title^3", "summary^2", "body"],
+      "operator": "or",
+      "minimum_should_match": "75%"
+    }
+  }
+}
+```
+
+### How BM25F Scoring Works
+
+The BM25F algorithm extends the traditional BM25 scoring to handle multiple fields:
+
+1. **Term Frequency Combination**: Term frequencies from all specified fields are combined, weighted by field boost values
+2. **Shared Document Frequency**: Document frequency is calculated across all fields together, not per-field
+3. **Unified Scoring**: The final score treats the document as if all fields were concatenated into a single field
+
+This approach provides more intuitive scoring compared to alternatives like `multi_match` with `cross_fields`, which scores each field independently and then combines scores.
+
+### Comparison with Other Multi-Field Queries
+
+| Query Type | Scoring Approach | Use Case |
+|------------|------------------|----------|
+| `combined_fields` | BM25F (unified field scoring) | Related text fields representing same content |
+| `multi_match` (best_fields) | Max score across fields | Different content types per field |
+| `multi_match` (cross_fields) | Per-field scoring, combined | Mixed field types (may have issues) |
+| `query_string` | Per-field with operators | Complex query syntax needed |
+
+## Limitations
+
+- **Text Fields Only**: Only supports text field types. Attempting to use keyword, numeric, date, or other field types will result in an `IllegalArgumentException`
+- **Same Analyzer Required**: All specified fields must use the same search analyzer. Fields with different analyzers cannot be combined in a single query
+- **No Phrase Support**: Phrase queries (quoted strings like `"exact phrase"`) are explicitly not supported and will throw an error
+- **Experimental Status**: The feature is marked as `@opensearch.experimental`, indicating the API may change in future releases
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18724](https://github.com/opensearch-project/OpenSearch/pull/18724) | Add combined_fields query to utilize Lucene's CombinedField (BM25F Text) |
+
+## References
+
+- [Issue #3996](https://github.com/opensearch-project/OpenSearch/issues/3996): Original feature request for combined_fields (BM25F) support
+- [Documentation Issue #10209](https://github.com/opensearch-project/documentation-website/issues/10209): Documentation request for combined_fields query
+- [BM25F and combined_fields query](https://opensourceconnections.com/blog/2021/06/30/better-term-centric-scoring-in-elasticsearch-with-bm25f-and-the-combined_fields-query/): Background on BM25F scoring algorithm and its benefits
+
+## Change History
+
+- **v3.2.0** (2025-07): Initial implementation of combined_fields query with BM25F scoring support

--- a/docs/releases/v3.2.0/features/opensearch/combined-fields-query.md
+++ b/docs/releases/v3.2.0/features/opensearch/combined-fields-query.md
@@ -1,0 +1,116 @@
+# Combined Fields Query
+
+## Summary
+
+OpenSearch v3.2.0 introduces the `combined_fields` query, a new full-text search query type that treats multiple text fields as a single combined field for scoring purposes. This query leverages Lucene's `CombinedFieldQuery` to implement the BM25F (BM25 for multi-field documents) scoring algorithm, providing more accurate relevance ranking when searching across multiple related text fields like title, body, and summary.
+
+## Details
+
+### What's New in v3.2.0
+
+The `combined_fields` query is a new query type that addresses a common challenge in multi-field search: how to properly score documents when search terms appear across different fields. Unlike `multi_match` with `cross_fields` type, which can encounter issues with non-text fields, `combined_fields` is specifically designed for text fields and uses a principled BM25F scoring approach.
+
+### Technical Changes
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph "Query Processing"
+        A[combined_fields Query] --> B[CombinedFieldsQueryBuilder]
+        B --> C{Validate Fields}
+        C -->|Text Fields Only| D[Validate Shared Analyzer]
+        D --> E[Build Lucene Query]
+        E --> F[CombinedFieldQuery]
+    end
+    
+    subgraph "BM25F Scoring"
+        F --> G[Combine Term Statistics]
+        G --> H[Calculate Field Weights]
+        H --> I[Unified BM25F Score]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `CombinedFieldsQueryBuilder` | Query builder that constructs combined fields queries with field weighting support |
+| `Builder` (inner class) | Extends Lucene's `QueryBuilder` to create `CombinedFieldQuery` instances |
+
+#### Query Parameters
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `query` | String | The search text to analyze and match | Required |
+| `fields` | Array | List of text fields with optional boost values (e.g., `["title^3", "content"]`) | Required |
+| `operator` | String | Boolean operator for combining terms: `AND` or `OR` | `OR` |
+| `minimum_should_match` | String | Minimum number of terms that must match (e.g., `"2"`, `"75%"`) | None |
+| `boost` | Float | Query-level boost factor | `1.0` |
+
+### Usage Example
+
+```json
+GET my_index/_search
+{
+  "query": {
+    "combined_fields": {
+      "query": "distributed systems architecture",
+      "fields": ["title^3", "summary^2", "content"],
+      "operator": "AND"
+    }
+  }
+}
+```
+
+With `minimum_should_match`:
+
+```json
+GET my_index/_search
+{
+  "query": {
+    "combined_fields": {
+      "query": "machine learning algorithms",
+      "fields": ["headline^3", "summary^2", "content"],
+      "operator": "or",
+      "minimum_should_match": "75%"
+    }
+  }
+}
+```
+
+### Key Benefits
+
+1. **BM25F Scoring**: Uses the BM25F algorithm which combines term and collection statistics across fields, treating them as if indexed into a single field
+2. **Field Weighting**: Supports per-field boost values to prioritize matches in more important fields
+3. **Term-Centric Approach**: Scores each term across all fields together, rather than field-by-field
+4. **Consistent Analyzer Requirement**: Ensures all fields use the same search analyzer for accurate scoring
+
+### Constraints
+
+- **Text Fields Only**: Only supports text field types; non-text fields will throw an error
+- **Same Analyzer Required**: All specified fields must use the same search analyzer
+- **No Phrase Support**: Phrase queries are not supported within combined fields
+
+## Limitations
+
+- The query is marked as `@opensearch.experimental`, indicating it may evolve in future releases
+- All fields must share the same search analyzer - fields with different analyzers cannot be combined
+- Only text fields are supported; attempting to use keyword, numeric, or other field types will result in an error
+- Phrase queries (quoted strings) are explicitly not supported
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18724](https://github.com/opensearch-project/OpenSearch/pull/18724) | Add combined_fields query to utilize Lucene's CombinedField (BM25F Text) |
+
+## References
+
+- [Issue #3996](https://github.com/opensearch-project/OpenSearch/issues/3996): Original feature request for combined_fields support
+- [Documentation Issue #10209](https://github.com/opensearch-project/documentation-website/issues/10209): Documentation request for combined_fields query
+- [BM25F and combined_fields query](https://opensourceconnections.com/blog/2021/06/30/better-term-centric-scoring-in-elasticsearch-with-bm25f-and-the-combined_fields-query/): Background on BM25F scoring algorithm
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/combined-fields-query.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -10,6 +10,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 
 | Item | Category | Description |
 |------|----------|-------------|
+| [Combined Fields Query](features/opensearch/combined-fields-query.md) | feature | New combined_fields query with BM25F scoring for multi-field text search |
 | [GRPC Transport](features/opensearch/grpc-transport.md) | feature | GA release - module migration, plugin extensibility, proper gRPC status codes |
 | [Derived Source Integration](features/opensearch/derived-source.md) | feature | Integration of derived source feature across get/search/recovery paths |
 | [IndexFieldDataService Async Close](features/opensearch/indexfielddataservice-async-close.md) | bugfix | Async field data cache clearing to prevent cluster applier thread blocking |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Combined Fields Query feature introduced in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/combined-fields-query.md`
- Feature report: `docs/features/opensearch/combined-fields-query.md`

### Key Changes in v3.2.0
- New `combined_fields` query type for multi-field text search
- Uses Lucene's `CombinedFieldQuery` with BM25F scoring algorithm
- Supports field weighting, AND/OR operators, and minimum_should_match
- Text fields only with same analyzer requirement

### Resources Used
- PR: [#18724](https://github.com/opensearch-project/OpenSearch/pull/18724)
- Issue: [#3996](https://github.com/opensearch-project/OpenSearch/issues/3996)
- Documentation Issue: [#10209](https://github.com/opensearch-project/documentation-website/issues/10209)

Closes #1116