### PR TITLE
docs: add Security Configuration Management report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -188,6 +188,7 @@
 - [Security Bugfixes](security/security-bugfixes.md)
 - [Security Cache Management](security/security-cache-management.md)
 - [Security Configuration](security/security-configuration.md)
+- [Security Configuration Versioning](security/security-configuration-versioning.md)
 - [Security Debugging](security/security-debugging.md)
 - [Security Permissions](security/security-permissions.md)
 - [Permission Validation](security/permission-validation.md)

--- a/docs/features/security/security-configuration-versioning.md
+++ b/docs/features/security/security-configuration-versioning.md
@@ -1,0 +1,221 @@
+# Security Configuration Versioning
+
+## Summary
+
+Security Configuration Versioning is an experimental feature that provides a comprehensive versioning system for OpenSearch security configurations. It enables administrators to track all changes to security settings, view configuration history, and provides the foundation for future rollback and roll-forward capabilities. The feature automatically creates version snapshots whenever security configurations change, storing them in a dedicated system index.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Client Layer"
+        REST[REST API Requests]
+        SA[securityadmin Script]
+    end
+    
+    subgraph "Security Plugin"
+        API[Security REST API]
+        CR[ConfigurationRepository]
+        DCF[DynamicConfigFactory]
+        VH[SecurityConfigVersionHandler]
+    end
+    
+    subgraph "Version Management"
+        VL[SecurityConfigVersionsLoader]
+        DC[SecurityConfigDiffCalculator]
+    end
+    
+    subgraph "Storage Layer"
+        SI[".opendistro_security<br/>(Primary Config)"]
+        VI[".opensearch_security_config_versions<br/>(Version History)"]
+    end
+    
+    REST --> API
+    SA --> SI
+    API --> CR
+    CR --> SI
+    CR -->|onChange| DCF
+    DCF -->|subscribe| VH
+    VH --> VL
+    VH --> DC
+    VL --> VI
+    DC -->|diff detected| VH
+    VH -->|save snapshot| VI
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Config Change] --> B{Cluster Manager?}
+    B -->|No| C[Skip]
+    B -->|Yes| D{Feature Enabled?}
+    D -->|No| C
+    D -->|Yes| E[Load Latest Version]
+    E --> F{Config Changed?}
+    F -->|No| G[Skip Version Update]
+    F -->|Yes| H[Create New Version]
+    H --> I[Save to Index]
+    I --> J[Apply Retention Policy]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SecurityConfigVersionHandler` | Core handler that listens for configuration changes and manages version creation |
+| `SecurityConfigVersionsLoader` | Utility for loading version documents from the system index (sync and async) |
+| `SecurityConfigDiffCalculator` | Computes JSON diffs between configuration versions to detect changes |
+| `SecurityConfigVersionDocument` | Data model representing the version document structure |
+| `SecurityConfigVersionDocument.Version` | Individual version entry with timestamp, modifier, and config snapshot |
+| `SecurityConfigVersionDocument.HistoricSecurityConfig` | Configuration snapshot for a specific config type |
+
+### Configuration
+
+| Setting | Description | Default | Scope |
+|---------|-------------|---------|-------|
+| `plugins.security.configurations_versions.enabled` | Enable/disable the versioning feature | `false` | Node |
+| `plugins.security.config_versions_index_name` | Custom name for the versions index | `.opensearch_security_config_versions` | Node |
+| `plugins.security.config_version.retention_count` | Maximum number of versions to retain | `10` | Node, Final |
+
+### Version Document Schema
+
+```json
+{
+  "_index": ".opensearch_security_config_versions",
+  "_id": "opensearch_security_config_versions",
+  "_source": {
+    "versions": [
+      {
+        "version_id": "v1",
+        "timestamp": "2025-05-22T08:46:11.887620466Z",
+        "modified_by": "system",
+        "security_configs": {
+          "config": {
+            "lastUpdated": "2025-05-22T08:46:11.887620466Z",
+            "configData": { }
+          },
+          "roles": {
+            "lastUpdated": "2025-05-22T08:46:11.887620466Z",
+            "configData": { }
+          },
+          "rolesmapping": {
+            "lastUpdated": "2025-05-22T08:46:11.887620466Z",
+            "configData": { }
+          },
+          "internalusers": {
+            "lastUpdated": "2025-05-22T08:46:11.887620466Z",
+            "configData": { }
+          },
+          "actiongroups": {
+            "lastUpdated": "2025-05-22T08:46:11.887620466Z",
+            "configData": { }
+          },
+          "tenants": {
+            "lastUpdated": "2025-05-22T08:46:11.887620466Z",
+            "configData": { }
+          },
+          "nodesdn": {
+            "lastUpdated": "2025-05-22T08:46:11.887620466Z",
+            "configData": { }
+          },
+          "whitelist": {
+            "lastUpdated": "2025-05-22T08:46:11.887620466Z",
+            "configData": { }
+          },
+          "audit": {
+            "lastUpdated": "2025-05-22T08:46:11.887620466Z",
+            "configData": { }
+          },
+          "allowlist": {
+            "lastUpdated": "2025-05-22T08:46:11.887620466Z",
+            "configData": { }
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+### Usage Example
+
+#### Enable the Feature
+
+```yaml
+# opensearch.yml
+plugins.security.configurations_versions.enabled: true
+plugins.security.config_version.retention_count: 20
+```
+
+#### Trigger Version Creation
+
+Any security configuration change via REST API triggers version creation:
+
+```bash
+# Create internal user
+curl -XPUT "https://localhost:9200/_plugins/_security/api/internalusers/newuser" \
+  -u 'admin:admin' --insecure \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "password": "SecurePassword123!",
+    "backend_roles": ["analyst"],
+    "attributes": {
+      "department": "security"
+    }
+  }'
+
+# Update role mapping
+curl -XPATCH "https://localhost:9200/_plugins/_security/api/rolesmapping/all_access" \
+  -u 'admin:admin' --insecure \
+  -H 'Content-Type: application/json' \
+  -d '[
+    {
+      "op": "add",
+      "path": "/backend_roles/-",
+      "value": "new_admin_role"
+    }
+  ]'
+```
+
+#### View Version Index
+
+```bash
+curl -XGET "https://localhost:9200/.opensearch_security_config_versions/_search?pretty" \
+  -u 'admin:admin' --insecure
+```
+
+### Key Behaviors
+
+1. **Cluster Manager Exclusivity**: Only the elected cluster manager node creates versions to prevent duplicates
+2. **Change Detection**: Uses JSON diff (zjsonpatch library) to detect actual configuration changes
+3. **Idempotent Updates**: No version created if configuration content is identical to the latest version
+4. **Automatic Retention**: Asynchronously prunes old versions exceeding the retention count
+5. **Optimistic Concurrency Control**: Uses sequence numbers and primary terms to handle concurrent updates
+6. **System Index Protection**: The versions index is created as a system index with appropriate settings
+
+## Limitations
+
+- **Experimental Status**: Feature is disabled by default and marked as experimental
+- **No Rollback API Yet**: Current implementation provides versioning infrastructure only; rollback/roll-forward APIs are planned
+- **Full Snapshots**: Each version stores complete configuration snapshots (not incremental diffs)
+- **Single Document Storage**: All versions stored in a single document, which may impact performance with many versions
+- **Cluster Manager Dependency**: Requires an elected cluster manager for version tracking
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#5357](https://github.com/opensearch-project/security/pull/5357) | Initial implementation of versioned security configuration management |
+
+## References
+
+- [Issue #5093](https://github.com/opensearch-project/security/issues/5093): Original feature request for tracking security index patches
+- [Security Configuration Documentation](https://docs.opensearch.org/3.0/security/configuration/index/)
+- [Security Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/security-settings/)
+
+## Change History
+
+- **v3.2.0** (2025-06-18): Initial implementation with versioning infrastructure, change detection, and retention policy

--- a/docs/releases/v3.2.0/features/security/security-configuration-management.md
+++ b/docs/releases/v3.2.0/features/security/security-configuration-management.md
@@ -1,0 +1,142 @@
+# Security Configuration Management
+
+## Summary
+
+This release introduces an experimental versioned security configuration management feature that enables tracking, rollback, and roll-forward capabilities for OpenSearch security configurations. The feature stores complete security configuration snapshots in a dedicated system index, allowing administrators to view configuration history and potentially restore previous states.
+
+## Details
+
+### What's New in v3.2.0
+
+A comprehensive versioning system for the OpenSearch security index has been implemented. This system automatically creates version snapshots whenever security configurations change, providing a complete audit trail of security changes.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Security Configuration Flow"
+        API[Security REST API]
+        DCF[DynamicConfigFactory]
+        VH[SecurityConfigVersionHandler]
+        VL[SecurityConfigVersionsLoader]
+        DC[SecurityConfigDiffCalculator]
+    end
+    
+    subgraph "Storage"
+        SI[.opendistro_security]
+        VI[.opensearch_security_config_versions]
+    end
+    
+    API -->|PUT/PATCH| SI
+    SI -->|onChange| DCF
+    DCF -->|subscribe| VH
+    VH -->|load| VL
+    VL -->|read| VI
+    VH -->|compare| DC
+    DC -->|diff detected| VH
+    VH -->|save version| VI
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `SecurityConfigVersionHandler` | Manages version creation and storage on configuration changes |
+| `SecurityConfigVersionsLoader` | Loads version documents from the system index |
+| `SecurityConfigDiffCalculator` | Computes differences between configuration versions using JSON diff |
+| `SecurityConfigVersionDocument` | Document structure for storing versioned configurations |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.configurations_versions.enabled` | Enable/disable versioning feature | `false` |
+| `plugins.security.config_versions_index_name` | Name of the versions index | `.opensearch_security_config_versions` |
+| `plugins.security.config_version.retention_count` | Maximum versions to retain | `10` |
+
+### Version Index Structure
+
+The `.opensearch_security_config_versions` index stores configuration snapshots:
+
+```json
+{
+  "versions": [
+    {
+      "version_id": "v1",
+      "timestamp": "2025-05-22T08:46:11.887620466Z",
+      "modified_by": "system",
+      "security_configs": {
+        "rolesmapping": {
+          "lastUpdated": "2025-05-22T08:46:11.887620466Z",
+          "configData": {
+            "all_access": {
+              "backend_roles": ["admin"],
+              "description": "Maps admin to all_access"
+            }
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+### Usage Example
+
+Enable the feature in `opensearch.yml`:
+
+```yaml
+plugins.security.configurations_versions.enabled: true
+plugins.security.config_version.retention_count: 10
+```
+
+When security configurations change via REST API:
+
+```bash
+# Create a user - triggers version update
+curl -XPUT https://localhost:9200/_plugins/_security/api/internalusers/testuser \
+  -u 'admin:password' --insecure \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "password": "SecurePassword123!",
+    "backend_roles": ["admin"]
+  }'
+```
+
+Log output shows version creation:
+
+```
+Detected changes in security configuration: [{"op":"add","path":"/internalusers/testuser",...}]
+Successfully saved version v2 to .opensearch_security_config_versions
+```
+
+### Key Behaviors
+
+- **Cluster Manager Only**: Version updates only occur on the elected cluster manager node
+- **Change Detection**: No version created if configuration hasn't changed
+- **Automatic Retention**: Old versions are automatically pruned based on retention count
+- **Optimistic Concurrency**: Uses sequence numbers to handle concurrent updates
+
+## Limitations
+
+- **Experimental Feature**: Disabled by default, requires explicit enablement
+- **No Rollback API**: This release provides versioning infrastructure only; rollback/roll-forward APIs are planned for future releases
+- **Storage Overhead**: Each version stores complete configuration snapshots
+- **Cluster Manager Dependency**: Version tracking requires an elected cluster manager
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5357](https://github.com/opensearch-project/security/pull/5357) | Introduced new experimental versioned security configuration management feature |
+
+## References
+
+- [Issue #5093](https://github.com/opensearch-project/security/issues/5093): Create a mechanism for tracking patches to the security index
+- [Security Configuration Documentation](https://docs.opensearch.org/3.0/security/configuration/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/security-configuration-versioning.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -290,3 +290,4 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 |------|----------|-------------|
 | [SPIFFE X.509 SVID Support](features/security/spiffe-x.509-svid-support.md) | feature | SPIFFE-based workload identity authentication via SPIFFEPrincipalExtractor |
 | [Argon2 Password Hashing](features/security/argon2-password-hashing.md) | feature | Argon2 password hashing algorithm support with full parameter configurability |
+| [Security Configuration Management](features/security/security-configuration-management.md) | feature | Experimental versioned security configuration management with rollback/roll-forward foundation |


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security Configuration Management feature introduced in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/security/security-configuration-management.md`
- Feature report: `docs/features/security/security-configuration-versioning.md`

### Key Changes in v3.2.0
- Introduced experimental versioned security configuration management feature
- New system index `.opensearch_security_config_versions` for storing configuration snapshots
- Automatic version creation on security configuration changes
- Change detection using JSON diff to avoid unnecessary versions
- Configurable retention policy for old versions
- Cluster manager-only version updates to prevent duplicates

### Resources Used
- PR: [opensearch-project/security#5357](https://github.com/opensearch-project/security/pull/5357)
- Issue: [opensearch-project/security#5093](https://github.com/opensearch-project/security/issues/5093)
- Docs: [Security Configuration](https://docs.opensearch.org/3.0/security/configuration/index/)

Closes #1043