### PR TITLE
docs: add Reindex API report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -102,6 +102,7 @@
 - [Randomness](opensearch/randomness.md)
 - [Reactor Netty Transport](opensearch/reactor-netty-transport.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)
+- [Reindex API](opensearch/reindex-api.md)
 - [Replication](opensearch/replication.md)
 - [Request Cache](opensearch/request-cache.md)
 - [Rescore Named Queries](opensearch/rescore-named-queries.md)

--- a/docs/features/opensearch/reindex-api.md
+++ b/docs/features/opensearch/reindex-api.md
@@ -1,0 +1,135 @@
+# Reindex API
+
+## Summary
+
+The Reindex API allows copying documents from one index to another, with support for transformations, filtering, and parallel processing through slicing. It is essential for index migrations, data transformations, and reindexing after mapping changes.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Reindex Operation"
+        A[Client Request] --> B[Coordinator Node]
+        B --> C{Sliced?}
+        C -->|Yes| D[Validate Slices]
+        D --> E[Create Sub-requests]
+        E --> F[Shard 1]
+        E --> G[Shard 2]
+        E --> H[Shard N]
+        C -->|No| I[Single Request]
+        I --> J[Execute on Shards]
+        F --> K[Bulk Index to Dest]
+        G --> K
+        H --> K
+        J --> K
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Source Index] --> B[Scroll Query]
+    B --> C[Fetch Documents]
+    C --> D{Transform?}
+    D -->|Yes| E[Apply Script]
+    D -->|No| F[Bulk Request]
+    E --> F
+    F --> G[Destination Index]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `BulkByScrollParallelizationHelper` | Manages parallel execution of reindex operations using slices |
+| `Reindexer` | Core reindex logic, handles local and remote reindex operations |
+| `TransportReindexAction` | Transport action for handling reindex requests |
+| `BulkByScrollTask` | Task that tracks progress of bulk-by-scroll operations |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.max_slices_per_scroll` | Maximum number of slices allowed per scroll/reindex operation | 1024 |
+| `reindex.remote.whitelist` | List of remote hosts allowed for remote reindex | Empty |
+
+### Usage Example
+
+```json
+// Basic reindex
+POST _reindex
+{
+  "source": {
+    "index": "source_index"
+  },
+  "dest": {
+    "index": "dest_index"
+  }
+}
+
+// Reindex with slices for parallel processing
+POST _reindex?slices=auto
+{
+  "source": {
+    "index": "source_index"
+  },
+  "dest": {
+    "index": "dest_index"
+  }
+}
+
+// Reindex with query filter
+POST _reindex
+{
+  "source": {
+    "index": "source_index",
+    "query": {
+      "term": {
+        "status": "active"
+      }
+    }
+  },
+  "dest": {
+    "index": "dest_index"
+  }
+}
+
+// Reindex with script transformation
+POST _reindex
+{
+  "source": {
+    "index": "source_index"
+  },
+  "dest": {
+    "index": "dest_index"
+  },
+  "script": {
+    "source": "ctx._source.timestamp = ctx._source.remove('date')"
+  }
+}
+```
+
+## Limitations
+
+- Remote reindex requires explicit whitelist configuration
+- Large reindex operations should use slices for better performance
+- The `slices` parameter must not exceed `index.max_slices_per_scroll` (default: 1024)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#18964](https://github.com/opensearch-project/OpenSearch/pull/18964) | Fix slice validation to prevent OOM on coordinator |
+
+## References
+
+- [Issue #18963](https://github.com/opensearch-project/OpenSearch/issues/18963): Bug report for OOM with large slice values
+- [Reindex API Documentation](https://docs.opensearch.org/3.0/api-reference/document-apis/reindex/): Official API documentation
+- [Reindex Data Guide](https://docs.opensearch.org/3.0/im-plugin/reindex-data/): Guide for reindexing data
+
+## Change History
+
+- **v3.3.0** (2026-01-11): Fixed slice validation to prevent JVM OOM on coordinator when using excessively large slice values

--- a/docs/releases/v3.3.0/features/opensearch/reindex-api.md
+++ b/docs/releases/v3.3.0/features/opensearch/reindex-api.md
@@ -1,0 +1,110 @@
+# Reindex API
+
+## Summary
+
+This release fixes a critical bug where using an excessively large `slices` parameter in reindex operations could cause JVM OutOfMemoryError on the coordinator node. The fix moves slice validation from individual shards to the coordinator node, preventing memory exhaustion from accumulated error responses.
+
+## Details
+
+### What's New in v3.3.0
+
+The slice parameter validation for reindex, delete-by-query, and update-by-query operations is now performed on the coordinator node instead of on each shard.
+
+### Technical Changes
+
+#### Problem Background
+
+Previously, when a user specified an excessively large `slices` value (e.g., 10000) in a reindex request, the validation against `index.max_slices_per_scroll` (default: 1024) occurred on each shard. This caused:
+
+1. Each shard to throw an `IllegalArgumentException`
+2. With many shards (e.g., 100), this created `slices × shards` error objects (1,000,000 `ShardSearchFailure` objects)
+3. These accumulated on the coordinator, causing JVM OOM
+
+```mermaid
+graph TB
+    subgraph "Before v3.3.0"
+        A[Coordinator] -->|slices=10000| B[Shard 1]
+        A -->|slices=10000| C[Shard 2]
+        A -->|slices=10000| D[Shard N]
+        B -->|Error| E[ShardSearchFailure]
+        C -->|Error| F[ShardSearchFailure]
+        D -->|Error| G[ShardSearchFailure]
+        E --> H[OOM on Coordinator]
+        F --> H
+        G --> H
+    end
+```
+
+#### Solution
+
+The fix validates the slice count against `index.max_slices_per_scroll` on the coordinator node before distributing sub-requests to shards:
+
+```mermaid
+graph TB
+    subgraph "After v3.3.0"
+        A[Coordinator] -->|Validate slices| B{slices <= max?}
+        B -->|No| C[IllegalArgumentException]
+        B -->|Yes| D[Distribute to Shards]
+        D --> E[Shard 1]
+        D --> F[Shard 2]
+        D --> G[Shard N]
+    end
+```
+
+#### Modified Components
+
+| Component | Description |
+|-----------|-------------|
+| `BulkByScrollParallelizationHelper` | Added early validation of slice count against `index.max_slices_per_scroll` |
+| `Reindexer` | Passes cluster metadata to parallelization helper |
+| `TransportDeleteByQueryAction` | Passes cluster metadata to parallelization helper |
+| `TransportUpdateByQueryAction` | Passes cluster metadata to parallelization helper |
+
+#### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.max_slices_per_scroll` | Maximum number of slices allowed per scroll/reindex operation | 1024 |
+
+### Usage Example
+
+```json
+// This will now fail fast on the coordinator with a clear error message
+POST _reindex?slices=2000
+{
+   "source": {
+      "index": "source_index"
+   },
+   "dest": {
+      "index": "dest_index"
+   }
+}
+
+// Error response (immediate, no OOM risk):
+// "The number of slices [2000] is too large. It must be less than [1024]. 
+//  This limit can be set by changing the [index.max_slices_per_scroll] index level setting."
+```
+
+### Migration Notes
+
+No migration required. This is a bug fix that improves error handling without changing the API contract.
+
+## Limitations
+
+- The `index.max_slices_per_scroll` setting is per-index; when reindexing from multiple source indexes, the smallest limit applies
+- The default limit of 1024 slices remains unchanged
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18964](https://github.com/opensearch-project/OpenSearch/pull/18964) | Fix Using an excessively large reindex slice can lead to a JVM OutOfMemoryError on coordinator |
+
+## References
+
+- [Issue #18963](https://github.com/opensearch-project/OpenSearch/issues/18963): Bug report - Using an excessively large reindex slice can lead to a JVM OutOfMemoryError on coordinator
+- [Reindex API Documentation](https://docs.opensearch.org/3.0/api-reference/document-apis/reindex/): Official reindex API documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/reindex-api.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -10,6 +10,7 @@
 - [Derived Fields](features/opensearch/derived-fields.md)
 - [Netty Arena Settings](features/opensearch/netty-arena-settings.md)
 - [Reactor Netty Transport](features/opensearch/reactor-netty-transport.md)
+- [Reindex API](features/opensearch/reindex-api.md)
 - [Request Cache](features/opensearch/request-cache.md)
 - [Search Stats - Negative Value Handling](features/opensearch/search-stats.md)
 - [Store Subdirectory Module](features/opensearch/store-subdirectory-module.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Reindex API bug fix in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/reindex-api.md`
- Feature report: `docs/features/opensearch/reindex-api.md`

### Key Changes in v3.3.0
- Fixed slice validation to prevent JVM OutOfMemoryError on coordinator when using excessively large slice values
- Validation now occurs on coordinator node instead of individual shards

### Related
- PR: [opensearch-project/OpenSearch#18964](https://github.com/opensearch-project/OpenSearch/pull/18964)
- Issue: [opensearch-project/OpenSearch#18963](https://github.com/opensearch-project/OpenSearch/issues/18963)