### PR TITLE
docs: add Security FIPS Compliance report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -197,6 +197,7 @@
 - [JWT Authentication](security/jwt-authentication.md)
 - [Multi-Tenancy](security/multi-tenancy.md)
 - [Resource Access Control Framework](security/resource-access-control-framework.md)
+- [Security FIPS Compliance](security/security-fips-compliance.md)
 
 ## security-dashboards
 

--- a/docs/features/security/security-fips-compliance.md
+++ b/docs/features/security/security-fips-compliance.md
@@ -1,0 +1,139 @@
+# Security FIPS Compliance
+
+## Summary
+
+OpenSearch Security plugin supports FIPS 140-2 compliance, enabling deployment in government and regulated environments that require FIPS-validated cryptographic modules. This is achieved through the use of BouncyCastle FIPS (BC-FIPS) libraries and careful isolation of dependencies that have FIPS compatibility issues.
+
+FIPS 140-2 (Federal Information Processing Standard) is a U.S. government security standard that specifies requirements for cryptographic modules. Organizations in government, healthcare, finance, and other regulated industries often require FIPS-compliant software.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Security Plugin"
+        SP[Security Plugin Core]
+        SAML[SAML Authentication]
+        TLS[TLS/SSL Handling]
+        CERT[Certificate Management]
+    end
+    
+    subgraph "Cryptographic Layer"
+        BCFIPS[BC-FIPS Provider]
+        BCPKIX[bcpkix-fips]
+        BCUTIL[bcutil-fips]
+    end
+    
+    subgraph "OpenSAML Layer"
+        SHADOW[OpenSAML Shadow JAR]
+        SHIB[Shibboleth Libraries]
+    end
+    
+    SP --> BCFIPS
+    SAML --> SHADOW
+    TLS --> BCPKIX
+    CERT --> BCUTIL
+    SHADOW --> SHIB
+    SHADOW -.->|Excluded| NC[NamedCurve Classes]
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Authentication Flow"
+        REQ[Client Request] --> AUTH[Authentication]
+        AUTH --> |SAML| SAML_PROC[SAML Processor]
+        AUTH --> |JWT| JWT_PROC[JWT Processor]
+        AUTH --> |Basic| BASIC_PROC[Basic Auth]
+    end
+    
+    subgraph "Cryptographic Operations"
+        SAML_PROC --> SIGN[Signature Verification]
+        JWT_PROC --> SIGN
+        SIGN --> BCFIPS_OP[BC-FIPS Operations]
+        BCFIPS_OP --> RESULT[Auth Result]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `BouncyCastleFipsProvider` | FIPS 140-2 validated cryptographic provider |
+| `bc-fips` | Core FIPS cryptographic library |
+| `bcpkix-fips` | PKIX/CMS/EAC/PKCS/OCSP/TSP/OPENSSL support |
+| `bcutil-fips` | Utility classes for FIPS operations |
+| `libs/opensaml` | Shadow JAR subproject isolating OpenSAML dependencies |
+
+### Configuration
+
+FIPS compliance is enabled by default in v3.2.0+. No additional configuration is required.
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| N/A | FIPS libraries are the default | Enabled |
+
+### Usage Example
+
+FIPS compliance is transparent to users. Standard security configurations work without modification:
+
+```yaml
+# opensearch.yml - Standard TLS configuration works with FIPS
+plugins.security.ssl.transport.enabled: true
+plugins.security.ssl.transport.pemcert_filepath: node.pem
+plugins.security.ssl.transport.pemkey_filepath: node-key.pem
+plugins.security.ssl.transport.pemtrustedcas_filepath: root-ca.pem
+
+plugins.security.ssl.http.enabled: true
+plugins.security.ssl.http.pemcert_filepath: node.pem
+plugins.security.ssl.http.pemkey_filepath: node-key.pem
+plugins.security.ssl.http.pemtrustedcas_filepath: root-ca.pem
+```
+
+SAML authentication configuration remains unchanged:
+
+```yaml
+# config.yml - SAML configuration
+authc:
+  saml_auth_domain:
+    http_enabled: true
+    transport_enabled: false
+    order: 1
+    http_authenticator:
+      type: saml
+      challenge: true
+      config:
+        idp:
+          metadata_file: idp-metadata.xml
+          entity_id: urn:example:idp
+        sp:
+          entity_id: https://opensearch.example.com
+        kibana_url: https://dashboards.example.com
+        roles_key: Role
+```
+
+## Limitations
+
+- **OpenSAML Compatibility**: OpenSAML versions 4.0+ have dependencies on standard BouncyCastle classes not present in BC-FIPS. The shadow JAR approach excludes these classes, which may affect certain elliptic curve operations
+- **NamedCurve Service**: The `org.opensaml.security.crypto.ec.NamedCurve` service is excluded from the shadow JAR
+- **JDK Requirements**: FIPS mode may have specific JDK version requirements depending on the deployment environment
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#5404](https://github.com/opensearch-project/security/pull/5404) | Moved OpenSAML jars to Shadow Jar configuration |
+| v3.2.0 | [#5439](https://github.com/opensearch-project/security/pull/5439) | Replaced standard BouncyCastle with BC-FIPS |
+
+## References
+
+- [Issue #5438](https://github.com/opensearch-project/security/issues/5438): Complete transition to FIPS distribution of BouncyCastle
+- [Issue #4915](https://github.com/opensearch-project/security/issues/4915): OpenSAML incompatibility with BC-FIPS
+- [Issue #3420](https://github.com/opensearch-project/security/issues/3420): RFC for FIPS 140-2 enforced mode support
+- [Shibboleth FIPS Documentation](https://shibboleth.atlassian.net/wiki/spaces/DEV/pages/1159627167/FIPS): OpenSAML FIPS considerations
+
+## Change History
+
+- **v3.2.0** (2025-06): Full FIPS 140-2 compliance with BC-FIPS libraries and OpenSAML shadow JAR isolation

--- a/docs/releases/v3.2.0/features/security/security-fips-compliance.md
+++ b/docs/releases/v3.2.0/features/security/security-fips-compliance.md
@@ -1,0 +1,113 @@
+# Security FIPS Compliance
+
+## Summary
+
+OpenSearch Security plugin v3.2.0 introduces full FIPS 140-2 compliance by replacing the standard BouncyCastle cryptographic library with BC-FIPS (BouncyCastle FIPS) and isolating OpenSAML dependencies into a shadow JAR configuration. This enables OpenSearch to run in FIPS-enforced environments required by government and regulated industries.
+
+## Details
+
+### What's New in v3.2.0
+
+This release completes the transition to FIPS-compliant cryptographic libraries through two key changes:
+
+1. **OpenSAML Shadow JAR Isolation**: Moved OpenSAML dependencies to a separate shadow JAR to avoid conflicts with FIPS libraries
+2. **BouncyCastle FIPS Replacement**: Replaced standard BouncyCastle (`bcprov-jdk18on`, `bcpkix-jdk18on`, `bcutil-jdk18on`) with BC-FIPS equivalents (`bc-fips`, `bcpkix-fips`, `bcutil-fips`)
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.2.0"
+        A1[Security Plugin] --> B1[BouncyCastle Standard]
+        A1 --> C1[OpenSAML]
+        C1 --> B1
+    end
+    
+    subgraph "v3.2.0"
+        A2[Security Plugin] --> B2[BC-FIPS Libraries]
+        A2 --> C2[OpenSAML Shadow JAR]
+        C2 -.->|Excluded| D2[NamedCurve Classes]
+        B2 --> E2[BouncyCastleFipsProvider]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `libs/opensaml` | New Gradle subproject containing OpenSAML shadow JAR configuration |
+| `BouncyCastleFipsProvider` | FIPS-compliant security provider replacing `BouncyCastleProvider` |
+
+#### Dependency Changes
+
+| Old Dependency | New Dependency | Version |
+|----------------|----------------|---------|
+| `bcprov-jdk18on:1.81` | `bc-fips` | 2.0.0 |
+| `bcpkix-jdk18on:1.81` | `bcpkix-fips` | 2.0.7 |
+| `bcutil-jdk18on:1.81` | `bcutil-fips` | 2.0.3 |
+
+#### Shadow JAR Configuration
+
+The OpenSAML shadow JAR excludes classes that conflict with FIPS mode:
+
+```groovy
+tasks.shadowJar {
+    mergeServiceFiles()
+    exclude 'org/bouncycastle/**'
+    exclude 'META-INF/versions/**/org/bouncycastle/**'
+    exclude 'META-INF/services/org.opensaml.security.crypto.ec.NamedCurve'
+}
+```
+
+### Code Changes
+
+The security provider initialization was updated to use FIPS-compliant classes:
+
+```java
+// Before
+private static final Provider DEFAULT_SECURITY_PROVIDER = new BouncyCastleProvider();
+
+// After
+private static final Provider DEFAULT_SECURITY_PROVIDER = new BouncyCastleFipsProvider();
+```
+
+OpenSAML initialization now configures FIPS-compatible key derivation:
+
+```java
+System.setProperty(
+    DefaultSecurityConfigurationBootstrap.CONFIG_PROPERTY_ECDH_DEFAULT_KDF,
+    DefaultSecurityConfigurationBootstrap.PBKDF2
+);
+```
+
+### Migration Notes
+
+For users upgrading to v3.2.0:
+
+1. **No configuration changes required** - The FIPS libraries are now the default
+2. **SAML authentication** continues to work without modification
+3. **Certificate handling** uses the same APIs with FIPS-compliant implementations
+
+## Limitations
+
+- OpenSAML versions past 4.0 have inherent FIPS compatibility issues; the shadow JAR approach works around this by excluding problematic classes
+- The `NamedCurve` service is excluded from OpenSAML, which may affect certain elliptic curve operations within SAML processing
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5404](https://github.com/opensearch-project/security/pull/5404) | Moved OpenSAML jars to Shadow Jar configuration for FIPS compatibility |
+| [#5439](https://github.com/opensearch-project/security/pull/5439) | Replaced standard BouncyCastle with BC-FIPS |
+
+## References
+
+- [Issue #5438](https://github.com/opensearch-project/security/issues/5438): Complete transition to FIPS distribution of BouncyCastle
+- [Issue #4915](https://github.com/opensearch-project/security/issues/4915): OpenSAML incompatibility with BC-FIPS
+- [Issue #3420](https://github.com/opensearch-project/security/issues/3420): RFC for FIPS 140-2 enforced mode support
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/security/security-fips-compliance.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -252,6 +252,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 
 | Item | Category | Description |
 |------|----------|-------------|
+| [Security FIPS Compliance](features/security/security-fips-compliance.md) | enhancement | Full FIPS 140-2 compliance with BC-FIPS libraries and OpenSAML shadow JAR isolation |
 | [Security Performance Optimization](features/security/security-performance-optimization.md) | enhancement | Precomputed privileges toggle and optimized wildcard matching |
 | [Star Tree Security Integration](features/security/star-tree-security-integration.md) | enhancement | Disable star-tree optimization for users with DLS/FLS/Field Masking restrictions |
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security FIPS Compliance enhancement in OpenSearch v3.2.0.

### Changes

- **Release Report**: `docs/releases/v3.2.0/features/security/security-fips-compliance.md`
- **Feature Report**: `docs/features/security/security-fips-compliance.md`
- Updated release index and features index

### Key Changes in v3.2.0

1. **OpenSAML Shadow JAR Isolation** (PR #5404): Moved OpenSAML dependencies to a separate shadow JAR to avoid conflicts with FIPS libraries
2. **BouncyCastle FIPS Replacement** (PR #5439): Replaced standard BouncyCastle with BC-FIPS equivalents

### Related Issue

Closes #1051