### PR TITLE
docs: add terms-query-rewriting report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -135,6 +135,7 @@
 - [Workload Management](opensearch/workload-management.md)
 - [Hierarchical & ACL-aware Routing](opensearch/hierarchical-acl-aware-routing.md)
 - [Terms Lookup Query](opensearch/terms-lookup-query.md)
+- [Terms Query](opensearch/terms-query.md)
 
 ## opensearch-dashboards
 

--- a/docs/features/opensearch/terms-query.md
+++ b/docs/features/opensearch/terms-query.md
@@ -1,0 +1,162 @@
+# Terms Query
+
+## Summary
+
+The `terms` query searches for documents containing one or more exact terms in a specified field. It supports multiple values, terms lookup from other documents, and bitmap filtering for efficient large-scale filtering. OpenSearch optimizes `terms` queries by rewriting them into complement range queries when used in `must_not` clauses.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph "Terms Query Processing"
+        TQ[Terms Query] --> Parser[Query Parser]
+        Parser --> Rewriter[Query Rewriter]
+        Rewriter --> |"must_not context"| Complement[Complement Calculator]
+        Rewriter --> |"normal context"| Direct[Direct Execution]
+        Complement --> RangeQueries[Range Queries]
+        RangeQueries --> Executor[Query Executor]
+        Direct --> Executor
+    end
+    
+    subgraph "ComplementHelperUtils"
+        CH[ComplementHelperUtils] --> NVT[numberValueToComplement]
+        CH --> NVTC[numberValuesToComplement]
+        NVTC --> |"whole numbers"| Skip[Skip consecutive ranges]
+        NVTC --> |"other numbers"| Full[Full range coverage]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `TermsQueryBuilder` | Builds and executes terms queries |
+| `ComplementHelperUtils` | Calculates complement ranges for query rewriting |
+| `numberValuesToComplement()` | Converts sorted values to complement range queries |
+| `numberValueToComplement()` | Converts single value to complement ranges |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.max_terms_count` | Maximum number of terms allowed in a terms query | 65,536 |
+
+### Query Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `<field>` | String | Field to search in |
+| `boost` | Float | Relevance score weight (default: 1.0) |
+| `_name` | String | Query name for tagging |
+| `value_type` | String | Value type: `default` or `bitmap` |
+
+### Usage Examples
+
+#### Basic Terms Query
+
+```json
+GET index/_search
+{
+  "query": {
+    "terms": {
+      "status": ["active", "pending", "review"]
+    }
+  }
+}
+```
+
+#### Terms Lookup
+
+```json
+GET products/_search
+{
+  "query": {
+    "terms": {
+      "product_id": {
+        "index": "customers",
+        "id": "customer123",
+        "path": "purchased_products"
+      }
+    }
+  }
+}
+```
+
+#### Bitmap Filtering (v2.17+)
+
+```json
+POST products/_search
+{
+  "query": {
+    "terms": {
+      "product_id": ["<base64-encoded-bitmap>"],
+      "value_type": "bitmap"
+    }
+  }
+}
+```
+
+#### Must Not with Terms
+
+```json
+GET index/_search
+{
+  "query": {
+    "bool": {
+      "must_not": [
+        {
+          "terms": {
+            "status": [0, 1, 2]
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+### Query Rewriting Optimization
+
+When a `terms` query is used in a `must_not` clause, OpenSearch rewrites it into complement range queries for better performance. For whole number fields with consecutive values, intermediate ranges are skipped since no values can exist between consecutive integers.
+
+```mermaid
+flowchart LR
+    subgraph "Input"
+        A["must_not: terms [1, 2, 3]"]
+    end
+    
+    subgraph "Rewritten"
+        B["range: (-∞, 1)"]
+        C["range: (3, +∞)"]
+    end
+    
+    A --> B
+    A --> C
+```
+
+## Limitations
+
+- Maximum 65,536 terms by default (configurable via `index.max_terms_count`)
+- Highlighting may not be guaranteed depending on highlighter type and term count
+- Terms lookup requires `_source` to be enabled
+- Bitmap filtering requires encoding terms as roaring bitmaps
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19587](https://github.com/opensearch-project/OpenSearch/pull/19587) | Fix rewriting terms query with consecutive whole numbers |
+| v2.17.0 | - | Added bitmap filtering support |
+
+## References
+
+- [Issue #19566](https://github.com/opensearch-project/OpenSearch/issues/19566): Bug report for must_not terms query issue
+- [Terms Query Documentation](https://docs.opensearch.org/3.0/query-dsl/term/terms/): Official documentation
+- [Roaring Bitmap](https://github.com/RoaringBitmap/RoaringBitmap): Bitmap encoding library
+
+## Change History
+
+- **v3.3.0** (2025-10-09): Fixed incorrect rewriting of terms query with more than 2 consecutive whole numbers in `must_not` clauses
+- **v2.17.0**: Added bitmap filtering support for efficient large-scale term filtering

--- a/docs/releases/v3.3.0/features/opensearch/terms-query-rewriting.md
+++ b/docs/releases/v3.3.0/features/opensearch/terms-query-rewriting.md
@@ -1,0 +1,106 @@
+# Terms Query Rewriting
+
+## Summary
+
+This release fixes a bug in the terms query rewriting logic that caused incorrect results when using `must_not` with a `terms` query containing more than two consecutive whole numbers. The bug was introduced in OpenSearch 3.2.0 and caused documents to be incorrectly returned when they should have been excluded.
+
+## Details
+
+### What's New in v3.3.0
+
+This fix corrects the complement calculation for terms queries with consecutive integer values. The issue occurred in the `ComplementHelperUtils.numberValuesToComplement()` method, which is used when rewriting `must_not` clauses containing `terms` queries.
+
+### Technical Changes
+
+#### Bug Description
+
+When a `terms` query with consecutive whole numbers (e.g., `[0, 1, 2]`) was wrapped in a `must_not` clause, the query rewriter would incorrectly calculate the complement ranges. This happened because the `lastValue` variable was not being updated when consecutive values were skipped, causing subsequent range calculations to be incorrect.
+
+#### The Fix
+
+The fix adds a single line to update `lastValue` when consecutive whole numbers are detected:
+
+```java
+if (isWholeNumber && value.longValue() - lastValue.longValue() == 1) {
+    lastValue = value;  // This line was added
+    continue;
+}
+```
+
+#### How Complement Calculation Works
+
+The `ComplementHelperUtils` class converts a `terms` query into a set of range queries that match everything except the specified terms. For whole number fields, consecutive values are optimized by skipping intermediate ranges since no value can exist between them.
+
+```mermaid
+flowchart TB
+    subgraph "Before Fix (Buggy)"
+        A1["terms: [1, 2, 3]"] --> B1["lastValue not updated"]
+        B1 --> C1["Incorrect ranges generated"]
+        C1 --> D1["Wrong documents returned"]
+    end
+    
+    subgraph "After Fix (Correct)"
+        A2["terms: [1, 2, 3]"] --> B2["lastValue updated for each term"]
+        B2 --> C2["Correct complement ranges"]
+        C2 --> D2["Correct exclusion behavior"]
+    end
+```
+
+#### Expected Complement Ranges
+
+For a `terms` query with values `[1, 2, 3]` on an integer field, the correct complement should be:
+
+| Range | Description |
+|-------|-------------|
+| `(-∞, 1)` | All values less than 1 |
+| `(3, +∞)` | All values greater than 3 |
+
+The intermediate ranges `(1, 2)` and `(2, 3)` are correctly skipped because no integer values exist in those ranges.
+
+### Usage Example
+
+The bug manifested when using `must_not` with consecutive integer terms:
+
+```json
+// This query was returning incorrect results in v3.2.0
+GET test/_search
+{
+  "query": {
+    "bool": {
+      "must_not": [
+        {
+          "terms": {
+            "status": [0, 1, 2]
+          }
+        }
+      ]
+    }
+  }
+}
+```
+
+With the fix, this query now correctly returns no documents when all documents have status values of 0, 1, or 2.
+
+### Migration Notes
+
+No migration is required. This is a bug fix that restores the expected behavior from OpenSearch 3.1.0 and earlier versions.
+
+## Limitations
+
+- This fix specifically addresses the complement calculation for whole number fields
+- The optimization for skipping consecutive values only applies to integer-type fields
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19587](https://github.com/opensearch-project/OpenSearch/pull/19587) | Fix rewriting terms query with consecutive whole numbers |
+
+## References
+
+- [Issue #19566](https://github.com/opensearch-project/OpenSearch/issues/19566): Bug report for must_not wrapping terms query
+- [Terms Query Documentation](https://docs.opensearch.org/3.0/query-dsl/term/terms/): Official documentation for terms queries
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/terms-query.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -2,6 +2,10 @@
 
 ## Release Reports
 
+### OpenSearch
+
+- [Terms Query Rewriting](features/opensearch/terms-query-rewriting.md)
+
 ### OpenSearch Dashboards
 
 - [OpenSearch Dashboards AI Chat](features/opensearch-dashboards/opensearch-dashboards-ai-chat.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Terms Query Rewriting fix in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/terms-query-rewriting.md`
- Feature report: `docs/features/opensearch/terms-query.md` (new)

### Key Changes in v3.3.0
- Fixed incorrect rewriting of terms query with more than 2 consecutive whole numbers
- The bug caused `must_not` clauses with consecutive integer terms to return incorrect results
- Fix adds a single line to update `lastValue` in `ComplementHelperUtils.numberValuesToComplement()`

### Related
- Resolves investigation for GitHub Issue #1442
- OpenSearch PR: [#19587](https://github.com/opensearch-project/OpenSearch/pull/19587)
- OpenSearch Issue: [#19566](https://github.com/opensearch-project/OpenSearch/issues/19566)