### PR TITLE
docs: add rescore-named-queries report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -90,6 +90,7 @@
 - [Randomness](opensearch/randomness.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)
 - [Replication](opensearch/replication.md)
+- [Rescore Named Queries](opensearch/rescore-named-queries.md)
 - [Remote Store](opensearch/remote-store.md)
 - [Repository Rate Limiters](opensearch/repository-rate-limiters.md)
 - [RestHandler.Wrapper](opensearch/resthandler-wrapper.md)

--- a/docs/features/opensearch/rescore-named-queries.md
+++ b/docs/features/opensearch/rescore-named-queries.md
@@ -1,0 +1,209 @@
+# Rescore Named Queries
+
+## Summary
+
+Rescore Named Queries enables named query clauses defined within rescore queries to be surfaced in the `matched_queries` array of search hits. This feature allows users to identify which specific rescore query clauses matched a document and contributed to its final ranking score, providing better observability for debugging, logging, and building ML models that rely on signal-level match information.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Search Request"
+        MQ[Main Query]
+        RQ[Rescore Query]
+        NQ1["_name: main_match"]
+        NQ2["_name: rescore_match"]
+    end
+    
+    subgraph "Query Parsing"
+        QSC[QueryShardContext]
+        PQ1[ParsedQuery - Main]
+        PQ2[ParsedQuery - Rescore]
+        NF1[Named Filters - Main]
+        NF2[Named Filters - Rescore]
+    end
+    
+    subgraph "Rescore Processing"
+        RC[RescoreContext]
+        QRC[QueryRescoreContext]
+    end
+    
+    subgraph "Fetch Phase"
+        MQP[MatchedQueriesPhase]
+        COLLECT[Collect All Named Queries]
+    end
+    
+    subgraph "Search Response"
+        MQA[matched_queries Array]
+    end
+    
+    MQ --> NQ1
+    RQ --> NQ2
+    NQ1 --> QSC
+    NQ2 --> QSC
+    QSC --> PQ1
+    QSC --> PQ2
+    PQ1 --> NF1
+    PQ2 --> NF2
+    PQ2 --> QRC
+    QRC --> RC
+    NF1 --> MQP
+    RC --> MQP
+    MQP --> COLLECT
+    COLLECT --> MQA
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Search Request with Named Queries] --> B[Parse Main Query]
+    A --> C[Parse Rescore Query]
+    B --> D[Store Named Filters in ParsedQuery]
+    C --> E[Store Named Filters in QueryRescoreContext]
+    D --> F[MatchedQueriesPhase]
+    E --> F
+    F --> G[Merge All Named Filters]
+    G --> H[Evaluate Against Documents]
+    H --> I[Build matched_queries Response]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ParsedQuery` | Holds the Lucene query and associated named filters map |
+| `RescoreContext` | Base class for rescore contexts, provides `getParsedQueries()` method |
+| `QueryRescoreContext` | Stores `ParsedQuery` instead of raw `Query` to preserve named query metadata |
+| `QueryRescorerBuilder` | Builds rescore context using `context.toQuery()` to capture named filters |
+| `MatchedQueriesPhase` | Fetch sub-phase that collects and evaluates all named queries including from rescore |
+| `DfsPhase` | Distributed frequency search phase, updated to work with `ParsedQuery` |
+
+### Configuration
+
+This feature requires no additional configuration. Named queries in rescore work automatically when:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `_name` | Query parameter to name a query clause | None |
+| `include_named_queries_score` | Search parameter to include scores in matched_queries | `false` |
+
+### Usage Example
+
+#### Basic Named Query in Rescore
+
+```json
+GET /my_index/_search
+{
+  "query": {
+    "match": {
+      "title": {
+        "query": "search engine",
+        "_name": "title_match"
+      }
+    }
+  },
+  "rescore": {
+    "window_size": 100,
+    "query": {
+      "rescore_query": {
+        "match_phrase": {
+          "content": {
+            "query": "distributed search",
+            "_name": "content_phrase"
+          }
+        }
+      },
+      "query_weight": 0.7,
+      "rescore_query_weight": 1.2
+    }
+  }
+}
+```
+
+#### Response
+
+```json
+{
+  "hits": {
+    "hits": [
+      {
+        "_index": "my_index",
+        "_id": "1",
+        "_score": 5.234,
+        "matched_queries": ["title_match", "content_phrase"]
+      }
+    ]
+  }
+}
+```
+
+#### With Scores
+
+```json
+GET /my_index/_search?include_named_queries_score=true
+{
+  "query": {
+    "match": {
+      "title": {
+        "query": "search",
+        "_name": "main_query"
+      }
+    }
+  },
+  "rescore": {
+    "window_size": 50,
+    "query": {
+      "rescore_query": {
+        "match": {
+          "content": {
+            "query": "relevance",
+            "_name": "rescore_query"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### Response with Scores
+
+```json
+{
+  "hits": {
+    "hits": [
+      {
+        "_id": "1",
+        "matched_queries": {
+          "main_query": 2.345,
+          "rescore_query": 1.567
+        }
+      }
+    ]
+  }
+}
+```
+
+## Limitations
+
+- Only supported in OpenSearch 3.2.0 and above
+- Custom rescorer implementations must override `getParsedQueries()` to support named queries
+- Named queries are evaluated per-document during the fetch phase, which may have performance implications for very large result sets
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18697](https://github.com/opensearch-project/OpenSearch/pull/18697) | Include named queries from rescore contexts in matched_queries array |
+
+## References
+
+- [Issue #18665](https://github.com/opensearch-project/OpenSearch/issues/18665): Original feature request
+- [Highlight query matches](https://docs.opensearch.org/3.2/search-plugins/searching-data/highlight/): Documentation on rescore and highlighting
+
+## Change History
+
+- **v3.2.0** (2025-07-09): Initial implementation - named queries from rescore contexts now appear in matched_queries array

--- a/docs/releases/v3.2.0/features/opensearch/rescore-named-queries.md
+++ b/docs/releases/v3.2.0/features/opensearch/rescore-named-queries.md
@@ -1,0 +1,201 @@
+# Rescore Named Queries
+
+## Summary
+
+OpenSearch v3.2.0 adds support for surfacing named queries from rescore contexts in the `matched_queries` array of search hits. Previously, when a `_name` was specified inside a `rescore.query.rescore_query`, that name was not included in `matched_queries` even if the query matched and impacted the final score. This enhancement enables better debugging, logging, and ML model building that relies on signal-level match information.
+
+## Details
+
+### What's New in v3.2.0
+
+Named queries defined within rescore query clauses are now propagated to the `matched_queries` array in search results. This includes support for:
+
+- Named query names appearing in `matched_queries` array
+- Named query scores when `include_named_queries_score` is set to `true`
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Search Request"
+        Q[Main Query with _name]
+        R[Rescore Query with _name]
+    end
+    
+    subgraph "Query Processing"
+        QSC[QueryShardContext]
+        PQ[ParsedQuery]
+        NF[Named Filters Map]
+    end
+    
+    subgraph "Fetch Phase"
+        MQP[MatchedQueriesPhase]
+        RC[RescoreContext]
+    end
+    
+    subgraph "Response"
+        MQ[matched_queries array]
+    end
+    
+    Q --> QSC
+    R --> QSC
+    QSC --> PQ
+    PQ --> NF
+    NF --> MQP
+    RC --> MQP
+    MQP --> MQ
+```
+
+#### Modified Components
+
+| Component | Description |
+|-----------|-------------|
+| `RescoreContext` | Added `getParsedQueries()` method to return `ParsedQuery` objects with named filters |
+| `QueryRescoreContext` | Changed from storing raw `Query` to `ParsedQuery` to preserve named query metadata |
+| `QueryRescorerBuilder` | Updated to use `context.toQuery()` instead of `queryBuilder.toQuery()` |
+| `MatchedQueriesPhase` | Extended to collect named queries from rescore contexts |
+| `DfsPhase` | Updated to use `ParsedQuery` from rescore contexts |
+
+#### Key Code Changes
+
+The core change is in `MatchedQueriesPhase.java`:
+
+```java
+if (context.rescore() != null) {
+    for (RescoreContext rescoreContext : context.rescore()) {
+        rescoreContext.getParsedQueries()
+            .forEach(query -> namedQueries.putAll(query.namedFilters()));
+    }
+}
+```
+
+### Usage Example
+
+```json
+PUT /rescore_test
+{
+  "mappings": {
+    "properties": {
+      "headline": { "type": "text" },
+      "summary": { "type": "text" }
+    }
+  }
+}
+
+POST /rescore_test/_doc/1
+{
+  "headline": "OpenSearch rescore behavior",
+  "summary": "This document illustrates how rescore affects scoring."
+}
+
+GET /rescore_test/_search
+{
+  "query": {
+    "match": {
+      "headline": {
+        "query": "rescore behavior",
+        "_name": "headline_match"
+      }
+    }
+  },
+  "rescore": {
+    "window_size": 50,
+    "query": {
+      "rescore_query": {
+        "match_phrase": {
+          "summary": {
+            "query": "rescore affects scoring",
+            "_name": "summary_phrase_match"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Response now includes both named queries:
+
+```json
+{
+  "hits": {
+    "hits": [
+      {
+        "_id": "1",
+        "matched_queries": ["headline_match", "summary_phrase_match"]
+      }
+    ]
+  }
+}
+```
+
+### With Named Query Scores
+
+```json
+GET /rescore_test/_search?include_named_queries_score=true
+{
+  "query": {
+    "match": {
+      "headline": {
+        "query": "rescore",
+        "_name": "main_query"
+      }
+    }
+  },
+  "rescore": {
+    "window_size": 10,
+    "query": {
+      "rescore_query": {
+        "match": {
+          "summary": {
+            "query": "scoring",
+            "_name": "rescore_query"
+          }
+        }
+      },
+      "query_weight": 0.5,
+      "rescore_query_weight": 1.5
+    }
+  }
+}
+```
+
+Response includes scores for each named query:
+
+```json
+{
+  "hits": {
+    "hits": [
+      {
+        "_id": "1",
+        "matched_queries": {
+          "main_query": 1.2345,
+          "rescore_query": 0.9876
+        }
+      }
+    ]
+  }
+}
+```
+
+## Limitations
+
+- Named queries in rescore are only supported in OpenSearch 3.2.0 and above
+- The feature works with the standard query rescorer; custom rescorers need to implement `getParsedQueries()` method
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18697](https://github.com/opensearch-project/OpenSearch/pull/18697) | Include named queries from rescore contexts in matched_queries array |
+
+## References
+
+- [Issue #18665](https://github.com/opensearch-project/OpenSearch/issues/18665): Feature request for surfacing named rescore queries
+- [Highlight query matches](https://docs.opensearch.org/3.2/search-plugins/searching-data/highlight/): Documentation on using rescore with highlighting
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/rescore-named-queries.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -73,3 +73,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Approximation Framework Enhancements](features/opensearch/approximation-framework-enhancements.md) | feature | search_after support, range queries with now, multi-sort handling |
 | [Star Tree Index](features/opensearch/star-tree-index.md) | feature | IP field search support and star-tree search statistics |
 | [Clusterless Mode](features/opensearch/clusterless-mode.md) | feature | Experimental clusterless startup mode and custom remote store path prefix |
+| [Rescore Named Queries](features/opensearch/rescore-named-queries.md) | feature | Surface named queries from rescore contexts in matched_queries array |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Rescore Named Queries feature introduced in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/rescore-named-queries.md`
- Feature report: `docs/features/opensearch/rescore-named-queries.md`

### Feature Overview
OpenSearch v3.2.0 adds support for surfacing named queries from rescore contexts in the `matched_queries` array of search hits. Previously, when a `_name` was specified inside a `rescore.query.rescore_query`, that name was not included in `matched_queries` even if the query matched and impacted the final score.

### Key Changes in v3.2.0
- Named query names from rescore queries now appear in `matched_queries` array
- Named query scores are included when `include_named_queries_score` is set to `true`
- Modified components: `RescoreContext`, `QueryRescoreContext`, `QueryRescorerBuilder`, `MatchedQueriesPhase`, `DfsPhase`

### Related
- PR: opensearch-project/OpenSearch#18697
- Issue: opensearch-project/OpenSearch#18665
- Investigation Issue: #1110