### PR TITLE
docs: add notifications-plugin-infrastructure report for v3.2.0

### DIFF
--- a/docs/features/notifications/notifications-plugin.md
+++ b/docs/features/notifications/notifications-plugin.md
@@ -97,6 +97,7 @@ POST _plugins/_notifications/configs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#1057](https://github.com/opensearch-project/notifications/pull/1057) | Updated gradle, jdk and other dependencies |
 | v3.1.0 | [#1036](https://github.com/opensearch-project/notifications/pull/1036) | Upgrade javax to jakarta mail |
 | v3.1.0 | [#1027](https://github.com/opensearch-project/notifications/pull/1027) | Version increment to 3.1.0-SNAPSHOT |
 
@@ -104,7 +105,9 @@ POST _plugins/_notifications/configs
 
 - [OpenSearch Notifications Repository](https://github.com/opensearch-project/notifications)
 - [Jakarta Mail 2.0 Specification](https://jakarta.ee/specifications/mail/2.0/)
+- [Gradle 8.14 Release Notes](https://docs.gradle.org/8.14/release-notes.html)
 
 ## Change History
 
+- **v3.2.0** (2026-01-11): Infrastructure updates - Gradle 8.14, JaCoCo 0.8.13, nebula.ospackage 12.0.0, JDK 24 CI support
 - **v3.1.0** (2026-01-10): Migrated from javax.mail to jakarta.mail APIs to avoid version conflicts; updated greenmail test dependency to 2.0.1

--- a/docs/releases/v3.2.0/features/notifications/notifications-plugin-infrastructure.md
+++ b/docs/releases/v3.2.0/features/notifications/notifications-plugin-infrastructure.md
@@ -1,0 +1,73 @@
+# Notifications Plugin Infrastructure
+
+## Summary
+
+Infrastructure updates for the OpenSearch Notifications plugin in v3.2.0, including Gradle 8.14 upgrade, JDK 24 CI support, JaCoCo 0.8.13 for code coverage, and dependency updates for nebula.ospackage plugin.
+
+## Details
+
+### What's New in v3.2.0
+
+This release focuses on build infrastructure modernization and CI/CD improvements for the Notifications plugin.
+
+### Technical Changes
+
+#### Build System Updates
+
+| Component | Previous | Updated |
+|-----------|----------|---------|
+| Gradle | 8.10.2 | 8.14 |
+| JaCoCo | 0.8.12 | 0.8.13 |
+| nebula.ospackage | 11.5.0 | 12.0.0 |
+| CI JDK Matrix | 21, 23 | 21, 24 |
+
+#### Gradle Wrapper Changes
+
+The Gradle wrapper has been updated with:
+- New distribution URL pointing to Gradle 8.14
+- SHA256 checksum validation enabled
+- Distribution URL validation enabled
+- Updated wrapper JAR execution method (using `-jar` flag)
+
+#### CI/CD Updates
+
+The GitHub Actions workflow (`notifications-test-and-build-workflow.yml`) now tests against:
+- JDK 21 (LTS)
+- JDK 24 (latest)
+
+This ensures compatibility with both the current LTS release and the latest JDK version.
+
+#### Version Fetching Update
+
+The build script now fetches the latest OpenSearch version from the `3.1` branch instead of `2.x`:
+```groovy
+def url = 'https://raw.githubusercontent.com/opensearch-project/OpenSearch/refs/heads/3.1/buildSrc/version.properties'
+```
+
+### Usage Example
+
+No user-facing changes. These are internal build infrastructure updates.
+
+### Migration Notes
+
+No migration required. These changes are transparent to users.
+
+## Limitations
+
+None specific to this release.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1057](https://github.com/opensearch-project/notifications/pull/1057) | Updated gradle, jdk and other dependencies |
+
+## References
+
+- [Gradle 8.14 Release Notes](https://docs.gradle.org/8.14/release-notes.html)
+- [JaCoCo 0.8.13 Release](https://www.jacoco.org/jacoco/trunk/doc/changes.html)
+- [OpenSearch Notifications Repository](https://github.com/opensearch-project/notifications)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/notifications/notifications-plugin.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -117,3 +117,9 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | Item | Category | Description |
 |------|----------|-------------|
 | [OpenSearch Learning to Rank](features/opensearch-learning-to-rank-base/opensearch-learning-to-rank.md) | bugfix | Gradle 8.14 upgrade, JDK24 support, flaky test fix for similarity score comparisons |
+
+### Notifications
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Notifications Plugin Infrastructure](features/notifications/notifications-plugin-infrastructure.md) | bugfix | Gradle 8.14 upgrade, JaCoCo 0.8.13, nebula.ospackage 12.0.0, JDK24 CI support |


### PR DESCRIPTION
## Summary

Investigation report for Notifications Plugin Infrastructure updates in v3.2.0.

### Changes
- Created release report: `docs/releases/v3.2.0/features/notifications/notifications-plugin-infrastructure.md`
- Updated feature report: `docs/features/notifications/notifications-plugin.md`
- Updated release index: `docs/releases/v3.2.0/index.md`

### Key Updates in v3.2.0
- Gradle upgraded from 8.10.2 to 8.14
- JaCoCo upgraded from 0.8.12 to 0.8.13
- nebula.ospackage upgraded from 11.5.0 to 12.0.0
- CI JDK matrix updated from [21, 23] to [21, 24]

Closes #1086