### PR TITLE
docs: add cluster-state-caching report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -28,6 +28,7 @@
 - [Cluster Stats API](opensearch/cluster-stats-api.md)
 - [Cluster Info & Resource Stats](opensearch/cluster-info-resource-stats.md)
 - [Cluster Manager Metrics](opensearch/cluster-manager-metrics.md)
+- [Cluster State Caching](opensearch/cluster-state-caching.md)
 - [Code Cleanup](opensearch/code-cleanup.md)
 - [Code Coverage (Gradle)](opensearch/code-coverage-gradle.md)
 - [Combined Fields Query](opensearch/combined-fields-query.md)

--- a/docs/features/opensearch/cluster-state-caching.md
+++ b/docs/features/opensearch/cluster-state-caching.md
@@ -1,0 +1,142 @@
+# Cluster State Caching
+
+## Summary
+
+Cluster state caching optimizes the node join process by caching serialized cluster state on the cluster manager node. When multiple nodes join a cluster simultaneously, the cluster manager can reuse the cached serialized state instead of re-serializing it for each joining node. The cache is keyed by both cluster state version and OpenSearch software version to ensure compatibility in mixed-version clusters.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Cluster Manager Node"
+        JH[JoinHelper]
+        SCSC[SerializedClusterStateCache]
+        CSU[CompressedStreamUtils]
+        TS[TransportService]
+    end
+    
+    subgraph "Cache Structure"
+        CSV[Cluster State Version]
+        VM[Version Map]
+        V1[Version A Bytes]
+        V2[Version B Bytes]
+    end
+    
+    subgraph "Joining Nodes"
+        N1[Node Version A]
+        N2[Node Version B]
+    end
+    
+    JH --> SCSC
+    SCSC --> CSV
+    CSV --> VM
+    VM --> V1
+    VM --> V2
+    
+    JH -->|sendValidateJoinRequest| TS
+    TS -->|VALIDATE_COMPRESSED_JOIN_ACTION_NAME| N1
+    TS -->|VALIDATE_COMPRESSED_JOIN_ACTION_NAME| N2
+```
+
+### Node Join Validation Flow
+
+```mermaid
+sequenceDiagram
+    participant JN as Joining Node
+    participant CM as Cluster Manager
+    participant JH as JoinHelper
+    participant Cache as SerializedClusterStateCache
+    participant CSU as CompressedStreamUtils
+    
+    JN->>CM: Join Request
+    CM->>JH: sendValidateJoinRequest(node, state)
+    
+    alt Node version < 2.9.0
+        JH->>JN: VALIDATE_JOIN_ACTION_NAME (uncompressed)
+    else Node version >= 2.9.0
+        JH->>Cache: updateAndGet(currentCache)
+        
+        alt Cache miss or version mismatch
+            Cache->>CSU: createCompressedStream(nodeVersion, state)
+            CSU-->>Cache: BytesReference
+            Cache-->>JH: Updated cache with new entry
+        else Cache hit
+            Cache-->>JH: Existing BytesReference
+        end
+        
+        JH->>JN: VALIDATE_COMPRESSED_JOIN_ACTION_NAME
+    end
+    
+    JN->>JN: Decompress & validate cluster state
+    JN-->>CM: Validation response
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `JoinHelper` | Coordinates the node join process, manages the serialized cluster state cache |
+| `SerializedClusterStateCache` | Inner class that caches serialized cluster state by cluster state version and OpenSearch version |
+| `CompressedStreamUtils` | Utility for creating compressed, version-specific serialized streams |
+| `BytesTransportRequest` | Transport request containing the compressed cluster state bytes |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| N/A | Cluster state caching is automatic and requires no configuration | - |
+
+### Cache Implementation Details
+
+The `SerializedClusterStateCache` class provides version-aware caching:
+
+```java
+public static final class SerializedClusterStateCache {
+    private final Long clusterStateVersion;
+    private final Map<Version, BytesReference> serialisedClusterStateBySoftwareVersion;
+    private static final int MAX_VERSIONS_SIZE = 2;
+}
+```
+
+Key behaviors:
+- **Cache invalidation**: When cluster state version changes, the entire cache is replaced
+- **Version-specific serialization**: Each OpenSearch version gets its own serialized representation
+- **Size limit**: Maximum of 2 versions cached to prevent unbounded memory growth
+- **LRU eviction**: When limit is reached, the oldest entry is removed
+
+### Usage Example
+
+The caching is transparent and automatic. During node join:
+
+```mermaid
+flowchart LR
+    A[Node Join Request] --> B{Cache Check}
+    B -->|Hit| C[Return Cached Bytes]
+    B -->|Miss| D[Serialize State]
+    D --> E[Store in Cache]
+    E --> C
+    C --> F[Send to Joining Node]
+```
+
+## Limitations
+
+- Cache is limited to 2 OpenSearch versions (`MAX_VERSIONS_SIZE = 2`)
+- Cache is invalidated on every cluster state version change
+- Only applies to nodes running OpenSearch 2.9.0 or later (older nodes use uncompressed validation)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19307](https://github.com/opensearch-project/OpenSearch/pull/19307) | Fix: Cache serialised cluster state based on cluster state version and node version |
+
+## References
+
+- [Issue #19272](https://github.com/opensearch-project/OpenSearch/issues/19272): [BUG] Join Failure - Mixed Version cluster
+- [JoinHelper.java](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/cluster/coordination/JoinHelper.java): Source implementation
+
+## Change History
+
+- **v3.3.0** (2025-09-30): Fixed cluster state caching to use both cluster state version and node version as cache keys, resolving join failures in mixed-version clusters

--- a/docs/releases/v3.3.0/features/opensearch/cluster-state-caching.md
+++ b/docs/releases/v3.3.0/features/opensearch/cluster-state-caching.md
@@ -1,0 +1,130 @@
+# Cluster State Caching
+
+## Summary
+
+This release fixes a critical bug in cluster state caching during node join validation that caused join failures in mixed-version clusters. The fix introduces version-aware caching that maintains separate serialized cluster states for different OpenSearch versions, ensuring nodes can properly deserialize the cluster state during the join process.
+
+## Details
+
+### What's New in v3.3.0
+
+The cluster manager node caches serialized cluster state to optimize the join validation process when multiple nodes join simultaneously. Previously, this cache only considered the cluster state version, which caused issues when nodes of different OpenSearch versions (e.g., 2.19 and 3.1) attempted to join the same cluster.
+
+Version-specific attributes introduced in OpenSearch 2.17 and 3.1 made the cached serialized state incompatible across different versions. When a node tried to deserialize a cached state serialized for a different version, it would fail, causing join failures.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Cluster Manager Node"
+        JH[JoinHelper]
+        SCSC[SerializedClusterStateCache]
+        CSU[CompressedStreamUtils]
+    end
+    
+    subgraph "Cache Structure"
+        CSV[Cluster State Version]
+        V1[Version 2.19 State]
+        V2[Version 3.1 State]
+    end
+    
+    subgraph "Joining Nodes"
+        N1[Node v2.19]
+        N2[Node v3.1]
+    end
+    
+    JH --> SCSC
+    SCSC --> CSV
+    CSV --> V1
+    CSV --> V2
+    
+    JH -->|Serialize for v2.19| CSU
+    JH -->|Serialize for v3.1| CSU
+    CSU -->|Version-specific bytes| V1
+    CSU -->|Version-specific bytes| V2
+    
+    V1 -->|Send| N1
+    V2 -->|Send| N2
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `SerializedClusterStateCache` | New inner class in `JoinHelper` that caches serialized cluster state keyed by both cluster state version and OpenSearch software version |
+
+#### Cache Design
+
+The new `SerializedClusterStateCache` class maintains:
+
+- `clusterStateVersion`: The cluster state version this cache is for
+- `serialisedClusterStateBySoftwareVersion`: A map from OpenSearch `Version` to serialized `BytesReference`
+- `MAX_VERSIONS_SIZE`: Limits cache to 2 versions to prevent unbounded memory growth
+
+```java
+public static final class SerializedClusterStateCache {
+    private final Long clusterStateVersion;
+    private final Map<Version, BytesReference> serialisedClusterStateBySoftwareVersion;
+    private static final int MAX_VERSIONS_SIZE = 2;
+    // ...
+}
+```
+
+#### Cache Behavior
+
+1. When cluster state version changes, the entire cache is invalidated
+2. For each joining node, the cache checks if a serialized state exists for that node's version
+3. If not found, a new serialized state is created using `CompressedStreamUtils.createCompressedStream()` with the target node's version
+4. The cache evicts the oldest entry when `MAX_VERSIONS_SIZE` is reached
+
+### Usage Example
+
+No configuration changes are required. The fix is automatically applied during node join operations:
+
+```mermaid
+sequenceDiagram
+    participant CM as Cluster Manager
+    participant Cache as SerializedClusterStateCache
+    participant N1 as Node (v2.19)
+    participant N2 as Node (v3.1)
+    
+    N1->>CM: Join Request
+    CM->>Cache: Get state for v2.19
+    Cache-->>CM: Cache miss
+    CM->>Cache: Serialize & store for v2.19
+    CM->>N1: Send v2.19-compatible state
+    
+    N2->>CM: Join Request
+    CM->>Cache: Get state for v3.1
+    Cache-->>CM: Cache miss
+    CM->>Cache: Serialize & store for v3.1
+    CM->>N2: Send v3.1-compatible state
+    
+    Note over CM,N2: Both nodes successfully join
+```
+
+### Migration Notes
+
+No migration required. This is a bug fix that improves cluster stability during rolling upgrades and mixed-version operations.
+
+## Limitations
+
+- Cache is limited to 2 OpenSearch versions (`MAX_VERSIONS_SIZE = 2`) to prevent memory issues
+- In clusters with more than 2 different OpenSearch versions joining simultaneously, some cache misses may occur (causing re-serialization)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19307](https://github.com/opensearch-project/OpenSearch/pull/19307) | Cache serialised cluster state based on cluster state version and node version |
+
+## References
+
+- [Issue #19272](https://github.com/opensearch-project/OpenSearch/issues/19272): [BUG] Join Failure - Mixed Version cluster
+- [JoinHelper.java](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/cluster/coordination/JoinHelper.java): Implementation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/cluster-state-caching.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -4,6 +4,7 @@
 
 ### OpenSearch
 
+- [Cluster State Caching](features/opensearch/cluster-state-caching.md)
 - [Derived Fields](features/opensearch/derived-fields.md)
 - [Netty Arena Settings](features/opensearch/netty-arena-settings.md)
 - [Search Stats - Negative Value Handling](features/opensearch/search-stats.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Cluster State Caching fix in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/cluster-state-caching.md`
- Feature report: `docs/features/opensearch/cluster-state-caching.md`

### Key Changes in v3.3.0
- Fixed cluster state caching to use both cluster state version and node version as cache keys
- Resolves join failures in mixed-version clusters (e.g., 2.19 and 3.1)
- Introduced `SerializedClusterStateCache` class with version-aware caching

### Resources Used
- PR: [#19307](https://github.com/opensearch-project/OpenSearch/pull/19307)
- Issue: [#19272](https://github.com/opensearch-project/OpenSearch/issues/19272)

Closes #1437