### PR TITLE
docs: add Argon2 password hashing report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -181,6 +181,7 @@
 ## security
 
 - [Alerting Comments Security](security/alerting-comments-security.md)
+- [Argon2 Password Hashing](security/argon2-password-hashing.md)
 - [Auxiliary Transport SSL](security/auxiliary-transport-ssl.md)
 - [Correlation Alerts](security/correlation-alerts.md)
 - [Security Auth Enhancements](security/security-auth-enhancements.md)

--- a/docs/features/security/argon2-password-hashing.md
+++ b/docs/features/security/argon2-password-hashing.md
@@ -1,0 +1,189 @@
+# Argon2 Password Hashing
+
+## Summary
+
+Argon2 is a modern, memory-hard password hashing algorithm available in the OpenSearch Security plugin. It provides enhanced protection against GPU-based and ASIC-based brute-force attacks by requiring significant memory during hash computation. Argon2 won the Password Hashing Competition in 2015 and is recommended by OWASP for password storage.
+
+OpenSearch supports three password hashing algorithms:
+- **BCrypt** (default): Traditional, well-established algorithm
+- **PBKDF2**: Standards-based algorithm with configurable iterations
+- **Argon2**: Modern memory-hard algorithm with maximum configurability
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Security Plugin"
+        Auth[Authentication Layer]
+        PH[PasswordHasherFactory]
+    end
+    
+    subgraph "Password Hashers"
+        BCrypt[BCryptPasswordHasher]
+        PBKDF2[PBKDF2PasswordHasher]
+        Argon2[Argon2PasswordHasher]
+    end
+    
+    subgraph "External Library"
+        P4J[password4j]
+    end
+    
+    subgraph "Configuration"
+        YML[opensearch.yml]
+        IU[internal_users.yml]
+    end
+    
+    Auth --> PH
+    PH --> BCrypt
+    PH --> PBKDF2
+    PH --> Argon2
+    Argon2 --> P4J
+    YML --> PH
+    IU --> Auth
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Hash Generation"
+        PW1[Plain Password] --> Hasher[Argon2PasswordHasher]
+        Salt[Random Salt 32 bytes] --> Hasher
+        Hasher --> Hash[Argon2 Hash String]
+    end
+    
+    subgraph "Hash Verification"
+        PW2[Input Password] --> Verify[check method]
+        StoredHash[Stored Hash] --> Verify
+        Verify --> Extract[Extract params from hash]
+        Extract --> Recompute[Recompute hash]
+        Recompute --> Compare[Compare hashes]
+        Compare --> Result[true/false]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `Argon2PasswordHasher` | Core hasher implementation using password4j library |
+| `PasswordHasherFactory` | Factory that creates appropriate hasher based on configuration |
+| `ConfigConstants` | Defines configuration keys and default values |
+| `Hasher` | CLI tool for generating password hashes |
+| `AuditMessage` | Updated to redact Argon2 hashes in audit logs |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.password.hashing.algorithm` | Algorithm selection: `bcrypt`, `pbkdf2`, or `argon2` | `bcrypt` |
+| `plugins.security.password.hashing.argon2.memory` | Memory usage in KiB | `65536` (64 MiB) |
+| `plugins.security.password.hashing.argon2.iterations` | Number of passes over memory | `3` |
+| `plugins.security.password.hashing.argon2.parallelism` | Degree of parallelism | `1` |
+| `plugins.security.password.hashing.argon2.length` | Output hash length in bytes | `32` |
+| `plugins.security.password.hashing.argon2.type` | Variant: `argon2id`, `argon2i`, `argon2d` | `argon2id` |
+| `plugins.security.password.hashing.argon2.version` | Algorithm version: `16` or `19` | `19` |
+
+### Argon2 Variants
+
+| Variant | Description | Use Case |
+|---------|-------------|----------|
+| `argon2id` | Hybrid of argon2i and argon2d | **Recommended** - Best general-purpose choice |
+| `argon2i` | Data-independent memory access | Side-channel attack resistance |
+| `argon2d` | Data-dependent memory access | Maximum GPU resistance |
+
+### Usage Example
+
+#### Enable Argon2 in opensearch.yml
+
+```yaml
+# Select Argon2 as the password hashing algorithm
+plugins.security.password.hashing.algorithm: argon2
+
+# Optional: Customize Argon2 parameters
+plugins.security.password.hashing.argon2.memory: 65536
+plugins.security.password.hashing.argon2.iterations: 3
+plugins.security.password.hashing.argon2.parallelism: 1
+plugins.security.password.hashing.argon2.length: 32
+plugins.security.password.hashing.argon2.type: argon2id
+plugins.security.password.hashing.argon2.version: 19
+```
+
+#### Generate Hash Using CLI
+
+```bash
+# Default Argon2 settings
+./plugins/opensearch-security/tools/hash.sh -p "password" -a Argon2
+
+# Custom settings
+./plugins/opensearch-security/tools/hash.sh -p "password" -a Argon2 \
+  --memory 47104 \
+  --iterations 1 \
+  --parallelism 2 \
+  --length 64 \
+  --type argon2d \
+  --version 19
+```
+
+#### Configure Internal Users
+
+```yaml
+# internal_users.yml
+admin:
+  hash: "$argon2id$v=19$m=65536,t=3,p=1$c29tZXNhbHQ$Kd/lnpB1yuLHOY3qaqb1+T05DtEJFqS1U6tuJZWo8dg"
+  reserved: true
+  backend_roles:
+    - admin
+  description: "Admin user"
+
+regular_user:
+  hash: "$argon2id$v=19$m=65536,t=3,p=1$c29tZXNhbHQ$yVRXZf42Us8V75OOAivJijZ9g5wqkTE1hMxfG03YMTg"
+  reserved: false
+  backend_roles: []
+  description: "Regular user"
+```
+
+### Hash Format
+
+Argon2 hashes follow the PHC (Password Hashing Competition) string format:
+
+```
+$argon2id$v=19$m=65536,t=3,p=1$<salt>$<hash>
+```
+
+| Component | Description |
+|-----------|-------------|
+| `argon2id` | Algorithm variant |
+| `v=19` | Version number |
+| `m=65536` | Memory in KiB |
+| `t=3` | Iterations (time cost) |
+| `p=1` | Parallelism |
+| `<salt>` | Base64-encoded salt |
+| `<hash>` | Base64-encoded hash |
+
+## Limitations
+
+- **Memory Requirements**: Argon2 requires significant memory during authentication; ensure adequate RAM
+- **Cluster Consistency**: All nodes must use identical password hashing configuration
+- **Migration Overhead**: Switching algorithms requires regenerating all password hashes
+- **Performance Trade-off**: Higher security settings increase authentication latency
+- **Version Compatibility**: Argon2 support requires OpenSearch 3.2.0 or later
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#5441](https://github.com/opensearch-project/security/pull/5441) | Initial Argon2 implementation |
+
+## References
+
+- [Issue #4592](https://github.com/opensearch-project/security/issues/4592): Feature request for Argon2 support
+- [Issue #4590](https://github.com/opensearch-project/security/issues/4590): Related BCrypt configuration feature
+- [Issue #4524](https://github.com/opensearch-project/security/pull/4524): Password hashing configuration foundation
+- [Security Settings Documentation](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/security-settings/): Official configuration reference
+
+## Change History
+
+- **v3.2.0** (2025-07): Initial implementation with full parameter configurability

--- a/docs/releases/v3.2.0/features/security/argon2-password-hashing.md
+++ b/docs/releases/v3.2.0/features/security/argon2-password-hashing.md
@@ -1,0 +1,133 @@
+# Argon2 Password Hashing
+
+## Summary
+
+OpenSearch v3.2.0 introduces support for the Argon2 password hashing algorithm in the Security plugin. Argon2 is a modern, memory-hard password hashing algorithm that won the Password Hashing Competition in 2015. This addition provides administrators with a third option for password hashing alongside the existing BCrypt (default) and PBKDF2 algorithms, offering enhanced security for environments requiring stronger protection against GPU-based and ASIC-based attacks.
+
+## Details
+
+### What's New in v3.2.0
+
+This release adds comprehensive Argon2 support with full configurability of all algorithm parameters:
+
+- **Memory**: Amount of memory used during hashing (default: 64 MiB / 65536 KiB)
+- **Iterations**: Number of passes over the memory (default: 3)
+- **Parallelism**: Degree of parallelism (default: 1)
+- **Length**: Output hash length in bytes (default: 32)
+- **Type**: Algorithm variant - argon2id (default), argon2i, or argon2d
+- **Version**: Algorithm version - 16 or 19 (default)
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Password Hashing Framework"
+        PH[PasswordHasherFactory]
+        BCrypt[BCryptPasswordHasher]
+        PBKDF2[PBKDF2PasswordHasher]
+        Argon2[Argon2PasswordHasher]
+    end
+    
+    subgraph "Configuration"
+        Settings[opensearch.yml]
+        ConfigConstants[ConfigConstants.java]
+    end
+    
+    subgraph "Tools"
+        Hasher[Hasher CLI Tool]
+    end
+    
+    Settings --> PH
+    ConfigConstants --> PH
+    PH --> BCrypt
+    PH --> PBKDF2
+    PH --> Argon2
+    Hasher --> PH
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `Argon2PasswordHasher` | Core implementation using password4j library |
+| `Argon2CustomConfigHashingTests` | Integration tests for custom configurations |
+| `Argon2DefaultConfigHashingTests` | Integration tests for default configurations |
+| `Argon2PasswordHasherTests` | Unit tests for the hasher |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.password.hashing.algorithm` | Hashing algorithm selection | `bcrypt` |
+| `plugins.security.password.hashing.argon2.memory` | Memory in KiB | `65536` |
+| `plugins.security.password.hashing.argon2.iterations` | Number of iterations | `3` |
+| `plugins.security.password.hashing.argon2.parallelism` | Parallel threads | `1` |
+| `plugins.security.password.hashing.argon2.length` | Output length in bytes | `32` |
+| `plugins.security.password.hashing.argon2.type` | Variant (argon2id/argon2i/argon2d) | `argon2id` |
+| `plugins.security.password.hashing.argon2.version` | Algorithm version (16 or 19) | `19` |
+
+### Usage Example
+
+#### Configuration in opensearch.yml
+
+```yaml
+plugins.security.password.hashing.algorithm: argon2
+plugins.security.password.hashing.argon2.memory: 65536
+plugins.security.password.hashing.argon2.iterations: 3
+plugins.security.password.hashing.argon2.parallelism: 1
+plugins.security.password.hashing.argon2.length: 32
+plugins.security.password.hashing.argon2.type: argon2id
+plugins.security.password.hashing.argon2.version: 19
+```
+
+#### Using the Hasher CLI Tool
+
+```bash
+# Generate Argon2 hash with default settings
+./plugins/opensearch-security/tools/hash.sh -p "mypassword" -a Argon2
+
+# Generate Argon2 hash with custom settings
+./plugins/opensearch-security/tools/hash.sh -p "mypassword" -a Argon2 \
+  -m 47104 -i 1 -par 2 -l 64 -t argon2d -v 19
+```
+
+#### Internal Users Configuration
+
+```yaml
+admin:
+  hash: "$argon2id$v=19$m=65536,t=3,p=1$c29tZXNhbHQ$Kd/lnpB1yuLHOY3qaqb1+T05DtEJFqS1U6tuJZWo8dg"
+  reserved: false
+  backend_roles: []
+  description: "Admin user with Argon2 hashed password"
+```
+
+### Migration Notes
+
+1. **Rehashing Required**: If changing from BCrypt or PBKDF2 to Argon2, all existing password hashes must be regenerated
+2. **Memory Considerations**: Argon2 is memory-intensive by design; ensure nodes have sufficient RAM
+3. **Performance Impact**: Higher memory/iteration settings increase security but also authentication latency
+4. **Backward Compatibility**: Existing BCrypt and PBKDF2 hashes continue to work; the algorithm setting only affects new hash generation
+
+## Limitations
+
+- All nodes in a cluster must use the same password hashing configuration
+- Changing algorithm settings requires rehashing all passwords
+- Higher memory settings may impact authentication performance under heavy load
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5441](https://github.com/opensearch-project/security/pull/5441) | Adds Argon2 support for password hashing |
+
+## References
+
+- [Issue #4592](https://github.com/opensearch-project/security/issues/4592): Feature request for Argon2 support
+- [Issue #4590](https://github.com/opensearch-project/security/issues/4590): Related BCrypt configuration feature
+- [Security Settings Documentation](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/security-settings/): Password hashing configuration
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/security/argon2-password-hashing.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -288,3 +288,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | Item | Category | Description |
 |------|----------|-------------|
 | [SPIFFE X.509 SVID Support](features/security/spiffe-x.509-svid-support.md) | feature | SPIFFE-based workload identity authentication via SPIFFEPrincipalExtractor |
+| [Argon2 Password Hashing](features/security/argon2-password-hashing.md) | feature | Argon2 password hashing algorithm support with full parameter configurability |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Argon2 password hashing feature introduced in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/security/argon2-password-hashing.md`
- Feature report: `docs/features/security/argon2-password-hashing.md`

### Key Changes in v3.2.0
- Added Argon2 as a third password hashing algorithm option (alongside BCrypt and PBKDF2)
- Full configurability of Argon2 parameters: memory, iterations, parallelism, length, type, version
- Updated Hasher CLI tool with Argon2 support
- Audit log hash redaction for Argon2 hashes

### Resources Used
- PR: [opensearch-project/security#5441](https://github.com/opensearch-project/security/pull/5441)
- Issue: [opensearch-project/security#4592](https://github.com/opensearch-project/security/issues/4592)

Closes #1045