### PR TITLE
docs: add OpenSearch Learning to Rank report for v3.2.0

### DIFF
--- a/docs/features/learning/learning-to-rank.md
+++ b/docs/features/learning/learning-to-rank.md
@@ -146,6 +146,8 @@ POST my_index/_search
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#202](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/202) | Bump gradle to 8.14, codecov to v5 and support JDK24 |
+| v3.2.0 | [#205](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/205) | Fix flaky test with ULP tolerance adjustment |
 | v3.0.0 | [#151](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/151) | Add XGBoost model parser for correct serialization format |
 | v3.0.0 | [#158](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/158) | Fix test for ApproximateScoreQuery |
 
@@ -162,4 +164,5 @@ POST my_index/_search
 
 ## Change History
 
+- **v3.2.0** (2025-09-16): Build infrastructure upgrade (Gradle 8.14, JDK 24 support); fixed flaky test with ULP tolerance adjustment
 - **v3.0.0** (2025-05-13): Added XGBoost raw JSON parser for proper `save_model` format support; fixed ApproximateScoreQuery test

--- a/docs/releases/v3.2.0/features/opensearch-learning-to-rank-base/opensearch-learning-to-rank.md
+++ b/docs/releases/v3.2.0/features/opensearch-learning-to-rank-base/opensearch-learning-to-rank.md
@@ -1,0 +1,61 @@
+# OpenSearch Learning to Rank
+
+## Summary
+
+This release includes infrastructure and test stability improvements for the Learning to Rank plugin. The changes upgrade the build toolchain to Gradle 8.14 with JDK 24 support and fix flaky test failures caused by floating-point precision issues in similarity score comparisons.
+
+## Details
+
+### What's New in v3.2.0
+
+Two bug fixes improve the plugin's build infrastructure and test reliability:
+
+1. **Build Toolchain Upgrade**: Gradle upgraded from 8.10.2 to 8.14, codecov action updated to v5, and JDK 24 support added to CI matrix
+2. **Flaky Test Fix**: ULP (Units in Last Place) tolerance for similarity score comparisons increased from 1 to 30,000 to handle floating-point precision variations
+
+### Technical Changes
+
+#### Build Infrastructure Updates
+
+| Component | Before | After |
+|-----------|--------|-------|
+| Gradle | 8.10.2 | 8.14 |
+| Codecov Action | v4 | v5 |
+| JDK CI Matrix | 21, 23 | 21, 24 |
+
+#### Test Stability Fix
+
+The `LtrQueryTests.testOnRewrittenQueries` test was failing intermittently due to floating-point precision differences in similarity score calculations. Different similarity classes (e.g., `IBSimilarity`) produce varying floating-point accuracy.
+
+```java
+// Before: Strict comparison (1 ULP tolerance)
+private static final int SCORE_NB_ULP_PREC = 1;
+
+// After: Relaxed comparison (30,000 ULP tolerance)
+private static final int SCORE_NB_ULP_PREC = 30000;
+```
+
+The ULP (Units in Last Place) value of 30,000 means there can be up to 30,000 representable floating-point numbers between compared similarity scores. This accommodates the inherent precision variations without indicating logic errors.
+
+## Limitations
+
+- The relaxed ULP tolerance is specific to test assertions and does not affect production scoring behavior
+- JDK 23 support removed from CI matrix in favor of JDK 24
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#202](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/202) | Bump gradle to 8.14, codecov to v5 and support JDK24 |
+| [#205](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/205) | Updating ULP for similarity score comparisons to 30000 to avoid flaky tests |
+
+## References
+
+- [Issue #196](https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/196): Distribution Build Failed for opensearch-learning-to-rank-base-3.2.0
+- [Issue #152](https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/152): Flaky test LtrQueryTests.testOnRewrittenQueries
+- [Learning to Rank Documentation](https://docs.opensearch.org/3.0/search-plugins/ltr/index/)
+- [GitHub Repository](https://github.com/opensearch-project/opensearch-learning-to-rank-base)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/learning/learning-to-rank.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -111,3 +111,9 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | Item | Category | Description |
 |------|----------|-------------|
 | [Performance Analyzer Infrastructure](features/performance-analyzer/performance-analyzer-infrastructure.md) | bugfix | Bump SpotBugs to 6.2.2 and Checkstyle to 10.26.1 |
+
+### Learning to Rank
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [OpenSearch Learning to Rank](features/opensearch-learning-to-rank-base/opensearch-learning-to-rank.md) | bugfix | Gradle 8.14 upgrade, JDK24 support, flaky test fix for similarity score comparisons |


### PR DESCRIPTION
## Summary

This PR adds documentation for the OpenSearch Learning to Rank plugin changes in v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/opensearch-learning-to-rank-base/opensearch-learning-to-rank.md`
- Feature report updated: `docs/features/learning/learning-to-rank.md`

### Key Changes in v3.2.0
- **Build Infrastructure Upgrade**: Gradle 8.10.2 → 8.14, codecov v4 → v5, JDK 24 support
- **Flaky Test Fix**: ULP tolerance for similarity score comparisons increased from 1 to 30,000

### Related PRs
- [#202](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/202): Bump gradle to 8.14, codecov to v5 and support JDK24
- [#205](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/205): Updating ULP for similarity score comparisons to 30000 to avoid flaky tests

Closes #1087