### PR TITLE
docs: add ml-commons-testing-coverage report for v3.2.0

### DIFF
--- a/docs/features/ml-commons/ml-commons-test-fixes.md
+++ b/docs/features/ml-commons/ml-commons-test-fixes.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-This feature tracks test infrastructure improvements and documentation additions for the ML Commons plugin, including fixes for multi-node cluster integration tests and tutorials for integrating external services like Amazon Bedrock Guardrails.
+This feature tracks test infrastructure improvements and documentation additions for the ML Commons plugin, including fixes for multi-node cluster integration tests, memory container unit tests, integration test stability fixes, and tutorials for integrating external services like Amazon Bedrock Guardrails.
 
 ## Details
 
@@ -10,22 +10,35 @@ This feature tracks test infrastructure improvements and documentation additions
 
 ```mermaid
 graph TB
-    subgraph "ML Commons Testing"
+    subgraph "ML Commons Testing Infrastructure"
         IT[Integration Tests]
-        SIT[Search Index Tool IT]
-        MN[Multi-Node Support]
+        UT[Unit Tests]
+        COV[Code Coverage]
     end
     
-    subgraph "Guardrails Integration"
-        GR[Guardrails Model]
-        BR[Bedrock Runtime]
-        CM[Claude Model]
+    subgraph "Integration Test Components"
+        SIT[Search Index Tool IT]
+        MN[Multi-Node Support]
+        CFG[Config Index Preservation]
+    end
+    
+    subgraph "Unit Test Coverage"
+        MC[Memory Container Tests]
+        TR[Transport Action Tests]
+        REST[REST Action Tests]
+    end
+    
+    subgraph "Coverage Tools"
+        JAC[JaCoCo 0.8.13]
     end
     
     IT --> SIT
-    SIT --> MN
-    GR --> BR
-    CM --> GR
+    IT --> MN
+    IT --> CFG
+    UT --> MC
+    UT --> TR
+    UT --> REST
+    COV --> JAC
 ```
 
 ### Components
@@ -34,13 +47,18 @@ graph TB
 |-----------|-------------|
 | Search Index Tool IT | Integration tests for the Search Index Tool functionality |
 | Multi-Node Test Support | Enables running integration tests across distributed clusters |
-| Bedrock Guardrails Tutorial | Documentation for integrating Amazon Bedrock Guardrails |
+| Config Index Preservation | Preserves `.plugins-ml-config` index during test cleanup for master key consistency |
+| Memory Container Tests | Comprehensive unit tests for memory container CRUD operations |
+| Transport Action Tests | Tests for `TransportCreateMemoryContainerAction` and `TransportGetMemoryContainerAction` |
+| REST Action Tests | Tests for REST API endpoints for memory containers |
+| JaCoCo | Code coverage tool upgraded to 0.8.13 |
 
 ### Configuration
 
 | Setting | Description | Default |
 |---------|-------------|---------|
 | `numNodes` | Number of nodes for integration test cluster | 1 |
+| `jacoco.toolVersion` | JaCoCo version for code coverage | 0.8.13 |
 | `guardrails.input_guardrail.model_id` | Model ID for input validation | - |
 | `guardrails.input_guardrail.response_filter` | JSONPath to extract guardrail action | - |
 | `guardrails.input_guardrail.response_validation_regex` | Regex to validate allowed responses | - |
@@ -52,6 +70,12 @@ graph TB
 ./gradlew opensearch-ml-plugin:integTest \
   --tests "org.opensearch.ml.rest.RestSearchIndexToolIT" \
   -PnumNodes=3
+```
+
+**Running Memory Container Unit Tests:**
+```bash
+./gradlew :opensearch-ml-plugin:test \
+  --tests "*MemoryContainer*"
 ```
 
 **Configuring Bedrock Guardrails:**
@@ -76,20 +100,28 @@ POST /_plugins/_ml/models/_register?deploy=true
 
 - Bedrock Guardrails require AWS credentials and pre-configured guardrails in AWS console
 - Multi-node test execution requires additional system resources
+- Memory container integration tests are planned for future releases
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#3883](https://github.com/opensearch-project/ml-commons/pull/3883) | SearchIndexTool arguments parsing logic improvement |
+| v3.2.0 | [#3989](https://github.com/opensearch-project/ml-commons/pull/3989) | Keep .plugins-ml-config index for integration tests |
+| v3.2.0 | [#4056](https://github.com/opensearch-project/ml-commons/pull/4056) | Unit tests for create and get memory container |
+| v3.2.0 | [#4057](https://github.com/opensearch-project/ml-commons/pull/4057) | Additional unit tests and JaCoCo upgrade |
 | v2.17.0 | [#2407](https://github.com/opensearch-project/ml-commons/pull/2407) | Test: recover search index tool IT in multi node cluster |
 | v2.17.0 | [#2695](https://github.com/opensearch-project/ml-commons/pull/2695) | Add tutorial for Bedrock Guardrails |
 
 ## References
 
 - [Issue #2362](https://github.com/opensearch-project/ml-commons/issues/2362): Original bug report for multi-node test failure
+- [Issue #2560](https://github.com/opensearch-project/ml-commons/issues/2560): Master key consistency issue
+- [Issue #3834](https://github.com/opensearch-project/ml-commons/issues/3834): MCP tool schema alignment
 - [OpenSearch Guardrails Documentation](https://opensearch.org/docs/latest/ml-commons-plugin/remote-models/guardrails/)
 - [AWS Bedrock Guardrails](https://docs.aws.amazon.com/bedrock/latest/userguide/guardrails-create.html)
 
 ## Change History
 
+- **v3.2.0** (2025-08-05): Added memory container unit tests, integration test stability fix, JaCoCo upgrade to 0.8.13
 - **v2.17.0** (2024-09-17): Added multi-node cluster test support and Bedrock Guardrails tutorial

--- a/docs/releases/v3.2.0/features/ml-commons/ml-commons-testing-coverage.md
+++ b/docs/releases/v3.2.0/features/ml-commons/ml-commons-testing-coverage.md
@@ -1,0 +1,107 @@
+# ML Commons Testing & Coverage
+
+## Summary
+
+This release item improves the testing infrastructure and code coverage for the ML Commons plugin. The changes include fixing integration test stability issues, adding comprehensive unit tests for memory container functionality, and upgrading the JaCoCo code coverage tool.
+
+## Details
+
+### What's New in v3.2.0
+
+The ML Commons plugin received significant testing improvements in v3.2.0:
+
+1. **Integration Test Stability Fix**: Resolved a critical issue where integration tests would fail intermittently due to master key inconsistency in the `.plugins-ml-config` index
+2. **Memory Container Unit Tests**: Added comprehensive unit tests for the new memory container feature
+3. **JaCoCo Upgrade**: Upgraded JaCoCo from 0.8.12 to 0.8.13 for improved code coverage reporting
+4. **SearchIndexTool Improvements**: Enhanced argument parsing logic for better MCP compatibility
+
+### Technical Changes
+
+#### Integration Test Fix (PR #3989)
+
+The fix addresses a race condition in integration tests where:
+- The `.plugins-ml-config` index was being deleted between tests
+- The `MLSyncUpJob` (running every 10 seconds) would recreate the index with a new master key
+- This caused "tag mismatch" exceptions when connectors encrypted with the old key were decrypted with the new key
+
+**Solution**: The `.plugins-ml-config` index is now preserved during test cleanup to maintain master key consistency.
+
+```java
+// Before: Index was deleted
+if (indexName != null && !".opendistro_security".equals(indexName)) {
+    adminClient().performRequest(new Request("DELETE", "/" + indexName));
+}
+
+// After: Index is preserved
+if (indexName != null && !".opendistro_security".equals(indexName) 
+    && !".plugins-ml-config".equals(indexName)) {
+    adminClient().performRequest(new Request("DELETE", "/" + indexName));
+}
+```
+
+#### Memory Container Unit Tests (PRs #4056, #4057)
+
+Added comprehensive test coverage for memory container functionality:
+
+| Test Class | Coverage Area |
+|------------|---------------|
+| `MLMemoryContainerTests` | Memory container model serialization/deserialization |
+| `MemoryStorageConfigTests` | Storage configuration validation |
+| `MLCreateMemoryContainerInputTests` | Create request input validation |
+| `MLCreateMemoryContainerRequestTests` | Transport request handling |
+| `MLCreateMemoryContainerResponseTests` | Response serialization |
+| `MLMemoryContainerGetRequestTests` | Get request validation |
+| `MLMemoryContainerGetResponseTests` | Get response handling |
+| `TransportCreateMemoryContainerActionTests` | Create action business logic |
+| `TransportGetMemoryContainerActionTests` | Get action with access control |
+| `RestMLCreateMemoryContainerActionTests` | REST API create endpoint |
+| `RestMLGetMemoryContainerActionTests` | REST API get endpoint |
+
+#### SearchIndexTool Enhancement (PR #3883)
+
+Improved argument parsing to support both MCP and ReAct agent schemas:
+
+```java
+// Now supports both formats:
+// 1. Arguments from "input" key (ReAct agent)
+// 2. Arguments directly from parameters (MCP)
+String index = Optional.ofNullable(jsonObject)
+    .map(x -> x.get(INDEX_FIELD))
+    .map(JsonElement::getAsString)
+    .orElse(parameters.getOrDefault(INDEX_FIELD, null));
+```
+
+### JaCoCo Coverage Exclusions Removed
+
+The following classes were removed from JaCoCo exclusions as they now have test coverage:
+
+- `TransportCreateMemoryContainerAction`
+- `TransportGetMemoryContainerAction`
+- `TransportAddMemoryAction`
+- `RestMLCreateMemoryContainerAction`
+- `RestMLGetMemoryContainerAction`
+- `RestMLAddMemoryAction`
+
+## Limitations
+
+- The integration test fix is specific to the ML Commons test infrastructure
+- Memory container tests focus on unit testing; integration tests are planned for future releases
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3883](https://github.com/opensearch-project/ml-commons/pull/3883) | SearchIndexTool arguments parsing logic improvement |
+| [#3989](https://github.com/opensearch-project/ml-commons/pull/3989) | Keep .plugins-ml-config index for integration tests |
+| [#4056](https://github.com/opensearch-project/ml-commons/pull/4056) | Unit tests for create and get memory container |
+| [#4057](https://github.com/opensearch-project/ml-commons/pull/4057) | Additional unit tests and JaCoCo upgrade |
+
+## References
+
+- [Issue #2560](https://github.com/opensearch-project/ml-commons/issues/2560): Related to master key consistency
+- [Issue #3834](https://github.com/opensearch-project/ml-commons/issues/3834): MCP tool schema alignment
+- [ML Commons Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/): Official ML Commons docs
+
+## Related Feature Report
+
+- [ML Commons Agent Framework](../../../features/ml-commons/ml-commons-agent-framework.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -123,3 +123,9 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | Item | Category | Description |
 |------|----------|-------------|
 | [Notifications Plugin Infrastructure](features/notifications/notifications-plugin-infrastructure.md) | bugfix | Gradle 8.14 upgrade, JaCoCo 0.8.13, nebula.ospackage 12.0.0, JDK24 CI support |
+
+### ML Commons
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [ML Commons Testing & Coverage](features/ml-commons/ml-commons-testing-coverage.md) | bugfix | Integration test stability fix, memory container unit tests, JaCoCo 0.8.13 upgrade |


### PR DESCRIPTION
## Summary

This PR adds documentation for the ML Commons Testing & Coverage improvements in v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/ml-commons/ml-commons-testing-coverage.md`
- Feature report: `docs/features/ml-commons/ml-commons-test-fixes.md` (updated)

### Key Changes in v3.2.0
- Integration test stability fix: Preserve `.plugins-ml-config` index during test cleanup
- Memory container unit tests: Comprehensive test coverage for memory container CRUD operations
- JaCoCo upgrade: 0.8.12 → 0.8.13
- SearchIndexTool enhancement: Support both MCP and ReAct agent argument schemas

### Related PRs
- [#3883](https://github.com/opensearch-project/ml-commons/pull/3883): SearchIndexTool arguments parsing
- [#3989](https://github.com/opensearch-project/ml-commons/pull/3989): Integration test fix
- [#4056](https://github.com/opensearch-project/ml-commons/pull/4056): Memory container unit tests
- [#4057](https://github.com/opensearch-project/ml-commons/pull/4057): Additional tests and JaCoCo upgrade

Closes #1085