### PR TITLE
docs: add geospatial-infrastructure report for v3.2.0

### DIFF
--- a/docs/features/geospatial/geospatial-plugin.md
+++ b/docs/features/geospatial/geospatial-plugin.md
@@ -67,6 +67,7 @@ The plugin uses Gradle for building and Maven for artifact publishing. POM files
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#776](https://github.com/opensearch-project/geospatial/pull/776) | Upgrade gradle to 8.14.3 and run CI checks with JDK24 |
 | v3.0.0 | [#732](https://github.com/opensearch-project/geospatial/pull/732) | Persist licenses and developer fields in pom file |
 
 ## References
@@ -78,4 +79,5 @@ The plugin uses Gradle for building and Maven for artifact publishing. POM files
 
 ## Change History
 
+- **v3.2.0** (2026-01-11): Upgraded Gradle to 8.14.3, enabled JDK 24 CI checks, updated Lombok plugin to 8.14
 - **v3.0.0** (2025-05-06): Fixed Maven POM metadata to include license, description, and developer information for all published artifacts

--- a/docs/releases/v3.2.0/features/geospatial/geospatial-infrastructure.md
+++ b/docs/releases/v3.2.0/features/geospatial/geospatial-infrastructure.md
@@ -1,0 +1,75 @@
+# Geospatial Infrastructure
+
+## Summary
+
+This release updates the Geospatial plugin's build infrastructure by upgrading Gradle to version 8.14.3 and enabling CI checks with JDK 24. These changes ensure compatibility with the latest Java runtime and improve build tooling.
+
+## Details
+
+### What's New in v3.2.0
+
+The Geospatial plugin build infrastructure has been modernized with the following updates:
+
+1. **Gradle Upgrade**: Updated from 8.10.2 to 8.14.3
+2. **JDK 24 Support**: CI workflows now run tests with JDK 21 and JDK 24 (replacing JDK 23)
+3. **Lombok Plugin Update**: Upgraded to version 8.14 with new plugin DSL syntax
+4. **Test Fix**: Improved test reliability for duplicate key handling
+
+### Technical Changes
+
+#### Build Configuration Updates
+
+| Component | Previous | New |
+|-----------|----------|-----|
+| Gradle | 8.10.2 | 8.14.3 |
+| CI JDK Matrix | 21, 23 | 21, 24 |
+| Lombok Plugin | 8.4 (classpath) | 8.14 (plugins DSL) |
+
+#### CI Workflow Changes
+
+The following workflow files were updated to use JDK 24:
+
+- `.github/workflows/CI.yml` - Main CI workflow
+- `.github/workflows/test_security.yml` - Security tests
+
+#### Gradle Plugin Migration
+
+The Lombok plugin declaration was migrated from classpath-based to plugins DSL:
+
+```groovy
+// Before (classpath in buildscript)
+classpath "io.freefair.gradle:lombok-plugin:8.4"
+apply plugin: 'io.freefair.lombok'
+
+// After (plugins DSL)
+plugins {
+    id "io.freefair.lombok" version "8.14"
+}
+```
+
+This change applies to both the main `build.gradle` and `client/build.gradle`.
+
+#### Test Improvements
+
+Fixed a flaky test in `UploadStatsServiceTests.java` that could fail due to duplicate random keys by adding deduplication logic.
+
+## Limitations
+
+- JDK 24 is the latest supported version; older JDK versions below 21 are not supported
+- Gradle 8.14.3 requires compatible plugin versions
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#776](https://github.com/opensearch-project/geospatial/pull/776) | Upgrade gradle to 8.14.3 and run CI checks with JDK24 |
+
+## References
+
+- [Gradle 8.14.3 Release Notes](https://docs.gradle.org/8.14.3/release-notes.html): Gradle release information
+- [JDK 24 Release](https://openjdk.org/projects/jdk/24/): OpenJDK 24 project page
+- [Lombok Gradle Plugin](https://plugins.gradle.org/plugin/io.freefair.lombok): Lombok plugin for Gradle
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/geospatial/geospatial-plugin.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -93,3 +93,9 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Warm Indices](features/opensearch/warm-indices.md) | feature | Write block on flood watermark, addressable space-based FS stats, resize restrictions |
 | [Hierarchical & ACL-aware Routing](features/opensearch/hierarchical-acl-aware-routing.md) | feature | New routing processors for hierarchical paths and ACL-based document co-location |
 | [Terms Lookup Query Enhancement](features/opensearch/terms-lookup-query-enhancement.md) | feature | Query clause support for terms lookup enabling multi-document value extraction |
+
+### Geospatial
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Geospatial Infrastructure](features/geospatial/geospatial-infrastructure.md) | bugfix | Upgrade Gradle to 8.14.3 and run CI checks with JDK24 |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Geospatial Infrastructure bugfix in OpenSearch v3.2.0.

### Changes

- **Release report**: `docs/releases/v3.2.0/features/geospatial/geospatial-infrastructure.md`
- **Feature report update**: `docs/features/geospatial/geospatial-plugin.md` (added v3.2.0 entry)
- **Release index update**: Added Geospatial section to v3.2.0 index

### Key Changes in v3.2.0

- Gradle upgraded from 8.10.2 to 8.14.3
- CI workflows updated to run with JDK 21 and JDK 24 (replacing JDK 23)
- Lombok plugin updated to version 8.14 with new plugins DSL syntax
- Test fix for duplicate key handling in UploadStatsServiceTests

### Related Issue

Closes #1090