### PR TITLE
docs: add dashboards-core-bugfixes report for v3.2.0

### DIFF
--- a/docs/features/dashboards-assistant/dashboards-core-bugfixes.md
+++ b/docs/features/dashboards-assistant/dashboards-core-bugfixes.md
@@ -1,0 +1,84 @@
+# Dashboards Core Bugfixes
+
+## Summary
+
+This document tracks bugfixes and maintenance changes to the OpenSearch Dashboards Assistant plugin's core testing infrastructure. These fixes ensure reliable unit test execution in Jest environments.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Test Environment"
+        Jest[Jest Test Runner]
+        JSDom[jsdom Environment]
+        SetupTests[setupTests.ts]
+    end
+    
+    subgraph "Mocks"
+        WorkerMock[Worker Mock]
+        MonacoMock[Monaco Editor Mock]
+    end
+    
+    subgraph "Components Under Test"
+        NLQFactory[NLQVisualizationEmbeddableFactory]
+        Monaco[react-monaco-editor]
+    end
+    
+    Jest --> JSDom
+    JSDom --> SetupTests
+    SetupTests --> WorkerMock
+    NLQFactory --> Monaco
+    Monaco -.->|requires| WorkerMock
+    MonacoMock -.->|replaces| Monaco
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `test/setupTests.ts` | Global test setup file that configures the Jest environment |
+| `Worker` mock | No-op implementation of Web Worker API for jsdom |
+| Monaco editor mock | Jest mock that replaces react-monaco-editor with null component |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `window.Worker` | Global Worker constructor mock | Empty function |
+
+### Usage Example
+
+```typescript
+// In test files that use Monaco editor
+jest.mock('react-monaco-editor', () => () => null);
+
+describe('ComponentUsingMonaco', () => {
+  it('should work without Worker errors', () => {
+    // Test code here
+  });
+});
+```
+
+## Limitations
+
+- Worker mock does not provide actual Web Worker functionality
+- Monaco editor mock returns null, so tests cannot verify Monaco-specific behavior
+- Tests requiring real Worker behavior need additional setup
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#593](https://github.com/opensearch-project/dashboards-assistant/pull/593) | Fix failed unit tests due to missing Worker |
+
+## References
+
+- [PR #593](https://github.com/opensearch-project/dashboards-assistant/pull/593): Initial fix implementation
+- [OpenSearch Dashboards Assistant](https://github.com/opensearch-project/dashboards-assistant): Repository
+- [Jest jsdom Environment](https://jestjs.io/docs/configuration#testenvironment-string): Jest documentation
+
+## Change History
+
+- **v3.2.0**: Added Worker mock and Monaco editor mock to fix unit test failures

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -381,6 +381,7 @@
 - [AI Assistant / Chatbot](dashboards-assistant/ai-assistant-chatbot.md)
 - [CI Configuration](dashboards-assistant/ci-configuration.md)
 - [Dashboards Assistant](dashboards-assistant/dashboards-assistant.md)
+- [Dashboards Core Bugfixes](dashboards-assistant/dashboards-core-bugfixes.md)
 - [Text to Visualization (t2viz)](dashboards-assistant/text-to-visualization.md)
 
 ## k-nn

--- a/docs/releases/v3.2.0/features/dashboards-assistant/dashboards-core-bugfixes.md
+++ b/docs/releases/v3.2.0/features/dashboards-assistant/dashboards-core-bugfixes.md
@@ -1,0 +1,69 @@
+# Dashboards Core Bugfixes
+
+## Summary
+
+This release fixes unit test failures in the OpenSearch Dashboards Assistant plugin caused by missing Web Worker support in the Jest test environment. The fix ensures that tests for the NLQ (Natural Language Query) visualization embeddable component run successfully.
+
+## Details
+
+### What's New in v3.2.0
+
+This bugfix addresses test infrastructure issues that were causing unit tests to fail when running in Jest's jsdom environment.
+
+### Technical Changes
+
+#### Problem
+
+Unit tests for the `NLQVisualizationEmbeddableFactory` component were failing because:
+1. The `react-monaco-editor` component requires Web Worker support
+2. Jest's jsdom environment does not provide a native `Worker` implementation
+3. The Monaco editor (used for code/query editing) relies on Web Workers for syntax highlighting and language services
+
+#### Solution
+
+The fix adds two changes to the test setup:
+
+1. **Global Worker Mock** (`test/setupTests.ts`):
+   ```typescript
+   // @ts-ignore
+   window.Worker = function () {};
+   ```
+   This provides a no-op Worker constructor globally for all tests.
+
+2. **Monaco Editor Mock** (`nlq_vis_embeddable_factory.test.ts`):
+   ```typescript
+   jest.mock('react-monaco-editor', () => () => null);
+   ```
+   This mocks the Monaco editor component to return null, avoiding Worker-related errors.
+
+#### Files Changed
+
+| File | Change |
+|------|--------|
+| `test/setupTests.ts` | Added fake Worker constructor |
+| `public/components/visualization/embeddable/nlq_vis_embeddable_factory.test.ts` | Added Monaco editor mock |
+| `CHANGELOG.md` | Added changelog entry |
+
+### Usage Example
+
+No user-facing changes. This fix only affects the development and CI/CD test environment.
+
+## Limitations
+
+- The Worker mock is a no-op implementation and does not provide actual Web Worker functionality
+- Tests that rely on real Worker behavior would need additional mocking
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#593](https://github.com/opensearch-project/dashboards-assistant/pull/593) | Fix failed unit tests due to missing Worker |
+
+## References
+
+- [PR #593](https://github.com/opensearch-project/dashboards-assistant/pull/593): Main implementation
+- [OpenSearch Dashboards Assistant](https://github.com/opensearch-project/dashboards-assistant): Repository
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-assistant/dashboards-core-bugfixes.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -199,6 +199,12 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 |------|----------|-------------|
 | [Reporting Plugin](features/reporting/reporting-plugin.md) | bugfix | System context for index creation, tenant URL parsing fix |
 
+### Dashboards Assistant
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Dashboards Core Bugfixes](features/dashboards-assistant/dashboards-core-bugfixes.md) | bugfix | Fix unit test failures due to missing Worker in Jest environment |
+
 ### Multi-Repository
 
 | Item | Category | Description |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dashboards Core Bugfixes release item in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/dashboards-assistant/dashboards-core-bugfixes.md`
- Feature report: `docs/features/dashboards-assistant/dashboards-core-bugfixes.md`

### Key Changes in v3.2.0
- Added Worker mock in `test/setupTests.ts` to fix Jest test environment
- Added Monaco editor mock in `nlq_vis_embeddable_factory.test.ts`

### Resources Used
- PR: [#593](https://github.com/opensearch-project/dashboards-assistant/pull/593)

Closes #1067