### PR TITLE
docs: add OpenSearch Dashboards Traces report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -166,6 +166,7 @@
 - [Dynamic Config](opensearch-dashboards/dynamic-config.md)
 - [Experimental Features](opensearch-dashboards/experimental-features.md)
 - [Explore Plugin](opensearch-dashboards/explore.md)
+- [Explore Traces](opensearch-dashboards/explore-traces.md)
 - [i18n & Localization](opensearch-dashboards/i18n-localization.md)
 - [Input Control Visualization](opensearch-dashboards/input-control-visualization.md)
 - [Monaco Editor](opensearch-dashboards/monaco-editor.md)

--- a/docs/features/opensearch-dashboards/explore-traces.md
+++ b/docs/features/opensearch-dashboards/explore-traces.md
@@ -1,0 +1,213 @@
+# Explore Traces
+
+## Summary
+
+Explore Traces is a feature in OpenSearch Dashboards that provides comprehensive trace visualization and analysis capabilities within the Explore application. It enables users to visualize distributed traces, correlate traces with logs, view timeline waterfall charts, and analyze trace metrics through interactive charts. The feature supports both local and external data sources, providing a unified experience for observability workflows.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Explore Application"
+        TABS[Tab Registry]
+        TRACES[Traces Tab]
+        LOGS[Logs Tab]
+    end
+    
+    subgraph "Trace Visualization"
+        CHARTS[Trace Charts]
+        TABLE[Traces Table]
+        DETAILS[Trace Details]
+    end
+    
+    subgraph "Trace Details Components"
+        TREE[Tree View]
+        TIMELINE[Timeline Waterfall]
+        LOGTAB[Logs Tab]
+        FLYOUT[Span Flyout]
+    end
+    
+    subgraph "Data Layer"
+        CORR[Correlation Saved Object]
+        LOCAL[Local Indices]
+        EXT[External Datasource]
+        SCHEMA[OTEL Schema]
+    end
+    
+    TABS --> TRACES
+    TABS --> LOGS
+    TRACES --> CHARTS
+    TRACES --> TABLE
+    TABLE --> DETAILS
+    DETAILS --> TREE
+    TREE --> TIMELINE
+    DETAILS --> LOGTAB
+    TREE --> FLYOUT
+    CORR --> LOGTAB
+    LOCAL --> TRACES
+    EXT --> TRACES
+    SCHEMA --> TRACES
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph Input
+        SPAN[Span Data]
+        OTEL[OTEL Schema]
+        LOGS[Log Data]
+    end
+    
+    subgraph Processing
+        PROC[Chart Processor]
+        RANGE[Time Range Calc]
+        COLOR[Service Color]
+    end
+    
+    subgraph Visualization
+        REQ[Request Count Chart]
+        ERR[Error Count Chart]
+        LAT[Latency Chart]
+        WATER[Waterfall Bars]
+    end
+    
+    SPAN --> PROC
+    OTEL --> PROC
+    PROC --> REQ
+    PROC --> ERR
+    PROC --> LAT
+    SPAN --> RANGE
+    RANGE --> WATER
+    SPAN --> COLOR
+    COLOR --> WATER
+    LOGS --> LOGTAB[Log Correlation Tab]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Traces Tab | Main interface for viewing and filtering traces in Explore |
+| Trace Charts | Line charts showing request count, error count, and latency over time |
+| Traces Table | Paginated table with configurable default columns |
+| Trace Details | Detailed view of individual traces with multiple tabs |
+| Tree View | Hierarchical span table with parent-child relationships |
+| Timeline Waterfall | Inline waterfall bars showing span timing relative to trace |
+| Timeline Ruler | Ruler with millisecond measurements for visual comparison |
+| Logs Tab | Correlated logs view with redirect to Discover |
+| Span Flyout | Detailed span information panel |
+| Correlation Saved Object | Stores trace-to-log correlation configuration |
+| Tab Registry | Flavor-based tab registration system |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `explore:defaultTraceColumns` | Default columns for Explore traces tab | Experimental |
+| Correlation Type | `APM-Correlation` for trace-log relationships | N/A |
+| Log Service Name Field | Field mapping for service name in logs | `service.name` |
+| Log Span ID Field | Field mapping for span ID in logs | `span_id` |
+| Log Trace ID Field | Field mapping for trace ID in logs | `trace_id` |
+| Timestamp Field | Timestamp field for log correlation | `@timestamp` |
+
+### Usage Example
+
+#### Viewing Traces in Explore
+
+```
+1. Navigate to Explore application
+2. Select a trace dataset (local or external)
+3. View trace charts showing:
+   - Request count over time
+   - Error count over time
+   - Latency distribution
+4. Click on a trace row to view details
+```
+
+#### Using Timeline Waterfall
+
+```
+1. Open Trace Details page
+2. Navigate to "Tree view" tab
+3. View the "Timeline" column with waterfall bars
+4. Bars are color-coded by service name
+5. Hover over bars to see:
+   - Duration (ms)
+   - Start time (relative)
+   - End time (relative)
+6. Drag column border to resize
+```
+
+#### Setting Up Log Correlation
+
+```json
+// Create correlation saved object
+POST .kibana/_doc/correlations:trace-logs-1
+{
+  "type": "correlations",
+  "correlations": {
+    "type": "APM-Correlation",
+    "entities": [
+      {
+        "tracesDataset": {
+          "id": "trace-index-pattern-id"
+        }
+      },
+      {
+        "logsDataset": {
+          "id": "logs-index-pattern-id",
+          "meta": {
+            "logServiceNameField": "service.name",
+            "logSpanIdField": "span_id",
+            "logTraceIdField": "trace_id",
+            "timestamp": "@timestamp"
+          }
+        }
+      }
+    ]
+  }
+}
+```
+
+#### Querying External Datasource
+
+```
+1. Configure external data source in Dashboards Management
+2. Navigate to Explore → Traces
+3. Select external data source from dropdown
+4. Query traces from external cluster
+```
+
+## Limitations
+
+- Service map tab is currently disabled
+- Nanosecond precision may be lost in PPL queries; fallback to `durationNano` field is implemented
+- Start time rounding may occur with imprecise data
+- Maximum spans displayed limited by browser performance
+- Log correlation requires manual saved object configuration
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#10386](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10386) | Add Correlations Saved Object Type Registration |
+| v3.3.0 | [#10392](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10392) | Add traces chart (request count, error count, latency) |
+| v3.3.0 | [#10393](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10393) | Trace Details: Log correlation (tabs + redirect) |
+| v3.3.0 | [#10406](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10406) | Add experimental default trace columns UI setting |
+| v3.3.0 | [#10418](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10418) | Trace Details: Support external datasets |
+| v3.3.0 | [#10431](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10431) | Switch primary schema for trace details, disable service map |
+| v3.3.0 | [#10642](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10642) | Add Timeline waterfall bars column to SpanDetailTableHierarchy |
+
+## References
+
+- [Trace Analytics Documentation](https://docs.opensearch.org/3.0/observing-your-data/trace/ta-dashboards/): Official trace analytics guide
+- [Simple Schema for Observability](https://docs.opensearch.org/3.0/observing-your-data/ss4o/): SS4O schema definitions
+- [Observability Overview](https://docs.opensearch.org/3.0/observing-your-data/): OpenSearch observability features
+- [OpenTelemetry Protocol](https://opentelemetry.io/docs/specs/otel/): OTEL specification
+
+## Change History
+
+- **v3.3.0** (2026-03-18): Initial implementation with trace charts, log correlation, timeline waterfall visualization, external datasource support, configurable default columns, and OTEL schema support

--- a/docs/releases/v3.3.0/features/opensearch-dashboards/opensearch-dashboards-traces.md
+++ b/docs/releases/v3.3.0/features/opensearch-dashboards/opensearch-dashboards-traces.md
@@ -1,0 +1,173 @@
+# OpenSearch Dashboards Traces
+
+## Summary
+
+OpenSearch Dashboards v3.3.0 introduces comprehensive trace visualization capabilities within the Explore application. This release adds trace charts, log correlation, timeline waterfall visualization, external datasource support, and configurable default columns, providing a unified experience for analyzing distributed traces alongside logs.
+
+## Details
+
+### What's New in v3.3.0
+
+This release brings 7 PRs that significantly enhance trace analysis capabilities in OpenSearch Dashboards:
+
+1. **Correlation Saved Object** - Foundation for trace-to-log correlation
+2. **Traces Chart** - Request count, error count, and latency visualizations
+3. **Log Correlation** - Tabs and redirect functionality for trace-log correlation
+4. **Default Columns Setting** - Configurable default trace columns in Explore
+5. **External Datasource Support** - Query traces from external data sources
+6. **Schema Switch** - Primary schema change for trace details with service map disabled
+7. **Timeline Waterfall** - Inline waterfall bars in span table tree view
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Explore Application"
+        TRACES[Traces Tab]
+        LOGS[Logs Tab]
+        CHARTS[Trace Charts]
+    end
+    
+    subgraph "Trace Details"
+        TREE[Tree View Table]
+        TIMELINE[Timeline Waterfall]
+        FLYOUT[Span Flyout]
+        LOGTAB[Logs Tab]
+    end
+    
+    subgraph "Data Layer"
+        CORR[Correlation Saved Object]
+        EXT[External Datasource]
+        LOCAL[Local Indices]
+    end
+    
+    TRACES --> CHARTS
+    TRACES --> TREE
+    TREE --> TIMELINE
+    TREE --> FLYOUT
+    CORR --> LOGTAB
+    EXT --> TRACES
+    LOCAL --> TRACES
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| Correlation Saved Object | Stores trace-to-log correlation configuration between datasets |
+| Traces Chart Processor | Constructs request count, error count, and latency chart data |
+| TimelineWaterfallBar | Renders waterfall bars for span time ranges with color-coded services |
+| TimelineRuler | Displays ruler with millisecond measurements for visual comparison |
+| TimelineHeader | Combines "Timeline" text with the ruler component |
+| useTimelineBarRange | Hook calculating relative bar offset and width based on span time |
+| useTimelineBarColor | Hook determining bar color based on service name |
+| useTimelineTicks | Hook calculating optimal tick marks for timeline ruler |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `explore:defaultTraceColumns` | Default columns displayed in Explore traces tab | Experimental |
+| Correlation Saved Object Type | `correlations` type for storing trace-log relationships | N/A |
+
+#### Correlation Saved Object Schema
+
+```json
+{
+  "id": "trace-to-logs-correlation-5678",
+  "type": "correlations",
+  "attributes": {
+    "type": "APM-Correlation",
+    "entities": [
+      {
+        "tracesDataset": {
+          "id": "references[0].id"
+        }
+      },
+      {
+        "logsDataset": {
+          "id": "references[1].id",
+          "meta": {
+            "logServiceNameField": "service.name",
+            "logSpanIdField": "span_id",
+            "logTraceIdField": "trace_id",
+            "timestamp": "@timestamp"
+          }
+        }
+      }
+    ]
+  },
+  "references": [
+    {
+      "name": "entities[0].index",
+      "type": "index-pattern",
+      "id": "trace-index-pattern-id"
+    },
+    {
+      "name": "entities[1].index",
+      "type": "index-pattern",
+      "id": "logs-index-pattern-id"
+    }
+  ]
+}
+```
+
+### Usage Example
+
+#### Viewing Traces with Timeline Waterfall
+
+```
+1. Navigate to Explore → Traces tab
+2. Select a trace dataset
+3. Click on a trace to view details
+4. Go to "Tree view" tab
+5. View inline waterfall bars in the "Timeline" column
+6. Hover over bars to see Duration, Start, and End milliseconds
+7. Drag column to resize and observe responsive scaling
+```
+
+#### Configuring Log Correlation
+
+```
+1. Create a correlation saved object linking trace and log datasets
+2. Navigate to Trace Details page
+3. Click "Logs" tab to view correlated logs
+4. Click "View in Discover" to redirect with context
+```
+
+### Migration Notes
+
+- The primary schema for trace details has been switched; existing custom configurations may need adjustment
+- Service map tab is temporarily disabled in this release
+- Duration calculation now checks `endTime-startTime` first, falling back to `durationNano` field for better precision
+
+## Limitations
+
+- Service map tab is disabled in this release
+- Nanosecond precision may be lost when querying via PPL; duration fallback logic is implemented
+- Start time rounding may occur if data lacks expected precision
+- Timeline waterfall requires proper span time range data
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10386](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10386) | Add Correlations Saved Object Type Registration |
+| [#10392](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10392) | Add traces chart (request count, error count, latency) |
+| [#10393](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10393) | Trace Details: Log correlation (tabs + redirect) |
+| [#10406](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10406) | Add experimental default trace columns UI setting |
+| [#10418](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10418) | Trace Details: Support external datasets |
+| [#10431](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10431) | Switch primary schema for trace details, disable service map |
+| [#10642](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10642) | Add Timeline waterfall bars column to SpanDetailTableHierarchy |
+
+## References
+
+- [Trace Analytics Documentation](https://docs.opensearch.org/3.0/observing-your-data/trace/ta-dashboards/): Official trace analytics guide
+- [Simple Schema for Observability](https://docs.opensearch.org/3.0/observing-your-data/ss4o/): SS4O schema definitions
+- [Observability Overview](https://docs.opensearch.org/3.0/observing-your-data/): OpenSearch observability features
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/explore-traces.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -7,5 +7,6 @@
 - [OpenSearch Dashboards AI Chat](features/opensearch-dashboards/opensearch-dashboards-ai-chat.md)
 - [OpenSearch Dashboards Bug Fixes](features/opensearch-dashboards/opensearch-dashboards-bug-fixes.md)
 - [OpenSearch Dashboards Dataset Explorer](features/opensearch-dashboards/opensearch-dashboards-dataset-explorer.md)
+- [OpenSearch Dashboards Traces](features/opensearch-dashboards/opensearch-dashboards-traces.md)
 - [OpenSearch Dashboards UI Enhancements](features/opensearch-dashboards/opensearch-dashboards-ui-enhancements.md)
 - [PPL/Query Enhancements](features/opensearch-dashboards/ppl-query-enhancements.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the OpenSearch Dashboards Traces feature introduced in v3.3.0.

## Changes

### Release Report
- `docs/releases/v3.3.0/features/opensearch-dashboards/opensearch-dashboards-traces.md`

### Feature Report
- `docs/features/opensearch-dashboards/explore-traces.md`

## Key Features Documented

1. **Correlation Saved Object** - Foundation for trace-to-log correlation
2. **Traces Chart** - Request count, error count, and latency visualizations
3. **Log Correlation** - Tabs and redirect functionality for trace-log correlation
4. **Default Columns Setting** - Configurable default trace columns in Explore
5. **External Datasource Support** - Query traces from external data sources
6. **Schema Switch** - Primary schema change for trace details
7. **Timeline Waterfall** - Inline waterfall bars in span table tree view

## Related PRs

| PR | Description |
|----|-------------|
| [#10386](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10386) | Add Correlations Saved Object Type Registration |
| [#10392](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10392) | Add traces chart |
| [#10393](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10393) | Trace Details: Log correlation |
| [#10406](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10406) | Add experimental default trace columns UI setting |
| [#10418](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10418) | Trace Details: Support external datasets |
| [#10431](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10431) | Switch primary schema for trace details |
| [#10642](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10642) | Add Timeline waterfall bars column |

Closes #1449