### PR TITLE
docs: add OpenSearch Dashboards Dataset Explorer report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -158,6 +158,7 @@
 - [Data Importer](opensearch-dashboards/data-importer.md)
 - [Data Source Permissions](opensearch-dashboards/data-source-permissions.md)
 - [Data Source Selector](opensearch-dashboards/data-source-selector.md)
+- [Dataset Explorer](opensearch-dashboards/dataset-explorer.md)
 - [Dependency Updates](opensearch-dashboards/dependency-updates.md)
 - [Dev Tools](opensearch-dashboards/dev-tools.md)
 - [Discover](opensearch-dashboards/discover.md)

--- a/docs/features/opensearch-dashboards/dataset-explorer.md
+++ b/docs/features/opensearch-dashboards/dataset-explorer.md
@@ -1,0 +1,183 @@
+# Dataset Explorer
+
+## Summary
+
+The Dataset Explorer is a feature in OpenSearch Dashboards that provides an enhanced interface for selecting and managing datasets. It allows users to browse, filter, and select datasets (index patterns and indexes) for use in the Explore application. The feature includes signal type filtering to separate different types of observability data (logs, metrics, traces) and a dedicated dataset management plugin.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        subgraph "Data Plugin"
+            DV[Data Views Service]
+            DS[Dataset Service]
+            DSC[Dataset Selector Component]
+        end
+        
+        subgraph "Dataset Management Plugin"
+            DMP[Dataset Management]
+            CW[Create Dataset Wizard]
+            DL[Dataset List]
+        end
+        
+        subgraph "Explore Plugin"
+            EXP[Explore App]
+            QP[Query Panel]
+            DSW[Dataset Select Widget]
+        end
+    end
+    
+    subgraph "Data Sources"
+        IP[Index Patterns]
+        IDX[Indexes]
+        EDS[External Data Sources]
+    end
+    
+    EXP --> QP
+    QP --> DSW
+    DSW --> DSC
+    DSC --> DV
+    DSC --> DS
+    DV --> IP
+    DS --> IDX
+    DS --> EDS
+    DMP --> DV
+    CW --> DV
+    DL --> DV
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User Opens Explore] --> B[Load Available Datasets]
+    B --> C{Check App Flavor}
+    C -->|Traces| D[Filter: signalType = traces]
+    C -->|Logs/Other| E[Filter: signalType != traces]
+    D --> F[Display Filtered Datasets]
+    E --> F
+    F --> G[User Selects Dataset]
+    G --> H[Update Query Context]
+    H --> I[Execute Query]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `DatasetSelect` | Main dataset selector component with filtering and search |
+| `DatasetSelector` | Advanced dataset selector with type navigation |
+| `DetailedDataset` | Extended dataset interface with metadata |
+| `SignalType` | Enum for categorizing datasets by signal type |
+| `DatasetSelectWidget` | Explore-specific wrapper with flavor-based filtering |
+| `dataset_management` | Plugin for dataset CRUD operations |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `datasetManagement.enabled` | Enable the dataset management plugin | `false` |
+| `datasetManagement.aliasedAsIndexPattern` | Display datasets as "Index Patterns" in UI | `true` |
+| `explore.supportedTypes` | Dataset types supported in Explore | `['INDEXES', 'INDEX_PATTERN']` |
+
+### SignalType Values
+
+| Value | Description | Use Case |
+|-------|-------------|----------|
+| `logs` | Log data | Log Explorer, general log analysis |
+| `metrics` | Metric data | Metrics visualization |
+| `traces` | Trace data | Distributed tracing, APM |
+
+### Usage Example
+
+#### Basic Dataset Selection
+
+```typescript
+import { DatasetSelect } from '@opensearch-project/opensearch-dashboards/data';
+
+const MyComponent = () => {
+  const handleSelect = (dataset: Dataset) => {
+    console.log('Selected dataset:', dataset);
+  };
+
+  return (
+    <DatasetSelect
+      onSelect={handleSelect}
+      appName="my-app"
+      supportedTypes={['INDEX_PATTERN', 'INDEXES']}
+    />
+  );
+};
+```
+
+#### Filtering by SignalType
+
+```typescript
+import { DatasetSelect, DetailedDataset, SignalType } from '@opensearch-project/opensearch-dashboards/data';
+
+const TracesDatasetSelector = () => {
+  const onFilter = (dataset: DetailedDataset) => {
+    return dataset.signalType === SignalType.Traces;
+  };
+
+  return (
+    <DatasetSelect
+      onSelect={handleSelect}
+      onFilter={onFilter}
+    />
+  );
+};
+```
+
+#### Creating a Dataset with SignalType
+
+```typescript
+// Via saved objects API
+const createTracesDataset = async () => {
+  await savedObjects.create('index-pattern', {
+    title: 'traces-*',
+    timeFieldName: 'timestamp',
+    signalType: 'traces',
+  });
+};
+```
+
+### Configuration File
+
+```yaml
+# opensearch_dashboards.yml
+
+# Enable dataset management plugin
+datasetManagement.enabled: true
+
+# Use "Dataset" label instead of "Index Pattern"
+datasetManagement.aliasedAsIndexPattern: false
+```
+
+## Limitations
+
+- SignalType must be set via API; no UI for setting during creation yet
+- Dataset management plugin is experimental and disabled by default
+- Only three signal types are currently supported (logs, metrics, traces)
+- Filtering is binary (traces vs non-traces) in the current implementation
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#10355](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10355) | Update for datasets, redirection, and accordion timeline |
+| v3.3.0 | [#10379](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10379) | Allow apps to configure available types in the dataset explorer |
+| v3.3.0 | [#10491](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10491) | Introduce dataset SignalType |
+| v3.3.0 | [#10554](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10554) | Dataset type and management |
+
+## References
+
+- [OpenSearch 3.3 Release Blog](https://opensearch.org/blog/explore-opensearch-3-3/)
+- [Data Sources Documentation](https://docs.opensearch.org/3.0/dashboards/management/data-sources/)
+
+## Change History
+
+- **v3.3.0** (2026-01-11): Initial implementation with SignalType filtering, configurable dataset types, and dataset management plugin

--- a/docs/releases/v3.3.0/features/opensearch-dashboards/opensearch-dashboards-dataset-explorer.md
+++ b/docs/releases/v3.3.0/features/opensearch-dashboards/opensearch-dashboards-dataset-explorer.md
@@ -1,0 +1,132 @@
+# OpenSearch Dashboards Dataset Explorer
+
+## Summary
+
+OpenSearch Dashboards v3.3.0 introduces the Dataset Explorer, a new feature that enhances how users select and manage datasets in the Explore application. This release adds configurable dataset type filtering, a new SignalType attribute for data views, and a new dataset management plugin that provides a dedicated UI for managing datasets.
+
+## Details
+
+### What's New in v3.3.0
+
+The Dataset Explorer feature introduces several key enhancements:
+
+1. **Configurable Dataset Types**: Applications can now configure which dataset types are available in the dataset selector UI
+2. **SignalType Attribute**: A new `signalType` attribute for DataView/IndexPattern to filter datasets by signal type (logs, metrics, traces)
+3. **Dataset Management Plugin**: A new plugin (`dataset_management`) for managing datasets, gated behind a feature flag
+4. **Improved Dataset Selection**: Enhanced dataset selector with filtering capabilities based on signal type
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Dataset Explorer"
+        DS[Dataset Selector]
+        DSM[Dataset Management Plugin]
+        DV[Data Views Service]
+    end
+    
+    subgraph "Signal Type Filtering"
+        ST[SignalType Attribute]
+        TF[Traces Filter]
+        LF[Logs Filter]
+    end
+    
+    subgraph "Applications"
+        EXP[Explore Plugin]
+        TR[Traces Page]
+        LOG[Logs Page]
+    end
+    
+    DS --> DV
+    DS --> ST
+    DSM --> DV
+    EXP --> DS
+    TR --> TF
+    LOG --> LF
+    TF --> ST
+    LF --> ST
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `SignalType` | Enum defining signal types: `logs`, `metrics`, `traces` |
+| `DatasetSelect` | Enhanced dataset selector component with `onFilter` prop |
+| `DetailedDataset` | Extended Dataset interface with `signalType` property |
+| `dataset_management` | New plugin for dataset management UI |
+| `getFlavorFromAppId` | Helper to extract flavor from app ID |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `datasetManagement.enabled` | Enable dataset management plugin | `false` |
+| `datasetManagement.aliasedAsIndexPattern` | Label datasets as index patterns | `true` |
+| `explore.supportedTypes` | Configure supported dataset types in Explore | `['INDEXES', 'INDEX_PATTERN']` |
+
+#### API Changes
+
+The `DataView` and `IndexPattern` interfaces now include a `signalType` property:
+
+```typescript
+export interface IIndexPattern {
+  // ... existing properties
+  signalType?: string;  // 'logs' | 'metrics' | 'traces'
+}
+```
+
+### Usage Example
+
+```typescript
+// Configure dataset selector to filter by signal type
+const DatasetSelectWidget = () => {
+  const flavorId = useFlavorId();
+  
+  const onFilter = useCallback((detailedDataset: DetailedDataset) => {
+    if (flavorId === ExploreFlavor.Traces) {
+      return detailedDataset.signalType === SignalType.Traces;
+    }
+    return detailedDataset.signalType !== SignalType.Traces;
+  }, [flavorId]);
+
+  return (
+    <DatasetSelect
+      onSelect={handleDatasetSelect}
+      supportedTypes={supportedTypes}
+      onFilter={onFilter}
+    />
+  );
+};
+```
+
+### Migration Notes
+
+- Enable the dataset management plugin by setting `datasetManagement.enabled: true` in `opensearch_dashboards.yml`
+- Existing index patterns will have `signalType` as `undefined` and will be treated as non-traces datasets
+- To use traces-specific datasets, create index patterns with `signalType: 'traces'`
+
+## Limitations
+
+- Dataset management plugin is behind a feature flag and disabled by default
+- SignalType filtering only distinguishes between traces and non-traces datasets currently
+- UI for setting signalType during dataset creation is not yet available (must be set via API)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10355](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10355) | Update for datasets, redirection, and accordion timeline |
+| [#10379](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10379) | Allow apps to configure available types in the dataset explorer |
+| [#10491](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10491) | Introduce dataset SignalType |
+| [#10554](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10554) | Dataset type and management |
+
+## References
+
+- [OpenSearch 3.3 Release Blog](https://opensearch.org/blog/explore-opensearch-3-3/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/dataset-explorer.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -6,5 +6,6 @@
 
 - [OpenSearch Dashboards AI Chat](features/opensearch-dashboards/opensearch-dashboards-ai-chat.md)
 - [OpenSearch Dashboards Bug Fixes](features/opensearch-dashboards/opensearch-dashboards-bug-fixes.md)
+- [OpenSearch Dashboards Dataset Explorer](features/opensearch-dashboards/opensearch-dashboards-dataset-explorer.md)
 - [OpenSearch Dashboards UI Enhancements](features/opensearch-dashboards/opensearch-dashboards-ui-enhancements.md)
 - [PPL/Query Enhancements](features/opensearch-dashboards/ppl-query-enhancements.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the OpenSearch Dashboards Dataset Explorer feature introduced in v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch-dashboards/opensearch-dashboards-dataset-explorer.md`
- Feature report: `docs/features/opensearch-dashboards/dataset-explorer.md`

### Key Changes in v3.3.0
- Configurable dataset types in the dataset selector UI
- New `SignalType` attribute for DataView/IndexPattern (logs, metrics, traces)
- Dataset management plugin (behind feature flag)
- Signal type filtering for Explore application flavors

### Related PRs
- [#10355](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10355): Update for datasets, redirection, and accordion timeline
- [#10379](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10379): Allow apps to configure available types in the dataset explorer
- [#10491](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10491): Introduce dataset SignalType
- [#10554](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10554): Dataset type and management

Closes #1450