### PR TITLE
docs: add SQL/PPL Documentation report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -246,6 +246,7 @@
 - [Calcite Query Engine](sql/calcite-query-engine.md)
 - [Flint Index Operations](sql/flint-index-operations.md)
 - [Flint Query Scheduler](sql/flint-query-scheduler.md)
+- [PPL Documentation](sql/ppl-documentation.md)
 - [Security Lake Data Source](sql/security-lake-data-source.md)
 - [SQL Error Handling](sql/sql-error-handling.md)
 - [SQL Pagination](sql/sql-pagination.md)

--- a/docs/features/sql/ppl-documentation.md
+++ b/docs/features/sql/ppl-documentation.md
@@ -1,0 +1,141 @@
+# PPL Documentation
+
+## Summary
+
+PPL (Piped Processing Language) documentation provides comprehensive reference materials for OpenSearch's query language designed for log analysis and observability workflows. The documentation covers command syntax, function references, and engine limitations to help users effectively query and analyze data stored in OpenSearch.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "PPL Documentation Structure"
+        Index[PPL Index]
+        
+        subgraph "Commands"
+            Search[search]
+            Where[where]
+            Fields[fields]
+            Stats[stats]
+            Join[join]
+            Lookup[lookup]
+            More[...]
+        end
+        
+        subgraph "Functions"
+            Agg[Aggregation]
+            String[String]
+            DateTime[Date/Time]
+            Math[Math]
+            Condition[Condition]
+            Collection[Collection]
+            Crypto[Cryptographic]
+            JSON[JSON]
+            IP[IP Address]
+        end
+        
+        subgraph "Reference"
+            Syntax[Syntax Guide]
+            DataTypes[Data Types]
+            Limitations[Limitations]
+        end
+    end
+    
+    Index --> Commands
+    Index --> Functions
+    Index --> Reference
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| PPL Index | Main entry point listing all commands and functions |
+| Commands Reference | Detailed documentation for each PPL command |
+| Functions Reference | Documentation for built-in functions by category |
+| Limitations | Engine-specific limitations and fallback behavior |
+| Syntax Guide | PPL query structure and formatting rules |
+
+### Function Categories
+
+| Category | Description | Example Functions |
+|----------|-------------|-------------------|
+| Aggregation | Statistical aggregations | `count`, `sum`, `avg`, `min`, `max`, `percentile` |
+| String | Text manipulation | `concat`, `length`, `lower`, `upper`, `trim`, `substring` |
+| Date/Time | Temporal operations | `now`, `date_add`, `datediff`, `timestamp` |
+| Math | Mathematical operations | `abs`, `ceil`, `floor`, `round`, `sqrt`, `pow` |
+| Condition | Conditional logic | `if`, `ifnull`, `nullif`, `coalesce`, `case` |
+| Collection | Array/multi-value operations | `array_length`, `array_contains` |
+| Cryptographic | Hash and encryption | `md5`, `sha1`, `sha2` |
+| JSON | JSON parsing and manipulation | `json_extract`, `json_valid`, `json_keys` |
+| IP Address | IP address operations | `cidrmatch`, `geoip` |
+| Relevance | Full-text search | `match`, `match_phrase`, `query_string` |
+
+### Engine Limitations
+
+The SQL/PPL plugin uses multiple query engines with different capabilities:
+
+| Engine | Status | Description |
+|--------|--------|-------------|
+| V1 | Legacy | Original SQL processing engine |
+| V2 | Active | Modern SQL/PPL engine with most features |
+| V3 (Calcite) | Experimental | Apache Calcite-based engine for advanced PPL |
+
+#### V3 Calcite Engine Unsupported Features
+
+Features that fall back to V2 engine:
+- All SQL queries
+- `dedup` with `consecutive=true`
+- Search commands (AD, ML, Kmeans)
+- Commands with `fetch_size` parameter
+- Search functions (match, match_phrase, etc.)
+
+### Usage Example
+
+```ppl
+# Basic query with filtering and aggregation
+source=logs 
+| where status_code >= 400 
+| stats count() by host 
+| sort - count()
+
+# Using collection functions
+source=events 
+| eval tag_count = array_length(tags)
+| where tag_count > 3
+
+# Using JSON functions
+source=api_logs 
+| eval response_status = json_extract(response_body, '$.status')
+| where response_status = 'error'
+
+# Using cryptographic functions
+source=users 
+| eval email_hash = md5(email)
+| fields user_id, email_hash
+```
+
+## Limitations
+
+- Documentation accuracy depends on keeping pace with feature development
+- Some experimental features may have incomplete documentation
+- Cross-version documentation differences require version-specific references
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#3868](https://github.com/opensearch-project/sql/pull/3868) | Update ppl documentation index for new functions |
+| v3.2.0 | [#3801](https://github.com/opensearch-project/sql/pull/3801) | Update the limitation docs |
+
+## References
+
+- [PPL Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/ppl/index/): Official PPL reference
+- [PPL Functions](https://docs.opensearch.org/3.0/search-plugins/sql/functions/): Function reference
+- [SQL/PPL Limitations](https://docs.opensearch.org/3.0/search-plugins/sql/limitation/): Engine limitations
+- [SQL Plugin Repository](https://github.com/opensearch-project/sql): Source code and in-repo documentation
+
+## Change History
+
+- **v3.2.0** (2026-01-11): Added Collection, Cryptographic, and JSON function categories to index; updated V3 engine limitations to reflect newly supported features

--- a/docs/releases/v3.2.0/features/sql/ppl-documentation.md
+++ b/docs/releases/v3.2.0/features/sql/ppl-documentation.md
@@ -1,0 +1,94 @@
+# SQL/PPL Documentation
+
+## Summary
+
+This release item updates the PPL documentation index and limitations documentation for the SQL plugin. The changes add missing function categories (Collection, Cryptographic, JSON) to the PPL documentation index and update the V3 Calcite engine limitations documentation to reflect the current state of supported features.
+
+## Details
+
+### What's New in v3.2.0
+
+Two documentation updates improve the accuracy and completeness of PPL reference materials:
+
+1. **PPL Documentation Index Update**: Added links to three new function categories that were missing from the main documentation index:
+   - Collection Functions
+   - Cryptographic Functions
+   - JSON Functions
+
+2. **V3 Engine Limitations Update**: Streamlined the limitations documentation to reflect features that are now supported in the V3 Calcite engine, removing items that were previously listed as unsupported but have since been implemented.
+
+### Technical Changes
+
+#### Documentation Index Changes
+
+The PPL index (`docs/user/ppl/index.rst`) was updated to include links to function documentation that was added in previous releases but missing from the index:
+
+| Function Category | Description | Related PR |
+|-------------------|-------------|------------|
+| Collection Functions | Array/multi-value field operations | [#3584](https://github.com/opensearch-project/sql/pull/3584) |
+| Cryptographic Functions | Hash and encryption functions | [#3574](https://github.com/opensearch-project/sql/pull/3574) |
+| JSON Functions | JSON parsing and manipulation | [#3559](https://github.com/opensearch-project/sql/pull/3559) |
+
+#### Limitations Documentation Changes
+
+The V3 engine limitations documentation was updated in multiple files:
+- `docs/dev/intro-v3-engine.md`: Updated version references from "3.0.0-beta" to "3.0.0"
+- `docs/user/limitations/limitations.rst`: Added Calcite engine limitations section
+- `docs/user/ppl/limitations/limitations.rst`: Added unsupported functionalities section
+
+Items removed from the unsupported list (now supported in V3):
+- `trendline`
+- `show datasource`
+- `explain`
+- `describe`
+- `top` and `rare`
+- `fillnull`
+- `patterns`
+- Query with metadata fields (`_id`, `_doc`, etc.)
+- JSON relevant functions (`cast to json`, `json`, `json_valid`)
+
+Items that remain unsupported in V3 (fallback to V2):
+- All SQL queries
+- `dedup` with `consecutive=true`
+- Search relevant commands (AD, ML, Kmeans)
+- Commands with `fetch_size` parameter
+- Search relevant functions (match, match_phrase, etc.)
+
+### Usage Example
+
+After these documentation updates, users can find the new function categories in the PPL reference:
+
+```ppl
+# Collection Functions example
+source=logs | eval arr_len = array_length(tags)
+
+# Cryptographic Functions example
+source=users | eval hash = md5(email)
+
+# JSON Functions example
+source=events | eval parsed = json_extract(payload, '$.status')
+```
+
+## Limitations
+
+- Documentation updates only; no functional changes to the SQL/PPL plugin
+- The V3 Calcite engine remains experimental
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3868](https://github.com/opensearch-project/sql/pull/3868) | Update ppl documentation index for new functions |
+| [#3801](https://github.com/opensearch-project/sql/pull/3801) | Update the limitation docs |
+
+## References
+
+- [PR #3559](https://github.com/opensearch-project/sql/pull/3559): JSON functions implementation
+- [PR #3584](https://github.com/opensearch-project/sql/pull/3584): Array/Collection functions implementation
+- [PR #3574](https://github.com/opensearch-project/sql/pull/3574): Cryptographic functions implementation
+- [PPL Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/ppl/index/): Official PPL reference
+- [SQL/PPL Limitations](https://docs.opensearch.org/3.0/search-plugins/sql/limitation/): Engine limitations
+
+## Related Feature Report
+
+- [Calcite Query Engine](../../../../features/sql/calcite-query-engine.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -142,6 +142,12 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 |------|----------|-------------|
 | [Release Notes & Documentation](features/query-insights/release-notes-documentation.md) | bugfix | Release notes for v3.2.0 with reader search limit increase and infrastructure updates |
 
+### SQL
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [SQL/PPL Documentation](features/sql/ppl-documentation.md) | bugfix | Update PPL documentation index and V3 engine limitations |
+
 ### Multi-Repository
 
 | Item | Category | Description |


### PR DESCRIPTION
## Summary

This PR adds documentation reports for the SQL/PPL Documentation bugfix in v3.2.0.

### Changes

**Release Report**: `docs/releases/v3.2.0/features/sql/ppl-documentation.md`
- Documents the PPL documentation index update (PR #3868)
- Documents the V3 engine limitations update (PR #3801)

**Feature Report**: `docs/features/sql/ppl-documentation.md`
- Comprehensive PPL documentation reference
- Function categories overview
- Engine limitations summary

### Related Issue

Closes #1080

### PRs Investigated

| PR | Description |
|----|-------------|
| [opensearch-project/sql#3868](https://github.com/opensearch-project/sql/pull/3868) | Update ppl documentation index for new functions |
| [opensearch-project/sql#3801](https://github.com/opensearch-project/sql/pull/3801) | Update the limitation docs |