### PR TITLE
docs: add Semantic Version Field Type report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -107,6 +107,7 @@
 - [Secure Transport Settings](opensearch/secure-transport-settings.md)
 - [Segment Replication](opensearch/segment-replication.md)
 - [Segment Warmer](opensearch/segment-warmer.md)
+- [Semantic Version Field Type](opensearch/semantic-version-field-type.md)
 - [Settings Management](opensearch/settings-management.md)
 - [Snapshot Restore Enhancements](opensearch/snapshot-restore-enhancements.md)
 - [Star Tree Index](opensearch/star-tree-index.md)

--- a/docs/features/opensearch/semantic-version-field-type.md
+++ b/docs/features/opensearch/semantic-version-field-type.md
@@ -1,0 +1,233 @@
+# Semantic Version Field Type
+
+## Summary
+
+The `version` field type in OpenSearch provides native support for indexing and querying semantic version strings following the [SemVer 2.0.0 specification](https://semver.org/). This enables proper version-aware sorting, range queries, and filtering for software version tracking, package management, and release management use cases.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Index Time"
+        Input[Version String<br/>e.g., 1.0.0-alpha+build.1] --> Parser[SemanticVersion Parser]
+        Parser --> Validate{Valid SemVer?}
+        Validate -->|Yes| Components[Extract Components]
+        Validate -->|No| Error[Throw Exception]
+        Components --> Original[Original String<br/>for term queries]
+        Components --> Normalized[Normalized String<br/>for range/sort]
+    end
+    
+    subgraph "Storage"
+        Original --> KeywordField[Keyword Field]
+        Normalized --> NormalizedField[Normalized Field]
+        Normalized --> DocValues[SortedSet DocValues]
+    end
+    
+    subgraph "Query Time"
+        TermQuery[Term Query] --> KeywordField
+        RangeQuery[Range Query] --> NormalizedField
+        Sort[Sort] --> DocValues
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[User Input<br/>1.0.0-alpha] --> B[Parse & Validate]
+    B --> C[Normalize<br/>Zero-pad numbers]
+    C --> D[Index<br/>Multiple fields]
+    D --> E[Query<br/>Term/Range/Sort]
+    E --> F[Results<br/>Correct ordering]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SemanticVersion` | Core model class representing a parsed semantic version with major, minor, patch, pre-release, and build metadata |
+| `SemanticVersionFieldMapper` | Field mapper that handles document parsing and field creation |
+| `SemanticVersionFieldType` | Field type that generates queries for term, range, prefix, wildcard, regex, and fuzzy operations |
+| `SemanticVersionFieldMapper.Builder` | Builder for configuring field mapper parameters |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `type` | Field type identifier | `version` (required) |
+| `index` | Whether the field is searchable | `true` |
+| `doc_values` | Enable doc values for sorting and aggregations | `true` |
+| `store` | Store original value separately for retrieval | `false` |
+
+### Usage Example
+
+**Index Mapping:**
+```json
+PUT software_releases
+{
+  "mappings": {
+    "properties": {
+      "name": { "type": "keyword" },
+      "version": { "type": "version" },
+      "release_date": { "type": "date" },
+      "description": { "type": "text" }
+    }
+  }
+}
+```
+
+**Index Documents:**
+```json
+POST software_releases/_bulk
+{ "index": {} }
+{ "name": "OpenSearch", "version": "2.0.0", "release_date": "2024-01-01" }
+{ "index": {} }
+{ "name": "OpenSearch", "version": "2.0.0-rc.1", "release_date": "2023-12-15" }
+{ "index": {} }
+{ "name": "OpenSearch", "version": "2.0.0-beta", "release_date": "2023-12-01" }
+{ "index": {} }
+{ "name": "OpenSearch", "version": "2.0.0-alpha", "release_date": "2023-11-15" }
+{ "index": {} }
+{ "name": "OpenSearch", "version": "1.3.0", "release_date": "2023-06-01" }
+```
+
+**Range Query - Find versions between 1.0.0 and 2.0.0:**
+```json
+GET software_releases/_search
+{
+  "query": {
+    "range": {
+      "version": {
+        "gte": "1.0.0",
+        "lt": "2.0.0"
+      }
+    }
+  }
+}
+```
+
+**Sort by Version (ascending):**
+```json
+GET software_releases/_search
+{
+  "query": { "match_all": {} },
+  "sort": [{ "version": { "order": "asc" }}]
+}
+```
+
+**Result Order:**
+```
+1.3.0
+2.0.0-alpha
+2.0.0-beta
+2.0.0-rc.1
+2.0.0
+```
+
+**Term Query - Exact Match:**
+```json
+GET software_releases/_search
+{
+  "query": {
+    "term": { "version": "2.0.0-beta" }
+  }
+}
+```
+
+**Prefix Query - All 2.x versions:**
+```json
+GET software_releases/_search
+{
+  "query": {
+    "prefix": { "version": "2." }
+  }
+}
+```
+
+**Wildcard Query:**
+```json
+GET software_releases/_search
+{
+  "query": {
+    "wildcard": { "version": "2.0.0-*" }
+  }
+}
+```
+
+### Version Format
+
+The field accepts version strings following SemVer 2.0.0:
+
+```
+MAJOR.MINOR.PATCH[-PRERELEASE][+BUILD]
+```
+
+| Component | Description | Example |
+|-----------|-------------|---------|
+| MAJOR | Breaking changes | `2` in `2.0.0` |
+| MINOR | Backward-compatible features | `1` in `1.1.0` |
+| PATCH | Backward-compatible fixes | `3` in `1.0.3` |
+| PRERELEASE | Pre-release identifier (optional) | `alpha.1` in `1.0.0-alpha.1` |
+| BUILD | Build metadata (optional, ignored for ordering) | `build.123` in `1.0.0+build.123` |
+
+### Version Precedence Rules
+
+1. Compare major, minor, patch as integers
+2. Pre-release versions have lower precedence than release versions
+3. Pre-release identifiers compared left-to-right:
+   - Numeric identifiers compared as integers
+   - Alphanumeric identifiers compared lexically
+   - Numeric < Alphanumeric
+   - Shorter < Longer (when all preceding are equal)
+4. Build metadata is ignored for precedence
+
+**Example Ordering (lowest to highest):**
+```
+1.0.0-alpha
+1.0.0-alpha.1
+1.0.0-alpha.beta
+1.0.0-beta
+1.0.0-beta.2
+1.0.0-beta.11
+1.0.0-rc.1
+1.0.0
+1.0.0+build.1  (equal to 1.0.0)
+1.0.1
+1.1.0
+2.0.0
+```
+
+### Internal Normalization
+
+For correct lexicographical sorting, version numbers are internally normalized:
+
+- Major, minor, patch are zero-padded to 20 digits
+- Pre-release versions append `-prerelease` (lowercase)
+- Release versions append `~` (sorts after any pre-release)
+
+Example: `1.0.0-alpha` → `00000000000000000001.00000000000000000000.00000000000000000000-alpha`
+
+## Limitations
+
+- Aggregations on version fields are not yet fully supported
+- Version strings must strictly conform to SemVer 2.0.0 format
+- Leading zeros in numeric identifiers are invalid (e.g., `01.0.0`)
+- Maximum version number is limited by integer range
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18454](https://github.com/opensearch-project/OpenSearch/pull/18454) | Initial implementation of Semantic Version field type |
+
+## References
+
+- [Issue #16814](https://github.com/opensearch-project/OpenSearch/issues/16814): Original feature request
+- [Semantic Versioning 2.0.0](https://semver.org/): Official SemVer specification
+- [SemVer Regex](https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string): Official regex for validation
+
+## Change History
+
+- **v3.2.0**: Initial implementation with support for term, range, prefix, wildcard, regex, and fuzzy queries

--- a/docs/releases/v3.2.0/features/opensearch/semantic-version-field-type.md
+++ b/docs/releases/v3.2.0/features/opensearch/semantic-version-field-type.md
@@ -1,0 +1,161 @@
+# Semantic Version Field Type
+
+## Summary
+
+OpenSearch v3.2.0 introduces a new `version` field type that enables native indexing and querying of semantic version strings following the [SemVer 2.0.0 specification](https://semver.org/). This field type allows correct ordering and range queries for version strings like `1.0.0`, `1.0.0-alpha`, and `2.1.0+build.1`, addressing a long-requested feature for version-aware sorting and filtering.
+
+## Details
+
+### What's New in v3.2.0
+
+The `version` field type provides:
+
+- Native semantic versioning support with proper precedence ordering
+- Pre-release version handling (`-alpha`, `-beta`, `-rc.1`)
+- Build metadata support (`+build.123`) - ignored for ordering per SemVer spec
+- Comprehensive query support including term, range, prefix, wildcard, regex, and fuzzy queries
+- Proper sorting that respects semantic version precedence
+
+### Technical Changes
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph "Indexing"
+        Input[Version String] --> Parser[SemanticVersion.parse]
+        Parser --> Normalized[Normalized String]
+        Parser --> Original[Original String]
+        Original --> TermField[Term Field - Exact Match]
+        Normalized --> DocValues[Doc Values - Sorting/Range]
+        Normalized --> NormalizedField[Normalized Field - Range Queries]
+    end
+    
+    subgraph "Querying"
+        TermQuery[Term Query] --> TermField
+        RangeQuery[Range Query] --> NormalizedField
+        SortQuery[Sort] --> DocValues
+        PrefixQuery[Prefix/Wildcard] --> TermField
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `SemanticVersion` | Core class for parsing, comparing, and normalizing semantic version strings |
+| `SemanticVersionFieldMapper` | Field mapper that handles indexing and query generation |
+| `SemanticVersionFieldType` | Field type supporting term, range, prefix, wildcard, regex, and fuzzy queries |
+
+#### Mapping Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `type` | Must be `version` | Required |
+| `index` | Enable indexing for search | `true` |
+| `doc_values` | Enable doc values for sorting/aggregations | `true` |
+| `store` | Store original value for retrieval | `false` |
+
+### Usage Example
+
+**Create index with version field:**
+```json
+PUT test_versions
+{
+  "mappings": {
+    "properties": {
+      "app": { "type": "keyword" },
+      "version": { "type": "version" },
+      "release_date": { "type": "date" }
+    }
+  }
+}
+```
+
+**Index documents:**
+```json
+POST test_versions/_bulk
+{ "index": {} }
+{ "app": "MyApp", "version": "1.0.0", "release_date": "2023-01-01" }
+{ "index": {} }
+{ "app": "MyApp", "version": "1.0.0-alpha", "release_date": "2022-12-01" }
+{ "index": {} }
+{ "app": "MyApp", "version": "1.0.0-beta", "release_date": "2022-12-15" }
+{ "index": {} }
+{ "app": "MyApp", "version": "2.0.0", "release_date": "2024-01-01" }
+```
+
+**Range query:**
+```json
+GET test_versions/_search
+{
+  "query": {
+    "range": {
+      "version": { "gte": "1.0.0", "lt": "2.0.0" }
+    }
+  }
+}
+```
+
+**Sort by version:**
+```json
+GET test_versions/_search
+{
+  "query": { "match_all": {} },
+  "sort": [{ "version": { "order": "asc" }}]
+}
+```
+
+Results are sorted correctly: `1.0.0-alpha` < `1.0.0-beta` < `1.0.0` < `2.0.0`
+
+### Supported Query Types
+
+| Query Type | Support | Notes |
+|------------|---------|-------|
+| `term` | ✅ | Exact version match |
+| `terms` | ✅ | Multiple version match |
+| `range` | ✅ | Semantic version ordering |
+| `prefix` | ✅ | Version prefix matching |
+| `wildcard` | ✅ | Pattern matching |
+| `regexp` | ✅ | Regex pattern matching |
+| `fuzzy` | ✅ | Fuzzy version matching |
+| `exists` | ✅ | Field existence check |
+| `match` | ✅ | Full-text match |
+| `match_phrase` | ✅ | Phrase matching |
+
+### Version Precedence
+
+Following SemVer 2.0.0 specification:
+
+1. Major, minor, patch versions compared numerically
+2. Pre-release versions have lower precedence than normal versions
+3. Pre-release identifiers compared left-to-right
+4. Numeric identifiers compared as integers
+5. Alphanumeric identifiers compared lexically
+6. Build metadata is ignored for precedence
+
+Example ordering:
+```
+1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-rc.1 < 1.0.0
+```
+
+## Limitations
+
+- Aggregations on version fields are not yet fully supported (added to test denylist)
+- Version strings must conform to SemVer 2.0.0 format
+- Leading zeros in numeric identifiers are not allowed (e.g., `01.0.0` is invalid)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18454](https://github.com/opensearch-project/OpenSearch/pull/18454) | Add Semantic Version field type mapper |
+
+## References
+
+- [Issue #16814](https://github.com/opensearch-project/OpenSearch/issues/16814): Feature request for semantic versioning support
+- [Semantic Versioning 2.0.0](https://semver.org/): SemVer specification
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/semantic-version-field-type.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -75,3 +75,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Star Tree Index](features/opensearch/star-tree-index.md) | feature | IP field search support and star-tree search statistics |
 | [Clusterless Mode](features/opensearch/clusterless-mode.md) | feature | Experimental clusterless startup mode and custom remote store path prefix |
 | [Rescore Named Queries](features/opensearch/rescore-named-queries.md) | feature | Surface named queries from rescore contexts in matched_queries array |
+| [Semantic Version Field Type](features/opensearch/semantic-version-field-type.md) | feature | New `version` field type for semantic versioning with proper ordering and range queries |


### PR DESCRIPTION
## Summary

This PR adds documentation for the **Semantic Version Field Type** feature introduced in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/semantic-version-field-type.md`
- Feature report: `docs/features/opensearch/semantic-version-field-type.md`

### Key Changes in v3.2.0
- New `version` field type for indexing and querying semantic version strings
- Follows SemVer 2.0.0 specification with proper precedence ordering
- Supports pre-release versions (`-alpha`, `-beta`, `-rc.1`) and build metadata (`+build.123`)
- Comprehensive query support: term, range, prefix, wildcard, regex, fuzzy queries
- Proper sorting that respects semantic version precedence

### Resources Used
- PR: [#18454](https://github.com/opensearch-project/OpenSearch/pull/18454)
- Issue: [#16814](https://github.com/opensearch-project/OpenSearch/issues/16814)

Closes #1108