### PR TITLE
docs: add Security Analytics Bugfixes report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -201,6 +201,10 @@
 
 - [Security Dashboards Plugin](security-dashboards/security-dashboards-plugin.md)
 
+## security-analytics-dashboards-plugin
+
+- [Security Analytics](security-analytics-dashboards-plugin/security-analytics.md)
+
 ## remote
 
 - [Security CVE Fixes](remote/security-cve-fixes.md)

--- a/docs/features/security-analytics-dashboards-plugin/security-analytics.md
+++ b/docs/features/security-analytics-dashboards-plugin/security-analytics.md
@@ -1,0 +1,110 @@
+# Security Analytics
+
+## Summary
+
+Security Analytics is a security information and event management (SIEM) solution for OpenSearch, designed to investigate, detect, analyze, and respond to security threats. It provides out-of-the-box threat detection using Sigma rules, correlation capabilities to identify relationships between security events across different log sources, and threat intelligence integration for IOC-based detection.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        SA[Security Analytics Plugin]
+        subgraph "Pages"
+            DET[Detectors]
+            FIND[Findings]
+            ALERT[Alerts]
+            CORR[Correlations]
+            RULES[Rules]
+            TI[Threat Intelligence]
+        end
+    end
+    
+    subgraph "OpenSearch Backend"
+        SAP[Security Analytics Plugin]
+        CE[Correlation Engine]
+        TIP[Threat Intel Plugin]
+    end
+    
+    subgraph "Data Sources"
+        LOGS[Log Data]
+        FEEDS[Threat Intel Feeds]
+    end
+    
+    SA --> DET
+    SA --> FIND
+    SA --> ALERT
+    SA --> CORR
+    SA --> RULES
+    SA --> TI
+    
+    DET --> SAP
+    FIND --> SAP
+    ALERT --> SAP
+    CORR --> CE
+    TI --> TIP
+    
+    LOGS --> SAP
+    FEEDS --> TIP
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Detectors | Configure threat detection for specific log types using Sigma rules |
+| Findings | Security events identified by detectors matching rules |
+| Alerts | Notifications triggered when findings meet specified conditions |
+| Correlations | Relationships between findings from different log sources |
+| Rules | Sigma-based detection rules for identifying threats |
+| Threat Intelligence | IOC-based detection using external threat feeds |
+
+### Key Features
+
+#### Threat Detection
+- Pre-packaged Sigma rules for common log types
+- Custom rule creation and import
+- Multiple log type support (CloudTrail, VPC Flow, Windows, etc.)
+
+#### Correlation Engine
+- Cross-log-type correlation rules
+- Visual correlation graph
+- Time-window based correlation
+
+#### Threat Intelligence
+- External threat feed integration
+- IOC type support (IP, domain, hash, etc.)
+- Automated scanning of log sources
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security_analytics.correlation_time_window` | Time window for correlations | 5m |
+| `plugins.security_analytics.filter_by_backend_roles` | Enable backend role filtering | false |
+
+## Limitations
+
+- Correlation graph visualization requires sufficient findings data
+- Vega-based visualizations may have compatibility issues in certain environments
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#1313](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1313) | Remove correlated findings bar chart that uses vega |
+| v3.2.0 | [#1312](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1312) | Update API call to get IOC types |
+
+## References
+
+- [Security Analytics Documentation](https://docs.opensearch.org/3.0/security-analytics/)
+- [Setting up Security Analytics](https://docs.opensearch.org/3.0/security-analytics/sec-analytics-config/index/)
+- [Threat Intelligence](https://docs.opensearch.org/3.0/security-analytics/threat-intelligence/index/)
+- [Working with the Correlation Graph](https://docs.opensearch.org/3.0/security-analytics/usage/correlation-graph/)
+- [Security Analytics Settings](https://docs.opensearch.org/3.0/security-analytics/settings/)
+
+## Change History
+
+- **v3.2.0** (2026-01): Bugfixes for correlations page (removed Vega chart) and IOC types API update

--- a/docs/releases/v3.2.0/features/security-analytics-dashboards-plugin/security-analytics-bugfixes.md
+++ b/docs/releases/v3.2.0/features/security-analytics-dashboards-plugin/security-analytics-bugfixes.md
@@ -1,0 +1,81 @@
+# Security Analytics Bugfixes
+
+## Summary
+
+This release includes two bugfixes for the Security Analytics Dashboards plugin that improve the stability and reliability of the correlations page and threat intelligence IOC type retrieval.
+
+## Details
+
+### What's New in v3.2.0
+
+Two critical bugfixes address issues in the Security Analytics Dashboards plugin:
+
+1. **Correlations Page Fix**: Removed the correlated findings bar chart that was causing the correlations page to break due to Vega visualization issues.
+
+2. **IOC Types API Update**: Changed the method for fetching threat intelligence IOC types from a direct `_search` call to using the `searchThreatIntelSource` API, improving reliability and removing dependency on internal index access.
+
+### Technical Changes
+
+#### Correlations Page Fix (PR #1313)
+
+The correlated findings bar chart component using Vega visualization was causing the correlations page to fail. The fix removes this visualization component entirely:
+
+- Removed `renderCorrelatedFindingsChart` method from `CorrelationsTableView.tsx`
+- Removed unused imports (`EuiPanel`, `EuiFlexGroup`, `EuiTitle`, `EuiSpacer`, `EuiEmptyPrompt`, `EuiSmallButton`, `EuiText`, `ChartContainer`, `renderVisualization`)
+- The correlations table functionality remains intact
+
+#### IOC Types API Update (PR #1312)
+
+Changed how IOC (Indicator of Compromise) types are fetched for threat intelligence log source configuration:
+
+| Before | After |
+|--------|-------|
+| Direct `_search` call to `.opensearch-sap-ioc*` index | `searchThreatIntelSource` API call |
+| Required index-level access | Uses service API |
+| Single source of IOC types | Aggregates IOC types from all threat intel sources |
+
+The new implementation:
+1. Calls `threatIntelService.searchThreatIntelSource()`
+2. Iterates through all threat intel sources
+3. Collects unique IOC types using a `Set`
+4. Returns deduplicated array of IOC types
+
+### Usage Example
+
+The IOC types are now fetched through the threat intel service:
+
+```typescript
+const loadIocTypes = async () => {
+  const res = await threatIntelService.searchThreatIntelSource();
+  if (res.ok) {
+    const uniqueIocTypes = new Set<string>();
+    res.response.forEach((threatIntelSource) => {
+      if (threatIntelSource.ioc_types && Array.isArray(threatIntelSource.ioc_types)) {
+        threatIntelSource.ioc_types.forEach((iocType) => uniqueIocTypes.add(iocType));
+      }
+    });
+    setIocTypes(Array.from(uniqueIocTypes));
+  }
+};
+```
+
+## Limitations
+
+- The correlated findings bar chart visualization has been removed; users will need to rely on the correlation graph and table views for visualizing correlated findings.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1313](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1313) | Remove correlated findings bar chart that uses vega |
+| [#1312](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1312) | Update API call to get IOC types |
+
+## References
+
+- [Security Analytics Documentation](https://docs.opensearch.org/3.0/security-analytics/)
+- [Threat Intelligence Documentation](https://docs.opensearch.org/3.0/security-analytics/threat-intelligence/index/)
+- [Working with the Correlation Graph](https://docs.opensearch.org/3.0/security-analytics/usage/correlation-graph/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security-analytics-dashboards-plugin/security-analytics.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -168,6 +168,12 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 |------|----------|-------------|
 | [Flow Framework Bugfixes](features/flow-framework/flow-framework-bugfixes.md) | bugfix | Memory fixes, error handling, 3.1+ API compatibility, race condition fix, default template fixes |
 
+### Security Analytics Dashboards Plugin
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Security Analytics Bugfixes](features/security-analytics-dashboards-plugin/security-analytics-bugfixes.md) | bugfix | Remove Vega-based correlated findings chart, update IOC types API |
+
 ### Multi-Repository
 
 | Item | Category | Description |


### PR DESCRIPTION
## Summary

This PR adds documentation for Security Analytics Bugfixes in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/security-analytics-dashboards-plugin/security-analytics-bugfixes.md`
- Feature report: `docs/features/security-analytics-dashboards-plugin/security-analytics.md`

### Key Changes in v3.2.0

1. **Correlations Page Fix (PR #1313)**: Removed the correlated findings bar chart that was causing the correlations page to break due to Vega visualization issues.

2. **IOC Types API Update (PR #1312)**: Changed the method for fetching threat intelligence IOC types from a direct `_search` call to using the `searchThreatIntelSource` API, improving reliability.

### Resources Used
- PR: [#1313](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1313)
- PR: [#1312](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1312)
- Docs: https://docs.opensearch.org/3.0/security-analytics/

Closes #1073