### PR TITLE
docs: add request-cache report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -102,6 +102,7 @@
 - [Reactor Netty Transport](opensearch/reactor-netty-transport.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)
 - [Replication](opensearch/replication.md)
+- [Request Cache](opensearch/request-cache.md)
 - [Rescore Named Queries](opensearch/rescore-named-queries.md)
 - [Remote Store](opensearch/remote-store.md)
 - [Remote Store Metadata API](opensearch/remote-store-metadata-api.md)

--- a/docs/features/opensearch/request-cache.md
+++ b/docs/features/opensearch/request-cache.md
@@ -1,0 +1,139 @@
+# Request Cache
+
+## Summary
+
+The OpenSearch request cache is a shard-level caching mechanism that stores the results of frequently executed search queries to improve search performance and reduce cluster load. It automatically invalidates cached entries when documents are updated or index settings change, ensuring fresh results.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Request Cache Architecture"
+        A[Search Request] --> B{Cacheable?}
+        B -->|Yes| C{Cache Hit?}
+        B -->|No| G[Execute Query]
+        C -->|Yes| D[Return Cached Result]
+        C -->|No| E[Execute Query]
+        E --> F[Store in Cache]
+        F --> D
+        G --> D
+    end
+    
+    subgraph "Cache Invalidation"
+        H[Document Update] --> I[IndexReader Close]
+        I --> J[Invalidate Cache Keys]
+        K[Index Refresh] --> I
+        L[Mapping Change] --> M[Mark Non-Cacheable]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Cache Clear Flow"
+        A[Clear Cache API] --> B[TransportClearIndicesCacheAction]
+        B --> C[Per-Shard: Queue Cleanup Key]
+        C --> D[Node Operation Hook]
+        D --> E[Force Clean Cache]
+        E --> F[Single Iteration Through Keys]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `IndicesRequestCache` | Main cache implementation managing cached search results |
+| `IndicesRequestCache.CacheCleanupManager` | Manages cleanup keys and scheduled cache cleaning |
+| `TransportClearIndicesCacheAction` | Handles cache clear API requests with node-level optimization |
+| `TransportBroadcastByNodeAction` | Base class providing node-level hook for post-shard operations |
+| `QueryShardContext` | Tracks query cacheability during query building |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `indices.cache.cleanup_interval` | Interval for background cleanup task | `1m` |
+| `indices.requests.cache.size` | Cache size as percentage of heap | `1%` |
+| `index.requests.cache.enable` | Enable/disable cache per index | `true` |
+| `indices.requests.cache.maximum_cacheable_size` | Maximum `size` parameter for cacheable queries | `0` |
+
+### Cacheability Rules
+
+Queries are **not cacheable** when:
+- `size` > `indices.requests.cache.maximum_cacheable_size` (default: only `size=0` cacheable)
+- Query uses `Math.random()` or other non-deterministic functions
+- Query uses relative times like `now` or `new Date()`
+- Query is a scroll query or profiled query
+- Query is a DFS query
+- Query targets keyword fields with `use_similarity: true` (v3.3.0+)
+- Query targets keyword fields with `split_queries_on_whitespace: true` (v3.3.0+)
+
+### Usage Example
+
+```bash
+# Enable request cache for an index
+PUT /my_index/_settings
+{
+  "index.requests.cache.enable": true
+}
+
+# Force cache a specific request
+GET /my_index/_search?request_cache=true
+{
+  "size": 0,
+  "aggs": {
+    "popular_tags": {
+      "terms": { "field": "tags" }
+    }
+  }
+}
+
+# Clear request cache
+POST /my_index/_cache/clear?request=true
+
+# Monitor cache statistics
+GET /_nodes/stats/indices/request_cache
+```
+
+### Monitoring
+
+```bash
+# Node-level cache stats
+GET /_nodes/stats/indices/request_cache
+
+# Response includes:
+# - memory_size_in_bytes: Current cache size
+# - evictions: Number of evictions
+# - hit_count: Cache hits
+# - miss_count: Cache misses
+```
+
+## Limitations
+
+- Only queries with `size=0` are cached by default (configurable in v2.19+)
+- Cache is invalidated on every index refresh
+- Queries on keyword fields with non-default `use_similarity` or `split_queries_on_whitespace` are not cacheable
+- Cache size is limited to a percentage of heap memory
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19263](https://github.com/opensearch-project/OpenSearch/pull/19263) | Remove unnecessary iteration per-shard in request cache cleanup |
+| v3.3.0 | [#19385](https://github.com/opensearch-project/OpenSearch/pull/19385) | Disable request cache for queries on fields with non-default keyword parameters |
+
+## References
+
+- [Documentation: Index request cache](https://docs.opensearch.org/3.0/search-plugins/caching/request-cache/)
+- [Documentation: Tiered cache](https://docs.opensearch.org/3.0/search-plugins/caching/tiered-cache/)
+- [Issue #19118](https://github.com/opensearch-project/OpenSearch/issues/19118): Repeated iteration through keys on cache clear API
+- [Issue #19183](https://github.com/opensearch-project/OpenSearch/issues/19183): Add node-level hook to TransportBroadcastByNodeAction
+- [Issue #19279](https://github.com/opensearch-project/OpenSearch/issues/19279): Dynamically updating mapping parameters does not wipe request cache entries
+
+## Change History
+
+- **v3.3.0**: Optimized cache clear performance by adding node-level hook; disabled caching for keyword fields with non-default `use_similarity` or `split_queries_on_whitespace`

--- a/docs/releases/v3.3.0/features/opensearch/request-cache.md
+++ b/docs/releases/v3.3.0/features/opensearch/request-cache.md
@@ -1,0 +1,134 @@
+# Request Cache
+
+## Summary
+
+OpenSearch v3.3.0 introduces two improvements to the request cache: optimized cache clear operations and prevention of stale responses when keyword field mapping parameters are dynamically updated.
+
+## Details
+
+### What's New in v3.3.0
+
+#### 1. Optimized Cache Clear Performance
+
+The cache clear operation has been significantly optimized by removing unnecessary per-shard iterations. Previously, when clearing the request cache via the Clear Cache API, the system would iterate through all cache keys once per shard, causing high latency especially when using disk-based tiered caching.
+
+**Performance Improvement:**
+
+| Scenario | Before | After | Improvement |
+|----------|--------|-------|-------------|
+| 2M keys, 10 indices (disk tier) | 131.56 sec | 60.62 sec | ~54% faster |
+
+#### 2. Stale Response Prevention for Keyword Fields
+
+Queries on keyword fields with non-default values for `use_similarity` or `split_queries_on_whitespace` parameters are now automatically excluded from the request cache. This prevents stale/incorrect results when these dynamically updateable parameters are changed.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Cache Clear Flow (Before v3.3.0)"
+        A1[Clear Cache API] --> B1[Per-Shard Operation]
+        B1 --> C1[Queue Cleanup Key]
+        C1 --> D1[Force Clean Cache]
+        D1 --> E1[Iterate All Keys]
+        E1 --> B1
+    end
+    
+    subgraph "Cache Clear Flow (v3.3.0)"
+        A2[Clear Cache API] --> B2[Per-Shard Operation]
+        B2 --> C2[Queue Cleanup Key]
+        C2 --> D2[Node Operation Hook]
+        D2 --> E2[Single Force Clean]
+        E2 --> F2[Iterate All Keys Once]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `TransportBroadcastByNodeAction.nodeOperation()` | New node-level hook that executes once per node after all shard-level operations complete |
+| `IndicesRequestCache.forceCleanCache()` | Separated method to force cache cleanup without enqueueing cleanup keys |
+| `IndicesService.forceClearNodewideCaches()` | Node-wide cache clearing method called from the node operation hook |
+| `QueryShardContext.setIsCacheable()` | New method to mark queries as non-cacheable |
+
+#### Code Changes
+
+**TransportBroadcastByNodeAction** - Added node-level hook:
+```java
+protected void nodeOperation(
+    List<ShardOperationResult> results, 
+    List<BroadcastShardOperationFailedException> accumulatedExceptions
+) {}
+```
+
+**KeywordFieldMapper** - Added cacheability check:
+```java
+private void checkToDisableCaching(QueryShardContext context) {
+    if (useSimilarity || splitQueriesOnWhitespace) {
+        context.setIsCacheable(false);
+    }
+}
+```
+
+### Usage Example
+
+The cache clear API behavior remains unchanged from a user perspective:
+
+```bash
+# Clear request cache for specific index
+POST /my_index/_cache/clear?request=true
+
+# Clear request cache for all indices
+POST /_cache/clear?request=true
+```
+
+For keyword fields, queries are automatically excluded from caching when non-default parameters are used:
+
+```json
+PUT /my_index
+{
+  "mappings": {
+    "properties": {
+      "tags": {
+        "type": "keyword",
+        "use_similarity": true
+      }
+    }
+  }
+}
+```
+
+Queries on the `tags` field will not be cached, preventing stale results if `use_similarity` is later changed.
+
+### Migration Notes
+
+- No migration required - changes are backward compatible
+- Existing cache clear operations will automatically benefit from improved performance
+- Queries on keyword fields with `use_similarity: true` or `split_queries_on_whitespace: true` will no longer be cached
+
+## Limitations
+
+- The node-level hook is specific to `TransportBroadcastByNodeAction` subclasses
+- Field data cache optimization using the same pattern is planned for a future release
+- Queries on keyword fields with non-default `use_similarity` or `split_queries_on_whitespace` cannot be cached
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19263](https://github.com/opensearch-project/OpenSearch/pull/19263) | Remove unnecessary iteration per-shard in request cache cleanup |
+| [#19385](https://github.com/opensearch-project/OpenSearch/pull/19385) | Disable request cache for queries on fields with non-default `use_similarity` or `split_queries_on_whitespace` |
+
+## References
+
+- [Issue #19118](https://github.com/opensearch-project/OpenSearch/issues/19118): Repeated iteration through keys on cache clear API
+- [Issue #19183](https://github.com/opensearch-project/OpenSearch/issues/19183): Add node-level hook to TransportBroadcastByNodeAction
+- [Issue #19279](https://github.com/opensearch-project/OpenSearch/issues/19279): Dynamically updating mapping parameters does not wipe request cache entries
+- [Documentation: Index request cache](https://docs.opensearch.org/3.0/search-plugins/caching/request-cache/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/request-cache.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -9,6 +9,7 @@
 - [Derived Fields](features/opensearch/derived-fields.md)
 - [Netty Arena Settings](features/opensearch/netty-arena-settings.md)
 - [Reactor Netty Transport](features/opensearch/reactor-netty-transport.md)
+- [Request Cache](features/opensearch/request-cache.md)
 - [Search Stats - Negative Value Handling](features/opensearch/search-stats.md)
 - [Store Subdirectory Module](features/opensearch/store-subdirectory-module.md)
 - [Terms Query Rewriting](features/opensearch/terms-query-rewriting.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for Request Cache improvements in OpenSearch v3.3.0.

### Changes in v3.3.0

1. **Optimized Cache Clear Performance** (PR #19263)
   - Added node-level hook to `TransportBroadcastByNodeAction` to run cache cleanup once per node instead of once per shard
   - Reduces cache clear time by ~54% when using disk-based tiered caching

2. **Stale Response Prevention** (PR #19385)
   - Queries on keyword fields with non-default `use_similarity` or `split_queries_on_whitespace` are now excluded from caching
   - Prevents stale/incorrect results when these dynamically updateable parameters are changed

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/request-cache.md`
- Feature report: `docs/features/opensearch/request-cache.md` (new)

### Related Issues
- Resolves investigation for GitHub Issue #1434