### PR TITLE
docs: add derived fields report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -52,6 +52,7 @@
 - [Cluster State Management](opensearch/cluster-state-management.md)
 - [Clusterless Mode](opensearch/clusterless-mode.md)
 - [Dependency Management](opensearch/dependency-management.md)
+- [Derived Fields](opensearch/derived-fields.md)
 - [Derived Source](opensearch/derived-source.md)
 - [Docker Compose v2 Support](opensearch/docker-compose-v2-support.md)
 - [Dynamic Threadpool Resize](opensearch/dynamic-threadpool-resize.md)

--- a/docs/features/opensearch/derived-fields.md
+++ b/docs/features/opensearch/derived-fields.md
@@ -1,0 +1,164 @@
+# Derived Fields
+
+## Summary
+
+Derived fields allow you to create new fields dynamically by executing scripts on existing fields at query time. The source data can come from either the `_source` field or doc values. Once defined in an index mapping or search request, derived fields can be queried like regular fields, enabling real-time data transformation without reindexing.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Query Time Processing"
+        Q[Search Query] --> DFQ[DerivedFieldQuery]
+        DFQ --> VF[ValueFetcher]
+        VF --> SRC[_source / doc_values]
+        SRC --> Script[Painless Script]
+        Script --> MI[MemoryIndex]
+        MI --> LQ[Lucene Query Execution]
+        LQ --> Results[Search Results]
+    end
+    
+    subgraph "Index Mapping"
+        IM[Index Mapping] --> DF[Derived Field Definition]
+        DF --> Type[Field Type]
+        DF --> Scr[Script]
+        DF --> Opt[Optional: format, prefilter_field]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Document] --> B[_source / doc_values]
+    B --> C[DerivedFieldValueFetcher]
+    C --> D[Execute Script]
+    D --> E[emit values]
+    E --> F[IndexableField]
+    F --> G[MemoryIndex]
+    G --> H[Query Execution]
+    H --> I[Match Result]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `DerivedFieldQuery` | Wraps a Lucene query to execute against derived field values |
+| `DerivedFieldValueFetcher` | Retrieves source values and executes scripts to produce derived values |
+| `DerivedFieldScript` | Painless script context for derived field computation |
+| `MemoryIndex` | In-memory Lucene index used to execute queries against derived values |
+
+### Supported Field Types
+
+| Type | Emit Format | Multi-valued |
+|------|-------------|--------------|
+| `boolean` | `emit(boolean)` | No |
+| `date` | `emit(long timeInMillis)` | Yes |
+| `double` | `emit(double)` | Yes |
+| `float` | `emit(float)` | Yes |
+| `geo_point` | `emit(double lat, double lon)` | Yes |
+| `ip` | `emit(String ip)` | Yes |
+| `keyword` | `emit(String)` | Yes |
+| `long` | `emit(long)` | Yes |
+| `object` | `emit(String json)` | Yes |
+| `text` | `emit(String)` | Yes |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.query.derived_field.enabled` | Enable/disable derived fields at index level | `true` |
+| `search.derived_field.enabled` | Enable/disable derived fields at cluster level | `true` |
+| `search.allow_expensive_queries` | Must be `true` for derived fields to work | `true` |
+
+### Usage Example
+
+Define a derived field in index mapping:
+
+```json
+PUT /logs/_mapping
+{
+  "derived": {
+    "method": {
+      "type": "keyword",
+      "script": {
+        "source": "emit(doc['request.keyword'].value.splitOnToken(' ')[1])"
+      }
+    },
+    "timestamp": {
+      "type": "date",
+      "format": "epoch_millis",
+      "script": {
+        "source": "emit(Long.parseLong(doc['request.keyword'].value.splitOnToken(' ')[0]))"
+      }
+    }
+  }
+}
+```
+
+Query the derived field:
+
+```json
+POST /logs/_search
+{
+  "query": {
+    "bool": {
+      "must": [
+        { "term": { "method": "GET" } },
+        { "range": { "timestamp": { "gte": "now-1d" } } }
+      ]
+    }
+  },
+  "fields": ["method", "timestamp"]
+}
+```
+
+### Performance Optimization
+
+Use `prefilter_field` to prune the search space:
+
+```json
+PUT /logs/_mapping
+{
+  "derived": {
+    "method": {
+      "type": "keyword",
+      "script": {
+        "source": "emit(doc['request.keyword'].value.splitOnToken(' ')[1])"
+      },
+      "prefilter_field": "request"
+    }
+  }
+}
+```
+
+## Limitations
+
+- **Scoring and sorting**: Not yet supported on derived fields
+- **Aggregations**: Most types supported since v2.17; geographic, significant terms/text, and scripted metric aggregations not supported
+- **Dashboard support**: Fields not displayed in available fields list (can still filter by name)
+- **Chained derived fields**: One derived field cannot reference another
+- **Join field type**: Derived fields not supported for join fields
+- **Performance**: Computed at query time, may impact performance on large datasets
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19496](https://github.com/opensearch-project/OpenSearch/pull/19496) | Fix derived field rewrite to handle range queries |
+| v2.17.0 | - | Added aggregation support for derived fields |
+| v2.15.0 | - | Initial implementation of derived fields |
+
+## References
+
+- [Issue #19337](https://github.com/opensearch-project/OpenSearch/issues/19337): Bug report for derived field rewrite issues with range queries
+- [Documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/derived/): Official derived field documentation
+
+## Change History
+
+- **v3.3.0**: Fixed query rewrite for range queries on derived fields by implementing selective rewrite based on query type
+- **v2.17.0**: Added support for most aggregation types on derived fields
+- **v2.15.0**: Initial implementation of derived fields feature

--- a/docs/releases/v3.3.0/features/opensearch/derived-fields.md
+++ b/docs/releases/v3.3.0/features/opensearch/derived-fields.md
@@ -1,0 +1,108 @@
+# Derived Fields
+
+## Summary
+
+This release fixes a bug in derived field query rewriting that caused range queries to incorrectly return no results. The fix implements selective query rewriting based on query type, preventing `PointRangeQuery` and related queries from being rewritten in a way that breaks derived field functionality.
+
+## Details
+
+### What's New in v3.3.0
+
+The `DerivedFieldQuery.rewrite()` method has been restored with intelligent query-type detection. Previously, the rewrite logic was commented out due to issues with range queries at the Lucene layer. This fix introduces a `needsRewrite()` method that selectively skips rewriting for query types that would break when rewritten against non-indexed derived fields.
+
+### Technical Changes
+
+#### Problem Background
+
+Derived fields are computed dynamically from `_source` or doc values and are not indexed. When Lucene's `PointRangeQuery` is rewritten, it checks for point values in the index. Since derived fields have no indexed point values, the rewrite incorrectly returns a `MatchNoDocsQuery`, causing range queries on derived fields to return zero results.
+
+#### Solution: Selective Rewrite
+
+The fix adds a `needsRewrite()` method that checks the query type before attempting rewrite:
+
+```java
+private boolean needsRewrite() {
+    if (query instanceof PointRangeQuery) {
+        return false;
+    }
+
+    if (query instanceof ApproximateScoreQuery approximateQuery) {
+        Query originalQuery = approximateQuery.getOriginalQuery();
+        if (originalQuery instanceof IndexOrDocValuesQuery indexOrDocValuesQuery) {
+            Query indexQuery = indexOrDocValuesQuery.getIndexQuery();
+            return !(indexQuery instanceof PointRangeQuery);
+        }
+    }
+
+    if (query instanceof IndexOrDocValuesQuery indexOrDocValuesQuery) {
+        Query indexQuery = indexOrDocValuesQuery.getIndexQuery();
+        return !(indexQuery instanceof PointRangeQuery);
+    }
+
+    return true;
+}
+```
+
+#### Query Types Handled
+
+| Query Type | Rewrite Behavior |
+|------------|------------------|
+| `PointRangeQuery` | Skip rewrite (return `this`) |
+| `ApproximateScoreQuery` wrapping `IndexOrDocValuesQuery` with `PointRangeQuery` | Skip rewrite |
+| `IndexOrDocValuesQuery` with `PointRangeQuery` | Skip rewrite |
+| All other queries | Proceed with normal rewrite |
+
+### Usage Example
+
+Range queries on derived fields now work correctly:
+
+```json
+POST /logs/_search
+{
+  "query": {
+    "range": {
+      "derived_timestamp": {
+        "gte": "2024-01-01",
+        "lte": "2024-12-31"
+      }
+    }
+  }
+}
+```
+
+Where `derived_timestamp` is defined as:
+
+```json
+PUT /logs/_mapping
+{
+  "derived": {
+    "derived_timestamp": {
+      "type": "date",
+      "script": {
+        "source": "emit(Long.parseLong(doc['raw_timestamp'].value))"
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Derived fields are still computed at query time, which may impact performance for large datasets
+- Scoring and sorting on derived fields are not yet supported
+- Chained derived fields (one derived field referencing another) are not supported
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19496](https://github.com/opensearch-project/OpenSearch/pull/19496) | Fix derived field rewrite to handle range queries |
+
+## References
+
+- [Issue #19337](https://github.com/opensearch-project/OpenSearch/issues/19337): Bug report for derived field rewrite issues
+- [Documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/derived/): Derived field type documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/derived-fields.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -4,6 +4,7 @@
 
 ### OpenSearch
 
+- [Derived Fields](features/opensearch/derived-fields.md)
 - [Terms Query Rewriting](features/opensearch/terms-query-rewriting.md)
 
 ### OpenSearch Dashboards


### PR DESCRIPTION
## Summary

This PR adds documentation for the Derived Fields feature fix in OpenSearch v3.3.0.

### Changes

- **Release Report**: `docs/releases/v3.3.0/features/opensearch/derived-fields.md`
  - Documents the fix for derived field query rewriting to handle range queries
  - Explains the selective rewrite approach based on query type

- **Feature Report**: `docs/features/opensearch/derived-fields.md`
  - Comprehensive documentation of the Derived Fields feature
  - Architecture diagrams, supported types, configuration options
  - Usage examples and performance optimization tips

### Related

- Resolves investigation for GitHub Issue #1441
- Related OpenSearch PR: [#19496](https://github.com/opensearch-project/OpenSearch/pull/19496)
- Related OpenSearch Issue: [#19337](https://github.com/opensearch-project/OpenSearch/issues/19337)