### PR TITLE
docs: add clusterless-mode report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -44,6 +44,7 @@
 - [Mapping Transformer](opensearch/mapping-transformer.md)
 - [Cluster Manager Task Throttling](opensearch/cluster-manager-throttling.md)
 - [Cluster State Management](opensearch/cluster-state-management.md)
+- [Clusterless Mode](opensearch/clusterless-mode.md)
 - [Dependency Management](opensearch/dependency-management.md)
 - [Derived Source](opensearch/derived-source.md)
 - [Docker Compose v2 Support](opensearch/docker-compose-v2-support.md)

--- a/docs/features/opensearch/clusterless-mode.md
+++ b/docs/features/opensearch/clusterless-mode.md
@@ -1,0 +1,155 @@
+# Clusterless Mode
+
+## Summary
+
+Clusterless mode is an experimental capability that enables OpenSearch nodes to operate independently without joining a traditional cluster. This feature supports cloud-native architectures where data nodes can function as shared-nothing components, fetching index segments from remote storage without requiring cluster manager coordination.
+
+Key benefits include:
+- **Horizontal scalability**: Data nodes can scale linearly without shared bottlenecks
+- **Reduced contention**: No waiting on cluster state propagation
+- **Better fault isolation**: Node failures don't affect other nodes
+- **Easier operations**: Nodes can be added/removed like microservices
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Clusterless Architecture"
+        subgraph "Writer Nodes"
+            W1[Writer 1]
+            W2[Writer 2]
+        end
+        
+        subgraph "Remote Store"
+            RS[(S3/Remote Storage)]
+        end
+        
+        subgraph "Searcher Nodes"
+            S1[Searcher 1]
+            S2[Searcher 2]
+        end
+        
+        subgraph "Coordinator"
+            C[Coordinator Node]
+        end
+        
+        W1 -->|"segments (path: writer-1)"| RS
+        W2 -->|"segments (path: writer-2)"| RS
+        RS -->|"replicate"| S1
+        RS -->|"replicate"| S2
+        C --> S1
+        C --> S2
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Clusterless Node Startup"
+        A[Node Start] --> B{ClusterPlugin.isClusterless?}
+        B -->|Yes| C[Create LocalClusterService]
+        B -->|No| D[Create Standard ClusterService]
+        C --> E[Create LocalDiscovery]
+        E --> F[Bootstrap Local Cluster State]
+        F --> G[Node Ready]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `LocalClusterService` | ClusterService implementation that operates without cluster manager. Uses a dummy `ClusterManagerService` and manages only local cluster state |
+| `LocalDiscovery` | Discovery implementation that only discovers the local node. Creates a bootstrap cluster state with just the local node |
+| `LocalShardStateAction` | Handles shard state changes (started/failed) locally without communicating with cluster manager |
+| `ClusterPlugin.isClusterless()` | Plugin interface method that signals the node should start in clusterless mode |
+
+### Configuration
+
+| Setting | Description | Default | Scope |
+|---------|-------------|---------|-------|
+| `index.remote_store.segment.path_prefix` | Unique identifier injected into remote store paths to support multiple writers | `null` | Index |
+
+#### Path Prefix Validation Rules
+
+- Remote store must be enabled (`index.remote_store.enabled: true`)
+- Cannot contain path separators: `/`, `\`
+- Cannot contain drive specifiers: `:`
+- Empty or whitespace values are ignored (backward compatible)
+
+### Remote Store Path Structure
+
+Without path prefix (traditional):
+```
+remote_repository/hash/index-uuid/shard-id/segments/data/file
+```
+
+With path prefix (clusterless):
+```
+remote_repository/hash/index-uuid/shard-id/<path-prefix>/segments/data/file
+```
+
+### Usage Example
+
+#### Implementing a Clusterless Plugin
+
+```java
+public class ClusterlessPlugin extends Plugin implements ClusterPlugin {
+    
+    @Override
+    public boolean isClusterless() {
+        return true;
+    }
+    
+    // Additional plugin implementation for managing
+    // cluster state, routing, and coordination
+}
+```
+
+#### Configuring Writer Path Prefix
+
+```json
+PUT /my-index/_settings
+{
+  "index.remote_store.segment.path_prefix": "writer-node-1"
+}
+```
+
+#### Configuring Searcher to Replicate from Specific Writer
+
+```json
+PUT /my-index/_settings
+{
+  "index.remote_store.segment.path_prefix": "writer-node-1"
+}
+```
+
+## Limitations
+
+- **Experimental**: Feature is experimental and APIs may change in future releases
+- **Plugin required**: Requires custom plugin implementing `ClusterPlugin.isClusterless()`
+- **No cluster state updates**: `submitStateUpdateTasks()` throws `UnsupportedOperationException`
+- **Single node discovery**: Only local node is discoverable
+- **No GatewayService**: Gateway service is not created in clusterless mode
+- **Limited actions**: Some transport actions that require Discovery are not available
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18479](https://github.com/opensearch-project/OpenSearch/pull/18479) | Start in "clusterless" mode if a clusterless ClusterPlugin is loaded |
+| v3.2.0 | [#18857](https://github.com/opensearch-project/OpenSearch/pull/18857) | Add support for custom remote store segment path prefix |
+
+## References
+
+- [Issue #17957](https://github.com/opensearch-project/OpenSearch/issues/17957): RFC - Cloud-native OpenSearch
+- [Issue #18750](https://github.com/opensearch-project/OpenSearch/issues/18750): Feature request for custom remote store path component
+- [Remote-backed storage documentation](https://docs.opensearch.org/3.2/tuning-your-cluster/availability-and-recovery/remote-store/index/)
+- [Segment replication documentation](https://docs.opensearch.org/3.2/tuning-your-cluster/availability-and-recovery/segment-replication/index/)
+
+## Change History
+
+- **v3.2.0** (2025-07): Initial experimental implementation with clusterless startup mode and custom remote store path prefix support

--- a/docs/releases/v3.2.0/features/opensearch/clusterless-mode.md
+++ b/docs/releases/v3.2.0/features/opensearch/clusterless-mode.md
@@ -1,0 +1,122 @@
+# Clusterless Mode
+
+## Summary
+
+OpenSearch v3.2.0 introduces experimental support for "clusterless" mode, enabling nodes to operate independently without joining a traditional cluster. This foundational capability supports cloud-native architectures where nodes can function as shared-nothing data nodes, fetching segments from remote storage without cluster manager coordination.
+
+## Details
+
+### What's New in v3.2.0
+
+This release adds two key capabilities for clusterless operation:
+
+1. **Clusterless Startup Mode**: Nodes can start without discovering or joining a cluster when a clusterless `ClusterPlugin` is loaded
+2. **Custom Remote Store Path Prefix**: A new index setting allows injecting unique writer identifiers into remote store paths, enabling multiple writers to write to the same shard without conflicts
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Traditional Mode"
+        CM[Cluster Manager]
+        DN1[Data Node 1]
+        DN2[Data Node 2]
+        CM --> DN1
+        CM --> DN2
+    end
+    
+    subgraph "Clusterless Mode"
+        LN1[Local Node 1]
+        LN2[Local Node 2]
+        RS[(Remote Store)]
+        LN1 --> RS
+        LN2 --> RS
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `LocalClusterService` | ClusterService implementation without cluster manager coordination |
+| `LocalDiscovery` | Discovery implementation that only "discovers" the local node |
+| `LocalShardStateAction` | Applies shard state changes directly to local cluster state |
+| `ClusterPlugin.isClusterless()` | Plugin interface method to indicate clusterless mode |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.remote_store.segment.path_prefix` | Unique writer identifier injected into remote store paths | `null` (empty) |
+
+The path prefix setting:
+- Is index-scoped and dynamic
+- Only works when `index.remote_store.enabled` is `true`
+- Cannot contain path separators (`/`, `\`) or drive specifiers (`:`)
+- Empty/whitespace values are ignored for backward compatibility
+
+#### Path Structure Change
+
+**Before:**
+```
+remote_repository/hash/index-uuid/shard-id/segments/data/file
+```
+
+**After (with path prefix):**
+```
+remote_repository/hash/index-uuid/shard-id/writer-node-id/segments/data/file
+```
+
+### Usage Example
+
+To enable clusterless mode, implement a `ClusterPlugin` that returns `true` from `isClusterless()`:
+
+```java
+public class MyClusterlessPlugin extends Plugin implements ClusterPlugin {
+    @Override
+    public boolean isClusterless() {
+        return true;
+    }
+}
+```
+
+To configure a unique writer path prefix:
+
+```json
+PUT /my-index/_settings
+{
+  "index.remote_store.segment.path_prefix": "writer-node-1"
+}
+```
+
+### Migration Notes
+
+- This is an **experimental** feature and not recommended for production use
+- Clusterless mode requires a custom plugin that implements `ClusterPlugin.isClusterless()`
+- Existing remote store indexes are not affected unless the path prefix setting is explicitly configured
+
+## Limitations
+
+- **Experimental status**: The feature is marked experimental and APIs may change
+- **Plugin required**: Clusterless mode requires a custom plugin implementation
+- **No cluster state updates**: `submitStateUpdateTasks` throws `UnsupportedOperationException` in clusterless mode
+- **Limited discovery**: Only the local node is discoverable in clusterless mode
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18479](https://github.com/opensearch-project/OpenSearch/pull/18479) | Start in "clusterless" mode if a clusterless ClusterPlugin is loaded |
+| [#18857](https://github.com/opensearch-project/OpenSearch/pull/18857) | Add support for custom remote store segment path prefix |
+
+## References
+
+- [Issue #17957](https://github.com/opensearch-project/OpenSearch/issues/17957): RFC - Cloud-native OpenSearch
+- [Issue #18750](https://github.com/opensearch-project/OpenSearch/issues/18750): Feature request for custom remote store path component
+- [Remote-backed storage documentation](https://docs.opensearch.org/3.2/tuning-your-cluster/availability-and-recovery/remote-store/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/clusterless-mode.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -70,3 +70,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Streaming Transport & Aggregation](features/opensearch/streaming-transport-aggregation.md) | feature | Stream transport framework and streaming aggregation for memory-efficient high-cardinality aggregations |
 | [Approximation Framework Enhancements](features/opensearch/approximation-framework-enhancements.md) | feature | search_after support, range queries with now, multi-sort handling |
 | [Star Tree Index](features/opensearch/star-tree-index.md) | feature | IP field search support and star-tree search statistics |
+| [Clusterless Mode](features/opensearch/clusterless-mode.md) | feature | Experimental clusterless startup mode and custom remote store path prefix |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Clusterless Mode feature introduced in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/clusterless-mode.md`
- Feature report: `docs/features/opensearch/clusterless-mode.md`

### Key Changes in v3.2.0

**Clusterless Mode** is an experimental capability that enables OpenSearch nodes to operate independently without joining a traditional cluster:

1. **Clusterless Startup Mode** (PR #18479): Nodes can start without discovering or joining a cluster when a clusterless `ClusterPlugin` is loaded
2. **Custom Remote Store Path Prefix** (PR #18857): New index setting `index.remote_store.segment.path_prefix` allows injecting unique writer identifiers into remote store paths

### New Components
- `LocalClusterService` - ClusterService without cluster manager coordination
- `LocalDiscovery` - Discovery that only discovers the local node
- `LocalShardStateAction` - Local shard state change handling
- `ClusterPlugin.isClusterless()` - Plugin interface for clusterless mode

### Related Issues
- Closes #1113

### Resources Used
- PR: #18479, #18857
- Issue: #17957 (RFC - Cloud-native OpenSearch), #18750