### PR TITLE
docs: add anomaly detection bugfixes report for v3.2.0

### DIFF
--- a/docs/features/anomaly-detection/anomaly-detection.md
+++ b/docs/features/anomaly-detection/anomaly-detection.md
@@ -231,6 +231,15 @@ POST _plugins/_anomaly_detection/detectors/<detector_id>/_start
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#1508](https://github.com/opensearch-project/anomaly-detection/pull/1508) | Fixing concurrency bug on writer |
+| v3.2.0 | [#1528](https://github.com/opensearch-project/anomaly-detection/pull/1528) | Fix: advance past current interval & anchor on now |
+| v3.2.0 | [#1535](https://github.com/opensearch-project/anomaly-detection/pull/1535) | Changing search calls on interval calculation |
+| v3.2.0 | [#1537](https://github.com/opensearch-project/anomaly-detection/pull/1537) | Bumping gradle and nebula versions |
+| v3.2.0 | [#1054](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1054) | Allow stopping forecaster from FORECAST_FAILURE state |
+| v3.2.0 | [#1058](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1058) | Improve indicator helper, fix zero-value plotting |
+| v3.2.0 | [#1060](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1060) | Wrap data filter in detector creation |
+| v3.2.0 | [#1064](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1064) | Fix ribbon encoding issue in contextual launch |
+| v3.2.0 | [#1068](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1068) | Fix: fetch full forecaster list, and fix delete bug |
 | v3.0.0 | [#1460](https://github.com/opensearch-project/anomaly-detection/pull/1460) | AWS SAM template for WAF log analysis |
 | v3.0.0 | [#1446](https://github.com/opensearch-project/anomaly-detection/pull/1446) | Distinguish local cluster when name matches remote |
 | v3.0.0 | [#1424](https://github.com/opensearch-project/anomaly-detection/pull/1424) | Fix breaking changes for 3.0.0 release |
@@ -258,6 +267,7 @@ POST _plugins/_anomaly_detection/detectors/<detector_id>/_start
 
 ## Change History
 
+- **v3.2.0** (2025-08-05): Concurrency bug fixes for HCAD multi-node clusters (ConcurrentModificationException, NullPointerException), forecasting interval calculation fixes, Dashboards UI improvements (data filter wrapping, zero-value plotting, forecaster list fetch, delete bug fix), build infrastructure updates (Gradle 8.14, Nebula 12.2.1)
 - **v3.0.0** (2025-05-06): AWS SAM template for WAF logs, cross-cluster improvements, OpenSearch 3.0.0 compatibility updates, Java Agent migration
 - **v2.18.0** (2024-11-05): Added suppression rule validation in AnomalyDetector constructor for immediate feedback on configuration errors, fixed default rules bug when empty ruleset provided, upgraded RCF to v4.2.0, Dashboards bugfixes for custom result index rendering, historical analysis route path, custom result index field reset, and preview support for suppression rules and imputation options
 - **v2.17.0** (2024-09-17): Fixed inference logic with new `lastSeenExecutionEndTime` tracking, standardized config index mapping (`defaultFill` → `default_fill`), improved null checks for imputation options, bugfixes for real-time/historical task flag management, null aggregation handling, Dashboards data source integration

--- a/docs/releases/v3.2.0/features/anomaly-detection/anomaly-detection-bugfixes.md
+++ b/docs/releases/v3.2.0/features/anomaly-detection/anomaly-detection-bugfixes.md
@@ -1,0 +1,86 @@
+# Anomaly Detection Bugfixes
+
+## Summary
+
+OpenSearch v3.2.0 includes 10 bug fixes for the Anomaly Detection plugin, addressing concurrency issues in multi-node clusters, forecasting interval calculation problems, UI/UX improvements in the Dashboards plugin, and build infrastructure updates. These fixes improve stability for high-cardinality anomaly detection (HCAD) workloads and enhance the forecasting feature experience.
+
+## Details
+
+### What's New in v3.2.0
+
+This release focuses on stability improvements and bug fixes across both the backend anomaly-detection plugin and the anomaly-detection-dashboards-plugin.
+
+### Technical Changes
+
+#### Backend Fixes (anomaly-detection)
+
+| Fix | Description | Impact |
+|-----|-------------|--------|
+| Concurrency bug in BatchWorker | Fixed `ConcurrentModificationException` in bulk result handling | Prevents crashes in HCAD multi-node clusters |
+| NullPointerException in ADTaskManager | Fixed null `rcfTotalUpdates` handling in `triageState()` | Improves real-time task state management |
+| ConcurrentHashMap null key handling | Fixed NPE with null key handling | Prevents unexpected failures |
+| Interval calculation search calls | Changed to use `asyncRequestWithInjectedSecurity` | Fixes security context issues |
+| Early failure on no shards | Added early failure check for time-bound search | Better error handling |
+| Forecast interval exploration | Changed `nextNiceInterval()` comparison from `>=` to `>` | Fixes `suggestForecast` failures on sample data |
+| Interval anchoring | Anchor on current time instead of future timestamp | Consistent behavior across forecast modes |
+
+#### Dashboards Fixes (anomaly-detection-dashboards-plugin)
+
+| Fix | Description | Impact |
+|-----|-------------|--------|
+| Data filter wrapping | Truncate long filters and wrap multiple filters | Fixes "Next" button disappearing |
+| Indicator helper text | Corrected forecasting indicator helper text | Better user guidance |
+| Zero-value plotting | Explicit null check to avoid skipping 0 values | Accurate chart rendering |
+| Absolute date handling | Support for absolute date inputs from date picker | Improved date selection |
+| FORECAST_FAILURE state | Allow stopping forecaster from failure state | Better error recovery |
+| Ribbon encoding | Fixed encoding issue in contextual launch | Correct navigation |
+| Forecaster list fetch | Fetch complete list with explicit `size: MAX_FORECASTER` | Shows all forecasters |
+| Delete bug | Fixed delete action using wrong forecaster object | Correct deletion behavior |
+| Minimum shingle size | Enforce `min={4}` in SuggestParametersDialog | Prevent invalid configurations |
+| Suggest anomaly detector | Restrict to OpenSearch datasets only | Appropriate feature availability |
+
+### Usage Example
+
+No configuration changes required. These fixes are automatically applied when upgrading to v3.2.0.
+
+### Migration Notes
+
+- No breaking changes
+- Existing detectors and forecasters continue to work without modification
+- Users experiencing HCAD crashes on multi-node clusters should upgrade to resolve concurrency issues
+
+## Limitations
+
+- The forecasting feature remains in active development
+- High-cardinality detection still requires sufficient cluster resources
+
+## Related PRs
+
+### Backend (anomaly-detection)
+
+| PR | Description |
+|----|-------------|
+| [#1508](https://github.com/opensearch-project/anomaly-detection/pull/1508) | Fixing concurrency bug on writer |
+| [#1528](https://github.com/opensearch-project/anomaly-detection/pull/1528) | Fix: advance past current interval & anchor on now |
+| [#1535](https://github.com/opensearch-project/anomaly-detection/pull/1535) | Changing search calls on interval calculation |
+| [#1537](https://github.com/opensearch-project/anomaly-detection/pull/1537) | Bumping gradle and nebula versions |
+
+### Dashboards (anomaly-detection-dashboards-plugin)
+
+| PR | Description |
+|----|-------------|
+| [#1001](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1001) | Restrict Suggest anomaly detector to only show for OpenSearch datasets |
+| [#1054](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1054) | Allow stopping forecaster from FORECAST_FAILURE state and minor cleanups |
+| [#1058](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1058) | Improve indicator helper, fix zero-value plotting etc |
+| [#1060](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1060) | Wrap data filter in detector creation |
+| [#1064](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1064) | Fix ribbon encoding issue in contextual launch |
+| [#1068](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/1068) | Fix: fetch full forecaster list, and fix delete bug |
+
+## References
+
+- [Anomaly Detection Documentation](https://docs.opensearch.org/3.0/observing-your-data/ad/index/): Official documentation
+- [GitHub Issue #715](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/issues/715): Data filter UI issue
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/anomaly-detection/anomaly-detection.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -175,6 +175,12 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 |------|----------|-------------|
 | [Asynchronous Search Bugfix](features/asynchronous-search/asynchronous-search-bugfix.md) | bugfix | Gradle 8.14.3 upgrade, JDK 24 CI support, Maven snapshot endpoint migration |
 
+### Anomaly Detection
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Anomaly Detection Bugfixes](features/anomaly-detection/anomaly-detection-bugfixes.md) | bugfix | Concurrency fixes for HCAD, forecasting interval calculation, Dashboards UI improvements |
+
 ### Cross-Cluster Replication
 
 | Item | Category | Description |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Anomaly Detection bugfixes in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/anomaly-detection/anomaly-detection-bugfixes.md`
- Feature report updated: `docs/features/anomaly-detection/anomaly-detection.md`

### Key Changes in v3.2.0

**Backend (anomaly-detection)**
- Fixed ConcurrentModificationException in BatchWorker for HCAD multi-node clusters
- Fixed NullPointerException in ADTaskManager.triageState()
- Fixed forecasting interval calculation (nextNiceInterval comparison, anchoring on now)
- Changed interval calculation to use asyncRequestWithInjectedSecurity
- Bumped Gradle to 8.14 and Nebula to 12.2.1

**Dashboards (anomaly-detection-dashboards-plugin)**
- Fixed data filter wrapping in detector creation (resolves #715)
- Fixed zero-value plotting bug
- Fixed forecaster list fetch and delete bug
- Fixed ribbon encoding issue in contextual launch
- Allow stopping forecaster from FORECAST_FAILURE state
- Restrict Suggest anomaly detector to OpenSearch datasets only

### PRs Investigated
- Backend: #1508, #1528, #1535, #1537
- Dashboards: #1001, #1054, #1058, #1060, #1064, #1068

Closes #1064