### PR TITLE
docs: add observability service map report for v3.2.0

### DIFF
--- a/docs/features/dashboards-observability/trace-analytics.md
+++ b/docs/features/dashboards-observability/trace-analytics.md
@@ -98,6 +98,8 @@ flowchart TB
 | MDS ID | Multi-Data Source identifier | Local cluster |
 | `observability:traceAnalyticsSpanIndices` | Custom span indices (supports wildcards and CCS) | Empty |
 | `observability:traceAnalyticsServiceIndices` | Custom service indices (supports wildcards and CCS) | Empty |
+| `observability:traceAnalyticsServiceMapMaxNodes` | Maximum nodes in service map queries | 500 |
+| `observability:traceAnalyticsServiceMapMaxEdges` | Maximum edges in service map queries | 1000 |
 
 ### Usage Example
 
@@ -140,6 +142,7 @@ http://host:port/app/observability-traces#/services
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#2472](https://github.com/opensearch-project/dashboards-observability/pull/2472) | [Traces] Make service map max nodes and max edges values user-configurable |
 | v3.2.0 | [#2475](https://github.com/opensearch-project/dashboards-observability/pull/2475) | [Bug] Traces error display - fix nested status.code handling |
 | v3.2.0 | [#2478](https://github.com/opensearch-project/dashboards-observability/pull/2478) | [Bug] Fixed metrics viz not showing up in local cluster |
 | v3.1.0 | [#2457](https://github.com/opensearch-project/dashboards-observability/pull/2457) | Merge custom source and data prepper mode |
@@ -171,7 +174,7 @@ http://host:port/app/observability-traces#/services
 
 ## Change History
 
-- **v3.2.0** (2026-02-18): Bug fixes for traces error display (nested status.code handling) and metrics visualization rendering in local cluster instances
+- **v3.2.0** (2026-02-18): User-configurable service map max nodes and max edges settings, bug fixes for traces error display (nested status.code handling) and metrics visualization rendering in local cluster instances
 - **v3.1.0** (2026-01-21): Merged custom source mode into default Data Prepper mode, span flyout support for new Data Prepper format with nested field flattening, unified experience with cross-cluster search, custom indices, data grid, and dynamic filters
 - **v3.0.0** (2025-02-25): Custom logs correlation, data grid migration, OTEL attributes support, service view optimizations, Amazon Network Firewall integration, trace-to-logs correlation improvements
 - **v2.17.0** (2024-09-17): Custom source support (experimental) for custom span/service indices with CCS support, landing page changed to Traces, Multi-Data Source bug fixes, URL routing fixes, breadcrumb navigation improvements

--- a/docs/releases/v3.2.0/features/observability/observability-service-map.md
+++ b/docs/releases/v3.2.0/features/observability/observability-service-map.md
@@ -1,0 +1,85 @@
+# Observability Service Map
+
+## Summary
+
+This enhancement makes the service map maximum nodes and maximum edges values user-configurable in OpenSearch Dashboards Observability plugin. Previously, these were hardcoded constants (500 nodes, 1000 edges), which could result in inaccurate service maps for large-scale deployments with more than 500 unique services.
+
+## Details
+
+### What's New in v3.2.0
+
+Users can now configure the maximum number of nodes and edges displayed in service maps through the Advanced Settings panel in OpenSearch Dashboards. This addresses a limitation where organizations with large microservice architectures (650+ services) could not visualize complete service relationships.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.2.0"
+        CONST[Hardcoded Constants]
+        CONST --> |"500 nodes"| QUERY1[Service Map Query]
+        CONST --> |"1000 edges"| QUERY1
+    end
+    
+    subgraph "After v3.2.0"
+        UI[Advanced Settings UI]
+        SETTINGS[UI Settings Service]
+        UI --> SETTINGS
+        SETTINGS --> |"configurable"| QUERY2[Service Map Query]
+    end
+```
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `observability:traceAnalyticsServiceMapMaxNodes` | Maximum number of nodes (services) in service map queries | 500 |
+| `observability:traceAnalyticsServiceMapMaxEdges` | Maximum number of edges (connections) in service map queries | 1000 |
+
+#### Changed Files
+
+| File | Change |
+|------|--------|
+| `common/constants/trace_analytics.ts` | Replaced hardcoded constants with setting keys and defaults |
+| `public/components/trace_analytics/components/common/helper_functions.tsx` | Added getter/setter methods for new settings |
+| `public/components/trace_analytics/requests/queries/services_queries.ts` | Updated queries to use configurable values |
+| `server/plugin_helper/register_settings.ts` | Registered new UI settings with schema validation |
+
+### Usage Example
+
+Navigate to **Management** → **Advanced Settings** → **Observability** section:
+
+```
+Trace analytics service map maximum nodes: 1000
+Trace analytics service map maximum edges: 2000
+```
+
+After updating these settings, the service map will request up to the configured number of nodes and edges, allowing visualization of larger service architectures.
+
+### Migration Notes
+
+- No migration required - existing deployments will use the default values (500 nodes, 1000 edges)
+- Users with large service deployments should increase these values based on their environment
+- Higher values may impact query performance and browser rendering
+
+## Limitations
+
+- Very high values may cause performance degradation in both query execution and UI rendering
+- Settings apply globally to all users in the tenant
+- Minimum value is 1 for both settings
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2472](https://github.com/opensearch-project/dashboards-observability/pull/2472) | [Traces] Make service map max nodes and max edges values user-configurable |
+
+## References
+
+- [Issue #2471](https://github.com/opensearch-project/dashboards-observability/issues/2471): Feature request for configurable service map limits
+- [Trace Analytics Documentation](https://docs.opensearch.org/latest/observing-your-data/trace/ta-dashboards/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-observability/trace-analytics.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -99,6 +99,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | Item | Category | Description |
 |------|----------|-------------|
 | [Observability Infrastructure](features/observability/observability-infrastructure.md) | bugfix | Maven snapshot publishing migration, Gradle 8.14.3 upgrade, JDK24 CI support |
+| [Observability Service Map](features/observability/observability-service-map.md) | enhancement | User-configurable service map max nodes and max edges settings |
 
 ### Dashboards Observability
 


### PR DESCRIPTION
## Summary

Add release report for Observability Service Map enhancement in v3.2.0.

### Changes
- Created release report: `docs/releases/v3.2.0/features/observability/observability-service-map.md`
- Updated feature report: `docs/features/dashboards-observability/trace-analytics.md`
  - Added new configuration settings to Configuration table
  - Added PR #2472 to Related PRs table
  - Updated Change History with v3.2.0 entry
- Updated release index: `docs/releases/v3.2.0/index.md`

### Key Enhancement
Makes service map max nodes and max edges values user-configurable through Advanced Settings:
- `observability:traceAnalyticsServiceMapMaxNodes` (default: 500)
- `observability:traceAnalyticsServiceMapMaxEdges` (default: 1000)

This addresses a limitation where organizations with large microservice architectures (650+ services) could not visualize complete service relationships.

### Related
- PR: opensearch-project/dashboards-observability#2472
- Issue: opensearch-project/dashboards-observability#2471
- Tracking Issue: #1057