### PR TITLE
docs: add observability-bugfixes report for v3.2.0

### DIFF
--- a/docs/features/dashboards-observability/trace-analytics.md
+++ b/docs/features/dashboards-observability/trace-analytics.md
@@ -140,6 +140,8 @@ http://host:port/app/observability-traces#/services
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#2475](https://github.com/opensearch-project/dashboards-observability/pull/2475) | [Bug] Traces error display - fix nested status.code handling |
+| v3.2.0 | [#2478](https://github.com/opensearch-project/dashboards-observability/pull/2478) | [Bug] Fixed metrics viz not showing up in local cluster |
 | v3.1.0 | [#2457](https://github.com/opensearch-project/dashboards-observability/pull/2457) | Merge custom source and data prepper mode |
 | v3.1.0 | [#2450](https://github.com/opensearch-project/dashboards-observability/pull/2450) | Span Flyout - support new format with nested field flattening |
 | v3.0.0 | [#2375](https://github.com/opensearch-project/dashboards-observability/pull/2375) | Support custom logs correlation |
@@ -169,6 +171,7 @@ http://host:port/app/observability-traces#/services
 
 ## Change History
 
+- **v3.2.0** (2026-02-18): Bug fixes for traces error display (nested status.code handling) and metrics visualization rendering in local cluster instances
 - **v3.1.0** (2026-01-21): Merged custom source mode into default Data Prepper mode, span flyout support for new Data Prepper format with nested field flattening, unified experience with cross-cluster search, custom indices, data grid, and dynamic filters
 - **v3.0.0** (2025-02-25): Custom logs correlation, data grid migration, OTEL attributes support, service view optimizations, Amazon Network Firewall integration, trace-to-logs correlation improvements
 - **v2.17.0** (2024-09-17): Custom source support (experimental) for custom span/service indices with CCS support, landing page changed to Traces, Multi-Data Source bug fixes, URL routing fixes, breadcrumb navigation improvements

--- a/docs/releases/v3.2.0/features/dashboards-observability/observability-bugfixes.md
+++ b/docs/releases/v3.2.0/features/dashboards-observability/observability-bugfixes.md
@@ -1,0 +1,78 @@
+# Observability Bugfixes
+
+## Summary
+
+This release includes two bug fixes for the Dashboards Observability plugin that address issues with trace error display and metrics visualization rendering. These fixes improve the reliability of trace analytics error detection and ensure metrics visualizations display correctly in local cluster instances.
+
+## Details
+
+### What's New in v3.2.0
+
+Two bug fixes addressing critical display issues in the Observability plugin:
+
+1. **Traces Error Display Fix**: Improved error detection for traces using nested `status.code` field format
+2. **Metrics Visualization Fix**: Fixed metrics visualizations not rendering in local cluster instances
+
+### Technical Changes
+
+#### Traces Error Display (PR #2475)
+
+The fix addresses error display issues when trace data uses nested field format (`status.code`) instead of flat format (`status.code` as string key).
+
+**Changes to `trace_view_helpers.tsx`:**
+- Added fallback check for individual span errors when trace group error is not found
+- Now checks both `span._source.status?.code === 2` and `span._source['status.code'] === 2`
+
+**Changes to `traces_request_handler.ts`:**
+- Updated error detection to handle both nested and flat status code formats
+- Condition changed from `hit._source['status.code'] === 2` to `hit._source.status?.code === 2 || hit._source['status.code'] === 2`
+
+**Changes to `traces_custom_indices_table.tsx`:**
+- Exported `resolveFieldValue` function for testing
+- Added `getNestedValue` helper for resolving nested field paths like `status.code`
+- Enhanced field resolution to support nested object traversal
+
+#### Metrics Visualization Fix (PR #2478)
+
+Fixed metrics visualizations not appearing in local cluster instances by ensuring the `dataSourceMDSId` parameter is properly handled.
+
+**Changes to `custom_panels/helpers/utils.tsx`:**
+- Changed `dataSourceMDSId` to `dataSourceMDSId ?? ''` to provide empty string fallback when undefined
+- Prevents API call failures when Multi-Data Source ID is not set
+
+### Usage Example
+
+The fixes are automatic and require no configuration changes. Error indicators now correctly display in:
+
+1. **Trace Table**: Error column shows warning icon for traces with errors
+2. **Gantt Chart**: Span labels include "⚠ Error" suffix for error spans
+
+```typescript
+// Error detection now handles both formats:
+// Format 1: Nested object
+{ status: { code: 2 } }
+
+// Format 2: Flat key (legacy)
+{ 'status.code': 2 }
+```
+
+## Limitations
+
+- Error detection relies on status code value of `2` (OTel ERROR status)
+- Metrics visualization fix only affects local cluster instances without MDS configuration
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2475](https://github.com/opensearch-project/dashboards-observability/pull/2475) | [Bug] Traces error display |
+| [#2478](https://github.com/opensearch-project/dashboards-observability/pull/2478) | [Bug] Fixed metrics viz not showing up |
+
+## References
+
+- [Trace Analytics Documentation](https://docs.opensearch.org/3.2/observing-your-data/trace/ta-dashboards/): Official trace analytics guide
+- [Data Prepper OTel Span Template](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/opensearch/src/main/resources/index-template/otel-v1-apm-span-index-standard-template.json): New Data Prepper format reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-observability/trace-analytics.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -100,6 +100,12 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 |------|----------|-------------|
 | [Observability Infrastructure](features/observability/observability-infrastructure.md) | bugfix | Maven snapshot publishing migration, Gradle 8.14.3 upgrade, JDK24 CI support |
 
+### Dashboards Observability
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Observability Bugfixes](features/dashboards-observability/observability-bugfixes.md) | bugfix | Traces error display fix (nested status.code), metrics visualization fix for local cluster |
+
 ### Geospatial
 
 | Item | Category | Description |


### PR DESCRIPTION
## Summary

Add release report for Observability Bugfixes in v3.2.0.

### Changes
- Created release report: `docs/releases/v3.2.0/features/dashboards-observability/observability-bugfixes.md`
- Updated feature report: `docs/features/dashboards-observability/trace-analytics.md`
- Updated release index: `docs/releases/v3.2.0/index.md`

### PRs Investigated
- [#2475](https://github.com/opensearch-project/dashboards-observability/pull/2475): Traces error display fix
- [#2478](https://github.com/opensearch-project/dashboards-observability/pull/2478): Metrics visualization fix

### Key Findings
1. **Traces Error Display**: Fixed error detection for nested `status.code` field format in trace data
2. **Metrics Visualization**: Fixed metrics not rendering in local cluster by handling undefined `dataSourceMDSId`

Closes #1068