### PR TITLE
docs: add permission-validation report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -189,6 +189,7 @@
 - [Security Configuration](security/security-configuration.md)
 - [Security Debugging](security/security-debugging.md)
 - [Security Permissions](security/security-permissions.md)
+- [Permission Validation](security/permission-validation.md)
 - [Security Performance Improvements](security/security-performance-improvements.md)
 - [Security Plugin](security/security-plugin.md)
 - [Security Plugin Dependencies](security/security-plugin-dependencies.md)

--- a/docs/features/security/permission-validation.md
+++ b/docs/features/security/permission-validation.md
@@ -1,0 +1,146 @@
+# Permission Validation
+
+## Summary
+
+Permission Validation is a security feature that allows users to test whether they have sufficient permissions to execute an API request without actually executing it. By adding a query parameter to any REST endpoint, users can safely preview authorization results, enabling risk-free permission testing and faster security configuration validation.
+
+This feature addresses the challenge of configuring Fine-Grained Access Control (FGAC) permissions, where administrators previously had no way to verify permission configurations without actually executing operations and potentially impacting users.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Permission Validation Flow"
+        A[REST Request with has_permission_check=true] --> B[SecurityRestFilter]
+        B --> C{Is Super Admin?}
+        C -->|Yes| D[Return accessAllowed: true]
+        C -->|No| E[Set Thread Context Header]
+        E --> F[SecurityFilter]
+        F --> G[PrivilegesEvaluator]
+        G --> H{Privileges Allowed?}
+        H -->|Yes| I[PermissionCheckResponse: allowed]
+        H -->|No| J[PermissionCheckResponse: denied + missing privileges]
+        I --> K[Return Response]
+        J --> K
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Input
+        A[REST Request]
+        B[Query Param: has_permission_check=true]
+    end
+    subgraph Processing
+        C[Authentication]
+        D[Authorization Check]
+        E[Privilege Evaluation]
+    end
+    subgraph Output
+        F[accessAllowed: boolean]
+        G[missingPrivileges: array]
+    end
+    A --> C
+    B --> C
+    C --> D
+    D --> E
+    E --> F
+    E --> G
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SecurityRestFilter` | Intercepts REST requests and detects the `has_permission_check` parameter |
+| `SecurityFilter` | Handles the permission check after privilege evaluation |
+| `PermissionCheckResponse` | Response object containing `accessAllowed` and `missingPrivileges` |
+| `PrivilegesEvaluator` | Evaluates user privileges against requested actions |
+
+### Configuration
+
+This feature requires no additional configuration. It is enabled by default when the Security plugin is active.
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| N/A | Feature is always available when Security plugin is enabled | Enabled |
+
+### Usage Example
+
+#### Basic Permission Check
+
+```bash
+# Check cluster health permission
+GET /_cluster/health?has_permission_check=true
+```
+
+Response when allowed:
+```json
+{
+  "accessAllowed": true,
+  "missingPrivileges": []
+}
+```
+
+Response when denied:
+```json
+{
+  "accessAllowed": false,
+  "missingPrivileges": ["cluster:monitor/health"]
+}
+```
+
+#### Write Operation Check
+
+```bash
+# Check document write permission
+PUT /my_index/_doc/1?has_permission_check=true
+{
+  "title": "Test Document"
+}
+```
+
+#### Index Management Check
+
+```bash
+# Check index creation permission
+PUT /new_index?has_permission_check=true
+{
+  "settings": {
+    "number_of_shards": 1
+  }
+}
+```
+
+### Use Cases
+
+1. **Role Configuration Validation**: Administrators can verify that a role has the correct permissions before assigning it to users
+2. **Troubleshooting Access Issues**: Quickly identify which specific permissions a user is missing
+3. **Pre-deployment Testing**: Validate permission configurations in staging before applying to production
+4. **Audit and Compliance**: Document and verify that users have appropriate access levels
+
+## Limitations
+
+- Permission check only validates authorization; request syntax errors are still rejected before the check
+- Super admins always receive `accessAllowed: true` as they bypass normal privilege evaluation
+- The check reflects permissions at request time; very recent role changes may not be reflected if caching is involved
+- Does not simulate document-level or field-level security restrictions
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#5496](https://github.com/opensearch-project/security/pull/5496) | Initial implementation of permission validation via query parameter |
+
+## References
+
+- [Issue #5468](https://github.com/opensearch-project/security/issues/5468): Original feature request for Security Permissions Simulation
+- [Permissions Documentation](https://docs.opensearch.org/3.2/security/access-control/permissions/): Official documentation on OpenSearch permissions
+
+## Change History
+
+- **v3.2.0** (2025-07-25): Initial implementation - Added `has_permission_check` query parameter for permission validation without request execution

--- a/docs/releases/v3.2.0/features/security/permission-validation.md
+++ b/docs/releases/v3.2.0/features/security/permission-validation.md
@@ -1,0 +1,116 @@
+# Permission Validation
+
+## Summary
+
+OpenSearch v3.2.0 introduces a permission validation feature that allows users to check whether they have sufficient permissions to execute an API request without actually executing it. By adding the `has_permission_check=true` query parameter to any REST endpoint, users can safely preview whether an action would be allowed or denied, along with a list of any missing privileges.
+
+This feature enables risk-free permission testing, reduces user disruption during role configuration, and provides faster validation of security configurations.
+
+## Details
+
+### What's New in v3.2.0
+
+The permission validation feature adds a new query parameter `has_permission_check` that can be appended to any existing REST API endpoint. When set to `true`, the request goes through the normal authentication and authorization flow but stops before executing the actual operation, returning a permission check response instead.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Request Flow"
+        A[REST Request] --> B{has_permission_check?}
+        B -->|false| C[Normal Execution]
+        B -->|true| D[SecurityRestFilter]
+        D --> E{Super Admin?}
+        E -->|yes| F[Return accessAllowed: true]
+        E -->|no| G[SecurityFilter]
+        G --> H[PrivilegesEvaluator]
+        H --> I[PermissionCheckResponse]
+        I --> J[Return Result]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `PermissionCheckResponse` | Response class that returns `accessAllowed` boolean and `missingPrivileges` array |
+| `HAS_PERMISSION_CHECK_PARAM` | Query parameter constant (`has_permission_check`) |
+
+#### Request Flow
+
+1. User sends a request with `?has_permission_check=true`
+2. `SecurityRestFilter` detects the parameter and sets a thread context header
+3. For super admins, immediately returns `accessAllowed: true` with empty `missingPrivileges`
+4. For regular users, the request proceeds through normal privilege evaluation
+5. `SecurityFilter` intercepts after privilege evaluation and returns the result without executing the operation
+
+### Usage Example
+
+Check if the current user can access cluster health:
+
+```bash
+GET /_cluster/health?has_permission_check=true
+```
+
+Response when access is allowed:
+
+```json
+{
+  "accessAllowed": true,
+  "missingPrivileges": []
+}
+```
+
+Response when access is denied:
+
+```json
+{
+  "accessAllowed": false,
+  "missingPrivileges": ["cluster:monitor/health"]
+}
+```
+
+This works with any REST endpoint:
+
+```bash
+# Check write permission
+PUT /my_index/_doc/1?has_permission_check=true
+{
+  "title": "Test Document"
+}
+
+# Check index creation permission
+PUT /new_index?has_permission_check=true
+
+# Check bulk operation permission
+POST /_bulk?has_permission_check=true
+{"index": {"_index": "test"}}
+{"field": "value"}
+```
+
+### Migration Notes
+
+This is a new feature with no migration required. The feature is available immediately after upgrading to v3.2.0.
+
+## Limitations
+
+- The permission check only validates authorization, not request validity (e.g., malformed JSON will still be rejected before permission check)
+- Super admins always receive `accessAllowed: true` as they bypass normal privilege evaluation
+- The feature checks permissions at the time of the request; cached permissions may not reflect very recent role changes
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5496](https://github.com/opensearch-project/security/pull/5496) | Add url query param (has_permission_check=true) to check if a user has access to call an API |
+
+## References
+
+- [Issue #5468](https://github.com/opensearch-project/security/issues/5468): Security Permissions Simulation feature request
+- [Permissions Documentation](https://docs.opensearch.org/3.2/security/access-control/permissions/): Official documentation on permissions and the `perform_permission_check` parameter
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/permission-validation.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -252,6 +252,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 
 | Item | Category | Description |
 |------|----------|-------------|
+| [Permission Validation](features/security/permission-validation.md) | feature | Query parameter to check API permissions without executing the request |
 | [Auxiliary Transport SSL](features/security/auxiliary-transport-ssl.md) | feature | TLS support for auxiliary transports (gRPC, etc.) with per-transport SSL configuration |
 | [Security FIPS Compliance](features/security/security-fips-compliance.md) | enhancement | Full FIPS 140-2 compliance with BC-FIPS libraries and OpenSAML shadow JAR isolation |
 | [Security Performance Optimization](features/security/security-performance-optimization.md) | enhancement | Precomputed privileges toggle and optimized wildcard matching |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Permission Validation feature introduced in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/security/permission-validation.md`
- Feature report: `docs/features/security/permission-validation.md`

### Feature Overview

Permission Validation allows users to check whether they have sufficient permissions to execute an API request without actually executing it. By adding `?has_permission_check=true` to any REST endpoint, users can safely preview authorization results.

### Key Changes in v3.2.0
- New `has_permission_check` query parameter for all REST endpoints
- Returns `accessAllowed` boolean and `missingPrivileges` array
- Enables risk-free permission testing and faster security configuration validation

### Resources Used
- PR: [opensearch-project/security#5496](https://github.com/opensearch-project/security/pull/5496)
- Issue: [opensearch-project/security#5468](https://github.com/opensearch-project/security/issues/5468)
- Docs: [Permissions Documentation](https://docs.opensearch.org/3.2/security/access-control/permissions/)