### PR TITLE
docs: add System Ingest Processor report for v3.2.0

### DIFF
--- a/docs/features/opensearch/system-ingest-pipeline.md
+++ b/docs/features/opensearch/system-ingest-pipeline.md
@@ -68,13 +68,22 @@ flowchart TB
 | `cluster.ingest.system_pipeline_enabled` | Enable/disable system ingest pipeline feature cluster-wide | `true` |
 | `cluster.ingest.max_number_processors` | Maximum number of processors allowed in a pipeline | `Integer.MAX_VALUE` |
 
+### Factory Configuration Keys
+
+| Key | Type | Description | Since |
+|-----|------|-------------|-------|
+| `INDEX_MAPPINGS` | `Map<String, Object>` | Mappings from the existing index | v3.1.0 |
+| `INDEX_TEMPLATE_MAPPINGS` | `List<Map<String, Object>>` | Mappings from matched templates | v3.1.0 |
+| `INDEX_SETTINGS` | `Settings` | Settings from the existing index | v3.2.0 |
+| `INDEX_TEMPLATE_SETTINGS` | `List<Settings>` | Settings from matched templates | v3.2.0 |
+
 ### Pipeline Types and Execution Order
 
 | Order | Pipeline Type | Source | Can Change Target Index |
 |-------|--------------|--------|------------------------|
 | 1 | DEFAULT | User-defined or index setting | Yes |
 | 2 | FINAL | Index setting | No |
-| 3 | SYSTEM_FINAL | Auto-generated from mapping | No |
+| 3 | SYSTEM_FINAL | Auto-generated from mapping/settings | No |
 
 ### Update Operation Behavior
 
@@ -192,6 +201,7 @@ PUT _cluster/settings
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#18708](https://github.com/opensearch-project/OpenSearch/pull/18708) | Pass index settings to system ingest processor factories |
 | v3.1.0 | [#17817](https://github.com/opensearch-project/OpenSearch/pull/17817) | Introduce system generated ingest pipeline |
 | v3.1.0 | [#18277](https://github.com/opensearch-project/OpenSearch/pull/18277) | Support system ingest pipelines for bulk update operations |
 
@@ -202,10 +212,12 @@ PUT _cluster/settings
 - [Issue #17742](https://github.com/opensearch-project/OpenSearch/issues/17742): Add configurability to run ingest pipelines during document update operations
 - [Issue #18151](https://github.com/opensearch-project/OpenSearch/issues/18151): Related issue resolved by #17817
 - [Issue #17819](https://github.com/opensearch-project/OpenSearch/issues/17819): Partially resolved by #17817
+- [Issue #1349](https://github.com/opensearch-project/neural-search/issues/1349): Semantic Field Enhancement - Configure Batch Size for Embedding Generation
 - [Blog: Making ingestion smarter](https://opensearch.org/blog/making-ingestion-smarter-system-ingest-pipelines-in-opensearch/): Official announcement blog
 - [Neural Search Semantic Field RFC](https://github.com/opensearch-project/neural-search/issues/1211): Primary use case for system ingest pipelines
 
 ## Change History
 
+- **v3.2.0** (2025-07-09): Added index settings support for processor factories (#18708)
 - **v3.1.0** (2025-05-09): Initial implementation of system ingest pipeline (#17817)
 - **v3.1.0** (2025-06-11): Added bulk update operation support (#18277)

--- a/docs/releases/v3.2.0/features/opensearch/system-ingest-processor.md
+++ b/docs/releases/v3.2.0/features/opensearch/system-ingest-processor.md
@@ -1,0 +1,160 @@
+# System Ingest Processor
+
+## Summary
+
+This enhancement adds the ability to pass index settings to system ingest processor factories, enabling plugins to make decisions about processor creation based on index-level configuration. Previously, system ingest processors could only access index mappings; now they can also access index settings from both the index itself and matched templates.
+
+## Details
+
+### What's New in v3.2.0
+
+Added two new configuration keys for system ingest processor factories:
+- `INDEX_SETTINGS`: Access settings from an existing index
+- `INDEX_TEMPLATE_SETTINGS`: Access settings from matched index templates (v1 and v2)
+
+This enables plugins like Neural Search to configure system ingest processor behavior through index settings rather than relying solely on index mappings.
+
+### Technical Changes
+
+#### New Configuration Keys
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `INDEX_SETTINGS` | `Settings` | Settings from the existing index |
+| `INDEX_TEMPLATE_SETTINGS` | `List<Settings>` | Settings from matched templates (later templates can override earlier ones) |
+
+#### API Changes
+
+The `SystemIngestPipelineConfigKeys` class now includes:
+
+```java
+public class SystemIngestPipelineConfigKeys {
+    // Existing keys
+    public static final String INDEX_MAPPINGS = "index_mappings";
+    public static final String INDEX_TEMPLATE_MAPPINGS = "index_template_mappings";
+    
+    // New in v3.2.0
+    public static final String INDEX_SETTINGS = "index_settings";
+    public static final String INDEX_TEMPLATE_SETTINGS = "index_template_settings";
+}
+```
+
+#### IngestService Changes
+
+The `IngestService` now passes settings to processor factories in three scenarios:
+
+1. **Existing Index**: Settings from `IndexMetadata.getSettings()`
+2. **V1 Templates**: Settings collected from all matched `IndexTemplateMetadata`
+3. **V2 Templates**: Settings resolved via `MetadataIndexTemplateService.resolveSettings()`
+
+### Usage Example
+
+#### Defining a Custom Index Setting
+
+```java
+public class ExampleSystemIngestProcessorPlugin extends Plugin implements IngestPlugin {
+    
+    public static final Setting<Boolean> TRIGGER_SETTING = Setting.boolSetting(
+        "index.example_system_ingest_processor_plugin.trigger_setting",
+        false,
+        Setting.Property.IndexScope,
+        Setting.Property.Dynamic
+    );
+    
+    @Override
+    public List<Setting<?>> getSettings() {
+        return List.of(TRIGGER_SETTING);
+    }
+    
+    @Override
+    public Map<String, Processor.Factory> getSystemIngestProcessors(Processor.Parameters parameters) {
+        return Map.of(ExampleSystemIngestProcessorFactory.TYPE, new ExampleSystemIngestProcessorFactory());
+    }
+}
+```
+
+#### Using Settings in Factory
+
+```java
+public class ExampleSystemIngestProcessorFactory extends AbstractBatchingSystemProcessor.Factory {
+    
+    @Override
+    protected AbstractBatchingSystemProcessor newProcessor(String tag, String description, Map<String, Object> config) {
+        final List<Settings> settings = new ArrayList<>();
+        
+        // Get settings from index
+        final Object settingsFromIndex = config.get(INDEX_SETTINGS);
+        if (settingsFromIndex instanceof Settings) {
+            settings.add((Settings) settingsFromIndex);
+        }
+        
+        // Get settings from templates
+        final Object settingsFromTemplates = config.get(INDEX_TEMPLATE_SETTINGS);
+        if (settingsFromTemplates instanceof List) {
+            settings.addAll((Collection<? extends Settings>) settingsFromTemplates);
+        }
+        
+        // Check trigger setting (later settings override earlier ones)
+        boolean isTriggerEnabled = false;
+        for (final Settings setting : settings) {
+            if (setting.hasValue(TRIGGER_SETTING.getKey())) {
+                isTriggerEnabled = TRIGGER_SETTING.get(setting);
+            }
+        }
+        
+        return isTriggerEnabled ? new ExampleSystemIngestProcessor(tag, description, DEFAULT_BATCH_SIZE) : null;
+    }
+}
+```
+
+#### Creating Index with Trigger Setting
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index.example_system_ingest_processor_plugin.trigger_setting": true
+  }
+}
+```
+
+#### Using Index Template
+
+```json
+PUT _index_template/example-template
+{
+  "index_patterns": ["example-*"],
+  "template": {
+    "settings": {
+      "index.example_system_ingest_processor_plugin.trigger_setting": true
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- Existing system ingest processors continue to work without changes
+- To use index settings, update your processor factory to read from `INDEX_SETTINGS` or `INDEX_TEMPLATE_SETTINGS`
+- For v1 templates with multiple matches, settings are provided as a list in order of precedence
+
+## Limitations
+
+- Settings from templates are provided as a list; the factory must handle precedence logic
+- Dynamic setting changes require index mapping update to trigger cache invalidation
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18708](https://github.com/opensearch-project/OpenSearch/pull/18708) | Pass index settings to system ingest processor factories |
+
+## References
+
+- [Issue #1349](https://github.com/opensearch-project/neural-search/issues/1349): Semantic Field Enhancement - Configure Batch Size for Embedding Generation
+- [Blog: Making ingestion smarter](https://opensearch.org/blog/making-ingestion-smarter-system-ingest-pipelines-in-opensearch/): System ingest pipeline overview
+- [Ingest Pipelines Documentation](https://docs.opensearch.org/3.2/ingest-pipelines/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/system-ingest-pipeline.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -43,6 +43,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Rule-based Auto Tagging Fix](features/opensearch/rule-based-auto-tagging-fix.md) | bugfix | Fix delete rule event consumption for wildcard index based rules |
 | [Rule Cardinality Limit](features/opensearch/rule-cardinality-limit.md) | feature | Configurable limit on WLM auto-tagging rule cardinality (default: 200) |
 | [System Ingest Pipeline Fix](features/opensearch/system-ingest-pipeline-fix.md) | bugfix | Fix system ingest pipeline to properly handle index templates |
+| [System Ingest Processor](features/opensearch/system-ingest-processor.md) | feature | Pass index settings to system ingest processor factories |
 | [Azure Repository Fixes](features/opensearch/azure-repository-fixes.md) | bugfix | Fix SOCKS5 proxy authentication for Azure repository |
 | [Profiler Enhancements](features/opensearch/profiler-enhancements.md) | bugfix | Fix concurrent timings in profiler for concurrent segment search |
 | [Plugin Profiling](features/opensearch/plugin-profiling.md) | feature | Plugin profiling extensibility and multi-shard fetch phase profiling |


### PR DESCRIPTION
## Summary

This PR adds documentation for the System Ingest Processor enhancement in OpenSearch v3.2.0.

### Changes

**Release Report**: `docs/releases/v3.2.0/features/opensearch/system-ingest-processor.md`
- Documents the new capability to pass index settings to system ingest processor factories
- Includes usage examples for defining custom index settings and using them in processor factories
- Covers both direct index settings and index template settings

**Feature Report Update**: `docs/features/opensearch/system-ingest-pipeline.md`
- Added new Factory Configuration Keys table documenting `INDEX_SETTINGS` and `INDEX_TEMPLATE_SETTINGS`
- Updated Related PRs table with v3.2.0 PR #18708
- Updated Change History with v3.2.0 entry
- Added reference to neural-search Issue #1349

### Key Changes in v3.2.0

- New `INDEX_SETTINGS` config key for accessing settings from existing indexes
- New `INDEX_TEMPLATE_SETTINGS` config key for accessing settings from matched templates
- Enables plugins to configure system ingest processor behavior through index settings

### Related

- PR: [opensearch-project/OpenSearch#18708](https://github.com/opensearch-project/OpenSearch/pull/18708)
- Issue: [opensearch-project/neural-search#1349](https://github.com/opensearch-project/neural-search/issues/1349)