### PR TITLE
docs: add Reactor Netty Transport report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -98,6 +98,7 @@
 - [Query Phase Plugin Extension](opensearch/query-phase-plugin-extension.md)
 - [Query String & Regex Queries](opensearch/query-string-regex.md)
 - [Randomness](opensearch/randomness.md)
+- [Reactor Netty Transport](opensearch/reactor-netty-transport.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)
 - [Replication](opensearch/replication.md)
 - [Rescore Named Queries](opensearch/rescore-named-queries.md)

--- a/docs/features/opensearch/reactor-netty-transport.md
+++ b/docs/features/opensearch/reactor-netty-transport.md
@@ -1,0 +1,123 @@
+# Reactor Netty Transport
+
+## Summary
+
+The Reactor Netty Transport (`transport-reactor-netty4`) is an experimental HTTP transport plugin for OpenSearch based on [Project Reactor](https://github.com/reactor/reactor-netty) and Netty 4. It provides reactive, non-blocking HTTP communication with support for streaming APIs, HTTP/2, and Server-Sent Events (SSE), enabling features like the built-in MCP server and streaming bulk operations.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch HTTP Layer"
+        Client[HTTP Client]
+        
+        subgraph "Transport Options"
+            Netty4[transport-netty4<br/>Default]
+            ReactorNetty[transport-reactor-netty4<br/>Experimental]
+        end
+        
+        subgraph "Reactor Netty Components"
+            ServerTransport[ReactorNetty4HttpServerTransport]
+            NonStreaming[NonStreamingHttpChannel]
+            Streaming[StreamingHttpChannel]
+            BaseChannel[BaseHttpChannel]
+        end
+        
+        Handler[Request Handler]
+    end
+    
+    Client --> Netty4
+    Client --> ReactorNetty
+    ReactorNetty --> ServerTransport
+    ServerTransport --> NonStreaming
+    ServerTransport --> Streaming
+    NonStreaming --> BaseChannel
+    Streaming --> BaseChannel
+    BaseChannel --> Handler
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Streaming Request"
+        Request[HTTP Request] --> Transport[Reactor Netty Transport]
+        Transport --> SSE[SSE/Streaming Handler]
+        SSE --> Response[Chunked Response]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ReactorNetty4HttpServerTransport` | Main HTTP server transport implementation |
+| `ReactorNetty4NonStreamingHttpChannel` | Channel for standard request/response |
+| `ReactorNetty4StreamingHttpChannel` | Channel for streaming responses (SSE) |
+| `ReactorNetty4BaseHttpChannel` | Shared utility for SSL handler retrieval |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `http.type` | Transport type (`reactor-netty4` or `reactor-netty4-secure`) | `netty4` |
+
+### Usage Example
+
+```yaml
+# opensearch.yml
+
+# Enable reactor-netty4 transport (without security plugin managing TLS)
+http.type: reactor-netty4
+
+# Enable reactor-netty4 transport with built-in TLS (for use with security plugin)
+http.type: reactor-netty4-secure
+```
+
+Installation:
+
+```bash
+# Install the plugin
+./bin/opensearch-plugin install transport-reactor-netty4
+
+# Start OpenSearch
+./bin/opensearch
+```
+
+### Use Cases
+
+The Reactor Netty transport enables several advanced features:
+
+1. **MCP Server**: The built-in Model Context Protocol server requires streaming support
+2. **Streaming Bulk API**: Enables streaming bulk indexing operations
+3. **HTTP/2 Support**: Native HTTP/2 protocol support
+4. **Server-Sent Events**: Real-time streaming responses for AI/ML operations
+
+## Limitations
+
+- Experimental feature - not recommended for production without thorough testing
+- Requires explicit plugin installation
+- Some features may have different behavior compared to the default Netty4 transport
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19458](https://github.com/opensearch-project/OpenSearch/pull/19458) | Fix SslHandler retrieval for Security plugin compatibility |
+| v3.2.0 | - | Added `SecureHttpTransportParameters` interface |
+| v2.17.0 | - | Initial streaming support |
+
+## References
+
+- [Network Settings Documentation](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/network-settings/): Official configuration guide
+- [Streaming Bulk API](https://docs.opensearch.org/3.0/api-reference/document-apis/bulk-streaming/): Streaming bulk documentation
+- [Forum Discussion](https://forum.opensearch.org/t/pods-not-coming-up-after-using-transport-reactor-netty4-plugin-for-mcp-server/26990): Security plugin compatibility issue
+- [Project Reactor](https://github.com/reactor/reactor-netty): Underlying reactive framework
+
+## Change History
+
+- **v3.3.0** (2025-09-29): Fixed SslHandler retrieval logic for Security plugin compatibility, added clientAuth support
+- **v3.2.0** (2025-07-15): Added `SecureHttpTransportParameters` interface for cleaner SSL configuration
+- **v2.17.0** (2024-09-17): Initial streaming support with reactor-netty4 transport

--- a/docs/releases/v3.3.0/features/opensearch/reactor-netty-transport.md
+++ b/docs/releases/v3.3.0/features/opensearch/reactor-netty-transport.md
@@ -1,0 +1,119 @@
+# Reactor Netty Transport
+
+## Summary
+
+This release fixes a critical bug in the `transport-reactor-netty4` plugin that prevented the OpenSearch Security plugin from working correctly. When the reactor-netty4 transport was enabled, the `securityadmin.sh` tool failed with a 403 Forbidden error because the `SslHandler` could not be located due to different naming conventions used by Reactor Netty.
+
+## Details
+
+### What's New in v3.3.0
+
+The fix implements proper `SslHandler` retrieval logic for the `transport-reactor-netty4` plugin, enabling compatibility with the OpenSearch Security plugin.
+
+### Technical Changes
+
+#### Problem Background
+
+When `transport-reactor-netty4` plugin is activated with `http.type: reactor-netty4-secure`, the Security plugin's `securityadmin.sh` tool failed with:
+
+```
+ERR: An unexpected ResponseException occured: method [GET], host [https://localhost:9200], 
+URI [/_plugins/_security/whoami], status line [HTTP/2.0 403 Forbidden]
+```
+
+The root cause was that the Security plugin tries to locate the `SslHandler` by name, but the `transport-reactor-netty4` plugin uses a different naming convention (`NettyPipeline.SslHandler` from Reactor Netty) compared to the standard Netty4 transport.
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "HTTP Request Flow"
+        Client[Client Request]
+        Transport[Reactor Netty4 Transport]
+        Security[Security Plugin]
+        Handler[Request Handler]
+    end
+    
+    subgraph "SSL Handler Retrieval (Fixed)"
+        BaseChannel[ReactorNetty4BaseHttpChannel]
+        Pipeline[Channel Pipeline]
+        SslHandler[SslHandler]
+    end
+    
+    Client --> Transport
+    Transport --> Security
+    Security --> BaseChannel
+    BaseChannel --> Pipeline
+    Pipeline --> SslHandler
+    Security --> Handler
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ReactorNetty4BaseHttpChannel` | New utility class providing SSL handler retrieval logic for Reactor Netty channels |
+
+#### Implementation Details
+
+The fix introduces a new `ReactorNetty4BaseHttpChannel` class that provides a `get()` method to retrieve channel attributes including:
+
+- `channel` - The underlying Netty channel
+- `ssl_http` - The SSL handler instance
+- `ssl_engine` - The SSL engine for certificate access
+
+The method handles the Reactor Netty pipeline structure where the SSL handler may be in the parent channel's pipeline rather than the current channel.
+
+#### Modified Components
+
+| Component | Change |
+|-----------|--------|
+| `ReactorNetty4NonStreamingHttpChannel` | Added `get()` method override using `ReactorNetty4BaseHttpChannel` |
+| `ReactorNetty4StreamingHttpChannel` | Added `get()` method override using `ReactorNetty4BaseHttpChannel` |
+| `ReactorNetty4HttpServerTransport` | Added `clientAuth` configuration support |
+
+### Usage Example
+
+After this fix, the standard setup works correctly:
+
+```bash
+# Install the plugin
+./bin/opensearch-plugin install transport-reactor-netty4
+
+# Configure opensearch.yml
+http.type: reactor-netty4-secure
+
+# Start OpenSearch
+./bin/opensearch
+
+# Security admin now works correctly
+./plugins/opensearch-security/tools/securityadmin.sh \
+  -cacert config/root-ca.pem \
+  -cert config/admin.pem \
+  -key config/admin-key.pem
+```
+
+### Migration Notes
+
+Users who were affected by this bug and had to use workarounds (like starting the cluster without the reactor-netty4 transport and enabling it after security initialization) can now use the standard installation process.
+
+## Limitations
+
+- The `transport-reactor-netty4` plugin remains experimental
+- Requires explicit installation: `./bin/opensearch-plugin install transport-reactor-netty4`
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19458](https://github.com/opensearch-project/OpenSearch/pull/19458) | Implement SslHandler retrieval logic for transport-reactor-netty4 plugin |
+
+## References
+
+- [Forum Discussion](https://forum.opensearch.org/t/pods-not-coming-up-after-using-transport-reactor-netty4-plugin-for-mcp-server/26990): Original bug report
+- [Security Plugin PR #5667](https://github.com/opensearch-project/security/pull/5667): Companion fix in Security plugin
+- [Network Settings Documentation](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/network-settings/): Transport configuration
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/reactor-netty-transport.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -7,6 +7,7 @@
 - [Cluster State Caching](features/opensearch/cluster-state-caching.md)
 - [Derived Fields](features/opensearch/derived-fields.md)
 - [Netty Arena Settings](features/opensearch/netty-arena-settings.md)
+- [Reactor Netty Transport](features/opensearch/reactor-netty-transport.md)
 - [Search Stats - Negative Value Handling](features/opensearch/search-stats.md)
 - [Store Subdirectory Module](features/opensearch/store-subdirectory-module.md)
 - [Terms Query Rewriting](features/opensearch/terms-query-rewriting.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Reactor Netty Transport bugfix in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/reactor-netty-transport.md`
- Feature report: `docs/features/opensearch/reactor-netty-transport.md`

### Key Changes in v3.3.0
- Fixed SslHandler retrieval logic for transport-reactor-netty4 plugin
- Added `ReactorNetty4BaseHttpChannel` utility class for SSL handler access
- Enabled Security plugin compatibility with reactor-netty4 transport
- Added clientAuth configuration support

### Resources Used
- PR: [#19458](https://github.com/opensearch-project/OpenSearch/pull/19458)
- Forum: https://forum.opensearch.org/t/pods-not-coming-up-after-using-transport-reactor-netty4-plugin-for-mcp-server/26990
- Docs: https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/network-settings/

Closes #1436