### PR TITLE
docs: add SPIFFE X.509 SVID Support report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -198,6 +198,7 @@
 - [Multi-Tenancy](security/multi-tenancy.md)
 - [Resource Access Control Framework](security/resource-access-control-framework.md)
 - [Security FIPS Compliance](security/security-fips-compliance.md)
+- [SPIFFE X.509 SVID Support](security/spiffe-x.509-svid-support.md)
 
 ## security-dashboards
 

--- a/docs/features/security/spiffe-x.509-svid-support.md
+++ b/docs/features/security/spiffe-x.509-svid-support.md
@@ -1,0 +1,130 @@
+# SPIFFE X.509 SVID Support
+
+## Summary
+
+SPIFFE (Secure Production Identity Framework for Everyone) X.509 SVID support enables OpenSearch to authenticate nodes and administrators using SPIFFE-based workload identities. This allows organizations already using SPIFFE for service mesh or workload identity to leverage their existing PKI infrastructure for OpenSearch cluster authentication, reducing operational complexity and improving security posture.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "SPIFFE Infrastructure"
+        SPIRE[SPIRE Server]
+        Agent[SPIRE Agent]
+        SVID[X.509 SVID Certificate]
+    end
+    
+    subgraph "OpenSearch Node"
+        TLS[TLS Layer]
+        SPE[SPIFFEPrincipalExtractor]
+        Security[Security Plugin]
+    end
+    
+    subgraph "Authentication Flow"
+        Principal[Principal Extraction]
+        RoleMap[Role Mapping]
+        Access[Access Control]
+    end
+    
+    SPIRE --> Agent
+    Agent --> SVID
+    SVID --> TLS
+    TLS --> SPE
+    SPE --> Principal
+    Principal --> Security
+    Security --> RoleMap
+    RoleMap --> Access
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Client/Node presents X.509 Certificate] --> B[TLS Handshake]
+    B --> C[Extract Subject Alternative Names]
+    C --> D{Contains URI SAN?}
+    D -->|No| E[Return null]
+    D -->|Yes| F{URI starts with spiffe://?}
+    F -->|No| G[Continue to next SAN]
+    G --> D
+    F -->|Yes| H[Return CN=spiffe://...]
+    H --> I[Security Plugin Authentication]
+    I --> J[Role Mapping Lookup]
+    J --> K[Grant/Deny Access]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SPIFFEPrincipalExtractor` | Extracts SPIFFE URIs from X.509 certificate SANs and formats them as principals |
+| `PrincipalExtractor` | Interface that `SPIFFEPrincipalExtractor` implements |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.ssl.transport.principal_extractor_class` | Fully qualified class name of the principal extractor | Default DN-based extractor |
+
+### Usage Example
+
+#### Enable SPIFFE Authentication
+
+```yaml
+# opensearch.yml
+plugins.security.ssl.transport.principal_extractor_class: org.opensearch.security.ssl.transport.SPIFFEPrincipalExtractor
+```
+
+#### Configure Role Mappings
+
+```yaml
+# roles_mapping.yml
+all_access:
+  users:
+    - "CN=spiffe://example.org/admin"
+
+readall:
+  users:
+    - "CN=spiffe://example.org/workload/*"
+```
+
+#### Certificate Requirements
+
+Certificates must include a SPIFFE URI in the Subject Alternative Name extension:
+
+```
+X509v3 Subject Alternative Name:
+    URI:spiffe://trust-domain/path/to/workload
+```
+
+Example SPIFFE ID format:
+- `spiffe://example.org/ns/production/sa/opensearch`
+- `spiffe://cluster.local/workload/opensearch-node-1`
+
+## Limitations
+
+- Only the first SPIFFE URI in the certificate SANs is used
+- Certificates without SPIFFE URIs will have `null` returned (default behavior applies)
+- Trust domain validation is not performed by the extractor (handled by TLS layer)
+- Requires SPIFFE-compliant certificates following the X509-SVID specification
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#5521](https://github.com/opensearch-project/security/pull/5521) | Initial implementation of SPIFFEPrincipalExtractor |
+
+## References
+
+- [SPIFFE Official Website](https://spiffe.io/)
+- [X509-SVID Specification](https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md)
+- [SPIRE Documentation](https://spiffe.io/docs/latest/spire-about/)
+- [OpenSearch TLS Configuration](https://docs.opensearch.org/3.0/security/configuration/tls/)
+- [Client Certificate Authentication](https://docs.opensearch.org/3.0/security/authentication-backends/client-auth/)
+- [Security Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/security-settings/)
+
+## Change History
+
+- **v3.2.0**: Initial implementation of SPIFFE X.509 SVID support via `SPIFFEPrincipalExtractor`

--- a/docs/releases/v3.2.0/features/security/spiffe-x.509-svid-support.md
+++ b/docs/releases/v3.2.0/features/security/spiffe-x.509-svid-support.md
@@ -1,0 +1,131 @@
+# SPIFFE X.509 SVID Support
+
+## Summary
+
+OpenSearch v3.2.0 introduces support for SPIFFE (Secure Production Identity Framework for Everyone) X.509 SVID (SPIFFE Verifiable Identity Document) authentication. This feature enables cluster operators to use existing SPIFFE-based workload identities for node and admin authentication, eliminating the need to set up dedicated PKI infrastructure for OpenSearch.
+
+## Details
+
+### What's New in v3.2.0
+
+A new `SPIFFEPrincipalExtractor` class has been added to the Security plugin that extracts SPIFFE URIs from X.509 certificate Subject Alternative Names (SANs) for use as authentication principals.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "TLS Handshake"
+        Cert[X.509 Certificate]
+        SAN[Subject Alternative Names]
+    end
+    
+    subgraph "Principal Extraction"
+        SPE[SPIFFEPrincipalExtractor]
+        URI[SPIFFE URI Detection]
+        Principal[Principal: CN=spiffe://...]
+    end
+    
+    subgraph "Authentication"
+        Auth[Security Plugin Auth]
+        RoleMapping[Role Mapping]
+    end
+    
+    Cert --> SAN
+    SAN --> SPE
+    SPE --> URI
+    URI --> Principal
+    Principal --> Auth
+    Auth --> RoleMapping
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `SPIFFEPrincipalExtractor` | Implementation of `PrincipalExtractor` that extracts SPIFFE URIs from certificate SANs |
+| `SPIFFEPrincipalExtractorTest` | Unit tests covering various edge cases |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.ssl.transport.principal_extractor_class` | Class to use for extracting principals from certificates | (default extractor) |
+
+To enable SPIFFE authentication, configure:
+
+```yaml
+plugins.security.ssl.transport.principal_extractor_class: org.opensearch.security.ssl.transport.SPIFFEPrincipalExtractor
+```
+
+### Usage Example
+
+#### Certificate Requirements
+
+The X.509 certificate must contain a SPIFFE URI in the Subject Alternative Name (SAN) extension:
+
+```
+X509v3 Subject Alternative Name:
+    URI:spiffe://example.org/workload/opensearch-node-1
+```
+
+#### Configuration
+
+1. Configure the principal extractor in `opensearch.yml`:
+
+```yaml
+plugins.security.ssl.transport.principal_extractor_class: org.opensearch.security.ssl.transport.SPIFFEPrincipalExtractor
+```
+
+2. Map the SPIFFE identity to roles in `roles_mapping.yml`:
+
+```yaml
+admin:
+  users:
+    - "CN=spiffe://example.org/workload/opensearch-admin"
+
+node:
+  users:
+    - "CN=spiffe://example.org/workload/opensearch-node-*"
+```
+
+#### How It Works
+
+1. During TLS handshake, the certificate is presented
+2. `SPIFFEPrincipalExtractor` parses the certificate's SANs
+3. Looks for URI type SANs (type 6) starting with `spiffe://`
+4. Returns the principal as `CN=spiffe://...`
+5. The Security plugin uses this principal for authentication and role mapping
+
+### Migration Notes
+
+- No migration required - this is an additive feature
+- Existing configurations continue to work unchanged
+- To adopt SPIFFE authentication:
+  1. Ensure certificates contain SPIFFE URIs in SANs
+  2. Configure the principal extractor class
+  3. Update role mappings to use SPIFFE-based principals
+
+## Limitations
+
+- Only extracts the first SPIFFE URI found in the certificate SANs
+- Returns `null` if no SPIFFE URI is present (falls back to default behavior)
+- Requires certificates to follow the [X509-SVID specification](https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5521](https://github.com/opensearch-project/security/pull/5521) | Add SPIFFEPrincipalExtractor |
+
+## References
+
+- [SPIFFE Official Website](https://spiffe.io/)
+- [X509-SVID Specification](https://github.com/spiffe/spiffe/blob/main/standards/X509-SVID.md)
+- [OpenSearch TLS Configuration](https://docs.opensearch.org/3.0/security/configuration/tls/)
+- [Client Certificate Authentication](https://docs.opensearch.org/3.0/security/authentication-backends/client-auth/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/spiffe-x.509-svid-support.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -280,3 +280,9 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | Item | Category | Description |
 |------|----------|-------------|
 | [Security Dashboards Enhancements](features/security-dashboards-plugin/security-dashboards-enhancements.md) | enhancement | Full index pattern display in role view, added missing index permissions |
+
+### Security
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [SPIFFE X.509 SVID Support](features/security/spiffe-x.509-svid-support.md) | feature | SPIFFE-based workload identity authentication via SPIFFEPrincipalExtractor |


### PR DESCRIPTION
## Summary

This PR adds documentation for the SPIFFE X.509 SVID Support feature introduced in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/security/spiffe-x.509-svid-support.md`
- Feature report: `docs/features/security/spiffe-x.509-svid-support.md`

### Key Changes in v3.2.0
- New `SPIFFEPrincipalExtractor` class for extracting SPIFFE URIs from X.509 certificate SANs
- Enables SPIFFE-based workload identity authentication for node and admin authentication
- Allows organizations to leverage existing SPIFFE PKI infrastructure for OpenSearch

### Resources Used
- PR: opensearch-project/security#5521
- Docs: https://docs.opensearch.org/3.0/security/configuration/tls/
- Docs: https://docs.opensearch.org/3.0/security/authentication-backends/client-auth/

Closes #1048