### PR TITLE
docs: add release-notes-documentation report for v3.2.0

### DIFF
--- a/docs/features/query-insights/query-insights.md
+++ b/docs/features/query-insights/query-insights.md
@@ -185,6 +185,11 @@ GET /_insights/live_queries?sort=latency&size=5
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#381](https://github.com/opensearch-project/query-insights/pull/381) | Increase reader search limit to 500 and fix sort by metric type |
+| v3.2.0 | [#392](https://github.com/opensearch-project/query-insights/pull/392) | Update Maven endpoint and bump Gradle/Java versions |
+| v3.2.0 | [#393](https://github.com/opensearch-project/query-insights/pull/393) | Fix codecov configuration |
+| v3.2.0 | [#394](https://github.com/opensearch-project/query-insights/pull/394) | Migrate to codecov v3 |
+| v3.2.0 | [#395](https://github.com/opensearch-project/query-insights/pull/395) | Add release notes for 3.2.0 |
 | v3.1.0 | [#326](https://github.com/opensearch-project/query-insights/pull/326) | Add metric labels to historical data |
 | v3.1.0 | [#336](https://github.com/opensearch-project/query-insights/pull/336) | Consolidate grouping settings |
 | v3.1.0 | [#308](https://github.com/opensearch-project/query-insights/pull/308) | Add setting to exclude certain indices |
@@ -241,6 +246,7 @@ GET /_insights/live_queries?sort=latency&size=5
 
 ## Change History
 
+- **v3.2.0**: Increased reader search limit to 500 and fixed sort by metric type; infrastructure updates including Maven endpoint migration, Gradle and Java version bumps; codecov configuration fixes
 - **v3.1.0**: Added metric labels to historical data for filtering by metric type; consolidated grouping settings under `grouping.*` namespace; added `excluded_indices` setting to filter indices from insights; refactored local index reader to use asynchronous operations; added `is_cancelled` field to Live Queries API; new Live Queries Dashboard with real-time monitoring, auto-refresh, visual breakdowns, and query cancellation; new Workload Management Dashboard for query group management; fixed duplicate API requests on overview page; fixed node-level top queries request parameter serialization bug; improved Cypress test stability; fixed CI version mismatch; added multi-node cluster integration tests
 - **v3.0.0**: Added Live Queries API, default index template, verbose parameter, profile query filtering, strict hash check
 - **v2.18.0**: Added Health Stats API for monitoring plugin health; added OpenTelemetry error metrics counters; added field name and type support for query shape grouping (defaults changed to `true`); added time range parameters for historical query retrieval; added cache eviction and cluster state listener for index field type mappings

--- a/docs/releases/v3.2.0/features/query-insights/release-notes-documentation.md
+++ b/docs/releases/v3.2.0/features/query-insights/release-notes-documentation.md
@@ -1,0 +1,63 @@
+# Release Notes & Documentation
+
+## Summary
+
+This release item covers the automated release notes generation for the Query Insights plugin in OpenSearch v3.2.0. The release notes document enhancements, infrastructure updates, and maintenance changes included in this version.
+
+## Details
+
+### What's New in v3.2.0
+
+The Query Insights plugin v3.2.0 release includes:
+
+1. **Enhancements**: Increased reader search limit to 500 and fixed sort by metric type
+2. **Infrastructure Updates**: Maven endpoint migration, Gradle and Java version bumps
+3. **CI/CD Improvements**: Codecov configuration fixes
+
+### Technical Changes
+
+#### Enhancements
+
+| Change | PR | Description |
+|--------|-----|-------------|
+| Reader Search Limit | [#381](https://github.com/opensearch-project/query-insights/pull/381) | Increase reader search limit from default to 500 and fix sort by metric type |
+
+#### Infrastructure
+
+| Change | PR | Description |
+|--------|-----|-------------|
+| Build System | [#392](https://github.com/opensearch-project/query-insights/pull/392) | Update Maven endpoint and bump Gradle/Java versions |
+| Codecov Fix | [#393](https://github.com/opensearch-project/query-insights/pull/393) | Fix codecov configuration |
+| Codecov v3 | [#394](https://github.com/opensearch-project/query-insights/pull/394) | Migrate to codecov v3 |
+
+#### Maintenance
+
+| Change | PR | Description |
+|--------|-----|-------------|
+| Version Increment | [#380](https://github.com/opensearch-project/query-insights/pull/380) | Increment version to 3.2.0-SNAPSHOT |
+| Release Notes | [#395](https://github.com/opensearch-project/query-insights/pull/395) | Add release notes for 3.2.0 |
+
+## Limitations
+
+- This is a documentation-only release item
+- No functional changes to the Query Insights plugin core functionality
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#380](https://github.com/opensearch-project/query-insights/pull/380) | Version increment to 3.2.0-SNAPSHOT |
+| [#381](https://github.com/opensearch-project/query-insights/pull/381) | Increase reader search limit to 500 |
+| [#392](https://github.com/opensearch-project/query-insights/pull/392) | Maven endpoint and build updates |
+| [#393](https://github.com/opensearch-project/query-insights/pull/393) | Codecov fix |
+| [#394](https://github.com/opensearch-project/query-insights/pull/394) | Codecov v3 migration |
+| [#395](https://github.com/opensearch-project/query-insights/pull/395) | Release notes for 3.2.0 |
+
+## References
+
+- [Query Insights Plugin Repository](https://github.com/opensearch-project/query-insights)
+- [Release Notes 3.2.0](https://github.com/opensearch-project/query-insights/blob/main/release-notes/opensearch-query-insights.release-notes-3.2.0.0.md)
+
+## Related Feature Report
+
+- [Query Insights Feature Documentation](../../../../features/query-insights/query-insights.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -135,3 +135,9 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | Item | Category | Description |
 |------|----------|-------------|
 | [Repository Maintenance](features/dashboards-search-relevance/repository-maintenance.md) | bugfix | Maintainer updates, issue templates, codecov integration, GitHub Actions dependency bumps |
+
+### Query Insights
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Release Notes & Documentation](features/query-insights/release-notes-documentation.md) | bugfix | Release notes for v3.2.0 with reader search limit increase and infrastructure updates |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Query Insights plugin release notes in OpenSearch v3.2.0.

### Changes
- Created release report: `docs/releases/v3.2.0/features/query-insights/release-notes-documentation.md`
- Updated feature report: `docs/features/query-insights/query-insights.md` with v3.2.0 changes
- Updated release index: `docs/releases/v3.2.0/index.md`

### Key Changes in v3.2.0
- Increased reader search limit to 500 and fixed sort by metric type (#381)
- Infrastructure updates: Maven endpoint migration, Gradle/Java version bumps (#392)
- Codecov configuration fixes (#393, #394)

Closes #1083