### PR TITLE
docs: add search stats negative value handling report for v3.3.0

### DIFF
--- a/docs/features/opensearch/search-request-stats.md
+++ b/docs/features/opensearch/search-request-stats.md
@@ -161,16 +161,19 @@ GET _nodes/<node_id>/stats/indices/search
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#19340](https://github.com/opensearch-project/OpenSearch/pull/19340) | Handle negative search request nodes stats |
 | v2.17.0 | [#15054](https://github.com/opensearch-project/OpenSearch/pull/15054) | Initial implementation - Add took time to request nodes stats |
 | v2.18.0 | [#16290](https://github.com/opensearch-project/OpenSearch/pull/16290) | Enable search.request_stats_enabled by default |
 | v2.18.0 | [#16320](https://github.com/opensearch-project/OpenSearch/pull/16320) | Backport to 2.x branch |
 
 ## References
 
+- [Issue #16598](https://github.com/opensearch-project/OpenSearch/issues/16598): Bug report - Negative Search Stats causing nodes/stats API failures
 - [Issue #10768](https://github.com/opensearch-project/OpenSearch/issues/10768): Original feature request - Search stats for coordinator node misses total search request time
 - [Nodes Stats API Documentation](https://docs.opensearch.org/latest/api-reference/nodes-apis/nodes-stats/): Official API documentation
 
 ## Change History
 
+- **v3.3.0** (2025-09-30): Fixed negative search stats handling - writes 0 instead of negative values to prevent serialization errors
 - **v2.18.0** (2024-11-05): Enabled `search.request_stats_enabled` by default
 - **v2.17.0** (2024-09-17): Initial implementation with `took` statistics and phase breakdowns

--- a/docs/releases/v3.3.0/features/opensearch/search-stats.md
+++ b/docs/releases/v3.3.0/features/opensearch/search-stats.md
@@ -1,0 +1,88 @@
+# Search Stats - Negative Value Handling
+
+## Summary
+
+This release fixes a critical bug where negative search statistics values caused exceptions when accessing the `/_nodes/stats` API. The fix ensures that negative `current` values in search request phase statistics are handled gracefully by writing `0` instead, preventing serialization failures.
+
+## Details
+
+### What's New in v3.3.0
+
+This release addresses a bug where search statistics could become negative due to race conditions in phase tracking, causing the nodes stats API to fail with `IllegalStateException`.
+
+### Technical Changes
+
+#### Bug Description
+
+The issue occurred in the `SearchStats.PhaseStatsLongHolder` class when serializing statistics:
+
+1. The `current` counter tracks active search phases
+2. Due to multiple exit paths from a phase, the counter could be decremented more than once
+3. When `current` became negative, `StreamOutput.writeVLong()` threw an exception because VLong encoding doesn't support negative values
+
+#### Error Example
+
+```
+java.lang.IllegalStateException: Negative longs unsupported, use writeLong or writeZLong for negative numbers [-3]
+    at org.opensearch.common.io.stream.StreamOutput.writeVLong(StreamOutput.java:307)
+    at org.opensearch.index.search.stats.SearchStats$PhaseStatsLongHolder.writeTo(SearchStats.java:88)
+```
+
+#### Solution
+
+The fix adds defensive checks in the `writeTo()` method:
+
+```java
+@Override
+public void writeTo(StreamOutput out) throws IOException {
+    if (current < 0) {
+        out.writeVLong(0);
+    } else {
+        out.writeVLong(current);
+    }
+    out.writeVLong(total);
+    out.writeVLong(timeInMillis);
+}
+```
+
+Additionally, warning logs are emitted when negative values are detected:
+
+```java
+requestStatsLongHolder.requestStatsHolder.forEach((phaseName, phaseStats) -> {
+    if (phaseStats.current < 0) {
+        PhaseStatsLongHolder.logger.warn(
+            "SearchRequestStats 'current' is negative for phase '{}': {}",
+            phaseName,
+            phaseStats.current
+        );
+    }
+});
+```
+
+#### Why Not Use ZLong?
+
+The PR author considered using `ZLong` (which supports negative values) but rejected it due to potential serialization compatibility issues between different OpenSearch versions during rolling upgrades.
+
+### Migration Notes
+
+No migration required. The fix is backward compatible and automatically handles negative values.
+
+## Limitations
+
+- The fix treats the symptom (negative values) rather than the root cause (race condition in phase tracking)
+- Negative values are logged as warnings for monitoring but the underlying race condition may still occur
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19340](https://github.com/opensearch-project/OpenSearch/pull/19340) | Handle negative search request nodes stats |
+
+## References
+
+- [Issue #16598](https://github.com/opensearch-project/OpenSearch/issues/16598): Bug report - Negative Search Stats causing nodes/stats API failures
+- [Nodes Stats API Documentation](https://docs.opensearch.org/3.0/api-reference/nodes-apis/nodes-stats/): Official API documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/search-request-stats.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -5,6 +5,7 @@
 ### OpenSearch
 
 - [Derived Fields](features/opensearch/derived-fields.md)
+- [Search Stats - Negative Value Handling](features/opensearch/search-stats.md)
 - [Terms Query Rewriting](features/opensearch/terms-query-rewriting.md)
 
 ### OpenSearch Dashboards


### PR DESCRIPTION
## Summary

This PR adds documentation for the Search Stats negative value handling fix in OpenSearch v3.3.0.

## Changes

### Release Report
- Created `docs/releases/v3.3.0/features/opensearch/search-stats.md`
- Documents the bug fix for negative search statistics causing `IllegalStateException` in nodes stats API

### Feature Report Update
- Updated `docs/features/opensearch/search-request-stats.md`
- Added v3.3.0 PR reference and change history entry

### Release Index
- Updated `docs/releases/v3.3.0/index.md` with link to new report

## Related Issue
- Closes #1440

## Key Changes in v3.3.0
- Fixed negative `current` values in `SearchStats.PhaseStatsLongHolder` causing serialization errors
- Added defensive check to write `0` instead of negative values
- Added warning logs when negative values are detected