### PR TITLE
docs: add ML Commons Error Handling report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -318,6 +318,7 @@
 - [ML Commons Connector and Model Validation](ml-commons/connector-model-validation.md)
 - [ML Commons Connector Blueprints](ml-commons/ml-commons-blueprints.md)
 - [ML Commons Documentation & Tutorials](ml-commons/ml-commons-documentation-tutorials.md)
+- [ML Commons Error Handling](ml-commons/ml-commons-error-handling.md)
 - [ML Commons MCP (Model Context Protocol)](ml-commons/ml-commons-mcp.md)
 - [ML Commons Memory Metadata](ml-commons/ml-commons-memory-metadata.md)
 - [ML Commons Model & Inference](ml-commons/ml-commons-model-inference.md)

--- a/docs/features/ml-commons/ml-commons-error-handling.md
+++ b/docs/features/ml-commons/ml-commons-error-handling.md
@@ -1,0 +1,148 @@
+# ML Commons Error Handling
+
+## Summary
+
+ML Commons error handling ensures that invalid client requests return appropriate HTTP 400 (Bad Request) errors instead of HTTP 500 (Internal Server Error). This follows REST API best practices by distinguishing between client errors (4xx) and server errors (5xx), making it easier for developers to debug issues and build robust applications.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph Client
+        REQ[API Request]
+    end
+    
+    subgraph "ML Commons Plugin"
+        subgraph "Request Processing"
+            VAL[Input Validation]
+            PARSE[JSON Parsing]
+        end
+        
+        subgraph "Exception Handling"
+            JPE[JsonParseException]
+            IAE[IllegalArgumentException]
+            MLE[MLException]
+        end
+        
+        subgraph "Response"
+            R400[HTTP 400 Bad Request]
+            R500[HTTP 500 Internal Error]
+        end
+    end
+    
+    REQ --> VAL
+    VAL --> PARSE
+    PARSE -->|Invalid JSON| JPE
+    VAL -->|Invalid Arguments| IAE
+    PARSE -->|Server Error| MLE
+    
+    JPE --> R400
+    IAE --> R400
+    MLE --> R500
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| MLCommonsClassLoader | Central class loader that handles ML input initialization and propagates appropriate exceptions |
+| TransportMcpToolsRegisterAction | Transport action for MCP tool registration that validates tool uniqueness |
+| JsonParseException | Exception thrown for malformed JSON input, results in HTTP 400 |
+| IllegalArgumentException | Exception thrown for invalid arguments (e.g., duplicate tools), results in HTTP 400 |
+
+### Error Categories
+
+| Error Type | HTTP Status | When Thrown |
+|------------|-------------|-------------|
+| JsonParseException | 400 | Malformed JSON in request body |
+| IllegalArgumentException | 400 | Invalid parameter values, duplicate resources |
+| MLException | 500 | Internal ML processing errors |
+| NullPointerException | 500 | Unexpected null values (server bug) |
+
+### Configuration
+
+No additional configuration is required. Error handling improvements are applied automatically.
+
+### Usage Example
+
+#### Proper Error Response for Invalid JSON
+
+```bash
+# Request with invalid JSON (unquoted value)
+POST /_plugins/_ml/agents/<agent_id>/_execute
+{
+  "parameters": {
+    "question": "Test query",
+    "is_async": invalid_value
+  }
+}
+
+# Response (HTTP 400)
+{
+    "error": {
+        "root_cause": [
+            {
+                "type": "json_parse_exception",
+                "reason": "Unrecognized token 'invalid_value': was expecting JSON value"
+            }
+        ],
+        "type": "json_parse_exception",
+        "reason": "Unrecognized token 'invalid_value': was expecting JSON value"
+    },
+    "status": 400
+}
+```
+
+#### Proper Error Response for Duplicate MCP Tool
+
+```bash
+# Request to register duplicate tool
+POST /_plugins/_ml/mcp/tools/_register
+{
+  "tools": [
+    {
+      "type": "SearchIndexTool",
+      "name": "my_search_tool"
+    }
+  ]
+}
+
+# Response when tool already exists (HTTP 400)
+{
+    "error": {
+        "root_cause": [
+            {
+                "type": "illegal_argument_exception",
+                "reason": "Unable to register tools: [my_search_tool] as they already exist"
+            }
+        ],
+        "type": "illegal_argument_exception",
+        "reason": "Unable to register tools: [my_search_tool] as they already exist"
+    },
+    "status": 400
+}
+```
+
+## Limitations
+
+- Error handling improvements are applied incrementally; some edge cases may still return 500 errors
+- Custom exception types from external connectors may not follow this pattern
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#3988](https://github.com/opensearch-project/ml-commons/pull/3988) | Throw proper 400 errors instead of 500 for agent execute and MCP |
+
+## References
+
+- [Issue #3987](https://github.com/opensearch-project/ml-commons/issues/3987): Original feature request for improved error handling
+- [Execute Agent API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/agent-apis/execute-agent/): Agent execution documentation
+- [Register MCP Tools API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/mcp-server-apis/register-mcp-tools/): MCP tool registration documentation
+- [Using MCP Tools](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/mcp/index/): MCP integration overview
+
+## Change History
+
+- **v3.2.0**: Initial implementation - proper 400 errors for agent execution and MCP tool registration

--- a/docs/releases/v3.2.0/features/ml-commons/ml-commons-error-handling.md
+++ b/docs/releases/v3.2.0/features/ml-commons/ml-commons-error-handling.md
@@ -1,0 +1,167 @@
+# ML Commons Error Handling
+
+## Summary
+
+This enhancement improves error handling in ML Commons by returning proper HTTP 400 (Bad Request) errors instead of HTTP 500 (Internal Server Error) for invalid client inputs. This change affects agent execution and MCP tool registration APIs, providing clearer error messages and following REST API best practices.
+
+## Details
+
+### What's New in v3.2.0
+
+The PR addresses two specific scenarios where invalid client input was incorrectly returning 500 errors:
+
+1. **Agent Execution**: Invalid JSON values in agent execution requests (e.g., unquoted strings) now return 400 errors with `JsonParseException`
+2. **MCP Tool Registration**: Attempting to register tools with duplicate names now returns 400 errors with `IllegalArgumentException`
+
+### Technical Changes
+
+#### Error Flow
+
+```mermaid
+flowchart TB
+    subgraph Before["Before v3.2.0"]
+        A1[Invalid Request] --> B1[Internal Processing]
+        B1 --> C1[NullPointerException / OpenSearchException]
+        C1 --> D1[HTTP 500 Error]
+    end
+    
+    subgraph After["After v3.2.0"]
+        A2[Invalid Request] --> B2[Input Validation]
+        B2 --> C2[JsonParseException / IllegalArgumentException]
+        C2 --> D2[HTTP 400 Error]
+    end
+```
+
+#### Modified Components
+
+| Component | File | Change |
+|-----------|------|--------|
+| MLCommonsClassLoader | `common/src/main/java/org/opensearch/ml/common/MLCommonsClassLoader.java` | Added `JsonParseException` handling in `init()`, `initConnector()`, and `initMLInput()` methods |
+| TransportMcpToolsRegisterAction | `plugin/src/main/java/org/opensearch/ml/action/mcpserver/TransportMcpToolsRegisterAction.java` | Changed `OpenSearchException` to `IllegalArgumentException` for duplicate tool registration |
+
+#### Exception Handling Changes
+
+The `MLCommonsClassLoader.init()` method now properly propagates `JsonParseException`:
+
+```java
+private static <T, S> S init(Map<T, Class<?>> map, T type, Object[] initArgs, 
+                              Class<?>... constructorParameterTypes) throws JsonParseException {
+    // ...
+    } catch (InvocationTargetException e) {
+        Throwable cause = e.getCause();
+        if (cause instanceof MLException) {
+            throw (MLException) cause;
+        } else if (cause instanceof IllegalArgumentException) {
+            throw (IllegalArgumentException) cause;
+        } else if (cause instanceof JsonParseException) {
+            throw (JsonParseException) cause;  // NEW: Propagate JSON parse errors
+        }
+        // ...
+    }
+}
+```
+
+### Usage Example
+
+#### Agent Execution - Invalid JSON
+
+Request with invalid JSON value:
+```json
+POST /_plugins/_ml/agents/<agent_id>/_execute
+{
+  "parameters": {
+    "question": "Give me statistics about my cluster",
+    "is_async": random
+  }
+}
+```
+
+Before (v3.1.x):
+```json
+{
+    "error": {
+        "type": "null_pointer_exception",
+        "reason": "Cannot invoke \"org.opensearch.ml.common.input.MLInput.setAlgorithm...\" because \"mlInput\" is null"
+    },
+    "status": 500
+}
+```
+
+After (v3.2.0):
+```json
+{
+    "error": {
+        "type": "json_parse_exception",
+        "reason": "Unrecognized token 'random': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')"
+    },
+    "status": 400
+}
+```
+
+#### MCP Tool Registration - Duplicate Tool
+
+Request to register an already existing tool:
+```json
+POST /_plugins/_ml/mcp/tools/_register
+{
+  "tools": [
+    {
+      "type": "SearchIndexTool",
+      "name": "existing_tool",
+      "attributes": {
+        "type": "search"
+      }
+    }
+  ]
+}
+```
+
+Before (v3.1.x):
+```json
+{
+    "error": {
+        "type": "exception",
+        "reason": "Unable to register tools: [existing_tool] as they already exist"
+    },
+    "status": 500
+}
+```
+
+After (v3.2.0):
+```json
+{
+    "error": {
+        "type": "illegal_argument_exception",
+        "reason": "Unable to register tools: [existing_tool] as they already exist"
+    },
+    "status": 400
+}
+```
+
+### Migration Notes
+
+This is a non-breaking change that improves API behavior. Client applications that rely on HTTP status codes for error handling will now receive more accurate status codes:
+
+- Applications checking for 4xx errors to identify client-side issues will now correctly catch these cases
+- Error messages remain the same, only the HTTP status code and exception type change
+
+## Limitations
+
+- This PR addresses specific error scenarios; other edge cases may still return 500 errors
+- Only affects agent execution and MCP tool registration APIs
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3988](https://github.com/opensearch-project/ml-commons/pull/3988) | Throw proper 400 errors instead of 500 for agent execute and MCP |
+
+## References
+
+- [Issue #3987](https://github.com/opensearch-project/ml-commons/issues/3987): Original feature request
+- [Execute Agent API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/agent-apis/execute-agent/): Official documentation
+- [Register MCP Tools API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/mcp-server-apis/register-mcp-tools/): Official documentation
+
+## Related Feature Report
+
+- [ML Commons Error Handling](../../../features/ml-commons/ml-commons-error-handling.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -147,6 +147,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 |------|----------|-------------|
 | [ML Commons Testing & Coverage](features/ml-commons/ml-commons-testing-coverage.md) | bugfix | Integration test stability fix, memory container unit tests, JaCoCo 0.8.13 upgrade |
 | [ML Commons Documentation & Tutorials](features/ml-commons/ml-commons-documentation-tutorials.md) | bugfix | Multi-modal search, semantic highlighter, neural sparse, language identification, agentic RAG tutorials |
+| [ML Commons Error Handling](features/ml-commons/ml-commons-error-handling.md) | enhancement | Proper 400 errors instead of 500 for agent execute and MCP tool registration |
 
 ### Dashboards Search Relevance
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the ML Commons Error Handling enhancement in OpenSearch v3.2.0.

### Changes

- **Release Report**: `docs/releases/v3.2.0/features/ml-commons/ml-commons-error-handling.md`
- **Feature Report**: `docs/features/ml-commons/ml-commons-error-handling.md`
- Updated release index and features index

### Key Points

This enhancement improves error handling in ML Commons by returning proper HTTP 400 (Bad Request) errors instead of HTTP 500 (Internal Server Error) for invalid client inputs:

1. **Agent Execution**: Invalid JSON values now return 400 errors with `JsonParseException`
2. **MCP Tool Registration**: Duplicate tool names now return 400 errors with `IllegalArgumentException`

### Related

- Closes #1038
- Related PR: [opensearch-project/ml-commons#3988](https://github.com/opensearch-project/ml-commons/pull/3988)
- Related Issue: [opensearch-project/ml-commons#3987](https://github.com/opensearch-project/ml-commons/issues/3987)