### PR TITLE
docs: add BooleanQuery rewrite optimizations report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -16,6 +16,7 @@
 ## opensearch
 
 - [Approximation Framework](opensearch/approximation-framework.md)
+- [BooleanQuery Rewrite Optimizations](opensearch/booleanquery-rewrite-optimizations.md)
 - [Aggregation Task Cancellation](opensearch/aggregation-task-cancellation.md)
 - [Async Shard Batch Fetch](opensearch/async-shard-batch-fetch.md)
 - [Async Shard Fetch Metrics](opensearch/async-shard-fetch-metrics.md)

--- a/docs/features/opensearch/booleanquery-rewrite-optimizations.md
+++ b/docs/features/opensearch/booleanquery-rewrite-optimizations.md
@@ -1,0 +1,184 @@
+# BooleanQuery Rewrite Optimizations
+
+## Summary
+
+BooleanQuery rewrite optimizations automatically transform slow query patterns into faster equivalents during query execution. OpenSearch analyzes boolean queries and applies mathematical transformations to improve performance without changing query semantics. These optimizations target common patterns like `must_not` clauses on numeric fields, delivering up to 54x performance improvements for exclusion queries.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "BoolQueryBuilder Rewrite Pipeline"
+        A[Original BoolQueryBuilder] --> B[doRewrite]
+        B --> C{Check must_not clauses}
+        C --> D[rewriteMustNotRangeClausesToShould]
+        D --> E{ComplementAwareQueryBuilder?}
+        E -->|Yes| F[Get field name via WithFieldName]
+        F --> G{Single field occurrence?}
+        G -->|Yes| H{All docs single-valued?}
+        H -->|Yes| I[getComplement from QueryShardContext]
+        I --> J[Create nested should clause]
+        J --> K[Move to must clause]
+        E -->|No| L[Keep in must_not]
+        G -->|No| L
+        H -->|No| L
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Input
+        A["must_not: term(status=200)"]
+    end
+    subgraph Processing
+        B[NumberFieldType.parse] --> C[ComplementHelperUtils]
+        C --> D["Range: (-∞, 200)"]
+        C --> E["Range: (200, +∞)"]
+    end
+    subgraph Output
+        F["must: bool(should: [range<200, range>200])"]
+    end
+    A --> B
+    D --> F
+    E --> F
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `BoolQueryBuilder` | Main query builder that orchestrates the rewrite process |
+| `ComplementAwareQueryBuilder` | Interface for queries that can provide complement range queries |
+| `ComplementHelperUtils` | Utility class for constructing complement ranges from numeric values |
+| `WithFieldName` | Interface to identify the target field of a query |
+| `RangeQueryBuilder` | Implements `ComplementAwareQueryBuilder` for range queries |
+| `MatchQueryBuilder` | Implements `ComplementAwareQueryBuilder` for numeric match queries |
+| `TermQueryBuilder` | Implements `ComplementAwareQueryBuilder` for numeric term queries |
+| `TermsQueryBuilder` | Implements `ComplementAwareQueryBuilder` for numeric terms queries |
+
+### Supported Query Types
+
+| Query Type | Numeric Fields | Text/Keyword Fields |
+|------------|----------------|---------------------|
+| Range | ✅ Rewritten | ❌ Not applicable |
+| Match | ✅ Rewritten | ❌ Not rewritten |
+| Term | ✅ Rewritten | ❌ Not rewritten |
+| Terms | ✅ Rewritten | ❌ Not rewritten |
+
+### Configuration
+
+This optimization is enabled by default and requires no configuration. It applies automatically during query rewrite when conditions are met.
+
+### Usage Example
+
+**Excluding a single value:**
+```json
+// Original query
+{
+  "query": {
+    "bool": {
+      "must_not": {
+        "term": { "http_status": 200 }
+      }
+    }
+  }
+}
+
+// Internally rewritten to
+{
+  "query": {
+    "bool": {
+      "must": {
+        "bool": {
+          "should": [
+            { "range": { "http_status": { "lt": 200 } } },
+            { "range": { "http_status": { "gt": 200 } } }
+          ],
+          "minimum_should_match": 1
+        }
+      }
+    }
+  }
+}
+```
+
+**Excluding multiple values:**
+```json
+// Original query
+{
+  "query": {
+    "bool": {
+      "must_not": {
+        "terms": { "http_status": [200, 500] }
+      }
+    }
+  }
+}
+
+// Internally rewritten to
+{
+  "query": {
+    "bool": {
+      "must": {
+        "bool": {
+          "should": [
+            { "range": { "http_status": { "lt": 200 } } },
+            { "range": { "http_status": { "gt": 200, "lt": 500 } } },
+            { "range": { "http_status": { "gt": 500 } } }
+          ],
+          "minimum_should_match": 1
+        }
+      }
+    }
+  }
+}
+```
+
+### Performance Characteristics
+
+The optimization provides significant speedups because:
+
+1. **Avoids full index scan**: `must_not` requires gathering all documents then filtering
+2. **Leverages BKD trees**: Range queries use efficient point-based data structures
+3. **Early termination**: Can stop processing once enough matches are found
+
+Benchmark results on `http_logs` dataset:
+
+| Scenario | Before (ms) | After (ms) | Improvement |
+|----------|-------------|------------|-------------|
+| Exclude common value (84% of docs) | 1021 | 20.72 | 49x |
+| Exclude rare value (0.5% of docs) | 515.6 | 12.03 | 43x |
+| Exclude very rare value (0.00025%) | 481.6 | 9.49 | 44x |
+| Exclude multiple values | 958.6 | 17.76 | 54x |
+
+## Limitations
+
+- **Numeric fields only**: Text and keyword fields cannot be rewritten
+- **Single-valued fields**: Multi-valued fields are not optimized
+- **Single field per must_not**: Multiple queries on the same field prevent rewrite
+- **No BITMAP support**: Terms queries with BITMAP value type are not rewritten
+- **No termsLookup support**: Terms queries using termsLookup are not rewritten
+- **QueryShardContext required**: Match/term/terms rewrites need shard context (range queries don't)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18498](https://github.com/opensearch-project/OpenSearch/pull/18498) | Extend must_not rewrite to numeric match, term, and terms queries |
+| v3.0.0 | [#17655](https://github.com/opensearch-project/OpenSearch/pull/17655) | Initial must_not rewrite for range queries |
+| v3.0.0 | [#18541](https://github.com/opensearch-project/OpenSearch/pull/18541) | Boolean must → filter rewrite for constant-scoring queries |
+
+## References
+
+- [Issue #17586](https://github.com/opensearch-project/OpenSearch/issues/17586): Original feature request with detailed benchmarks
+- [Boolean Query Documentation](https://docs.opensearch.org/3.0/query-dsl/compound/bool/): Official boolean query docs
+- [Issue #18784](https://github.com/opensearch-project/OpenSearch/issues/18784): RFC for multi-clause boolean query approximation
+
+## Change History
+
+- **v3.2.0** (2025-07-22): Extended must_not rewrite to numeric match, term, and terms queries
+- **v3.0.0**: Initial implementation of must_not rewrite for range queries; must → filter rewrite for constant-scoring queries

--- a/docs/releases/v3.2.0/features/opensearch/booleanquery-rewrite-optimizations.md
+++ b/docs/releases/v3.2.0/features/opensearch/booleanquery-rewrite-optimizations.md
@@ -1,0 +1,146 @@
+# BooleanQuery Rewrite Optimizations
+
+## Summary
+
+OpenSearch 3.2.0 introduces automatic query rewrite optimizations for BooleanQuery `must_not` clauses on numeric fields. When a `must_not` clause contains a match, term, or terms query on a numeric field, OpenSearch automatically rewrites it to an equivalent `should` clause containing range queries that represent the complement. This optimization delivers up to 54x performance improvement for common exclusion patterns.
+
+## Details
+
+### What's New in v3.2.0
+
+This release extends the existing BooleanQuery `must_not` rewrite optimization (introduced for range queries) to support:
+
+- **Match queries** on numeric fields
+- **Term queries** on numeric fields  
+- **Terms queries** on numeric fields (multiple values)
+
+The optimization transforms slow `must_not` clauses into faster `should` clauses by computing the mathematical complement of the excluded values.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Query Rewrite Process"
+        A[BoolQueryBuilder.doRewrite] --> B{Is must_not clause?}
+        B -->|Yes| C{Implements ComplementAwareQueryBuilder?}
+        C -->|Yes| D{Single field occurrence?}
+        D -->|Yes| E{All docs have single value?}
+        E -->|Yes| F[Get complement ranges]
+        F --> G[Create nested should clause]
+        G --> H[Add to must clause]
+        B -->|No| I[Keep original]
+        C -->|No| I
+        D -->|No| I
+        E -->|No| I
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ComplementAwareQueryBuilder` | Interface for queries that can provide their complement as range queries |
+| `ComplementHelperUtils` | Utility class with helper functions to construct complement range queries |
+| `WithFieldName` | Interface to identify queries that target a specific field |
+
+#### Query Rewrite Flow
+
+```mermaid
+flowchart LR
+    A["must_not: term(status=200)"] --> B[ComplementAwareQueryBuilder.getComplement]
+    B --> C["should: [range(status<200), range(status>200)]"]
+    C --> D[Wrap in nested bool with minimumShouldMatch=1]
+    D --> E[Add to must clause]
+```
+
+### Usage Example
+
+Original query (slow):
+```json
+{
+  "query": {
+    "bool": {
+      "must_not": {
+        "term": { "status": 200 }
+      }
+    }
+  }
+}
+```
+
+Internally rewritten to (fast):
+```json
+{
+  "query": {
+    "bool": {
+      "must": {
+        "bool": {
+          "should": [
+            { "range": { "status": { "lt": 200 } } },
+            { "range": { "status": { "gt": 200 } } }
+          ],
+          "minimum_should_match": 1
+        }
+      }
+    }
+  }
+}
+```
+
+### Performance Benchmarks
+
+Benchmarks on `http_logs` dataset (c5.2xl EC2 instances):
+
+| Excluded Value | Query Type | p50 Before (ms) | p50 After (ms) | Speedup |
+|----------------|------------|-----------------|----------------|---------|
+| 200 | `must_not` of `match` | 1021 | 20.72 | 49x |
+| 200 | `must_not` of `term` | 1011 | 18.83 | 54x |
+| 404 | `must_not` of `match` | 515.6 | 12.03 | 43x |
+| 404 | `must_not` of `term` | 513.0 | 12.01 | 43x |
+| 500 | `must_not` of `match` | 481.6 | 9.49 | 44x |
+| 500 | `must_not` of `term` | 487.3 | 9.53 | 51x |
+| 200, 500 | `must_not` of `terms` | 958.6 | 17.76 | 54x |
+| 404, 500 | `must_not` of `terms` | 508.1 | 11.75 | 43x |
+
+### Why This Optimization Works
+
+The `must_not` clause is inherently slow because it must:
+1. Gather all documents in the index
+2. Filter out documents matching the excluded condition
+
+By rewriting to `should` clauses with the complement ranges, OpenSearch can:
+1. Directly iterate over matching documents using efficient BKD tree traversal
+2. Skip the expensive filtering step entirely
+
+### Conditions for Rewrite
+
+The optimization applies when:
+1. The `must_not` clause contains a `ComplementAwareQueryBuilder` (match, term, terms, or range on numeric fields)
+2. There is exactly one query per field in the `must_not` clause
+3. All documents in the field have exactly one value (no multi-valued fields)
+
+## Limitations
+
+- Only applies to numeric fields (integer, long, float, double, short)
+- Does not apply to text or keyword fields
+- Requires single-valued fields (multi-valued fields are not rewritten)
+- Multiple `must_not` clauses on the same field are not rewritten
+- Terms queries using BITMAP value type are not rewritten
+- Terms queries using termsLookup are not rewritten
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18498](https://github.com/opensearch-project/OpenSearch/pull/18498) | Extend BooleanQuery must_not rewrite to numeric match, term, and terms queries |
+
+## References
+
+- [Issue #17586](https://github.com/opensearch-project/OpenSearch/issues/17586): Feature request for BooleanQuery rewrites
+- [Boolean Query Documentation](https://docs.opensearch.org/3.0/query-dsl/compound/bool/): Official docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/booleanquery-rewrite-optimizations.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -78,6 +78,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Star Tree Index](features/opensearch/star-tree-index.md) | feature | IP field search support and star-tree search statistics |
 | [Clusterless Mode](features/opensearch/clusterless-mode.md) | feature | Experimental clusterless startup mode and custom remote store path prefix |
 | [Cluster Info & Resource Stats](features/opensearch/cluster-info-resource-stats.md) | feature | Add NodeResourceUsageStats to ClusterInfo for cluster-wide resource visibility |
+| [BooleanQuery Rewrite Optimizations](features/opensearch/booleanquery-rewrite-optimizations.md) | feature | Extend must_not rewrite to numeric match, term, and terms queries (up to 54x speedup) |
 | [Rescore Named Queries](features/opensearch/rescore-named-queries.md) | feature | Surface named queries from rescore contexts in matched_queries array |
 | [Semantic Version Field Type](features/opensearch/semantic-version-field-type.md) | feature | New `version` field type for semantic versioning with proper ordering and range queries |
 | [Query Phase Plugin Extension](features/opensearch/query-phase-plugin-extension.md) | feature | Plugin extensibility for injecting custom QueryCollectorContext during QueryPhase |


### PR DESCRIPTION
## Summary

This PR adds documentation for the BooleanQuery Rewrite Optimizations feature in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/booleanquery-rewrite-optimizations.md`
- Feature report: `docs/features/opensearch/booleanquery-rewrite-optimizations.md`

### Key Changes in v3.2.0
- Extended `must_not` rewrite optimization to numeric match, term, and terms queries
- Introduced `ComplementAwareQueryBuilder` interface for queries that can provide complement ranges
- Added `ComplementHelperUtils` utility class for constructing complement range queries
- Performance improvements up to 54x for common exclusion patterns on numeric fields

### Resources Used
- PR: [#18498](https://github.com/opensearch-project/OpenSearch/pull/18498)
- Issue: [#17586](https://github.com/opensearch-project/OpenSearch/issues/17586)
- Docs: [Boolean Query](https://docs.opensearch.org/3.0/query-dsl/compound/bool/)