### PR TITLE
docs: add k-NN Vector Search report for v3.2.0

### DIFF
--- a/docs/features/k-nn/vector-search-k-nn.md
+++ b/docs/features/k-nn/vector-search-k-nn.md
@@ -68,6 +68,9 @@ flowchart TB
 | `KNNCircuitBreaker` | Prevents OOM by limiting memory usage |
 | `RemoteNativeIndexBuildStrategy` | Offloads index building to remote infrastructure |
 | `RemoteIndexClient` | HTTP client for remote build service communication |
+| `QuantizedKNNVectorValues` | Abstraction for quantized vector values (v3.2.0+) |
+| `FaissIndexBQ` | Faiss struct supporting ADC with full-precision queries (v3.2.0+) |
+| `QFrameBitEncoder` | Binary encoder with random rotation support (v3.2.0+) |
 
 ### Supported Engines
 
@@ -95,6 +98,14 @@ flowchart TB
 | `knn.memory.circuit_breaker.limit.<tier>` | Node-specific limit by tier (v3.0.0+) | Cluster default |
 | `knn.cache.item.expiry.enabled` | Enable cache expiry | `false` |
 | `knn.cache.item.expiry.minutes` | Cache expiry time | `180` |
+| `knn.index_thread_qty` | Index thread quantity (dynamic in v3.2.0+) | 1 (4 for 32+ cores) |
+
+#### Binary Quantization Settings (v3.2.0+)
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `encoder.parameters.enable_adc` | Enable Asymmetric Distance Computation | `false` |
+| `encoder.parameters.enable_random_rotation` | Enable random rotation for binary quantization | `false` |
 
 #### Remote Index Build Settings (v3.0.0+)
 
@@ -212,6 +223,13 @@ PUT /_cluster/settings
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.2.0 | [#2819](https://github.com/opensearch-project/k-NN/pull/2819) | Support GPU indexing for FP16, Byte and Binary |
+| v3.2.0 | [#2718](https://github.com/opensearch-project/k-NN/pull/2718) | Add random rotation feature to binary encoder |
+| v3.2.0 | [#2733](https://github.com/opensearch-project/k-NN/pull/2733) | Asymmetric Distance Computation (ADC) for binary quantized faiss indices |
+| v3.2.0 | [#2817](https://github.com/opensearch-project/k-NN/pull/2817) | Extend transport-grpc module to support GRPC KNN queries |
+| v3.2.0 | [#2824](https://github.com/opensearch-project/k-NN/pull/2824) | Add nested search support for IndexBinaryHNSWCagra |
+| v3.2.0 | [#2806](https://github.com/opensearch-project/k-NN/pull/2806) | Dynamic index thread quantity defaults based on processor sizes |
+| v3.2.0 | [#2810](https://github.com/opensearch-project/k-NN/pull/2810) | Fix @ collision in NativeMemoryCacheKeyHelper |
 | v3.1.0 | [#2735](https://github.com/opensearch-project/k-NN/pull/2735) | Integrate LuceneOnFaiss memory-optimized search into KNNWeight |
 | v3.1.0 | [#2709](https://github.com/opensearch-project/k-NN/pull/2709) | Add rescore to Lucene Vector Search Query |
 | v3.1.0 | [#2750](https://github.com/opensearch-project/k-NN/pull/2750) | Update rescore context for 4X Compression |
@@ -258,9 +276,15 @@ PUT /_cluster/settings
 - [Issue #2193](https://github.com/opensearch-project/k-NN/issues/2193): Fix k-NN build due to lucene upgrade
 - [Issue #2134](https://github.com/opensearch-project/k-NN/issues/2134): Regression in cohere-10m force merge latency
 - [OpenSearch 3.0 Blog](https://opensearch.org/blog/opensearch-3-0-what-to-expect/): Release overview
+- [Issue #2796](https://github.com/opensearch-project/k-NN/issues/2796): GPU indexing RFC
+- [Issue #2714](https://github.com/opensearch-project/k-NN/issues/2714): ADC and Random Rotation RFC
+- [Issue #2816](https://github.com/opensearch-project/k-NN/issues/2816): gRPC k-NN support
+- [Binary Quantization Documentation](https://docs.opensearch.org/3.0/vector-search/optimizing-storage/binary-quantization/): Binary quantization guide
+- [ADC Blog Post](https://opensearch.org/blog/asymmetric-distance-computation-for-binary-quantization/): ADC technical deep-dive
 
 ## Change History
 
+- **v3.2.0** (2025-10-01): GPU indexing support for FP16, Byte, and Binary vectors via Cagra2; Asymmetric Distance Computation (ADC) for improved recall on binary quantized indices; random rotation feature for binary encoder; gRPC support for k-NN queries; nested search support for IndexBinaryHNSWCagra; dynamic index thread quantity defaults (4 threads for 32+ core machines); NativeMemoryCacheKeyHelper @ collision fix
 - **v3.1.0** (2025-07-15): Memory-optimized search (LuceneOnFaiss) integration into KNNWeight with layered architecture; rescore support for Lucene engine; 4x compression rescore context optimization; derived source indexing optimization; script scoring performance improvement for binary vectors; TopDocs refactoring for search results
 - **v3.0.0** (2025-05-06): Breaking changes removing deprecated index settings; node-level circuit breakers; filter function in KNNQueryBuilder; concurrency optimizations for graph loading; Remote Native Index Build foundation
 - **v2.18.0** (2024-11-05): Lucene 9.12 codec compatibility (KNN9120Codec); force merge performance optimization for non-quantization cases (~20% improvement); removed deprecated benchmarks folder; code refactoring improvements

--- a/docs/releases/v3.2.0/features/k-nn/k-nn-vector-search.md
+++ b/docs/releases/v3.2.0/features/k-nn/k-nn-vector-search.md
@@ -1,0 +1,165 @@
+# k-NN Vector Search
+
+## Summary
+
+OpenSearch v3.2.0 brings significant enhancements to the k-NN plugin, including GPU indexing support for additional vector types (FP16, Byte, Binary), improved recall through Asymmetric Distance Computation (ADC) and random rotation for binary quantization, gRPC support for k-NN queries, enhanced profiling capabilities, and performance optimizations for indexing on large machines.
+
+## Details
+
+### What's New in v3.2.0
+
+This release introduces four major feature areas and several enhancements:
+
+1. **GPU Indexing for FP16, Byte, and Binary Vectors** - Extends GPU acceleration to additional vector types
+2. **Asymmetric Distance Computation (ADC)** - Improves recall for binary quantized indices
+3. **Random Rotation for Binary Quantization** - Enhances recall on datasets with uneven variance
+4. **gRPC Support for k-NN Queries** - Enables high-performance k-NN queries via gRPC
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "v3.2.0 k-NN Enhancements"
+        subgraph "GPU Indexing"
+            FP16[FP16 Vectors] --> GPU[GPU Index Builder]
+            Byte[Byte Vectors] --> GPU
+            Binary[Binary Vectors] --> GPU
+            GPU --> Cagra2[Cagra2 Binary HNSW]
+        end
+        
+        subgraph "Binary Quantization"
+            BQ[Binary Encoder] --> RR[Random Rotation]
+            RR --> ADC[ADC Search]
+            ADC --> Results[Improved Recall]
+        end
+        
+        subgraph "gRPC Integration"
+            Client[gRPC Client] --> Transport[transport-grpc Module]
+            Transport --> KNN[k-NN Query Handler]
+        end
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `QuantizedKNNVectorValues` | Abstraction for quantized vector values for serialization and remote storage upload |
+| `FaissIndexBQ` | Faiss struct supporting ADC with full-precision query vectors |
+| `QFrameBitEncoder` | Encoder supporting random rotation setting for binary quantization |
+| `OneBitScalarQuantizationState` | Stores rotation matrix and threshold means for 1-bit quantization |
+| `MultiBitScalarQuantizationState` | Stores rotation matrix for multi-bit quantization |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `encoder.parameters.enable_adc` | Enable Asymmetric Distance Computation for binary indices | `false` |
+| `encoder.parameters.enable_random_rotation` | Enable random rotation for binary quantization | `false` |
+| `knn.index_thread_qty` | Dynamic index thread quantity (4 for 32+ cores, 1 otherwise) | Dynamic |
+
+### Usage Example
+
+#### Binary Quantization with ADC and Random Rotation
+
+```json
+PUT /vector-index
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "vector_field": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "space_type": "l2",
+          "parameters": {
+            "encoder": {
+              "name": "binary",
+              "parameters": {
+                "bits": 1,
+                "enable_adc": true,
+                "enable_random_rotation": true
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### GPU Indexing for FP16 Vectors
+
+```json
+PUT /gpu-vector-index
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 128,
+        "data_type": "float16",
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "space_type": "l2"
+        }
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- ADC and random rotation are opt-in features; existing binary quantized indices continue to work without changes
+- GPU indexing for FP16/Byte/Binary requires appropriate GPU hardware and drivers
+- gRPC k-NN queries require the `transport-grpc` module to be enabled
+
+## Limitations
+
+- ADC is currently only supported for 1-bit Faiss binary indices
+- Random rotation adds computational overhead during indexing and search
+- gRPC integration tests require `OpenSearchGrpcTestCase` fixture (planned for future release)
+- PR #1413 (collapse bug fix) was not accessible for investigation
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2819](https://github.com/opensearch-project/k-NN/pull/2819) | Support GPU indexing for FP16, Byte and Binary |
+| [#2718](https://github.com/opensearch-project/k-NN/pull/2718) | Add random rotation feature to binary encoder |
+| [#2733](https://github.com/opensearch-project/k-NN/pull/2733) | Asymmetric Distance Computation (ADC) for binary quantized faiss indices |
+| [#2817](https://github.com/opensearch-project/k-NN/pull/2817) | Extend transport-grpc module to support GRPC KNN queries |
+| [#2824](https://github.com/opensearch-project/k-NN/pull/2824) | Add nested search support for IndexBinaryHNSWCagra |
+| [#2806](https://github.com/opensearch-project/k-NN/pull/2806) | Dynamic index thread quantity defaults based on processor sizes |
+| [#2810](https://github.com/opensearch-project/k-NN/pull/2810) | Fix @ collision in NativeMemoryCacheKeyHelper |
+
+## References
+
+- [Issue #2796](https://github.com/opensearch-project/k-NN/issues/2796): GPU indexing RFC
+- [Issue #2714](https://github.com/opensearch-project/k-NN/issues/2714): ADC and Random Rotation RFC
+- [Issue #2816](https://github.com/opensearch-project/k-NN/issues/2816): gRPC k-NN support
+- [Issue #2747](https://github.com/opensearch-project/k-NN/issues/2747): Index thread quantity optimization
+- [Issue #2809](https://github.com/opensearch-project/k-NN/issues/2809): NativeMemoryCacheKeyHelper @ collision
+- [Binary Quantization Documentation](https://docs.opensearch.org/3.0/vector-search/optimizing-storage/binary-quantization/): Official docs
+- [ADC Blog Post](https://opensearch.org/blog/asymmetric-distance-computation-for-binary-quantization/): Technical deep-dive
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/k-nn/vector-search-k-nn.md)

--- a/docs/releases/v3.2.0/index.md
+++ b/docs/releases/v3.2.0/index.md
@@ -215,6 +215,7 @@ This page indexes all investigated release items for OpenSearch v3.2.0.
 
 | Item | Category | Description |
 |------|----------|-------------|
+| [k-NN Vector Search](features/k-nn/k-nn-vector-search.md) | feature | GPU indexing for FP16/Byte/Binary, ADC, random rotation, gRPC support, dynamic thread defaults |
 | [Lucene-on-Faiss: ADC Support](features/k-nn/lucene-on-faiss.md) | enhancement | ADC support for memory-optimized search with binary quantized indexes |
 | [Remote Vector Index Build](features/k-nn/remote-vector-index-build.md) | bugfix | Don't fall back to CPU on terminal failures during remote index build |
 


### PR DESCRIPTION
## Summary

This PR adds documentation for k-NN Vector Search enhancements in OpenSearch v3.2.0.

### Key Changes in v3.2.0

**New Features:**
- GPU indexing support for FP16, Byte, and Binary vectors via Cagra2
- Asymmetric Distance Computation (ADC) for improved recall on binary quantized indices
- Random rotation feature for binary encoder to improve recall on datasets with uneven variance
- gRPC support for k-NN queries via transport-grpc module
- Nested search support for IndexBinaryHNSWCagra

**Enhancements:**
- Dynamic index thread quantity defaults (4 threads for 32+ core machines)

**Bug Fixes:**
- Fix @ collision in NativeMemoryCacheKeyHelper for vector index filenames

### Reports Created
- Release report: `docs/releases/v3.2.0/features/k-nn/k-nn-vector-search.md`
- Feature report updated: `docs/features/k-nn/vector-search-k-nn.md`

### Related PRs
- #2819: GPU indexing for FP16, Byte and Binary
- #2718: Random rotation feature
- #2733: ADC for binary quantized indices
- #2817: gRPC k-NN queries
- #2824: Nested search for IndexBinaryHNSWCagra
- #2806: Dynamic index thread defaults
- #2810: NativeMemoryCacheKeyHelper fix

Closes #1032