### PR TITLE
docs: add Approximation Framework numeric types extension report for v3.2.0

### DIFF
--- a/docs/features/opensearch/approximation-framework.md
+++ b/docs/features/opensearch/approximation-framework.md
@@ -82,7 +82,11 @@ flowchart TB
 
 | Query Type | Example | Optimization | Since |
 |------------|---------|--------------|-------|
-| Range Query | `{"range": {"@timestamp": {"gte": "now-1d"}}}` | Early termination on BKD traversal | v3.0.0 |
+| Range Query (long/date) | `{"range": {"@timestamp": {"gte": "now-1d"}}}` | Early termination on BKD traversal | v3.0.0 |
+| Range Query (int) | `{"range": {"status_code": {"gte": 400}}}` | Early termination on BKD traversal | v3.2.0 |
+| Range Query (float/double) | `{"range": {"temperature": {"gte": 20.0}}}` | Early termination on BKD traversal | v3.2.0 |
+| Range Query (half_float) | `{"range": {"score": {"gte": 0.5}}}` | Early termination on BKD traversal | v3.2.0 |
+| Range Query (unsigned_long) | `{"range": {"counter": {"gte": 1000}}}` | Early termination on BKD traversal | v3.2.0 |
 | Match All + Sort | `{"match_all": {}, "sort": [{"@timestamp": "desc"}]}` | Rewritten to bounded range with early termination | v3.0.0 |
 | Range + Sort | `{"range": {...}, "sort": [...]}` | Optimized left/right traversal based on sort order | v3.0.0 |
 | Range with `now` | `{"range": {"@timestamp": {"gte": "now-1h"}}}` | Approximation applied to `DateRangeIncludingNowQuery` | v3.2.0 |
@@ -165,6 +169,7 @@ GET logs/_search
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#18530](https://github.com/opensearch-project/OpenSearch/pull/18530) | Extend Approximation Framework to other numeric types (int, float, double, half_float, unsigned_long) |
 | v3.2.0 | [#18896](https://github.com/opensearch-project/OpenSearch/pull/18896) | Support `search_after` numeric queries with Approximation Framework |
 | v3.2.0 | [#18511](https://github.com/opensearch-project/OpenSearch/pull/18511) | Added approximation support for range queries with `now` in date field |
 | v3.2.0 | [#18763](https://github.com/opensearch-project/OpenSearch/pull/18763) | Disable approximation framework when dealing with multiple sorts |
@@ -173,6 +178,7 @@ GET logs/_search
 
 ## References
 
+- [Issue #14406](https://github.com/opensearch-project/OpenSearch/issues/14406): Feature request to expand ApproximatePointRangeQuery to other numeric types
 - [Issue #18341](https://github.com/opensearch-project/OpenSearch/issues/18341): Feature request for DFS traversal strategy
 - [Issue #18546](https://github.com/opensearch-project/OpenSearch/issues/18546): Feature request for `search_after` support
 - [Issue #18503](https://github.com/opensearch-project/OpenSearch/issues/18503): Bug report for `now` range queries skipping approximation
@@ -182,6 +188,6 @@ GET logs/_search
 
 ## Change History
 
-- **v3.2.0**: Added `search_after` support for numeric queries, approximation for range queries with `now`, automatic disabling for multiple sort fields
+- **v3.2.0**: Extended Approximation Framework to all numeric types (int, float, double, half_float, unsigned_long); added `search_after` support for numeric queries; approximation for range queries with `now`; automatic disabling for multiple sort fields
 - **v3.1.0** (2025-06-10): Enhanced BKD traversal with DFS strategy for skewed datasets, smart subtree skipping
 - **v3.0.0**: Initial GA release with basic early termination support

--- a/docs/releases/v3.2.0/features/opensearch/approximation-framework-numeric-types.md
+++ b/docs/releases/v3.2.0/features/opensearch/approximation-framework-numeric-types.md
@@ -1,0 +1,167 @@
+# Approximation Framework: Numeric Types Extension
+
+## Summary
+
+OpenSearch v3.2.0 extends the Approximation Framework to support all numeric field types beyond the previously supported `long` type. This enhancement enables early termination optimization for range queries on `int`, `float`, `double`, `half_float`, and `unsigned_long` fields, significantly improving query performance for numeric range queries across all data types.
+
+## Details
+
+### What's New in v3.2.0
+
+Prior to this release, the Approximation Framework only applied to `long` fields (including date fields). This update extends the optimization to all numeric types:
+
+| Numeric Type | Support Status | Notes |
+|--------------|----------------|-------|
+| `long` | Existing | Already supported |
+| `integer` | **New** | Also covers `byte` and `short` |
+| `float` | **New** | Single-precision floating point |
+| `double` | **New** | Double-precision floating point |
+| `half_float` | **New** | 16-bit floating point |
+| `unsigned_long` | **New** | Index sort not supported |
+
+### Technical Changes
+
+#### New Format Decoders in ApproximatePointRangeQuery
+
+New format decoders were added to support byte array decoding for each numeric type:
+
+```java
+public static final Function<byte[], String> INT_FORMAT = 
+    bytes -> Integer.toString(IntPoint.decodeDimension(bytes, 0));
+    
+public static final Function<byte[], String> HALF_FLOAT_FORMAT = 
+    bytes -> Float.toString(HalfFloatPoint.decodeDimension(bytes, 0));
+    
+public static final Function<byte[], String> FLOAT_FORMAT = 
+    bytes -> Float.toString(FloatPoint.decodeDimension(bytes, 0));
+    
+public static final Function<byte[], String> DOUBLE_FORMAT = 
+    bytes -> Double.toString(DoublePoint.decodeDimension(bytes, 0));
+    
+public static final Function<byte[], String> UNSIGNED_LONG_FORMAT = 
+    bytes -> BigIntegerPoint.decodeDimension(bytes, 0).toString();
+```
+
+#### NumberFieldMapper Changes
+
+Each numeric type's `rangeQuery()` method was updated to wrap queries with `ApproximateScoreQuery`:
+
+```java
+// Example for INTEGER type
+return new ApproximateScoreQuery(
+    query,
+    new ApproximatePointRangeQuery(
+        field,
+        IntPoint.pack(new int[] { l }).bytes,
+        IntPoint.pack(new int[] { u }).bytes,
+        APPROX_QUERY_NUMERIC_DIMS,
+        ApproximatePointRangeQuery.INT_FORMAT
+    )
+);
+```
+
+#### Index Sort Support
+
+The implementation also adds `IndexSortSortedNumericDocValuesRangeQuery` support for numeric types that support index sorting:
+
+| Type | Index Sort Support |
+|------|-------------------|
+| `integer` | ✓ |
+| `long` | ✓ |
+| `float` | ✓ |
+| `double` | ✓ |
+| `half_float` | ✓ |
+| `unsigned_long` | ✗ (not supported by OpenSearch) |
+
+### Performance Improvements
+
+Based on benchmark results from the `http_logs` and `nyc_taxis` datasets:
+
+| Query Type | Dataset | Before | After | Improvement |
+|------------|---------|--------|-------|-------------|
+| `range_with_asc_sort` | http_logs | ~300 ms | ~30 ms | ~90% |
+| `range_size` | http_logs | ~48 ms | ~8 ms | ~83% |
+| `range_with_desc_sort` | http_logs | ~312 ms | ~31 ms | ~90% |
+| `desc_sort_passenger_count` | nyc_taxis | ~17 ms | ~12 ms | ~29% |
+
+### Usage Example
+
+```json
+// Integer field range query - now optimized
+GET metrics/_search
+{
+  "query": {
+    "range": {
+      "status_code": {
+        "gte": 400,
+        "lt": 500
+      }
+    }
+  },
+  "sort": [{ "status_code": "asc" }],
+  "size": 100
+}
+```
+
+```json
+// Float field range query - now optimized
+GET sensors/_search
+{
+  "query": {
+    "range": {
+      "temperature": {
+        "gte": 20.0,
+        "lte": 30.0
+      }
+    }
+  },
+  "sort": [{ "temperature": "desc" }],
+  "size": 50
+}
+```
+
+```json
+// Double field range query - now optimized
+GET transactions/_search
+{
+  "query": {
+    "range": {
+      "amount": {
+        "gte": 100.00,
+        "lte": 1000.00
+      }
+    }
+  },
+  "sort": [{ "amount": "asc" }],
+  "size": 100
+}
+```
+
+### Migration Notes
+
+This enhancement is transparent and requires no configuration changes. Existing range queries on numeric fields will automatically benefit from the optimization when eligibility criteria are met.
+
+## Limitations
+
+- `unsigned_long` fields do not support index sorting, so `IndexSortSortedNumericDocValuesRangeQuery` optimization is not available for this type
+- Same eligibility criteria as the base Approximation Framework apply:
+  - No aggregations in the query
+  - `track_total_hits` not set to `true`
+  - Sort field matches the range query field (if sorting)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18530](https://github.com/opensearch-project/OpenSearch/pull/18530) | Extend Approximation Framework to other numeric types |
+
+## References
+
+- [Issue #14406](https://github.com/opensearch-project/OpenSearch/issues/14406): Feature request to expand ApproximatePointRangeQuery to other numeric types
+- [Issue #18334](https://github.com/opensearch-project/OpenSearch/issues/18334): Related tracking issue
+- [Lucene PR #14784](https://github.com/apache/lucene/pull/14784): Related Lucene enhancement for `pack` support in sandbox types
+- [OpenSearch Approximation Framework Blog](https://opensearch.org/blog/opensearch-approximation-framework/): Comprehensive overview
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/approximation-framework.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -72,6 +72,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Remote Store Segment Warming](features/opensearch/remote-store-segment-warming.md) | feature | Remote store support for merged segment warming to reduce replication lag |
 | [Streaming Transport & Aggregation](features/opensearch/streaming-transport-aggregation.md) | feature | Stream transport framework and streaming aggregation for memory-efficient high-cardinality aggregations |
 | [Approximation Framework Enhancements](features/opensearch/approximation-framework-enhancements.md) | feature | search_after support, range queries with now, multi-sort handling |
+| [Approximation Framework: Numeric Types](features/opensearch/approximation-framework-numeric-types.md) | feature | Extend Approximation Framework to int, float, double, half_float, unsigned_long |
 | [Star Tree Index](features/opensearch/star-tree-index.md) | feature | IP field search support and star-tree search statistics |
 | [Clusterless Mode](features/opensearch/clusterless-mode.md) | feature | Experimental clusterless startup mode and custom remote store path prefix |
 | [Rescore Named Queries](features/opensearch/rescore-named-queries.md) | feature | Surface named queries from rescore contexts in matched_queries array |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Approximation Framework numeric types extension in OpenSearch v3.2.0.

### Changes

1. **New Release Report**: `docs/releases/v3.2.0/features/opensearch/approximation-framework-numeric-types.md`
   - Documents PR #18530 which extends the Approximation Framework to support all numeric types (int, float, double, half_float, unsigned_long)
   - Includes technical details on new format decoders and NumberFieldMapper changes
   - Documents performance improvements from benchmarks

2. **Updated Feature Report**: `docs/features/opensearch/approximation-framework.md`
   - Added PR #18530 to Related PRs table
   - Added Issue #14406 to References
   - Updated Change History to include numeric types extension
   - Updated Supported Query Types table to show all numeric types

3. **Updated Release Index**: `docs/releases/v3.2.0/index.md`
   - Added link to the new release report

### Related Issue

Closes #1107