### PR TITLE
docs: add Semantic Field enhancements report for v3.2.0

### DIFF
--- a/docs/features/neural-search/semantic-field.md
+++ b/docs/features/neural-search/semantic-field.md
@@ -103,15 +103,15 @@ flowchart LR
 | `semantic_info_field_name` | Custom name for semantic info field | Auto-generated | v3.0.0 |
 | `chunking` | Enable text chunking (boolean or array of strategies) | `false` | v3.1.0 |
 | `semantic_field_search_analyzer` | Analyzer for sparse query tokenization | None | v3.1.0 |
-| `dense_embedding_config` | Custom settings for knn_vector field | Auto from model | v3.1.0 |
-| `sparse_encoding_config` | Pruning configuration for sparse vectors | `max_ratio: 0.1` | v3.1.0 |
-| `skip_existing_embedding` | Skip embedding generation if unchanged | `false` | v3.1.0 |
+| `dense_embedding_config` | Custom settings for knn_vector field (space_type, method, engine, parameters) | Auto from model | v3.2.0 |
+| `sparse_encoding_config` | Pruning configuration for sparse vectors (`prune_type`, `prune_ratio`) | `max_ratio: 0.1` | v3.2.0 |
+| `skip_existing_embedding` | Skip embedding generation if unchanged | `false` | v3.2.0 |
 
 ### Index Settings
 
 | Setting | Description | Default | Since |
 |---------|-------------|---------|-------|
-| `index.neural_search.semantic_ingest_batch_size` | Documents per batch during ingestion | `10` | v3.1.0 |
+| `index.neural_search.semantic_ingest_batch_size` | Documents per batch during ingestion (1-100) | `10` | v3.2.0 |
 
 ### Supported Raw Field Types
 
@@ -240,6 +240,13 @@ GET /my-nlp-index/_search
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#1420](https://github.com/opensearch-project/neural-search/pull/1420) | Support configuring the auto-generated knn_vector field through the semantic field |
+| v3.2.0 | [#1438](https://github.com/opensearch-project/neural-search/pull/1438) | Support configuring the ingest batch size for the semantic field |
+| v3.2.0 | [#1434](https://github.com/opensearch-project/neural-search/pull/1434) | Allow configuring prune strategies for sparse encoding in semantic fields |
+| v3.2.0 | [#1446](https://github.com/opensearch-project/neural-search/pull/1446) | Support configuring the chunking strategies through the semantic field |
+| v3.2.0 | [#1480](https://github.com/opensearch-project/neural-search/pull/1480) | Support configuring reusing existing embedding for the semantic field |
+| v3.2.0 | [#1427](https://github.com/opensearch-project/neural-search/pull/1427) | Handle remote dense model properly during mapping transform |
+| v3.2.0 | [#1475](https://github.com/opensearch-project/neural-search/pull/1475) | Fix minimal supported version for neural sparse query analyzer field |
 | v3.1.0 | [#1276](https://github.com/opensearch-project/neural-search/pull/1276) | Add semantic mapping transformer |
 | v3.1.0 | [#1309](https://github.com/opensearch-project/neural-search/pull/1309) | Add semantic ingest processor |
 | v3.1.0 | [#1315](https://github.com/opensearch-project/neural-search/pull/1315) | Implement query logic for semantic field |
@@ -261,5 +268,6 @@ GET /my-nlp-index/_search
 
 | Version | Date | Changes |
 |---------|------|---------|
+| v3.2.0 | 2025-09 | knn_vector field configuration, ingest batch size setting, sparse encoding prune strategies, chunking strategies configuration, embedding reuse option, remote dense model handling fix, neural sparse analyzer version fix |
 | v3.1.0 | 2025-06 | Semantic mapping transformer, ingest processor, query logic, chunking support, search analyzer support, stats tracking |
 | v3.0.0 | 2025-03 | Initial semantic field mapper implementation (feature-flagged) |

--- a/docs/releases/v3.2.0/features/neural-search/semantic-field.md
+++ b/docs/releases/v3.2.0/features/neural-search/semantic-field.md
@@ -1,0 +1,219 @@
+# Semantic Field Enhancements
+
+## Summary
+
+OpenSearch v3.2.0 introduces significant enhancements to the semantic field type, providing users with greater control over embedding generation and vector field configuration. These improvements allow fine-tuning of batch processing, sparse encoding pruning strategies, text chunking algorithms, embedding reuse, and knn_vector field parameters—all directly through the semantic field mapping.
+
+## Details
+
+### What's New in v3.2.0
+
+This release adds five new configuration capabilities to the semantic field:
+
+1. **knn_vector Field Configuration**: Configure the auto-generated knn_vector field parameters directly through the semantic field
+2. **Ingest Batch Size**: Control the number of documents processed per batch during embedding generation
+3. **Sparse Encoding Prune Strategies**: Configure pruning strategies for sparse vector embeddings
+4. **Chunking Strategies**: Define custom text chunking algorithms for long documents
+5. **Embedding Reuse**: Skip embedding regeneration when document content hasn't changed
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Semantic Field Configuration (v3.2.0)"
+        SF[Semantic Field Mapping]
+        DEC[dense_embedding_config]
+        SEC[sparse_encoding_config]
+        CC[chunking config]
+        BS[batch_size setting]
+        SE[skip_existing_embedding]
+    end
+    
+    subgraph "Generated Components"
+        KNN[knn_vector field]
+        RF[rank_features field]
+        SIP[Semantic Ingest Processor]
+    end
+    
+    SF --> DEC
+    SF --> SEC
+    SF --> CC
+    SF --> BS
+    SF --> SE
+    
+    DEC -->|configures| KNN
+    SEC -->|configures| RF
+    CC -->|configures| SIP
+    BS -->|configures| SIP
+    SE -->|configures| SIP
+```
+
+#### New Configuration Parameters
+
+| Parameter | Description | Default | PR |
+|-----------|-------------|---------|-----|
+| `dense_embedding_config` | Custom settings for auto-generated knn_vector field (dimension, space_type, method, etc.) | Auto from model | [#1420](https://github.com/opensearch-project/neural-search/pull/1420) |
+| `index.neural_search.semantic_ingest_batch_size` | Documents per batch during ingestion (1-100) | `10` | [#1438](https://github.com/opensearch-project/neural-search/pull/1438) |
+| `sparse_encoding_config.prune_type` | Pruning strategy: `max_ratio`, `alpha_mass`, `top_k`, `abs_value`, `none` | `max_ratio` | [#1434](https://github.com/opensearch-project/neural-search/pull/1434) |
+| `sparse_encoding_config.prune_ratio` | Ratio for pruning strategy | `0.1` | [#1434](https://github.com/opensearch-project/neural-search/pull/1434) |
+| `chunking` | Array of chunking algorithm configurations | `false` | [#1446](https://github.com/opensearch-project/neural-search/pull/1446) |
+| `skip_existing_embedding` | Reuse existing embeddings when content unchanged | `false` | [#1480](https://github.com/opensearch-project/neural-search/pull/1480) |
+
+### Usage Examples
+
+#### Configure knn_vector Field Parameters
+
+```json
+PUT /my-semantic-index
+{
+  "settings": {
+    "index.knn": true
+  },
+  "mappings": {
+    "properties": {
+      "content": {
+        "type": "semantic",
+        "model_id": "my-embedding-model",
+        "dense_embedding_config": {
+          "space_type": "cosinesimil",
+          "method": {
+            "name": "hnsw",
+            "engine": "faiss",
+            "parameters": {
+              "ef_construction": 256,
+              "m": 16
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### Configure Ingest Batch Size
+
+```json
+PUT /my-semantic-index
+{
+  "settings": {
+    "index.knn": true,
+    "index.neural_search.semantic_ingest_batch_size": 20
+  },
+  "mappings": {
+    "properties": {
+      "content": {
+        "type": "semantic",
+        "model_id": "my-embedding-model"
+      }
+    }
+  }
+}
+```
+
+#### Configure Sparse Encoding Pruning
+
+```json
+PUT /my-sparse-index
+{
+  "mappings": {
+    "properties": {
+      "content": {
+        "type": "semantic",
+        "model_id": "my-sparse-model",
+        "sparse_encoding_config": {
+          "prune_type": "top_k",
+          "prune_ratio": 50
+        }
+      }
+    }
+  }
+}
+```
+
+#### Configure Chunking Strategies
+
+```json
+PUT /my-chunked-index
+{
+  "settings": {
+    "index.knn": true
+  },
+  "mappings": {
+    "properties": {
+      "content": {
+        "type": "semantic",
+        "model_id": "my-embedding-model",
+        "chunking": [
+          {
+            "algorithm": "delimiter",
+            "parameters": { "delimiter": "\n\n" }
+          },
+          {
+            "algorithm": "fixed_token_length",
+            "parameters": { "token_limit": 256, "overlap_rate": 0.2 }
+          }
+        ]
+      }
+    }
+  }
+}
+```
+
+#### Enable Embedding Reuse
+
+```json
+PUT /my-semantic-index
+{
+  "settings": {
+    "index.knn": true
+  },
+  "mappings": {
+    "properties": {
+      "content": {
+        "type": "semantic",
+        "model_id": "my-embedding-model",
+        "skip_existing_embedding": true
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- Existing semantic field indexes continue to work without changes
+- New configuration parameters are optional and have sensible defaults
+- To use new features, update index mappings or create new indexes with the desired configuration
+
+## Limitations
+
+- `dense_embedding_config` cannot override the dimension (determined by model)
+- `skip_existing_embedding` requires the document to have existing embeddings to reuse
+- Chunking configuration cannot be changed after index creation
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1420](https://github.com/opensearch-project/neural-search/pull/1420) | Support configuring the auto-generated knn_vector field through the semantic field |
+| [#1438](https://github.com/opensearch-project/neural-search/pull/1438) | Support configuring the ingest batch size for the semantic field |
+| [#1434](https://github.com/opensearch-project/neural-search/pull/1434) | Allow configuring prune strategies for sparse encoding in semantic fields |
+| [#1446](https://github.com/opensearch-project/neural-search/pull/1446) | Support configuring the chunking strategies through the semantic field |
+| [#1480](https://github.com/opensearch-project/neural-search/pull/1480) | Support configuring reusing existing embedding for the semantic field |
+| [#1427](https://github.com/opensearch-project/neural-search/pull/1427) | Handle remote dense model properly during mapping transform |
+| [#1475](https://github.com/opensearch-project/neural-search/pull/1475) | Fix minimal supported version for neural sparse query analyzer field |
+
+## References
+
+- [Issue #1349](https://github.com/opensearch-project/neural-search/issues/1349): Configure batch size for embedding generation
+- [Issue #1350](https://github.com/opensearch-project/neural-search/issues/1350): Allow to reuse existing embedding
+- [Issue #1351](https://github.com/opensearch-project/neural-search/issues/1351): Allow to configure prune for embedding generation
+- [Issue #1354](https://github.com/opensearch-project/neural-search/issues/1354): Allow to configure chunking
+- [Issue #803](https://github.com/opensearch-project/neural-search/issues/803): Neural Search field type proposal
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/neural-search/semantic-field.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -23,6 +23,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 |------|----------|-------------|
 | [Agentic Search](features/neural-search/agentic-search.md) | feature | [Experimental] Natural language search with agentic query clause and translator processor |
 | [Hybrid Query Normalization](features/neural-search/hybrid-query-normalization.md) | enhancement | Upper bound for min-max normalization, inner hits with collapse, configurable collapse document storage |
+| [Semantic Field](features/neural-search/semantic-field.md) | enhancement | knn_vector field configuration, batch size, prune strategies, chunking, embedding reuse |
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for Semantic Field enhancements in OpenSearch v3.2.0.

### Reports Created
- Release report: `docs/releases/v3.2.0/features/neural-search/semantic-field.md`
- Feature report: `docs/features/neural-search/semantic-field.md` (updated)

### Key Changes in v3.2.0
- **knn_vector Field Configuration**: Configure auto-generated knn_vector field parameters directly through semantic field
- **Ingest Batch Size**: Control documents per batch during embedding generation (1-100, default: 10)
- **Sparse Encoding Prune Strategies**: Configure pruning strategies (`max_ratio`, `alpha_mass`, `top_k`, `abs_value`, `none`)
- **Chunking Strategies**: Define custom text chunking algorithms for long documents
- **Embedding Reuse**: Skip embedding regeneration when document content hasn't changed

### Related PRs
- [#1420](https://github.com/opensearch-project/neural-search/pull/1420): knn_vector field configuration
- [#1438](https://github.com/opensearch-project/neural-search/pull/1438): Ingest batch size
- [#1434](https://github.com/opensearch-project/neural-search/pull/1434): Prune strategies
- [#1446](https://github.com/opensearch-project/neural-search/pull/1446): Chunking strategies
- [#1480](https://github.com/opensearch-project/neural-search/pull/1480): Embedding reuse
- [#1427](https://github.com/opensearch-project/neural-search/pull/1427): Remote dense model fix
- [#1475](https://github.com/opensearch-project/neural-search/pull/1475): Neural sparse analyzer version fix

Closes #1039