### PR TITLE
docs: add OpenSearch Dashboards Plugin Compatibility report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -174,6 +174,7 @@
 - [Navigation](opensearch-dashboards/navigation.md)
 - [OpenSearch UI (OUI)](opensearch-dashboards/oui.md)
 - [OSD Optimizer Cache](opensearch-dashboards/osd-optimizer-cache.md)
+- [Plugin Compatibility](opensearch-dashboards/plugin-compatibility.md)
 - [Query Editor](opensearch-dashboards/query-editor.md)
 - [Query Enhancements](opensearch-dashboards/query-enhancements.md)
 - [Sample Data](opensearch-dashboards/sample-data.md)

--- a/docs/features/opensearch-dashboards/plugin-compatibility.md
+++ b/docs/features/opensearch-dashboards/plugin-compatibility.md
@@ -1,0 +1,120 @@
+# Plugin Compatibility
+
+## Summary
+
+OpenSearch Dashboards plugin compatibility controls how plugins are validated against the Dashboards version during installation. The system ensures plugins are compatible with the running Dashboards instance, preventing runtime errors from version mismatches. Starting in v3.3.0, administrators can configure the validation strictness using the `--single-version` CLI flag.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Plugin Installation"
+        CLI[opensearch-dashboards-plugin install] --> Settings[Parse Settings]
+        Settings --> Download[Download Plugin]
+        Download --> Extract[Extract to Working Dir]
+        Extract --> ReadManifest[Read opensearch_dashboards.json]
+        ReadManifest --> Validate[assertVersion]
+    end
+    
+    subgraph "Version Validation"
+        Validate --> CheckMode{singleVersion Mode}
+        CheckMode -->|strict| StrictCheck[semver.eq comparison]
+        CheckMode -->|ignore| IgnoreCheck[Major version warning]
+        StrictCheck -->|match| Success[Continue Install]
+        StrictCheck -->|mismatch| Fail[Throw Error]
+        IgnoreCheck --> Success
+    end
+    
+    subgraph "Installation Complete"
+        Success --> Rename[Rename to Plugin Dir]
+        Rename --> Done[Installation Complete]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Plugin Archive] --> B[Extract]
+    B --> C[Read Manifest]
+    C --> D[Get opensearchDashboardsVersion]
+    D --> E[cleanVersion]
+    E --> F[semver.parse]
+    F --> G{Mode Check}
+    G -->|strict| H[Exact Match]
+    G -->|ignore| I[Major Version Check]
+    H --> J[Install/Reject]
+    I --> K[Install with Warning]
+```
+
+### Components
+
+| Component | File | Description |
+|-----------|------|-------------|
+| CLI Plugin Install | `src/cli_plugin/install/index.js` | Command-line interface for plugin installation |
+| Settings Parser | `src/cli_plugin/install/settings.js` | Parses CLI options including `singleVersion` |
+| Version Validator | `src/cli_plugin/install/opensearch_dashboards.js` | `assertVersion()` function for compatibility checks |
+| Manifest Parser | `src/core/server/plugins/discovery/plugin_manifest_parser.ts` | Server-side plugin manifest validation |
+
+### Configuration
+
+| Setting | Description | Default | Values |
+|---------|-------------|---------|--------|
+| `--single-version` | Version validation mode for plugin installation | `strict` | `strict`, `ignore` |
+
+### Usage Example
+
+```bash
+# Install plugin with strict version matching (default)
+bin/opensearch-dashboards-plugin install https://example.com/plugin-3.3.0.zip
+
+# Install plugin ignoring version mismatch (for development/testing)
+bin/opensearch-dashboards-plugin install --single-version ignore https://example.com/plugin-3.2.0.zip
+```
+
+### Version Validation Logic
+
+```javascript
+// Strict mode: exact version match required
+if (mode === 'strict') {
+  if (!semver.eq(actualVersion, expectedVersion)) {
+    throw new Error(`Plugin incompatible with OpenSearch Dashboards`);
+  }
+}
+
+// Ignore mode: warn on major version difference only
+if (mode === 'ignore') {
+  if (actualVersion.major !== expectedVersion.major) {
+    logger.log('WARNING: Major version differs');
+  }
+}
+```
+
+### Special Cases
+
+- **Development override**: Plugins with `opensearchDashboardsVersion: "opensearchDashboards"` bypass all version checks
+- **Invalid versions**: Both plugin and Dashboards versions must be valid semver; invalid formats throw errors
+
+## Limitations
+
+- Server-side manifest parsing (`plugin_manifest_parser.ts`) still requires exact version match
+- The `ignore` mode does not guarantee plugin functionality with mismatched versions
+- Only CLI installation supports the `--single-version` flag; programmatic installation uses strict mode
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#10273](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10273) | Add `--single-version` flag with strict/ignore modes |
+
+## References
+
+- [Managing OpenSearch Dashboards plugins](https://docs.opensearch.org/3.0/install-and-configure/install-dashboards/plugins/): Official plugin management documentation
+- [Introduction to OpenSearch Dashboard Plugins](https://opensearch.org/blog/dashboards-plugins-intro/): Plugin architecture overview
+- [A comprehensive guide to setting up and connecting self-managed OpenSearch Dashboards](https://opensearch.org/blog/a-comprehensive-guide-to-setup-and-connect-self-managed-dashboards-with-amazon-opensearch-domain/): Discusses version compatibility bypass
+
+## Change History
+
+- **v3.3.0** (2026-01-11): Added `--single-version` CLI flag with `strict` and `ignore` modes for flexible version validation

--- a/docs/releases/v3.3.0/features/opensearch-dashboards/opensearch-dashboards-plugin-compatibility.md
+++ b/docs/releases/v3.3.0/features/opensearch-dashboards/opensearch-dashboards-plugin-compatibility.md
@@ -1,0 +1,97 @@
+# OpenSearch Dashboards Plugin Compatibility
+
+## Summary
+
+This release introduces enhanced plugin version compatibility controls for OpenSearch Dashboards through a new `--single-version` CLI flag. Administrators can now choose between `strict` mode (requiring exact version match) and `ignore` mode (allowing version mismatches with warnings), providing flexibility for development and testing scenarios while maintaining production safety.
+
+## Details
+
+### What's New in v3.3.0
+
+The plugin installation CLI (`opensearch-dashboards-plugin install`) now supports a `--single-version` flag that controls how version compatibility is validated between plugins and OpenSearch Dashboards.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Plugin Installation Flow"
+        CLI[CLI Command] --> Parse[Parse Options]
+        Parse --> Download[Download Plugin]
+        Download --> Extract[Extract Archive]
+        Extract --> Validate[Version Validation]
+        Validate --> Mode{singleVersion Mode}
+        Mode -->|strict| Strict[Exact Match Required]
+        Mode -->|ignore| Ignore[Warning Only]
+        Strict -->|match| Install[Install Plugin]
+        Strict -->|mismatch| Error[Error & Exit]
+        Ignore --> Install
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `--single-version` flag | CLI option to set version validation mode |
+| `assertVersion()` update | Enhanced version checking with mode support |
+| semver integration | Uses semver library for precise version comparison |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `--single-version` | Version validation mode: `strict` or `ignore` | `strict` |
+
+### Usage Example
+
+```bash
+# Default strict mode - requires exact version match
+bin/opensearch-dashboards-plugin install <plugin-url>
+
+# Explicit strict mode
+bin/opensearch-dashboards-plugin install --single-version strict <plugin-url>
+
+# Ignore mode - allows version mismatch with warning
+bin/opensearch-dashboards-plugin install --single-version ignore <plugin-url>
+```
+
+#### Behavior by Mode
+
+**Strict Mode (default)**:
+- Requires exact version match between plugin and OpenSearch Dashboards
+- Fails installation if versions differ (even minor/patch versions)
+- Recommended for production environments
+
+**Ignore Mode**:
+- Allows installation regardless of version mismatch
+- Logs warning if major versions differ
+- Useful for development, testing, or connecting to managed services
+
+### Migration Notes
+
+- Existing installations are unaffected; default behavior remains `strict`
+- For development environments connecting to different versions, use `--single-version ignore`
+- The `opensearchDashboards` special version value continues to bypass all version checks
+
+## Limitations
+
+- The `ignore` mode only warns on major version differences; minor/patch mismatches are silently allowed
+- Plugin functionality is not guaranteed when using `ignore` mode with mismatched versions
+- Server-side plugin manifest parsing still uses exact version matching
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10273](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10273) | Enhanced plugin version compatibility with strict/ignore modes |
+
+## References
+
+- [Managing OpenSearch Dashboards plugins](https://docs.opensearch.org/3.0/install-and-configure/install-dashboards/plugins/): Official documentation on plugin management
+- [Introduction to OpenSearch Dashboard Plugins](https://opensearch.org/blog/dashboards-plugins-intro/): Blog post on plugin architecture
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/plugin-compatibility.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -14,3 +14,4 @@
 - [OpenSearch Dashboards Visualization Enhancements](features/opensearch-dashboards/opensearch-dashboards-visualization-enhancements.md)
 - [PPL/Query Enhancements](features/opensearch-dashboards/ppl-query-enhancements.md)
 - [OpenSearch Dashboards Keyboard Shortcuts](features/opensearch-dashboards/opensearch-dashboards-keyboard-shortcuts.md)
+- [OpenSearch Dashboards Plugin Compatibility](features/opensearch-dashboards/opensearch-dashboards-plugin-compatibility.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the OpenSearch Dashboards Plugin Compatibility feature introduced in v3.3.0.

### Changes
- **Release report**: `docs/releases/v3.3.0/features/opensearch-dashboards/opensearch-dashboards-plugin-compatibility.md`
- **Feature report**: `docs/features/opensearch-dashboards/plugin-compatibility.md`
- Updated release and feature indexes

### Feature Overview
The `--single-version` CLI flag for `opensearch-dashboards-plugin install` allows administrators to control version validation:
- `strict` (default): Requires exact version match
- `ignore`: Allows version mismatch with warning for major version differences

### Related
- PR: opensearch-project/OpenSearch-Dashboards#10273
- Issue: #1444