### PR TITLE
docs: add remote-vector-index-build report for v3.2.0

### DIFF
--- a/docs/features/k-nn/remote-vector-index-build.md
+++ b/docs/features/k-nn/remote-vector-index-build.md
@@ -196,6 +196,7 @@ POST my-vectors/_bulk
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#2773](https://github.com/opensearch-project/k-NN/pull/2773) | Don't fall back to CPU on terminal failures |
 | v3.1.0 | [#2662](https://github.com/opensearch-project/k-NN/pull/2662) | Add tuned repository upload/download buffer sizes |
 | v3.1.0 | [#2734](https://github.com/opensearch-project/k-NN/pull/2734) | Add segment size upper bound setting and GA settings changes |
 | v3.1.0 | [#2693](https://github.com/opensearch-project/k-NN/pull/2693) | Fix remote build metrics timing and add exception logging |
@@ -212,6 +213,7 @@ POST my-vectors/_bulk
 - [Issue #2391](https://github.com/opensearch-project/k-NN/issues/2391): Meta issue tracking all remote build work
 - [Issue #2518](https://github.com/opensearch-project/k-NN/issues/2518): Low-level design document
 - [Issue #2553](https://github.com/opensearch-project/k-NN/issues/2553): Integration testing support meta issue
+- [Issue #2766](https://github.com/opensearch-project/k-NN/issues/2766): Bug report - Terminate Index build request if Failed to write index in segment
 - [Documentation](https://docs.opensearch.org/3.0/vector-search/remote-index-build/): Official OpenSearch docs
 - [Remote Vector Index Builder](https://github.com/opensearch-project/remote-vector-index-builder): GPU build service
 - [User Guide](https://github.com/opensearch-project/remote-vector-index-builder/blob/main/USER_GUIDE.md): Service setup instructions
@@ -219,6 +221,7 @@ POST my-vectors/_bulk
 
 ## Change History
 
+- **v3.2.0** (2025-06-27): Improved error handling - don't fall back to CPU on terminal failures (e.g., IndexInput closed, index deleted). Added `TerminalIOException` to distinguish recoverable vs terminal I/O errors.
 - **v3.1.0** (2025-06-16): GA preparation with tuned buffer sizes (50MB vector upload/download, 8KB doc ID), new segment size upper bound setting (`knn.remote_index_build.size.max`), renamed settings for production use, fixed metrics timing for CPU fallback, improved exception logging
 - **v3.1.0** (2025-05-13): Added comprehensive integration test support with `@ExpectRemoteBuildValidation` annotation, updated GitHub Actions workflow to use official Docker image and run all ITs, fixed MockNode constructor compatibility
 - **v3.0.0** (2025-05-06): Initial experimental implementation with HTTP client, S3 repository integration, metrics, and COSINESIMIL support

--- a/docs/releases/v3.2.0/features/k-nn/remote-vector-index-build.md
+++ b/docs/releases/v3.2.0/features/k-nn/remote-vector-index-build.md
@@ -1,0 +1,109 @@
+# Remote Vector Index Build
+
+## Summary
+
+This bugfix improves the error handling behavior of the Remote Vector Index Build feature when terminal failures occur during GPU-accelerated index construction. Previously, when hard failures like "IndexInput is closed" or "index is deleted" occurred, the system would unnecessarily fall back to CPU build, only to encounter the same failure again before ultimately failing the shard. This fix introduces a new `TerminalIOException` that signals the build process to terminate immediately without attempting a CPU fallback, avoiding wasted compute resources.
+
+## Details
+
+### What's New in v3.2.0
+
+The fix addresses an inefficiency in the remote build fallback mechanism. When writing the downloaded index to the local segment fails due to terminal conditions (e.g., closed IndexOutput, deleted index), the system now properly terminates the request instead of attempting a futile CPU fallback.
+
+### Technical Changes
+
+#### New Exception Class
+
+A new `TerminalIOException` class distinguishes between recoverable and terminal I/O failures:
+
+```java
+public class TerminalIOException extends IOException {
+    public TerminalIOException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}
+```
+
+#### Exception Flow
+
+```mermaid
+graph TB
+    subgraph Remote Build Process
+        A[Start Remote Build] --> B[Upload Vectors to S3]
+        B --> C[Submit Build Request]
+        C --> D[Poll for Completion]
+        D --> E[Download Index from S3]
+        E --> F{Write to IndexOutput}
+    end
+    
+    subgraph Error Handling
+        F -->|Success| G[Build Complete]
+        F -->|TerminalIOException| H[Terminate Request]
+        F -->|Other Exception| I[Fall Back to CPU]
+    end
+    
+    H --> J[Fail Shard]
+    I --> K[Retry with CPU Build]
+```
+
+#### Modified Components
+
+| Component | Change |
+|-----------|--------|
+| `TerminalIOException` | New exception class for terminal I/O failures |
+| `IndexOutputWithBuffer` | Wraps `IndexOutput.writeBytes()` failures in `TerminalIOException` |
+| `RemoteIndexBuildStrategy` | Catches and rethrows `TerminalIOException` without fallback |
+| `KNNRemoteIndexBuildValue` | Added `reset()` method for test cleanup |
+
+#### Code Changes
+
+The `IndexOutputWithBuffer.writeFromStreamWithBuffer()` method now wraps write failures:
+
+```java
+try {
+    indexOutput.writeBytes(outputBuffer, 0, bytesRead);
+} catch (IOException e) {
+    throw new TerminalIOException("Failed to write to indexOutput", e);
+}
+```
+
+The `RemoteIndexBuildStrategy.buildAndWriteIndex()` method catches and rethrows terminal exceptions:
+
+```java
+try {
+    // ... remote build process
+} catch (TerminalIOException e) {
+    throw e;  // Don't fall back, terminate immediately
+} catch (Exception e) {
+    log.error("Failed to build index remotely: " + indexInfo, e);
+    // Fall back to CPU build
+}
+```
+
+### Usage Example
+
+No configuration changes required. The fix is automatic and applies to all remote vector index builds. When a terminal failure occurs during the write phase, users will see the failure immediately rather than after an unnecessary CPU fallback attempt.
+
+### Migration Notes
+
+No migration required. This is a transparent bugfix that improves error handling behavior.
+
+## Limitations
+
+- Only applies to failures during the final write phase (downloading index from S3 to local segment)
+- Other types of failures (S3 connectivity, build service errors) still trigger CPU fallback as before
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2773](https://github.com/opensearch-project/k-NN/pull/2773) | Don't fall back to CPU on terminal exceptions |
+
+## References
+
+- [Issue #2766](https://github.com/opensearch-project/k-NN/issues/2766): Bug report - Terminate Index build request if Failed to write index in segment
+- [Documentation](https://docs.opensearch.org/3.0/vector-search/remote-index-build/): Remote index build documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/k-nn/remote-vector-index-build.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -155,6 +155,12 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 |------|----------|-------------|
 | [Asynchronous Search Bugfix](features/asynchronous-search/asynchronous-search-bugfix.md) | bugfix | Gradle 8.14.3 upgrade, JDK 24 CI support, Maven snapshot endpoint migration |
 
+### k-NN
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Remote Vector Index Build](features/k-nn/remote-vector-index-build.md) | bugfix | Don't fall back to CPU on terminal failures during remote index build |
+
 ### Multi-Repository
 
 | Item | Category | Description |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Remote Vector Index Build bugfix in v3.2.0.

### Changes
- **Release report**: `docs/releases/v3.2.0/features/k-nn/remote-vector-index-build.md`
- **Feature report update**: `docs/features/k-nn/remote-vector-index-build.md`
- **Release index update**: Added k-NN section

### Key Changes in v3.2.0
- Introduced `TerminalIOException` to distinguish between recoverable and terminal I/O failures
- Modified `RemoteIndexBuildStrategy` to terminate immediately on terminal failures instead of falling back to CPU
- Prevents wasted compute when hard failures (IndexInput closed, index deleted) occur during remote build

### Related
- PR: [opensearch-project/k-NN#2773](https://github.com/opensearch-project/k-NN/pull/2773)
- Issue: [opensearch-project/k-NN#2766](https://github.com/opensearch-project/k-NN/issues/2766)