### PR TITLE
docs: add Search Relevance Bugfixes report for v3.2.0

### DIFF
--- a/docs/features/search-relevance/search-relevance-workbench.md
+++ b/docs/features/search-relevance/search-relevance-workbench.md
@@ -149,6 +149,13 @@ The plugin includes test data based on Amazon's ESCI (Shopping Queries Dataset):
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#578](https://github.com/opensearch-project/dashboards-search-relevance/pull/578) | Improve messaging when backend plugin is disabled |
+| v3.2.0 | [#582](https://github.com/opensearch-project/dashboards-search-relevance/pull/582) | Do not show Pipeline error if there are no pipelines yet |
+| v3.2.0 | [#585](https://github.com/opensearch-project/dashboards-search-relevance/pull/585) | Avoid validation results overflow in Search Configuration creation |
+| v3.2.0 | [#586](https://github.com/opensearch-project/dashboards-search-relevance/pull/586) | Fix wrong unique number of results in Venn diagram |
+| v3.2.0 | [#176](https://github.com/opensearch-project/search-relevance/pull/176) | Bug fix on REST APIs error status for creations |
+| v3.2.0 | [#177](https://github.com/opensearch-project/search-relevance/pull/177) | Added queryText and referenceAnswer text validation from manual input |
+| v3.2.0 | [#187](https://github.com/opensearch-project/search-relevance/pull/187) | Fixed pipeline parameter being ignored in pairwise metrics processing for hybrid |
 | v3.2.0 | [#612](https://github.com/opensearch-project/dashboards-search-relevance/pull/612) | Bug fixes for error messages not render correctly for toast notifications |
 | v3.1.0 | [#533](https://github.com/opensearch-project/opensearch-dashboards-search-relevance/pull/533) | Add search relevance workbench features (Dashboards) |
 | v3.1.0 | [#26](https://github.com/opensearch-project/opensearch-search-relevance/pull/26) | Added new experiment type for hybrid search |
@@ -189,9 +196,16 @@ The plugin includes test data based on Amazon's ESCI (Shopping Queries Dataset):
 - [Issue #95](https://github.com/opensearch-project/search-relevance/issues/95): LLM judgment duplication
 - [Issue #109](https://github.com/opensearch-project/search-relevance/issues/109): Missing variants in Hybrid Optimizer
 - [Issue #114](https://github.com/opensearch-project/search-relevance/issues/114): Input validation
+- [Issue #170](https://github.com/opensearch-project/search-relevance/issues/170): Missing pipeline name in experiments
+- [Issue #186](https://github.com/opensearch-project/search-relevance/issues/186): Input validation for query sets
+- [Issue #529](https://github.com/opensearch-project/dashboards-search-relevance/issues/529): Venn diagram incorrect counts
+- [Issue #543](https://github.com/opensearch-project/dashboards-search-relevance/issues/543): Backend plugin disabled messaging
+- [Issue #557](https://github.com/opensearch-project/dashboards-search-relevance/issues/557): Pipeline error when no pipelines exist
+- [Issue #584](https://github.com/opensearch-project/dashboards-search-relevance/issues/584): Validation results overflow
 
 ## Change History
 
+- **v3.2.0** (2026-01-10): Bug fixes - backend plugin disabled messaging, pipeline error suppression, validation results overflow, Venn diagram statistics, REST API error status, input validation, pipeline parameter fix
 - **v3.2.0** (2026-01-10): Fixed toast notification error messages not rendering correctly across multiple UI components
 - **v3.1.0** (2025-06-16): Major feature additions - hybrid search experiment type, feature flag, external judgment import, Stats API, URL path changes, security integration with roles
 - **v3.1.0** (2025-06-16): Bug fixes - data model restructuring, LLM judgment improvements, search request builder fix, hybrid optimizer fix, input validation

--- a/docs/releases/v3.2.0/features/search-relevance/search-relevance-bugfixes.md
+++ b/docs/releases/v3.2.0/features/search-relevance/search-relevance-bugfixes.md
@@ -1,0 +1,82 @@
+# Search Relevance Bugfixes
+
+## Summary
+
+This release includes 7 bug fixes across the Search Relevance Workbench components (both dashboards-search-relevance and search-relevance repositories). The fixes improve error handling, UI stability, and input validation for the experimental Search Relevance Workbench feature.
+
+## Details
+
+### What's New in v3.2.0
+
+This release focuses on improving the user experience and stability of the Search Relevance Workbench through targeted bug fixes in both the frontend (dashboards-search-relevance) and backend (search-relevance) components.
+
+### Bug Fixes
+
+#### Dashboards Search Relevance (Frontend)
+
+| PR | Fix | Description |
+|----|-----|-------------|
+| [#578](https://github.com/opensearch-project/dashboards-search-relevance/pull/578) | Backend plugin disabled messaging | Improved error messaging when the backend plugin is not enabled, helping users identify configuration issues |
+| [#582](https://github.com/opensearch-project/dashboards-search-relevance/pull/582) | Pipeline error suppression | Suppress false 404 errors when no pipelines exist yet (OpenSearch returns 404 for empty pipeline searches) |
+| [#585](https://github.com/opensearch-project/dashboards-search-relevance/pull/585) | Validation results overflow | Fix horizontal overflow in the validation results table during Search Configuration creation |
+| [#586](https://github.com/opensearch-project/dashboards-search-relevance/pull/586) | Venn diagram statistics | Fix incorrect unique result counts in the eyeballing tool's Venn diagram when switching between queries |
+
+#### Search Relevance (Backend)
+
+| PR | Fix | Description |
+|----|-----|-------------|
+| [#176](https://github.com/opensearch-project/search-relevance/pull/176) | REST API error status | Return proper 4xx status codes instead of 500 for validation errors (e.g., duplicate search configurations in PAIRWISE_COMPARISON) |
+| [#177](https://github.com/opensearch-project/search-relevance/pull/177) | Input validation | Add text validation for queryText and referenceAnswer fields with character limits (name: 50, description: 250, queryText/referenceAnswer: 2000) |
+| [#187](https://github.com/opensearch-project/search-relevance/pull/187) | Pipeline parameter fix | Fix missing pipeline name in pointwise experiments when using hybrid queries with search configurations |
+
+### Technical Changes
+
+#### Frontend Fixes
+
+The Venn diagram fix (#586) addresses a React state synchronization issue where `result1`, `result2`, and `statistics` were updated in separate `useEffect` blocks, causing stale data to be displayed during query transitions. The fix consolidates these updates into a single effect.
+
+#### Backend Fixes
+
+The REST API error status fix (#176) ensures proper HTTP status codes are returned:
+- `BAD_REQUEST (400)` for validation errors like duplicate search configurations
+- Previously returned `INTERNAL_SERVER_ERROR (500)` for these cases
+
+Input validation (#177) adds JSON parsing validation and length checks:
+```java
+// Validation limits
+name: max 50 characters
+description: max 250 characters  
+queryText: max 2000 characters
+referenceAnswer: max 2000 characters
+```
+
+## Limitations
+
+- These fixes are part of the experimental Search Relevance Workbench feature
+- Backend plugin must be enabled via cluster settings for full functionality
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#578](https://github.com/opensearch-project/dashboards-search-relevance/pull/578) | dashboards-search-relevance | Improve messaging when backend plugin is disabled |
+| [#582](https://github.com/opensearch-project/dashboards-search-relevance/pull/582) | dashboards-search-relevance | Do not show Pipeline error if there are no pipelines yet |
+| [#585](https://github.com/opensearch-project/dashboards-search-relevance/pull/585) | dashboards-search-relevance | Avoid validation results overflow in Search Configuration creation |
+| [#586](https://github.com/opensearch-project/dashboards-search-relevance/pull/586) | dashboards-search-relevance | Fix wrong unique number of results in Venn diagram |
+| [#176](https://github.com/opensearch-project/search-relevance/pull/176) | search-relevance | Bug fix on REST APIs error status for creations |
+| [#177](https://github.com/opensearch-project/search-relevance/pull/177) | search-relevance | Added queryText and referenceAnswer text validation from manual input |
+| [#187](https://github.com/opensearch-project/search-relevance/pull/187) | search-relevance | Fixed pipeline parameter being ignored in pairwise metrics processing for hybrid |
+
+## References
+
+- [Issue #543](https://github.com/opensearch-project/dashboards-search-relevance/issues/543): Backend plugin disabled messaging
+- [Issue #557](https://github.com/opensearch-project/dashboards-search-relevance/issues/557): Pipeline error when no pipelines exist
+- [Issue #584](https://github.com/opensearch-project/dashboards-search-relevance/issues/584): Validation results overflow
+- [Issue #529](https://github.com/opensearch-project/dashboards-search-relevance/issues/529): Venn diagram incorrect counts
+- [Issue #186](https://github.com/opensearch-project/search-relevance/issues/186): Input validation for query sets
+- [Issue #170](https://github.com/opensearch-project/search-relevance/issues/170): Missing pipeline name in experiments
+- [OpenSearch Issue #15917](https://github.com/opensearch-project/OpenSearch/issues/15917): 404 when searching for pipelines when none exist
+
+## Related Feature Report
+
+- [Search Relevance Workbench](../../../features/search-relevance/search-relevance-workbench.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -139,6 +139,12 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [Toast Notification Bugfix](features/dashboards-search-relevance/toast-notification-bugfix.md) | bugfix | Fix error messages not rendering correctly in toast notifications |
 | [Repository Maintenance](features/dashboards-search-relevance/repository-maintenance.md) | bugfix | Maintainer updates, issue templates, codecov integration, GitHub Actions dependency bumps |
 
+### Search Relevance
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Search Relevance Bugfixes](features/search-relevance/search-relevance-bugfixes.md) | bugfix | 7 bug fixes: error messaging, pipeline errors, UI overflow, Venn diagram, REST API status, input validation, pipeline parameter |
+
 ### Query Insights
 
 | Item | Category | Description |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Search Relevance Bugfixes in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/search-relevance/search-relevance-bugfixes.md`
- Feature report updated: `docs/features/search-relevance/search-relevance-workbench.md`

### Key Changes in v3.2.0

**Dashboards Search Relevance (Frontend):**
- Improved error messaging when backend plugin is disabled (#578)
- Suppress false 404 errors when no pipelines exist (#582)
- Fix horizontal overflow in validation results table (#585)
- Fix incorrect Venn diagram statistics when switching queries (#586)

**Search Relevance (Backend):**
- Return proper 4xx status codes instead of 500 for validation errors (#176)
- Add text validation for queryText and referenceAnswer fields (#177)
- Fix missing pipeline name in pointwise experiments (#187)

### Related Issue
Closes #1071