### PR TITLE
docs: add Alias Write Index Policy report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -16,6 +16,7 @@
 
 ## opensearch
 
+- [Alias Write Index Policy](opensearch/alias-write-index-policy.md)
 - [Approximation Framework](opensearch/approximation-framework.md)
 - [BooleanQuery Rewrite Optimizations](opensearch/booleanquery-rewrite-optimizations.md)
 - [Aggregation Task Cancellation](opensearch/aggregation-task-cancellation.md)

--- a/docs/features/opensearch/alias-write-index-policy.md
+++ b/docs/features/opensearch/alias-write-index-policy.md
@@ -1,0 +1,122 @@
+# Alias Write Index Policy
+
+## Summary
+
+The Alias Write Index Policy feature provides control over how the `is_write_index` attribute of aliases is handled during snapshot restore operations. This enables safe bidirectional Cross-Cluster Replication (CCR) by preventing write alias conflicts when restoring snapshots to follower clusters.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Restore Snapshot Flow"
+        A[Restore Request] --> B{alias_write_index_policy}
+        B -->|PRESERVE| C[Keep Original is_write_index]
+        B -->|STRIP_WRITE_INDEX| D[Force is_write_index=false]
+        C --> E[Apply Aliases to Index]
+        D --> E
+    end
+    
+    subgraph "Bidirectional CCR Use Case"
+        F[Leader Cluster] -->|Snapshot| G[Repository]
+        G -->|Restore with strip_write_index| H[Follower Cluster]
+        F -->|Write via Alias| I[Index A]
+        H -->|Read Only Alias| J[Index A Copy]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[RestoreSnapshotRequest] --> B[RestoreService]
+    B --> C[Process Aliases]
+    C --> D{Check Policy}
+    D -->|PRESERVE| E[Use Original writeIndex]
+    D -->|STRIP_WRITE_INDEX| F[Set writeIndex=false]
+    E --> G[Create AliasMetadata]
+    F --> G
+    G --> H[Apply to Restored Index]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `AliasWriteIndexPolicy` | Enum in `RestoreSnapshotRequest` defining policy options |
+| `RestoreSnapshotRequest` | Extended with `aliasWriteIndexPolicy` field |
+| `RestoreService` | Applies policy during alias restoration |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `alias_write_index_policy` | REST parameter for restore requests | `preserve` |
+
+### Policy Options
+
+| Policy | Behavior |
+|--------|----------|
+| `preserve` | Maintains original `is_write_index` value from snapshot |
+| `strip_write_index` | Forces `is_write_index=false` on all restored aliases |
+
+### Usage Example
+
+#### Basic Restore with Policy
+
+```json
+POST /_snapshot/my_repository/my_snapshot/_restore
+{
+  "indices": "logs-*",
+  "include_aliases": true,
+  "alias_write_index_policy": "strip_write_index"
+}
+```
+
+#### Bidirectional CCR Setup
+
+```json
+// On follower cluster - restore without write conflicts
+POST /_snapshot/shared_repo/leader_snapshot/_restore
+{
+  "indices": "orders",
+  "rename_pattern": "orders",
+  "rename_replacement": "orders_replica",
+  "include_aliases": true,
+  "alias_write_index_policy": "strip_write_index"
+}
+```
+
+### Problem Solved
+
+Before this feature, restoring an index that was a write index for an alias would fail if:
+- The target cluster already had a write index for that alias
+- Multiple indices from the snapshot shared the same alias with `is_write_index=true`
+
+Error message:
+```
+Failed to restore snapshot: alias [rollover_alias] has more than one write index
+```
+
+## Limitations
+
+- Policy applies to all aliases in the restore operation (no per-alias control)
+- Only affects aliases being restored, not existing aliases in the cluster
+- Requires OpenSearch 3.3.0 or later
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19368](https://github.com/opensearch-project/OpenSearch/pull/19368) | Enable Safe Bidirectional CCR via Alias policy on Restore |
+
+## References
+
+- [Issue #16139](https://github.com/opensearch-project/OpenSearch/issues/16139): Original bug report for write index restore failure
+- [Restore Snapshot API](https://docs.opensearch.org/3.0/api-reference/snapshots/restore-snapshot/): Official documentation
+- [Alias API](https://docs.opensearch.org/3.0/api-reference/index-apis/alias/): Alias `is_write_index` documentation
+
+## Change History
+
+- **v3.3.0** (2025): Initial implementation - Added `alias_write_index_policy` parameter to Restore Snapshot API

--- a/docs/releases/v3.3.0/features/opensearch/alias-write-index-policy.md
+++ b/docs/releases/v3.3.0/features/opensearch/alias-write-index-policy.md
@@ -1,0 +1,88 @@
+# Alias Write Index Policy
+
+## Summary
+
+OpenSearch v3.3.0 introduces a new `alias_write_index_policy` parameter for the Restore Snapshot API. This feature allows users to control how the `is_write_index` attribute of aliases is handled during snapshot restore operations, enabling safe bidirectional Cross-Cluster Replication (CCR) scenarios.
+
+## Details
+
+### What's New in v3.3.0
+
+The new `alias_write_index_policy` parameter provides control over alias write index behavior during restore:
+
+- **PRESERVE** (default): Maintains the original `is_write_index` attribute from the snapshot
+- **STRIP_WRITE_INDEX**: Forces `is_write_index=false` on all restored aliases
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `AliasWriteIndexPolicy` | Enum defining policy options: `PRESERVE` and `STRIP_WRITE_INDEX` |
+| `alias_write_index_policy` | New REST parameter for restore snapshot requests |
+
+#### API Changes
+
+The Restore Snapshot API now accepts a new parameter:
+
+```
+POST /_snapshot/{repository}/{snapshot}/_restore
+{
+  "alias_write_index_policy": "strip_write_index"
+}
+```
+
+| Parameter | Type | Description | Default |
+|-----------|------|-------------|---------|
+| `alias_write_index_policy` | String | Controls write index handling: `preserve` or `strip_write_index` | `preserve` |
+
+### Usage Example
+
+```json
+POST /_snapshot/my_repository/my_snapshot/_restore
+{
+  "indices": "my_index",
+  "include_aliases": true,
+  "alias_write_index_policy": "strip_write_index"
+}
+```
+
+This restores `my_index` with all its aliases, but forces `is_write_index=false` on all aliases to prevent write conflicts.
+
+### Use Case: Bidirectional CCR
+
+When setting up bidirectional Cross-Cluster Replication:
+
+1. Leader cluster has index with alias where `is_write_index=true`
+2. Snapshot is taken and restored to follower cluster
+3. Without this feature, restore fails due to "alias has more than one write index" error
+4. With `strip_write_index` policy, follower's restored aliases have `is_write_index=false`
+5. Both clusters can now operate without write alias conflicts
+
+### Migration Notes
+
+- Existing restore operations are unaffected (default is `PRESERVE`)
+- Use `strip_write_index` when restoring to clusters that already have write aliases
+- The policy is applied post-rename during alias restoration
+
+## Limitations
+
+- Only applies to aliases restored from snapshots
+- Does not affect existing aliases in the target cluster
+- Cannot selectively apply policy to specific aliases (applies to all)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19368](https://github.com/opensearch-project/OpenSearch/pull/19368) | Enable Safe Bidirectional CCR via Alias policy on Restore |
+
+## References
+
+- [Issue #16139](https://github.com/opensearch-project/OpenSearch/issues/16139): Unable to restore an index from snapshot that was a write index at the time
+- [Restore Snapshot API](https://docs.opensearch.org/3.0/api-reference/snapshots/restore-snapshot/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/alias-write-index-policy.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -4,6 +4,7 @@
 
 ### OpenSearch
 
+- [Alias Write Index Policy](features/opensearch/alias-write-index-policy.md)
 - [Cardinality Aggregation](features/opensearch/cardinality-aggregation.md)
 - [Cluster State Caching](features/opensearch/cluster-state-caching.md)
 - [Derived Fields](features/opensearch/derived-fields.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Alias Write Index Policy feature introduced in OpenSearch v3.3.0.

### Feature Overview

The `alias_write_index_policy` parameter for the Restore Snapshot API allows users to control how the `is_write_index` attribute of aliases is handled during snapshot restore operations. This enables safe bidirectional Cross-Cluster Replication (CCR) scenarios.

### Policy Options
- **PRESERVE** (default): Maintains the original `is_write_index` attribute from the snapshot
- **STRIP_WRITE_INDEX**: Forces `is_write_index=false` on all restored aliases

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/alias-write-index-policy.md`
- Feature report: `docs/features/opensearch/alias-write-index-policy.md`

### Related
- PR: opensearch-project/OpenSearch#19368
- Issue: opensearch-project/OpenSearch#16139