### PR TITLE
docs: add ML Commons Sparse Encoding report for v3.2.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -323,6 +323,7 @@
 - [ML Commons Memory Metadata](ml-commons/ml-commons-memory-metadata.md)
 - [ML Commons Model & Inference](ml-commons/ml-commons-model-inference.md)
 - [ML Commons Model Deployment](ml-commons/ml-commons-model-deployment.md)
+- [ML Commons Sparse Encoding](ml-commons/ml-commons-sparse-encoding.md)
 - [ML Commons Stability and Reliability](ml-commons/ml-commons-stability.md)
 - [ML Commons Test Fixes](ml-commons/ml-commons-test-fixes.md)
 - [ML Config API](ml-commons/ml-config-api.md)

--- a/docs/features/ml-commons/ml-commons-sparse-encoding.md
+++ b/docs/features/ml-commons/ml-commons-sparse-encoding.md
@@ -1,0 +1,139 @@
+# ML Commons Sparse Encoding
+
+## Summary
+
+ML Commons Sparse Encoding provides sparse vector embedding capabilities for semantic search in OpenSearch. Sparse encoding models convert text into token-weight pairs, enabling efficient neural sparse search using Lucene's inverted index. This feature supports multiple output formats including human-readable word tokens and numeric token IDs.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "ML Commons Sparse Encoding"
+        Input[Text Input] --> Model[Sparse Encoding Model]
+        Model --> Translator[SparseEncodingTranslator]
+        Translator --> Format{Output Format}
+        Format -->|WORD| WordOutput["{'hello': 6.94, 'world': 3.42}"]
+        Format -->|TOKEN_ID| TokenOutput["{'7592': 6.94, '2088': 3.42}"]
+    end
+    
+    subgraph "Sparse Tokenizer"
+        TokenInput[Text Input] --> Tokenizer[Sparse Tokenizer Model]
+        Tokenizer --> TokenFormat{Output Format}
+        TokenFormat -->|WORD| TokenWordOut["{'token': weight}"]
+        TokenFormat -->|TOKEN_ID| TokenIdOut["{'id': weight}"]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Predict API Request] --> B[Parse Parameters]
+    B --> C{sparse_embedding_format?}
+    C -->|WORD| D[Default Word Format]
+    C -->|TOKEN_ID| E[Token ID Format]
+    D --> F[TextEmbeddingModel.predict]
+    E --> F
+    F --> G[SparseEncodingTranslator]
+    G --> H[Process NDArray Output]
+    H --> I{Format Selection}
+    I -->|WORD| J[Decode Token IDs to Words]
+    I -->|TOKEN_ID| K[Use Raw Token IDs]
+    J --> L[Return Response]
+    K --> L
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SparseEmbeddingFormat` | Enum defining output formats: `WORD` (default) and `TOKEN_ID` |
+| `AsymmetricTextEmbeddingParameters` | Parameters class supporting `sparse_embedding_format` for sparse models |
+| `TextEmbeddingSparseEncodingModel` | Model implementation for sparse encoding inference |
+| `SparseTokenizerModel` | Model implementation for sparse tokenization |
+| `SparseEncodingTranslator` | Translates model output to specified format |
+| `HFModelTokenizer` | Lucene tokenizer supporting both word and token ID output |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `sparse_embedding_format` | Output format for sparse embeddings | `WORD` |
+| `content_type` | Content type for asymmetric models (QUERY/PASSAGE) | None |
+
+### Supported Models
+
+Sparse encoding supports two function types:
+
+| Function Name | Description |
+|---------------|-------------|
+| `SPARSE_ENCODING` | Full sparse encoding with token expansion |
+| `SPARSE_TOKENIZE` | Tokenization-only mode using IDF weights |
+
+### Usage Example
+
+#### Register a Sparse Encoding Model
+```json
+POST /_plugins/_ml/models/_register
+{
+  "name": "amazon/neural-sparse/opensearch-neural-sparse-encoding-doc-v3-distill",
+  "version": "1.0.0",
+  "model_format": "TORCH_SCRIPT"
+}
+```
+
+#### Predict with WORD Format (Default)
+```json
+POST _plugins/_ml/models/<model_id>/_predict
+{
+  "text_docs": ["OpenSearch neural sparse search"],
+  "parameters": {
+    "sparse_embedding_format": "WORD"
+  }
+}
+```
+
+#### Predict with TOKEN_ID Format
+```json
+POST _plugins/_ml/models/<model_id>/_predict
+{
+  "text_docs": ["OpenSearch neural sparse search"],
+  "parameters": {
+    "sparse_embedding_format": "TOKEN_ID"
+  }
+}
+```
+
+### Output Format Comparison
+
+| Format | Output Example | Use Case |
+|--------|----------------|----------|
+| WORD | `{"search": 5.2, "neural": 4.1}` | Human-readable, debugging |
+| TOKEN_ID | `{"3198": 5.2, "15503": 4.1}` | Reduced storage, numeric operations |
+
+## Limitations
+
+- TOKEN_ID format requires models with tokenizer vocabulary
+- Remote models may not support format selection (connector-dependent)
+- Format is per-request; no model-level default configuration
+- Array-based format (indices/values) not yet supported
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.2.0 | [#3963](https://github.com/opensearch-project/ml-commons/pull/3963) | Sparse encoding/tokenize support TOKEN_ID format embedding |
+
+## References
+
+- [Issue #3865](https://github.com/opensearch-project/ml-commons/issues/3865): RFC - Support additional output formats for sparse models
+- [Register Model API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/model-apis/register-model/): Model registration documentation
+- [Neural Sparse Search](https://docs.opensearch.org/3.0/vector-search/ai-search/neural-sparse-search/): Neural sparse search guide
+- [Sparse Encoding Processor](https://docs.opensearch.org/3.0/ingest-pipelines/processors/sparse-encoding/): Ingest pipeline processor
+- [Improving document retrieval with sparse semantic encoders](https://opensearch.org/blog/improving-document-retrieval-with-sparse-semantic-encoders/): Technical blog post
+
+## Change History
+
+- **v3.2.0** (2025-07-21): Added TOKEN_ID format support for sparse encoding and sparse tokenize models

--- a/docs/releases/v3.2.0/features/ml-commons/ml-commons-sparse-encoding.md
+++ b/docs/releases/v3.2.0/features/ml-commons/ml-commons-sparse-encoding.md
@@ -1,0 +1,134 @@
+# ML Commons Sparse Encoding
+
+## Summary
+
+OpenSearch v3.2.0 adds TOKEN_ID format support for sparse encoding and sparse tokenize models. This enhancement allows users to choose between human-readable word tokens (default) or numeric token IDs as output format, reducing storage requirements and improving compatibility with certain vector operations.
+
+## Details
+
+### What's New in v3.2.0
+
+This release introduces a new `sparse_embedding_format` parameter for sparse encoding (`SPARSE_ENCODING`) and sparse tokenize (`SPARSE_TOKENIZE`) models. Users can now select between two output formats at inference time:
+
+- **WORD** (default): Human-readable token strings (e.g., `{"hello": 6.94, "world": 3.42}`)
+- **TOKEN_ID**: Numeric token IDs from the tokenizer vocabulary (e.g., `{"7592": 6.94, "2088": 3.42}`)
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `SparseEmbeddingFormat` | New enum defining `WORD` and `TOKEN_ID` output formats |
+| `AsymmetricTextEmbeddingParameters` | Extended to support sparse encoding algorithms with new `sparse_embedding_format` field |
+
+#### Modified Components
+
+| Component | Changes |
+|-----------|---------|
+| `SparseEncodingTranslator` | Processes `sparse_embedding_format` from input and converts output accordingly |
+| `SparseTokenizerModel` | Reads format parameter and outputs token IDs or words based on selection |
+| `TextEmbeddingModel` | Passes `sparse_embedding_format` to predictor input |
+| `HFModelTokenizer` | Supports TOKEN_ID format via TypeAttribute for Lucene analysis |
+| `MachineLearningPlugin` | Registers XContent entries for SPARSE_ENCODING and SPARSE_TOKENIZE parameters |
+
+#### API Changes
+
+The predict API now accepts `sparse_embedding_format` in the parameters object:
+
+```json
+POST _plugins/_ml/models/<model_id>/_predict
+{
+  "text_docs": ["hello world"],
+  "parameters": {
+    "sparse_embedding_format": "TOKEN_ID"
+  }
+}
+```
+
+#### Version Compatibility
+
+- The `sparse_embedding_format` field is only serialized for OpenSearch v3.2.0 and later
+- Older versions default to `WORD` format for backward compatibility
+- Stream input/output handles version-aware serialization
+
+### Usage Example
+
+#### WORD Format (Default)
+```json
+POST _plugins/_ml/models/<sparse_model_id>/_predict
+{
+  "text_docs": ["hello world"],
+  "parameters": {
+    "sparse_embedding_format": "WORD"
+  }
+}
+
+// Response
+{
+  "inference_results": [{
+    "output": [{
+      "dataAsMap": {
+        "response": [{
+          "hello": 6.9377565,
+          "world": 3.4208686
+        }]
+      }
+    }]
+  }]
+}
+```
+
+#### TOKEN_ID Format
+```json
+POST _plugins/_ml/models/<sparse_model_id>/_predict
+{
+  "text_docs": ["hello world"],
+  "parameters": {
+    "sparse_embedding_format": "TOKEN_ID"
+  }
+}
+
+// Response
+{
+  "inference_results": [{
+    "output": [{
+      "dataAsMap": {
+        "response": [{
+          "7592": 6.9377565,
+          "2088": 3.4208686
+        }]
+      }
+    }]
+  }]
+}
+```
+
+### Migration Notes
+
+- No migration required; existing models continue to work with default `WORD` format
+- To use TOKEN_ID format, simply add the `sparse_embedding_format` parameter to predict requests
+- Both sparse encoding and sparse tokenize models support this parameter
+
+## Limitations
+
+- TOKEN_ID format requires the model to have a tokenizer with vocabulary mapping
+- Remote models may not support this parameter (depends on connector implementation)
+- The format selection is per-request; there is no model-level default configuration
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3963](https://github.com/opensearch-project/ml-commons/pull/3963) | Sparse encoding/tokenize support TOKEN_ID format embedding |
+
+## References
+
+- [Issue #3865](https://github.com/opensearch-project/ml-commons/issues/3865): RFC - Support additional output formats for sparse models
+- [Register Model API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/model-apis/register-model/): Official documentation for model registration
+- [Neural Sparse Search](https://docs.opensearch.org/3.0/vector-search/ai-search/neural-sparse-search/): Neural sparse search documentation
+- [Improving document retrieval with sparse semantic encoders](https://opensearch.org/blog/improving-document-retrieval-with-sparse-semantic-encoders/): Blog post on sparse encoding
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/ml-commons-sparse-encoding.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -145,6 +145,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 
 | Item | Category | Description |
 |------|----------|-------------|
+| [ML Commons Sparse Encoding](features/ml-commons/ml-commons-sparse-encoding.md) | enhancement | TOKEN_ID format support for sparse encoding/tokenize models |
 | [ML Commons Model Deployment](features/ml-commons/ml-commons-model-deployment.md) | enhancement | Auto-deploy remote models in partially deployed status |
 | [ML Commons Testing & Coverage](features/ml-commons/ml-commons-testing-coverage.md) | bugfix | Integration test stability fix, memory container unit tests, JaCoCo 0.8.13 upgrade |
 | [ML Commons Documentation & Tutorials](features/ml-commons/ml-commons-documentation-tutorials.md) | bugfix | Multi-modal search, semantic highlighter, neural sparse, language identification, agentic RAG tutorials |


### PR DESCRIPTION
## Summary

This PR adds documentation for the ML Commons Sparse Encoding enhancement in OpenSearch v3.2.0.

### Changes
- **Release report**: `docs/releases/v3.2.0/features/ml-commons/ml-commons-sparse-encoding.md`
- **Feature report**: `docs/features/ml-commons/ml-commons-sparse-encoding.md`
- Updated release index and features index

### Key Feature
OpenSearch v3.2.0 adds TOKEN_ID format support for sparse encoding and sparse tokenize models. Users can now choose between:
- **WORD** (default): Human-readable token strings
- **TOKEN_ID**: Numeric token IDs for reduced storage and improved compatibility

### Related
- Closes #1036
- PR: [opensearch-project/ml-commons#3963](https://github.com/opensearch-project/ml-commons/pull/3963)
- Issue: [opensearch-project/ml-commons#3865](https://github.com/opensearch-project/ml-commons/issues/3865)