### PR TITLE
docs: add repository-maintenance report for v3.2.0

### DIFF
--- a/docs/features/dashboards-search-relevance/repository-maintenance.md
+++ b/docs/features/dashboards-search-relevance/repository-maintenance.md
@@ -1,0 +1,91 @@
+# Repository Maintenance
+
+## Summary
+
+Repository maintenance encompasses the ongoing activities required to keep OpenSearch plugin repositories healthy, secure, and well-maintained. This includes managing maintainer lists, standardizing contribution workflows through templates, integrating test coverage tools, and keeping CI/CD dependencies up to date.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Repository Maintenance"
+        M[Maintainer Management]
+        T[Issue/PR Templates]
+        C[Code Coverage]
+        CI[CI/CD Dependencies]
+    end
+    
+    subgraph "Benefits"
+        Q[Code Quality]
+        S[Security]
+        P[Project Health]
+        D[Developer Experience]
+    end
+    
+    M --> P
+    T --> D
+    C --> Q
+    CI --> S
+    CI --> Q
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| MAINTAINERS.md | List of active maintainers and emeritus contributors |
+| Issue Templates | Standardized templates for bug reports and feature requests |
+| PR Templates | Templates for pull request descriptions |
+| Codecov Integration | Automated test coverage reporting |
+| GitHub Actions | CI/CD workflow automation |
+
+### Maintainer Governance
+
+OpenSearch projects follow a maintainer governance model:
+- **Active Maintainers**: Have merge rights and responsibility for code review
+- **Emeritus Maintainers**: Former maintainers who are no longer active but recognized for past contributions
+- Maintainer transitions help ensure project continuity and health
+
+### Test Coverage Integration
+
+Codecov integration provides:
+- Automated coverage reports on pull requests
+- Coverage trend tracking over time
+- Coverage badges for repository README
+- Identification of untested code paths
+
+### CI/CD Best Practices
+
+Keeping GitHub Actions dependencies updated ensures:
+- Security patches are applied promptly
+- Compatibility with latest GitHub features
+- Reliable and efficient CI/CD pipelines
+- Reduced technical debt
+
+## Limitations
+
+- Maintainer changes require consensus from existing maintainers
+- Coverage thresholds may need adjustment per repository
+- GitHub Actions updates may introduce breaking changes requiring workflow adjustments
+
+## Related PRs
+
+| Version | PR | Repository | Description |
+|---------|-----|------------|-------------|
+| v3.2.0 | [#569](https://github.com/opensearch-project/dashboards-search-relevance/pull/569) | dashboards-search-relevance | Adding new maintainers |
+| v3.2.0 | [#576](https://github.com/opensearch-project/dashboards-search-relevance/pull/576) | dashboards-search-relevance | Update maintainer list |
+| v3.2.0 | [#601](https://github.com/opensearch-project/dashboards-search-relevance/pull/601) | dashboards-search-relevance | Add issue template and codecov |
+| v3.2.0 | [#2260](https://github.com/opensearch-project/security/pull/2260) | security | Bump actions/checkout |
+| v3.2.0 | [#2263](https://github.com/opensearch-project/security/pull/2263) | security | Bump codecov/codecov-action |
+
+## References
+
+- [OpenSearch Maintainer Guidelines](https://github.com/opensearch-project/.github/blob/main/MAINTAINERS.md)
+- [Codecov Documentation](https://docs.codecov.com/)
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)
+
+## Change History
+
+- **v3.2.0** (2026-01): Maintainer updates, issue templates, codecov integration, GitHub Actions dependency bumps

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -221,6 +221,7 @@
 
 - [Build Maintenance](dashboards-search-relevance/build-maintenance.md)
 - [Documentation Maintenance](dashboards-search-relevance/documentation-maintenance.md)
+- [Repository Maintenance](dashboards-search-relevance/repository-maintenance.md)
 - [Search Comparison](dashboards-search-relevance/search-comparison.md)
 
 ## search-relevance

--- a/docs/releases/v3.2.0/features/dashboards-search-relevance/repository-maintenance.md
+++ b/docs/releases/v3.2.0/features/dashboards-search-relevance/repository-maintenance.md
@@ -1,0 +1,83 @@
+# Repository Maintenance
+
+## Summary
+
+This release item covers repository maintenance activities for the dashboards-search-relevance and security plugins in OpenSearch v3.2.0. The changes include maintainer updates, addition of issue templates, codecov integration for test coverage reporting, and GitHub Actions dependency bumps to improve CI/CD infrastructure.
+
+## Details
+
+### What's New in v3.2.0
+
+#### Maintainer Updates (dashboards-search-relevance)
+
+The dashboards-search-relevance repository received significant maintainer updates to ensure continued project health:
+
+- Added @fen-qin and @epugh as new maintainers to recognize their contributions
+- Updated maintainer list by moving inactive maintainers to Emeritus status
+- New maintainer team committed to addressing open issues, adding features, and keeping the project active
+
+#### Issue Templates and Test Coverage (dashboards-search-relevance)
+
+As part of "Operation Enhancement":
+- Added standardized issue templates for better issue tracking
+- Integrated codecov for test coverage reporting
+- Bumped binary OpenSearch version to 3.2
+
+#### GitHub Actions Dependency Bumps (security)
+
+Updated GitHub Actions dependencies to newer versions for improved security and functionality:
+
+| Action | Previous Version | New Version |
+|--------|------------------|-------------|
+| `actions/checkout` | 2 | 4 |
+| `codecov/codecov-action` | 4 | 5 |
+| `actions/github-script` | 6 | 7 |
+| `tibdex/github-app-token` | 1.5.0 | 2.1.0 |
+| `stefanzweifel/git-auto-commit-action` | 5 | 6 |
+| `derek-ho/start-opensearch` | 6 | 7 |
+| `SvanBoxel/delete-merged-branch` | (older) | (newer) |
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| Issue Templates | Standardized templates for bug reports and feature requests |
+| Codecov Integration | Automated test coverage reporting in CI pipeline |
+
+#### CI/CD Improvements
+
+The GitHub Actions updates provide:
+- Better security through updated action versions
+- Improved compatibility with newer GitHub features
+- More reliable CI/CD workflows
+
+## Limitations
+
+- These are infrastructure/maintenance changes with no user-facing feature impact
+- GitHub Actions updates may require workflow file adjustments in forks
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#569](https://github.com/opensearch-project/dashboards-search-relevance/pull/569) | dashboards-search-relevance | Adding @fen-qin and @epugh as maintainers |
+| [#576](https://github.com/opensearch-project/dashboards-search-relevance/pull/576) | dashboards-search-relevance | Update maintainers list |
+| [#601](https://github.com/opensearch-project/dashboards-search-relevance/pull/601) | dashboards-search-relevance | Add issue template and codecov |
+| [#201](https://github.com/opensearch-project/dashboards-search-relevance/pull/201) | dashboards-search-relevance | Adding template for feature technical design |
+| [#2260](https://github.com/opensearch-project/security/pull/2260) | security | Bump actions/checkout from 2 to 4 |
+| [#2263](https://github.com/opensearch-project/security/pull/2263) | security | Bump codecov/codecov-action from 4 to 5 |
+| [#2259](https://github.com/opensearch-project/security/pull/2259) | security | Bump actions/github-script from 6 to 7 |
+| [#2262](https://github.com/opensearch-project/security/pull/2262) | security | Bump tibdex/github-app-token from 1.5.0 to 2.1.0 |
+| [#2265](https://github.com/opensearch-project/security/pull/2265) | security | Bump SvanBoxel/delete-merged-branch |
+| [#2267](https://github.com/opensearch-project/security/pull/2267) | security | Bump derek-ho/start-opensearch from 6 to 7 |
+| [#2268](https://github.com/opensearch-project/security/pull/2268) | security | Bump stefanzweifel/git-auto-commit-action from 5 to 6 |
+
+## References
+
+- [Issue #562](https://github.com/opensearch-project/dashboards-search-relevance/issues/562): Request for issue templates and codecov
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/dashboards-search-relevance/repository-maintenance.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -129,3 +129,9 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | Item | Category | Description |
 |------|----------|-------------|
 | [ML Commons Testing & Coverage](features/ml-commons/ml-commons-testing-coverage.md) | bugfix | Integration test stability fix, memory container unit tests, JaCoCo 0.8.13 upgrade |
+
+### Dashboards Search Relevance
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Repository Maintenance](features/dashboards-search-relevance/repository-maintenance.md) | bugfix | Maintainer updates, issue templates, codecov integration, GitHub Actions dependency bumps |


### PR DESCRIPTION
## Summary

Add release and feature reports for Repository Maintenance in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/dashboards-search-relevance/repository-maintenance.md`
- Feature report: `docs/features/dashboards-search-relevance/repository-maintenance.md`

### Key Changes in v3.2.0
- Maintainer updates for dashboards-search-relevance (added @fen-qin and @epugh)
- Updated maintainer list with emeritus status for inactive maintainers
- Added issue templates and codecov integration for test coverage
- GitHub Actions dependency bumps for security plugin

### Related Issue
Closes #1084