### PR TITLE
docs: add star-tree-index report for v3.2.0

### DIFF
--- a/docs/features/opensearch/star-tree-index.md
+++ b/docs/features/opensearch/star-tree-index.md
@@ -82,7 +82,25 @@ flowchart TB
 | `max_leaf_docs` | Maximum documents per leaf node | `10000` |
 | `skip_star_node_creation_for_dimensions` | Dimensions to skip star node creation | `[]` |
 
+### Monitoring
+
+Star-tree search statistics are available (v3.2.0+) through the stats APIs:
+
+| Metric | Description |
+|--------|-------------|
+| `startree_query_total` | Total queries resolved using star-tree |
+| `startree_query_time_in_millis` | Time spent in star-tree queries |
+| `startree_query_current` | Currently running star-tree queries |
+
+Access via `/_nodes/stats/indices/search`, `/_stats/search`, or `/_stats/search?level=shards`.
+
 ### Supported Features
+
+#### Supported Dimension Types
+- Numeric types: integer, long, float, double, half_float, unsigned_long
+- Keyword fields
+- IP fields (v3.2.0+)
+- Date fields (for date_dimension)
 
 #### Queries
 - Term query
@@ -170,6 +188,8 @@ POST /logs/_search
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#18707](https://github.com/opensearch-project/OpenSearch/pull/18707) | Add star-tree search statistics |
+| v3.2.0 | [#18671](https://github.com/opensearch-project/OpenSearch/pull/18671) | Add IP field search support |
 | v3.1.0 | [#18070](https://github.com/opensearch-project/OpenSearch/pull/18070) | Remove feature flag, add index-level star-tree search setting |
 | v3.1.0 | [#18048](https://github.com/opensearch-project/OpenSearch/pull/18048) | Support nested bucket aggregations |
 | v3.1.0 | [#17855](https://github.com/opensearch-project/OpenSearch/pull/17855) | Support date range queries in aggregations |
@@ -185,6 +205,7 @@ POST /logs/_search
 - [Issue #17274](https://github.com/opensearch-project/OpenSearch/issues/17274): Nested bucket aggregations
 - [Issue #16551](https://github.com/opensearch-project/OpenSearch/issues/16551): Bucket terms aggregation feature request
 - [Issue #16553](https://github.com/opensearch-project/OpenSearch/issues/16553): Range aggregations feature request
+- [Issue #16547](https://github.com/opensearch-project/OpenSearch/issues/16547): IP field support feature request
 - [Issue #15231](https://github.com/opensearch-project/OpenSearch/issues/15231): Unsigned long support
 - [Issue #17267](https://github.com/opensearch-project/OpenSearch/issues/17267): Boolean query support
 - [Issue #15257](https://github.com/opensearch-project/OpenSearch/issues/15257): Star-tree tracking issue
@@ -194,6 +215,7 @@ POST /logs/_search
 
 ## Change History
 
+- **v3.2.0** (2025-09-16): Added IP field search support, star-tree search statistics (query count, time, current)
 - **v3.1.0** (2025-06-10): Production-ready status, removed feature flag, added index-level setting, date range query support, nested bucket aggregations
 - **v3.0.0** (2025-05-12): Added boolean query support, terms aggregations, range aggregations, unsigned-long support
 - **v2.19** (2024-12-10): Added date histogram aggregations, term/terms/range query support

--- a/docs/releases/v3.2.0/features/opensearch/star-tree-index.md
+++ b/docs/releases/v3.2.0/features/opensearch/star-tree-index.md
@@ -1,0 +1,139 @@
+# Star Tree Index
+
+## Summary
+
+OpenSearch v3.2.0 enhances the star-tree index feature with two key improvements: support for IP field type in star-tree queries and new search statistics for monitoring star-tree query performance. These additions expand the dimension types available for star-tree aggregations and provide visibility into star-tree usage at the node, index, and shard levels.
+
+## Details
+
+### What's New in v3.2.0
+
+#### IP Field Search Support
+
+Star-tree index now supports the `ip` field type as a dimension in star-tree queries. This enables aggregations with queries filtering on IP address fields, which is particularly useful for network analytics, security monitoring, and log analysis use cases.
+
+The implementation adds a new `IpFieldMapper` class that handles:
+- Parsing IP addresses from various input types (`InetAddress`, `BytesRef`, `String`)
+- Converting IP values to sortable `BytesRef` using Lucene's `InetAddressPoint.encode()`
+- Supporting both exact match and range-based filtering on IP dimensions
+
+#### Star-Tree Search Statistics
+
+New metrics are now available to monitor star-tree query performance across nodes, indices, and shards:
+
+| Metric | Description |
+|--------|-------------|
+| `startree_query_total` | Total number of queries resolved using star-tree |
+| `startree_query_time_in_millis` | Total time spent resolving queries using star-tree |
+| `startree_query_current` | Number of currently running star-tree queries |
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `IpFieldMapper` | Handles IP address dimension filtering in star-tree queries |
+| `OrdinalFieldMapper` | Abstract base class for ordinal-based dimension mappers (keyword, IP) |
+| `StarTreeSearchStatsIT` | Integration tests for star-tree search statistics |
+
+#### API Changes
+
+Statistics are available through existing stats APIs:
+
+```bash
+# Node-level stats
+GET /_nodes/stats/indices/search
+
+# Index-level stats
+GET /_stats/search
+
+# Shard-level stats
+GET /_stats/search?level=shards
+```
+
+Example response showing star-tree stats:
+```json
+{
+  "search": {
+    "query_total": 7,
+    "query_time_in_millis": 74,
+    "startree_query_total": 4,
+    "startree_query_time_in_millis": 40,
+    "startree_query_current": 0
+  }
+}
+```
+
+### Usage Example
+
+```yaml
+# Index mapping with IP field as star-tree dimension
+PUT logs
+{
+  "settings": {
+    "index.composite_index": true,
+    "index.append_only.enabled": true
+  },
+  "mappings": {
+    "composite": {
+      "network_aggs": {
+        "type": "star_tree",
+        "config": {
+          "ordered_dimensions": [
+            { "name": "client_ip" },
+            { "name": "status" }
+          ],
+          "metrics": [
+            { "name": "bytes", "stats": ["sum", "avg"] }
+          ]
+        }
+      }
+    },
+    "properties": {
+      "client_ip": { "type": "ip" },
+      "status": { "type": "integer" },
+      "bytes": { "type": "long" }
+    }
+  }
+}
+```
+
+```json
+// Query with IP field filter - automatically uses star-tree
+POST /logs/_search
+{
+  "size": 0,
+  "query": {
+    "term": { "client_ip": "192.168.1.1" }
+  },
+  "aggs": {
+    "total_bytes": { "sum": { "field": "bytes" } }
+  }
+}
+```
+
+## Limitations
+
+- IP field support is limited to IPv4 and IPv6 addresses
+- Star-tree statistics are only available in OpenSearch 3.2.0+
+- Existing star-tree limitations still apply (immutable data, no updates/deletes)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18707](https://github.com/opensearch-project/OpenSearch/pull/18707) | Add star-tree search related stats for nodes, indices, and shards |
+| [#18671](https://github.com/opensearch-project/OpenSearch/pull/18671) | Add search support for IP field type in star-tree queries |
+
+## References
+
+- [Issue #16547](https://github.com/opensearch-project/OpenSearch/issues/16547): IP field support feature request
+- [Documentation PR #10667](https://github.com/opensearch-project/documentation-website/pull/10667): Star-tree stats documentation
+- [Documentation PR #10668](https://github.com/opensearch-project/documentation-website/pull/10668): IP field support documentation
+- [Star-tree index documentation](https://docs.opensearch.org/3.0/search-plugins/star-tree-index/): Official documentation
+- [OpenSearch 3.2 announcement](https://opensearch.org/blog/introducing-opensearch-3-2-next-generation-search-and-anayltics-with-enchanced-ai-capabilities/): Release blog post
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/star-tree-index.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -69,3 +69,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Remote Store Segment Warming](features/opensearch/remote-store-segment-warming.md) | feature | Remote store support for merged segment warming to reduce replication lag |
 | [Streaming Transport & Aggregation](features/opensearch/streaming-transport-aggregation.md) | feature | Stream transport framework and streaming aggregation for memory-efficient high-cardinality aggregations |
 | [Approximation Framework Enhancements](features/opensearch/approximation-framework-enhancements.md) | feature | search_after support, range queries with now, multi-sort handling |
+| [Star Tree Index](features/opensearch/star-tree-index.md) | feature | IP field search support and star-tree search statistics |


### PR DESCRIPTION
## Summary

This PR adds documentation for Star Tree Index enhancements in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/star-tree-index.md`
- Feature report: `docs/features/opensearch/star-tree-index.md` (updated)

### Key Changes in v3.2.0

1. **IP Field Search Support** ([#18671](https://github.com/opensearch-project/OpenSearch/pull/18671))
   - Star-tree index now supports `ip` field type as a dimension
   - Enables aggregations with queries filtering on IP address fields
   - Useful for network analytics, security monitoring, and log analysis

2. **Star-Tree Search Statistics** ([#18707](https://github.com/opensearch-project/OpenSearch/pull/18707))
   - New metrics: `startree_query_total`, `startree_query_time_in_millis`, `startree_query_current`
   - Available at node, index, and shard levels via stats APIs

### Resources Used
- PR: #18707, #18671
- Issue: #16547
- Docs: https://docs.opensearch.org/3.0/search-plugins/star-tree-index/
- Blog: https://opensearch.org/blog/introducing-opensearch-3-2-next-generation-search-and-anayltics-with-enchanced-ai-capabilities/