### PR TITLE
docs: add observability-infrastructure report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -319,6 +319,7 @@
 
 ## observability
 
+- [Observability Infrastructure](observability/observability-infrastructure.md)
 - [Observability Integrations](observability/observability-integrations.md)
 - [Release Maintenance](observability/release-maintenance.md)
 - [Trace Analytics Bug Fixes](observability/trace-analytics-bug-fixes.md)

--- a/docs/features/observability/observability-infrastructure.md
+++ b/docs/features/observability/observability-infrastructure.md
@@ -1,0 +1,96 @@
+# Observability Infrastructure
+
+## Summary
+
+This feature tracks infrastructure and build system maintenance for the OpenSearch Observability plugin, including CI/CD pipeline updates, dependency management, Gradle upgrades, and Maven publishing configuration. These changes ensure the plugin remains compatible with the latest tooling and follows OpenSearch project-wide infrastructure standards.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Observability Plugin"
+        OBS[observability<br/>Backend Plugin]
+        BUILD[build.gradle]
+        CI[GitHub Actions CI]
+    end
+    
+    subgraph "Build Infrastructure"
+        GRADLE[Gradle Wrapper]
+        KOTLIN[Kotlin Compiler]
+        DETEKT[Detekt Static Analysis]
+    end
+    
+    subgraph "Publishing"
+        MAVEN[Maven Central Portal]
+        SECRETS[1Password Secrets]
+    end
+    
+    OBS --> BUILD
+    BUILD --> GRADLE
+    BUILD --> KOTLIN
+    BUILD --> DETEKT
+    CI --> SECRETS
+    CI --> MAVEN
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| build.gradle | Main build configuration with dependencies and publishing setup |
+| gradle-wrapper.properties | Gradle version and distribution configuration |
+| maven-publish.yml | GitHub Actions workflow for Maven snapshot publishing |
+| opensearch-observability-test-and-build-workflow.yml | CI workflow for testing and building |
+
+### Configuration
+
+| Setting | Description | Current Value |
+|---------|-------------|---------------|
+| Gradle Version | Build tool version | 8.14.3 |
+| Kotlin Version | Kotlin compiler version | 2.2.0 |
+| Nebula OSPackage | Packaging plugin version | 12.0.0 |
+| Maven Snapshots URL | Repository for snapshot publishing | `https://central.sonatype.com/repository/maven-snapshots/` |
+| CI Java Versions | JDK versions for CI testing | 21, 24 |
+| Detekt JVM Target | Static analysis JVM target | 21 |
+
+### Usage Example
+
+```groovy
+// build.gradle - Maven publishing configuration
+publishing {
+    repositories {
+        maven {
+            name = "Snapshots"
+            url = "https://central.sonatype.com/repository/maven-snapshots/"
+            credentials {
+                username "$System.env.SONATYPE_USERNAME"
+                password "$System.env.SONATYPE_PASSWORD"
+            }
+        }
+    }
+}
+```
+
+## Limitations
+
+- Detekt static analysis does not yet support JDK 24, requiring JVM target override
+- Legacy Sonatype URL maintained for backward compatibility during transition
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#1931](https://github.com/opensearch-project/observability/pull/1931) | Update maven snapshot publish endpoint and credential |
+| v3.2.0 | [#1937](https://github.com/opensearch-project/observability/pull/1937) | Upgrade gradle to 8.14.3 and run CI checks with JDK24 |
+
+## References
+
+- [observability repository](https://github.com/opensearch-project/observability)
+- [Issue #5551](https://github.com/opensearch-project/opensearch-build/issues/5551): Plugin snapshot publishing migration
+- [Sonatype Central Portal Snapshots](https://central.sonatype.org/publish/publish-portal-snapshots/)
+
+## Change History
+
+- **v3.2.0** (2025-08-04): Maven snapshot publishing migration to Central Portal, Gradle 8.14.3 upgrade, JDK 24 CI support

--- a/docs/releases/v3.2.0/features/observability/observability-infrastructure.md
+++ b/docs/releases/v3.2.0/features/observability/observability-infrastructure.md
@@ -1,0 +1,114 @@
+# Observability Infrastructure
+
+## Summary
+
+This release includes infrastructure maintenance updates for the OpenSearch Observability plugin, focusing on Maven snapshot publishing migration and Gradle/JDK upgrades to ensure continued CI/CD compatibility and build reliability.
+
+## Details
+
+### What's New in v3.2.0
+
+Two key infrastructure changes were made:
+
+1. **Maven Snapshot Publishing Migration**: Updated the Maven snapshot publish endpoint from the legacy Sonatype OSS repository to the new Central Portal endpoint, along with credential management migration from AWS Secrets Manager to 1Password.
+
+2. **Gradle and JDK Upgrade**: Upgraded Gradle from 8.10.2 to 8.14.3 and added JDK 24 support for CI checks.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "CI/CD Pipeline"
+        GHA[GitHub Actions]
+        OP[1Password Secrets]
+        GRADLE[Gradle 8.14.3]
+    end
+    
+    subgraph "Maven Publishing"
+        OLD[aws.oss.sonatype.org<br/>Legacy]
+        NEW[central.sonatype.com<br/>New Portal]
+    end
+    
+    subgraph "Build Matrix"
+        JDK21[JDK 21]
+        JDK24[JDK 24]
+    end
+    
+    GHA --> OP
+    GHA --> GRADLE
+    GRADLE --> NEW
+    GRADLE --> JDK21
+    GRADLE --> JDK24
+    
+    OLD -.->|Deprecated| NEW
+```
+
+#### New Configuration
+
+| Setting | Description | Old Value | New Value |
+|---------|-------------|-----------|-----------|
+| Maven Snapshots URL | Repository for snapshot publishing | `https://aws.oss.sonatype.org/content/repositories/snapshots` | `https://central.sonatype.com/repository/maven-snapshots/` |
+| Gradle Version | Build tool version | 8.10.2 | 8.14.3 |
+| Kotlin Version | Kotlin compiler version | 2.0.21 | 2.2.0 |
+| Nebula OSPackage | Packaging plugin version | 11.6.0 | 12.0.0 |
+| CI Java Matrix | JDK versions for CI | [21] | [21, 24] |
+
+#### Credential Management Changes
+
+| Aspect | Before | After |
+|--------|--------|-------|
+| Secret Storage | AWS Secrets Manager | 1Password |
+| Authentication | AWS IAM Role (`PUBLISH_SNAPSHOTS_ROLE`) | 1Password Service Account Token |
+| Credential Retrieval | `aws secretsmanager get-secret-value` | `1password/load-secrets-action` |
+
+### Usage Example
+
+The new Maven publishing workflow:
+
+```yaml
+# .github/workflows/maven-publish.yml
+- name: Load secret
+  uses: 1password/load-secrets-action@v2
+  with:
+    export-env: true
+  env:
+    OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+    SONATYPE_USERNAME: op://opensearch-infra-secrets/maven-central-portal-credentials/username
+    SONATYPE_PASSWORD: op://opensearch-infra-secrets/maven-central-portal-credentials/password
+
+- name: publish snapshots to maven
+  run: |
+    ./gradlew publishPluginZipPublicationToSnapshotsRepository
+```
+
+### Migration Notes
+
+For plugin maintainers:
+1. Update `build.gradle` to use the new Central Portal URL
+2. Add the new repository URL to both `buildscript.repositories` and project `repositories`
+3. Configure 1Password secrets in GitHub repository settings
+4. Update CI workflows to use `1password/load-secrets-action`
+
+## Limitations
+
+- Detekt static analysis tool does not yet support JDK 24, requiring `jvmTarget = "21"` workaround
+- Legacy Sonatype URL is kept as fallback in repositories for backward compatibility
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1931](https://github.com/opensearch-project/observability/pull/1931) | Update the maven snapshot publish endpoint and credential |
+| [#1937](https://github.com/opensearch-project/observability/pull/1937) | Upgrade gradle to 8.14.3 and run CI checks with JDK24 |
+
+## References
+
+- [Issue #1932](https://github.com/opensearch-project/observability/issues/1932): Release version 3.2.0
+- [Issue #5551](https://github.com/opensearch-project/opensearch-build/issues/5551): Plugin snapshot publishing migration
+- [Sonatype Central Portal Snapshots](https://central.sonatype.org/publish/publish-portal-snapshots/): Official migration documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/observability/observability-infrastructure.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -94,6 +94,12 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Hierarchical & ACL-aware Routing](features/opensearch/hierarchical-acl-aware-routing.md) | feature | New routing processors for hierarchical paths and ACL-based document co-location |
 | [Terms Lookup Query Enhancement](features/opensearch/terms-lookup-query-enhancement.md) | feature | Query clause support for terms lookup enabling multi-document value extraction |
 
+### Observability
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Observability Infrastructure](features/observability/observability-infrastructure.md) | bugfix | Maven snapshot publishing migration, Gradle 8.14.3 upgrade, JDK24 CI support |
+
 ### Geospatial
 
 | Item | Category | Description |


### PR DESCRIPTION
## Summary

Investigation of GitHub Issue #1088: [bugfix] Observability Infrastructure

### Reports Created
- Release report: `docs/releases/v3.2.0/features/observability/observability-infrastructure.md`
- Feature report: `docs/features/observability/observability-infrastructure.md`

### Key Changes in v3.2.0
- Maven snapshot publishing migration from legacy Sonatype OSS to Central Portal
- Credential management migration from AWS Secrets Manager to 1Password
- Gradle upgrade from 8.10.2 to 8.14.3
- JDK 24 support added to CI matrix
- Kotlin version updated to 2.2.0

### PRs Investigated
- [#1931](https://github.com/opensearch-project/observability/pull/1931): Update maven snapshot publish endpoint and credential
- [#1937](https://github.com/opensearch-project/observability/pull/1937): Upgrade gradle to 8.14.3 and run CI checks with JDK24