### PR TITLE
docs: add CVE Fixes & Dependency Updates report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -280,6 +280,10 @@
 - [Testing Library Updates](multi-plugin/testing-library-updates.md)
 - [Version Bumps & Release Notes](multi-plugin/version-bumps-release-notes.md)
 
+## multi-repo
+
+- [CVE Fixes & Dependency Updates](multi-repo/cve-fixes-dependency-updates.md)
+
 ## opensearch-remote-metadata-sdk
 
 - [Remote Metadata SDK](opensearch-remote-metadata-sdk/remote-metadata-sdk.md)

--- a/docs/features/multi-repo/cve-fixes-dependency-updates.md
+++ b/docs/features/multi-repo/cve-fixes-dependency-updates.md
@@ -1,0 +1,99 @@
+# CVE Fixes & Dependency Updates
+
+## Summary
+
+OpenSearch maintains security by regularly updating dependencies to address Common Vulnerabilities and Exposures (CVEs). This document tracks security-related dependency updates across OpenSearch repositories, ensuring users are aware of patched vulnerabilities and can verify their deployments are secure.
+
+## Details
+
+### Security Update Process
+
+OpenSearch follows a proactive security update process:
+
+1. **Vulnerability Detection**: Automated scanning tools (e.g., Dependabot, Mend) identify vulnerable dependencies
+2. **Impact Assessment**: Security team evaluates the severity and exploitability
+3. **Patch Development**: Updates are applied to affected repositories
+4. **Release Integration**: Fixes are included in the next appropriate release
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Vulnerability Sources"
+        NVD[National Vulnerability Database]
+        GHSA[GitHub Security Advisories]
+        OSA[OpenSearch Advisories]
+    end
+    
+    subgraph "Detection"
+        Scan[Dependency Scanning]
+        Bot[Automated Bots]
+    end
+    
+    subgraph "Remediation"
+        PR[Pull Request]
+        Review[Security Review]
+        Merge[Merge & Release]
+    end
+    
+    NVD --> Scan
+    GHSA --> Scan
+    OSA --> Scan
+    Scan --> Bot
+    Bot --> PR
+    PR --> Review
+    Review --> Merge
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Dependency Scanning | Automated tools that check for known vulnerabilities |
+| Security Advisories | Published notices about vulnerabilities and fixes |
+| Resolution Strategies | Gradle/npm configurations to force secure versions |
+
+### Configuration
+
+Dependency version forcing in Gradle:
+
+```gradle
+configurations.all {
+    resolutionStrategy {
+        force 'vulnerable-package:secure-version'
+    }
+}
+```
+
+Dependency resolution in npm/yarn:
+
+```json
+{
+  "resolutions": {
+    "vulnerable-package": "^secure-version"
+  }
+}
+```
+
+## Limitations
+
+- Transitive dependencies may require explicit forcing
+- Some CVE fixes may require code changes beyond version bumps
+- Security patches should be applied promptly after release
+
+## Related PRs
+
+| Version | PR | Repository | Description |
+|---------|-----|------------|-------------|
+| v3.2.0 | [#4062](https://github.com/opensearch-project/ml-commons/pull/4062) | ml-commons | CVE-2025-48734: beanutils fix |
+| v3.2.0 | [#503](https://github.com/opensearch-project/dashboards-query-workbench/pull/503) | dashboards-query-workbench | CVE-2025-7783: form-data fix |
+
+## References
+
+- [OpenSearch Security Advisories](https://advisories.opensearch.org/): Official security advisory database
+- [GitHub Advisory Database](https://github.com/advisories): GitHub's CVE database
+- [National Vulnerability Database](https://nvd.nist.gov/): NIST CVE database
+
+## Change History
+
+- **v3.2.0**: CVE-2025-48734 (beanutils) and CVE-2025-7783 (form-data) fixes

--- a/docs/releases/v3.2.0/features/multi-repo/cve-fixes-dependency-updates.md
+++ b/docs/releases/v3.2.0/features/multi-repo/cve-fixes-dependency-updates.md
@@ -1,0 +1,81 @@
+# CVE Fixes & Dependency Updates
+
+## Summary
+
+OpenSearch v3.2.0 includes critical security fixes addressing multiple CVE vulnerabilities across several repositories. These updates patch security issues in third-party dependencies including `commons-beanutils` in ml-commons and `form-data` (via `@cypress/request`) in dashboards-query-workbench.
+
+## Details
+
+### What's New in v3.2.0
+
+This release addresses the following security vulnerabilities:
+
+| CVE | Severity | Repository | Description |
+|-----|----------|------------|-------------|
+| CVE-2025-48734 | High | ml-commons | Vulnerability in commons-beanutils 1.9.4 |
+| CVE-2025-7783 | Critical | dashboards-query-workbench | Unsafe random function in form-data for boundary selection |
+
+### Technical Changes
+
+#### ml-commons: CVE-2025-48734 Fix
+
+The vulnerability exists in `commons-beanutils` version 1.9.4, which is a transitive dependency from `tribuo-clustering-kmeans:4.2.1`. The fix forces the dependency to version 1.11.0.
+
+**Changed Files:**
+- `ml-algorithms/build.gradle`: Added explicit dependency on `commons-beanutils:1.11.0`
+- `plugin/build.gradle`: Added resolution strategy to force `commons-beanutils:1.11.0`
+
+```gradle
+// ml-algorithms/build.gradle
+implementation 'commons-beanutils:commons-beanutils:1.11.0'
+
+// plugin/build.gradle
+configurations.all {
+    resolutionStrategy.force 'commons-beanutils:commons-beanutils:1.11.0'
+}
+```
+
+#### dashboards-query-workbench: CVE-2025-7783 Fix
+
+CVE-2025-7783 is a critical vulnerability in the `form-data` npm package. The package uses `Math.random()` to select boundary values for multipart form-encoded data. Since `Math.random()` is predictable, an attacker who can observe other random values could predict the boundary and inject malicious parameters.
+
+**Changed Files:**
+- `package.json`: Updated `@cypress/request` from `^3.0.0` to `^3.0.9`
+- `yarn.lock`: Updated transitive dependencies including `form-data` to 4.0.4
+
+```json
+// package.json
+{
+  "resolutions": {
+    "@cypress/request": "^3.0.9"
+  }
+}
+```
+
+The update to `@cypress/request` 3.0.9 brings in `form-data` 4.0.4 which uses cryptographically secure random values for boundary generation.
+
+### Migration Notes
+
+No migration steps required. These are dependency updates that do not change any APIs or configurations.
+
+## Limitations
+
+- The CVE fixes are specific to the affected repositories
+- Users running older versions should upgrade to receive these security patches
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#4062](https://github.com/opensearch-project/ml-commons/pull/4062) | ml-commons | CVE fix: beanutils |
+| [#503](https://github.com/opensearch-project/dashboards-query-workbench/pull/503) | dashboards-query-workbench | Update cypress/request (CVE-2025-7783) |
+
+## References
+
+- [CVE-2025-48734](https://advisories.opensearch.org/advisories/CVE-2025-48734): OpenSearch Security Advisory for beanutils
+- [CVE-2025-7783 / GHSA-fjxv-7rqg-78g4](https://github.com/advisories/GHSA-fjxv-7rqg-78g4): form-data uses unsafe random function
+- [form-data security fix](https://github.com/form-data/form-data/commit/3d17230): Patch commit in form-data
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/multi-repo/cve-fixes-dependency-updates.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -141,3 +141,9 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | Item | Category | Description |
 |------|----------|-------------|
 | [Release Notes & Documentation](features/query-insights/release-notes-documentation.md) | bugfix | Release notes for v3.2.0 with reader search limit increase and infrastructure updates |
+
+### Multi-Repository
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [CVE Fixes & Dependency Updates](features/multi-repo/cve-fixes-dependency-updates.md) | bugfix | CVE-2025-48734 (beanutils) and CVE-2025-7783 (form-data) security fixes |


### PR DESCRIPTION
## Summary

This PR adds documentation for CVE fixes and dependency updates in OpenSearch v3.2.0.

### CVEs Addressed

| CVE | Severity | Repository | Fix |
|-----|----------|------------|-----|
| CVE-2025-48734 | High | ml-commons | Update commons-beanutils to 1.11.0 |
| CVE-2025-7783 | Critical | dashboards-query-workbench | Update @cypress/request to 3.0.9 (form-data fix) |

### Reports Created

- Release report: `docs/releases/v3.2.0/features/multi-repo/cve-fixes-dependency-updates.md`
- Feature report: `docs/features/multi-repo/cve-fixes-dependency-updates.md`

### Related PRs

- [ml-commons#4062](https://github.com/opensearch-project/ml-commons/pull/4062): CVE fix: beanutils
- [dashboards-query-workbench#503](https://github.com/opensearch-project/dashboards-query-workbench/pull/503): Update cypress/request

Closes #1082