### PR TITLE
docs: add cardinality aggregation report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -24,6 +24,7 @@
 - [Automata & Regex Optimization](opensearch/automata-regex-optimization.md)
 - [Azure Repository](opensearch/azure-repository.md)
 - [Bulk API](opensearch/bulk-api.md)
+- [Cardinality Aggregation](opensearch/cardinality-aggregation.md)
 - [Cat Indices API](opensearch/cat-indices-api.md)
 - [Cluster Stats API](opensearch/cluster-stats-api.md)
 - [Cluster Info & Resource Stats](opensearch/cluster-info-resource-stats.md)

--- a/docs/features/opensearch/cardinality-aggregation.md
+++ b/docs/features/opensearch/cardinality-aggregation.md
@@ -1,0 +1,129 @@
+# Cardinality Aggregation
+
+## Summary
+
+The cardinality aggregation is a single-value metric aggregation that estimates the count of unique (distinct) values for a field. It uses the HyperLogLog++ (HLL++) algorithm to provide approximate counts with configurable precision, making it memory-efficient for high-cardinality fields.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Cardinality Aggregation"
+        Query[Search Query] --> Collector[Collector Selection]
+        Collector --> Empty[EmptyCollector]
+        Collector --> Direct[DirectCollector]
+        Collector --> Ordinals[OrdinalsCollector]
+        Collector --> Hybrid[HybridCollector]
+        
+        Direct --> HLL[HyperLogLog++]
+        Ordinals --> HLL
+        Hybrid --> HLL
+        
+        HLL --> Result[Cardinality Result]
+    end
+    
+    subgraph "Pruning Optimization"
+        Collector --> Pruning{Can Prune?}
+        Pruning -->|Yes| PruningCollector[PruningCollector]
+        PruningCollector --> NoOp[NoOpCollector]
+        Pruning -->|No| Direct
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `CardinalityAggregator` | Main aggregator class that orchestrates cardinality computation |
+| `HyperLogLogPlusPlus` | HLL++ implementation for approximate distinct counting |
+| `EmptyCollector` | No-op collector for empty value sources |
+| `DirectCollector` | Collects hash values directly into HLL++ |
+| `OrdinalsCollector` | Uses ordinals for efficient collection on keyword fields |
+| `HybridCollector` | Starts with ordinals, switches to direct if memory threshold exceeded |
+| `PruningCollector` | Enables dynamic pruning optimization for term fields |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `precision_threshold` | Threshold below which counts are expected to be accurate | 3000 |
+| `execution_hint` | How to run aggregation: `ordinals` or `direct` | Auto |
+| `search.aggregations.cardinality.pruning_threshold` | Max terms for pruning optimization | Configurable |
+| `search.aggregations.cardinality.hybrid_collector.enabled` | Enable hybrid collector | `true` |
+| `search.aggregations.cardinality.hybrid_collector.memory_threshold` | Memory threshold for hybrid collector | `1%` |
+
+### Usage Example
+
+```json
+GET /my-index/_search
+{
+  "size": 0,
+  "aggs": {
+    "unique_users": {
+      "cardinality": {
+        "field": "user_id",
+        "precision_threshold": 10000
+      }
+    }
+  }
+}
+```
+
+Response:
+```json
+{
+  "aggregations": {
+    "unique_users": {
+      "value": 12345
+    }
+  }
+}
+```
+
+### Collector Selection Logic
+
+The aggregator selects the optimal collector based on:
+
+1. **EmptyCollector**: When no values source exists
+2. **DirectCollector**: For numeric fields or when ordinals overhead is too high
+3. **OrdinalsCollector**: For keyword fields with low cardinality (memory efficient)
+4. **HybridCollector**: Starts with ordinals, switches to direct if memory exceeds threshold
+
+### Dynamic Pruning Optimization
+
+When enabled, the pruning optimization can significantly improve performance by:
+- Building a priority queue of term iterators
+- Pruning terms after they've been collected
+- Using a competitive iterator to skip non-matching documents
+
+Requirements for pruning:
+- No parent aggregator
+- No sub-aggregations
+- No missing value handling
+- No script
+- Term count below threshold
+
+## Limitations
+
+- Cardinality counts are approximate (uses HLL++ algorithm)
+- Accuracy depends on `precision_threshold` setting
+- High-cardinality fields may consume significant memory with ordinals collector
+- Pruning optimization may not apply in all scenarios
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19473](https://github.com/opensearch-project/OpenSearch/pull/19473) | Fix cardinality agg pruning optimization by self collecting |
+
+## References
+
+- [Cardinality Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/metric/cardinality/)
+- [HyperLogLog++ Paper](https://static.googleusercontent.com/media/research.google.com/fr//pubs/archive/40671.pdf)
+- [Issue #19367](https://github.com/opensearch-project/OpenSearch/issues/19367): Performance regression after Lucene 10.3.0
+
+## Change History
+
+- **v3.3.0**: Fixed pruning optimization regression caused by Lucene 10.3.0's BulkScorer behavior; replaced with self-collecting approach

--- a/docs/releases/v3.3.0/features/opensearch/cardinality-aggregation.md
+++ b/docs/releases/v3.3.0/features/opensearch/cardinality-aggregation.md
@@ -1,0 +1,98 @@
+# Cardinality Aggregation Pruning Fix
+
+## Summary
+
+This release fixes a performance regression in the cardinality aggregation pruning optimization that was introduced after merging Lucene 10.3.0. The fix replaces the use of `BulkScorer` with a custom self-collecting approach to avoid incorrect document matching caused by Lucene's `DenseConjunctionBulkCollector` `scoreWindow` logic.
+
+## Details
+
+### What's New in v3.3.0
+
+The cardinality aggregation's dynamic pruning optimization experienced a severe performance regression (from ~5ms to ~5s on the big5 benchmark's `cardinality-low` query) after the Lucene 10.3.0 upgrade. This fix restores the expected performance by implementing self-collection instead of relying on Lucene's `BulkScorer`.
+
+### Technical Changes
+
+#### Problem
+
+The `DenseConjunctionBulkCollector` in Lucene 10.3.0 was matching too many documents due to its `scoreWindow` logic, causing the pruning optimization to process far more documents than necessary.
+
+#### Solution
+
+The fix replaces `BulkScorer` with a custom `bulkCollect` method that:
+1. Uses `Scorer` directly instead of `BulkScorer`
+2. Implements manual iteration with `DocIdSetIterator`
+3. Properly handles the competitive iterator for pruning
+
+```java
+// Before (problematic)
+BulkScorer scorer = weight.bulkScorer(ctx);
+scorer.score(pruningCollector, liveDocs, 0, DocIdSetIterator.NO_MORE_DOCS);
+
+// After (fixed)
+Scorer scorer = weight.scorer(ctx);
+pruningCollector.setScorer(scorer);
+DocIdSetIterator iterator = scorer.iterator();
+bulkCollect(ctx.reader().getLiveDocs(), iterator, pruningCollector);
+```
+
+#### New bulkCollect Method
+
+```java
+private void bulkCollect(Bits acceptDocs, DocIdSetIterator iterator, 
+                         Collector pruningCollector) throws IOException {
+    DocIdSetIterator competitiveIterator = pruningCollector.competitiveIterator();
+    int doc = iterator.nextDoc();
+    while (doc < DocIdSetIterator.NO_MORE_DOCS) {
+        if (competitiveIterator.docID() < doc) {
+            int competitiveNext = competitiveIterator.advance(doc);
+            if (competitiveNext != doc) {
+                doc = iterator.advance(competitiveNext);
+                continue;
+            }
+        }
+        if ((acceptDocs == null || acceptDocs.get(doc))) {
+            pruningCollector.collect(doc);
+        }
+        doc = iterator.nextDoc();
+    }
+}
+```
+
+### Scope
+
+This optimization only applies when:
+- Running a cardinality aggregation without sub-aggregations
+- The pruning optimization is enabled (controlled by `search.aggregations.cardinality.pruning_threshold`)
+- The field's term count is below the pruning threshold
+
+### Fallback Option
+
+If issues persist, the pruning optimization can be disabled via index setting:
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "search.aggregations.cardinality.pruning_threshold": 0
+  }
+}
+```
+
+## Limitations
+
+- The fix is specific to the interaction between cardinality aggregation pruning and Lucene 10.3.0's `BulkScorer` behavior
+- A Lucene issue will be raised to track the underlying `DenseConjunctionBulkCollector` behavior
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19473](https://github.com/opensearch-project/OpenSearch/pull/19473) | Fix cardinality agg pruning optimization by self collecting |
+
+## References
+
+- [Issue #19367](https://github.com/opensearch-project/OpenSearch/issues/19367): big5.cardinality-low aggs regression after merging Lucene 10.3.0
+- [Cardinality Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/metric/cardinality/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/cardinality-aggregation.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -4,6 +4,7 @@
 
 ### OpenSearch
 
+- [Cardinality Aggregation](features/opensearch/cardinality-aggregation.md)
 - [Cluster State Caching](features/opensearch/cluster-state-caching.md)
 - [Derived Fields](features/opensearch/derived-fields.md)
 - [Netty Arena Settings](features/opensearch/netty-arena-settings.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the cardinality aggregation pruning fix in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/cardinality-aggregation.md`
- Feature report: `docs/features/opensearch/cardinality-aggregation.md`

### Key Changes in v3.3.0
- Fixed performance regression in cardinality aggregation pruning optimization
- Replaced `BulkScorer` with custom self-collecting approach to avoid Lucene 10.3.0's `DenseConjunctionBulkCollector` issues
- Performance restored from ~5s back to ~5ms on big5 benchmark

### Resources Used
- PR: [#19473](https://github.com/opensearch-project/OpenSearch/pull/19473)
- Issue: [#19367](https://github.com/opensearch-project/OpenSearch/issues/19367)
- Docs: https://docs.opensearch.org/3.0/aggregations/metric/cardinality/

Closes #1435