### PR TITLE
docs: add warm-indices report for v3.2.0

### DIFF
--- a/docs/features/opensearch/warm-storage-tiering.md
+++ b/docs/features/opensearch/warm-storage-tiering.md
@@ -191,7 +191,9 @@ PUT _plugins/_ism/policies/hot-warm-policy
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#18375](https://github.com/opensearch-project/OpenSearch/pull/18375) | Add support for Warm Indices Write Block on Flood Watermark breach |
 | v3.2.0 | [#18767](https://github.com/opensearch-project/OpenSearch/pull/18767) | FS stats for warm nodes based on addressable space; changed default remote_data_ratio from 0 to 5 (min: 1) |
+| v3.2.0 | [#18686](https://github.com/opensearch-project/OpenSearch/pull/18686) | Disallow resize for Warm Index, add Parameterized ITs for close in remote store |
 | v3.2.0 | [#18666](https://github.com/opensearch-project/OpenSearch/pull/18666) | Replaced CPU load average with AverageTracker classes, adjusted default thresholds |
 | v3.1.0 | [#18082](https://github.com/opensearch-project/OpenSearch/pull/18082) | Add Warm Disk Threshold Allocation Decider for Warm shards |
 | v3.1.0 | [#18229](https://github.com/opensearch-project/OpenSearch/pull/18229) | Added Auto Force Merge Manager to enhance hot to warm migration |
@@ -207,5 +209,5 @@ PUT _plugins/_ism/policies/hot-warm-policy
 
 ## Change History
 
-- **v3.2.0** (2025-07-22): Added WarmFsService for accurate warm node FS stats based on addressable space; changed default remote_data_ratio from 0 to 5 with minimum of 1; improved resource monitoring with AverageTracker classes for CPU and JVM; adjusted default thresholds (CPU: 75%, Disk: 85%, Merge delay: 15s)
+- **v3.2.0** (2025-07-22): Added write block support for warm indices on flood watermark breach; added WarmFsService for accurate warm node FS stats based on addressable space; disallowed resize operations (clone/shrink/split) on warm indices; changed default remote_data_ratio from 0 to 5 with minimum of 1; improved resource monitoring with AverageTracker classes for CPU and JVM; adjusted default thresholds (CPU: 75%, Disk: 85%, Merge delay: 15s)
 - **v3.1.0** (2025-06-10): Added WarmDiskThresholdDecider for intelligent warm shard allocation and AutoForceMergeManager for automated segment optimization during hot-to-warm migration

--- a/docs/releases/v3.2.0/features/opensearch/warm-indices.md
+++ b/docs/releases/v3.2.0/features/opensearch/warm-indices.md
@@ -1,0 +1,149 @@
+# Warm Indices
+
+## Summary
+
+OpenSearch v3.2.0 enhances warm indices with three key improvements: write block support when flood watermark is breached, accurate filesystem statistics based on addressable space rather than physical disk, and restrictions on resize operations for warm indices. These changes improve operational safety and monitoring accuracy for warm tier deployments.
+
+## Details
+
+### What's New in v3.2.0
+
+This release adds critical operational improvements for warm indices:
+
+1. **Write Block on Flood Watermark Breach** - Warm indices now automatically apply write blocks when the flood stage watermark is exceeded, preventing data loss from disk pressure
+2. **Addressable Space-based FS Stats** - Warm nodes report filesystem statistics based on total addressable space (file cache × remote_data_ratio) instead of physical disk, providing accurate capacity planning metrics
+3. **Resize Operation Restrictions** - Clone, shrink, and split operations are now explicitly disallowed on warm indices to prevent data integrity issues
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Disk Threshold Monitoring"
+        DTM[DiskThresholdMonitor]
+        NDE[NodeDiskEvaluator]
+        HDE[HotNodeDiskThresholdEvaluator]
+        WDE[WarmNodeDiskThresholdEvaluator]
+    end
+    
+    subgraph "FS Stats"
+        FSP[FsServiceProvider]
+        FS[FsService]
+        WFS[WarmFsService]
+    end
+    
+    subgraph "Warm Node"
+        FC[FileCache]
+        IS[IndicesService]
+        PS[Primary Shards]
+    end
+    
+    DTM --> NDE
+    NDE --> HDE
+    NDE --> WDE
+    WDE -->|Calculate Thresholds| FC
+    
+    FSP -->|Hot Node| FS
+    FSP -->|Warm Node| WFS
+    WFS --> FC
+    WFS --> IS
+    IS --> PS
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `DiskThresholdEvaluator` | Interface for disk threshold evaluation logic with watermark checking methods |
+| `HotNodeDiskThresholdEvaluator` | Standard disk usage evaluation for hot nodes using physical disk metrics |
+| `WarmNodeDiskThresholdEvaluator` | Warm-specific evaluation using addressable space (cache × ratio) |
+| `NodeDiskEvaluator` | Composite evaluator that delegates to hot or warm evaluator based on node type |
+| `FsServiceProvider` | Factory that creates appropriate FsService based on node type |
+| `WarmFsService` | Specialized FsService for warm nodes calculating disk usage from primary shard sizes |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.filecache.remote_data_ratio` | Ratio of remote data to file cache size | `5.0` (changed from `0.0`, min: `1.0`) |
+
+### Usage Example
+
+#### Warm Node FS Stats Response
+
+```json
+GET /_nodes/warm-node/stats/fs
+{
+  "nodes": {
+    "warm-node-id": {
+      "fs": {
+        "total": {
+          "total_in_bytes": 2097152000,
+          "free_in_bytes": 2064519020,
+          "available_in_bytes": 2064519020,
+          "cache_reserved_in_bytes": 1048576000,
+          "cache_utilized": 32632980
+        },
+        "data": [
+          {
+            "path": "/warm",
+            "mount": "warm",
+            "type": "warm",
+            "total_in_bytes": 2097152000,
+            "free_in_bytes": 2064519020,
+            "available_in_bytes": 2064519020,
+            "cache_reserved_in_bytes": 1048576000,
+            "cache_utilized": 32632980
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+The `total_in_bytes` is calculated as `file_cache_size × remote_data_ratio` (e.g., 1GB cache × 2 ratio = 2GB total addressable space).
+
+#### Resize Operation Error
+
+```json
+POST /warm-index/_shrink/target-index
+// Response:
+{
+  "error": {
+    "type": "illegal_state_exception",
+    "reason": "cannot resize warm index"
+  },
+  "status": 400
+}
+```
+
+### Migration Notes
+
+- **remote_data_ratio default changed**: The default value changed from `0` (unlimited) to `5`. Clusters relying on the previous unlimited behavior should explicitly set `cluster.filecache.remote_data_ratio: 0` or adjust capacity planning
+- **Minimum ratio enforced**: The minimum allowed value is now `1.0` instead of `0.0`
+- **Resize operations blocked**: Any existing automation that attempts to resize warm indices will now fail and needs to be updated
+
+## Limitations
+
+- Write blocks on warm indices during flood stage may impact ingestion pipelines targeting warm indices
+- FS stats for warm nodes show virtual path `/warm` instead of actual filesystem paths
+- Resize restrictions apply to all warm indices regardless of their current state
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18375](https://github.com/opensearch-project/OpenSearch/pull/18375) | Add support for Warm Indices Write Block on Flood Watermark breach |
+| [#18767](https://github.com/opensearch-project/OpenSearch/pull/18767) | FS stats for warm nodes based on addressable space |
+| [#18686](https://github.com/opensearch-project/OpenSearch/pull/18686) | Disallow resize for Warm Index, add Parameterized ITs for close in remote store |
+
+## References
+
+- [Issue #18768](https://github.com/opensearch-project/OpenSearch/issues/18768): [WRITABLE WARM] FS stats for warm nodes
+- [Searchable Snapshots Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/warm-storage-tiering.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -90,3 +90,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Secure Transport Parameters](features/opensearch/secure-transport-parameters.md) | feature | SecureHttpTransportParameters API for cleaner SSL configuration in Reactor Netty 4 HTTP transport |
 | [Custom Index Name Resolver](features/opensearch/custom-index-name-resolver.md) | feature | Plugin extensibility for custom index name expression resolvers |
 | [Workload Management](features/opensearch/workload-management.md) | feature | WLM mode validation for CRUD operations, naming consistency updates, logging improvements |
+| [Warm Indices](features/opensearch/warm-indices.md) | feature | Write block on flood watermark, addressable space-based FS stats, resize restrictions |


### PR DESCRIPTION
## Summary

Add documentation for Warm Indices enhancements in OpenSearch v3.2.0.

### Changes in v3.2.0

1. **Write Block on Flood Watermark Breach** (PR #18375)
   - Warm indices now automatically apply write blocks when flood stage watermark is exceeded
   - New `DiskThresholdEvaluator` interface with hot/warm node implementations

2. **Addressable Space-based FS Stats** (PR #18767)
   - Warm nodes report FS stats based on total addressable space (file cache × remote_data_ratio)
   - New `WarmFsService` and `FsServiceProvider` components
   - Default `remote_data_ratio` changed from 0 to 5 (min: 1)

3. **Resize Operation Restrictions** (PR #18686)
   - Clone, shrink, and split operations are now disallowed on warm indices
   - Added parameterized integration tests for close operations in remote store

### Files Changed

- Created: `docs/releases/v3.2.0/features/opensearch/warm-indices.md`
- Updated: `docs/features/opensearch/warm-storage-tiering.md`
- Updated: `docs/releases/v3.2.0/index.md`

### Related Issue

Closes #1093