### PR TITLE
docs: add agentic search report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -2,6 +2,7 @@
 
 ## neural-search
 
+- [Agentic Search](neural-search/agentic-search.md)
 - [Batch Ingestion](neural-search/batch-ingestion.md)
 - [Hybrid Query](neural-search/hybrid-query.md)
 - [Neural Search Bug Fixes](neural-search/neural-search-bug-fixes.md)

--- a/docs/features/neural-search/agentic-search.md
+++ b/docs/features/neural-search/agentic-search.md
@@ -1,0 +1,197 @@
+# Agentic Search
+
+## Summary
+
+Agentic Search is an LLM-enhanced search capability that allows users to interact with OpenSearch using natural language queries. Instead of constructing complex DSL queries manually, users can ask questions in plain language, and an intelligent agent interprets the intent, selects appropriate tools, and generates optimized search queries automatically.
+
+Key benefits:
+- **Natural language interface**: Query data without learning DSL syntax
+- **Intent understanding**: Agent interprets user goals beyond simple keyword matching
+- **Automatic query generation**: Converts natural language to optimized OpenSearch queries
+- **Tool-based architecture**: Extensible through ML Commons agent framework
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "User Interface"
+        A[Natural Language Query]
+    end
+    
+    subgraph "Neural Search Plugin"
+        B[agentic query clause]
+        C[Search Pipeline]
+        D[agentic_query_translator processor]
+    end
+    
+    subgraph "ML Commons"
+        E[Agent Execution]
+        F[ListIndexTool]
+        G[IndexMappingTool]
+        H[QueryPlanningTool]
+        I[WebSearchTool]
+    end
+    
+    subgraph "OpenSearch Core"
+        J[Query Execution]
+        K[Search Results]
+    end
+    
+    A --> B
+    B --> C
+    C --> D
+    D --> E
+    E --> F
+    E --> G
+    E --> H
+    E --> I
+    E --> L[Generated DSL]
+    L --> J
+    J --> K
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[User Query] --> B[AgenticSearchQueryBuilder]
+    B --> C[AgenticQueryTranslatorProcessor]
+    C --> D{Has agentic query?}
+    D -->|No| E[Pass through]
+    D -->|Yes| F[Extract query_text & query_fields]
+    F --> G[Get index mappings]
+    G --> H[Execute ML Agent]
+    H --> I[Parse DSL response]
+    I --> J[Replace query in request]
+    J --> K[Execute search]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `AgenticSearchQueryBuilder` | Query builder that parses and validates the `agentic` query clause |
+| `AgenticQueryTranslatorProcessor` | Search request processor that orchestrates agent execution |
+| `MLCommonsClientAccessor` | Client for invoking ML agents with retry support |
+| `NeuralSearchClusterUtil` | Utility for retrieving index mappings |
+| `NeuralSearchSettingsAccessor` | Settings accessor for feature flag management |
+
+### Configuration
+
+| Setting | Description | Default | Scope |
+|---------|-------------|---------|-------|
+| `plugins.neural_search.agentic_search_enabled` | Enable/disable agentic search feature | `false` | Node, Dynamic |
+
+### Usage Example
+
+#### 1. Enable the Feature
+
+```json
+PUT _cluster/settings
+{
+  "transient": {
+    "plugins.neural_search.agentic_search_enabled": "true"
+  }
+}
+```
+
+#### 2. Create an ML Agent
+
+Create an agent with tools for query planning:
+
+```json
+POST /_plugins/_ml/agents/_register
+{
+  "name": "agentic_search_agent",
+  "type": "conversational",
+  "description": "Agent for agentic search",
+  "llm": {
+    "model_id": "<your-llm-model-id>"
+  },
+  "tools": [
+    {
+      "type": "ListIndexTool"
+    },
+    {
+      "type": "IndexMappingTool"
+    },
+    {
+      "type": "QueryPlanningTool"
+    }
+  ]
+}
+```
+
+#### 3. Create Search Pipeline
+
+```json
+PUT _search/pipeline/agentic_pipeline
+{
+  "request_processors": [
+    {
+      "agentic_query_translator": {
+        "agent_id": "<agent-id-from-step-2>"
+      }
+    }
+  ]
+}
+```
+
+#### 4. Execute Natural Language Search
+
+```json
+GET /products/_search?search_pipeline=agentic_pipeline
+{
+  "query": {
+    "agentic": {
+      "query_text": "Find red cars under $30,000",
+      "query_fields": ["title", "description", "price", "color"]
+    }
+  }
+}
+```
+
+### Query Clause Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `query_text` | string | Yes | Natural language query |
+| `query_fields` | array | No | Fields to consider for query generation (max 25) |
+
+### Processor Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `agent_id` | string | Yes | ID of the ML agent to execute |
+| `tag` | string | No | Processor tag for identification |
+| `description` | string | No | Processor description |
+| `ignore_failure` | boolean | No | Whether to ignore processor failures |
+
+## Limitations
+
+- **Experimental feature**: May change in future releases without backward compatibility
+- **Top-level query only**: Cannot be nested inside bool, function_score, or other compound queries
+- **Exclusive search mode**: Cannot be combined with aggregations, sort, highlighters, post_filter, suggest, rescores, or collapse
+- **Agent dependency**: Requires a properly configured ML agent with appropriate tools
+- **Query field limit**: Maximum of 25 query fields allowed
+- **Latency**: Additional latency due to LLM inference for query generation
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#1484](https://github.com/opensearch-project/neural-search/pull/1484) | Initial implementation of agentic search query clause and processor |
+
+## References
+
+- [Issue #1479](https://github.com/opensearch-project/neural-search/issues/1479): RFC - Design for Agentic Search
+- [Blog: Introducing agentic search in OpenSearch](https://opensearch.org/blog/introducing-agentic-search-in-opensearch-transforming-data-interaction-through-natural-language/): Official announcement
+- [Agentic AI Documentation](https://docs.opensearch.org/3.0/tutorials/gen-ai/agents/index/): Agent tutorials
+- [ML Commons Agents](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/agents/index/): Agent framework documentation
+- [Tools Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/tools/index/): Available tools for agents
+
+## Change History
+
+- **v3.2.0** (2026-01-10): Initial experimental implementation with `agentic` query clause and `agentic_query_translator` processor

--- a/docs/releases/v3.2.0/features/neural-search/agentic-search.md
+++ b/docs/releases/v3.2.0/features/neural-search/agentic-search.md
@@ -1,0 +1,132 @@
+# Agentic Search
+
+## Summary
+
+Agentic Search is an experimental feature introduced in OpenSearch v3.2.0 that enables natural language search queries. Users can interact with their data using plain language questions instead of constructing complex DSL queries manually. The feature uses an LLM-powered agent to interpret user intent, plan query execution, and generate optimized OpenSearch queries automatically.
+
+## Details
+
+### What's New in v3.2.0
+
+This release introduces the foundational components for agentic search:
+
+- **New `agentic` query clause**: A new query type that accepts natural language input
+- **`agentic_query_translator` search request processor**: Translates natural language queries to OpenSearch DSL using ML agents
+- **Feature flag control**: Disabled by default, enabled via cluster setting
+
+### Technical Changes
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph "Search Request Flow"
+        A[User Query] --> B[agentic query clause]
+        B --> C[Search Pipeline]
+        C --> D[agentic_query_translator processor]
+        D --> E[ML Agent Execution]
+        E --> F[Generated DSL Query]
+        F --> G[OpenSearch Execution]
+        G --> H[Search Results]
+    end
+    
+    subgraph "ML Commons Integration"
+        E --> I[Agent with Tools]
+        I --> J[Index Mapping Tool]
+        I --> K[Query Planning Tool]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `AgenticSearchQueryBuilder` | Query builder for the `agentic` query clause |
+| `AgenticQueryTranslatorProcessor` | Search request processor that invokes ML agents |
+| `MLCommonsClientAccessor.executeAgent()` | New method to execute ML agents with parameters |
+| `NeuralSearchClusterUtil.getIndexMapping()` | Utility to retrieve index mappings for agent context |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.neural_search.agentic_search_enabled` | Feature flag to enable/disable agentic search | `false` |
+
+### Usage Example
+
+1. Enable the feature:
+```json
+PUT _cluster/settings
+{
+  "transient": {
+    "plugins.neural_search.agentic_search_enabled": "true"
+  }
+}
+```
+
+2. Create a search pipeline with the agentic query translator:
+```json
+PUT _search/pipeline/agentic_pipeline
+{
+  "request_processors": [
+    {
+      "agentic_query_translator": {
+        "agent_id": "<your-agent-id>"
+      }
+    }
+  ]
+}
+```
+
+3. Execute a natural language search:
+```json
+GET /<index_name>/_search?search_pipeline=agentic_pipeline
+{
+  "query": {
+    "agentic": {
+      "query_text": "Find me a red car",
+      "query_fields": ["title", "description", "location"]
+    }
+  }
+}
+```
+
+#### Query Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `query_text` | Yes | Natural language query string |
+| `query_fields` | No | List of fields to consider (max 25 fields) |
+
+### Migration Notes
+
+This is a new experimental feature. To adopt:
+
+1. Enable the feature flag in cluster settings
+2. Create an ML agent with appropriate tools (ListIndexTool, IndexMappingTool, QueryPlanningTool)
+3. Create a search pipeline with the `agentic_query_translator` processor
+4. Use the `agentic` query clause in search requests
+
+## Limitations
+
+- **Experimental status**: Feature is marked experimental and may change in future releases
+- **Must be top-level query**: The `agentic` query cannot be nested inside other queries (e.g., bool query)
+- **Cannot combine with other search features**: Agentic search cannot be used with aggregations, sort, highlighters, post_filter, suggest, rescores, or collapse
+- **Requires ML agent setup**: An ML agent must be configured with appropriate tools before use
+- **Single query type**: The processor only handles `AgenticSearchQueryBuilder` queries
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1484](https://github.com/opensearch-project/neural-search/pull/1484) | [Experimental] Adds agentic search query clause and agentic query translator search request processor |
+
+## References
+
+- [Issue #1479](https://github.com/opensearch-project/neural-search/issues/1479): RFC - Design for Agentic Search
+- [Blog: Introducing agentic search in OpenSearch](https://opensearch.org/blog/introducing-agentic-search-in-opensearch-transforming-data-interaction-through-natural-language/): Official announcement
+- [Agentic AI Documentation](https://docs.opensearch.org/3.0/tutorials/gen-ai/agents/index/): Agent tutorials
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/neural-search/agentic-search.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -17,6 +17,12 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 | [IndexFieldDataService Async Close](features/opensearch/indexfielddataservice-async-close.md) | bugfix | Async field data cache clearing to prevent cluster applier thread blocking |
 | [Staggered Merge Optimization](features/opensearch/staggered-merge-optimization.md) | bugfix | Replace CPU load average with AverageTracker classes, adjust default thresholds |
 
+### Neural Search
+
+| Item | Category | Description |
+|------|----------|-------------|
+| [Agentic Search](features/neural-search/agentic-search.md) | feature | [Experimental] Natural language search with agentic query clause and translator processor |
+
 ### OpenSearch Dashboards
 
 | Item | Category | Description |


### PR DESCRIPTION
## Summary

Add documentation for Agentic Search feature introduced in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/neural-search/agentic-search.md`
- Feature report: `docs/features/neural-search/agentic-search.md`

### Key Changes in v3.2.0
- New `agentic` query clause for natural language search
- `agentic_query_translator` search request processor
- Feature flag: `plugins.neural_search.agentic_search_enabled`
- Integration with ML Commons agent framework

### Resources Used
- PR: [opensearch-project/neural-search#1484](https://github.com/opensearch-project/neural-search/pull/1484)
- Issue: [opensearch-project/neural-search#1479](https://github.com/opensearch-project/neural-search/issues/1479)
- Blog: [Introducing agentic search in OpenSearch](https://opensearch.org/blog/introducing-agentic-search-in-opensearch-transforming-data-interaction-through-natural-language/)

Closes #1041