### PR TITLE
docs: add netty-arena-settings report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -73,6 +73,7 @@
 - [Merge & Segment Settings](opensearch/merge-segment-settings.md)
 - [Multi-Search API](opensearch/multi-search-api.md)
 - [Nested Aggregations](opensearch/nested-aggregations.md)
+- [Netty Arena Settings](opensearch/netty-arena-settings.md)
 - [Network Configuration](opensearch/network-configuration.md)
 - [Node Join/Leave](opensearch/node-join-leave.md)
 - [Nodes Info API](opensearch/nodes-info-api.md)

--- a/docs/features/opensearch/netty-arena-settings.md
+++ b/docs/features/opensearch/netty-arena-settings.md
@@ -1,0 +1,120 @@
+# Netty Arena Settings
+
+## Summary
+
+OpenSearch configures Lucene's MMapDirectory shared Arena pooling behavior through JVM options to optimize memory-mapped file handling. By default, OpenSearch sets `sharedArenaMaxPermits=1` to disable shared Arena pooling, which prevents memory-mapped segment bloat and virtual address space exhaustion issues that can occur in high-throughput environments with frequent stats calls.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Index Storage"
+        IS[Index Shard] --> HD[HybridDirectory]
+        HD --> MMD[MMapDirectory]
+        MMD --> Arena[Memory Arena]
+    end
+    
+    subgraph "Memory Arena Management"
+        Arena --> |sharedArenaMaxPermits=1| CA[Confined Arena]
+        Arena --> |sharedArenaMaxPermits>1| SA[Shared Arena Pool]
+    end
+    
+    subgraph "File System"
+        CA --> MMap1[Memory Mapped Files]
+        SA --> MMap2[Pooled Memory Mappings]
+    end
+    
+    subgraph "Stats Operations"
+        Stats[Stats API Call] --> Engine[Engine.segmentsStats]
+        Engine --> CR[CompoundReader]
+        CR --> MMD
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Stats API Request] --> B[NodeService.stats]
+    B --> C[IndicesService.stats]
+    C --> D[IndexShard.segmentStats]
+    D --> E[Engine.fillSegmentStats]
+    E --> F[CompoundReader]
+    F --> G{Arena Mode}
+    G --> |Confined| H[Create New Arena]
+    G --> |Shared| I[Reuse Pooled Arena]
+    H --> J[Memory Map File]
+    I --> K[Add to Shared Mapping]
+    J --> L[Return Stats]
+    K --> L
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `MMapDirectory` | Lucene's memory-mapped file directory implementation |
+| `MemorySegmentIndexInputProvider` | Handles memory segment creation for file access |
+| `HybridDirectory` | OpenSearch's directory wrapper combining NIO and MMap |
+| `CompoundReader` | Reads compound files (`.cfs`) containing multiple index segments |
+| `Arena` | Java memory management construct for memory-mapped regions |
+
+### Configuration
+
+| Setting | Description | Default | Location |
+|---------|-------------|---------|----------|
+| `org.apache.lucene.store.MMapDirectory.sharedArenaMaxPermits` | Maximum permits for shared Arena pooling. Value of 1 disables pooling. | `1` | `jvm.options` |
+
+### Usage Example
+
+The setting is configured in `config/jvm.options`:
+
+```properties
+# For cases with high memory-mapped file counts, a lower value can improve stability and
+# prevent issues like "leaked" maps or performance degradation. A value of 1 effectively
+# disables the shared Arena pooling and uses a confined Arena for each MMapDirectory
+-Dorg.apache.lucene.store.MMapDirectory.sharedArenaMaxPermits=1
+```
+
+To override for specific use cases (not recommended):
+
+```properties
+# Enable shared Arena pooling with up to 256 permits (Lucene default)
+-Dorg.apache.lucene.store.MMapDirectory.sharedArenaMaxPermits=256
+```
+
+### Monitoring
+
+Check current memory mappings:
+
+```bash
+# Count memory-mapped index files
+cat /proc/$(pgrep -f opensearch)/maps | grep "indices" | wc -l
+
+# Check for duplicate mappings (indicates potential issue)
+cat /proc/$(pgrep -f opensearch)/maps | grep "indices" | awk '{print $6}' | sort | uniq -c | sort -rn | head -10
+```
+
+## Limitations
+
+- Disabling shared Arena pooling may slightly increase overhead for Arena creation/destruction
+- The setting is a JVM-level configuration and requires a restart to change
+- Does not address the root cause in Lucene's CompoundReader behavior with `IOContext.DEFAULT`
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19503](https://github.com/opensearch-project/OpenSearch/pull/19503) | Setting number of sharedArenaMaxPermits to 1 |
+
+## References
+
+- [Issue #19482](https://github.com/opensearch-project/OpenSearch/issues/19482): BUG - Frequent stats calls causing memory mapped segments to bloat up
+- [Lucene MMapDirectory JavaDoc](https://lucene.apache.org/core/10_0_0/core/org/apache/lucene/store/MMapDirectory.html): Official API documentation
+- [Blog: Use Lucene's MMapDirectory on 64bit](https://blog.thetaphi.de/2012/07/use-lucenes-mmapdirectory-on-64bit.html): Background on memory mapping behavior
+
+## Change History
+
+- **v3.3.0** (2025-10-02): Initial implementation - Set `sharedArenaMaxPermits=1` as default to mitigate memory-mapped segment bloat

--- a/docs/releases/v3.3.0/features/opensearch/netty-arena-settings.md
+++ b/docs/releases/v3.3.0/features/opensearch/netty-arena-settings.md
@@ -1,0 +1,107 @@
+# Netty Arena Settings
+
+## Summary
+
+This release introduces a JVM configuration change that sets `sharedArenaMaxPermits` to 1 for Lucene's MMapDirectory. This change mitigates memory-mapped segment bloat issues that can occur when frequent stats calls cause repeated memory mapping of compound files, potentially exhausting virtual address space.
+
+## Details
+
+### What's New in v3.3.0
+
+A new JVM option is added to the default `jvm.options` configuration file:
+
+```
+-Dorg.apache.lucene.store.MMapDirectory.sharedArenaMaxPermits=1
+```
+
+This setting effectively disables shared Arena pooling for MMapDirectory instances, using a confined Arena for each instance instead.
+
+### Technical Changes
+
+#### Background: The Problem
+
+When using shared Arena pooling, Lucene groups index files together into a single shared Arena to reduce the costly operation of closing an Arena. However, in specific cases with high memory-mapped file counts, this pooling can cause:
+
+- **Memory-mapped segment bloat**: Repeated entries (hundreds) for the same compound files in `/proc/<pid>/maps`
+- **Virtual address space exhaustion**: VmSize growing to extreme values (e.g., 200 TB)
+- **"Leaked" maps**: Memory mappings that persist longer than expected
+- **Performance degradation**: Slowdowns due to Arena management overhead
+
+The issue manifests when stats calls periodically trigger memory mapping of compound files (`.cfs`) using `IOContext.DEFAULT` in Lucene's CompoundReader.
+
+#### The Solution
+
+Setting `sharedArenaMaxPermits=1` forces each MMapDirectory instance to use a confined Arena rather than sharing Arenas across multiple files. This:
+
+1. Prevents accumulation of duplicate memory mappings
+2. Improves stability in environments with high memory-mapped file counts
+3. Avoids performance issues associated with closing shared Arenas
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before (Default Pooling)"
+        A1[MMapDirectory 1] --> SA[Shared Arena Pool]
+        A2[MMapDirectory 2] --> SA
+        A3[MMapDirectory N] --> SA
+        SA --> MM1[Memory Mappings]
+        SA --> MM2[Accumulated Mappings]
+    end
+    
+    subgraph "After (sharedArenaMaxPermits=1)"
+        B1[MMapDirectory 1] --> CA1[Confined Arena 1]
+        B2[MMapDirectory 2] --> CA2[Confined Arena 2]
+        B3[MMapDirectory N] --> CAN[Confined Arena N]
+        CA1 --> M1[Isolated Mapping]
+        CA2 --> M2[Isolated Mapping]
+        CAN --> MN[Isolated Mapping]
+    end
+```
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `-Dorg.apache.lucene.store.MMapDirectory.sharedArenaMaxPermits` | Maximum number of permits for shared Arena pooling. Value of 1 disables pooling. | `1` (new default in OpenSearch) |
+
+### Usage Example
+
+The setting is automatically applied via the default `jvm.options` file. No user action is required for new installations.
+
+For existing installations upgrading to v3.3.0, the setting will be applied automatically if using the default JVM options.
+
+To verify the setting is active:
+
+```bash
+# Check JVM arguments
+ps aux | grep opensearch | grep sharedArenaMaxPermits
+```
+
+### Migration Notes
+
+- **Automatic**: This change is applied automatically through the default `jvm.options` file
+- **No action required**: Existing clusters will benefit from this fix upon upgrade
+- **Override if needed**: Users can modify `jvm.options` to change the value if specific use cases require shared Arena pooling
+
+## Limitations
+
+- Setting `sharedArenaMaxPermits=1` may slightly increase the overhead of Arena creation/destruction for each MMapDirectory instance
+- The trade-off favors stability over potential minor performance gains from Arena pooling
+- This is a mitigation for the underlying issue; the root cause in Lucene's CompoundReader behavior remains
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19503](https://github.com/opensearch-project/OpenSearch/pull/19503) | Setting number of sharedArenaMaxPermits to 1 |
+
+## References
+
+- [Issue #19482](https://github.com/opensearch-project/OpenSearch/issues/19482): BUG - Frequent stats calls causing memory mapped segments to bloat up
+- [Lucene MMapDirectory](https://lucene.apache.org/core/10_0_0/core/org/apache/lucene/store/MMapDirectory.html): Official Lucene documentation
+- [Blog: Use Lucene's MMapDirectory on 64bit](https://blog.thetaphi.de/2012/07/use-lucenes-mmapdirectory-on-64bit.html): Background on MMapDirectory behavior
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/netty-arena-settings.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -5,6 +5,7 @@
 ### OpenSearch
 
 - [Derived Fields](features/opensearch/derived-fields.md)
+- [Netty Arena Settings](features/opensearch/netty-arena-settings.md)
 - [Search Stats - Negative Value Handling](features/opensearch/search-stats.md)
 - [Terms Query Rewriting](features/opensearch/terms-query-rewriting.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Netty Arena Settings feature introduced in OpenSearch v3.3.0.

### Changes

- **Release Report**: `docs/releases/v3.3.0/features/opensearch/netty-arena-settings.md`
- **Feature Report**: `docs/features/opensearch/netty-arena-settings.md`
- Updated release index and features index

### Feature Overview

OpenSearch v3.3.0 introduces a JVM configuration change that sets `sharedArenaMaxPermits=1` for Lucene's MMapDirectory. This mitigates memory-mapped segment bloat issues that can occur when frequent stats calls cause repeated memory mapping of compound files.

### Related

- PR: [opensearch-project/OpenSearch#19503](https://github.com/opensearch-project/OpenSearch/pull/19503)
- Issue: [opensearch-project/OpenSearch#19482](https://github.com/opensearch-project/OpenSearch/issues/19482)
- Investigation Issue: #1439