### PR TITLE
docs: add OpenSearch Dashboards AI Chat report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -138,6 +138,7 @@
 
 ## opensearch-dashboards
 
+- [AI Chat](opensearch-dashboards/ai-chat.md)
 - [Async Query](opensearch-dashboards/async-query.md)
 - [Banner Plugin](opensearch-dashboards/banner-plugin.md)
 - [Bar Chart Enhancements](opensearch-dashboards/bar-chart-enhancements.md)

--- a/docs/features/opensearch-dashboards/ai-chat.md
+++ b/docs/features/opensearch-dashboards/ai-chat.md
@@ -1,0 +1,274 @@
+# OpenSearch Dashboards AI Chat
+
+## Summary
+
+OpenSearch Dashboards AI Chat is an experimental AI-powered conversational interface that enables users to interact with their data using natural language. The feature consists of three main components: a Chat plugin providing the UI, a Context Provider plugin for automatic context capture, and an osd-agents package implementing an AG-UI compliant ReAct agent with AWS Bedrock integration.
+
+The AI assistant framework supports open standards like AG-UI protocol and Model Context Protocol (MCP), allowing external plugins to leverage intelligent assistance with customizable tools. Users can query data, execute actions, and receive context-aware responses without learning complex query syntax.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        subgraph "Chat Plugin"
+            ChatUI[Chat Window]
+            ChatService[Chat Service]
+            AgUIAgent[AG-UI Agent Client]
+        end
+        
+        subgraph "Context Provider Plugin"
+            PageContext[usePageContext]
+            DynamicContext[useDynamicContext]
+            AssistantAction[useAssistantAction]
+            GlobalStore[Global Context Store]
+        end
+        
+        Header[Header Button]
+        Sidecar[Sidecar Panel]
+    end
+    
+    subgraph "AG-UI Server (osd-agents)"
+        HTTPServer[HTTP Server]
+        AGUIAdapter[AG-UI Adapter]
+        
+        subgraph "ReAct Agent"
+            GraphBuilder[State Graph Builder]
+            GraphNodes[Graph Nodes]
+            ToolExecutor[Tool Executor]
+            PromptManager[Prompt Manager]
+        end
+        
+        BedrockClient[Bedrock Client]
+        MCPClients[MCP Clients]
+    end
+    
+    subgraph "External Services"
+        Bedrock[AWS Bedrock Claude]
+        MCPServers[MCP Servers]
+    end
+    
+    Header --> ChatUI
+    ChatUI --> Sidecar
+    ChatUI --> ChatService
+    ChatService --> AgUIAgent
+    
+    PageContext --> GlobalStore
+    DynamicContext --> GlobalStore
+    AssistantAction --> GlobalStore
+    GlobalStore --> ChatService
+    
+    AgUIAgent -->|SSE| HTTPServer
+    HTTPServer --> AGUIAdapter
+    AGUIAdapter --> GraphBuilder
+    GraphBuilder --> GraphNodes
+    GraphNodes --> ToolExecutor
+    GraphNodes --> BedrockClient
+    ToolExecutor --> MCPClients
+    
+    BedrockClient --> Bedrock
+    MCPClients --> MCPServers
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "User Interaction"
+        Input[User Message]
+        Context[Page Context]
+    end
+    
+    subgraph "Chat Plugin"
+        Format[Format Request]
+        Stream[Stream Response]
+    end
+    
+    subgraph "AG-UI Protocol"
+        RunStart[RUN_STARTED]
+        TextStart[TEXT_MESSAGE_START]
+        TextContent[TEXT_MESSAGE_CONTENT]
+        ToolStart[TOOL_CALL_START]
+        ToolResult[TOOL_CALL_RESULT]
+        RunEnd[RUN_FINISHED]
+    end
+    
+    subgraph "ReAct Agent"
+        Process[Process Input]
+        CallModel[Call Model]
+        ExecuteTools[Execute Tools]
+        Generate[Generate Response]
+    end
+    
+    Input --> Format
+    Context --> Format
+    Format --> RunStart
+    RunStart --> Process
+    Process --> CallModel
+    CallModel --> TextStart
+    TextStart --> TextContent
+    CallModel -->|Has Tools| ToolStart
+    ToolStart --> ExecuteTools
+    ExecuteTools --> ToolResult
+    ToolResult --> CallModel
+    CallModel -->|No Tools| Generate
+    Generate --> RunEnd
+    RunEnd --> Stream
+    Stream -->|Display| Input
+```
+
+### Components
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| Chat Plugin | `src/plugins/chat` | Main chat interface with streaming support |
+| Context Provider | `src/plugins/context_provider` | React hooks for context capture |
+| osd-agents | `packages/osd-agents` | AG-UI compliant ReAct agent server |
+| AG-UI Adapter | `src/ag_ui/base_ag_ui_adapter.ts` | Protocol translation layer |
+| ReAct Agent | `src/agents/langgraph/react_agent.ts` | LangGraph-based reasoning agent |
+| Bedrock Client | `src/agents/langgraph/bedrock_client.ts` | AWS Bedrock API integration |
+| MCP Clients | `src/mcp/` | Local and HTTP MCP server clients |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `chat.enabled` | Enable the Chat plugin in Dashboards | `false` |
+| `AG_UI_PORT` | Port for the AG-UI HTTP server | `3000` |
+| `AG_UI_HOST` | Host for the AG-UI server | `localhost` |
+| `AG_UI_CORS_ORIGINS` | Allowed CORS origins | `http://localhost:5601` |
+| `AWS_REGION` | AWS region for Bedrock | `us-west-2` |
+| `AWS_PROFILE` | AWS profile for authentication | `default` |
+| `SYSTEM_PROMPT` | Path to custom system prompt file | - |
+
+### Developer Hooks
+
+#### usePageContext
+Auto-captures URL state with zero configuration:
+```typescript
+import { usePageContext } from '@osd/context-provider';
+
+export function MyApp() {
+  usePageContext(); // Automatically captures URL parameters
+  return <div>Your App</div>;
+}
+```
+
+#### useDynamicContext
+Captures React state for AI awareness:
+```typescript
+import { useDynamicContext } from '@osd/context-provider';
+
+export function DataTable() {
+  const [selectedRows, setSelectedRows] = useState([]);
+  
+  useDynamicContext({
+    description: "Currently selected table rows",
+    value: selectedRows,
+    label: "@selected-rows" // Enables @mention in chat
+  });
+  
+  return <table>...</table>;
+}
+```
+
+#### useAssistantAction
+Registers tools the AI can execute:
+```typescript
+import { useAssistantAction } from '@osd/context-provider';
+
+useAssistantAction({
+  name: 'execute_ppl_query',
+  description: 'Execute a PPL query',
+  parameters: {
+    type: 'object',
+    properties: {
+      query: { type: 'string', description: 'The PPL query' }
+    },
+    required: ['query']
+  },
+  handler: async (args) => {
+    const result = await executeQuery(args.query);
+    return { success: true, result };
+  },
+  render: ({ status, args, result }) => (
+    <QueryResultPanel status={status} query={args?.query} result={result} />
+  )
+});
+```
+
+### AG-UI Event Types
+
+| Event | Description |
+|-------|-------------|
+| `RUN_STARTED` | Agent execution began |
+| `TEXT_MESSAGE_START` | New text message started |
+| `TEXT_MESSAGE_CONTENT` | Streaming text chunk |
+| `TEXT_MESSAGE_END` | Text message completed |
+| `TOOL_CALL_START` | Tool execution started |
+| `TOOL_CALL_ARGS` | Tool arguments streamed |
+| `TOOL_CALL_END` | Tool call definition complete |
+| `TOOL_CALL_RESULT` | Tool execution result |
+| `RUN_FINISHED` | Agent completed successfully |
+| `RUN_ERROR` | Error during execution |
+
+### Usage Example
+
+```yaml
+# opensearch_dashboards.yml
+chat.enabled: true
+```
+
+```bash
+# Start the AG-UI agent server
+cd packages/osd-agents
+npm install
+export AWS_REGION=us-west-2
+export AWS_PROFILE=default
+npm run start:ag-ui
+```
+
+```json
+// configuration/mcp_config.json
+{
+  "mcpServers": {
+    "opensearch-mcp-server": {
+      "command": "uvx",
+      "args": ["opensearch-mcp-server-py", "--mode", "multi"],
+      "disabled": false
+    }
+  }
+}
+```
+
+## Limitations
+
+- **Experimental**: Not production-ready, API may change
+- **AWS Bedrock Required**: Requires AWS credentials with Claude model access
+- **Single-threaded**: One conversation at a time per agent instance
+- **MCP Configuration**: Servers must be pre-configured before agent starts
+- **Limited Testing**: Comprehensive test coverage is ongoing
+- **No Persistence**: Conversation history not persisted across sessions
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#10600](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10600) | Add experimental AI Chat and Context Provider plugins |
+| v3.3.0 | [#10612](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10612) | AG-UI compliant LangGraph ReAct agent implementation |
+| v3.3.0 | [#10624](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10624) | Mark context provider and chat as experimental |
+
+## References
+
+- [RFC #10585](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10585): AI Assistant Framework for OpenSearch Dashboards
+- [RFC #10571](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10571): Context Design and Page Tools Architecture
+- [AG-UI Protocol Documentation](https://docs.ag-ui.com/introduction)
+- [Model Context Protocol](https://modelcontextprotocol.io/)
+- [LangGraph Documentation](https://langchain-ai.github.io/langgraph/)
+- [AWS Bedrock Documentation](https://docs.aws.amazon.com/bedrock/)
+
+## Change History
+
+- **v3.3.0** (2025-10): Initial implementation with Chat plugin, Context Provider plugin, and osd-agents ReAct agent

--- a/docs/releases/v3.3.0/features/opensearch-dashboards/opensearch-dashboards-ai-chat.md
+++ b/docs/releases/v3.3.0/features/opensearch-dashboards/opensearch-dashboards-ai-chat.md
@@ -1,0 +1,172 @@
+# OpenSearch Dashboards AI Chat
+
+## Summary
+
+OpenSearch Dashboards v3.3.0 introduces an experimental AI-powered chat interface that enables conversational data exploration. This feature includes two new plugins (Chat and Context Provider) and a reference ReAct agent implementation (osd-agents), allowing users to interact with their data using natural language while maintaining context awareness across dashboard interactions.
+
+## Details
+
+### What's New in v3.3.0
+
+This release introduces a complete AI assistant framework for OpenSearch Dashboards:
+
+1. **Chat Plugin** (`src/plugins/chat`): AI-powered chat interface integrated into the Dashboards header
+2. **Context Provider Plugin** (`src/plugins/context_provider`): React hooks for automatic context capture
+3. **osd-agents Package** (`packages/osd-agents`): AG-UI compliant ReAct agent with AWS Bedrock integration
+
+### Technical Changes
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        UI[Chat UI]
+        CP[Context Provider Plugin]
+        Chat[Chat Plugin]
+    end
+    
+    subgraph "AG-UI Protocol"
+        SSE[Server-Sent Events]
+        Events[Event Stream]
+    end
+    
+    subgraph "osd-agents Server"
+        Adapter[AG-UI Adapter]
+        Agent[ReAct Agent]
+        MCP[MCP Clients]
+    end
+    
+    subgraph "External Services"
+        Bedrock[AWS Bedrock]
+        MCPServers[MCP Servers]
+    end
+    
+    UI --> Chat
+    CP --> Chat
+    Chat --> SSE
+    SSE --> Adapter
+    Adapter --> Agent
+    Agent --> MCP
+    Agent --> Bedrock
+    MCP --> MCPServers
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| Chat Plugin | AI chat interface with streaming support, tool calling, and graph visualization |
+| Context Provider Plugin | React hooks (`usePageContext`, `useDynamicContext`, `useAssistantAction`) for context capture |
+| osd-agents | ReAct agent implementation with LangGraph, AWS Bedrock, and MCP integration |
+| AG-UI Adapter | Protocol adapter for AG-UI compliant communication |
+| TextMessageManager | Manages text message lifecycle with tool call interruption support |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `chat.enabled` | Enable the Chat plugin | `false` |
+| `AG_UI_PORT` | Port for AG-UI server | `3000` |
+| `AWS_REGION` | AWS region for Bedrock | `us-west-2` |
+| `AWS_PROFILE` | AWS profile for authentication | `default` |
+
+### Key Features
+
+#### Chat Plugin Features
+- Real-time streaming chat responses via Server-Sent Events (SSE)
+- Tool execution with visual feedback and result rendering
+- Conversation management with thread isolation
+- Graph visualization capabilities for time series data
+- Integration with OpenSearch Dashboards navigation and theming
+
+#### Context Provider Features
+- `usePageContext()`: Auto-captures URL state with zero configuration
+- `useDynamicContext()`: Captures React state and user interactions
+- `useAssistantAction()`: Registers tools the AI can execute
+- `useAssistantPrompts()`: Slash command support for quick actions
+- Text selection monitoring for context capture
+
+#### ReAct Agent Features
+- AG-UI protocol compliance for standardized agent interactions
+- ReAct pattern (Reasoning + Acting) with LangGraph state machine
+- Dynamic tool discovery via Model Context Protocol (MCP)
+- Dual operation modes: CLI for development, HTTP server for integration
+- AWS Bedrock integration with Claude models
+
+### Usage Example
+
+```typescript
+// Register a tool the AI can execute
+import { useAssistantAction } from '@osd/context-provider';
+
+export function useRefreshTool() {
+  useAssistantAction({
+    name: 'refresh_data',
+    description: 'Refresh the current data display',
+    parameters: { type: 'object', properties: {} },
+    handler: async () => {
+      await refreshData();
+      return { success: true, message: 'Data refreshed' };
+    },
+  });
+}
+
+// Capture page context automatically
+import { usePageContext } from '@osd/context-provider';
+
+export function MyApp() {
+  usePageContext(); // Auto-captures URL state
+  return <div>Your App UI...</div>;
+}
+```
+
+### Running the Agent
+
+```bash
+# Start the AG-UI server
+cd packages/osd-agents
+npm install
+export AWS_REGION=us-west-2
+export AWS_PROFILE=default
+npm run start:ag-ui
+
+# Enable chat in OpenSearch Dashboards
+# Add to opensearch_dashboards.yml:
+# chat.enabled: true
+```
+
+### Migration Notes
+
+This is a new experimental feature. To enable:
+1. Set `chat.enabled: true` in `opensearch_dashboards.yml`
+2. Deploy and configure the osd-agents server
+3. Configure MCP servers in `configuration/mcp_config.json`
+4. Ensure AWS Bedrock access with Claude model permissions
+
+## Limitations
+
+- **Experimental Status**: Not production-ready, API stability not guaranteed
+- **AWS Bedrock Required**: Requires AWS Bedrock access with Claude model permissions
+- **MCP Server Configuration**: MCP servers must be configured and accessible before agent starts
+- **Single-threaded**: One agent conversation at a time
+- **Limited Testing**: Comprehensive testing is ongoing
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10600](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10600) | Add experimental AI Chat and Context Provider plugins |
+| [#10612](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10612) | AG-UI compliant LangGraph ReAct agent implementation |
+| [#10624](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10624) | Mark context provider and chat as experimental |
+
+## References
+
+- [RFC #10585](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10585): AI Assistant Framework for OpenSearch Dashboards
+- [RFC #10571](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10571): Context Design and Page Tools Architecture
+- [AG-UI Protocol](https://docs.ag-ui.com/introduction): Agent UI protocol specification
+- [Model Context Protocol](https://modelcontextprotocol.io/): MCP specification
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/ai-chat.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -4,6 +4,7 @@
 
 ### OpenSearch Dashboards
 
+- [OpenSearch Dashboards AI Chat](features/opensearch-dashboards/opensearch-dashboards-ai-chat.md)
 - [OpenSearch Dashboards Bug Fixes](features/opensearch-dashboards/opensearch-dashboards-bug-fixes.md)
 - [OpenSearch Dashboards UI Enhancements](features/opensearch-dashboards/opensearch-dashboards-ui-enhancements.md)
 - [PPL/Query Enhancements](features/opensearch-dashboards/ppl-query-enhancements.md)


### PR DESCRIPTION
## Summary

Adds documentation for the OpenSearch Dashboards AI Chat feature introduced in v3.3.0.

## Reports Created

- **Release report**: `docs/releases/v3.3.0/features/opensearch-dashboards/opensearch-dashboards-ai-chat.md`
- **Feature report**: `docs/features/opensearch-dashboards/ai-chat.md`

## Feature Overview

OpenSearch Dashboards AI Chat is an experimental AI-powered conversational interface consisting of:

- **Chat Plugin** (`src/plugins/chat`): UI for AI conversations
- **Context Provider Plugin** (`src/plugins/context_provider`): Automatic context capture
- **osd-agents Package** (`packages/osd-agents`): AG-UI compliant ReAct agent with AWS Bedrock

### Key Technical Details

- AG-UI Protocol for standardized agent communication via SSE
- ReAct pattern (Reasoning + Acting) with LangGraph state machine
- AWS Bedrock integration with Claude models
- Model Context Protocol (MCP) for dynamic tool discovery

## Related PRs

- [#10600](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10600): Add experimental AI Chat and Context Provider plugins
- [#10612](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10612): AG-UI compliant LangGraph ReAct agent implementation
- [#10624](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10624): Mark context provider and chat as experimental

## Related Issue

Closes #1451