### PR TITLE
docs: add java-agent-accesscontroller report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -55,6 +55,7 @@
 - [Locale Provider](opensearch/locale-provider.md)
 - [HTTP API](opensearch/http-api.md)
 - [Jackson & Query Limits](opensearch/jackson--query-limits.md)
+- [Java Agent AccessController](opensearch/java-agent-accesscontroller.md)
 - [Source Field Matching](opensearch/source-field-matching.md)
 - [Cryptography & Security Libraries](opensearch/cryptography-security-libraries.md)
 - [Gradle Build System](opensearch/gradle-build-system.md)

--- a/docs/features/opensearch/java-agent-accesscontroller.md
+++ b/docs/features/opensearch/java-agent-accesscontroller.md
@@ -1,0 +1,161 @@
+# Java Agent AccessController
+
+## Summary
+
+OpenSearch provides `org.opensearch.secure_sm.AccessController`, a replacement for Java's deprecated `java.security.AccessController`. This utility class enables code to run in a privileged context, allowing the Java agent to properly truncate stack walking during permission checks. Plugin developers should use this class instead of the JDK's `AccessController`, which is scheduled for removal in JDK 24.
+
+## Details
+
+### Background
+
+OpenSearch 3.0 replaced the Java Security Manager (JSM) with a custom Java agent for security enforcement. The Java agent uses stack walking to determine which code is requesting privileged operations and checks permissions based on `plugin-security.policy` files.
+
+The JDK's `AccessController.doPrivileged` served as a marker to stop stack walking—only frames before the `doPrivileged` call were checked for permissions. With `AccessController` being removed from the JDK, OpenSearch needed its own equivalent.
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Application Layer"
+        Plugin[Plugin Code]
+        Core[OpenSearch Core]
+    end
+    subgraph "Security Layer"
+        AC[org.opensearch.secure_sm.AccessController]
+        Agent[Java Agent]
+        Extractor[StackCallerProtectionDomainChainExtractor]
+    end
+    subgraph "Permission Check"
+        Policy[plugin-security.policy]
+        Check[Permission Validation]
+    end
+    Plugin --> AC
+    Core --> AC
+    AC --> Agent
+    Agent --> Extractor
+    Extractor -->|"Extract ProtectionDomains"| Check
+    Policy --> Check
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Plugin calls doPrivileged] --> B[AccessController executes action]
+    B --> C[Java Agent intercepts privileged operation]
+    C --> D[StackWalker captures call stack]
+    D --> E[Extractor stops at AccessController frame]
+    E --> F[Extract ProtectionDomains from truncated stack]
+    F --> G[Check permissions against policy]
+    G --> H{Permitted?}
+    H -->|Yes| I[Allow operation]
+    H -->|No| J[Throw SecurityException]
+```
+
+### Components
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| `AccessController` | `libs/agent-sm/agent-policy` | Main utility class with `doPrivileged` methods |
+| `CheckedRunnable<E>` | Inner interface | Functional interface for void actions with checked exceptions |
+| `CheckedSupplier<R, E>` | Inner interface | Functional interface for suppliers with checked exceptions |
+| `StackCallerProtectionDomainChainExtractor` | `libs/agent-sm/agent` | Extracts ProtectionDomains, stops at AccessController frames |
+
+### API Reference
+
+| Method Signature | Description |
+|------------------|-------------|
+| `static void doPrivileged(Runnable action)` | Execute void action in privileged context |
+| `static <T> T doPrivileged(Supplier<T> action)` | Execute action with return value |
+| `static <T extends Exception> void doPrivilegedChecked(CheckedRunnable<T> action) throws T` | Execute void action that may throw checked exception |
+| `static <R, T extends Exception> R doPrivilegedChecked(CheckedSupplier<R, T> action) throws T` | Execute action with return value that may throw checked exception |
+
+### Configuration
+
+No additional configuration required. The AccessController is automatically recognized by the Java agent's stack walking logic.
+
+### Usage Examples
+
+#### Basic Privileged Action
+
+```java
+import org.opensearch.secure_sm.AccessController;
+
+// Void action
+AccessController.doPrivileged(() -> {
+    System.setProperty("my.property", "value");
+});
+
+// Action with return value
+String value = AccessController.doPrivileged(() -> {
+    return System.getProperty("my.property");
+});
+```
+
+#### Privileged Action with Checked Exception
+
+```java
+import org.opensearch.secure_sm.AccessController;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+// Void action with checked exception
+AccessController.doPrivilegedChecked(() -> {
+    Files.createDirectory(Path.of("/tmp/mydir"));
+});
+
+// Action with return value and checked exception
+byte[] content = AccessController.doPrivilegedChecked(() -> {
+    return Files.readAllBytes(Path.of("/tmp/myfile"));
+});
+```
+
+#### Migration from JDK AccessController
+
+```java
+// Before (JDK - deprecated)
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+CityResponse response = AccessController.doPrivileged(
+    (PrivilegedAction<CityResponse>) () -> {
+        return cache.putIfAbsent(ipAddress, CityResponse.class, ip -> {
+            return lazyLoader.get().city(ip);
+        });
+    }
+);
+
+// After (OpenSearch)
+import org.opensearch.secure_sm.AccessController;
+
+CityResponse response = AccessController.doPrivileged(() -> 
+    cache.putIfAbsent(ipAddress, CityResponse.class, ip -> {
+        return lazyLoader.get().city(ip);
+    })
+);
+```
+
+## Limitations
+
+- Does not replace `AccessControlContext` or related JSM classes
+- Only works with OpenSearch's Java agent security model
+- Complex permission inheritance patterns may need alternative approaches
+- The Java agent intercepts specific operations (file I/O, network), not all JSM permission types
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18346](https://github.com/opensearch-project/OpenSearch/pull/18346) | Create equivalents of JSM's AccessController in the java agent |
+
+## References
+
+- [Issue #18339](https://github.com/opensearch-project/OpenSearch/issues/18339): Feature request for AccessController replacement
+- [Issue #1687](https://github.com/opensearch-project/OpenSearch/issues/1687): Original JSM replacement discussion
+- [JEP 411](https://openjdk.org/jeps/411): Deprecate the Security Manager for Removal
+- [JEP 486](https://openjdk.org/jeps/486): Permanently Disable the Security Manager
+- [Blog: Finding a replacement for JSM in OpenSearch 3.0](https://opensearch.org/blog/finding-a-replacement-for-jsm-in-opensearch-3-0/): Detailed explanation of JSM replacement strategy
+
+## Change History
+
+- **v3.2.0** (2026-01-11): Initial implementation with `doPrivileged` and `doPrivilegedChecked` methods

--- a/docs/releases/v3.2.0/features/opensearch/java-agent-accesscontroller.md
+++ b/docs/releases/v3.2.0/features/opensearch/java-agent-accesscontroller.md
@@ -1,0 +1,137 @@
+# Java Agent AccessController
+
+## Summary
+
+OpenSearch v3.2.0 introduces `org.opensearch.secure_sm.AccessController`, a replacement for Java's deprecated `java.security.AccessController`. This new utility class provides methods to execute code in a privileged context, enabling the Java agent to properly truncate stack walking when checking permissions. This change prepares OpenSearch for JDK 24+, where the original `AccessController` will be removed.
+
+## Details
+
+### What's New in v3.2.0
+
+The JDK's `java.security.AccessController` is [marked for removal](https://github.com/openjdk/jdk24u/blob/master/src/java.base/share/classes/java/security/AccessController.java#L39) starting with JDK 24. OpenSearch 3.0 replaced the Java Security Manager (JSM) with a custom Java agent, but the agent still relied on `AccessController.doPrivileged` as a marker to know when to stop walking the call stack during permission checks.
+
+This release introduces OpenSearch's own `AccessController` class that:
+- Provides equivalent `doPrivileged` and `doPrivilegedChecked` methods
+- Acts as a stack frame marker for the Java agent's permission checking
+- Allows plugins to migrate away from the deprecated JDK class
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Plugin Code"
+        PC[Plugin Code]
+    end
+    subgraph "OpenSearch AccessController"
+        AC[org.opensearch.secure_sm.AccessController]
+        DP[doPrivileged / doPrivilegedChecked]
+    end
+    subgraph "Java Agent"
+        SW[StackWalker]
+        EX[StackCallerProtectionDomainChainExtractor]
+        PM[Permission Check]
+    end
+    PC --> DP
+    DP --> SW
+    SW --> EX
+    EX -->|"Stop at AccessController frame"| PM
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `org.opensearch.secure_sm.AccessController` | Replacement for JDK's `AccessController` with `doPrivileged` methods |
+| `AccessController.CheckedRunnable<E>` | Functional interface for actions that throw checked exceptions |
+| `AccessController.CheckedSupplier<R, E>` | Functional interface for suppliers that throw checked exceptions |
+
+#### API Methods
+
+| Method | Description |
+|--------|-------------|
+| `doPrivileged(Runnable)` | Execute action in privileged context (void return) |
+| `doPrivileged(Supplier<T>)` | Execute action in privileged context (with return value) |
+| `doPrivilegedChecked(CheckedRunnable<T>)` | Execute action that may throw checked exception (void return) |
+| `doPrivilegedChecked(CheckedSupplier<R, T>)` | Execute action that may throw checked exception (with return value) |
+
+### Usage Example
+
+```java
+import org.opensearch.secure_sm.AccessController;
+
+// Simple privileged action (void)
+AccessController.doPrivileged(() -> {
+    // code that requires privileges
+    performPrivilegedOperation();
+});
+
+// Privileged action with return value
+String result = AccessController.doPrivileged(() -> {
+    return readPrivilegedData();
+});
+
+// Privileged action with checked exception
+AccessController.doPrivilegedChecked(() -> {
+    // code that may throw IOException
+    Files.readAllBytes(path);
+});
+
+// Privileged action with return value and checked exception
+byte[] data = AccessController.doPrivilegedChecked(() -> {
+    return Files.readAllBytes(path);
+});
+```
+
+### Migration Notes
+
+Plugin developers should migrate from the JDK's `AccessController` to OpenSearch's replacement:
+
+**Before (deprecated):**
+```java
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+
+AccessController.doPrivileged((PrivilegedAction<Void>) () -> {
+    // privileged code
+    return null;
+});
+```
+
+**After:**
+```java
+import org.opensearch.secure_sm.AccessController;
+
+AccessController.doPrivileged(() -> {
+    // privileged code
+});
+```
+
+Key differences:
+- No need for `PrivilegedAction` or `PrivilegedExceptionAction` wrappers
+- Simpler lambda syntax with `Runnable`, `Supplier`, or custom functional interfaces
+- Located in `libs/agent-sm/agent-policy` module
+
+## Limitations
+
+- Does not provide replacements for `AccessControlContext` or other JSM-related classes
+- Complex use cases like `TikaImpl` that use `AccessControlContext` need alternative approaches
+- The Java agent only intercepts specific privileged operations (file/network access), not all JSM permission types
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18346](https://github.com/opensearch-project/OpenSearch/pull/18346) | Create equivalents of JSM's AccessController in the java agent |
+
+## References
+
+- [Issue #18339](https://github.com/opensearch-project/OpenSearch/issues/18339): Original feature request
+- [Issue #1687](https://github.com/opensearch-project/OpenSearch/issues/1687): JSM replacement discussion
+- [JEP 486](https://openjdk.org/jeps/486): JDK AccessController removal
+- [Blog: Finding a replacement for JSM in OpenSearch 3.0](https://opensearch.org/blog/finding-a-replacement-for-jsm-in-opensearch-3-0/): Background on JSM replacement strategy
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/java-agent-accesscontroller.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -84,3 +84,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Pull-based Ingestion](features/opensearch/pull-based-ingestion.md) | feature | File-based ingestion plugin (ingestion-fs) for local testing |
 | [Cat Indices API Enhancement](features/opensearch/cat-indices-api-enhancement.md) | feature | Add last index request timestamp columns to `_cat/indices` API |
 | [Remote Store Metadata API](features/opensearch/remote-store-metadata-api.md) | feature | New cluster-level API to fetch segment and translog metadata from remote store |
+| [Java Agent AccessController](features/opensearch/java-agent-accesscontroller.md) | feature | OpenSearch replacement for JDK's deprecated AccessController for privileged operations |


### PR DESCRIPTION
## Summary

Add documentation for the Java Agent AccessController feature introduced in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/java-agent-accesscontroller.md`
- Feature report: `docs/features/opensearch/java-agent-accesscontroller.md`

### Key Changes in v3.2.0
- New `org.opensearch.secure_sm.AccessController` class as replacement for JDK's deprecated `java.security.AccessController`
- Provides `doPrivileged` and `doPrivilegedChecked` methods for privileged operations
- Enables Java agent to properly truncate stack walking during permission checks
- Prepares OpenSearch for JDK 24+ where original AccessController will be removed

### Related
- PR: opensearch-project/OpenSearch#18346
- Issue: opensearch-project/OpenSearch#18339
- Tracking Issue: #1099