### PR TITLE
docs: add Query Insights Bugfixes report for v3.2.0

### DIFF
--- a/docs/features/query-insights/query-insights.md
+++ b/docs/features/query-insights/query-insights.md
@@ -190,6 +190,13 @@ GET /_insights/live_queries?sort=latency&size=5
 | v3.2.0 | [#393](https://github.com/opensearch-project/query-insights/pull/393) | Fix codecov configuration |
 | v3.2.0 | [#394](https://github.com/opensearch-project/query-insights/pull/394) | Migrate to codecov v3 |
 | v3.2.0 | [#395](https://github.com/opensearch-project/query-insights/pull/395) | Add release notes for 3.2.0 |
+| v3.2.0 | [#217](https://github.com/opensearch-project/query-insights-dashboards/pull/217) | MDS support for Inflight Queries |
+| v3.2.0 | [#243](https://github.com/opensearch-project/query-insights-dashboards/pull/243) | react-vis implementation for Live Queries Dashboards |
+| v3.2.0 | [#247](https://github.com/opensearch-project/query-insights-dashboards/pull/247) | Revert renderApp to use default export |
+| v3.2.0 | [#258](https://github.com/opensearch-project/query-insights-dashboards/pull/258) | Fix for UI bugs (number formatting, validation, refresh button) |
+| v3.2.0 | [#267](https://github.com/opensearch-project/query-insights-dashboards/pull/267) | Search bar fix for Top N Queries page |
+| v3.2.0 | [#285](https://github.com/opensearch-project/query-insights-dashboards/pull/285) | Fix top queries table sorting with correct id |
+| v3.2.0 | [#306](https://github.com/opensearch-project/query-insights-dashboards/pull/306) | Removed search bar Cypress tests |
 | v3.1.0 | [#326](https://github.com/opensearch-project/query-insights/pull/326) | Add metric labels to historical data |
 | v3.1.0 | [#336](https://github.com/opensearch-project/query-insights/pull/336) | Consolidate grouping settings |
 | v3.1.0 | [#308](https://github.com/opensearch-project/query-insights/pull/308) | Add setting to exclude certain indices |
@@ -246,7 +253,7 @@ GET /_insights/live_queries?sort=latency&size=5
 
 ## Change History
 
-- **v3.2.0**: Increased reader search limit to 500 and fixed sort by metric type; infrastructure updates including Maven endpoint migration, Gradle and Java version bumps; codecov configuration fixes
+- **v3.2.0**: Increased reader search limit to 500 and fixed sort by metric type; infrastructure updates including Maven endpoint migration, Gradle and Java version bumps; codecov configuration fixes; **Dashboards**: replaced Vega with react-vis for Live Queries visualizations to fix build errors; fixed search bar on Top N Queries page to properly filter by query ID; fixed table sorting with ID-based deduplication; added MDS support for Inflight Queries; multiple UI bug fixes including number formatting, validation messages, refresh button, and box plot updates; removed flaky Cypress tests for search bar
 - **v3.1.0**: Added metric labels to historical data for filtering by metric type; consolidated grouping settings under `grouping.*` namespace; added `excluded_indices` setting to filter indices from insights; refactored local index reader to use asynchronous operations; added `is_cancelled` field to Live Queries API; new Live Queries Dashboard with real-time monitoring, auto-refresh, visual breakdowns, and query cancellation; new Workload Management Dashboard for query group management; fixed duplicate API requests on overview page; fixed node-level top queries request parameter serialization bug; improved Cypress test stability; fixed CI version mismatch; added multi-node cluster integration tests
 - **v3.0.0**: Added Live Queries API, default index template, verbose parameter, profile query filtering, strict hash check
 - **v2.18.0**: Added Health Stats API for monitoring plugin health; added OpenTelemetry error metrics counters; added field name and type support for query shape grouping (defaults changed to `true`); added time range parameters for historical query retrieval; added cache eviction and cluster state listener for index field type mappings

--- a/docs/releases/v3.2.0/features/query-insights-dashboards/query-insights-bugfixes.md
+++ b/docs/releases/v3.2.0/features/query-insights-dashboards/query-insights-bugfixes.md
@@ -1,0 +1,115 @@
+# Query Insights Bugfixes
+
+## Summary
+
+This release item addresses multiple UI bugs and improvements in the Query Insights Dashboards plugin for OpenSearch v3.2.0. The fixes include replacing the Vega charting library with react-vis to resolve build errors, fixing the search bar functionality on the Top N Queries page, improving table sorting with correct ID-based deduplication, and various UI polish improvements including number formatting, validation messages, and refresh functionality.
+
+## Details
+
+### What's New in v3.2.0
+
+This release focuses on stability and usability improvements for the Query Insights Dashboards plugin:
+
+1. **Charting Library Migration**: Replaced Vega with react-vis for Live Queries visualizations
+2. **Search Bar Fix**: Fixed search functionality on Top N Queries overview page
+3. **Table Sorting Fix**: Improved deduplication logic using query IDs instead of JSON strings
+4. **UI Bug Fixes**: Multiple improvements to the detail page and rule creation workflow
+5. **Test Maintenance**: Removed flaky Cypress tests for search bar due to framework limitations
+
+### Technical Changes
+
+#### Charting Library Migration (PR #243)
+
+The Live Queries Dashboard previously used Vega for visualizations, which caused build errors in the distribution:
+
+```
+TypeError: vegaUtil.inherits is not a function
+```
+
+The fix replaces Vega with react-vis, a React-based visualization library that integrates better with the OpenSearch Dashboards build system.
+
+#### Search Bar Fix (PR #267)
+
+The search bar on the Top N Queries overview page was not functioning correctly:
+
+**Problem:**
+- When users entered a query record ID, the table results did not update
+- The `onSearchChange` handler was not properly parsing the AST for free-text terms
+
+**Solution:**
+- Fixed `onSearchChange` to correctly parse AST for free-text terms and update `searchText` state
+- Updated `filteredQueries` computation to properly filter by the ID column
+- Added placeholder text indicating the search bar applies to the ID column only
+
+#### Table Sorting Fix (PR #285)
+
+The deduplication logic for the top queries table was error-prone when using JSON string comparison:
+
+**Before:**
+```typescript
+// Error-prone JSON string comparison
+const uniqueQueries = [...new Set(queries.map(q => JSON.stringify(q)))];
+```
+
+**After:**
+```typescript
+// Reliable ID-based deduplication
+const uniqueQueries = [...new Map(queries.map(q => [q.id, q])).values()];
+```
+
+#### UI Bug Fixes (PR #258)
+
+Multiple UI improvements for better user experience:
+
+| Fix | Description |
+|-----|-------------|
+| Number formatting | Large numbers now formatted for readability on Detail page |
+| Validation messages | Added validation for invalid CPU/Memory usage inputs |
+| Error suppression | Suppressed unnecessary error for empty rule input during creation |
+| Description display | Fixed edge case where description was not displayed correctly |
+| Refresh button | Added Refresh button and "Last updated" timestamp to Detail page |
+| Normalized limits | Normalized CPU/memory limits display |
+| Box plot update | Updated box plot visualization |
+
+#### Cypress Test Removal (PR #306)
+
+Removed Cypress tests for the search bar functionality due to a known Cypress framework issue where the enter key event is not properly triggered after typing in the search bar. This is a documented Cypress limitation ([cypress-io/cypress#8267](https://github.com/cypress-io/cypress/issues/8267)).
+
+### Revert: renderApp Export (PR #247)
+
+Reverted PR #223 which changed `renderApp` to use default export. The original change was intended to prevent initialization race conditions but caused other issues.
+
+### MDS Support for Inflight Queries (PR #217)
+
+While labeled as an improvement, this PR adds Multi-Data Source (MDS) support to the Inflight Queries component:
+
+- Integrated data source selection via `DataSourceContext`
+- Unit tests wrapped with `DataSourceContext.Provider` to simulate data source selection
+
+## Limitations
+
+- Search bar on Top N Queries page only searches by query ID column
+- Cypress tests for search bar functionality are disabled due to framework limitations
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#217](https://github.com/opensearch-project/query-insights-dashboards/pull/217) | MDS support for Inflight Queries |
+| [#243](https://github.com/opensearch-project/query-insights-dashboards/pull/243) | react-vis implementation for Live Queries Dashboards |
+| [#247](https://github.com/opensearch-project/query-insights-dashboards/pull/247) | Revert renderApp to use default export |
+| [#258](https://github.com/opensearch-project/query-insights-dashboards/pull/258) | Fix for UI bugs |
+| [#267](https://github.com/opensearch-project/query-insights-dashboards/pull/267) | Search bar fix |
+| [#285](https://github.com/opensearch-project/query-insights-dashboards/pull/285) | Fix top queries table sorting with correct id |
+| [#306](https://github.com/opensearch-project/query-insights-dashboards/pull/306) | Removed search bar Cypress tests |
+
+## References
+
+- [Issue #214](https://github.com/opensearch-project/query-insights-dashboards/issues/214): Search bar not working
+- [Issue #152](https://github.com/opensearch-project/query-insights-dashboards/issues/152): MDS support for Live Queries
+- [Cypress Issue #8267](https://github.com/cypress-io/cypress/issues/8267): Enter key not triggered after typing
+- [Query Insights Dashboards Documentation](https://docs.opensearch.org/3.2/observing-your-data/query-insights/query-insights-dashboard/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/query-insights/query-insights.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -151,6 +151,12 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 |------|----------|-------------|
 | [Release Notes & Documentation](features/query-insights/release-notes-documentation.md) | bugfix | Release notes for v3.2.0 with reader search limit increase and infrastructure updates |
 
+### Query Insights Dashboards
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Query Insights Bugfixes](features/query-insights-dashboards/query-insights-bugfixes.md) | bugfix | react-vis migration, search bar fix, table sorting fix, UI improvements |
+
 ### SQL
 
 | Item | Category | Description |


### PR DESCRIPTION
## Summary

This PR adds documentation for Query Insights Dashboards bugfixes in OpenSearch v3.2.0.

## Changes

### Release Report Created
- `docs/releases/v3.2.0/features/query-insights-dashboards/query-insights-bugfixes.md`

### Feature Report Updated
- `docs/features/query-insights/query-insights.md` - Added v3.2.0 dashboard PRs and updated change history

### Release Index Updated
- `docs/releases/v3.2.0/index.md` - Added Query Insights Dashboards section

## Key Changes in v3.2.0

- **Charting Library Migration**: Replaced Vega with react-vis for Live Queries visualizations to fix build errors
- **Search Bar Fix**: Fixed search functionality on Top N Queries page to properly filter by query ID
- **Table Sorting Fix**: Improved deduplication logic using query IDs instead of JSON strings
- **UI Bug Fixes**: Number formatting, validation messages, refresh button, box plot updates
- **MDS Support**: Added Multi-Data Source support for Inflight Queries
- **Test Maintenance**: Removed flaky Cypress tests for search bar due to framework limitations

## Related PRs
- #217, #243, #247, #258, #267, #285, #306

Closes #1069