### PR TITLE
docs: add alerting-plugin report for v3.2.0

### DIFF
--- a/docs/features/alerting/alerting.md
+++ b/docs/features/alerting/alerting.md
@@ -155,6 +155,9 @@ POST _plugins/_alerting/monitors
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#1885](https://github.com/opensearch-project/alerting/pull/1885) | Fix MGet bug, randomize fan out distribution |
+| v3.2.0 | [#1818](https://github.com/opensearch-project/alerting/pull/1818) | Refactored consistent responses and fixed unrelated exceptions |
+| v3.2.0 | [#1869](https://github.com/opensearch-project/alerting/pull/1869) | Update the maven snapshot publish endpoint and credential |
 | v3.1.0 | [#1850](https://github.com/opensearch-project/alerting/pull/1850) | Timebox doc level monitor execution |
 | v3.1.0 | [#1854](https://github.com/opensearch-project/alerting/pull/1854) | Prevent dry run execution of doc level monitor with index pattern |
 | v3.1.0 | [#1856](https://github.com/opensearch-project/alerting/pull/1856) | Use transport service timeout instead of custom impl |
@@ -199,6 +202,7 @@ POST _plugins/_alerting/monitors
 - [Composite Monitors](https://docs.opensearch.org/3.0/observing-your-data/alerting/composite-monitors/): Composite monitor documentation
 - [Alerting Security](https://docs.opensearch.org/3.0/observing-your-data/alerting/security/): Security configuration for alerting
 - [Notifications Plugin](https://docs.opensearch.org/3.0/observing-your-data/notifications/index/): Notifications integration
+- [Issue #1057](https://github.com/opensearch-project/alerting/issues/1057): Return empty responses if there is no alerting config index created
 - [Issue #1853](https://github.com/opensearch-project/alerting/issues/1853): Timebox doc level monitor to avoid duplicate executions
 - [Issue #1859](https://github.com/opensearch-project/alerting/issues/1859): Change publish findings to accept a list of findings
 - [Issue #1617](https://github.com/opensearch-project/alerting/issues/1617): Distribution build issue
@@ -206,6 +210,7 @@ POST _plugins/_alerting/monitors
 
 ## Change History
 
+- **v3.2.0** (2025): MGet bug fix with proper finding-to-document mapping, randomized fan-out node distribution for better load balancing, consistent API responses when alerting config index doesn't exist, Maven snapshot publishing migration to Sonatype Central
 - **v3.1.0** (2025): Doc-level monitor timeboxing (3-4 min execution limit), batch findings publishing for improved performance, index pattern validation for doc-level monitors, threat intel monitor check fix, alert insight on dashboard overview page, log pattern extraction error handling
 - **v3.0.0** (2025): Bug fixes for bucket selector aggregation, Java Agent migration, and dashboard subfield selection
 - **v2.18.0** (2024-11-05): Doc-level monitor improvements including dynamic query index deletion (`delete_query_index_in_every_run` flag), query index lifecycle optimization, bucket-level monitor performance optimization for time-series indices, dashboard UX fit-and-finish updates, MDS compatibility fixes

--- a/docs/releases/v3.2.0/features/alerting/alerting-plugin.md
+++ b/docs/releases/v3.2.0/features/alerting/alerting-plugin.md
@@ -1,0 +1,128 @@
+# Alerting Plugin
+
+## Summary
+
+This release includes three bug fixes for the Alerting plugin: a fix for the MGet operation with randomized fan-out distribution, improved API responses when the alerting config index doesn't exist, and updated Maven snapshot publishing infrastructure.
+
+## Details
+
+### What's New in v3.2.0
+
+Three bug fixes improve the reliability and user experience of the Alerting plugin:
+
+1. **MGet Bug Fix & Fan-out Randomization**: Fixes a bug in the `getDocSources` method and refactors fan-out distribution to randomize node selection across monitor runs
+2. **Consistent API Responses**: Returns meaningful error messages or empty responses when the alerting config index doesn't exist
+3. **Maven Snapshot Publishing**: Updates the Maven snapshot publish endpoint and credentials following Sonatype migration
+
+### Technical Changes
+
+#### MGet Bug Fix & Fan-out Distribution (PR #1885)
+
+The `getDocSources` method had a bug where the `findingId` to document mapping was incorrect during batch MGet operations. The fix:
+
+- Moves the MGet request creation inside the batch loop
+- Creates a proper `docIdToFindingId` mapping to correctly associate documents with findings
+- Adds logging for MGet operation duration
+
+Additionally, the fan-out distribution logic was refactored:
+
+- Extracted to a new `MonitorFanOutUtils.kt` utility file
+- Randomizes node selection using `shuffled()` to distribute load evenly across runs
+- Simplified shard distribution algorithm using round-robin assignment
+
+```kotlin
+// New randomized node selection
+val shuffledNodes = allNodes.shuffled()
+val nodes = shuffledNodes.subList(0, totalNodes)
+
+// Round-robin shard assignment
+shardIdList.forEachIndexed { idx, shardId ->
+    val nodeIdx = idx % nodes.size
+    nodeShardAssignments[nodes[nodeIdx]]!!.add(shardId)
+}
+```
+
+#### Consistent API Responses (PR #1818)
+
+When no monitors exist, the alerting config index (`.opendistro-alerting-config`) is not created. Previously, GET and SEARCH API calls would return confusing `IndexNotFoundException` errors.
+
+**Before:**
+```json
+{
+  "error": {
+    "type": "alerting_exception",
+    "reason": "Configured indices are not found: [.opendistro-alerting-config]"
+  },
+  "status": 404
+}
+```
+
+**After (GET):**
+```json
+{
+  "error": {
+    "type": "alerting_exception",
+    "reason": "Monitor not found. Backing index is missing."
+  },
+  "status": 404
+}
+```
+
+**After (SEARCH):**
+```json
+{
+  "hits": {
+    "total": { "value": 0, "relation": "eq" },
+    "hits": []
+  }
+}
+```
+
+#### Maven Snapshot Publishing (PR #1869)
+
+Updates the Maven snapshot publishing infrastructure following Sonatype migration:
+
+- Changed snapshot URL from `https://aws.oss.sonatype.org/content/repositories/snapshots` to `https://central.sonatype.com/repository/maven-snapshots/`
+- Migrated from AWS Secrets Manager to 1Password for credential management
+- Updated GitHub Actions workflow to use `1password/load-secrets-action@v2`
+
+### Usage Example
+
+The API behavior changes are transparent to users. The improved error messages help diagnose issues:
+
+```bash
+# GET request when no monitors exist
+GET _plugins/_alerting/monitors/nonexistent-id
+# Returns: "Monitor not found. Backing index is missing." (404)
+
+# SEARCH request when no monitors exist
+GET _plugins/_alerting/monitors/_search
+{
+  "query": { "match_all": {} }
+}
+# Returns: Empty search response with 0 hits (200)
+```
+
+## Limitations
+
+- The fan-out randomization may result in different nodes being selected on each monitor run, which could affect debugging if issues are node-specific
+- The empty response behavior for SEARCH only applies when the index doesn't exist; other errors are still propagated
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1885](https://github.com/opensearch-project/alerting/pull/1885) | Fix MGet bug, randomize fan out distribution |
+| [#1818](https://github.com/opensearch-project/alerting/pull/1818) | Refactored consistent responses and fixed unrelated exceptions |
+| [#1869](https://github.com/opensearch-project/alerting/pull/1869) | Update the maven snapshot publish endpoint and credential |
+
+## References
+
+- [Issue #1057](https://github.com/opensearch-project/alerting/issues/1057): Return empty responses if there is no alerting config index created
+- [Issue #5551](https://github.com/opensearch-project/opensearch-build/issues/5551): Sonatype migration campaign
+- [Alerting Documentation](https://docs.opensearch.org/3.0/observing-your-data/alerting/index/): Official alerting documentation
+- [Monitors Documentation](https://docs.opensearch.org/3.0/observing-your-data/alerting/monitors/): Monitor types and configuration
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/alerting/alerting.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -175,6 +175,12 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 |------|----------|-------------|
 | [Asynchronous Search Bugfix](features/asynchronous-search/asynchronous-search-bugfix.md) | bugfix | Gradle 8.14.3 upgrade, JDK 24 CI support, Maven snapshot endpoint migration |
 
+### Alerting
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Alerting Plugin](features/alerting/alerting-plugin.md) | bugfix | MGet bug fix, randomized fan-out distribution, consistent API responses |
+
 ### Anomaly Detection
 
 | Item | Category | Description |


### PR DESCRIPTION
## Summary

Add release report for Alerting Plugin bugfixes in v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/alerting/alerting-plugin.md`
- Feature report: `docs/features/alerting/alerting.md` (updated)

### Key Changes in v3.2.0
- **MGet Bug Fix**: Fixed finding-to-document mapping in batch MGet operations
- **Randomized Fan-out**: Refactored fan-out distribution to randomize node selection for better load balancing
- **Consistent API Responses**: Returns meaningful error messages or empty responses when alerting config index doesn't exist
- **Maven Snapshot Publishing**: Updated to Sonatype Central following migration

### PRs Investigated
- [#1885](https://github.com/opensearch-project/alerting/pull/1885): Fix MGet bug, randomize fan out distribution
- [#1818](https://github.com/opensearch-project/alerting/pull/1818): Refactored consistent responses and fixed unrelated exceptions
- [#1869](https://github.com/opensearch-project/alerting/pull/1869): Update the maven snapshot publish endpoint and credential