### PR TITLE
docs: add Auxiliary Transport SSL report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -181,6 +181,7 @@
 ## security
 
 - [Alerting Comments Security](security/alerting-comments-security.md)
+- [Auxiliary Transport SSL](security/auxiliary-transport-ssl.md)
 - [Correlation Alerts](security/correlation-alerts.md)
 - [Security Auth Enhancements](security/security-auth-enhancements.md)
 - [Security Bugfixes](security/security-bugfixes.md)

--- a/docs/features/security/auxiliary-transport-ssl.md
+++ b/docs/features/security/auxiliary-transport-ssl.md
@@ -1,0 +1,146 @@
+# Auxiliary Transport SSL
+
+## Summary
+
+Auxiliary Transport SSL enables independent TLS/SSL configuration for pluggable auxiliary transports in OpenSearch. This feature allows each auxiliary transport (such as gRPC, Arrow Flight, or custom transports) to have its own certificate settings, client authentication mode, and cipher suites, providing encryption in transit for non-standard transport protocols.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Node"
+        subgraph "Security Plugin"
+            SSM[SslSettingsManager]
+            SCH[SslContextHandler]
+            CTR[CertType Registry]
+            SASP[SecureAuxTransportSettingsProvider]
+        end
+        
+        subgraph "Core Transports"
+            HTTP[HTTP Transport<br/>Port 9200]
+            TRANS[Node Transport<br/>Port 9300]
+        end
+        
+        subgraph "Auxiliary Transports"
+            GRPC[gRPC Transport<br/>Port 9400]
+            ARROW[Arrow Flight<br/>Port 9500]
+            CUSTOM[Custom Transport]
+        end
+    end
+    
+    SSM -->|Load Config| CTR
+    SSM -->|Create| SCH
+    CTR -->|Register| HTTP
+    CTR -->|Register| TRANS
+    CTR -->|Dynamic Register| GRPC
+    CTR -->|Dynamic Register| ARROW
+    CTR -->|Dynamic Register| CUSTOM
+    
+    SASP -->|Provide SSLContext| GRPC
+    SASP -->|Provide SSLContext| ARROW
+    SASP -->|Provide SSLContext| CUSTOM
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Node Startup] --> B[Load opensearch.yml]
+    B --> C{aux.transport.types<br/>configured?}
+    C -->|Yes| D[Register CertTypes<br/>for each aux transport]
+    C -->|No| E[Skip aux transport SSL]
+    D --> F{SSL enabled for<br/>aux transport?}
+    F -->|Yes| G[Validate SSL Config]
+    G --> H[Load Certificates]
+    H --> I[Create SslContextHandler]
+    I --> J[Register in CertType Registry]
+    J --> K[Provide SSLContext to<br/>Aux Transport Plugin]
+    F -->|No| L[Aux transport runs<br/>without TLS]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `CertType` | Identifies SSL configuration namespace and certificate type ID. Refactored from enum to class for dynamic registration |
+| `NodeCertTypeRegistry` | Thread-safe registry tracking all certificate types discovered on a node |
+| `SslSettingsManager` | Manages SSL configurations for all transport types, including dynamic auxiliary transports |
+| `SslContextHandler` | Wraps Netty SslContext and provides certificate management and hot-reload support |
+| `SecureAuxTransportSettingsProvider` | Interface providing SSL context and parameters to auxiliary transport plugins |
+| `SslParameters` | Encapsulates SSL parameters including provider, client auth mode, protocols, and ciphers |
+
+### Configuration
+
+Settings follow the pattern `plugins.security.ssl.aux.<transport-id>.<setting>`:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `enabled` | Enable TLS for the auxiliary transport | `false` |
+| `pemkey_filepath` | Path to private key file (PKCS #8 format) | Required if enabled |
+| `pemcert_filepath` | Path to X.509 certificate chain (PEM format) | Required if enabled |
+| `pemtrustedcas_filepath` | Path to root CA certificates (PEM format) | Required if `clientauth_mode: REQUIRE` |
+| `pemkey_password` | Password for encrypted private key | Optional |
+| `clientauth_mode` | Client authentication: `NONE`, `OPTIONAL`, `REQUIRE` | `OPTIONAL` |
+| `enabled_ciphers` | List of allowed TLS cipher suites | Default secure ciphers |
+| `enabled_protocols` | List of allowed TLS protocols | `TLSv1.3`, `TLSv1.2` |
+| `keystore_filepath` | Path to keystore file (JKS/PKCS12) | Alternative to PEM |
+| `keystore_type` | Keystore type: `JKS` or `PKCS12` | `JKS` |
+| `truststore_filepath` | Path to truststore file | Alternative to PEM trusted CAs |
+| `truststore_type` | Truststore type: `JKS` or `PKCS12` | `JKS` |
+
+### Usage Example
+
+```yaml
+# opensearch.yml
+
+# Enable secure gRPC auxiliary transport
+aux.transport.types: experimental-secure-transport-grpc
+aux.transport.experimental-secure-transport-grpc.port: '9400-9500'
+
+# Configure TLS for gRPC transport using PEM certificates
+plugins.security.ssl.aux.experimental-secure-transport-grpc.enabled: true
+plugins.security.ssl.aux.experimental-secure-transport-grpc.pemcert_filepath: node-cert.pem
+plugins.security.ssl.aux.experimental-secure-transport-grpc.pemkey_filepath: node-key.pem
+plugins.security.ssl.aux.experimental-secure-transport-grpc.pemtrustedcas_filepath: root-ca.pem
+plugins.security.ssl.aux.experimental-secure-transport-grpc.clientauth_mode: REQUIRE
+
+# Optional: Restrict ciphers and protocols
+plugins.security.ssl.aux.experimental-secure-transport-grpc.enabled_protocols:
+  - TLSv1.3
+plugins.security.ssl.aux.experimental-secure-transport-grpc.enabled_ciphers:
+  - TLS_AES_256_GCM_SHA384
+  - TLS_AES_128_GCM_SHA256
+```
+
+### Client Authentication Modes
+
+| Mode | Behavior |
+|------|----------|
+| `NONE` | Server does not request client certificate. Any TLS client can connect |
+| `OPTIONAL` | Server requests client certificate but accepts connections without one |
+| `REQUIRE` | Server requires valid client certificate from trusted CA |
+
+## Limitations
+
+- **TLS only, no authorization**: Provides encryption in transit only. No role-based access control or user authentication is enforced
+- **Certificate-based access control only**: Access is controlled solely through `clientauth_mode` and certificate trust
+- **JDK SSL provider**: Uses JDK SSL provider; OpenSSL provider is not supported
+- **No hot-reload for auxiliary transports**: Certificate hot-reload is supported but requires the same infrastructure as HTTP/Transport layers
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#5375](https://github.com/opensearch-project/security/pull/5375) | Add support for configuring auxiliary transports for SSL only |
+
+## References
+
+- [Issue #17795](https://github.com/opensearch-project/OpenSearch/issues/17795): Feature request for separation of auxiliary transport SSL configurations
+- [Documentation: Configuring TLS certificates](https://docs.opensearch.org/3.2/security/configuration/tls/): Official TLS configuration guide
+- [gRPC APIs Documentation](https://docs.opensearch.org/3.2/api-reference/grpc-apis/index/): gRPC transport documentation
+
+## Change History
+
+- **v3.2.0** (2025-08-01): Initial implementation - TLS support for auxiliary transports with per-transport configuration namespace

--- a/docs/releases/v3.2.0/features/security/auxiliary-transport-ssl.md
+++ b/docs/releases/v3.2.0/features/security/auxiliary-transport-ssl.md
@@ -1,0 +1,132 @@
+# Auxiliary Transport SSL
+
+## Summary
+
+OpenSearch v3.2.0 introduces TLS support for auxiliary transports in the Security plugin. This feature enables independent SSL/TLS configuration for pluggable auxiliary transports like gRPC, allowing each transport to have its own certificate settings, client authentication mode, and cipher suites. This is essential for securing the new gRPC transport layer that reached GA in v3.2.0.
+
+## Details
+
+### What's New in v3.2.0
+
+The Security plugin now provides TLS support for auxiliary transports through a new configuration namespace. Previously, auxiliary transports shared a single SSL configuration, but this release enables per-transport SSL settings identified by the transport's unique key.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Security Plugin"
+        SSM[SslSettingsManager]
+        SCH[SslContextHandler]
+        CT[CertType Registry]
+    end
+    
+    subgraph "Transport Layer"
+        HTTP[HTTP Transport]
+        TRANS[Node Transport]
+        AUX[Auxiliary Transports]
+    end
+    
+    subgraph "Auxiliary Transports"
+        GRPC[gRPC Transport]
+        ARROW[Arrow Flight]
+        OTHER[Other Plugins]
+    end
+    
+    SSM --> SCH
+    SSM --> CT
+    CT --> HTTP
+    CT --> TRANS
+    CT --> AUX
+    AUX --> GRPC
+    AUX --> ARROW
+    AUX --> OTHER
+    
+    SCH -->|SSL Context| GRPC
+    SCH -->|SSL Context| ARROW
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `CertType` class | Refactored from enum to class to support dynamic auxiliary transport registration |
+| `NodeCertTypeRegistry` | Write-only registry for tracking discovered certificate types on a node |
+| `SecureAuxTransportSettingsProvider` | Interface implementation providing SSL context and parameters to auxiliary transports |
+| `LegacyCertType` enum | Backward compatibility enum for node-to-node transport serialization |
+
+#### New Configuration
+
+Configuration settings follow the pattern `plugins.security.ssl.aux.<transport-id>.<setting>`:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.ssl.aux.<id>.enabled` | Enable TLS for the auxiliary transport | `false` |
+| `plugins.security.ssl.aux.<id>.pemkey_filepath` | Path to private key file (PKCS #8) | - |
+| `plugins.security.ssl.aux.<id>.pemcert_filepath` | Path to X.509 certificate chain (PEM) | - |
+| `plugins.security.ssl.aux.<id>.pemtrustedcas_filepath` | Path to root CA certificates (PEM) | - |
+| `plugins.security.ssl.aux.<id>.clientauth_mode` | Client authentication mode: `NONE`, `OPTIONAL`, `REQUIRE` | `OPTIONAL` |
+| `plugins.security.ssl.aux.<id>.enabled_ciphers` | Allowed TLS cipher suites | Default secure ciphers |
+| `plugins.security.ssl.aux.<id>.enabled_protocols` | Allowed TLS protocols | `TLSv1.3`, `TLSv1.2` |
+| `plugins.security.ssl.aux.<id>.keystore_filepath` | Path to keystore file (JKS/PKCS12) | - |
+| `plugins.security.ssl.aux.<id>.truststore_filepath` | Path to truststore file (JKS/PKCS12) | - |
+
+For the secure gRPC transport, use `experimental-secure-transport-grpc` as the transport ID.
+
+### Usage Example
+
+```yaml
+# Enable secure gRPC auxiliary transport
+aux.transport.types: experimental-secure-transport-grpc
+aux.transport.experimental-secure-transport-grpc.port: '9400-9500'
+
+# Configure TLS for gRPC transport
+plugins.security.ssl.aux.experimental-secure-transport-grpc.enabled: true
+plugins.security.ssl.aux.experimental-secure-transport-grpc.pemcert_filepath: esnode.pem
+plugins.security.ssl.aux.experimental-secure-transport-grpc.pemkey_filepath: esnode-key.pem
+plugins.security.ssl.aux.experimental-secure-transport-grpc.pemtrustedcas_filepath: root-ca.pem
+plugins.security.ssl.aux.experimental-secure-transport-grpc.clientauth_mode: REQUIRE
+```
+
+### Testing with gRPC
+
+```bash
+# Test plaintext connection (should fail with TLS enabled)
+grpcurl -plaintext localhost:9400 list
+
+# Test TLS without client certificate (works with clientauth_mode: NONE or OPTIONAL)
+grpcurl -insecure localhost:9400 list
+
+# Test TLS with client certificate (required when clientauth_mode: REQUIRE)
+grpcurl -insecure -cert esnode.pem -key esnode-key.pem localhost:9400 list
+```
+
+### Migration Notes
+
+- No migration required for existing deployments
+- Auxiliary transport SSL is opt-in via the `enabled` setting
+- Each auxiliary transport requires its own certificate configuration
+- The feature provides TLS encryption only; no authorization or user authentication is performed on auxiliary transport connections
+
+## Limitations
+
+- **No authorization**: Only TLS encryption is provided. No role-based access control or user authentication is enforced on auxiliary transport connections
+- **Certificate-based access only**: Access control is limited to `clientauth_mode` settings (allow/deny based on certificate presence and trust)
+- **JDK SSL provider only**: Uses JDK SSL provider; OpenSSL provider is not supported for auxiliary transports
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5375](https://github.com/opensearch-project/security/pull/5375) | Add support for configuring auxiliary transports for SSL only |
+
+## References
+
+- [Issue #17795](https://github.com/opensearch-project/OpenSearch/issues/17795): Feature request for separation of auxiliary transport SSL configurations
+- [Documentation: Configuring TLS certificates](https://docs.opensearch.org/3.2/security/configuration/tls/): Official TLS configuration guide
+- [gRPC Transport GA](https://opensearch.org/blog/introducing-opensearch-3-2-next-generation-search-and-anayltics-with-enchanced-ai-capabilities/): OpenSearch 3.2 release announcement
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/auxiliary-transport-ssl.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -252,6 +252,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 
 | Item | Category | Description |
 |------|----------|-------------|
+| [Auxiliary Transport SSL](features/security/auxiliary-transport-ssl.md) | feature | TLS support for auxiliary transports (gRPC, etc.) with per-transport SSL configuration |
 | [Security FIPS Compliance](features/security/security-fips-compliance.md) | enhancement | Full FIPS 140-2 compliance with BC-FIPS libraries and OpenSAML shadow JAR isolation |
 | [Security Performance Optimization](features/security/security-performance-optimization.md) | enhancement | Precomputed privileges toggle and optimized wildcard matching |
 | [Star Tree Security Integration](features/security/star-tree-security-integration.md) | enhancement | Disable star-tree optimization for users with DLS/FLS/Field Masking restrictions |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Auxiliary Transport SSL feature introduced in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/security/auxiliary-transport-ssl.md`
- Feature report: `docs/features/security/auxiliary-transport-ssl.md`

### Key Changes in v3.2.0
- TLS support for auxiliary transports (gRPC, Arrow Flight, etc.)
- Per-transport SSL configuration namespace (`plugins.security.ssl.aux.<transport-id>.<setting>`)
- Dynamic CertType registration for pluggable transports
- Support for PEM certificates and JKS/PKCS12 keystores
- Configurable client authentication modes (NONE, OPTIONAL, REQUIRE)

### Resources Used
- PR: opensearch-project/security#5375
- Issue: opensearch-project/OpenSearch#17795
- Docs: https://docs.opensearch.org/3.2/security/configuration/tls/

Closes #1047