### PR TITLE
docs: add Reporting Plugin bugfixes report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -216,6 +216,7 @@
 - [Integration Test Stability](reporting/integration-test-stability.md)
 - [Java Agent Migration](reporting/java-agent-migration.md)
 - [Release Maintenance](reporting/release-maintenance.md)
+- [Reporting Plugin](reporting/reporting-plugin.md)
 
 ## dashboards-reporting
 

--- a/docs/features/reporting/reporting-plugin.md
+++ b/docs/features/reporting/reporting-plugin.md
@@ -1,0 +1,127 @@
+# Reporting Plugin
+
+## Summary
+
+The OpenSearch Reporting plugin enables users to export and automate reports from OpenSearch Dashboards in PDF, PNG, and CSV formats. It provides both on-demand report generation and scheduled reporting capabilities, integrating with the OpenSearch security model for access control.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        UI[Dashboards UI] --> RP[Reporting Plugin]
+        RP --> CM[Context Menu]
+        RP --> RL[Report List]
+    end
+    
+    subgraph "OpenSearch"
+        RS[Reports Scheduler Plugin] --> RDI[Report Definitions Index]
+        RS --> RII[Report Instances Index]
+        RS --> JS[Job Scheduler]
+    end
+    
+    subgraph "Report Generation"
+        CM --> |On-demand| GEN[Report Generator]
+        JS --> |Scheduled| GEN
+        GEN --> PDF[PDF/PNG via Headless Browser]
+        GEN --> CSV[CSV via Query]
+    end
+    
+    UI --> RS
+    RP --> RS
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "User Request"
+        U[User] --> |Generate Report| D[Dashboards]
+    end
+    
+    subgraph "Processing"
+        D --> |API Call| S[Scheduler Plugin]
+        S --> |Create Instance| I[Report Instance]
+        S --> |Execute| G[Generator]
+    end
+    
+    subgraph "Output"
+        G --> |Render| R[Report File]
+        R --> |Download| U
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `dashboards-reporting` | OpenSearch Dashboards plugin for UI and report generation |
+| `reporting` | OpenSearch plugin for scheduling and managing report definitions |
+| `ReportDefinitionsIndex` | System index storing report definition configurations |
+| `ReportInstancesIndex` | System index storing generated report instances |
+| `Job Scheduler` | Handles scheduled report execution |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `opensearch_security.cookie.secure` | Secure cookie for authentication | `true` |
+| `opensearch.requestTimeout` | Timeout for report generation requests | `300000` |
+| `server.maxPayloadBytes` | Maximum payload size for reports | `10485760` |
+
+### System Indices
+
+| Index | Description |
+|-------|-------------|
+| `.opendistro-reports-definitions` | Stores report definition configurations |
+| `.opendistro-reports-instances` | Stores generated report metadata and status |
+
+### Usage Example
+
+Generate a CSV report from a saved search:
+
+1. Navigate to Discover
+2. Open a saved search
+3. Click "Reporting" in the top menu
+4. Select "Generate CSV"
+5. Download the generated report
+
+### Security Integration
+
+The Reporting plugin integrates with OpenSearch Security:
+
+- Report definitions respect document-level security (DLS)
+- Field-level security (FLS) is applied to CSV exports
+- Multi-tenancy support for isolated report management
+- System indices are created in system context to avoid permission issues
+
+## Limitations
+
+- CSV reports have a 10,000-row limit in OpenSearch version 2.16 and earlier
+- PDF/PNG generation requires a headless browser (Chromium)
+- Large reports may timeout depending on cluster configuration
+- Report scheduling requires the Job Scheduler plugin
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#1108](https://github.com/opensearch-project/reporting/pull/1108) | Create report indices in system context to avoid permission issues |
+| v3.2.0 | [#599](https://github.com/opensearch-project/dashboards-reporting/pull/599) | Fix tenant URL parsing when generating reports from Discover |
+
+## References
+
+- [Reporting Documentation](https://docs.opensearch.org/3.0/reporting/): Official OpenSearch Reporting documentation
+- [Reporting CLI](https://docs.opensearch.org/3.0/reporting/rep-cli-index/): Command-line interface for report generation
+- [Issue #998](https://github.com/opensearch-project/reporting/issues/998): Permission issue when creating reporting indices
+- [Issue #535](https://github.com/opensearch-project/dashboards-reporting/issues/535): Tenant URL parsing bug
+- [OpenSearch Reporting 101](https://opensearch.org/blog/feature-highlight-reporting/): Feature highlight blog post
+- [Reporting Repository](https://github.com/opensearch-project/reporting): Backend plugin repository
+- [Dashboards Reporting Repository](https://github.com/opensearch-project/dashboards-reporting): Frontend plugin repository
+
+## Change History
+
+- **v3.2.0** (2026-01-11): Fixed system index creation permissions and tenant URL parsing
+- **v3.1.0** (2025-06-13): Version increment and release notes maintenance

--- a/docs/releases/v3.2.0/features/reporting/reporting-plugin.md
+++ b/docs/releases/v3.2.0/features/reporting/reporting-plugin.md
@@ -1,0 +1,101 @@
+# Reporting Plugin
+
+## Summary
+
+OpenSearch v3.2.0 includes two bug fixes for the Reporting plugin that address permission issues when creating report indices and URL parsing problems when generating reports from Discover with security tenants enabled.
+
+## Details
+
+### What's New in v3.2.0
+
+Two critical bug fixes improve the reliability of report generation:
+
+1. **System Index Creation Permission Fix**: Report definitions and instances indices are now created in the system context, eliminating permission errors for users without explicit index creation privileges.
+
+2. **Tenant URL Parsing Fix**: Fixed URL parsing logic to correctly extract saved search IDs when security tenant parameters are present in the URL.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before Fix"
+        U1[User Request] --> RC1[Report Creation]
+        RC1 --> IC1[Index Creation]
+        IC1 --> |Permission Check| SEC1[Security Plugin]
+        SEC1 --> |Denied| ERR1[Permission Error]
+    end
+    
+    subgraph "After Fix"
+        U2[User Request] --> RC2[Report Creation]
+        RC2 --> SC[System Context]
+        SC --> IC2[Index Creation]
+        IC2 --> |Bypasses User Permissions| IDX[Index Created]
+    end
+```
+
+#### Bug Fix 1: System Context for Index Creation (PR #1108)
+
+The fix wraps index creation operations in a system context using `threadContext.stashContext()`:
+
+```kotlin
+// Before: Direct index creation (subject to user permissions)
+val actionFuture = client.admin().indices().create(request)
+
+// After: Index creation in system context (bypasses user permissions)
+client.threadPool().threadContext.stashContext().use {
+    val actionFuture = client.admin().indices().create(request)
+    // ...
+}
+```
+
+**Affected Files:**
+- `ReportDefinitionsIndex.kt` - Report definitions system index
+- `ReportInstancesIndex.kt` - Report instances system index
+
+**Root Cause:** When a user without `indices:admin/create` permission tried to generate their first report, the plugin attempted to create the system indices (`.opendistro-reports-definitions`, `.opendistro-reports-instances`) using the user's security context, resulting in permission denied errors.
+
+#### Bug Fix 2: Tenant URL Parsing (PR #599)
+
+The fix removes security tenant parameters from the URL before extracting the saved search ID:
+
+```javascript
+// Before: Regex matched 'discover' instead of the UUID
+const getUuidFromUrl = () => window.location.href.match(/([0-9a-zA-Z-]+)\?/);
+
+// After: Remove tenant parameter first
+const getUuidFromUrl = () => {
+  let href = window.location.href;
+  href = href.replace(/[?&]security_tenant=[^&#]*/g, '');
+  return href.match(/([0-9a-zA-Z-]+)\?/);
+};
+```
+
+**Root Cause:** URLs like `discover?security_tenant=global#/view/3ba638e0-b894-11e8-a6d9-e546fe2bba5f` were incorrectly parsed, extracting `discover` instead of the actual saved search ID `3ba638e0-b894-11e8-a6d9-e546fe2bba5f`.
+
+### Migration Notes
+
+No migration required. These are transparent bug fixes that improve existing functionality.
+
+## Limitations
+
+- The system context fix only applies to index creation; other operations still respect user permissions
+- The URL parsing fix specifically handles the `security_tenant` parameter; other query parameters may still interfere
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1108](https://github.com/opensearch-project/reporting/pull/1108) | Create report definitions and instances indices in system context |
+| [#599](https://github.com/opensearch-project/dashboards-reporting/pull/599) | Fix tenant issue when redirecting from Discover |
+
+## References
+
+- [Issue #998](https://github.com/opensearch-project/reporting/issues/998): Can't create reporting indices due to permission issue
+- [Issue #535](https://github.com/opensearch-project/dashboards-reporting/issues/535): Saved search id parsing logic does not consider tenant in URL
+- [Reporting Documentation](https://docs.opensearch.org/3.0/reporting/): Official OpenSearch Reporting documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/reporting/reporting-plugin.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -181,6 +181,12 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 |------|----------|-------------|
 | [Security Analytics Bugfixes](features/security-analytics-dashboards-plugin/security-analytics-bugfixes.md) | bugfix | Remove Vega-based correlated findings chart, update IOC types API |
 
+### Reporting
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Reporting Plugin](features/reporting/reporting-plugin.md) | bugfix | System context for index creation, tenant URL parsing fix |
+
 ### Multi-Repository
 
 | Item | Category | Description |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Reporting Plugin bugfixes in OpenSearch v3.2.0.

## Changes

### Release Report
- `docs/releases/v3.2.0/features/reporting/reporting-plugin.md`

### Feature Report
- `docs/features/reporting/reporting-plugin.md`

## Bug Fixes Documented

1. **System Context for Index Creation** (PR #1108)
   - Report definitions and instances indices are now created in system context
   - Fixes permission errors for users without `indices:admin/create` permission

2. **Tenant URL Parsing Fix** (PR #599)
   - Fixed URL parsing to correctly extract saved search IDs when security tenant parameters are present
   - Resolves report generation failures from Discover with multi-tenancy enabled

## Related Issue
Closes #1070