### PR TITLE
docs: add geospatial-plugin report for v3.2.0

### DIFF
--- a/docs/features/geospatial/ip2geo.md
+++ b/docs/features/geospatial/ip2geo.md
@@ -186,6 +186,8 @@ Fields available depend on the datasource. GeoLite2 City provides:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#782](https://github.com/opensearch-project/geospatial/pull/782) | Block redirect in IP2Geo and move validation to transport action |
+| v3.2.0 | [#715](https://github.com/opensearch-project/geospatial/pull/715) | Replace ThreadContext.stashContext with pluginSubject.runAs |
 | v3.1.0 | [#761](https://github.com/opensearch-project/geospatial/pull/761) | Reset datasource metadata on update failure |
 | v3.1.0 | [#766](https://github.com/opensearch-project/geospatial/pull/766) | Cache refresh and retry on errors |
 | v2.10.0 | - | Initial implementation |
@@ -195,8 +197,10 @@ Fields available depend on the datasource. GeoLite2 City provides:
 - [IP2Geo Documentation](https://docs.opensearch.org/3.0/ingest-pipelines/processors/ip2geo/): Official processor documentation
 - [MaxMind GeoLite2](https://dev.maxmind.com/geoip/geolite2-free-geolocation-data): GeoIP data source
 - [Geospatial Plugin](https://github.com/opensearch-project/geospatial): Source repository
+- [Issue #238](https://github.com/opensearch-project/opensearch-plugins/issues/238): META - Remove usages of ThreadContext.stashContext
 
 ## Change History
 
+- **v3.2.0** (2026-01-11): Security improvements - block HTTP redirects in datasource fetching, migrate to PluginSubject for system index access
 - **v3.1.0** (2026-01-10): Bug fixes for cache synchronization - reset metadata on failure, add retry logic with cache refresh
 - **v2.10.0**: Initial implementation of IP2Geo processor

--- a/docs/releases/v3.2.0/features/geospatial/geospatial-plugin.md
+++ b/docs/releases/v3.2.0/features/geospatial/geospatial-plugin.md
@@ -1,0 +1,103 @@
+# Geospatial Plugin Bugfixes
+
+## Summary
+
+This release includes two security and architecture improvements for the Geospatial plugin's IP2Geo feature:
+
+1. **HTTP Redirect Blocking**: Blocks HTTP redirects in IP2Geo datasource manifest and GeoIP data fetching to prevent potential security vulnerabilities
+2. **PluginSubject Migration**: Replaces `ThreadContext.stashContext` with `pluginSubject.runAs` for stricter system index ownership and improved security
+
+These changes improve the security posture of the IP2Geo processor by enforcing stricter controls over external HTTP connections and system index access.
+
+## Details
+
+### What's New in v3.2.0
+
+#### 1. HTTP Redirect Blocking (PR #782)
+
+The IP2Geo feature now blocks HTTP redirects when fetching datasource manifests and GeoIP data files. This prevents potential Server-Side Request Forgery (SSRF) attacks where a malicious endpoint could redirect requests to internal resources.
+
+**Key Changes:**
+- Added `HttpRedirectValidator` utility class to validate HTTP connections
+- Moved manifest validation from request validation to transport action execution
+- Redirects (HTTP 3xx status codes) now throw `IllegalArgumentException`
+
+#### 2. PluginSubject Migration (PR #715)
+
+Replaced the deprecated `ThreadContext.stashContext` pattern with the new `IdentityAwarePlugin` mechanism using `pluginSubject.runAs`. This provides:
+- Stricter ownership over system indices
+- Better visibility into which plugin performs privileged actions
+- Preparation for Java Security Manager permission enforcement in 3.0+
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.2.0"
+        A1[Request] --> B1[Validate Manifest in Request]
+        B1 --> C1[Transport Action]
+        C1 --> D1[StashedThreadContext.run]
+        D1 --> E1[System Index Access]
+    end
+    
+    subgraph "After v3.2.0"
+        A2[Request] --> B2[Basic URL Validation]
+        B2 --> C2[Transport Action]
+        C2 --> D2[Validate Manifest - No Redirects]
+        D2 --> E2[PluginClient.doExecute]
+        E2 --> F2[pluginSubject.runAs]
+        F2 --> G2[System Index Access]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `HttpRedirectValidator` | Utility class that validates HTTP connections don't attempt redirects |
+| `PluginClient` | FilterClient wrapper that executes transport actions as the plugin's system subject |
+
+#### Removed Components
+
+| Component | Description |
+|-----------|-------------|
+| `StashedThreadContext` | Helper class for running code with stashed thread context (replaced by PluginClient) |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugin-additional-permissions.yml` | Declares additional cluster permissions for the plugin | `indices:data/read/mget` |
+
+### Usage Example
+
+No changes to user-facing APIs. The security improvements are transparent to users.
+
+### Migration Notes
+
+- No user action required
+- Existing datasources continue to work
+- Endpoints that rely on HTTP redirects will now fail with an error message indicating redirects are not allowed
+
+## Limitations
+
+- HTTP redirects are now blocked for all IP2Geo datasource endpoints
+- If your GeoIP data provider uses redirects, you must use the final URL directly
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#782](https://github.com/opensearch-project/geospatial/pull/782) | Block redirect in IP2Geo and move validation to transport action |
+| [#715](https://github.com/opensearch-project/geospatial/pull/715) | Replace usages of ThreadContext.stashContext with pluginSubject.runAs |
+
+## References
+
+- [Issue #238](https://github.com/opensearch-project/opensearch-plugins/issues/238): META - Remove usages of ThreadContext.stashContext
+- [IP2Geo Documentation](https://docs.opensearch.org/3.0/ingest-pipelines/processors/ip2geo/): Official processor documentation
+
+## Related Feature Report
+
+- [Full IP2Geo documentation](../../../features/geospatial/ip2geo.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -105,6 +105,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | Item | Category | Description |
 |------|----------|-------------|
 | [Geospatial Infrastructure](features/geospatial/geospatial-infrastructure.md) | bugfix | Upgrade Gradle to 8.14.3 and run CI checks with JDK24 |
+| [Geospatial Plugin](features/geospatial/geospatial-plugin.md) | bugfix | Block HTTP redirects in IP2Geo, migrate to PluginSubject for system index access |
 
 ### Performance Analyzer
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Geospatial Plugin bugfixes in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/geospatial/geospatial-plugin.md`
- Feature report updated: `docs/features/geospatial/ip2geo.md`

### Key Changes in v3.2.0

1. **HTTP Redirect Blocking (PR #782)**
   - Blocks HTTP redirects in IP2Geo datasource manifest and GeoIP data fetching
   - Prevents potential SSRF attacks
   - Added `HttpRedirectValidator` utility class

2. **PluginSubject Migration (PR #715)**
   - Replaced `ThreadContext.stashContext` with `pluginSubject.runAs`
   - Implements `IdentityAwarePlugin` for stricter system index ownership
   - Added `PluginClient` wrapper for privileged operations

### Resources Used
- PR #782: https://github.com/opensearch-project/geospatial/pull/782
- PR #715: https://github.com/opensearch-project/geospatial/pull/715
- Issue #238: https://github.com/opensearch-project/opensearch-plugins/issues/238
- Docs: https://docs.opensearch.org/3.0/ingest-pipelines/processors/ip2geo/