### PR TITLE
docs: add asynchronous-search bugfix report for v3.2.0

### DIFF
--- a/docs/features/asynchronous-search/asynchronous-search.md
+++ b/docs/features/asynchronous-search/asynchronous-search.md
@@ -152,6 +152,8 @@ GET _plugins/_asynchronous_search/FklfVlU4eFdIUTh1Q1hyM3ZnT19fUVEUd29KLWZYUUI3Tz
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#754](https://github.com/opensearch-project/asynchronous-search/pull/754) | Gradle 8.14.3 upgrade and JDK 24 CI support |
+| v3.2.0 | [#748](https://github.com/opensearch-project/asynchronous-search/pull/748) | Maven snapshot publishing endpoint migration |
 | v3.0.0 | [#724](https://github.com/opensearch-project/asynchronous-search/pull/724) | Version increment for 3.0.0 GA |
 | v3.0.0 | [#698](https://github.com/opensearch-project/asynchronous-search/pull/698) | JDK23 support and Gradle 8.10.2 |
 | v3.0.0 | [#582](https://github.com/opensearch-project/asynchronous-search/pull/582) | JDK21 baseline for 3.0 |
@@ -165,5 +167,6 @@ GET _plugins/_asynchronous_search/FklfVlU4eFdIUTh1Q1hyM3ZnT19fUVEUd29KLWZYUUI3Tz
 
 ## Change History
 
+- **v3.2.0** (2025-09-02): Infrastructure maintenance - Gradle 8.14.3, JDK 24 CI support, Maven snapshot endpoint migration
 - **v3.0.0** (2025-05-06): GA release preparation - JDK21 baseline, Gradle 8.10.2, JDK23 support
 - **v1.0.0** (2021-07-12): Initial release with OpenSearch

--- a/docs/releases/v3.2.0/features/asynchronous-search/asynchronous-search-bugfix.md
+++ b/docs/releases/v3.2.0/features/asynchronous-search/asynchronous-search-bugfix.md
@@ -1,0 +1,84 @@
+# Asynchronous Search Bugfix
+
+## Summary
+
+Infrastructure maintenance updates for the Asynchronous Search plugin in v3.2.0, including Gradle upgrade to 8.14.3, JDK 24 CI support, and Maven snapshot publishing endpoint migration to Sonatype Central Portal.
+
+## Details
+
+### What's New in v3.2.0
+
+This release focuses on build infrastructure improvements and CI/CD pipeline updates:
+
+1. **Gradle 8.14.3 Upgrade**: Updated build system from Gradle 8.10.2 to 8.14.3
+2. **JDK 24 CI Support**: CI workflows now test against JDK 21 and JDK 24 (replacing JDK 23)
+3. **Maven Snapshot Publishing Migration**: Updated to new Sonatype Central Portal endpoints
+
+### Technical Changes
+
+#### Build System Updates
+
+| Component | Before | After |
+|-----------|--------|-------|
+| Gradle | 8.10.2 | 8.14.3 |
+| nebula.ospackage plugin | 11.10.0 | 12.0.0 |
+| CI JDK matrix | [21, 23] | [21, 24] |
+
+#### Maven Snapshot Publishing Migration
+
+The Maven snapshot publishing workflow was updated to accommodate Sonatype's migration to the Central Portal:
+
+| Setting | Before | After |
+|---------|--------|-------|
+| Snapshot URL | `https://aws.oss.sonatype.org/content/repositories/snapshots` | `https://central.sonatype.com/repository/maven-snapshots/` |
+| Credential Source | AWS Secrets Manager | 1Password via `OP_SERVICE_ACCOUNT_TOKEN` |
+| Authentication | AWS IAM role assumption | Sonatype username/password |
+
+#### CI Workflow Changes
+
+```yaml
+# build.yml - JDK matrix update
+strategy:
+  matrix:
+    java: [21, 24]  # Previously [21, 23]
+```
+
+The credential retrieval was migrated from AWS Secrets Manager to 1Password:
+
+```yaml
+# maven-publish.yml - New credential loading
+- name: Load secret
+  uses: 1password/load-secrets-action@v2
+  with:
+    export-env: true
+  env:
+    OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+    SONATYPE_USERNAME: op://opensearch-infra-secrets/maven-central-portal-credentials/username
+    SONATYPE_PASSWORD: op://opensearch-infra-secrets/maven-central-portal-credentials/password
+```
+
+### Migration Notes
+
+These changes are internal infrastructure updates and do not affect plugin functionality or user-facing APIs. No migration steps are required for users.
+
+## Limitations
+
+- No functional changes in this release
+- These are maintenance updates only
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#754](https://github.com/opensearch-project/asynchronous-search/pull/754) | Bump gradle to 8.14.3 and use JDK 24 in CI workflow |
+| [#748](https://github.com/opensearch-project/asynchronous-search/pull/748) | Update the Maven snapshot publish endpoint and credential |
+
+## References
+
+- [Sonatype Central Portal Snapshots](https://central.sonatype.org/publish/publish-portal-snapshots/)
+- [opensearch-build#5551](https://github.com/opensearch-project/opensearch-build/issues/5551): Maven snapshot migration campaign
+- [Asynchronous Search Documentation](https://docs.opensearch.org/3.0/search-plugins/async/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/asynchronous-search/asynchronous-search.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -149,6 +149,12 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 |------|----------|-------------|
 | [SQL/PPL Documentation](features/sql/ppl-documentation.md) | bugfix | Update PPL documentation index and V3 engine limitations |
 
+### Asynchronous Search
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Asynchronous Search Bugfix](features/asynchronous-search/asynchronous-search-bugfix.md) | bugfix | Gradle 8.14.3 upgrade, JDK 24 CI support, Maven snapshot endpoint migration |
+
 ### Multi-Repository
 
 | Item | Category | Description |


### PR DESCRIPTION
## Summary

Add release report for Asynchronous Search plugin bugfix in v3.2.0.

## Changes

### Release Report Created
- `docs/releases/v3.2.0/features/asynchronous-search/asynchronous-search-bugfix.md`

### Feature Report Updated
- `docs/features/asynchronous-search/asynchronous-search.md` - Added v3.2.0 PRs and change history

### Release Index Updated
- `docs/releases/v3.2.0/index.md` - Added Asynchronous Search section

## Key Changes in v3.2.0

- **Gradle 8.14.3**: Build system upgrade from 8.10.2
- **JDK 24 CI Support**: CI workflows now test against JDK 21 and 24 (replacing JDK 23)
- **Maven Snapshot Migration**: Updated to Sonatype Central Portal endpoints with 1Password credential management

## Related PRs
- [#754](https://github.com/opensearch-project/asynchronous-search/pull/754): Gradle and JDK updates
- [#748](https://github.com/opensearch-project/asynchronous-search/pull/748): Maven snapshot endpoint migration

Closes #1077