### PR TITLE
docs: add ML Commons Documentation & Tutorials report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -299,6 +299,7 @@
 - [ML Commons Connector](ml-commons/ml-commons-connector.md)
 - [ML Commons Connector and Model Validation](ml-commons/connector-model-validation.md)
 - [ML Commons Connector Blueprints](ml-commons/ml-commons-blueprints.md)
+- [ML Commons Documentation & Tutorials](ml-commons/ml-commons-documentation-tutorials.md)
 - [ML Commons MCP (Model Context Protocol)](ml-commons/ml-commons-mcp.md)
 - [ML Commons Memory Metadata](ml-commons/ml-commons-memory-metadata.md)
 - [ML Commons Model & Inference](ml-commons/ml-commons-model-inference.md)

--- a/docs/features/ml-commons/ml-commons-documentation-tutorials.md
+++ b/docs/features/ml-commons/ml-commons-documentation-tutorials.md
@@ -1,0 +1,178 @@
+# ML Commons Documentation & Tutorials
+
+## Summary
+
+ML Commons provides comprehensive documentation, tutorials, and blueprints to help users implement machine learning features in OpenSearch. This includes guides for multi-modal search, neural sparse models, semantic highlighting, language identification, agentic RAG, and integration with AWS services like Bedrock and SageMaker.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "ML Commons Documentation"
+        Tutorials[Tutorials]
+        Blueprints[Connector Blueprints]
+        Notebooks[Jupyter Notebooks]
+    end
+    
+    subgraph "Tutorial Categories"
+        MLInference[ML Inference Tutorials]
+        AgentFramework[Agent Framework Tutorials]
+        ModelServing[Model Serving Guides]
+    end
+    
+    subgraph "External Services"
+        Bedrock[AWS Bedrock]
+        SageMaker[AWS SageMaker]
+        OpenAI[OpenAI]
+    end
+    
+    Tutorials --> MLInference
+    Tutorials --> AgentFramework
+    Tutorials --> ModelServing
+    
+    MLInference --> Bedrock
+    MLInference --> SageMaker
+    AgentFramework --> Bedrock
+    Blueprints --> SageMaker
+    Blueprints --> OpenAI
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| ML Inference Tutorials | Step-by-step guides for using ML inference processors |
+| Agent Framework Tutorials | Guides for building conversational agents and RAG |
+| Connector Blueprints | Pre-built configurations for connecting to ML services |
+| Jupyter Notebooks | Interactive demos for hands-on learning |
+
+### Tutorial Categories
+
+#### ML Inference Tutorials
+
+| Tutorial | Description | Use Case |
+|----------|-------------|----------|
+| Multi-Modal Search | Bedrock Titan multi-modal embedding | Image + text search |
+| Language Identification | Automatic language detection during ingest | Multi-language search |
+| E-commerce Demo | Multi-modal search for products | Product search |
+
+#### Agent Framework Tutorials
+
+| Tutorial | Description | Use Case |
+|----------|-------------|----------|
+| Agentic RAG | Retrieval-augmented generation with agents | Knowledge base Q&A |
+
+#### Connector Blueprints
+
+| Blueprint | Service | Model Type |
+|-----------|---------|------------|
+| Semantic Highlighter | AWS SageMaker | Text highlighting |
+| Neural Sparse | AWS SageMaker | Sparse encoding |
+| Aleph Alpha | Aleph Alpha API | Text embedding |
+
+### Usage Example
+
+#### Setting Up Multi-Modal Search
+
+1. Create a connector for Bedrock Titan:
+
+```json
+POST _plugins/_ml/connectors/_create
+{
+  "name": "Bedrock Titan Multi-Modal",
+  "protocol": "aws_sigv4",
+  "parameters": {
+    "region": "us-east-1",
+    "service_name": "bedrock",
+    "model": "amazon.titan-embed-image-v1"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/invoke",
+      "request_body": "{\"inputText\": \"${parameters.inputText:-null}\", \"inputImage\": \"${parameters.inputImage:-null}\"}"
+    }
+  ]
+}
+```
+
+2. Create an ingest pipeline:
+
+```json
+PUT _ingest/pipeline/ml_inference_pipeline_multi_modal
+{
+  "processors": [
+    {
+      "ml_inference": {
+        "model_id": "your_model_id",
+        "input_map": [
+          {
+            "inputText": "name",
+            "inputImage": "image"
+          }
+        ],
+        "output_map": [
+          {
+            "multimodal_embedding": "embedding"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+3. Create a KNN index:
+
+```json
+PUT test-index
+{
+  "settings": {
+    "index": {
+      "default_pipeline": "ml_inference_pipeline_multi_modal",
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "multimodal_embedding": {
+        "type": "knn_vector",
+        "dimension": 1024
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- AWS service tutorials require appropriate IAM permissions
+- Multi-modal embedding requires images in Base64 format
+- Language identification accuracy depends on the underlying model
+- SageMaker blueprints require endpoint deployment
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#3576](https://github.com/opensearch-project/ml-commons/pull/3576) | Multi modal tutorial using ml inference processor |
+| v3.2.0 | [#3879](https://github.com/opensearch-project/ml-commons/pull/3879) | Semantic highlighter blueprint for SageMaker |
+| v3.2.0 | [#3857](https://github.com/opensearch-project/ml-commons/pull/3857) | Neural Sparse Remote Model documentation |
+| v3.2.0 | [#3966](https://github.com/opensearch-project/ml-commons/pull/3966) | Language identification tutorial |
+| v3.2.0 | [#3980](https://github.com/opensearch-project/ml-commons/pull/3980) | Aleph alpha blueprint link fix |
+| v3.2.0 | [#4045](https://github.com/opensearch-project/ml-commons/pull/4045) | Agentic RAG tutorial |
+| v3.2.0 | [#3944](https://github.com/opensearch-project/ml-commons/pull/3944) | Multi-modal search notebook |
+
+## References
+
+- [ML Commons Connector Blueprints](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/blueprints/)
+- [ML Inference Processor](https://docs.opensearch.org/3.0/ingest-pipelines/processors/ml-inference/)
+- [OpenSearch Tutorials](https://docs.opensearch.org/3.0/tutorials/)
+- [Agents and Tools](https://opensearch.org/docs/latest/ml-commons-plugin/agents-tools/index/)
+
+## Change History
+
+- **v3.2.0** (2025): Added multi-modal search tutorial, semantic highlighter blueprint, neural sparse documentation, language identification tutorial, agentic RAG tutorial, e-commerce demo notebook, and Aleph Alpha blueprint fix

--- a/docs/releases/v3.2.0/features/ml-commons/ml-commons-documentation-tutorials.md
+++ b/docs/releases/v3.2.0/features/ml-commons/ml-commons-documentation-tutorials.md
@@ -1,0 +1,153 @@
+# ML Commons Documentation & Tutorials
+
+## Summary
+
+This release item adds comprehensive documentation and tutorials to the ML Commons repository, covering multi-modal search, neural sparse models, semantic highlighting, language identification, agentic RAG, and e-commerce demos. These additions help users understand and implement ML-powered features in OpenSearch.
+
+## Details
+
+### What's New in v3.2.0
+
+Seven documentation and tutorial PRs were merged to enhance the ML Commons repository:
+
+1. **Multi-Modal Search Tutorial** - Step-by-step guide for using ML inference processor with Bedrock Titan multi-modal embedding model
+2. **Semantic Highlighter Blueprint** - AWS SageMaker blueprint for deploying semantic highlighter models
+3. **Neural Sparse Remote Model Documentation** - Guide for creating neural sparse models on SageMaker
+4. **Language Identification Tutorial** - Using ML inference ingest processor for automatic language detection
+5. **Agentic RAG Tutorial** - Building retrieval-augmented generation with conversational agents
+6. **E-commerce Demo Notebook** - Jupyter notebook demonstrating multi-modal search for e-commerce
+7. **Aleph Alpha Blueprint Fix** - Updated broken link in the Aleph Alpha blueprint
+
+### Technical Changes
+
+#### New Tutorials Added
+
+| Tutorial | Location | Description |
+|----------|----------|-------------|
+| Multi-Modal Search | `docs/tutorials/ml_inference/semantic_search/bedrock_titan_multi-modal_embedding_model.md` | Bedrock Titan multi-modal embedding with ML inference processors |
+| Language Identification | `docs/tutorials/ml_inference/language_identification/ml_inference_with_language_identification_ingest.md` | Automatic language detection during ingest |
+| Agentic RAG | `docs/tutorials/agent_framework/Agentic_RAG.md` | Building RAG with conversational agents |
+| E-commerce Demo | `docs/tutorials/ml_inference/ecommerce_demo.ipynb` | Multi-modal search notebook |
+
+#### New Blueprints Added
+
+| Blueprint | Location | Description |
+|-----------|----------|-------------|
+| Semantic Highlighter | `docs/remote_inference_blueprints/standard_blueprints/sagemaker_semantic_highlighter_standard_blueprint.md` | SageMaker semantic highlighter model |
+| Neural Sparse | `docs/model_serving_framework/deploy_sparse_model_to_SageMaker.ipynb` | Neural sparse model deployment |
+
+### Usage Examples
+
+#### Multi-Modal Search with Bedrock Titan
+
+```json
+POST _plugins/_ml/connectors/_create
+{
+  "name": "Amazon Bedrock Connector: bedrock Titan multi-modal embedding model",
+  "protocol": "aws_sigv4",
+  "parameters": {
+    "region": "us-east-1",
+    "service_name": "bedrock",
+    "model": "amazon.titan-embed-image-v1"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://bedrock-runtime.${parameters.region}.amazonaws.com/model/${parameters.model}/invoke",
+      "request_body": "{\"inputText\": \"${parameters.inputText:-null}\", \"inputImage\": \"${parameters.inputImage:-null}\"}"
+    }
+  ]
+}
+```
+
+#### Language Identification Pipeline
+
+```json
+PUT _ingest/pipeline/language_identification_pipeline
+{
+  "processors": [
+    {
+      "ml_inference": {
+        "model_id": "your_model_id",
+        "input_map": [
+          { "inputs": "name" },
+          { "inputs": "notes" }
+        ],
+        "output_map": [
+          { "predicted_name_language": "response[0].label" },
+          { "predicted_notes_language": "response[0].label" }
+        ]
+      }
+    },
+    {
+      "copy": {
+        "source_field": "name",
+        "target_field": "name_{{predicted_name_language}}"
+      }
+    }
+  ]
+}
+```
+
+#### Agentic RAG Agent
+
+```json
+POST _plugins/_ml/agents/_register
+{
+  "name": "RAG Agent",
+  "type": "conversational",
+  "llm": {
+    "model_id": "your_llm_id",
+    "parameters": {
+      "system_prompt": "You are a helpful assistant..."
+    }
+  },
+  "tools": [
+    {
+      "type": "SearchIndexTool",
+      "name": "retrieve_population_data",
+      "parameters": {
+        "query": {
+          "query": {
+            "neural": {
+              "embedding_field": {
+                "query_text": "${parameters.question}",
+                "model_id": "your_embedding_model_id"
+              }
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+## Limitations
+
+- Tutorials require specific AWS services (Bedrock, SageMaker) with appropriate permissions
+- Multi-modal embedding requires images in Base64 format
+- Language identification model supports limited languages based on the underlying model
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3576](https://github.com/opensearch-project/ml-commons/pull/3576) | Add multi modal tutorial using ml inference processor |
+| [#3879](https://github.com/opensearch-project/ml-commons/pull/3879) | Add blueprint for semantic highlighter model on AWS Sagemaker |
+| [#3857](https://github.com/opensearch-project/ml-commons/pull/3857) | Add Documentation for creating Neural Sparse Remote Model |
+| [#3966](https://github.com/opensearch-project/ml-commons/pull/3966) | Add tutorials for language_identification during ingest |
+| [#3980](https://github.com/opensearch-project/ml-commons/pull/3980) | Update link to the model in the aleph alpha blueprint |
+| [#4045](https://github.com/opensearch-project/ml-commons/pull/4045) | Add agentic rag tutorial |
+| [#3944](https://github.com/opensearch-project/ml-commons/pull/3944) | Notebook for step by step in multi-modal search in ml-inference processor |
+
+## References
+
+- [ML Commons Connector Blueprints](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/blueprints/)
+- [ML Inference Processor](https://docs.opensearch.org/3.0/ingest-pipelines/processors/ml-inference/)
+- [OpenSearch Tutorials](https://docs.opensearch.org/3.0/tutorials/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/ml-commons/ml-commons-documentation-tutorials.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -129,6 +129,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | Item | Category | Description |
 |------|----------|-------------|
 | [ML Commons Testing & Coverage](features/ml-commons/ml-commons-testing-coverage.md) | bugfix | Integration test stability fix, memory container unit tests, JaCoCo 0.8.13 upgrade |
+| [ML Commons Documentation & Tutorials](features/ml-commons/ml-commons-documentation-tutorials.md) | bugfix | Multi-modal search, semantic highlighter, neural sparse, language identification, agentic RAG tutorials |
 
 ### Dashboards Search Relevance
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the ML Commons Documentation & Tutorials release item in v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/ml-commons/ml-commons-documentation-tutorials.md`
- Feature report: `docs/features/ml-commons/ml-commons-documentation-tutorials.md`

### Key Changes in v3.2.0
- Multi-modal search tutorial using Bedrock Titan embedding model
- Semantic highlighter blueprint for AWS SageMaker
- Neural sparse remote model documentation
- Language identification tutorial using ML inference ingest processor
- Agentic RAG tutorial with conversational agents
- E-commerce demo notebook
- Aleph Alpha blueprint link fix

### PRs Investigated
- #3576: Add multi modal tutorial using ml inference processor
- #3879: Add blueprint for semantic highlighter model on AWS Sagemaker
- #3857: Add Documentation for creating Neural Sparse Remote Model
- #3966: Add tutorials for language_identification during ingest
- #3980: Update link to the model in the aleph alpha blueprint
- #4045: Add agentic rag tutorial
- #3944: Notebook for step by step in multi-modal search in ml-inference processor

Closes #1079