### PR TITLE
docs: add store-subdirectory-module report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -121,6 +121,7 @@
 - [Settings Management](opensearch/settings-management.md)
 - [Snapshot Restore Enhancements](opensearch/snapshot-restore-enhancements.md)
 - [Star Tree Index](opensearch/star-tree-index.md)
+- [Store Subdirectory Module](opensearch/store-subdirectory-module.md)
 - [Streaming Indexing](opensearch/streaming-indexing.md)
 - [Streaming Transport & Aggregation](opensearch/streaming-transport-aggregation.md)
 - [Stream Input/Output](opensearch/stream-inputoutput.md)

--- a/docs/features/opensearch/store-subdirectory-module.md
+++ b/docs/features/opensearch/store-subdirectory-module.md
@@ -1,0 +1,146 @@
+# Store Subdirectory Module
+
+## Summary
+
+The Store Subdirectory Module (`store-subdirectory`) is an OpenSearch module that enables handling files organized in subdirectories within shard data paths. It extends the standard OpenSearch Store to support peer recovery operations for files located in nested directories, ensuring subdirectory files are properly transferred between nodes during recovery.
+
+This module is useful for plugins or features that need to store additional data files in subdirectories alongside the standard Lucene index files.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Store Subdirectory Module"
+        SSP[SubdirectoryStorePlugin]
+        SAS[SubdirectoryAwareStore]
+        SAD[SubdirectoryAwareDirectory]
+    end
+    
+    subgraph "OpenSearch Core"
+        Store[Store]
+        Directory[Lucene Directory]
+        ShardPath[ShardPath]
+    end
+    
+    subgraph "Shard Data Path"
+        IndexDir[index/]
+        SubDir1[subdirectory1/]
+        SubDir2[subdirectory2/]
+        TranslogDir[translog/]
+        StateDir[_state/]
+    end
+    
+    SSP --> SAS
+    SAS --> Store
+    SAS --> SAD
+    SAD --> Directory
+    SAD --> ShardPath
+    
+    ShardPath --> IndexDir
+    ShardPath --> SubDir1
+    ShardPath --> SubDir2
+    ShardPath --> TranslogDir
+    ShardPath --> StateDir
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "File Operations"
+        A[File Request] --> B{Has Parent Path?}
+        B -->|Yes| C[Resolve to Subdirectory]
+        B -->|No| D[Resolve to Index Directory]
+        C --> E[SubdirectoryAwareDirectory]
+        D --> E
+        E --> F[Delegate to FSDirectory]
+    end
+    
+    subgraph "Recovery Flow"
+        G[Peer Recovery] --> H[getMetadata]
+        H --> I[Load Regular Segment Files]
+        H --> J[Load Subdirectory Files]
+        I --> K[MetadataSnapshot]
+        J --> K
+        K --> L[Transfer Files]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SubdirectoryStorePlugin` | Plugin entry point that registers the custom store factory |
+| `SubdirectoryAwareStore` | Extended Store implementation that handles subdirectory file operations |
+| `SubdirectoryAwareDirectory` | FilterDirectory wrapper that routes file operations to appropriate paths |
+| `SubdirectoryStoreFactory` | Factory for creating SubdirectoryAwareStore instances |
+
+### Configuration
+
+The module is enabled by setting the index store type:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.store.type` | Set to `subdirectory` to enable the module | `fs` |
+
+### Usage Example
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "store": {
+        "type": "subdirectory"
+      }
+    }
+  }
+}
+```
+
+### Key Features
+
+1. **Subdirectory File Handling**: Files with paths like `subdir/file.dat` are automatically resolved to the correct location within the shard data path.
+
+2. **Peer Recovery Support**: The module ensures subdirectory files are included in peer recovery operations through custom `IndexCommit` and metadata handling.
+
+3. **Metadata Snapshot**: Extended metadata snapshot includes both regular segment files and files in subdirectories.
+
+4. **Excluded Directories**: The module automatically excludes `index/`, `translog/`, and `_state/` directories from subdirectory scanning to avoid conflicts.
+
+### File Path Resolution
+
+```java
+// Files with parent path → resolved to shard data path
+"subdirectory/segments_1" → shardPath.getDataPath().resolve("subdirectory/segments_1")
+
+// Simple filenames → resolved to index directory  
+"segments_1" → shardPath.resolveIndex().resolve("segments_1")
+```
+
+## Limitations
+
+- Only works with local filesystem-based directories (FSDirectory)
+- Subdirectory files must follow Lucene file naming conventions for proper metadata handling
+- The `index/`, `translog/`, and `_state/` directories are excluded from subdirectory scanning
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#19132](https://github.com/opensearch-project/OpenSearch/pull/19132) | Initial implementation with recovery support |
+| v3.0.0 | [#20157](https://github.com/opensearch-project/OpenSearch/pull/20157) | Handle custom metadata files in subdirectory-store |
+| v3.3.0 | [#19470](https://github.com/opensearch-project/OpenSearch/pull/19470) | Fix stats API for SubdirectoryAwareStore |
+
+## References
+
+- [Issue #19131](https://github.com/opensearch-project/OpenSearch/issues/19131): Original feature request
+- [Issue #19468](https://github.com/opensearch-project/OpenSearch/issues/19468): Stats API bug report
+
+## Change History
+
+- **v3.3.0** (2026-01-11): Fixed stats API to correctly report store size by passing wrapped directory to base class
+- **v3.0.0** (2025-09-02): Added support for custom metadata files in subdirectory-store recovery
+- **v3.0.0** (2025-09-02): Initial implementation with SubdirectoryStorePlugin, SubdirectoryAwareStore, and peer recovery support

--- a/docs/releases/v3.3.0/features/opensearch/store-subdirectory-module.md
+++ b/docs/releases/v3.3.0/features/opensearch/store-subdirectory-module.md
@@ -1,0 +1,112 @@
+# Store Subdirectory Module - Stats API Fix
+
+## Summary
+
+This release fixes a bug in the `store-subdirectory` module where the stats API was not reporting correct store size values. The `SubdirectoryAwareStore` was initialized with a directory reference pointing only to the `/index` directory, causing incorrect size calculations. The fix refactors the store to pass the wrapped directory instance as a delegate to the base class, enabling accurate store size estimation.
+
+## Details
+
+### What's New in v3.3.0
+
+The `SubdirectoryAwareStore` class has been refactored to fix the stats API reporting incorrect store sizes.
+
+### Technical Changes
+
+#### Architecture Changes
+
+The key change is in how the `SubdirectoryAwareDirectory` is passed to the parent `Store` class:
+
+```mermaid
+graph TB
+    subgraph "Before Fix"
+        A1[SubdirectoryAwareStore] --> B1[Store base class]
+        B1 --> C1[directory /index only]
+        C1 --> D1[Incorrect stats]
+    end
+    
+    subgraph "After Fix"
+        A2[SubdirectoryAwareStore] --> B2[Store base class]
+        B2 --> C2[SubdirectoryAwareDirectory]
+        C2 --> D2[listAll includes subdirs]
+        D2 --> E2[Correct stats]
+    end
+```
+
+#### Code Changes
+
+| Change | Description |
+|--------|-------------|
+| Constructor refactoring | `SubdirectoryAwareDirectory` is now passed directly to the parent `Store` constructor |
+| Removed `directory()` override | No longer needed since the wrapped directory is passed to parent |
+| `listAll()` improvement | Uses `Files.walkFileTree()` instead of `Files.walk()` for better error handling |
+| Error handling | Added `visitFileFailed()` handler to gracefully skip inaccessible files |
+
+#### Before (Problematic)
+
+```java
+public SubdirectoryAwareStore(...) {
+    super(shardId, indexSettings, directory, shardLock, onClose, shardPath);
+    this.directory = new SubdirectoryAwareDirectory(super.directory(), shardPath);
+}
+
+@Override
+public Directory directory() {
+    return this.directory;
+}
+```
+
+#### After (Fixed)
+
+```java
+public SubdirectoryAwareStore(...) {
+    super(shardId, indexSettings, 
+          new SubdirectoryAwareDirectory(directory, shardPath), 
+          shardLock, onClose, shardPath);
+}
+// No directory() override needed
+```
+
+### Usage Example
+
+The stats API now correctly reports store size including files in subdirectories:
+
+```bash
+GET /_nodes/stats/indices/store
+```
+
+Response now includes accurate size for indices using the subdirectory-aware store:
+
+```json
+{
+  "indices": {
+    "store": {
+      "size_in_bytes": 12345678,
+      "reserved_in_bytes": 0
+    }
+  }
+}
+```
+
+### Migration Notes
+
+No migration required. This is a bug fix that automatically takes effect when upgrading to v3.3.0.
+
+## Limitations
+
+- The fix applies only to indices using the `store-subdirectory` module
+- Files that become inaccessible during size estimation are skipped with a debug log
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19470](https://github.com/opensearch-project/OpenSearch/pull/19470) | Fix stats API of SubdirectoryAwareStore |
+
+## References
+
+- [Issue #19468](https://github.com/opensearch-project/OpenSearch/issues/19468): Bug report for incorrect stats API values
+- [PR #19132](https://github.com/opensearch-project/OpenSearch/pull/19132): Original store-subdirectory module implementation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/store-subdirectory-module.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -7,6 +7,7 @@
 - [Derived Fields](features/opensearch/derived-fields.md)
 - [Netty Arena Settings](features/opensearch/netty-arena-settings.md)
 - [Search Stats - Negative Value Handling](features/opensearch/search-stats.md)
+- [Store Subdirectory Module](features/opensearch/store-subdirectory-module.md)
 - [Terms Query Rewriting](features/opensearch/terms-query-rewriting.md)
 
 ### OpenSearch Dashboards


### PR DESCRIPTION
## Summary

This PR adds documentation for the Store Subdirectory Module stats API fix in v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/store-subdirectory-module.md`
- Feature report: `docs/features/opensearch/store-subdirectory-module.md` (new)

### Key Changes in v3.3.0
- Fixed stats API to correctly report store size by passing wrapped directory to base class
- Improved error handling in `listAll()` using `Files.walkFileTree()` instead of `Files.walk()`

### Related Issue
Closes #1438

### Resources Used
- PR: [#19470](https://github.com/opensearch-project/OpenSearch/pull/19470)
- Issue: [#19468](https://github.com/opensearch-project/OpenSearch/issues/19468)