### PR TITLE
docs: add rule-cardinality-limit report for v3.2.0

### DIFF
--- a/docs/features/opensearch/workload-management.md
+++ b/docs/features/opensearch/workload-management.md
@@ -105,6 +105,7 @@ flowchart TB
 | `wlm.query_group.node.cpu_rejection_threshold` | CPU threshold triggering request rejection | - |
 | `wlm.query_group.node.memory_cancellation_threshold` | Memory threshold for marking node in duress | - |
 | `wlm.query_group.node.cpu_cancellation_threshold` | CPU threshold for marking node in duress | - |
+| `wlm.autotagging.max_rules` | Maximum number of auto-tagging rules allowed (v3.2.0+) | 200 (range: 10-500) |
 
 ### Operating Modes
 
@@ -252,6 +253,7 @@ GET _list/wlm_stats?size=50&sort=node_id&order=asc&next_token=<encrypted_token>
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#18663](https://github.com/opensearch-project/OpenSearch/pull/18663) | Add configurable limit on rule cardinality |
 | v3.2.0 | [#18628](https://github.com/opensearch-project/OpenSearch/pull/18628) | Fix delete rule event consumption for wildcard index based rules |
 | v3.1.0 | [#17638](https://github.com/opensearch-project/OpenSearch/pull/17638) | Add paginated wlm/stats API |
 | v3.1.0 | [#17336](https://github.com/opensearch-project/OpenSearch/pull/17336) | Add Get Rule API for auto-tagging |
@@ -281,6 +283,6 @@ GET _list/wlm_stats?size=50&sort=node_id&order=asc&next_token=<encrypted_token>
 
 ## Change History
 
-- **v3.2.0** (2026-01-10): Fixed delete rule event consumption for wildcard index based rules in `InMemoryRuleProcessingService`
+- **v3.2.0** (2026-01-10): Added configurable rule cardinality limit (`wlm.autotagging.max_rules`) with default of 200 rules (range: 10-500); Fixed delete rule event consumption for wildcard index based rules in `InMemoryRuleProcessingService`
 - **v3.1.0** (2026-01-10): Added rule-based auto-tagging with full CRUD API (`/_rules/workload_group`), WLM ActionFilter for automatic request tagging, refresh-based rule synchronization, and paginated `/_list/wlm_stats` API
 - **v2.18.0** (2024-10-22): Initial implementation with QueryGroup CRUD APIs, Stats API, resource cancellation framework, resiliency orchestrator, persistence, and enhanced rejection logic

--- a/docs/releases/v3.2.0/features/opensearch/rule-cardinality-limit.md
+++ b/docs/releases/v3.2.0/features/opensearch/rule-cardinality-limit.md
@@ -1,0 +1,111 @@
+# Rule Cardinality Limit
+
+## Summary
+
+This release introduces a configurable limit on the number of rules that can be created in the Workload Management (WLM) auto-tagging system. The feature prevents users from creating unlimited rule documents, which could lead to performance degradation and resource exhaustion. A default limit of 200 rules is enforced, with a configurable range between 10 and 500.
+
+## Details
+
+### What's New in v3.2.0
+
+OpenSearch v3.2.0 adds a cardinality check to the rule creation process in the WLM auto-tagging framework. Before creating a new rule, the system now validates that the total number of existing rules does not exceed the configured maximum. If the limit is reached, the create operation is rejected with an `OpenSearchRejectedExecutionException`.
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `MAX_WLM_RULES_SETTING` | Dynamic cluster setting to configure maximum allowed rules |
+| `performCardinalityCheck()` | Method in `IndexStoredRulePersistenceService` that validates rule count before creation |
+| `getCardinalityQuery()` | New method in `RuleQueryMapper` interface for counting existing rules |
+
+#### New Configuration
+
+| Setting | Description | Default | Range |
+|---------|-------------|---------|-------|
+| `wlm.autotagging.max_rules` | Maximum number of rules allowed in the system | 200 | 10-500 |
+
+The setting is:
+- **Node-scoped**: Applied at the node level
+- **Dynamic**: Can be updated at runtime without restart
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Rule Creation Flow"
+        A[Create Rule Request] --> B[IndexStoredRulePersistenceService]
+        B --> C{Index Exists?}
+        C -->|No| D[Fail: Index does not exist]
+        C -->|Yes| E[performCardinalityCheck]
+        E --> F{Count >= maxAllowedRulesCount?}
+        F -->|Yes| G[Reject: OpenSearchRejectedExecutionException]
+        F -->|No| H[validateNoDuplicateRule]
+        H --> I[persistRule]
+        I --> J[Success: CreateRuleResponse]
+    end
+```
+
+#### API Changes
+
+No new APIs are introduced. The existing Rule CRUD APIs now enforce the cardinality limit:
+
+- `PUT /_rules/workload_group` - Create rule (now validates cardinality)
+- `POST /_rules/workload_group` - Create rule (now validates cardinality)
+
+### Usage Example
+
+**Configure Maximum Rules:**
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "wlm.autotagging.max_rules": 300
+  }
+}
+```
+
+**Error Response When Limit Exceeded:**
+```json
+{
+  "error": {
+    "root_cause": [
+      {
+        "type": "rejected_execution_exception",
+        "reason": "This create operation will violate the cardinality limit of 200. Please delete some stale or redundant rules first"
+      }
+    ],
+    "type": "rejected_execution_exception",
+    "reason": "This create operation will violate the cardinality limit of 200. Please delete some stale or redundant rules first"
+  },
+  "status": 429
+}
+```
+
+### Migration Notes
+
+- Existing clusters with more than 200 rules will not be affected until new rule creation is attempted
+- Administrators should review and clean up unused rules if approaching the limit
+- The limit can be increased up to 500 if more rules are required
+
+## Limitations
+
+- The cardinality check uses a synchronous search operation which may add slight latency to rule creation
+- The error message currently shows the default limit (200) rather than the configured limit
+- The limit applies cluster-wide, not per feature type
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18663](https://github.com/opensearch-project/OpenSearch/pull/18663) | Add the configurable limit on rule cardinality |
+
+## References
+
+- [Workload Management Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/workload-management/wlm-feature-overview/)
+- [Rule Lifecycle API](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/rule-based-autotagging/rule-lifecycle-api/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/workload-management.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -40,6 +40,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | Item | Category | Description |
 |------|----------|-------------|
 | [Rule-based Auto Tagging Fix](features/opensearch/rule-based-auto-tagging-fix.md) | bugfix | Fix delete rule event consumption for wildcard index based rules |
+| [Rule Cardinality Limit](features/opensearch/rule-cardinality-limit.md) | feature | Configurable limit on WLM auto-tagging rule cardinality (default: 200) |
 | [System Ingest Pipeline Fix](features/opensearch/system-ingest-pipeline-fix.md) | bugfix | Fix system ingest pipeline to properly handle index templates |
 | [Azure Repository Fixes](features/opensearch/azure-repository-fixes.md) | bugfix | Fix SOCKS5 proxy authentication for Azure repository |
 | [Profiler Enhancements](features/opensearch/profiler-enhancements.md) | bugfix | Fix concurrent timings in profiler for concurrent segment search |


### PR DESCRIPTION
## Summary

Add documentation for the Rule Cardinality Limit feature introduced in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/rule-cardinality-limit.md`
- Feature report: `docs/features/opensearch/workload-management.md` (updated)

### Key Changes in v3.2.0
- Added configurable limit on WLM auto-tagging rule cardinality
- New setting `wlm.autotagging.max_rules` with default of 200 (range: 10-500)
- Cardinality check performed before rule creation to prevent resource exhaustion

### Resources Used
- PR: [#18663](https://github.com/opensearch-project/OpenSearch/pull/18663)
- Docs: [Workload Management](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/workload-management/wlm-feature-overview/)
- Docs: [Rule Lifecycle API](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/rule-based-autotagging/rule-lifecycle-api/)

Closes #1112