### PR TITLE
docs: add Performance Analyzer Infrastructure report for v3.2.0

### DIFF
--- a/docs/features/performance-analyzer/performance-analyzer.md
+++ b/docs/features/performance-analyzer/performance-analyzer.md
@@ -115,6 +115,7 @@ GET localhost:9600/_plugins/_performanceanalyzer/rca?name=HighHeapUsageClusterRC
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#826](https://github.com/opensearch-project/performance-analyzer/pull/826) | Bump SpotBugs to 6.2.2 and Checkstyle to 10.26.1 |
 | v2.17.0 | [#690](https://github.com/opensearch-project/performance-analyzer/pull/690) | Added CacheConfig Telemetry collectors |
 | v2.17.0 | [#712](https://github.com/opensearch-project/performance-analyzer/pull/712) | Bump PA to use 1.6.0 PA commons lib |
 
@@ -127,4 +128,5 @@ GET localhost:9600/_plugins/_performanceanalyzer/rca?name=HighHeapUsageClusterRC
 
 ## Change History
 
+- **v3.2.0** (2025-07-18): Build infrastructure update - SpotBugs 6.2.2, Checkstyle 10.26.1; Removed CVE-2025-27820 workaround
 - **v2.17.0** (2024-09-17): Added RTFCacheConfigMetricsCollector for cache configuration telemetry; Updated PA Commons dependency to 1.6.0

--- a/docs/releases/v3.2.0/features/performance-analyzer/performance-analyzer-infrastructure.md
+++ b/docs/releases/v3.2.0/features/performance-analyzer/performance-analyzer-infrastructure.md
@@ -1,0 +1,70 @@
+# Performance Analyzer Infrastructure
+
+## Summary
+
+This release updates the Performance Analyzer plugin's build infrastructure by bumping SpotBugs to version 6.2.2 and Checkstyle to version 10.26.1. The update also removes a previously required CVE workaround for Apache HttpComponents, simplifying the build configuration.
+
+## Details
+
+### What's New in v3.2.0
+
+This is a build infrastructure update that improves code quality tooling and removes obsolete security workarounds:
+
+1. **SpotBugs Update**: Upgraded from 6.0.7 to 6.2.2
+2. **Checkstyle Update**: Upgraded from 10.12.1 to 10.26.1
+3. **CVE Workaround Removal**: Removed the manual resolution strategy for CVE-2025-27820 (Apache HttpComponents)
+
+### Technical Changes
+
+#### Build Configuration Changes
+
+| Tool | Previous Version | New Version |
+|------|------------------|-------------|
+| SpotBugs | 6.0.7 | 6.2.2 |
+| Checkstyle | 10.12.1 | 10.26.1 |
+
+#### Removed Configuration
+
+The following CVE workaround was removed from `build.gradle`:
+
+```groovy
+// Previously required for CVE-2025-27820
+configurations.all {
+    resolutionStrategy {
+        force("org.apache.httpcomponents.client5:httpclient5:5.4.4")
+        force("org.apache.httpcomponents:httpcore:5.3.4")
+        force("org.apache.httpcomponents.core5:httpcore5-h2:5.3.4")
+        force("org.apache.httpcomponents.core5:httpcore5:5.3.4")
+    }
+}
+```
+
+This workaround is no longer needed as the updated dependencies now include the security fixes.
+
+### Impact
+
+- **Code Quality**: Updated static analysis tools provide better bug detection and code style enforcement
+- **Build Simplification**: Removal of manual dependency overrides reduces build complexity
+- **Security**: CVE-2025-27820 is now addressed through normal dependency resolution
+
+## Limitations
+
+- No functional changes to Performance Analyzer behavior
+- This is a build-time only change with no runtime impact
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#826](https://github.com/opensearch-project/performance-analyzer/pull/826) | Bump spotbug to 6.2.2 and checkstyle 10.26.1 |
+
+## References
+
+- [PR #826](https://github.com/opensearch-project/performance-analyzer/pull/826): Main implementation
+- [SpotBugs](https://spotbugs.github.io/): Static analysis tool for Java
+- [Checkstyle](https://checkstyle.org/): Code style checker for Java
+- [Performance Analyzer Documentation](https://docs.opensearch.org/latest/monitoring-your-cluster/pa/index/): Official docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/performance-analyzer/performance-analyzer.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -99,3 +99,9 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | Item | Category | Description |
 |------|----------|-------------|
 | [Geospatial Infrastructure](features/geospatial/geospatial-infrastructure.md) | bugfix | Upgrade Gradle to 8.14.3 and run CI checks with JDK24 |
+
+### Performance Analyzer
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Performance Analyzer Infrastructure](features/performance-analyzer/performance-analyzer-infrastructure.md) | bugfix | Bump SpotBugs to 6.2.2 and Checkstyle to 10.26.1 |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Performance Analyzer Infrastructure bugfix in OpenSearch v3.2.0.

### Changes

- **Release Report**: `docs/releases/v3.2.0/features/performance-analyzer/performance-analyzer-infrastructure.md`
- **Feature Report Update**: Updated `docs/features/performance-analyzer/performance-analyzer.md` with v3.2.0 changes
- **Release Index Update**: Added Performance Analyzer section to `docs/releases/v3.2.0/index.md`

### Release Item Details

- **PR**: [#826](https://github.com/opensearch-project/performance-analyzer/pull/826)
- **Category**: bugfix
- **Changes**:
  - Bump SpotBugs from 6.0.7 to 6.2.2
  - Bump Checkstyle from 10.12.1 to 10.26.1
  - Remove CVE-2025-27820 workaround (Apache HttpComponents)

Closes #1089