### PR TITLE
docs: add star-tree security integration report for v3.2.0

### DIFF
--- a/docs/features/opensearch/star-tree-index.md
+++ b/docs/features/opensearch/star-tree-index.md
@@ -82,6 +82,19 @@ flowchart TB
 | `max_leaf_docs` | Maximum documents per leaf node | `10000` |
 | `skip_star_node_creation_for_dimensions` | Dimensions to skip star node creation | `[]` |
 
+### Security Integration
+
+Star-tree query optimization is automatically disabled when security restrictions are applied (v3.2.0+):
+
+| Security Feature | Star-Tree Behavior |
+|------------------|-------------------|
+| Document-Level Security (DLS) | Disabled - falls back to standard aggregation |
+| Field-Level Security (FLS) | Disabled - falls back to standard aggregation |
+| Field Masking | Disabled - falls back to standard aggregation |
+| No restrictions | Enabled - uses precomputed aggregations |
+
+This ensures that precomputed aggregations don't bypass security filters. Users with DLS/FLS/Field Masking will experience standard aggregation performance rather than star-tree acceleration.
+
 ### Monitoring
 
 Star-tree search statistics are available (v3.2.0+) through the stats APIs:
@@ -188,6 +201,7 @@ POST /logs/_search
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [security#5492](https://github.com/opensearch-project/security/pull/5492) | Restrict star-tree for users with DLS/FLS/Field Masking |
 | v3.2.0 | [#18707](https://github.com/opensearch-project/OpenSearch/pull/18707) | Add star-tree search statistics |
 | v3.2.0 | [#18671](https://github.com/opensearch-project/OpenSearch/pull/18671) | Add IP field search support |
 | v3.1.0 | [#18070](https://github.com/opensearch-project/OpenSearch/pull/18070) | Remove feature flag, add index-level star-tree search setting |
@@ -215,7 +229,7 @@ POST /logs/_search
 
 ## Change History
 
-- **v3.2.0** (2025-09-16): Added IP field search support, star-tree search statistics (query count, time, current)
+- **v3.2.0** (2025-09-16): Added DLS/FLS/Field Masking security integration (disables star-tree for restricted users), IP field search support, star-tree search statistics (query count, time, current)
 - **v3.1.0** (2025-06-10): Production-ready status, removed feature flag, added index-level setting, date range query support, nested bucket aggregations
 - **v3.0.0** (2025-05-12): Added boolean query support, terms aggregations, range aggregations, unsigned-long support
 - **v2.19** (2024-12-10): Added date histogram aggregations, term/terms/range query support

--- a/docs/releases/v3.2.0/features/security/star-tree-security-integration.md
+++ b/docs/releases/v3.2.0/features/security/star-tree-security-integration.md
@@ -1,0 +1,126 @@
+# Star Tree Security Integration
+
+## Summary
+
+This enhancement restricts star-tree index query optimization for users with Document-Level Security (DLS), Field-Level Security (FLS), or Field Masking restrictions. When these security restrictions are applied, queries automatically fall back to standard aggregation behavior to ensure data access controls are properly enforced.
+
+## Details
+
+### What's New in v3.2.0
+
+Star-tree indexes precompute aggregations during indexing for faster query performance. However, these precomputed results don't account for security restrictions that filter documents or mask fields at query time. This release adds security-aware handling that disables star-tree optimization when DLS/FLS/Field Masking is active.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Query Processing with Security"
+        Query[Aggregation Query] --> SecCheck{Security<br/>Restrictions?}
+        SecCheck -->|None| StarTree[Star-Tree Query]
+        SecCheck -->|DLS/FLS/Masking| Fallback[Standard Aggregation]
+        
+        StarTree --> PreAgg[Return Precomputed<br/>Aggregations]
+        Fallback --> Filter[Apply Security Filters]
+        Filter --> Scan[Scan Filtered Documents]
+        Scan --> Compute[Compute Aggregations]
+    end
+```
+
+#### Implementation
+
+The security plugin's `DlsFlsValveImpl.handleSearchContext()` method now checks for star-tree query context and disables it when restrictions apply:
+
+```java
+// Restrict access for star tree index if there are any DLS/FLS/field masking restrictions
+if (searchContext.getQueryShardContext().getStarTreeQueryContext() != null) {
+    boolean flsUnrestricted = config.getFieldPrivileges().isUnrestricted(privilegesEvaluationContext, index);
+    boolean fieldMaskingUnrestricted = config.getFieldMasking().isUnrestricted(privilegesEvaluationContext, index);
+    if (!dlsRestriction.isUnrestricted() || !flsUnrestricted || !fieldMaskingUnrestricted) {
+        searchContext.getQueryShardContext().setStarTreeQueryContext(null);
+    }
+}
+```
+
+#### Security Restriction Types
+
+| Restriction | Effect on Star-Tree |
+|-------------|---------------------|
+| Document-Level Security (DLS) | Disabled - precomputed aggregations include all documents |
+| Field-Level Security (FLS) | Disabled - aggregations may include restricted fields |
+| Field Masking | Disabled - masked field values differ from indexed values |
+
+### Usage Example
+
+```yaml
+# Role with DLS restriction - star-tree will be disabled
+startree_dls_role:
+  index_permissions:
+    - index_patterns:
+        - "sales_index"
+      dls: '{"term": {"department": "engineering"}}'
+      allowed_actions:
+        - "indices:data/read/search*"
+
+# Role with FLS restriction - star-tree will be disabled
+startree_fls_role:
+  index_permissions:
+    - index_patterns:
+        - "sales_index"
+      fls:
+        - "department"
+        - "region"
+        - "sales_amount"
+        # sensitive_data field excluded
+      allowed_actions:
+        - "indices:data/read/search*"
+
+# Role with field masking - star-tree will be disabled
+startree_masked_role:
+  index_permissions:
+    - index_patterns:
+        - "sales_index"
+      masked_fields:
+        - "sensitive_data"
+      allowed_actions:
+        - "indices:data/read/search*"
+```
+
+### Migration Notes
+
+No migration required. The behavior change is automatic:
+- Users without DLS/FLS/Field Masking continue to benefit from star-tree optimization
+- Users with restrictions automatically fall back to standard aggregations with proper security filtering
+
+### Monitoring
+
+Use the star-tree search statistics to monitor the impact:
+
+```
+GET /_stats/search?pretty
+```
+
+Check `startree_query_total` - queries from restricted users will not increment this counter.
+
+## Limitations
+
+- Performance impact: Users with DLS/FLS/Field Masking will not benefit from star-tree query acceleration
+- No partial optimization: Even if only one field is masked, the entire star-tree optimization is disabled
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5492](https://github.com/opensearch-project/security/pull/5492) | Restricting star tree index for users with DLS/FLS/FieldMasking restrictions |
+
+## References
+
+- [Star-tree index documentation](https://docs.opensearch.org/3.0/search-plugins/star-tree-index/): Official star-tree documentation
+- [Document-level security](https://docs.opensearch.org/3.0/security/access-control/document-level-security/): DLS configuration
+- [Field-level security](https://docs.opensearch.org/3.0/security/access-control/field-level-security/): FLS configuration
+- [Field masking](https://docs.opensearch.org/3.0/security/access-control/field-masking/): Field masking configuration
+
+## Related Feature Report
+
+- [Star Tree Index feature documentation](../../../features/opensearch/star-tree-index.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -248,6 +248,12 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 |------|----------|-------------|
 | [Common Utils Bugfixes](features/common-utils/common-utils-bugfixes.md) | bugfix | CVE-2025-48734 fix, PublishFindingsRequest revert, Gradle 8.14/JDK 24 upgrade |
 
+### Security
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Star Tree Security Integration](features/security/star-tree-security-integration.md) | enhancement | Disable star-tree optimization for users with DLS/FLS/Field Masking restrictions |
+
 ### Common (Security)
 
 | Item | Category | Description |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Star Tree Security Integration feature in OpenSearch v3.2.0.

### Changes
- **Release report**: `docs/releases/v3.2.0/features/security/star-tree-security-integration.md`
- **Feature report update**: `docs/features/opensearch/star-tree-index.md` (added security integration section)
- **Release index update**: Added link to the new security report

### Key Points
- Star-tree query optimization is automatically disabled when DLS/FLS/Field Masking restrictions are applied
- Ensures precomputed aggregations don't bypass security filters
- Users with restrictions fall back to standard aggregation behavior

### Related
- Closes #1053
- PR: [opensearch-project/security#5492](https://github.com/opensearch-project/security/pull/5492)