### PR TITLE
docs: add tenancy access control report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -195,6 +195,7 @@
 - [Security Testing Framework](security/security-testing-framework.md)
 - [Security CI/CD](security/security-ci-cd.md)
 - [JWT Authentication](security/jwt-authentication.md)
+- [Multi-Tenancy](security/multi-tenancy.md)
 - [Resource Access Control Framework](security/resource-access-control-framework.md)
 
 ## security-dashboards

--- a/docs/features/security/multi-tenancy.md
+++ b/docs/features/security/multi-tenancy.md
@@ -1,0 +1,161 @@
+# Multi-Tenancy
+
+## Summary
+
+Multi-tenancy in OpenSearch Dashboards provides isolated workspaces called tenants for saving index patterns, visualizations, dashboards, and other saved objects. Users can have different levels of access (read, write, or none) to different tenants, enabling secure sharing of dashboards and visualizations across teams while maintaining data isolation.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        A[User Request] --> B[Security Plugin]
+        B --> C{Tenant Selection}
+        C --> D[Global Tenant]
+        C --> E[Private Tenant]
+        C --> F[Custom Tenants]
+    end
+    
+    subgraph "OpenSearch"
+        D --> G[.kibana index]
+        E --> H[.kibana_username index]
+        F --> I[.kibana_tenant index]
+    end
+    
+    subgraph "Security Plugin"
+        J[PrivilegesEvaluator] --> K[TenantPrivileges]
+        K --> L{Access Check}
+        L -->|WRITE| M[Full Access]
+        L -->|READ| N[View Only]
+        L -->|NONE| O[No Access]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User Login] --> B[Authentication]
+    B --> C[Role Mapping]
+    C --> D[Tenant Access Evaluation]
+    D --> E[Thread Context Serialization]
+    E --> F[Request Processing]
+    F --> G[Tenant-Specific Index Access]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Global Tenant | Shared tenant accessible to all users with appropriate permissions |
+| Private Tenant | User-specific tenant that cannot be shared |
+| Custom Tenants | Administrator-defined tenants for team collaboration |
+| TenantPrivileges | Evaluates user access levels to tenants |
+| PrivilegesEvaluator | Serializes user info including tenant access to thread context |
+
+### Tenant Types
+
+| Tenant Type | Index Pattern | Sharing | Use Case |
+|-------------|---------------|---------|----------|
+| Global | `.kibana` | All users | Organization-wide dashboards |
+| Private | `.kibana_<hash>_<username>` | Single user | Personal exploration |
+| Custom | `.kibana_<hash>_<tenant_name>` | Role-based | Team collaboration |
+
+### Configuration
+
+Configuration in `config/opensearch-security/config.yml`:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `multitenancy_enabled` | Enable/disable multi-tenancy | `true` |
+| `private_tenant_enabled` | Enable/disable private tenants | `true` |
+| `default_tenant` | Default tenant on login | `global tenant` |
+| `server_username` | Dashboards server user | `kibanaserver` |
+| `index` | Base Dashboards index | `.kibana` |
+
+Configuration in `opensearch_dashboards.yml`:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `opensearch_security.multitenancy.enabled` | Enable multi-tenancy in Dashboards | `true` |
+| `opensearch_security.multitenancy.tenants.enable_global` | Enable global tenant | `true` |
+| `opensearch_security.multitenancy.tenants.enable_private` | Enable private tenants | `true` |
+| `opensearch_security.multitenancy.tenants.preferred` | Tenant ordering preference | `["Private", "Global"]` |
+| `opensearch_security.multitenancy.enable_filter` | Enable tenant search filter | `false` |
+
+### Access Levels
+
+| Level | Description | Capabilities |
+|-------|-------------|--------------|
+| WRITE | Full access | Create, modify, delete saved objects |
+| READ | Read-only | View saved objects only |
+| NONE | No access | Cannot access tenant |
+
+### Thread Context Serialization
+
+User information including tenant access is serialized to thread context for downstream components:
+
+```
+username|backend_roles|mapped_roles|requested_tenant|access_level
+```
+
+Example:
+```
+admin|admin_role|all_access|global_tenant|WRITE
+```
+
+### Usage Example
+
+Defining tenant permissions in `roles.yml`:
+
+```yaml
+analyst_role:
+  tenant_permissions:
+    - tenant_patterns:
+        - "analytics"
+      allowed_actions:
+        - "kibana_all_write"
+    - tenant_patterns:
+        - "executive"
+      allowed_actions:
+        - "kibana_all_read"
+```
+
+Creating a tenant via REST API:
+
+```bash
+PUT _plugins/_security/api/tenants/analytics
+{
+  "description": "Analytics team tenant"
+}
+```
+
+## Limitations
+
+- Global tenant does not synchronize with private tenants
+- Tenant names are scrubbed of special characters in index names
+- Workspaces feature conflicts with multi-tenancy (must disable one)
+- Changes to tenant permissions during long-running requests may not be reflected
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#5519](https://github.com/opensearch-project/security/pull/5519) | Add tenancy access info to serialized user in threadcontext |
+| v3.0.0 | [#2218](https://github.com/opensearch-project/security/pull/2218) | Remove tenant panels when multitenancy disabled |
+| v2.17.0 | [#2057](https://github.com/opensearch-project/security-dashboards-plugin/pull/2057) | Do not register tenancy app if disabled in yml |
+
+## References
+
+- [OpenSearch Dashboards multi-tenancy](https://docs.opensearch.org/3.0/security/multi-tenancy/tenant-index/): Multi-tenancy overview
+- [Multi-tenancy configuration](https://docs.opensearch.org/3.0/security/multi-tenancy/multi-tenancy-config/): Configuration guide
+- [Dynamic configuration in OpenSearch Dashboards](https://docs.opensearch.org/3.0/security/multi-tenancy/dynamic-config/): Dynamic configuration
+- [PR #5519](https://github.com/opensearch-project/security/pull/5519): Tenancy access info implementation
+
+## Change History
+
+- **v3.2.0** (2025-07-30): Added tenancy access level (READ/WRITE/NONE) to serialized user info in thread context
+- **v3.0.0**: Removed tenant panels when multitenancy is disabled
+- **v2.17.0**: Fixed tenancy app registration when disabled in configuration

--- a/docs/releases/v3.2.0/features/common/tenancy-access-control.md
+++ b/docs/releases/v3.2.0/features/common/tenancy-access-control.md
@@ -1,0 +1,120 @@
+# Tenancy Access Control
+
+## Summary
+
+This enhancement adds tenancy access level information to the serialized user context in the thread context. When a user makes a request to OpenSearch, the security plugin now includes their access level (READ, WRITE, or NONE) for the requested tenant, enabling downstream components to make authorization decisions based on tenant permissions.
+
+## Details
+
+### What's New in v3.2.0
+
+The security plugin now serializes the user's tenancy access level into the thread context alongside existing user information. This provides a standardized way for other components to determine what level of access a user has to a specific tenant without needing to re-evaluate permissions.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Request Flow"
+        A[User Request] --> B[Security Filter]
+        B --> C[PrivilegesEvaluator]
+        C --> D[getTenancyAccess]
+        D --> E[TenantPrivileges]
+        E --> F{Check Access}
+        F -->|WRITE| G[WRITE_ACCESS]
+        F -->|READ| H[READ_ACCESS]
+        F -->|NONE| I[NO_ACCESS]
+    end
+    
+    subgraph "Thread Context"
+        G --> J[User Info String]
+        H --> J
+        I --> J
+        J --> K["username|roles|mappedRoles|tenant|accessLevel"]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `getTenancyAccess()` | New method in `PrivilegesEvaluator` that determines user's access level to the requested tenant |
+| Access Level Constants | `READ_ACCESS`, `WRITE_ACCESS`, `NO_ACCESS` constants for standardized access levels |
+| Tenant Constants | `USER_TENANT` (`__user__`) and `GLOBAL_TENANT` (`global_tenant`) for special tenant handling |
+
+#### Thread Context Format Change
+
+The user info string in thread context now includes two additional fields:
+
+| Field | Position | Description |
+|-------|----------|-------------|
+| Username | 1 | User's name (escaped) |
+| Roles | 2 | Comma-separated backend roles |
+| Mapped Roles | 3 | Comma-separated security roles |
+| Requested Tenant | 4 | The tenant being accessed |
+| Access Level | 5 | `READ`, `WRITE`, or `NONE` |
+
+**Before v3.2.0:**
+```
+username|role1,role2|mappedRole1,mappedRole2|tenantName
+```
+
+**After v3.2.0:**
+```
+username|role1,role2|mappedRole1,mappedRole2|tenantName|WRITE
+```
+
+### Access Level Determination
+
+The access level is determined by checking tenant privileges in order:
+
+1. **WRITE** - User has write access to the tenant (can save objects)
+2. **READ** - User has read-only access to the tenant (can view objects)
+3. **NONE** - User has no access to the tenant
+
+If no tenant is specified in the request, the global tenant is used as the default.
+
+### Usage Example
+
+Downstream components can parse the user info from thread context:
+
+```java
+String userInfo = threadContext.getTransient(OPENDISTRO_SECURITY_USER_INFO_THREAD_CONTEXT);
+String[] parts = userInfo.split("\\|");
+String username = parts[0];
+String roles = parts[1];
+String mappedRoles = parts[2];
+String requestedTenant = parts[3];
+String accessLevel = parts[4];  // "READ", "WRITE", or "NONE"
+
+if ("WRITE".equals(accessLevel)) {
+    // User can modify saved objects in this tenant
+} else if ("READ".equals(accessLevel)) {
+    // User can only view saved objects
+} else {
+    // User has no access to this tenant
+}
+```
+
+## Limitations
+
+- The access level is determined at request time and cached in thread context
+- Changes to tenant permissions during a long-running request won't be reflected
+- The format change may affect components that parse the user info string with strict field expectations
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5519](https://github.com/opensearch-project/security/pull/5519) | Add tenancy access info to serialized user in threadcontext |
+| [#5520](https://github.com/opensearch-project/security/pull/5520) | Backport to 2.19 branch |
+
+## References
+
+- [OpenSearch Dashboards multi-tenancy](https://docs.opensearch.org/3.0/security/multi-tenancy/tenant-index/): Multi-tenancy overview
+- [Multi-tenancy configuration](https://docs.opensearch.org/3.0/security/multi-tenancy/multi-tenancy-config/): Configuration guide
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/multi-tenancy.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -247,6 +247,12 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 |------|----------|-------------|
 | [Common Utils Bugfixes](features/common-utils/common-utils-bugfixes.md) | bugfix | CVE-2025-48734 fix, PublishFindingsRequest revert, Gradle 8.14/JDK 24 upgrade |
 
+### Common (Security)
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Tenancy Access Control](features/common/tenancy-access-control.md) | enhancement | Add tenancy access level (READ/WRITE/NONE) to serialized user in thread context |
+
 ### Custom Codecs
 
 | Item | Category | Description |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Tenancy Access Control enhancement in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/common/tenancy-access-control.md`
- Feature report: `docs/features/security/multi-tenancy.md`

### Key Changes in v3.2.0
- Added tenancy access level (READ/WRITE/NONE) to serialized user info in thread context
- New `getTenancyAccess()` method in `PrivilegesEvaluator` to determine user's access level
- Thread context format now includes access level as the 5th field

### Resources Used
- PR: [#5519](https://github.com/opensearch-project/security/pull/5519)
- Docs: [Multi-tenancy configuration](https://docs.opensearch.org/3.0/security/multi-tenancy/multi-tenancy-config/)

Closes #1055