### PR TITLE
docs: add Remote Store Metadata API report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -94,6 +94,7 @@
 - [Replication](opensearch/replication.md)
 - [Rescore Named Queries](opensearch/rescore-named-queries.md)
 - [Remote Store](opensearch/remote-store.md)
+- [Remote Store Metadata API](opensearch/remote-store-metadata-api.md)
 - [Repository Rate Limiters](opensearch/repository-rate-limiters.md)
 - [RestHandler.Wrapper](opensearch/resthandler-wrapper.md)
 - [Remote Store Metrics](opensearch/remote-store-metrics.md)

--- a/docs/features/opensearch/remote-store-metadata-api.md
+++ b/docs/features/opensearch/remote-store-metadata-api.md
@@ -1,0 +1,195 @@
+# Remote Store Metadata API
+
+## Summary
+
+The Remote Store Metadata API is a cluster-level API that enables users to retrieve detailed segment and translog metadata from remote-backed storage. This API provides visibility into the actual metadata files stored in remote repositories, including file checksums, sizes, replication checkpoints, and translog generation information. It complements the Remote Store Stats API by providing metadata content rather than performance metrics.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph Client Layer
+        REST[REST API Request]
+    end
+    
+    subgraph Transport Layer
+        REST --> RestHandler[RestRemoteStoreMetadataAction]
+        RestHandler --> TransportAction[TransportRemoteStoreMetadataAction]
+    end
+    
+    subgraph Data Access Layer
+        TransportAction --> IndexResolver[IndexNameExpressionResolver]
+        TransportAction --> SegmentDir[RemoteSegmentStoreDirectory]
+        TransportAction --> TranslogMgr[TranslogTransferManager]
+    end
+    
+    subgraph Remote Storage
+        SegmentDir --> SegmentRepo[(Segment Repository)]
+        TranslogMgr --> TranslogRepo[(Translog Repository)]
+    end
+    
+    subgraph Response
+        SegmentRepo --> ShardMeta[RemoteStoreShardMetadata]
+        TranslogRepo --> ShardMeta
+        ShardMeta --> Response[RemoteStoreMetadataResponse]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Client Request] --> B[Resolve Index Names]
+    B --> C[Iterate Shards]
+    C --> D{Remote Store Enabled?}
+    D -->|Yes| E[Fetch Segment Metadata]
+    D -->|No| F[Record Failure]
+    E --> G[Fetch Translog Metadata]
+    G --> H[Build ShardMetadata]
+    H --> I[Aggregate Response]
+    F --> I
+    I --> J[Return to Client]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `RemoteStoreMetadataAction` | Action type for the metadata API, registered as `cluster:admin/remote_store/metadata` |
+| `RemoteStoreMetadataRequest` | Broadcast request supporting index patterns and optional shard filtering |
+| `RemoteStoreMetadataResponse` | Aggregated response with per-shard metadata and failure information |
+| `RemoteStoreShardMetadata` | Per-shard metadata container with segment and translog file details |
+| `RemoteStoreMetadataRequestBuilder` | Fluent builder for client-side request construction |
+| `RestRemoteStoreMetadataAction` | REST handler exposing the API endpoints |
+| `TransportRemoteStoreMetadataAction` | Transport action that orchestrates metadata collection |
+
+### API Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| GET | `/_remotestore/metadata/{index}` | Fetch metadata for all shards of specified index(es) |
+| GET | `/_remotestore/metadata/{index}/{shard_id}` | Fetch metadata for a specific shard |
+
+### Request Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `index` | String | Index name or pattern (supports wildcards) |
+| `shard_id` | String | Optional shard ID to filter results |
+| `timeout` | TimeValue | Request timeout |
+
+### Response Structure
+
+```json
+{
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "failed": 0
+  },
+  "indices": {
+    "<index_name>": {
+      "shards": {
+        "<shard_id>": [
+          {
+            "index": "<index_name>",
+            "shard": 0,
+            "latest_segment_metadata_filename": "metadata__...",
+            "latest_translog_metadata_filename": "metadata__...",
+            "available_segment_metadata_files": {
+              "<filename>": {
+                "files": {
+                  "<segment_file>": {
+                    "original_name": "...",
+                    "checksum": "...",
+                    "length": 1024
+                  }
+                },
+                "replication_checkpoint": {
+                  "primary_term": 1,
+                  "segments_gen": 3,
+                  "segment_infos_version": 9,
+                  "codec": "Lucene101",
+                  "created_timestamp": 163477705159875
+                }
+              }
+            },
+            "available_translog_metadata_files": {
+              "<filename>": {
+                "primary_term": 1,
+                "generation": 3,
+                "min_translog_gen": 3,
+                "generation_to_primary_term": {"3": "1"}
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+### Usage Example
+
+```bash
+# Fetch metadata for all shards of an index
+GET /_remotestore/metadata/my-index?pretty
+
+# Fetch metadata for a specific shard
+GET /_remotestore/metadata/my-index/0?pretty
+
+# Fetch metadata for multiple indexes using wildcard
+GET /_remotestore/metadata/logs-*?pretty
+```
+
+### Client API
+
+```java
+// Using the client API
+RemoteStoreMetadataResponse response = client.admin()
+    .cluster()
+    .prepareRemoteStoreMetadata("my-index", "0")
+    .setTimeout(TimeValue.timeValueSeconds(30))
+    .get();
+
+// Process response
+response.groupByIndexAndShards().forEach((index, shardMap) -> {
+    shardMap.forEach((shardId, metadataList) -> {
+        for (RemoteStoreShardMetadata metadata : metadataList) {
+            System.out.println("Segment files: " + metadata.getSegmentMetadataFiles());
+            System.out.println("Translog files: " + metadata.getTranslogMetadataFiles());
+        }
+    });
+});
+```
+
+### Permissions
+
+When the Security plugin is enabled, users need the following permission:
+- `cluster:admin/remotestore/metadata`
+
+## Limitations
+
+- Only works with indexes that have remote store enabled (`index.remote_store.enabled: true`)
+- Returns up to 5 most recent metadata files per shard (configurable in implementation)
+- Marked as `@ExperimentalApi` - the API surface may change in future releases
+- Does not provide real-time metrics (use Remote Store Stats API for performance monitoring)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18257](https://github.com/opensearch-project/OpenSearch/pull/18257) | Initial implementation of Remote Store Metadata API |
+
+## References
+
+- [Remote-backed storage documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/remote-store/index/)
+- [Remote Store Stats API](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/remote-store/remote-store-stats-api/)
+- [Segment replication](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/segment-replication/index/)
+
+## Change History
+
+- **v3.2.0**: Initial implementation - Added cluster-level API to fetch segment and translog metadata from remote store

--- a/docs/releases/v3.2.0/features/opensearch/remote-store-metadata-api.md
+++ b/docs/releases/v3.2.0/features/opensearch/remote-store-metadata-api.md
@@ -1,0 +1,150 @@
+# Remote Store Metadata API
+
+## Summary
+
+OpenSearch v3.2.0 introduces a new cluster-level API (`/_remotestore/metadata`) that enables users to retrieve segment and translog metadata from remote-backed storage for specific indexes and shards. This API enhances observability and debugging capabilities for indexes backed by remote storage, complementing the existing Remote Store Stats API.
+
+## Details
+
+### What's New in v3.2.0
+
+This release adds a new REST API endpoint that fetches detailed metadata about segment and translog files stored in remote repositories. Unlike the Remote Store Stats API (which provides performance metrics), this new Metadata API returns the actual metadata file contents, including file checksums, sizes, and replication checkpoint information.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph Client
+        REST[REST Request]
+    end
+    subgraph OpenSearch Cluster
+        REST --> Handler[RestRemoteStoreMetadataAction]
+        Handler --> Transport[TransportRemoteStoreMetadataAction]
+        Transport --> SegDir[RemoteSegmentStoreDirectory]
+        Transport --> TranslogMgr[TranslogTransferManager]
+    end
+    subgraph Remote Store
+        SegDir --> SegRepo[(Segment Repository)]
+        TranslogMgr --> TranslogRepo[(Translog Repository)]
+    end
+    SegRepo --> Response[RemoteStoreMetadataResponse]
+    TranslogRepo --> Response
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `RemoteStoreMetadataAction` | Action type registered under `cluster:admin/remote_store/metadata` |
+| `RemoteStoreMetadataRequest` | Request object supporting index name and optional shard IDs |
+| `RemoteStoreMetadataResponse` | Response containing per-shard metadata with success/failure info |
+| `RemoteStoreShardMetadata` | Holds parsed segment and translog metadata per shard |
+| `RestRemoteStoreMetadataAction` | REST handler for the new endpoints |
+| `TransportRemoteStoreMetadataAction` | Transport action that collects metadata from remote store |
+
+#### API Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `GET /_remotestore/metadata/{index}` | Fetch metadata for all shards of an index |
+| `GET /_remotestore/metadata/{index}/{shard_id}` | Fetch metadata for a specific shard |
+
+### Usage Example
+
+```bash
+GET /_remotestore/metadata/my-index-1?pretty
+```
+
+```json
+{
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "failed": 0
+  },
+  "indices": {
+    "my-index-1": {
+      "shards": {
+        "0": [
+          {
+            "index": "my-index-1",
+            "shard": 0,
+            "latest_segment_metadata_filename": "metadata__9223372036854775806__...",
+            "latest_translog_metadata_filename": "metadata__9223372036854775806__...",
+            "available_segment_metadata_files": {
+              "metadata__...": {
+                "files": {
+                  "_0.cfe": {
+                    "original_name": "_0.cfe",
+                    "checksum": "624593751",
+                    "length": 517
+                  }
+                },
+                "replication_checkpoint": {
+                  "primary_term": 1,
+                  "segments_gen": 3,
+                  "segment_infos_version": 9,
+                  "codec": "Lucene101",
+                  "created_timestamp": 163477705159875
+                }
+              }
+            },
+            "available_translog_metadata_files": {
+              "metadata__...": {
+                "primary_term": 1,
+                "generation": 3,
+                "min_translog_gen": 3,
+                "generation_to_primary_term": {
+                  "3": "1"
+                }
+              }
+            }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+### Response Fields
+
+#### Segment Metadata Files
+
+| Field | Description |
+|-------|-------------|
+| `files` | Map of segment files with original name, checksum, and length |
+| `replication_checkpoint` | Contains primary_term, segments_gen, segment_infos_version, codec, and created_timestamp |
+
+#### Translog Metadata Files
+
+| Field | Description |
+|-------|-------------|
+| `primary_term` | Primary term of the translog |
+| `generation` | Current translog generation |
+| `min_translog_gen` | Minimum translog generation |
+| `generation_to_primary_term` | Mapping of generation to primary term |
+
+## Limitations
+
+- Only works with remote-store enabled indexes
+- Returns up to 5 most recent metadata files per shard
+- Requires `cluster:admin/remotestore/metadata` permission when Security plugin is enabled
+- Marked as `@ExperimentalApi` - API may change in future releases
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18257](https://github.com/opensearch-project/OpenSearch/pull/18257) | Created an API to fetch remote store metadata |
+
+## References
+
+- [Remote-backed storage documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/remote-store/index/)
+- [Remote Store Stats API](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/remote-store/remote-store-stats-api/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/remote-store-metadata-api.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -83,3 +83,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Search Pipeline in Templates](features/opensearch/search-pipeline-in-templates.md) | feature | Support for search pipeline in search and msearch template APIs |
 | [Pull-based Ingestion](features/opensearch/pull-based-ingestion.md) | feature | File-based ingestion plugin (ingestion-fs) for local testing |
 | [Cat Indices API Enhancement](features/opensearch/cat-indices-api-enhancement.md) | feature | Add last index request timestamp columns to `_cat/indices` API |
+| [Remote Store Metadata API](features/opensearch/remote-store-metadata-api.md) | feature | New cluster-level API to fetch segment and translog metadata from remote store |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Remote Store Metadata API feature introduced in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/remote-store-metadata-api.md`
- Feature report: `docs/features/opensearch/remote-store-metadata-api.md`

### Key Changes in v3.2.0
- New cluster-level API (`/_remotestore/metadata/{index}`) to fetch segment and translog metadata from remote store
- Provides visibility into metadata file contents including checksums, sizes, and replication checkpoints
- Complements the existing Remote Store Stats API (which provides performance metrics)

### Resources Used
- PR: [#18257](https://github.com/opensearch-project/OpenSearch/pull/18257)
- Docs: [Remote-backed storage](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/remote-store/index/)
- Docs: [Remote Store Stats API](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/remote-store/remote-store-stats-api/)

Closes #1100