### PR TITLE
docs: add code-coverage-gradle report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -25,6 +25,7 @@
 - [Cluster Stats API](opensearch/cluster-stats-api.md)
 - [Cluster Manager Metrics](opensearch/cluster-manager-metrics.md)
 - [Code Cleanup](opensearch/code-cleanup.md)
+- [Code Coverage (Gradle)](opensearch/code-coverage-gradle.md)
 - [Combined Fields Query](opensearch/combined-fields-query.md)
 - [Composite Aggregation](opensearch/composite-aggregation.md)
 - [Composite Directory Factory](opensearch/composite-directory-factory.md)

--- a/docs/features/opensearch/code-coverage-gradle.md
+++ b/docs/features/opensearch/code-coverage-gradle.md
@@ -1,0 +1,182 @@
+# Code Coverage (Gradle)
+
+## Summary
+
+OpenSearch provides local code coverage generation using Gradle with the JaCoCo plugin. This feature enables developers to generate coverage reports for unit tests, integration tests, and REST tests directly from their local environment, ensuring consistency with the coverage reported by GitHub CI workflows.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Gradle Build System"
+        GC[gradle/code-coverage.gradle]
+        JP[JaCoCo Plugin<br/>v0.8.13]
+    end
+    
+    subgraph "Test Types"
+        UT[Unit Tests<br/>test task]
+        ICT[Internal Cluster Tests<br/>internalClusterTest task]
+        JRT[Java REST Tests<br/>javaRestTest task]
+        YRT[YAML REST Tests<br/>yamlRestTest task]
+    end
+    
+    subgraph "Execution Data"
+        ED1[test.exec]
+        ED2[internalClusterTest.exec]
+        ED3[javaRestTest.exec]
+        ED4[yamlRestTest.exec]
+    end
+    
+    subgraph "Report Tasks"
+        JTR[jacocoTestReport]
+        TCR[testCodeCoverageReport]
+        TCRI[testCodeCoverageReportInternalClusterTest]
+        TCRJ[testCodeCoverageReportJavaRestTest]
+        TCRY[testCodeCoverageReportYamlRestTest]
+    end
+    
+    subgraph "Output"
+        XML[XML Report]
+        HTML[HTML Report]
+        CSV[CSV Report]
+    end
+    
+    GC --> JP
+    JP --> UT
+    JP --> ICT
+    JP --> JRT
+    JP --> YRT
+    
+    UT --> ED1
+    ICT --> ED2
+    JRT --> ED3
+    YRT --> ED4
+    
+    ED1 --> JTR
+    ED2 --> JTR
+    ED3 --> JTR
+    ED4 --> JTR
+    
+    JTR --> XML
+    JTR --> HTML
+    JTR --> CSV
+    
+    TCR --> XML
+    TCRI --> XML
+    TCRJ --> XML
+    TCRY --> XML
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Run Tests] --> B[JaCoCo Agent<br/>Instruments Code]
+    B --> C[Generate .exec Files]
+    C --> D[jacocoTestReport Task]
+    D --> E[Aggregate Execution Data]
+    E --> F[Generate Reports]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `gradle/code-coverage.gradle` | Main configuration file for JaCoCo integration |
+| `jacocoTestReport` | Enhanced task that aggregates all test type execution data |
+| `testCodeCoverageReport` | Dedicated report task for unit tests |
+| `testCodeCoverageReportInternalClusterTest` | Dedicated report task for internal cluster tests |
+| `testCodeCoverageReportJavaRestTest` | Dedicated report task for Java REST tests |
+| `testCodeCoverageReportYamlRestTest` | Dedicated report task for YAML REST tests |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `tests.coverage` | Enable coverage generation during `check` task | `false` |
+| `tests.coverage.report.xml` | Generate XML format report | `true` |
+| `tests.coverage.report.html` | Generate HTML format report | `false` |
+| `tests.coverage.report.csv` | Generate CSV format report | `false` |
+
+### Usage Examples
+
+#### Unit Test Coverage
+
+```bash
+# Run unit tests for a specific module
+./gradlew :server:test
+
+# Generate coverage report
+./gradlew :server:jacocoTestReport
+```
+
+#### Specific Test Coverage
+
+```bash
+# Run specific test
+./gradlew :server:test --tests "org.opensearch.search.approximate.ApproximatePointRangeQueryTests.testNycTaxiDataDistribution"
+
+# Generate HTML report
+./gradlew :server:jacocoTestReport -Dtests.coverage.report.html=true
+```
+
+#### Integration Test Coverage
+
+```bash
+# Run internal cluster tests
+./gradlew :server:internalClusterTest
+
+# Generate coverage report
+./gradlew :server:jacocoTestReport
+```
+
+#### REST Test Coverage
+
+```bash
+# Run Java REST tests
+./gradlew :qa:die-with-dignity:javaRestTest
+
+# Generate HTML report
+./gradlew :qa:die-with-dignity:jacocoTestReport -Dtests.coverage.report.html=true
+```
+
+#### Combined Coverage with Check Task
+
+```bash
+# Run all tests with coverage enabled
+./gradlew check -Dtests.coverage=true
+```
+
+### Report Output Location
+
+Reports are generated at:
+```
+$buildDir/build/reports/jacoco/test/html/
+```
+
+## Limitations
+
+- Coverage reports require running tests first to generate `.exec` execution data files
+- The `jacocoTestReport` task only executes if at least one `.exec` file exists
+- HTML and CSV reports are disabled by default to conserve disk space
+- Coverage is measured at the line and branch level
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18509](https://github.com/opensearch-project/OpenSearch/pull/18509) | Initial implementation - local code coverage with Gradle |
+
+## References
+
+- [PR #18509](https://github.com/opensearch-project/OpenSearch/pull/18509): Main implementation
+- [PR #18358](https://github.com/opensearch-project/OpenSearch/pull/18358): Related coverage improvement work
+- [PR #18376](https://github.com/opensearch-project/OpenSearch/pull/18376): javaRestTest coverage addition
+- [JaCoCo Gradle Plugin](https://docs.gradle.org/current/userguide/jacoco_plugin.html): Official Gradle documentation
+- [Issue #850](https://github.com/opensearch-project/OpenSearch/issues/850): Original feature request for test coverage reporting
+
+## Change History
+
+- **v3.2.0** (2025-06-13): Initial implementation - ability to run code coverage locally with Gradle and produce JaCoCo reports

--- a/docs/releases/v3.2.0/features/opensearch/code-coverage-gradle.md
+++ b/docs/releases/v3.2.0/features/opensearch/code-coverage-gradle.md
@@ -1,0 +1,140 @@
+# Code Coverage (Gradle)
+
+## Summary
+
+This release adds the ability to run code coverage locally using Gradle with the JaCoCo plugin. Developers can now generate coverage reports for unit tests, integration tests, and REST tests directly from their local environment, ensuring consistency with the coverage reported by GitHub CI.
+
+## Details
+
+### What's New in v3.2.0
+
+This enhancement enables local code coverage generation using Gradle, addressing the limitation where coverage reports were only available after the Gradle Check workflow passed on GitHub.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Test Execution"
+        UT[Unit Tests<br/>./gradlew test]
+        ICT[Integration Tests<br/>./gradlew internalClusterTest]
+        JRT[Java REST Tests<br/>./gradlew javaRestTest]
+    end
+    
+    subgraph "JaCoCo Agent"
+        JA[JaCoCo Agent<br/>jacoco-0.8.13]
+    end
+    
+    subgraph "Execution Data"
+        ED1[test.exec]
+        ED2[internalClusterTest.exec]
+        ED3[javaRestTest.exec]
+    end
+    
+    subgraph "Report Generation"
+        JTR[jacocoTestReport Task]
+        RPT[HTML/XML/CSV Reports]
+    end
+    
+    UT --> JA
+    ICT --> JA
+    JRT --> JA
+    JA --> ED1
+    JA --> ED2
+    JA --> ED3
+    ED1 --> JTR
+    ED2 --> JTR
+    ED3 --> JTR
+    JTR --> RPT
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `jacocoTestReport` task enhancement | Aggregates execution data from multiple test types |
+| `testCodeCoverageReport` | Coverage report for unit tests |
+| `testCodeCoverageReportJavaRestTest` | Coverage report for Java REST tests |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `tests.coverage` | Enable coverage during `check` task | `false` |
+| `tests.coverage.report.xml` | Generate XML report | `true` |
+| `tests.coverage.report.html` | Generate HTML report | `false` |
+| `tests.coverage.report.csv` | Generate CSV report | `false` |
+
+### Usage Example
+
+Run unit tests with coverage for a specific module:
+
+```bash
+# Run unit tests
+./gradlew :server:test
+
+# Generate coverage report
+./gradlew :server:jacocoTestReport
+```
+
+Run a specific test with HTML coverage report:
+
+```bash
+./gradlew :server:test --tests "org.opensearch.search.approximate.ApproximatePointRangeQueryTests.testNycTaxiDataDistribution"
+./gradlew :server:jacocoTestReport -Dtests.coverage.report.html=true
+```
+
+Run integration tests with coverage:
+
+```bash
+./gradlew :server:internalClusterTest
+./gradlew :server:jacocoTestReport
+```
+
+Run Java REST tests with coverage:
+
+```bash
+./gradlew :qa:die-with-dignity:javaRestTest
+./gradlew :qa:die-with-dignity:jacocoTestReport -Dtests.coverage.report.html=true
+```
+
+Generate combined coverage after `check` task:
+
+```bash
+./gradlew check -Dtests.coverage=true
+```
+
+### Report Location
+
+Coverage reports are generated at:
+```
+$buildDir/build/reports/jacoco/test/html/
+```
+
+### Migration Notes
+
+The previous commands `codeCoverageReportForUnitTest`, `codeCoverageReportForIntegrationTest`, and `codeCoverageReport` have been replaced with the new workflow using `jacocoTestReport`.
+
+## Limitations
+
+- Coverage reports require running tests first to generate `.exec` files
+- The `jacocoTestReport` task only runs if at least one `.exec` file exists
+- HTML and CSV reports are disabled by default to save disk space
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18509](https://github.com/opensearch-project/OpenSearch/pull/18509) | Ability to run Code Coverage locally with Gradle |
+
+## References
+
+- [PR #18509](https://github.com/opensearch-project/OpenSearch/pull/18509): Main implementation
+- [PR #18358](https://github.com/opensearch-project/OpenSearch/pull/18358): Related coverage improvement work
+- [PR #18376](https://github.com/opensearch-project/OpenSearch/pull/18376): javaRestTest coverage addition
+- [JaCoCo Gradle Plugin](https://docs.gradle.org/current/userguide/jacoco_plugin.html): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/code-coverage-gradle.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -10,6 +10,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 
 | Item | Category | Description |
 |------|----------|-------------|
+| [Code Coverage (Gradle)](features/opensearch/code-coverage-gradle.md) | feature | Local code coverage generation with Gradle and JaCoCo plugin |
 | [Combined Fields Query](features/opensearch/combined-fields-query.md) | feature | New combined_fields query with BM25F scoring for multi-field text search |
 | [GRPC Transport](features/opensearch/grpc-transport.md) | feature | GA release - module migration, plugin extensibility, proper gRPC status codes |
 | [Derived Source Integration](features/opensearch/derived-source.md) | feature | Integration of derived source feature across get/search/recovery paths |


### PR DESCRIPTION
## Summary

Add documentation for the Code Coverage (Gradle) feature introduced in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/code-coverage-gradle.md`
- Feature report: `docs/features/opensearch/code-coverage-gradle.md`

### Key Changes in v3.2.0
- Ability to run code coverage locally using Gradle with JaCoCo plugin
- Support for unit tests, integration tests, and REST tests coverage
- Configurable report formats (XML, HTML, CSV)
- Module-specific and test-specific coverage generation

### Resources Used
- PR: [#18509](https://github.com/opensearch-project/OpenSearch/pull/18509)
- Related: [#18358](https://github.com/opensearch-project/OpenSearch/pull/18358), [#18376](https://github.com/opensearch-project/OpenSearch/pull/18376)

Closes #1111