### PR TITLE
docs: add plugin profiling report for v3.2.0

### DIFF
--- a/docs/releases/v3.2.0/features/opensearch/plugin-profiling.md
+++ b/docs/releases/v3.2.0/features/opensearch/plugin-profiling.md
@@ -1,0 +1,178 @@
+# Plugin Profiling
+
+## Summary
+
+OpenSearch v3.2.0 introduces plugin profiling extensibility and multi-shard fetch phase profiling. Plugins can now contribute custom profiling metrics to the search profile output, and fetch phase profiling now works correctly across multi-shard queries.
+
+## Details
+
+### What's New in v3.2.0
+
+This release includes two major profiling enhancements:
+
+1. **Plugin Profiling Extensibility**: Plugins can now register custom `ProfileMetric` suppliers that are included in the query profile breakdown. This allows plugins like k-NN to provide detailed timing information about their internal operations.
+
+2. **Multi-Shard Fetch Phase Profiling**: Previously, fetch phase profiling only worked for single-shard queries. Now fetch profile results are properly collected from each shard and merged with query profile results on the coordinating node.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Search Request"
+        SR[Search Request with profile=true]
+    end
+    
+    subgraph "Query Phase"
+        QP[Query Profiler]
+        PP[Plugin Profilers]
+        QPB[QueryProfileBreakdown]
+    end
+    
+    subgraph "Fetch Phase"
+        FP[Fetch Profiler]
+        FSR[FetchSearchResult]
+    end
+    
+    subgraph "Coordinator Node"
+        SPC[SearchPhaseController]
+        MFP[mergeFetchProfiles]
+    end
+    
+    subgraph "Output"
+        PSR[ProfileShardResult]
+        QR[Query Results]
+        FR[Fetch Results]
+    end
+    
+    SR --> QP
+    SR --> FP
+    QP --> QPB
+    PP --> QPB
+    FP --> FSR
+    FSR --> SPC
+    QP --> SPC
+    SPC --> MFP
+    MFP --> PSR
+    PSR --> QR
+    PSR --> FR
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `SearchPlugin.ProfileMetricsProvider` | Interface for plugins to provide custom profile metrics |
+| `SearchProfileShardResults.buildFetchOnlyShardResults()` | Helper method to build fetch-only profile results for multi-shard queries |
+| `SearchPhaseController.mergeFetchProfiles()` | Merges fetch phase profiles with query phase profiles |
+| `FetchSearchResult.profileResults` | New field to carry fetch profile data back to coordinator |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| N/A | Plugin profiling is automatically enabled when plugins implement `ProfileMetricsProvider` | - |
+
+#### API Changes
+
+**SearchPlugin Interface Extension**
+
+Plugins can now implement `getQueryProfileMetricsProvider()` to contribute custom metrics:
+
+```java
+public interface SearchPlugin {
+    default Optional<ProfileMetricsProvider> getQueryProfileMetricsProvider() {
+        return Optional.empty();
+    }
+    
+    interface ProfileMetricsProvider {
+        Collection<Supplier<ProfileMetric>> getQueryProfileMetrics(
+            SearchContext searchContext, 
+            Query query
+        );
+    }
+}
+```
+
+**FetchSearchResult Changes**
+
+`FetchSearchResult` now includes profile data for multi-shard scenarios:
+
+```java
+public final class FetchSearchResult extends SearchPhaseResult {
+    private ProfileShardResult profileShardResults;
+    
+    public void profileResults(ProfileShardResult shardResults) { ... }
+    public ProfileShardResult getProfileResults() { ... }
+}
+```
+
+### Usage Example
+
+**Plugin Implementation**
+
+```java
+public class MySearchPlugin implements SearchPlugin {
+    @Override
+    public Optional<ProfileMetricsProvider> getQueryProfileMetricsProvider() {
+        return Optional.of((searchContext, query) -> {
+            if (query instanceof MyCustomQuery) {
+                return List.of(() -> new Timer("my_custom_operation"));
+            }
+            return Collections.emptyList();
+        });
+    }
+}
+```
+
+**Profile Response with Plugin Metrics**
+
+```json
+{
+  "profile": {
+    "shards": [{
+      "searches": [{
+        "query": [{
+          "type": "MyCustomQuery",
+          "breakdown": {
+            "create_weight": 10000,
+            "build_scorer": 50000,
+            "my_custom_operation": 25000,
+            "my_custom_operation_count": 5
+          }
+        }]
+      }]
+    }]
+  }
+}
+```
+
+### Migration Notes
+
+- Existing search requests with `profile: true` will automatically include fetch phase profiling for multi-shard queries
+- Plugin developers can optionally implement `ProfileMetricsProvider` to add custom metrics
+- No breaking changes to existing profile API responses
+
+## Limitations
+
+- Plugin metrics are only included in the query breakdown, not as separate sections
+- Fetch phase profiling adds serialization overhead for profile data between nodes
+- Custom metrics must be implemented as `ProfileMetric` (typically `Timer`) instances
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18656](https://github.com/opensearch-project/OpenSearch/pull/18656) | Extend profile capabilities to plugins |
+| [#18887](https://github.com/opensearch-project/OpenSearch/pull/18887) | Expand fetch phase profiling to multi-shard queries |
+
+## References
+
+- [Issue #18460](https://github.com/opensearch-project/OpenSearch/issues/18460): RFC for Profiling Extensibility
+- [Issue #18863](https://github.com/opensearch-project/OpenSearch/issues/18863): Multi-shard fetch profiling request
+- [Profile API Documentation](https://docs.opensearch.org/3.0/api-reference/search-apis/profile/): Official API reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/profiler.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -43,6 +43,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [System Ingest Pipeline Fix](features/opensearch/system-ingest-pipeline-fix.md) | bugfix | Fix system ingest pipeline to properly handle index templates |
 | [Azure Repository Fixes](features/opensearch/azure-repository-fixes.md) | bugfix | Fix SOCKS5 proxy authentication for Azure repository |
 | [Profiler Enhancements](features/opensearch/profiler-enhancements.md) | bugfix | Fix concurrent timings in profiler for concurrent segment search |
+| [Plugin Profiling](features/opensearch/plugin-profiling.md) | feature | Plugin profiling extensibility and multi-shard fetch phase profiling |
 | [Engine Optimization Fixes](features/opensearch/engine-optimization-fixes.md) | bugfix | Fix leafSorter optimization for ReadOnlyEngine and NRTReplicationEngine |
 | [Search Preference & Awareness Fix](features/opensearch/search-preference-awareness-fix.md) | bugfix | Fix custom preference string to ignore awareness attributes for consistent routing |
 | [Settings Management](features/opensearch/settings-management.md) | bugfix | Ignore archived settings on update to unblock settings modifications |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Plugin Profiling feature in OpenSearch v3.2.0.

### Changes

1. **Release Report**: `docs/releases/v3.2.0/features/opensearch/plugin-profiling.md`
   - Documents plugin profiling extensibility via `SearchPlugin.ProfileMetricsProvider`
   - Documents multi-shard fetch phase profiling improvements
   - Includes architecture diagrams, API changes, and usage examples

2. **Feature Report Update**: `docs/features/opensearch/profiler.md`
   - Updated architecture diagram to include plugin profilers and fetch phase
   - Added new components for plugin profiling
   - Updated limitations, PRs, references, and change history

3. **Release Index Update**: `docs/releases/v3.2.0/index.md`
   - Added plugin profiling entry

### Related PRs
- opensearch-project/OpenSearch#18656: Extend profile capabilities to plugins
- opensearch-project/OpenSearch#18887: Expand fetch phase profiling to multi-shard queries

### Related Issue
- Closes #1115