### PR TITLE
docs: add search-pipeline-in-templates report for v3.2.0

### DIFF
--- a/docs/features/opensearch/search-pipeline.md
+++ b/docs/features/opensearch/search-pipeline.md
@@ -126,6 +126,29 @@ GET /_msearch
 { "query": { "match": { "title": "opensearch" }}, "search_pipeline": "rerank_pipeline"}
 ```
 
+#### Using Pipeline with Search Template (v3.2.0+)
+
+```json
+POST /my-index/_search/template
+{
+  "id": "my_search_template",
+  "params": {
+    "query_string": "opensearch"
+  },
+  "search_pipeline": "my_pipeline"
+}
+```
+
+#### Using Pipeline with Multi-Search Template (v3.2.0+)
+
+```
+GET /_msearch/template
+{"index":"my-nlp-index1"}
+{"id":"search_template_1","params":{"play_name":"hello"}, "search_pipeline": "my_pipeline2"}
+{"index":"my-nlp-index1"}
+{"id":"search_template_2","params":{"play_name":"zoo"}, "search_pipeline": "my_pipeline1"}
+```
+
 #### Setting Default Pipeline
 
 ```json
@@ -159,22 +182,28 @@ POST /my-index/_search
 - Complex pipelines with ML inference can significantly increase latency
 - Pipeline errors can cause search failures if not handled properly
 - msearch pipeline support requires OpenSearch 2.18.0 or later
+- Search template pipeline support requires OpenSearch 3.2.0 or later
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#18564](https://github.com/opensearch-project/OpenSearch/pull/18564) | Added search pipeline support in search and msearch template |
 | v2.18.0 | [#15923](https://github.com/opensearch-project/OpenSearch/pull/15923) | Added msearch API support for search pipeline name |
 
 ## References
 
+- [Issue #18508](https://github.com/opensearch-project/OpenSearch/issues/18508): Feature request for search pipeline support in msearch template
 - [Issue #15748](https://github.com/opensearch-project/OpenSearch/issues/15748): Feature request for msearch pipeline support
 - [Search Pipelines Documentation](https://docs.opensearch.org/latest/search-plugins/search-pipelines/index/): Official documentation
 - [Using a Search Pipeline](https://docs.opensearch.org/latest/search-plugins/search-pipelines/using-search-pipeline/): Usage guide
 - [Creating a Search Pipeline](https://docs.opensearch.org/latest/search-plugins/search-pipelines/creating-search-pipeline/): Creation guide
+- [Search Templates Documentation](https://docs.opensearch.org/latest/api-reference/search-apis/search-template/): Search template API
+- [Multi-Search Template Documentation](https://docs.opensearch.org/latest/api-reference/search-apis/msearch-template/): Msearch template API
 - [Hybrid Search Blog](https://opensearch.org/blog/hybrid-search/): Hybrid search with normalization processor
 - [Optimizing Hybrid Search Blog](https://opensearch.org/blog/hybrid-search-optimization/): Performance optimization
 
 ## Change History
 
+- **v3.2.0** (2026-01-14): Added support for specifying search pipeline in search template and msearch template APIs
 - **v2.18.0** (2024-11-05): Added support for specifying search pipeline in msearch API request body

--- a/docs/releases/v3.2.0/features/opensearch/search-pipeline-in-templates.md
+++ b/docs/releases/v3.2.0/features/opensearch/search-pipeline-in-templates.md
@@ -1,0 +1,109 @@
+# Search Pipeline in Templates
+
+## Summary
+
+OpenSearch v3.2.0 adds support for specifying search pipelines directly in search template and multi-search template (msearch template) requests. This enhancement allows users to apply search pipelines to templated queries, enabling consistent query preprocessing and response postprocessing when using reusable search templates.
+
+## Details
+
+### What's New in v3.2.0
+
+This release extends the search pipeline functionality to work with search templates:
+
+- **Search Template API**: The `search_pipeline` parameter can now be specified in the request body when executing a search template
+- **Multi-Search Template API**: Each template request in an msearch template batch can specify its own search pipeline
+- **Stored Templates**: Search pipelines work with both inline and stored templates
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Search Template with Pipeline"
+        ST[Search Template Request] --> TP[Template Processing]
+        TP --> PP[Pipeline Assignment]
+        PP --> SR[Search Request]
+        SR --> SP[Search Pipeline]
+        SP --> SE[Search Execution]
+        SE --> RSP[Response Processors]
+        RSP --> FR[Final Response]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `SearchTemplateRequest.searchPipeline` | New field to store the pipeline name in template requests |
+| `RestSearchTemplateAction` pipeline handling | Logic to transfer pipeline from template request to search request |
+| `RestMultiSearchTemplateAction` pipeline handling | Logic to handle per-request pipelines in msearch template |
+
+#### API Changes
+
+The `SearchTemplateRequest` class now supports a `search_pipeline` field:
+
+```java
+public String getSearchPipeline();
+public void setSearchPipeline(String searchPipeline);
+```
+
+The `SearchTemplateRequestBuilder` also supports the new field:
+
+```java
+public SearchTemplateRequestBuilder setSearchPipeline(String searchPipeline);
+```
+
+### Usage Example
+
+#### Search Template with Pipeline
+
+```json
+POST /my-index/_search/template
+{
+  "id": "my_search_template",
+  "params": {
+    "query_string": "opensearch"
+  },
+  "search_pipeline": "my_pipeline"
+}
+```
+
+#### Multi-Search Template with Per-Request Pipelines
+
+```
+GET /_msearch/template
+{"index":"my-nlp-index1"}
+{"id":"search_template_1","params":{"play_name":"hello","from":0,"size":1}, "search_pipeline": "my_pipeline2"}
+{"index":"my-nlp-index1"}
+{"id":"search_template_2","params":{"play_name":"zoo","from":0,"size":1}, "search_pipeline": "my_pipeline1"}
+```
+
+### Migration Notes
+
+- No migration required - this is a new optional feature
+- Existing search templates continue to work without changes
+- To use pipelines with templates, simply add the `search_pipeline` field to your template requests
+
+## Limitations
+
+- The `search_pipeline` parameter is only available in the request body, not as a query parameter for template APIs
+- Pipeline must exist before being referenced in a template request
+- Version compatibility: This feature requires OpenSearch 3.2.0 or later
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18564](https://github.com/opensearch-project/OpenSearch/pull/18564) | Add support for search pipeline in search and msearch template |
+
+## References
+
+- [Issue #18508](https://github.com/opensearch-project/OpenSearch/issues/18508): Feature request for search pipeline support in msearch template
+- [Search Templates Documentation](https://docs.opensearch.org/latest/api-reference/search-apis/search-template/): Official search template docs
+- [Multi-Search Template Documentation](https://docs.opensearch.org/latest/api-reference/search-apis/msearch-template/): Official msearch template docs
+- [Search Pipelines Documentation](https://docs.opensearch.org/latest/search-plugins/search-pipelines/index/): Search pipeline overview
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/search-pipeline.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -80,3 +80,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Rescore Named Queries](features/opensearch/rescore-named-queries.md) | feature | Surface named queries from rescore contexts in matched_queries array |
 | [Semantic Version Field Type](features/opensearch/semantic-version-field-type.md) | feature | New `version` field type for semantic versioning with proper ordering and range queries |
 | [Query Phase Plugin Extension](features/opensearch/query-phase-plugin-extension.md) | feature | Plugin extensibility for injecting custom QueryCollectorContext during QueryPhase |
+| [Search Pipeline in Templates](features/opensearch/search-pipeline-in-templates.md) | feature | Support for search pipeline in search and msearch template APIs |


### PR DESCRIPTION
## Summary

This PR adds documentation for the "Search Pipeline in Templates" feature introduced in OpenSearch v3.2.0.

### Changes
- Created release report: `docs/releases/v3.2.0/features/opensearch/search-pipeline-in-templates.md`
- Updated feature report: `docs/features/opensearch/search-pipeline.md` with v3.2.0 changes
- Updated release index: `docs/releases/v3.2.0/index.md`

### Feature Overview
OpenSearch v3.2.0 adds support for specifying search pipelines directly in search template and multi-search template (msearch template) requests. This allows users to apply search pipelines to templated queries for consistent query preprocessing and response postprocessing.

### Key Changes in v3.2.0
- `search_pipeline` parameter support in Search Template API
- Per-request pipeline support in Multi-Search Template API
- Works with both inline and stored templates

### Related
- PR: [opensearch-project/OpenSearch#18564](https://github.com/opensearch-project/OpenSearch/pull/18564)
- Issue: [opensearch-project/OpenSearch#18508](https://github.com/opensearch-project/OpenSearch/issues/18508)
- Investigation Issue: #1103