### PR TITLE
docs: add Query Phase Plugin Extension report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -86,6 +86,7 @@
 - [Query Bug Fixes](opensearch/query-bug-fixes.md)
 - [Query Coordinator Context](opensearch/query-coordinator-context.md)
 - [Query Optimization](opensearch/query-optimization.md)
+- [Query Phase Plugin Extension](opensearch/query-phase-plugin-extension.md)
 - [Query String & Regex Queries](opensearch/query-string-regex.md)
 - [Randomness](opensearch/randomness.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)

--- a/docs/features/opensearch/query-phase-plugin-extension.md
+++ b/docs/features/opensearch/query-phase-plugin-extension.md
@@ -1,0 +1,189 @@
+# Query Phase Plugin Extension
+
+## Summary
+
+The Query Phase Plugin Extension provides an extensibility mechanism for OpenSearch plugins to inject custom `QueryCollectorContext` implementations during the Query Phase of search execution. This enables plugins to provide optimized collector implementations for custom query types, improving search performance by allowing collectors to be injected at the optimal point in the search lifecycle rather than through workarounds.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Search Execution"
+        SR[Search Request] --> QP[QueryPhase]
+        QP --> GCC[getQueryCollectorContext]
+        GCC --> REG[QueryCollectorContextSpecRegistry]
+        REG --> |"Iterate factories"| FAC1[Factory 1]
+        REG --> |"Iterate factories"| FAC2[Factory 2]
+        FAC1 --> |"Optional spec"| SPEC[QueryCollectorContextSpec]
+        SPEC --> QCC[QueryCollectorContext]
+        QCC --> COL[Collector Execution]
+        GCC --> |"No match: fallback"| TDC[TopDocsCollectorContext]
+        TDC --> COL
+    end
+    
+    subgraph "Plugin Bootstrap"
+        PLG[SearchPlugin] --> |"getCollectorContextSpecFactories()"| SM[SearchModule]
+        SM --> |"registerFactory()"| REG
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Registration
+        A[Plugin loads] --> B[SearchModule init]
+        B --> C[Register factories]
+        C --> D[Registry populated]
+    end
+    
+    subgraph "Search Time"
+        E[Query arrives] --> F[QueryPhase.searchWithCollector]
+        F --> G[getQueryCollectorContext]
+        G --> H{Factory match?}
+        H --> |Yes| I[Create QueryCollectorContextSpec]
+        H --> |No| J[Use TopDocsCollectorContext]
+        I --> K[Wrap as QueryCollectorContext]
+        K --> L[Execute search]
+        J --> L
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `QueryCollectorContextSpec` | Interface for defining custom collector behavior: creation, manager creation, and post-processing |
+| `QueryCollectorContextSpecFactory` | Factory interface that creates specs based on search context, query, and arguments |
+| `QueryCollectorContextSpecRegistry` | Static registry holding all registered factories, resolves specs at search time |
+| `QueryCollectorArguments` | Immutable arguments passed to factory (e.g., `hasFilterCollector` flag) |
+| `SearchPlugin.getCollectorContextSpecFactories()` | Extension point for plugins to register their factories |
+
+### Configuration
+
+This feature does not require any configuration. Plugins automatically register their factories during cluster bootstrap through the `SearchPlugin` interface.
+
+### Usage Example
+
+#### Implementing a Custom Collector Context Spec
+
+```java
+// Step 1: Implement QueryCollectorContextSpec
+public class CustomQueryCollectorContextSpec implements QueryCollectorContextSpec {
+    
+    private final SearchContext searchContext;
+    
+    public CustomQueryCollectorContextSpec(SearchContext searchContext) {
+        this.searchContext = searchContext;
+    }
+    
+    @Override
+    public String getContextName() {
+        return "custom_query_collector";
+    }
+    
+    @Override
+    public Collector create(Collector in) throws IOException {
+        // Wrap or replace the incoming collector
+        return new CustomCollector(in, searchContext);
+    }
+    
+    @Override
+    public CollectorManager<?, ReduceableSearchResult> createManager(
+            CollectorManager<?, ReduceableSearchResult> in) throws IOException {
+        // Create custom collector manager for concurrent search
+        return new CustomCollectorManager(in, searchContext);
+    }
+    
+    @Override
+    public void postProcess(QuerySearchResult result) throws IOException {
+        // Perform any post-processing on query results
+        // e.g., score normalization, result merging
+    }
+}
+```
+
+#### Implementing a Factory
+
+```java
+// Step 2: Implement QueryCollectorContextSpecFactory
+public class CustomQueryCollectorContextSpecFactory 
+        implements QueryCollectorContextSpecFactory {
+    
+    @Override
+    public Optional<QueryCollectorContextSpec> createQueryCollectorContextSpec(
+            SearchContext searchContext,
+            Query query,
+            QueryCollectorArguments queryCollectorArguments) throws IOException {
+        
+        // Check if this factory should handle the query
+        if (query instanceof CustomQuery) {
+            return Optional.of(new CustomQueryCollectorContextSpec(searchContext));
+        }
+        
+        // Return empty to let other factories or default handle it
+        return Optional.empty();
+    }
+}
+```
+
+#### Registering in Plugin
+
+```java
+// Step 3: Register factory in SearchPlugin
+public class CustomSearchPlugin extends Plugin implements SearchPlugin {
+    
+    @Override
+    public List<QueryCollectorContextSpecFactory> getCollectorContextSpecFactories() {
+        return List.of(new CustomQueryCollectorContextSpecFactory());
+    }
+}
+```
+
+### API Reference
+
+#### QueryCollectorContextSpec Interface
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `getContextName()` | `String` | Returns the name identifier for this collector context |
+| `create(Collector in)` | `Collector` | Creates a collector, optionally wrapping the input collector |
+| `createManager(CollectorManager in)` | `CollectorManager` | Creates a collector manager for concurrent search |
+| `postProcess(QuerySearchResult result)` | `void` | Post-processes the query search result |
+
+#### QueryCollectorArguments
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `hasFilterCollector()` | `boolean` | Whether the query has a filter collector |
+
+Built using the Builder pattern:
+```java
+QueryCollectorArguments args = new QueryCollectorArguments.Builder()
+    .hasFilterCollector(true)
+    .build();
+```
+
+## Limitations
+
+- **Experimental API**: Marked with `@ExperimentalApi`, subject to change in future versions
+- **Single spec per request**: Only one `QueryCollectorContextSpec` can be active per search request; the first matching factory wins
+- **Registration order matters**: Factories are evaluated in the order they were registered
+- **Static registry**: The registry is static, meaning all factories are shared across the cluster
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18637](https://github.com/opensearch-project/OpenSearch/pull/18637) | Initial implementation |
+
+## References
+
+- [Issue #18278](https://github.com/opensearch-project/OpenSearch/issues/18278): Original feature request
+- [PR #18007](https://github.com/opensearch-project/OpenSearch/pull/18007): POC for Hybrid Search in core (motivation and benchmarks)
+
+## Change History
+
+- **v3.2.0** (2025-07-01): Initial implementation - Added `QueryCollectorContextSpec`, `QueryCollectorContextSpecFactory`, `QueryCollectorContextSpecRegistry`, and `QueryCollectorArguments` classes. Extended `SearchPlugin` interface with `getCollectorContextSpecFactories()` method.

--- a/docs/releases/v3.2.0/features/opensearch/query-phase-plugin-extension.md
+++ b/docs/releases/v3.2.0/features/opensearch/query-phase-plugin-extension.md
@@ -1,0 +1,173 @@
+# Query Phase Plugin Extension
+
+## Summary
+
+This release introduces an extensibility mechanism that allows plugins to inject custom `QueryCollectorContext` during the Query Phase of search execution. Previously, the `TopDocsCollectorContext` was hardcoded in the search process, limiting plugins from providing custom collector implementations at the optimal point in the search lifecycle. This feature enables significant performance improvements for custom query types like hybrid queries.
+
+## Details
+
+### What's New in v3.2.0
+
+OpenSearch v3.2.0 adds a plugin extension point for injecting custom collector contexts during the Query Phase. This allows plugins to:
+
+1. Define custom `QueryCollectorContextSpec` implementations
+2. Register `QueryCollectorContextSpecFactory` instances during cluster bootstrap
+3. Have their custom collectors used instead of the default `TopDocsCollectorContext`
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Query Phase Execution"
+        QP[QueryPhase] --> GCC[getQueryCollectorContext]
+        GCC --> REG[QueryCollectorContextSpecRegistry]
+        REG --> |"Check registered factories"| FAC[QueryCollectorContextSpecFactory]
+        FAC --> |"Create spec if applicable"| SPEC[QueryCollectorContextSpec]
+        SPEC --> |"Wrap as"| QCC[QueryCollectorContext]
+        GCC --> |"Fallback"| TDC[TopDocsCollectorContext]
+    end
+    
+    subgraph "Plugin Registration"
+        SP[SearchPlugin] --> |"getCollectorContextSpecFactories()"| SM[SearchModule]
+        SM --> |"registerFactory()"| REG
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `QueryCollectorContextSpec` | Interface defining collector creation, manager creation, and post-processing |
+| `QueryCollectorContextSpecFactory` | Factory interface for creating `QueryCollectorContextSpec` based on search context and query |
+| `QueryCollectorContextSpecRegistry` | Static registry that holds all registered factories and resolves specs at search time |
+| `QueryCollectorArguments` | Arguments passed to factory for spec creation (e.g., `hasFilterCollector`) |
+
+#### New Interfaces
+
+**QueryCollectorContextSpec** (Experimental API):
+```java
+@ExperimentalApi
+public interface QueryCollectorContextSpec {
+    String getContextName();
+    Collector create(Collector in) throws IOException;
+    CollectorManager<?, ReduceableSearchResult> createManager(
+        CollectorManager<?, ReduceableSearchResult> in) throws IOException;
+    void postProcess(QuerySearchResult result) throws IOException;
+}
+```
+
+**QueryCollectorContextSpecFactory** (Experimental API):
+```java
+@ExperimentalApi
+public interface QueryCollectorContextSpecFactory {
+    Optional<QueryCollectorContextSpec> createQueryCollectorContextSpec(
+        SearchContext searchContext,
+        Query query,
+        QueryCollectorArguments queryCollectorArguments
+    ) throws IOException;
+}
+```
+
+#### SearchPlugin Extension
+
+Plugins can now implement `getCollectorContextSpecFactories()` in their `SearchPlugin`:
+
+```java
+public class MySearchPlugin extends Plugin implements SearchPlugin {
+    @Override
+    public List<QueryCollectorContextSpecFactory> getCollectorContextSpecFactories() {
+        return List.of(new MyQueryCollectorContextSpecFactory());
+    }
+}
+```
+
+### Usage Example
+
+```java
+// 1. Implement QueryCollectorContextSpec
+public class HybridQueryCollectorContextSpec implements QueryCollectorContextSpec {
+    @Override
+    public String getContextName() {
+        return "hybrid_query_collector";
+    }
+    
+    @Override
+    public Collector create(Collector in) throws IOException {
+        return new HybridTopScoreDocCollector(in);
+    }
+    
+    @Override
+    public CollectorManager<?, ReduceableSearchResult> createManager(
+            CollectorManager<?, ReduceableSearchResult> in) throws IOException {
+        return new HybridCollectorManager(in);
+    }
+    
+    @Override
+    public void postProcess(QuerySearchResult result) throws IOException {
+        // Custom post-processing logic
+    }
+}
+
+// 2. Implement QueryCollectorContextSpecFactory
+public class HybridQueryCollectorContextSpecFactory 
+        implements QueryCollectorContextSpecFactory {
+    @Override
+    public Optional<QueryCollectorContextSpec> createQueryCollectorContextSpec(
+            SearchContext searchContext,
+            Query query,
+            QueryCollectorArguments args) throws IOException {
+        // Only create spec for hybrid queries
+        if (query instanceof HybridQuery) {
+            return Optional.of(new HybridQueryCollectorContextSpec());
+        }
+        return Optional.empty();
+    }
+}
+
+// 3. Register in plugin
+public class NeuralSearchPlugin extends Plugin implements SearchPlugin {
+    @Override
+    public List<QueryCollectorContextSpecFactory> getCollectorContextSpecFactories() {
+        return List.of(new HybridQueryCollectorContextSpecFactory());
+    }
+}
+```
+
+### Performance Impact
+
+Based on benchmarking performed during development (noaa-semantic-search dataset with hybrid query using 3 subqueries):
+
+| Metric | Before (GA) | After (with extension) | Improvement |
+|--------|-------------|------------------------|-------------|
+| p50 latency | 280.16 ms | 246.99 ms | 11.83% |
+| p90 latency | 299.51 ms | 250.9 ms | 16.22% |
+| p99 latency | 326.92 ms | 289.33 ms | 11.49% |
+| p100 latency | 334.57 ms | 324.19 ms | 3.10% |
+
+The improvement comes from:
+- Eliminating the need for `EmptyCollectorContext` workarounds
+- Removing the custom `HybridQueryAggregationProcessor` wrapper
+- Injecting collectors at the optimal point in the search lifecycle
+
+## Limitations
+
+- This is an **Experimental API** (`@ExperimentalApi`) and may change in future versions
+- Only one `QueryCollectorContextSpec` can be active per search request (first matching factory wins)
+- Factories are evaluated in registration order
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18637](https://github.com/opensearch-project/OpenSearch/pull/18637) | Add functionality for plugins to inject QueryCollectorContext during QueryPhase |
+
+## References
+
+- [Issue #18278](https://github.com/opensearch-project/OpenSearch/issues/18278): Feature request for enabling collector context injection from plugins
+- [PR #18007](https://github.com/opensearch-project/OpenSearch/pull/18007): POC for moving Hybrid Search to OpenSearch core (benchmarking reference)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/query-phase-plugin-extension.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -79,3 +79,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Clusterless Mode](features/opensearch/clusterless-mode.md) | feature | Experimental clusterless startup mode and custom remote store path prefix |
 | [Rescore Named Queries](features/opensearch/rescore-named-queries.md) | feature | Surface named queries from rescore contexts in matched_queries array |
 | [Semantic Version Field Type](features/opensearch/semantic-version-field-type.md) | feature | New `version` field type for semantic versioning with proper ordering and range queries |
+| [Query Phase Plugin Extension](features/opensearch/query-phase-plugin-extension.md) | feature | Plugin extensibility for injecting custom QueryCollectorContext during QueryPhase |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Query Phase Plugin Extension feature introduced in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/query-phase-plugin-extension.md`
- Feature report: `docs/features/opensearch/query-phase-plugin-extension.md`

### Key Changes in v3.2.0
- Added `QueryCollectorContextSpec` interface for defining custom collector behavior
- Added `QueryCollectorContextSpecFactory` interface for creating specs based on search context
- Added `QueryCollectorContextSpecRegistry` for managing registered factories
- Extended `SearchPlugin` interface with `getCollectorContextSpecFactories()` method
- Enables plugins to inject custom `QueryCollectorContext` during QueryPhase execution

### Performance Impact
Based on benchmarking with hybrid queries:
- p50 latency: 11.83% improvement
- p90 latency: 16.22% improvement
- p99 latency: 11.49% improvement

### References
- PR: opensearch-project/OpenSearch#18637
- Issue: opensearch-project/OpenSearch#18278

Closes #1104