### PR TITLE
docs: add toast notification bugfix report for v3.2.0

### DIFF
--- a/docs/features/search-relevance/search-relevance-workbench.md
+++ b/docs/features/search-relevance/search-relevance-workbench.md
@@ -149,6 +149,7 @@ The plugin includes test data based on Amazon's ESCI (Shopping Queries Dataset):
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#612](https://github.com/opensearch-project/dashboards-search-relevance/pull/612) | Bug fixes for error messages not render correctly for toast notifications |
 | v3.1.0 | [#533](https://github.com/opensearch-project/opensearch-dashboards-search-relevance/pull/533) | Add search relevance workbench features (Dashboards) |
 | v3.1.0 | [#26](https://github.com/opensearch-project/opensearch-search-relevance/pull/26) | Added new experiment type for hybrid search |
 | v3.1.0 | [#29](https://github.com/opensearch-project/opensearch-search-relevance/pull/29) | Extend data model to adopt different experiment options/parameters |
@@ -191,6 +192,7 @@ The plugin includes test data based on Amazon's ESCI (Shopping Queries Dataset):
 
 ## Change History
 
+- **v3.2.0** (2026-01-10): Fixed toast notification error messages not rendering correctly across multiple UI components
 - **v3.1.0** (2025-06-16): Major feature additions - hybrid search experiment type, feature flag, external judgment import, Stats API, URL path changes, security integration with roles
 - **v3.1.0** (2025-06-16): Bug fixes - data model restructuring, LLM judgment improvements, search request builder fix, hybrid optimizer fix, input validation
 - **v3.1.0** (2025-06-06): Added realistic ESCI-based test dataset with 150 queries and matching judgments

--- a/docs/releases/v3.2.0/features/dashboards-search-relevance/toast-notification-bugfix.md
+++ b/docs/releases/v3.2.0/features/dashboards-search-relevance/toast-notification-bugfix.md
@@ -1,0 +1,83 @@
+# Toast Notification Error Message Bug Fix
+
+## Summary
+
+This bug fix resolves an issue where error messages were not rendering correctly in toast notifications within the Search Relevance Workbench plugin. Previously, when API calls failed, users would see generic error messages instead of the actual error details from the backend, making it difficult to diagnose issues.
+
+## Details
+
+### What's New in v3.2.0
+
+The fix ensures that error messages from backend API responses are properly extracted and displayed in toast notifications across multiple components of the Search Relevance Workbench.
+
+### Technical Changes
+
+#### Root Cause
+
+When the OpenSearch Dashboards HTTP client encounters an error, the actual error message is nested within the `body` property of the error object. The previous implementation passed the entire error object to `notifications.toasts.addError()`, which couldn't properly extract the nested message.
+
+#### Fix Implementation
+
+The fix modifies error handling across 9 files to use optional chaining to extract the error body:
+
+```typescript
+// Before
+notifications.toasts.addError(err, {
+  title: 'Failed to create experiment',
+});
+
+// After
+notifications.toasts.addError(err?.body || err, {
+  title: 'Failed to create experiment',
+});
+```
+
+#### Affected Components
+
+| Component | File | Description |
+|-----------|------|-------------|
+| Template Configuration | `experiment_create/configuration/template_configuration.tsx` | Experiment creation |
+| Evaluation Experiment View | `experiment_view/evaluation_experiment_view.tsx` | Document score processing |
+| Hybrid Optimizer View | `experiment_view/hybrid_optimizer_experiment_view.tsx` | Variant details loading |
+| Judgment Form | `judgment/hooks/use_judgment_form.ts` | Judgment creation |
+| Query Set Table | `query_set/components/query_set_table.tsx` | Pagination options |
+| Query Set Create | `query_set/views/query_set_create.tsx` | Query set creation |
+| Search Configuration Form | `search_configuration/hooks/use_search_configuration_form.ts` | Index fetching and config creation |
+| Search Configuration Listing | `search_configuration/views/search_configuration_listing.tsx` | Pagination options |
+
+### Usage Example
+
+When an error occurs (e.g., authorization failure), users now see the actual error message:
+
+**Before:**
+```
+Error: [object Object]
+```
+
+**After:**
+```
+Error: Search Relevance Workbench is disabled
+```
+
+### Migration Notes
+
+No migration required. This is a transparent bug fix that improves error message visibility.
+
+## Limitations
+
+- The fix relies on the error object having a `body` property containing the error message
+- If the backend returns errors in a different format, the fallback to the original error object is used
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#612](https://github.com/opensearch-project/dashboards-search-relevance/pull/612) | Bug fixes for error messages not render correctly for toast notifications |
+
+## References
+
+- [Issue #547](https://github.com/opensearch-project/dashboards-search-relevance/issues/547): Error messages are not surfaced to search relevance workbench
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-search-relevance/search-relevance-workbench.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -136,6 +136,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 
 | Item | Category | Description |
 |------|----------|-------------|
+| [Toast Notification Bugfix](features/dashboards-search-relevance/toast-notification-bugfix.md) | bugfix | Fix error messages not rendering correctly in toast notifications |
 | [Repository Maintenance](features/dashboards-search-relevance/repository-maintenance.md) | bugfix | Maintainer updates, issue templates, codecov integration, GitHub Actions dependency bumps |
 
 ### Query Insights


### PR DESCRIPTION
## Summary

This PR adds documentation for the toast notification error message bug fix in OpenSearch Dashboards Search Relevance plugin for v3.2.0.

## Changes

### Release Report
- Created `docs/releases/v3.2.0/features/dashboards-search-relevance/toast-notification-bugfix.md`
- Documents the fix for error messages not rendering correctly in toast notifications

### Feature Report Update
- Updated `docs/features/search-relevance/search-relevance-workbench.md`
- Added v3.2.0 PR reference and change history entry

### Release Index Update
- Updated `docs/releases/v3.2.0/index.md`
- Added link to the new release report

## Key Changes in v3.2.0

- Fixed error message extraction from API responses using optional chaining (`err?.body || err`)
- Applied fix across 9 UI components in the Search Relevance Workbench
- Users now see actual error messages instead of `[object Object]`

## Related Issue
- Closes #1072

## Resources Used
- PR: [#612](https://github.com/opensearch-project/dashboards-search-relevance/pull/612)
- Issue: [#547](https://github.com/opensearch-project/dashboards-search-relevance/issues/547)