### PR TITLE
docs: add Terms Lookup Query Enhancement report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -133,6 +133,7 @@
 - [Wildcard Field](opensearch/wildcard-field.md)
 - [Workload Management](opensearch/workload-management.md)
 - [Hierarchical & ACL-aware Routing](opensearch/hierarchical-acl-aware-routing.md)
+- [Terms Lookup Query](opensearch/terms-lookup-query.md)
 
 ## opensearch-dashboards
 

--- a/docs/features/opensearch/terms-lookup-query.md
+++ b/docs/features/opensearch/terms-lookup-query.md
@@ -1,0 +1,145 @@
+# Terms Lookup Query
+
+## Summary
+
+The Terms Lookup Query is a powerful feature in OpenSearch that allows filtering documents based on terms stored in another index. Instead of specifying filter values directly in the query, you can reference field values from documents in a separate index. This enables dynamic filtering scenarios where filter criteria are maintained separately from the search logic.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Terms Lookup Query Flow"
+        A[Search Request] --> B[Terms Query with Lookup]
+        B --> C{Lookup Method}
+        C -->|Document ID| D[GET Request]
+        C -->|Query Clause| E[Search Request]
+        D --> F[Extract Field Values]
+        E --> F
+        F --> G[Deduplicate Values]
+        G --> H[Build Terms Filter]
+        H --> I[Execute Main Search]
+        I --> J[Return Results]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Lookup Index"
+        L1[Document 1] --> V1[field: value1, value2]
+        L2[Document 2] --> V2[field: value3]
+    end
+    subgraph "Terms Extraction"
+        V1 --> T[Collected Terms]
+        V2 --> T
+        T --> D[Deduplicated: value1, value2, value3]
+    end
+    subgraph "Main Index"
+        D --> F[Terms Filter]
+        F --> R[Matching Documents]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `TermsQueryBuilder` | Main query builder that handles both direct values and lookup-based terms |
+| `TermsLookup` | Encapsulates lookup parameters (index, id/query, path, routing, store) |
+| Fetch Logic | Retrieves terms via GET (single doc) or Search (query-based) |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.max_terms_count` | Maximum number of terms allowed in a terms query | 65536 |
+| `index.max_result_window` | Maximum number of results for search-based lookup | 10000 |
+| `indices.query.max_clause_count` | Maximum clauses in a boolean query | 1024 |
+
+### Lookup Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `index` | String | Yes | Index containing the lookup document(s) |
+| `id` | String | Conditional | Document ID for single-document lookup |
+| `query` | Object | Conditional | Query clause for multi-document lookup |
+| `path` | String | Yes | Field path to extract values from |
+| `routing` | String | No | Custom routing value |
+| `store` | Boolean | No | Use stored fields instead of `_source` |
+
+### Usage Examples
+
+**Basic Terms Lookup (by ID):**
+```json
+GET /students/_search
+{
+  "query": {
+    "terms": {
+      "student_id": {
+        "index": "classes",
+        "id": "101",
+        "path": "enrolled"
+      }
+    }
+  }
+}
+```
+
+**Terms Lookup by Query (v3.2.0+):**
+```json
+GET /students/_search
+{
+  "query": {
+    "terms": {
+      "student_id": {
+        "index": "classes",
+        "path": "enrolled",
+        "query": {
+          "term": { "department": "engineering" }
+        }
+      }
+    }
+  }
+}
+```
+
+**Nested Field Lookup:**
+```json
+GET /students/_search
+{
+  "query": {
+    "terms": {
+      "student_id": {
+        "index": "classes",
+        "id": "102",
+        "path": "enrolled_students.id_list"
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- The `_source` mapping field must be enabled for terms lookup
+- Query-based lookup results are limited by index settings
+- Large term lists may impact query performance
+- Cannot use both `id` and `query` parameters simultaneously
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#18195](https://github.com/opensearch-project/OpenSearch/pull/18195) | Add query clause support for terms lookup |
+
+## References
+
+- [Issue #17599](https://github.com/opensearch-project/OpenSearch/issues/17599): Feature request for query-based lookup
+- [Terms Query Documentation](https://docs.opensearch.org/3.2/query-dsl/term/terms/): Official documentation
+
+## Change History
+
+- **v3.2.0** (2025-08-01): Added support for query clause in terms lookup, enabling multi-document value extraction

--- a/docs/releases/v3.2.0/features/opensearch/terms-lookup-query-enhancement.md
+++ b/docs/releases/v3.2.0/features/opensearch/terms-lookup-query-enhancement.md
@@ -1,0 +1,123 @@
+# Terms Lookup Query Enhancement
+
+## Summary
+
+OpenSearch v3.2.0 enhances the Terms Lookup Query to accept a query clause instead of only supporting a single document ID. This allows users to dynamically extract field values from multiple documents matching a query and use them as filter terms, enabling more flexible and powerful filtering scenarios.
+
+## Details
+
+### What's New in v3.2.0
+
+Previously, the Terms Lookup Query required specifying a single document ID to fetch terms from. This enhancement introduces the ability to use a query clause to match multiple documents and collect all values from a specified field across those matches.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Terms Lookup Query"
+        A[Terms Query] --> B{Lookup Type?}
+        B -->|id| C[Get Single Document]
+        B -->|query| D[Search Multiple Documents]
+        C --> E[Extract Field Values]
+        D --> E
+        E --> F[Build Terms Filter]
+        F --> G[Execute Search]
+    end
+```
+
+#### New Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `query` | Object | A query clause to match documents for terms extraction. Mutually exclusive with `id`. |
+
+#### Validation Rules
+
+- Either `id` or `query` must be specified, but not both
+- `index` and `path` remain required parameters
+- When using `query`, results are limited by `max_terms_count`, `max_result_window`, and `max_clause_count` settings
+
+#### Value Collection Behavior
+
+When using query-based lookup:
+- If a document does not contain the specified field, it is ignored
+- If the field is a list, all items are collected
+- If the field is a scalar, its value is collected
+- Values from multiple documents are flattened and deduplicated
+- If no documents match or none contain the field, the query matches nothing
+
+### Usage Example
+
+**Setup indexes:**
+```json
+PUT /users
+{
+  "mappings": {
+    "properties": {
+      "username": { "type": "keyword" }
+    }
+  }
+}
+
+PUT /groups
+{
+  "mappings": {
+    "properties": {
+      "group": { "type": "keyword" },
+      "members": { "type": "keyword" }
+    }
+  }
+}
+```
+
+**Query using terms lookup by query:**
+```json
+GET /users/_search
+{
+  "query": {
+    "terms": {
+      "username": {
+        "index": "groups",
+        "path": "members",
+        "query": {
+          "term": { "group": "g1" }
+        }
+      }
+    }
+  }
+}
+```
+
+This query:
+1. Searches the `groups` index for documents where `group` equals `g1`
+2. Collects all values from the `members` field across matching documents
+3. Uses those values as terms to filter the `users` index by `username`
+
+### Migration Notes
+
+- Existing queries using `id` parameter continue to work unchanged
+- To migrate from ID-based to query-based lookup, replace `id` with `query` parameter
+- Consider index settings limits when using query-based lookup with large result sets
+
+## Limitations
+
+- Total hits from the subquery cannot exceed the minimum of `max_terms_count`, `max_result_window`, and `max_clause_count`
+- Query-based lookup may have higher latency than ID-based lookup due to search execution
+- The `store` parameter works with both ID and query-based lookups
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18195](https://github.com/opensearch-project/OpenSearch/pull/18195) | Enhance terms lookup query to take a query clause |
+
+## References
+
+- [Issue #17599](https://github.com/opensearch-project/OpenSearch/issues/17599): Original feature request
+- [Terms Query Documentation](https://docs.opensearch.org/3.2/query-dsl/term/terms/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/terms-lookup-query.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -92,3 +92,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Workload Management](features/opensearch/workload-management.md) | feature | WLM mode validation for CRUD operations, naming consistency updates, logging improvements |
 | [Warm Indices](features/opensearch/warm-indices.md) | feature | Write block on flood watermark, addressable space-based FS stats, resize restrictions |
 | [Hierarchical & ACL-aware Routing](features/opensearch/hierarchical-acl-aware-routing.md) | feature | New routing processors for hierarchical paths and ACL-based document co-location |
+| [Terms Lookup Query Enhancement](features/opensearch/terms-lookup-query-enhancement.md) | feature | Query clause support for terms lookup enabling multi-document value extraction |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Terms Lookup Query Enhancement feature introduced in OpenSearch v3.2.0.

### Changes
- **Release report**: `docs/releases/v3.2.0/features/opensearch/terms-lookup-query-enhancement.md`
- **Feature report**: `docs/features/opensearch/terms-lookup-query.md`
- Updated release index and features index

### Feature Overview

The Terms Lookup Query has been enhanced to accept a query clause instead of only supporting a single document ID. This allows users to dynamically extract field values from multiple documents matching a query and use them as filter terms.

**Key changes:**
- New `query` parameter in terms lookup (mutually exclusive with `id`)
- Multi-document value extraction with automatic deduplication
- Validation against `max_terms_count`, `max_result_window`, and `max_clause_count` settings

### Related
- Resolves investigation Issue #1091
- OpenSearch PR: [#18195](https://github.com/opensearch-project/OpenSearch/pull/18195)
- Feature request: [#17599](https://github.com/opensearch-project/OpenSearch/issues/17599)