### PR TITLE
docs: add Cat Indices API Enhancement report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -22,6 +22,7 @@
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
 - [Azure Repository](opensearch/azure-repository.md)
 - [Bulk API](opensearch/bulk-api.md)
+- [Cat Indices API](opensearch/cat-indices-api.md)
 - [Cluster Stats API](opensearch/cluster-stats-api.md)
 - [Cluster Manager Metrics](opensearch/cluster-manager-metrics.md)
 - [Code Cleanup](opensearch/code-cleanup.md)

--- a/docs/features/opensearch/cat-indices-api.md
+++ b/docs/features/opensearch/cat-indices-api.md
@@ -1,0 +1,158 @@
+# Cat Indices API
+
+## Summary
+
+The Cat Indices API (`_cat/indices`) provides a human-readable, tabular view of index information in OpenSearch. It displays essential statistics about indexes including health status, document counts, storage size, and various operational metrics. The API supports numerous optional columns that can be selectively displayed using the `h` parameter.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Client Request"
+        REQ[GET /_cat/indices] --> RIA[RestIndicesAction]
+    end
+    
+    subgraph "Data Collection"
+        RIA --> GSR[GetSettingsRequest]
+        RIA --> CSR[ClusterStateRequest]
+        RIA --> CHR[ClusterHealthRequest]
+        RIA --> ISR[IndicesStatsRequest]
+    end
+    
+    subgraph "Response Building"
+        GSR --> GAL[GroupedActionListener]
+        CSR --> GAL
+        CHR --> GAL
+        ISR --> GAL
+        GAL --> TB[Table Builder]
+        TB --> RESP[Tabular Response]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Index Operations"
+        IDX[Index Request] --> SHARD[IndexShard]
+        DEL[Delete Request] --> SHARD
+        SHARD --> STATS[InternalIndexingStats]
+    end
+    
+    subgraph "Stats Collection"
+        STATS --> IS[IndexingStats]
+        IS --> CS[CommonStats]
+        CS --> IDXS[IndexStats]
+    end
+    
+    subgraph "API Response"
+        IDXS --> CAT[Cat Indices API]
+        CAT --> OUT[Formatted Output]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `RestIndicesAction` | REST handler for `/_cat/indices` endpoint |
+| `IndexingStats` | Statistics about indexing operations including counts, times, and timestamps |
+| `CommonStats` | Aggregated statistics for an index across all shards |
+| `MaxMetric` | Thread-safe metric for tracking maximum values (e.g., timestamps) |
+| `Table` | Utility class for building tabular output |
+
+### Configuration
+
+The Cat Indices API supports various query parameters:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `v` | Include column headers | `false` |
+| `h` | Comma-separated list of columns to display | Default columns |
+| `s` | Sort by column(s) | None |
+| `bytes` | Unit for byte values (`b`, `kb`, `mb`, `gb`, `tb`, `pb`) | N/A |
+| `health` | Filter by health status (`green`, `yellow`, `red`) | All |
+| `pri` | Show only primary shard statistics | `false` |
+| `local` | Return local information only | `false` |
+| `cluster_manager_timeout` | Timeout for cluster manager connection | 30s |
+
+### Available Columns
+
+The API provides extensive column options organized by category:
+
+**Basic Information:**
+- `health`, `status`, `index`, `uuid`, `pri`, `rep`
+
+**Document Statistics:**
+- `docs.count`, `docs.deleted`
+
+**Storage:**
+- `store.size`, `pri.store.size`
+
+**Indexing Statistics:**
+- `indexing.index_total`, `indexing.index_time`, `indexing.index_current`
+- `indexing.delete_total`, `indexing.delete_time`, `indexing.delete_current`
+- `indexing.index_failed`
+
+**Search Statistics:**
+- `search.query_total`, `search.query_time`, `search.query_current`
+- `search.fetch_total`, `search.fetch_time`, `search.fetch_current`
+- `search.scroll_total`, `search.scroll_time`, `search.scroll_current`
+
+**Timestamp Columns (v3.2.0+):**
+- `last_index_request_timestamp` - Epoch milliseconds of last index request
+- `last_index_request_timestamp_string` - ISO 8601 formatted timestamp
+
+### Usage Example
+
+Basic usage:
+```bash
+GET _cat/indices?v
+```
+
+Select specific columns:
+```bash
+GET _cat/indices?v&h=index,health,docs.count,store.size
+```
+
+Filter by health and sort:
+```bash
+GET _cat/indices?v&health=yellow&s=store.size:desc
+```
+
+Show indexing activity timestamps (v3.2.0+):
+```bash
+GET _cat/indices?v&h=index,last_index_request_timestamp,last_index_request_timestamp.string
+```
+
+Example output:
+```
+health status index   uuid                   pri rep docs.count store.size
+green  open   movies  UZbpfERBQ1-3GSH2bnM3sg   1   1          1      7.7kb
+yellow open   logs    abc123def456ghi789jkl   5   1     100000     50.2mb
+```
+
+## Limitations
+
+- Response size can be limited by `cat.indices.response.limit.number_of_indices` cluster setting
+- Some statistics may not be available for closed indices
+- Timestamp columns reset when shards are relocated or nodes restart
+- Mixed-version clusters may show incomplete data for newer columns
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18405](https://github.com/opensearch-project/OpenSearch/pull/18405) | Add last index request timestamp columns |
+
+## References
+
+- [Issue #10766](https://github.com/opensearch-project/OpenSearch/issues/10766): Stats API to identify which indices are getting updates
+- [CAT indices API Documentation](https://docs.opensearch.org/3.0/api-reference/cat/cat-indices/)
+- [CAT API Overview](https://docs.opensearch.org/3.0/api-reference/cat/index/)
+
+## Change History
+
+- **v3.2.0**: Added `last_index_request_timestamp` and `last_index_request_timestamp_string` columns to track indexing activity

--- a/docs/releases/v3.2.0/features/opensearch/cat-indices-api-enhancement.md
+++ b/docs/releases/v3.2.0/features/opensearch/cat-indices-api-enhancement.md
@@ -1,0 +1,112 @@
+# Cat Indices API Enhancement
+
+## Summary
+
+OpenSearch v3.2.0 enhances the `_cat/indices` API by adding two new columns that expose the timestamp of the last index request processed for each index. This feature helps operators quickly identify which indices are actively receiving updates, making it easier to monitor indexing activity and troubleshoot cluster performance issues.
+
+## Details
+
+### What's New in v3.2.0
+
+The `_cat/indices` API now includes two new optional columns:
+
+| Column | Alias | Description |
+|--------|-------|-------------|
+| `last_index_request_timestamp` | `last_index_ts`, `lastIndexRequestTimestamp` | Raw timestamp in milliseconds since epoch |
+| `last_index_request_timestamp_string` | `last_index_ts_string`, `lastIndexRequestTimestampString` | Human-readable UTC ISO 8601 format |
+
+This mirrors the existing approach for `creation.date` and `creation.date.string`, providing both machine-friendly and human-friendly representations.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Index Request Flow"
+        IR[Index/Delete Request] --> IS[IndexShard]
+        IS --> IIS[InternalIndexingStats]
+        IIS --> MM[MaxMetric]
+        MM --> TS[Timestamp Tracking]
+    end
+    
+    subgraph "Cat Indices API"
+        CAT[/_cat/indices] --> RIA[RestIndicesAction]
+        RIA --> ISR[IndicesStatsRequest]
+        ISR --> Stats[IndexingStats]
+        Stats --> Response[API Response]
+    end
+    
+    TS --> Stats
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `MaxMetric` | New metric class using `LongAccumulator` to track maximum timestamp values efficiently |
+| `maxLastIndexRequestTimestamp` field | Added to `IndexingStats.Stats` to store the timestamp |
+
+#### Implementation Details
+
+- The timestamp is updated on successful index and delete operations
+- Uses `LongAccumulator` with `Long::max` for thread-safe maximum value tracking
+- Timestamp is obtained from `ThreadPool.absoluteTimeInMillis()` for consistency
+- Aggregation across shards uses `Math.max()` to surface the most recent timestamp
+
+#### Serialization
+
+The new field is serialized only for OpenSearch v3.2.0 and later:
+- Nodes running v3.2.0+ will include `maxLastIndexRequestTimestamp` in the wire protocol
+- Older nodes will receive/send `0L` as the default value for backward compatibility
+
+### Usage Example
+
+Query the new columns:
+
+```bash
+GET _cat/indices?v&h=index,last_index_request_timestamp,last_index_request_timestamp.string
+```
+
+Example response:
+
+```
+index                          last_index_request_timestamp last_index_request_timestamp.string
+movies                         1710000000000                2024-03-09T16:00:00.000Z
+logs-2024.03                   1710001234567                2024-03-09T16:20:34.567Z
+```
+
+### Use Cases
+
+1. **Identifying Active Indices**: Quickly determine which indices are receiving updates during high indexing load
+2. **Troubleshooting**: When investigating cluster performance issues, identify which shards are actively processing requests
+3. **Monitoring**: Track indexing activity patterns across indices over time
+4. **Capacity Planning**: Understand which indices are most actively used for write operations
+
+### Migration Notes
+
+- No migration required - this is an additive change
+- New columns are disabled by default (use `h=` parameter to include them)
+- Mixed-version clusters will show `0` or `null` for nodes running older versions
+
+## Limitations
+
+- The timestamp reflects the last successful index or delete operation only
+- Bulk operations update the timestamp once per successful document
+- The timestamp is not persisted - it resets when a shard is relocated or the node restarts
+- In mixed-version clusters, older nodes will report `0` for this field
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18405](https://github.com/opensearch-project/OpenSearch/pull/18405) | Expose Last Index Request Timestamp in Cat Indices API |
+
+## References
+
+- [Issue #10766](https://github.com/opensearch-project/OpenSearch/issues/10766): Stats API to identify which indices (and shards?) are getting updates
+- [CAT indices API Documentation](https://docs.opensearch.org/3.0/api-reference/cat/cat-indices/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/cat-indices-api.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -82,3 +82,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Query Phase Plugin Extension](features/opensearch/query-phase-plugin-extension.md) | feature | Plugin extensibility for injecting custom QueryCollectorContext during QueryPhase |
 | [Search Pipeline in Templates](features/opensearch/search-pipeline-in-templates.md) | feature | Support for search pipeline in search and msearch template APIs |
 | [Pull-based Ingestion](features/opensearch/pull-based-ingestion.md) | feature | File-based ingestion plugin (ingestion-fs) for local testing |
+| [Cat Indices API Enhancement](features/opensearch/cat-indices-api-enhancement.md) | feature | Add last index request timestamp columns to `_cat/indices` API |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Cat Indices API Enhancement feature in OpenSearch v3.2.0.

### Feature Overview

The `_cat/indices` API now includes two new optional columns that expose the timestamp of the last index request processed for each index:

- `last_index_request_timestamp` - Raw timestamp in milliseconds since epoch
- `last_index_request_timestamp_string` - Human-readable UTC ISO 8601 format

This helps operators quickly identify which indices are actively receiving updates.

### Reports Created

- Release report: `docs/releases/v3.2.0/features/opensearch/cat-indices-api-enhancement.md`
- Feature report: `docs/features/opensearch/cat-indices-api.md`

### Related

- Resolves Issue #1101
- Based on [PR #18405](https://github.com/opensearch-project/OpenSearch/pull/18405) in opensearch-project/OpenSearch
- Original feature request: [Issue #10766](https://github.com/opensearch-project/OpenSearch/issues/10766)