### PR TITLE
docs: add Cluster Info & Resource Stats report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -24,6 +24,7 @@
 - [Bulk API](opensearch/bulk-api.md)
 - [Cat Indices API](opensearch/cat-indices-api.md)
 - [Cluster Stats API](opensearch/cluster-stats-api.md)
+- [Cluster Info & Resource Stats](opensearch/cluster-info-resource-stats.md)
 - [Cluster Manager Metrics](opensearch/cluster-manager-metrics.md)
 - [Code Cleanup](opensearch/code-cleanup.md)
 - [Code Coverage (Gradle)](opensearch/code-coverage-gradle.md)

--- a/docs/features/opensearch/cluster-info-resource-stats.md
+++ b/docs/features/opensearch/cluster-info-resource-stats.md
@@ -1,0 +1,153 @@
+# Cluster Info & Resource Stats
+
+## Summary
+
+The Cluster Info & Resource Stats feature extends OpenSearch's `ClusterInfo` service to include node-level resource usage statistics (CPU, JVM memory, I/O) alongside existing disk usage information. This enables cluster-wide visibility into resource consumption without requiring separate API calls to each node, supporting use cases like intelligent shard allocation, tiering decisions, and cluster health monitoring.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "InternalClusterInfoService"
+        Timer[Update Timer]
+        Timer -->|Periodic Refresh| NSR[NodesStats Request]
+        NSR -->|RESOURCE_USAGE_STATS metric| Nodes
+    end
+    
+    subgraph "Nodes"
+        N1[Node 1]
+        N2[Node 2]
+        N3[Node 3]
+    end
+    
+    subgraph "ClusterInfo"
+        DU[DiskUsage Map]
+        FC[FileCacheStats Map]
+        RU[NodeResourceUsageStats Map]
+    end
+    
+    Nodes -->|Response| Aggregator[Stats Aggregator]
+    Aggregator --> DU
+    Aggregator --> FC
+    Aggregator --> RU
+    
+    Consumer[Consumers] -->|getNodeResourceUsageStats| RU
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Collection
+        RT[ResourceTracker] -->|Moving Average| RUS[ResourceUsageStats]
+    end
+    
+    subgraph Aggregation
+        RUS -->|NodesStats Response| ICIS[InternalClusterInfoService]
+        ICIS -->|fillNodeResourceUsageStatsPerNode| CI[ClusterInfo]
+    end
+    
+    subgraph Consumption
+        CI -->|getNodeResourceUsageStats| TD[Tiering Decisions]
+        CI -->|getNodeResourceUsageStats| SA[Shard Allocation]
+        CI -->|getNodeResourceUsageStats| CM[Cluster Monitoring]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ClusterInfo` | Core class that aggregates cluster-wide statistics including disk usage, file cache stats, and resource usage stats |
+| `InternalClusterInfoService` | Service that periodically collects and aggregates node statistics |
+| `NodeResourceUsageStats` | Data class containing CPU, memory, and I/O utilization percentages for a node |
+| `NodesResourceUsageStats` | Container for resource usage stats across multiple nodes |
+| `IoUsageStats` | Data class for I/O utilization statistics (Linux only) |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.info.update.interval` | Interval for ClusterInfo refresh | 30s |
+| `node.resource.tracker.global_cpu_usage.window_duration` | Window duration for CPU usage moving average | 30s |
+| `node.resource.tracker.global_jvm_usage.window_duration` | Window duration for JVM memory moving average | 30s |
+| `node.resource.tracker.global_io_usage.window_duration` | Window duration for I/O usage moving average | 5s |
+
+### Usage Example
+
+#### Accessing Resource Usage Stats Programmatically
+
+```java
+// Get ClusterInfo from the service
+ClusterInfoService clusterInfoService = ...; // injected
+ClusterInfo clusterInfo = clusterInfoService.getClusterInfo();
+
+// Access resource usage stats for all nodes
+Map<String, NodeResourceUsageStats> resourceStats = clusterInfo.getNodeResourceUsageStats();
+
+for (Map.Entry<String, NodeResourceUsageStats> entry : resourceStats.entrySet()) {
+    String nodeId = entry.getKey();
+    NodeResourceUsageStats stats = entry.getValue();
+    
+    System.out.println("Node: " + nodeId);
+    System.out.println("  CPU: " + stats.getCpuUtilizationPercent() + "%");
+    System.out.println("  Memory: " + stats.getMemoryUtilizationPercent() + "%");
+    
+    IoUsageStats ioStats = stats.getIoUsageStats();
+    if (ioStats != null) {
+        System.out.println("  I/O: " + ioStats.getIoUtilisationPercent() + "%");
+    }
+}
+```
+
+#### JSON Response Format
+
+When serialized, the resource usage stats appear in the ClusterInfo response:
+
+```json
+{
+  "nodes": {
+    "node-id-1": {
+      "node_name": "node-1",
+      "least_available": { ... },
+      "most_available": { ... },
+      "node_resource_usage_stats": {
+        "node-id-1": {
+          "timestamp": 1698401391000,
+          "cpu_utilization_percent": "12.5",
+          "memory_utilization_percent": "45.2",
+          "io_usage_stats": {
+            "max_io_utilization_percent": "23.1"
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Resource usage stats require the `ResourceUsageCollector` to have collected sufficient data (typically 5-6 seconds after node startup)
+- I/O usage statistics are only available on Linux systems
+- Stats represent moving averages over configured window durations, not instantaneous values
+- Cluster manager nodes do not report resource usage stats by default (only data and warm nodes)
+- Stats are cleared when nodes are removed from the cluster
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18480](https://github.com/opensearch-project/OpenSearch/pull/18480) | Add NodeResourceUsageStats to ClusterInfo |
+
+## References
+
+- [Issue #18472](https://github.com/opensearch-project/OpenSearch/issues/18472): Original feature request for Writable Warm support
+- [Nodes Stats API Documentation](https://docs.opensearch.org/3.0/api-reference/nodes-apis/nodes-stats/): Official documentation including resource_usage_stats metric
+- [ClusterInfo.java](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/cluster/ClusterInfo.java): Source code
+
+## Change History
+
+- **v3.2.0** (2025-06-23): Initial implementation - Added NodeResourceUsageStats to ClusterInfo for cluster-wide resource visibility

--- a/docs/releases/v3.2.0/features/opensearch/cluster-info-resource-stats.md
+++ b/docs/releases/v3.2.0/features/opensearch/cluster-info-resource-stats.md
@@ -1,0 +1,127 @@
+# Cluster Info & Resource Stats
+
+## Summary
+
+This release adds `NodeResourceUsageStats` to `ClusterInfo`, making node-level resource usage statistics (CPU, JVM memory, I/O) available to all nodes in the cluster. Previously, resource usage stats were only available within the scope of the current node, requiring additional API calls to retrieve stats for other nodes.
+
+## Details
+
+### What's New in v3.2.0
+
+The `ClusterInfo` service now aggregates `NodeResourceUsageStats` alongside existing disk usage statistics. This enables any node in the cluster to access resource usage information for all other nodes without making separate NodeStats API calls.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.2.0"
+        N1[Node 1] -->|NodeStats API| N2[Node 2]
+        N1 -->|NodeStats API| N3[Node 3]
+    end
+    
+    subgraph "After v3.2.0"
+        CI[ClusterInfo Service]
+        CI -->|Aggregates| RU1[Node 1 ResourceUsageStats]
+        CI -->|Aggregates| RU2[Node 2 ResourceUsageStats]
+        CI -->|Aggregates| RU3[Node 3 ResourceUsageStats]
+        AN[Any Node] -->|getNodeResourceUsageStats| CI
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `NodeResourceUsageStats` in `ClusterInfo` | New field storing resource usage stats per node |
+| `fillNodeResourceUsageStatsPerNode()` | New method in `InternalClusterInfoService` to populate stats |
+| `getNodeResourceUsageStats()` | New getter method in `ClusterInfo` |
+
+#### New Configuration
+
+No new configuration settings are required. The feature uses existing resource tracker settings:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `node.resource.tracker.global_cpu_usage.window_duration` | Window duration for CPU usage tracking | 30s |
+| `node.resource.tracker.global_jvm_usage.window_duration` | Window duration for JVM memory tracking | 30s |
+| `node.resource.tracker.global_io_usage.window_duration` | Window duration for I/O usage tracking | 5s |
+
+#### API Changes
+
+The `ClusterInfo` constructor now accepts an additional parameter:
+
+```java
+public ClusterInfo(
+    final Map<String, DiskUsage> leastAvailableSpaceUsage,
+    final Map<String, DiskUsage> mostAvailableSpaceUsage,
+    final Map<String, Long> shardSizes,
+    final Map<ShardRouting, String> routingToDataPath,
+    final Map<NodeAndPath, ReservedSpace> reservedSpace,
+    final Map<String, AggregateFileCacheStats> nodeFileCacheStats,
+    final Map<String, NodeResourceUsageStats> nodeResourceUsageStats  // NEW
+)
+```
+
+The `NodeResourceUsageStats` class now implements `ToXContentFragment` for JSON serialization:
+
+```json
+{
+  "node_resource_usage_stats": {
+    "nodeId": {
+      "timestamp": 1698401391000,
+      "cpu_utilization_percent": "0.1",
+      "memory_utilization_percent": "3.9",
+      "io_usage_stats": {
+        "max_io_utilization_percent": "99.6"
+      }
+    }
+  }
+}
+```
+
+### Usage Example
+
+Resource usage stats are now included in the `ClusterInfo` response and can be accessed programmatically:
+
+```java
+ClusterInfo clusterInfo = clusterInfoService.getClusterInfo();
+Map<String, NodeResourceUsageStats> resourceStats = clusterInfo.getNodeResourceUsageStats();
+
+for (Map.Entry<String, NodeResourceUsageStats> entry : resourceStats.entrySet()) {
+    String nodeId = entry.getKey();
+    NodeResourceUsageStats stats = entry.getValue();
+    
+    double cpuPercent = stats.getCpuUtilizationPercent();
+    double memoryPercent = stats.getMemoryUtilizationPercent();
+    IoUsageStats ioStats = stats.getIoUsageStats();
+}
+```
+
+### Migration Notes
+
+- The old 6-parameter `ClusterInfo` constructor is deprecated and will be removed in a future release
+- Existing code using `ClusterInfo` should update to use the new 7-parameter constructor
+- Serialization is backward compatible: nodes running older versions will receive empty resource usage stats
+
+## Limitations
+
+- Resource usage stats require the `ResourceUsageCollector` to have collected sufficient data (typically 5-6 seconds after node startup)
+- I/O usage stats are only available on Linux systems
+- Stats are collected at configurable intervals and may not reflect real-time values
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18480](https://github.com/opensearch-project/OpenSearch/pull/18480) | Add NodeResourceUsageStats to ClusterInfo |
+
+## References
+
+- [Issue #18472](https://github.com/opensearch-project/OpenSearch/issues/18472): [Writable Warm] Adding Support For NodeResourceUsageStats in ClusterInfo
+- [Nodes Stats API Documentation](https://docs.opensearch.org/3.0/api-reference/nodes-apis/nodes-stats/): Official documentation for resource_usage_stats metric
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/cluster-info-resource-stats.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -77,6 +77,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Approximation Framework: Numeric Types](features/opensearch/approximation-framework-numeric-types.md) | feature | Extend Approximation Framework to int, float, double, half_float, unsigned_long |
 | [Star Tree Index](features/opensearch/star-tree-index.md) | feature | IP field search support and star-tree search statistics |
 | [Clusterless Mode](features/opensearch/clusterless-mode.md) | feature | Experimental clusterless startup mode and custom remote store path prefix |
+| [Cluster Info & Resource Stats](features/opensearch/cluster-info-resource-stats.md) | feature | Add NodeResourceUsageStats to ClusterInfo for cluster-wide resource visibility |
 | [Rescore Named Queries](features/opensearch/rescore-named-queries.md) | feature | Surface named queries from rescore contexts in matched_queries array |
 | [Semantic Version Field Type](features/opensearch/semantic-version-field-type.md) | feature | New `version` field type for semantic versioning with proper ordering and range queries |
 | [Query Phase Plugin Extension](features/opensearch/query-phase-plugin-extension.md) | feature | Plugin extensibility for injecting custom QueryCollectorContext during QueryPhase |


### PR DESCRIPTION
## Summary

This PR adds documentation for the **Cluster Info & Resource Stats** feature introduced in OpenSearch v3.2.0.

### Changes

- **Release Report**: `docs/releases/v3.2.0/features/opensearch/cluster-info-resource-stats.md`
  - Documents what's new in v3.2.0: NodeResourceUsageStats added to ClusterInfo
  - Technical changes including architecture diagram, new components, and API changes
  - Usage examples and migration notes

- **Feature Report**: `docs/features/opensearch/cluster-info-resource-stats.md`
  - Comprehensive documentation of the feature
  - Architecture and data flow diagrams
  - Configuration options and usage examples

### Key Changes in v3.2.0

- `ClusterInfo` now includes `NodeResourceUsageStats` for all nodes
- New `getNodeResourceUsageStats()` method provides cluster-wide resource visibility
- Enables intelligent shard allocation and tiering decisions based on resource usage
- Supports CPU, JVM memory, and I/O utilization metrics

### Related

- PR: [opensearch-project/OpenSearch#18480](https://github.com/opensearch-project/OpenSearch/pull/18480)
- Issue: [opensearch-project/OpenSearch#18472](https://github.com/opensearch-project/OpenSearch/issues/18472)