### PR TITLE
docs: add version-increment-maintenance report for v3.2.0

### DIFF
--- a/docs/features/multi-plugin/version-bumps-release-notes.md
+++ b/docs/features/multi-plugin/version-bumps-release-notes.md
@@ -77,6 +77,26 @@ release-notes/
 | v3.1.0 | [#1313](https://github.com/opensearch-project/index-management/pull/1313) | index-management | Increment to 3.1.0.0 |
 | v3.1.0 | [#572](https://github.com/opensearch-project/ml-commons/pull/572) | ml-commons | Bump version to 3.1.0.0 |
 | v3.1.0 | [#2451](https://github.com/opensearch-project/observability/pull/2451) | observability | Workflows - Version bump to 3.1.0 |
+| v3.2.0 | [#1892](https://github.com/opensearch-project/alerting/pull/1892) | alerting | Moved commons-beanutils pinning to core gradle |
+| v3.2.0 | [#1887](https://github.com/opensearch-project/alerting/pull/1887) | alerting | Pinned commons-beanutils to 1.11.0 |
+| v3.2.0 | [#1271](https://github.com/opensearch-project/alerting/pull/1271) | alerting | Increment to 3.2.0.0 |
+| v3.2.0 | [#751](https://github.com/opensearch-project/asynchronous-search/pull/751) | asynchronous-search | Increment to 3.2.0-SNAPSHOT |
+| v3.2.0 | [#262](https://github.com/opensearch-project/custom-codecs/pull/262) | custom | Increment to 3.2.0-SNAPSHOT |
+| v3.2.0 | [#1332](https://github.com/opensearch-project/index-management/pull/1332) | index-management | Increment to 3.2.0.0 |
+| v3.2.0 | [#1435](https://github.com/opensearch-project/index-management/pull/1435) | index-management | Increment to 3.2.0-SNAPSHOT |
+| v3.2.0 | [#437](https://github.com/opensearch-project/ml-commons/pull/437) | ml-commons | Increment to 3.2.0.0 |
+| v3.2.0 | [#365](https://github.com/opensearch-project/notifications/pull/365) | notifications | Increment to 3.2.0.0 |
+| v3.2.0 | [#2481](https://github.com/opensearch-project/observability/pull/2481) | observability | Increment to 3.2.0.0 |
+| v3.2.0 | [#1933](https://github.com/opensearch-project/observability/pull/1933) | observability | Increment to 3.2.0-SNAPSHOT |
+| v3.2.0 | [#295](https://github.com/opensearch-project/query-insights/pull/295) | query | Increment to 3.2.0.0 |
+| v3.2.0 | [#380](https://github.com/opensearch-project/query-insights/pull/380) | query | Increment to 3.2.0-SNAPSHOT |
+| v3.2.0 | [#485](https://github.com/opensearch-project/dashboards-notifications/pull/485) | dashboards | Increment to 3.2.0.0 |
+| v3.2.0 | [#603](https://github.com/opensearch-project/reporting/pull/603) | reporting | Increment to 3.2.0.0 |
+| v3.2.0 | [#1105](https://github.com/opensearch-project/reporting/pull/1105) | reporting | Increment to 3.2.0-SNAPSHOT |
+| v3.2.0 | [#1316](https://github.com/opensearch-project/security/pull/1316) | security | Increment to 3.2.0.0 |
+| v3.2.0 | [#191](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/191) | learning | Increment to 3.2.0-SNAPSHOT |
+| v3.2.0 | [#823](https://github.com/opensearch-project/performance-analyzer/pull/823) | performance | Increment to 3.2.0-SNAPSHOT |
+| v3.2.0 | [#86](https://github.com/opensearch-project/opensearch-system-templates/pull/86) | system | Increment to 3.2.0-SNAPSHOT |
 | v3.1.0 | [#3671](https://github.com/opensearch-project/sql/pull/3671) | sql | Bump setuptools to 78.1.1 |
 | v3.1.0 | [#18039](https://github.com/opensearch-project/OpenSearch/pull/18039) | OpenSearch | Bump Core main branch to 3.0.0 |
 | v3.0.0 | [#1843](https://github.com/opensearch-project/alerting/pull/1843) | alerting | Added 3.0 release notes |
@@ -102,6 +122,7 @@ release-notes/
 
 ## Change History
 
+- **v3.2.0** (2026-01-11): Version bumps across 14 repositories (alerting, asynchronous-search, custom, index-management, ml-commons, notifications, observability, query, dashboards, reporting, security, learning, performance, system)
 - **v3.1.0** (2026-01-10): Version bumps across 11 repositories (alerting, asynchronous-search, common-utils, dashboards-notifications, notifications, reporting, index-management-dashboards, index-management, ml-commons, observability, sql, OpenSearch core)
 - **v3.0.0** (2025-05-06): Version bumps and release notes across 9 repositories (alerting, common-utils, index-management, notifications, security, sql, and dashboard plugins)
 - **v2.18.0** (2024-11-05): Release notes across 5 repositories (alerting, common-utils, notifications, query-insights, security)

--- a/docs/releases/v3.2.0/features/multi-plugin/version-increment-maintenance.md
+++ b/docs/releases/v3.2.0/features/multi-plugin/version-increment-maintenance.md
@@ -1,0 +1,83 @@
+# Version Increment (Maintenance)
+
+## Summary
+
+Routine version increment PRs for v3.2.0 across 14 OpenSearch repositories. These automated changes update version strings and prepare repositories for the 3.2.0 release cycle.
+
+## Details
+
+### What's New in v3.2.0
+
+Version bumps to 3.2.0.0 (release) and 3.2.0-SNAPSHOT (development) across multiple plugins and components.
+
+### Technical Changes
+
+#### Repositories Updated
+
+| Repository | PRs | Type |
+|------------|-----|------|
+| alerting | 4 | Version bump + dependency fix |
+| asynchronous-search | 1 | SNAPSHOT |
+| custom | 1 | SNAPSHOT |
+| index-management | 2 | Release + SNAPSHOT |
+| ml-commons | 1 | Release |
+| notifications | 1 | Release |
+| observability | 2 | Release + SNAPSHOT |
+| query | 2 | Release + SNAPSHOT |
+| dashboards | 1 | Release |
+| reporting | 2 | Release + SNAPSHOT |
+| security | 1 | Release |
+| learning | 1 | SNAPSHOT |
+| performance | 1 | SNAPSHOT |
+| system | 1 | SNAPSHOT |
+
+#### Notable Changes
+
+The alerting repository includes additional dependency fixes:
+- PR #1892: Moved commons-beanutils pinning to core gradle file
+- PR #1887: Pinned commons-beanutils dependency to 1.11.0 version
+
+### Files Modified
+
+| File | Purpose |
+|------|---------|
+| `build.gradle` | Plugin version declaration |
+| `gradle.properties` | Version properties |
+
+## Limitations
+
+- Version bumps are mechanical changes with no functional impact
+- Timing must coordinate with release branch creation
+
+## Related PRs
+
+| PR | Title | Repository |
+|----|-------|------------|
+| [#1892](https://github.com/opensearch-project/alerting/pull/1892) | Moved the commons-beanutils pinning to the core gradle file | alerting |
+| [#1887](https://github.com/opensearch-project/alerting/pull/1887) | Pinned the commons-beanutils dependency to 1.11.0 version | alerting |
+| [#751](https://github.com/opensearch-project/asynchronous-search/pull/751) | [AUTO] Increment version to 3.2.0-SNAPSHOT | asynchronous-search |
+| [#262](https://github.com/opensearch-project/custom-codecs/pull/262) | [AUTO] Increment version to 3.2.0-SNAPSHOT | custom |
+| [#1271](https://github.com/opensearch-project/alerting/pull/1271) | Increment version to 3.2.0.0 | alerting |
+| [#1332](https://github.com/opensearch-project/index-management/pull/1332) | Increment version to 3.2.0.0 | index-management |
+| [#437](https://github.com/opensearch-project/ml-commons/pull/437) | Increment version to 3.2.0.0 | ml-commons |
+| [#365](https://github.com/opensearch-project/notifications/pull/365) | [AUTO] Increment version to 3.2.0.0 | notifications |
+| [#2481](https://github.com/opensearch-project/observability/pull/2481) | Increment version to 3.2.0.0 + Snapshots update | observability |
+| [#295](https://github.com/opensearch-project/query-insights/pull/295) | [AUTO] Increment version to 3.2.0.0 | query |
+| [#485](https://github.com/opensearch-project/dashboards-notifications/pull/485) | Increment version to 3.2.0.0 | dashboards |
+| [#603](https://github.com/opensearch-project/reporting/pull/603) | Increment version to 3.2.0.0 | reporting |
+| [#1316](https://github.com/opensearch-project/security/pull/1316) | [AUTO] Increment version to 3.2.0.0 | security |
+| [#1435](https://github.com/opensearch-project/index-management/pull/1435) | [AUTO] Increment version to 3.2.0-SNAPSHOT | index-management |
+| [#191](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/191) | [AUTO] Increment version to 3.2.0-SNAPSHOT | learning |
+| [#1933](https://github.com/opensearch-project/observability/pull/1933) | [AUTO] Increment version to 3.2.0-SNAPSHOT | observability |
+| [#1105](https://github.com/opensearch-project/reporting/pull/1105) | [AUTO] Increment version to 3.2.0-SNAPSHOT | reporting |
+| [#86](https://github.com/opensearch-project/opensearch-system-templates/pull/86) | [AUTO] Increment version to 3.2.0-SNAPSHOT | system |
+| [#823](https://github.com/opensearch-project/performance-analyzer/pull/823) | Increment version to 3.2.0-SNAPSHOT | performance |
+| [#380](https://github.com/opensearch-project/query-insights/pull/380) | [AUTO] Increment version to 3.2.0-SNAPSHOT | query |
+
+## References
+
+- [OpenSearch Release Process](https://github.com/opensearch-project/opensearch-build/blob/main/RELEASING.md): Official release documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/multi-plugin/version-bumps-release-notes.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -147,3 +147,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | Item | Category | Description |
 |------|----------|-------------|
 | [CVE Fixes & Dependency Updates](features/multi-repo/cve-fixes-dependency-updates.md) | bugfix | CVE-2025-48734 (beanutils) and CVE-2025-7783 (form-data) security fixes |
+| [Version Increment (Maintenance)](features/multi-plugin/version-increment-maintenance.md) | bugfix | Version bumps to 3.2.0 across 14 repositories |


### PR DESCRIPTION
## Summary

Add release report for version increment maintenance PRs in v3.2.0.

## Changes

- Created release report: `docs/releases/v3.2.0/features/multi-plugin/version-increment-maintenance.md`
- Updated feature report: `docs/features/multi-plugin/version-bumps-release-notes.md`
- Updated release index: `docs/releases/v3.2.0/index.md`

## Details

Version bumps to 3.2.0.0 (release) and 3.2.0-SNAPSHOT (development) across 14 repositories:
- alerting (4 PRs including dependency fixes)
- asynchronous-search, custom, index-management, ml-commons, notifications
- observability, query, dashboards, reporting, security
- learning, performance, system

Closes #1081