### PR TITLE
docs: add custom-index-name-resolver report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -34,6 +34,7 @@
 - [Composite Directory Factory](opensearch/composite-directory-factory.md)
 - [Concurrent Segment Search](opensearch/concurrent-segment-search.md)
 - [Crypto KMS Plugin](opensearch/crypto-kms-plugin.md)
+- [Custom Index Name Resolver](opensearch/custom-index-name-resolver.md)
 - [Deprecated Code Cleanup](opensearch/deprecated-code-cleanup.md)
 - [DocRequest Refactoring](opensearch/docrequest-refactoring.md)
 - [Dynamic Settings](opensearch/dynamic-settings.md)

--- a/docs/features/opensearch/custom-index-name-resolver.md
+++ b/docs/features/opensearch/custom-index-name-resolver.md
@@ -1,0 +1,141 @@
+# Custom Index Name Resolver
+
+## Summary
+
+Custom Index Name Resolver is a plugin extensibility feature that allows cluster plugins to implement custom index name expression resolvers. This enables plugins to define their own wildcards, patterns, or expression syntax for resolving index names, extending beyond the built-in date math and wildcard resolution capabilities.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "IndexNameExpressionResolver"
+        A[Expression Input] --> B[expressionResolvers List]
+        B --> C{For each resolver}
+        C --> D[Custom Resolvers]
+        D --> E[DateMathExpressionResolver]
+        E --> F[WildcardExpressionResolver]
+        F --> G[Resolved Index Names]
+    end
+    
+    subgraph "Plugin Registration Flow"
+        H[ClusterPlugin] -->|getIndexNameCustomResolvers| I[ClusterModule]
+        I -->|getCustomResolvers| J[IndexNameExpressionResolver Constructor]
+        J -->|adds to| B
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[API Request] --> B[Index Expression]
+    B --> C[Custom Resolver 1]
+    C --> D[Custom Resolver N]
+    D --> E[DateMath Resolver]
+    E --> F[Wildcard Resolver]
+    F --> G[Concrete Indices]
+    G --> H[Execute Operation]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `IndexNameExpressionResolver` | Core class that manages the chain of expression resolvers |
+| `ExpressionResolver` | Public interface for implementing custom resolvers |
+| `Context` | Provides cluster state and options to resolvers during resolution |
+| `ClusterPlugin.getIndexNameCustomResolvers()` | Plugin hook for registering custom resolvers |
+| `ClusterModule.getCustomResolvers()` | Collects resolvers from all cluster plugins |
+
+### Configuration
+
+This feature does not require configuration. Custom resolvers are registered programmatically through the ClusterPlugin interface.
+
+### Usage Example
+
+**Implementing a Custom Resolver**
+
+```java
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver.Context;
+import org.opensearch.cluster.metadata.IndexNameExpressionResolver.ExpressionResolver;
+
+public class TenantIndexResolver implements ExpressionResolver {
+    
+    private static final String TENANT_PREFIX = "_tenant:";
+    
+    @Override
+    public List<String> resolve(Context context, List<String> expressions) {
+        List<String> resolved = new ArrayList<>();
+        
+        for (String expression : expressions) {
+            if (expression.startsWith(TENANT_PREFIX)) {
+                String tenantId = expression.substring(TENANT_PREFIX.length());
+                // Resolve to tenant-specific index pattern
+                resolved.add("tenant-" + tenantId + "-*");
+            } else {
+                // Pass through unrecognized expressions
+                resolved.add(expression);
+            }
+        }
+        
+        return resolved;
+    }
+}
+```
+
+**Registering the Resolver in a Plugin**
+
+```java
+import org.opensearch.plugins.ClusterPlugin;
+import org.opensearch.plugins.Plugin;
+
+public class TenantPlugin extends Plugin implements ClusterPlugin {
+    
+    @Override
+    public Collection<IndexNameExpressionResolver.ExpressionResolver> getIndexNameCustomResolvers() {
+        return Collections.singletonList(new TenantIndexResolver());
+    }
+}
+```
+
+**Using the Custom Expression**
+
+```bash
+# Search across all indices for tenant "acme"
+GET /_tenant:acme/_search
+{
+  "query": { "match_all": {} }
+}
+```
+
+### Key Implementation Details
+
+1. **Resolution Order**: Custom resolvers execute first, followed by DateMathExpressionResolver, then WildcardExpressionResolver
+2. **Thread Safety**: Resolvers must be thread-safe as they're shared across requests
+3. **Deduplication**: Each resolver class can only be registered once; duplicates throw `IllegalArgumentException`
+4. **Pass-through**: Resolvers should pass through expressions they don't handle
+
+## Limitations
+
+- Custom resolvers cannot modify or override built-in resolver behavior
+- Resolver registration happens at node startup; dynamic registration is not supported
+- Each resolver class can only be registered once across all plugins
+- Custom expressions must not conflict with built-in patterns (wildcards, date math)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18593](https://github.com/opensearch-project/OpenSearch/pull/18593) | Initial implementation |
+
+## References
+
+- [Issue #18676](https://github.com/opensearch-project/OpenSearch/issues/18676): Original feature request
+- [Resolve Index API](https://docs.opensearch.org/3.0/api-reference/index-apis/resolve-index/): Index resolution documentation
+
+## Change History
+
+- **v3.2.0** (2025-07-04): Initial implementation - Added support for custom index name resolvers through ClusterPlugin interface

--- a/docs/releases/v3.2.0/features/opensearch/custom-index-name-resolver.md
+++ b/docs/releases/v3.2.0/features/opensearch/custom-index-name-resolver.md
@@ -1,0 +1,131 @@
+# Custom Index Name Resolver
+
+## Summary
+
+OpenSearch v3.2.0 introduces support for custom index name expression resolvers through the ClusterPlugin interface. This feature allows plugins to implement their own index name resolution logic, enabling custom wildcards and expression patterns beyond the built-in date math and wildcard resolvers.
+
+## Details
+
+### What's New in v3.2.0
+
+This release adds an extensibility point for cluster plugins to provide custom `ExpressionResolver` implementations. Previously, index name resolution was limited to the built-in `DateMathExpressionResolver` and `WildcardExpressionResolver`. Now plugins can register additional resolvers to handle custom expression patterns.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Index Name Resolution Chain"
+        A[Index Expression] --> B[Custom Resolvers]
+        B --> C[DateMathExpressionResolver]
+        C --> D[WildcardExpressionResolver]
+        D --> E[Concrete Indices]
+    end
+    
+    subgraph "Plugin Registration"
+        F[ClusterPlugin] -->|getIndexNameCustomResolvers| G[ClusterModule]
+        G -->|registers| B
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ExpressionResolver` interface | Public API (`@PublicApi(since = "3.1.0")`) for implementing custom index name resolvers |
+| `Context` class | Public API for accessing cluster state and resolution options during expression resolution |
+| `ClusterPlugin.getIndexNameCustomResolvers()` | New method for plugins to provide custom resolver implementations |
+
+#### API Changes
+
+**ClusterPlugin Interface**
+
+New method added:
+```java
+default Collection<IndexNameExpressionResolver.ExpressionResolver> getIndexNameCustomResolvers() {
+    return Collections.emptyList();
+}
+```
+
+**ExpressionResolver Interface**
+
+Made public with `@PublicApi(since = "3.1.0")`:
+```java
+public interface ExpressionResolver {
+    List<String> resolve(Context context, List<String> expressions);
+}
+```
+
+**Context Class**
+
+Made public with `@PublicApi(since = "3.1.0")` and added public constructor:
+```java
+public Context(ClusterState state, IndicesOptions options, boolean isSystemIndexAccessAllowed)
+```
+
+### Usage Example
+
+```java
+public class MyClusterPlugin extends Plugin implements ClusterPlugin {
+    
+    @Override
+    public Collection<IndexNameExpressionResolver.ExpressionResolver> getIndexNameCustomResolvers() {
+        return Collections.singletonList(new MyCustomResolver());
+    }
+}
+
+public class MyCustomResolver implements IndexNameExpressionResolver.ExpressionResolver {
+    
+    @Override
+    public List<String> resolve(IndexNameExpressionResolver.Context context, List<String> expressions) {
+        List<String> resolved = new ArrayList<>();
+        for (String expression : expressions) {
+            if (expression.startsWith("_my_custom_")) {
+                // Custom resolution logic
+                resolved.add(resolveCustomExpression(expression, context));
+            } else {
+                resolved.add(expression);
+            }
+        }
+        return resolved;
+    }
+}
+```
+
+### Resolution Order
+
+Custom resolvers are executed **before** the built-in resolvers:
+
+1. Custom resolvers (in registration order)
+2. DateMathExpressionResolver
+3. WildcardExpressionResolver
+
+This ordering ensures that custom expressions are resolved before the WildcardExpressionResolver attempts to match them, preventing exceptions for unrecognized patterns.
+
+### Migration Notes
+
+- Existing plugins do not require changes; the new method has a default implementation returning an empty list
+- Custom resolvers must handle expressions they don't recognize by passing them through unchanged
+- Duplicate resolver classes are not allowed and will throw `IllegalArgumentException`
+
+## Limitations
+
+- Custom resolvers cannot override the behavior of built-in resolvers
+- Each resolver class can only be registered once across all plugins
+- Custom resolvers must be thread-safe as they may be called concurrently
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18593](https://github.com/opensearch-project/OpenSearch/pull/18593) | Add support for custom index name resolver from cluster plugin |
+
+## References
+
+- [Issue #18676](https://github.com/opensearch-project/OpenSearch/issues/18676): Feature request for custom index name resolver support
+- [Resolve Index API](https://docs.opensearch.org/3.0/api-reference/index-apis/resolve-index/): Documentation on index resolution
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/custom-index-name-resolver.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -88,3 +88,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Remote Store Metadata API](features/opensearch/remote-store-metadata-api.md) | feature | New cluster-level API to fetch segment and translog metadata from remote store |
 | [Java Agent AccessController](features/opensearch/java-agent-accesscontroller.md) | feature | OpenSearch replacement for JDK's deprecated AccessController for privileged operations |
 | [Secure Transport Parameters](features/opensearch/secure-transport-parameters.md) | feature | SecureHttpTransportParameters API for cleaner SSL configuration in Reactor Netty 4 HTTP transport |
+| [Custom Index Name Resolver](features/opensearch/custom-index-name-resolver.md) | feature | Plugin extensibility for custom index name expression resolvers |


### PR DESCRIPTION
## Summary

Add release and feature reports for Custom Index Name Resolver feature in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/custom-index-name-resolver.md`
- Feature report: `docs/features/opensearch/custom-index-name-resolver.md`

### Key Changes in v3.2.0
- New `ExpressionResolver` public interface for implementing custom index name resolvers
- New `ClusterPlugin.getIndexNameCustomResolvers()` method for plugin registration
- Custom resolvers execute before built-in resolvers (DateMath, Wildcard)
- `Context` class made public for resolver implementations

### Resources Used
- PR: #18593
- Issue: #18676