### PR TITLE
docs: add Skills Plugin Enhancements report for v3.2.0

### DIFF
--- a/docs/features/skills/skills-tools.md
+++ b/docs/features/skills/skills-tools.md
@@ -145,6 +145,9 @@ The `type` parameter (defaults to `Opensearch`) is passed to the LLM model as `d
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#596](https://github.com/opensearch-project/skills/pull/596) | Merge index schema meta for PPLTool |
+| v3.2.0 | [#609](https://github.com/opensearch-project/skills/pull/609) | Mask error message in PPLTool |
+| v3.2.0 | [#618](https://github.com/opensearch-project/skills/pull/618) | Update parameter handling of tools |
 | v3.1.0 | [#587](https://github.com/opensearch-project/skills/pull/587) | Add data source type parameter to PPLTool for Spark/S3 support |
 | v3.1.0 | [#581](https://github.com/opensearch-project/skills/pull/581) | Fix fields bug in PPL tool (multi-field mapping support) |
 | v3.1.0 | [#575](https://github.com/opensearch-project/skills/pull/575) | Fix conflict in dependency versions |
@@ -167,6 +170,7 @@ The `type` parameter (defaults to `Opensearch`) is passed to the LLM model as `d
 
 ## Change History
 
+- **v3.2.0** (2026-01-11): Added index schema merging for PPLTool when using index patterns (merges mappings from all matching indexes); added error message masking in PPLTool to redact SageMaker ARNs and AWS account numbers; standardized parameter handling across all tools using `extractInputParameters` utility
 - **v3.1.0** (2025-05-06): Added data source type parameter (`datasourceType`) to PPLTool for Spark/S3 data source support; fixed PPLTool fields bug to properly expose multi-field mappings (e.g., `a.keyword`) to LLM for aggregation queries; fixed httpclient5 dependency version conflict in build.gradle, applied Spotless code formatting to WebSearchTool
 - **v3.0.0** (2025-02-25): Added WebSearchTool, fixed PPLTool empty list bug, updated dependencies, enhanced developer guide
 - **v2.18.0** (2024-11-12): Added LogPatternTool for log pattern analysis, added customizable prompt support for CreateAnomalyDetectorTool

--- a/docs/releases/v3.2.0/features/skills/skills-plugin-enhancements.md
+++ b/docs/releases/v3.2.0/features/skills/skills-plugin-enhancements.md
@@ -1,0 +1,126 @@
+# Skills Plugin Enhancements
+
+## Summary
+
+OpenSearch v3.2.0 brings several enhancements to the Skills plugin, including improved index schema merging for PPLTool when using index patterns, error message masking for security, and standardized parameter handling across all tools. These changes improve the reliability and security of agent-based workflows.
+
+## Details
+
+### What's New in v3.2.0
+
+#### Index Schema Merging for PPLTool
+
+Previously, when using index patterns (e.g., `logs-*`) with PPLTool, only the first matching index's mapping was used. This caused issues when different indexes had different field schemas.
+
+In v3.2.0, PPLTool now merges schema metadata from all matching indexes:
+- For nested/struct types: properties are merged recursively
+- For normal types with the same key: the latest value is used
+- For different keys: both are preserved
+
+This ensures the LLM receives a complete view of all available fields across the index pattern.
+
+#### Error Message Masking
+
+PPLTool now masks sensitive information in error messages from SageMaker endpoints:
+- AWS account numbers are redacted
+- SageMaker endpoint ARNs are replaced with `<SAGEMAKER_ENDPOINT>`
+- CloudWatch URLs are removed from error messages
+
+This prevents accidental exposure of infrastructure details in error responses.
+
+#### Standardized Parameter Handling
+
+All Tool implementations now use the new `extractInputParameters` utility from ML Commons:
+- `AbstractRetrieverTool`
+- `CreateAlertTool`
+- `CreateAnomalyDetectorTool`
+- `DynamicTool`
+- `LogPatternTool`
+- `PPLTool`
+- `RAGTool`
+- `SearchAlertsTool`
+- `SearchAnomalyDetectorsTool`
+- `SearchAnomalyResultsTool`
+- `SearchMonitorsTool`
+- `WebSearchTool`
+
+This change aligns with the ML Commons PR #4053 that introduced unified tool parameter handling and output filtering.
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `MergeRule` | Interface for index schema merge strategies |
+| `DeepMergeRule` | Merges nested/struct objects by recursively merging properties |
+| `LatestRule` | Fallback rule that keeps the latest value for conflicting keys |
+| `MergeRuleHelper` | Helper class that applies merge rules to index mappings |
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph PPLTool
+        GetMappings[Get Index Mappings]
+        MergeHelper[MergeRuleHelper]
+        ConstructTable[Construct Table Info]
+    end
+    
+    subgraph MergeRules
+        DeepMerge[DeepMergeRule]
+        Latest[LatestRule]
+    end
+    
+    GetMappings --> MergeHelper
+    MergeHelper --> DeepMerge
+    MergeHelper --> Latest
+    MergeHelper --> ConstructTable
+```
+
+### Usage Example
+
+When querying across multiple indexes with different schemas:
+
+```json
+{
+  "type": "PPLTool",
+  "parameters": {
+    "model_id": "<llm_model_id>",
+    "index": "logs-*",
+    "question": "Show me error counts by service"
+  }
+}
+```
+
+The merged schema will include fields from all matching indexes, enabling the LLM to generate accurate PPL queries.
+
+### Migration Notes
+
+No migration required. These changes are backward compatible.
+
+## Limitations
+
+- Schema merging may produce large field lists for index patterns matching many indexes with diverse schemas
+- Error masking only applies to SageMaker-related errors in PPLTool
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#596](https://github.com/opensearch-project/skills/pull/596) | Merge index schema meta for PPLTool |
+| [#609](https://github.com/opensearch-project/skills/pull/609) | Mask error message in PPLTool |
+| [#618](https://github.com/opensearch-project/skills/pull/618) | Update parameter handling of tools |
+| [#601](https://github.com/opensearch-project/skills/pull/601) | Update maven snapshot publish endpoint |
+| [#615](https://github.com/opensearch-project/skills/pull/615) | Bump gradle, java, lombok and fix AD configrequest change |
+| [#605](https://github.com/opensearch-project/skills/pull/605) | Bump version to 3.2.0.0 |
+
+## References
+
+- [Issue #617](https://github.com/opensearch-project/skills/issues/617): Parameter handling failures after ML Commons update
+- [ML Commons PR #4053](https://github.com/opensearch-project/ml-commons/pull/4053): Unified tool parameter handling
+- [PPL Tool Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/tools/ppl-tool/): Official PPL tool reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/skills/skills-tools.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -224,6 +224,12 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 |------|----------|-------------|
 | [Dashboards Core Bugfixes](features/dashboards-assistant/dashboards-core-bugfixes.md) | bugfix | Fix unit test failures due to missing Worker in Jest environment |
 
+### Skills
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Skills Plugin Enhancements](features/skills/skills-plugin-enhancements.md) | enhancement | Index schema merging for PPLTool, error message masking, standardized parameter handling |
+
 ### Multi-Repository
 
 | Item | Category | Description |


### PR DESCRIPTION
## Summary

This PR adds documentation for Skills Plugin Enhancements in OpenSearch v3.2.0.

### Key Changes in v3.2.0

- **Index Schema Merging**: PPLTool now merges schema metadata from all matching indexes when using index patterns, ensuring the LLM receives a complete view of available fields
- **Error Message Masking**: PPLTool masks sensitive information (AWS account numbers, SageMaker ARNs, CloudWatch URLs) in error messages
- **Standardized Parameter Handling**: All Tool implementations now use the `extractInputParameters` utility from ML Commons for consistent parameter handling

### Reports Created
- Release report: `docs/releases/v3.2.0/features/skills/skills-plugin-enhancements.md`
- Feature report: `docs/features/skills/skills-tools.md` (updated)

### Related PRs
- [#596](https://github.com/opensearch-project/skills/pull/596): Merge index schema meta
- [#609](https://github.com/opensearch-project/skills/pull/609): Mask error message in PPLTool
- [#618](https://github.com/opensearch-project/skills/pull/618): Update parameter handling of tools

Closes #1060