### PR TITLE
docs: add OpenSearch Dashboards Keyboard Shortcuts report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -169,6 +169,7 @@
 - [Explore Traces](opensearch-dashboards/explore-traces.md)
 - [i18n & Localization](opensearch-dashboards/i18n-localization.md)
 - [Input Control Visualization](opensearch-dashboards/input-control-visualization.md)
+- [Keyboard Shortcuts](opensearch-dashboards/keyboard-shortcuts.md)
 - [Monaco Editor](opensearch-dashboards/monaco-editor.md)
 - [Navigation](opensearch-dashboards/navigation.md)
 - [OpenSearch UI (OUI)](opensearch-dashboards/oui.md)

--- a/docs/features/opensearch-dashboards/keyboard-shortcuts.md
+++ b/docs/features/opensearch-dashboards/keyboard-shortcuts.md
@@ -1,0 +1,198 @@
+# Keyboard Shortcuts
+
+## Summary
+
+OpenSearch Dashboards Keyboard Shortcuts is a feature that enables users to navigate and interact with the application using keyboard combinations. It provides a centralized service for registering, managing, and executing shortcuts, along with a discoverable help modal and React integration hooks for plugin developers.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph Core["Core Public"]
+        KSS[KeyboardShortcutService]
+        Config[KeyboardShortcutConfig]
+        Types[ShortcutDefinition]
+    end
+    
+    subgraph Service["Service Methods"]
+        Setup[setup]
+        Start[start]
+        Stop[stop]
+        Register[register]
+        Unregister[unregister]
+        GetAll[getAllShortcuts]
+    end
+    
+    subgraph React["React Integration"]
+        Hook[useKeyboardShortcut]
+        Modal[KeyboardShortcutHelpModal]
+    end
+    
+    subgraph Plugins["Plugin Usage"]
+        Discover[Discover]
+        Dashboard[Dashboard]
+        Visualize[Visualize]
+        Data[Data]
+        Custom[Custom Plugins]
+    end
+    
+    Config --> KSS
+    Types --> KSS
+    KSS --> Setup
+    KSS --> Start
+    KSS --> Stop
+    KSS --> Register
+    KSS --> Unregister
+    KSS --> GetAll
+    
+    KSS --> Hook
+    GetAll --> Modal
+    
+    Plugins --> Register
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User Presses Keys] --> B{Shortcuts Enabled?}
+    B -->|No| C[Ignore]
+    B -->|Yes| D[KeyboardShortcutService]
+    D --> E[Parse Key Event]
+    E --> F{Match Registered Shortcut?}
+    F -->|No| G[Pass Through]
+    F -->|Yes| H[Execute Callback]
+    H --> I[Prevent Default]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `KeyboardShortcutService` | Core service that manages shortcut registration, event listening, and execution |
+| `KeyboardShortcutConfig` | Configuration interface with `enabled` boolean |
+| `ShortcutDefinition` | Interface defining shortcut properties (id, pluginId, name, category, keys, execute) |
+| `KeyboardShortcutHelpModal` | React component displaying all registered shortcuts in a categorized modal |
+| `KeyboardShortcutIcon` | Navigation icon component that triggers the help modal |
+| `useKeyboardShortcut` | React hook for registering shortcuts with automatic lifecycle management |
+| `KeyStringParser` | Utility for parsing key strings and generating platform-specific display strings |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `opensearchDashboards.keyboardShortcuts.enabled` | Enable or disable the keyboard shortcuts feature globally | `true` |
+
+### ShortcutDefinition Interface
+
+```typescript
+interface ShortcutDefinition {
+  id: string;           // Unique identifier for the shortcut
+  pluginId: string;     // Plugin that owns this shortcut
+  name: string;         // Human-readable name
+  category: string;     // Category for grouping in help modal
+  keys: string;         // Key combination (e.g., 'cmd+s', 'g d')
+  execute: () => void;  // Callback function to execute
+}
+```
+
+### Key Format
+
+The `keys` property supports:
+- **Modifier combinations**: `cmd+s`, `ctrl+shift+a`, `alt+f`
+- **Sequence shortcuts**: `g d` (press g, then d)
+- **Platform-agnostic modifiers**: `cmd` maps to Cmd on Mac, Ctrl on Windows/Linux
+
+### Built-in Shortcuts
+
+| Shortcut | Action | Category |
+|----------|--------|----------|
+| `Shift+/` | Show keyboard shortcuts help | Navigation |
+| `g d` | Go to Discover | Navigation |
+| `g b` | Go to Dashboard | Navigation |
+| `g v` | Go to Visualization | Navigation |
+| `Shift+t` | Open Date Picker | Open |
+| `Shift+r` | Refresh Results | Query |
+| `Cmd/Ctrl+/` | Comment/uncomment line | Editing |
+| `Shift+Option/Alt+/` | Block comment | Editing |
+
+### Usage Example
+
+#### Plugin Registration
+
+```typescript
+// In plugin's start() method
+public start(core: CoreStart) {
+  if (core.keyboardShortcut) {
+    core.keyboardShortcut.register({
+      id: 'my-custom-action',
+      pluginId: 'myPlugin',
+      name: 'My Custom Action',
+      category: 'custom',
+      keys: 'cmd+shift+m',
+      execute: () => {
+        // Perform action
+      },
+    });
+  }
+}
+```
+
+#### React Hook Usage
+
+```typescript
+function MyComponent() {
+  const { services } = useOpenSearchDashboards();
+  
+  const handleAction = useCallback(() => {
+    // Action logic
+  }, []);
+
+  services.keyboardShortcut?.useKeyboardShortcut({
+    id: 'component-action',
+    pluginId: 'myPlugin',
+    name: 'Component Action',
+    category: 'editing',
+    keys: 'cmd+e',
+    execute: handleAction,
+  });
+
+  return <div>Component</div>;
+}
+```
+
+#### Configuration
+
+```yaml
+# opensearch_dashboards.yml
+opensearchDashboards.keyboardShortcuts.enabled: true
+```
+
+## Limitations
+
+- Keyboard shortcuts may conflict with browser or operating system shortcuts
+- Sequence shortcuts require keys to be pressed within a defined time window
+- Shortcuts are disabled when focus is in text input fields to avoid conflicts
+- Navigation shortcuts require an active workspace selection
+- Custom shortcuts must have unique id+pluginId combinations
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#10409](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10409) | Add keyboard shortcuts configuration option |
+| v3.3.0 | [#10455](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10455) | Add useKeyboardShortcut hook |
+| v3.3.0 | [#10466](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10466) | Add keyboard shortcut help modal |
+| v3.3.0 | [#10509](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10509) | Register navigation shortcuts |
+| v3.3.0 | [#10543](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10543) | Add Cypress tests, enable by default |
+| v3.3.0 | [#10545](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10545) | Enable comment shortcuts in Query Editor |
+
+## References
+
+- [Dev Tools Console Documentation](https://docs.opensearch.org/3.0/dashboards/dev-tools/run-queries/): Keyboard shortcuts in Dev Tools
+
+## Change History
+
+- **v3.3.0** (2025-09): Initial implementation with configuration, help modal, React hooks, navigation shortcuts, and query editor shortcuts

--- a/docs/releases/v3.3.0/features/opensearch-dashboards/opensearch-dashboards-keyboard-shortcuts.md
+++ b/docs/releases/v3.3.0/features/opensearch-dashboards/opensearch-dashboards-keyboard-shortcuts.md
@@ -1,0 +1,167 @@
+# OpenSearch Dashboards Keyboard Shortcuts
+
+## Summary
+
+OpenSearch Dashboards v3.3.0 introduces a comprehensive keyboard shortcuts system that enables users to navigate and interact with the application more efficiently. This feature includes a configurable shortcuts service, a help modal for discoverability, React hooks for plugin integration, and pre-registered shortcuts for common navigation and actions.
+
+## Details
+
+### What's New in v3.3.0
+
+This release introduces the keyboard shortcuts feature as a new capability in OpenSearch Dashboards:
+
+- **Configurable Keyboard Shortcuts Service**: A core service that manages shortcut registration, execution, and lifecycle
+- **Help Modal**: An interactive modal (triggered by `Shift+/`) displaying all available shortcuts grouped by category
+- **React Hook Integration**: `useKeyboardShortcut` hook for easy shortcut registration in React components
+- **Pre-registered Navigation Shortcuts**: Built-in shortcuts for navigating to Discover, Dashboard, and Visualizations
+- **Query Editor Shortcuts**: Shortcuts for opening date picker, refreshing results, and commenting lines
+- **Cypress E2E Tests**: Comprehensive end-to-end testing for the keyboard shortcuts functionality
+
+### Technical Changes
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph Core["Core Service"]
+        KSS[KeyboardShortcutService]
+        KSS --> Register[register]
+        KSS --> Unregister[unregister]
+        KSS --> GetAll[getAllShortcuts]
+        KSS --> Hook[useKeyboardShortcut]
+    end
+    
+    subgraph UI["UI Components"]
+        Modal[KeyboardShortcutHelpModal]
+        Icon[KeyboardShortcutIcon]
+        Icon --> Modal
+    end
+    
+    subgraph Plugins["Plugin Integration"]
+        Discover[Discover Plugin]
+        Dashboard[Dashboard Plugin]
+        Visualize[Visualize Plugin]
+        Data[Data Plugin]
+    end
+    
+    KSS --> Modal
+    Discover --> KSS
+    Dashboard --> KSS
+    Visualize --> KSS
+    Data --> KSS
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `KeyboardShortcutService` | Core service managing shortcut registration and event handling |
+| `KeyboardShortcutHelpModal` | Modal component displaying all registered shortcuts |
+| `KeyboardShortcutIcon` | Navigation icon that triggers the help modal |
+| `useKeyboardShortcut` | React hook for registering shortcuts with automatic cleanup |
+| `KeyStringParser` | Utility for parsing and displaying key combinations |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `opensearchDashboards.keyboardShortcuts.enabled` | Enable/disable keyboard shortcuts feature | `true` |
+
+#### Pre-registered Shortcuts
+
+| Shortcut | Action | Category |
+|----------|--------|----------|
+| `Shift+/` | Show keyboard shortcuts help | Navigation |
+| `g d` | Go to Discover | Navigation |
+| `g b` | Go to Dashboard | Navigation |
+| `g v` | Go to Visualization | Navigation |
+| `Shift+t` | Open Date Picker | Open |
+| `Shift+r` | Refresh Results | Query |
+| `Cmd+/` (Mac) / `Ctrl+/` (Win) | Comment/uncomment line in Query Editor | Editing |
+| `Shift+Option+/` (Mac) / `Shift+Alt+/` (Win) | Block comment in Query Editor | Editing |
+
+### Usage Example
+
+#### Registering a Shortcut in a Plugin
+
+```typescript
+// In plugin start method
+if (core.keyboardShortcut) {
+  core.keyboardShortcut.register({
+    id: 'my-action',
+    pluginId: 'myPlugin',
+    name: 'My Action',
+    category: 'custom',
+    keys: 'cmd+shift+m',
+    execute: () => {
+      // Action to perform
+      console.log('Shortcut triggered!');
+    },
+  });
+}
+```
+
+#### Using the React Hook
+
+```typescript
+import { useOpenSearchDashboards } from '../../../opensearch_dashboards_react/public';
+
+function MyComponent() {
+  const { services } = useOpenSearchDashboards();
+  
+  const handleSave = useCallback(() => {
+    // Save action
+  }, []);
+
+  services.keyboardShortcut?.useKeyboardShortcut({
+    id: 'save',
+    pluginId: 'myPlugin',
+    name: 'Save',
+    category: 'editing',
+    keys: 'cmd+s',
+    execute: handleSave,
+  });
+
+  return <div>My Component</div>;
+}
+```
+
+#### Enabling Keyboard Shortcuts
+
+```yaml
+# opensearch_dashboards.yml
+opensearchDashboards.keyboardShortcuts.enabled: true
+```
+
+### Migration Notes
+
+- Keyboard shortcuts are enabled by default in v3.3.0
+- To disable, set `opensearchDashboards.keyboardShortcuts.enabled: false` in configuration
+- Plugins can register custom shortcuts using the `keyboardShortcut` service from `CoreStart`
+- The help modal is accessible via `Shift+/` or by clicking the keyboard icon in the left navigation
+
+## Limitations
+
+- Shortcuts may conflict with browser or OS-level shortcuts
+- Sequence shortcuts (like `g d`) require keys to be pressed within a short time window
+- Shortcuts are only active when keyboard shortcuts are enabled in configuration
+- Navigation shortcuts require a workspace to be selected
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10409](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10409) | Add keyboard shortcuts configuration option |
+| [#10455](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10455) | Add useKeyboardShortcut hook for React components |
+| [#10466](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10466) | Add keyboard shortcut help modal with interactive icon |
+| [#10509](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10509) | Register shortcuts for OSD (Discover, Dashboard, Visualization) |
+| [#10543](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10543) | Add Cypress tests and enable shortcuts by default |
+| [#10545](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10545) | Enable shortcuts to comment lines in Query Editor |
+
+## References
+
+- [Dev Tools Console - Keyboard Shortcuts](https://docs.opensearch.org/3.0/dashboards/dev-tools/run-queries/): Documentation on keyboard shortcuts in Dev Tools
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/keyboard-shortcuts.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -12,3 +12,4 @@
 - [OpenSearch Dashboards UI Enhancements](features/opensearch-dashboards/opensearch-dashboards-ui-enhancements.md)
 - [OpenSearch Dashboards Visualization Enhancements](features/opensearch-dashboards/opensearch-dashboards-visualization-enhancements.md)
 - [PPL/Query Enhancements](features/opensearch-dashboards/ppl-query-enhancements.md)
+- [OpenSearch Dashboards Keyboard Shortcuts](features/opensearch-dashboards/opensearch-dashboards-keyboard-shortcuts.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the OpenSearch Dashboards Keyboard Shortcuts feature introduced in v3.3.0.

## Reports Created

- **Release report**: `docs/releases/v3.3.0/features/opensearch-dashboards/opensearch-dashboards-keyboard-shortcuts.md`
- **Feature report**: `docs/features/opensearch-dashboards/keyboard-shortcuts.md`

## Key Changes in v3.3.0

- Configurable keyboard shortcuts service with `opensearchDashboards.keyboardShortcuts.enabled` setting
- Help modal accessible via `Shift+/` displaying all registered shortcuts
- `useKeyboardShortcut` React hook for plugin integration
- Pre-registered navigation shortcuts (`g d` for Discover, `g b` for Dashboard, `g v` for Visualization)
- Query editor shortcuts for date picker, refresh, and commenting lines
- Cypress E2E tests for the feature

## Related PRs

| PR | Description |
|----|-------------|
| [#10409](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10409) | Add keyboard shortcuts configuration option |
| [#10455](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10455) | Add useKeyboardShortcut hook |
| [#10466](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10466) | Add keyboard shortcut help modal |
| [#10509](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10509) | Register navigation shortcuts |
| [#10543](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10543) | Add Cypress tests |
| [#10545](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10545) | Enable comment shortcuts in Query Editor |

Closes #1446