### PR TITLE
docs: add workload-management report for v3.2.0

### DIFF
--- a/docs/features/opensearch/workload-management.md
+++ b/docs/features/opensearch/workload-management.md
@@ -255,7 +255,11 @@ GET _list/wlm_stats?size=50&sort=node_id&order=asc&next_token=<encrypted_token>
 |---------|-----|-------------|
 | v3.2.0 | [#18726](https://github.com/opensearch-project/OpenSearch/pull/18726) | Bug fix and improvements for rule-based auto tagging |
 | v3.2.0 | [#18663](https://github.com/opensearch-project/OpenSearch/pull/18663) | Add configurable limit on rule cardinality |
+| v3.2.0 | [#18652](https://github.com/opensearch-project/OpenSearch/pull/18652) | Add WLM mode validation for workload group CRUD requests |
 | v3.2.0 | [#18628](https://github.com/opensearch-project/OpenSearch/pull/18628) | Fix delete rule event consumption for wildcard index based rules |
+| v3.2.0 | [#18709](https://github.com/opensearch-project/OpenSearch/pull/18709) | Rename WorkloadGroupTestUtil to WorkloadManagementTestUtil |
+| v3.2.0 | [#18711](https://github.com/opensearch-project/OpenSearch/pull/18711) | Rename QueryGroup to WorkloadGroup in comments and Javadocs |
+| v3.2.0 | [#18712](https://github.com/opensearch-project/OpenSearch/pull/18712) | Modify logging message to show actual resiliency mode |
 | v3.1.0 | [#17638](https://github.com/opensearch-project/OpenSearch/pull/17638) | Add paginated wlm/stats API |
 | v3.1.0 | [#17336](https://github.com/opensearch-project/OpenSearch/pull/17336) | Add Get Rule API for auto-tagging |
 | v3.1.0 | [#17791](https://github.com/opensearch-project/OpenSearch/pull/17791) | Add WLM ActionFilter for automatic tagging |
@@ -284,6 +288,6 @@ GET _list/wlm_stats?size=50&sort=node_id&order=asc&next_token=<encrypted_token>
 
 ## Change History
 
-- **v3.2.0** (2026-01-10): Added configurable rule cardinality limit (`wlm.autotagging.max_rules`) with default of 200 rules (range: 10-500); Fixed delete rule event consumption for wildcard index based rules in `InMemoryRuleProcessingService`; Bug fixes and improvements including stricter attribute parameter extraction, centralized feature value validation, force refresh for immediate rule visibility, and graceful IndexNotFoundException handling
+- **v3.2.0** (2026-01-10): Added WLM mode validation for workload group CRUD requests (Create/Update/Delete operations now fail when WLM mode is `disabled` or `monitor_only`); Added `WlmClusterSettingValuesProvider` component for centralized cluster settings management; Renamed `WorkloadGroupTestUtil` to `WorkloadManagementTestUtil`; Updated all "QueryGroup" references to "WorkloadGroup" in comments and Javadocs; Improved logging to dynamically show actual resiliency mode; Added configurable rule cardinality limit (`wlm.autotagging.max_rules`) with default of 200 rules (range: 10-500); Fixed delete rule event consumption for wildcard index based rules; Bug fixes including stricter attribute parameter extraction, centralized feature value validation, force refresh for immediate rule visibility, and graceful IndexNotFoundException handling
 - **v3.1.0** (2026-01-10): Added rule-based auto-tagging with full CRUD API (`/_rules/workload_group`), WLM ActionFilter for automatic request tagging, refresh-based rule synchronization, and paginated `/_list/wlm_stats` API
 - **v2.18.0** (2024-10-22): Initial implementation with QueryGroup CRUD APIs, Stats API, resource cancellation framework, resiliency orchestrator, persistence, and enhanced rejection logic

--- a/docs/releases/v3.2.0/features/opensearch/workload-management.md
+++ b/docs/releases/v3.2.0/features/opensearch/workload-management.md
@@ -1,0 +1,118 @@
+# Workload Management
+
+## Summary
+
+This release includes improvements to Workload Management (WLM) focusing on code quality, naming consistency, and operational safety. Key changes include renaming test utilities and internal references from "QueryGroup" to "WorkloadGroup" for consistency, adding WLM mode validation to prevent workload group CRUD operations when WLM is disabled, and improving logging messages to dynamically reflect the actual resiliency mode.
+
+## Details
+
+### What's New in v3.2.0
+
+#### WLM Mode Validation for CRUD Operations
+
+A new validation mechanism prevents workload group Create, Update, and Delete operations when WLM mode is set to `disabled` or `monitor_only`. This ensures administrators cannot accidentally create or modify workload groups when the feature is not actively enforcing resource limits.
+
+```mermaid
+flowchart TB
+    A[Workload Group CRUD Request] --> B{Check WLM Mode}
+    B -->|enabled| C[Process Request]
+    B -->|disabled| D[Reject with Error]
+    B -->|monitor_only| D
+    C --> E[Execute Operation]
+    D --> F[Return IllegalStateException]
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `WlmClusterSettingValuesProvider` | Central provider for maintaining and supplying current WLM cluster settings values. Listens for setting updates and provides the latest values to REST handlers. |
+
+#### Technical Changes
+
+The `WlmClusterSettingValuesProvider` class:
+- Maintains a volatile `WlmMode` field updated via cluster settings listener
+- Provides `ensureWlmEnabled()` method that throws `IllegalStateException` when WLM is not enabled
+- Injected into `RestCreateWorkloadGroupAction`, `RestUpdateWorkloadGroupAction`, and `RestDeleteWorkloadGroupAction`
+
+The validation is performed in `prepareRequest()` before processing any CRUD operation:
+
+```java
+@Override
+protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+    nonPluginSettingValuesProvider.ensureWlmEnabled(getName());
+    // ... rest of request processing
+}
+```
+
+#### Naming Consistency Updates
+
+- Renamed `WorkloadGroupTestUtil` to `WorkloadManagementTestUtil` for broader applicability
+- Updated all remaining "QueryGroup" references in code comments, Javadocs, and identifiers to "WorkloadGroup"
+
+#### Logging Improvements
+
+The rejection reason logging in `WorkloadGroupService.rejectIfNeeded()` now dynamically includes the actual resiliency mode (`SOFT` or `ENFORCED`) from the WorkloadGroup object, instead of hardcoding "ENFORCED".
+
+### Usage Example
+
+**Attempting CRUD when WLM is disabled:**
+```bash
+# Set WLM mode to disabled
+PUT _cluster/settings
+{
+  "persistent": {
+    "wlm.workload_group.mode": "disabled"
+  }
+}
+
+# Attempt to create workload group - will fail
+PUT _wlm/workload_group
+{
+  "name": "analytics",
+  "resiliency_mode": "enforced",
+  "resource_limits": {
+    "cpu": 0.4,
+    "memory": 0.2
+  }
+}
+# Response: IllegalStateException - Cannot create workload group because 
+# workload management mode is disabled or monitor_only.
+```
+
+**Enable WLM before CRUD operations:**
+```bash
+PUT _cluster/settings
+{
+  "persistent": {
+    "wlm.workload_group.mode": "enabled"
+  }
+}
+```
+
+### Migration Notes
+
+If you have automation scripts that create or modify workload groups, ensure that WLM mode is set to `enabled` before executing those operations. Scripts that previously worked with WLM in `disabled` or `monitor_only` mode will now fail with an error.
+
+## Limitations
+
+- GET operations for workload groups are still allowed when WLM is disabled (read-only access)
+- The validation only applies to REST API operations; internal cluster state changes are not affected
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18652](https://github.com/opensearch-project/OpenSearch/pull/18652) | Add WLM mode validation for workload group CRUD requests |
+| [#18709](https://github.com/opensearch-project/OpenSearch/pull/18709) | Rename WorkloadGroupTestUtil to WorkloadManagementTestUtil |
+| [#18711](https://github.com/opensearch-project/OpenSearch/pull/18711) | Rename QueryGroup to WorkloadGroup in comments and Javadocs |
+| [#18712](https://github.com/opensearch-project/OpenSearch/pull/18712) | Modify logging message in WorkloadGroupService to show actual resiliency mode |
+
+## References
+
+- [Workload Management Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/workload-management/wlm-feature-overview/)
+- [Workload Group Lifecycle API](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/workload-management/workload-group-lifecycle-api/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/workload-management.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -89,3 +89,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Java Agent AccessController](features/opensearch/java-agent-accesscontroller.md) | feature | OpenSearch replacement for JDK's deprecated AccessController for privileged operations |
 | [Secure Transport Parameters](features/opensearch/secure-transport-parameters.md) | feature | SecureHttpTransportParameters API for cleaner SSL configuration in Reactor Netty 4 HTTP transport |
 | [Custom Index Name Resolver](features/opensearch/custom-index-name-resolver.md) | feature | Plugin extensibility for custom index name expression resolvers |
+| [Workload Management](features/opensearch/workload-management.md) | feature | WLM mode validation for CRUD operations, naming consistency updates, logging improvements |


### PR DESCRIPTION
## Summary

Add release report for Workload Management v3.2.0 improvements.

### Changes in v3.2.0
- WLM mode validation for workload group CRUD requests (Create/Update/Delete operations now fail when WLM mode is `disabled` or `monitor_only`)
- Added `WlmClusterSettingValuesProvider` component for centralized cluster settings management
- Renamed `WorkloadGroupTestUtil` to `WorkloadManagementTestUtil`
- Updated all "QueryGroup" references to "WorkloadGroup" in comments and Javadocs
- Improved logging to dynamically show actual resiliency mode

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch/workload-management.md`
- Feature report: `docs/features/opensearch/workload-management.md` (updated)

### Related PRs
- #18652: Add WLM mode validation for workload group CRUD requests
- #18709: Rename WorkloadGroupTestUtil to WorkloadManagementTestUtil
- #18711: Rename QueryGroup to WorkloadGroup in comments and Javadocs
- #18712: Modify logging message to show actual resiliency mode

Closes #1094