### PR TITLE
docs: add ML Commons Model Deployment report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -322,6 +322,7 @@
 - [ML Commons MCP (Model Context Protocol)](ml-commons/ml-commons-mcp.md)
 - [ML Commons Memory Metadata](ml-commons/ml-commons-memory-metadata.md)
 - [ML Commons Model & Inference](ml-commons/ml-commons-model-inference.md)
+- [ML Commons Model Deployment](ml-commons/ml-commons-model-deployment.md)
 - [ML Commons Stability and Reliability](ml-commons/ml-commons-stability.md)
 - [ML Commons Test Fixes](ml-commons/ml-commons-test-fixes.md)
 - [ML Config API](ml-commons/ml-config-api.md)

--- a/docs/features/ml-commons/ml-commons-model-deployment.md
+++ b/docs/features/ml-commons/ml-commons-model-deployment.md
@@ -1,0 +1,133 @@
+# ML Commons Model Deployment
+
+## Summary
+
+ML Commons Model Deployment provides automatic deployment capabilities for machine learning models in OpenSearch. The feature enables models to be automatically deployed when a predict request is made, eliminating the need for manual deployment steps. This includes support for deploying models to all eligible nodes in a cluster and handling partial deployment scenarios.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Model Deployment Flow"
+        A[Predict Request] --> B[MLPredictTaskRunner]
+        B --> C{Check Deployment Status}
+        C --> D{Needs Auto Deploy?}
+        D -->|Yes| E[MLModelManager.deployModel]
+        D -->|No| F[Route to Worker Node]
+        E --> G[Update Model Cache]
+        G --> F
+    end
+    
+    subgraph "Model Cache"
+        H[MLModelCache]
+        I[workerNodes]
+        J[targetWorkerNodes]
+        H --> I
+        H --> J
+    end
+    
+    subgraph "Sync Mechanism"
+        K[MLSyncUpCron]
+        K --> L[syncModelWorkerNodes]
+        L --> M[syncPlanningWorkerNodes]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Client] -->|Predict Request| B[MLPredictTaskRunner]
+    B -->|Check Cache| C[MLModelCacheHelper]
+    C -->|Get Worker Nodes| D[MLModelCache]
+    B -->|Deploy if needed| E[MLModelManager]
+    E -->|Update| C
+    B -->|Route Request| F[Worker Node]
+    F -->|Response| A
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `MLPredictTaskRunner` | Handles predict requests and triggers auto-deployment when needed |
+| `MLModelManager` | Manages model lifecycle including deployment and worker node tracking |
+| `MLModelCacheHelper` | Provides access to model cache data including worker nodes |
+| `MLModelCache` | Stores model state including current and target worker nodes |
+| `MLSyncUpCron` | Periodically syncs model worker node information across the cluster |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ml_commons.model_auto_deploy.enable` | Enable/disable automatic model deployment | `true` |
+| `plugins.ml_commons.model_auto_deploy.model_ttl_minutes` | Time-to-live for auto-deployed models | - |
+
+### Auto-Deployment Conditions
+
+Auto-deployment is triggered when:
+
+1. **No worker nodes**: Model has not been deployed to any node
+2. **Empty worker nodes**: Worker nodes array exists but is empty
+3. **Partial deployment**: Current worker nodes count is less than target worker nodes count (v3.2.0+)
+
+```java
+private boolean requiresAutoDeployment(String[] workerNodes, String[] targetWorkerNodes) {
+    return workerNodes == null
+        || workerNodes.length == 0
+        || (targetWorkerNodes != null && workerNodes.length < targetWorkerNodes.length);
+}
+```
+
+### Usage Example
+
+#### Registering a Model with Auto-Deploy
+
+```json
+POST /_plugins/_ml/models/_register
+{
+    "name": "my-embedding-model",
+    "function_name": "remote",
+    "model_group_id": "group123",
+    "connector_id": "connector456",
+    "deploy_setting": {
+        "is_auto_deploy_enabled": true
+    }
+}
+```
+
+#### Disabling Auto-Deploy Cluster-Wide
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "plugins.ml_commons.model_auto_deploy.enable": "false"
+  }
+}
+```
+
+## Limitations
+
+- Auto-deployment adds latency to the first predict request for an undeployed model
+- Planning worker nodes are stored in memory and may need re-sync after cluster restart
+- Auto-deployment only works for function types that support it (e.g., REMOTE models)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#3423](https://github.com/opensearch-project/ml-commons/pull/3423) | Run auto deploy remote model in partially deployed status |
+
+## References
+
+- [Deploy Model API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/model-apis/deploy-model/)
+- [Register Model API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/model-apis/register-model/)
+- [Connecting to externally hosted models](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/index/)
+- [Undeploy Model API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/model-apis/undeploy-model/)
+
+## Change History
+
+- **v3.2.0** (2025-07): Enhanced auto-deployment to handle partially deployed models by comparing current worker nodes against target worker nodes

--- a/docs/releases/v3.2.0/features/ml-commons/ml-commons-model-deployment.md
+++ b/docs/releases/v3.2.0/features/ml-commons/ml-commons-model-deployment.md
@@ -1,0 +1,101 @@
+# ML Commons Model Deployment
+
+## Summary
+
+This enhancement improves the auto-deployment behavior for remote models in ML Commons. Previously, auto-deploy only triggered when a model had zero running worker nodes. With this change, auto-deploy now also triggers when a model is in `PARTIALLY_DEPLOYED` status, ensuring models are fully deployed across all eligible nodes.
+
+## Details
+
+### What's New in v3.2.0
+
+The auto-deployment logic has been enhanced to handle partially deployed models. When a model is configured to deploy to all nodes but only some nodes have the model deployed, the system now automatically triggers deployment to the remaining nodes.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Predict Request Flow"
+        A[Predict Request] --> B{Check Worker Nodes}
+        B --> C{workerNodes == null<br/>OR length == 0?}
+        C -->|Yes| D[Trigger Auto Deploy]
+        C -->|No| E{targetWorkerNodes != null<br/>AND workerNodes < targetWorkerNodes?}
+        E -->|Yes| D
+        E -->|No| F[Dispatch to Worker]
+        D --> G[Deploy Model]
+        G --> F
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `MLModelCache.syncPlanningWorkerNodes()` | Syncs planning/target worker nodes for a model |
+| `MLModelCacheHelper.getTargetWorkerNodes()` | Retrieves target worker nodes for a model |
+| `MLModelCacheHelper.syncPlanningWorkerNodes()` | Syncs planning worker nodes across all models |
+| `MLModelManager.getTargetWorkerNodes()` | Gets target worker nodes from cache helper |
+| `MLModelManager.syncModelPlanningWorkerNodes()` | Syncs planning worker nodes based on eligible nodes |
+| `MLPredictTaskRunner.requiresAutoDeployment()` | Determines if auto-deployment is needed |
+
+#### Key Logic Change
+
+The `requiresAutoDeployment()` method now checks three conditions:
+
+```java
+private boolean requiresAutoDeployment(String[] workerNodes, String[] targetWorkerNodes) {
+    return workerNodes == null
+        || workerNodes.length == 0
+        || (targetWorkerNodes != null && workerNodes.length < targetWorkerNodes.length);
+}
+```
+
+This ensures auto-deployment triggers when:
+1. No worker nodes exist (original behavior)
+2. Worker nodes array is empty (original behavior)
+3. **NEW**: Current worker nodes count is less than target worker nodes count
+
+### Usage Example
+
+When a model is registered with `deploy_to_all_nodes: true` and some nodes fail to deploy:
+
+```json
+// Model status before fix
+{
+  "model_id": "abc123",
+  "model_state": "PARTIALLY_DEPLOYED",
+  "planning_worker_nodes": ["node1", "node2", "node3"],
+  "worker_nodes": ["node1"]  // Only 1 of 3 nodes deployed
+}
+
+// With this enhancement, a predict request will:
+// 1. Detect workerNodes.length (1) < targetWorkerNodes.length (3)
+// 2. Trigger auto-deployment to remaining nodes
+// 3. Route prediction to available nodes while deployment completes
+```
+
+### Migration Notes
+
+No migration required. This is a backward-compatible enhancement that improves reliability of model deployment.
+
+## Limitations
+
+- Auto-deployment must be enabled via `plugins.ml_commons.model_auto_deploy.enable` setting
+- Only applies to models configured with `deploy_to_all_nodes: true`
+- Planning worker nodes are synced in memory, so cluster restarts may require re-sync
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3423](https://github.com/opensearch-project/ml-commons/pull/3423) | Run auto deploy remote model in partially deployed status |
+
+## References
+
+- [Deploy Model API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/model-apis/deploy-model/)
+- [Connecting to externally hosted models](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/ml-commons-model-deployment.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -145,6 +145,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 
 | Item | Category | Description |
 |------|----------|-------------|
+| [ML Commons Model Deployment](features/ml-commons/ml-commons-model-deployment.md) | enhancement | Auto-deploy remote models in partially deployed status |
 | [ML Commons Testing & Coverage](features/ml-commons/ml-commons-testing-coverage.md) | bugfix | Integration test stability fix, memory container unit tests, JaCoCo 0.8.13 upgrade |
 | [ML Commons Documentation & Tutorials](features/ml-commons/ml-commons-documentation-tutorials.md) | bugfix | Multi-modal search, semantic highlighter, neural sparse, language identification, agentic RAG tutorials |
 | [ML Commons Error Handling](features/ml-commons/ml-commons-error-handling.md) | enhancement | Proper 400 errors instead of 500 for agent execute and MCP tool registration |


### PR DESCRIPTION
## Summary

This PR adds documentation for the ML Commons Model Deployment enhancement in v3.2.0.

### Changes

- **Release Report**: `docs/releases/v3.2.0/features/ml-commons/ml-commons-model-deployment.md`
- **Feature Report**: `docs/features/ml-commons/ml-commons-model-deployment.md`
- Updated release index and features index

### Key Enhancement

PR [#3423](https://github.com/opensearch-project/ml-commons/pull/3423) enhances the auto-deployment behavior for remote models. Previously, auto-deploy only triggered when a model had zero running worker nodes. With this change, auto-deploy now also triggers when a model is in `PARTIALLY_DEPLOYED` status, ensuring models are fully deployed across all eligible nodes.

### Technical Details

The `requiresAutoDeployment()` method now checks:
1. No worker nodes exist (original behavior)
2. Worker nodes array is empty (original behavior)
3. **NEW**: Current worker nodes count is less than target worker nodes count

Closes #1037