### PR TITLE
docs: add scaled-float-field report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -112,6 +112,7 @@
 - [RestHandler.Wrapper](opensearch/resthandler-wrapper.md)
 - [Remote Store Metrics](opensearch/remote-store-metrics.md)
 - [S3 Repository](opensearch/s3-repository.md)
+- [Scaled Float Field](opensearch/scaled-float-field.md)
 - [Search Backpressure](opensearch/search-backpressure.md)
 - [Search API Enhancements](opensearch/search-api-enhancements.md)
 - [Search Pipeline](opensearch/search-pipeline.md)

--- a/docs/features/opensearch/scaled-float-field.md
+++ b/docs/features/opensearch/scaled-float-field.md
@@ -1,0 +1,124 @@
+# Scaled Float Field
+
+## Summary
+
+The `scaled_float` field type stores floating-point values as long integers by multiplying them by a scaling factor. This provides disk space savings compared to native floating-point types while maintaining configurable precision. It's particularly useful for storing prices, percentages, and other decimal values where the precision requirements are known in advance.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Indexing"
+        A[Input Value] --> B[Parse as Double]
+        B --> C[Multiply by Scaling Factor]
+        C --> D[Round to Long]
+        D --> E[Store as Long]
+    end
+    subgraph "Querying"
+        F[Query Value] --> G[Parse as Double]
+        G --> H[Multiply by Scaling Factor]
+        H --> I[Round to Long]
+        I --> J[Match Against Stored Long]
+    end
+```
+
+### How It Works
+
+1. **At Index Time**: The input value is multiplied by the `scaling_factor` and rounded to the nearest long integer
+2. **At Query Time**: Query values undergo the same transformation before matching
+3. **At Retrieval Time**: Stored values are divided by the scaling factor to return the original precision
+
+### Configuration
+
+| Setting | Description | Required |
+|---------|-------------|----------|
+| `type` | Must be `scaled_float` | Yes |
+| `scaling_factor` | Multiplier for converting float to long | Yes |
+| `boost` | Field-level relevance boost | No (default: 1.0) |
+| `coerce` | Coerce strings to numbers | No (default: false) |
+| `doc_values` | Enable doc values for sorting/aggregations | No (default: true) |
+| `ignore_malformed` | Ignore malformed values | No (default: false) |
+| `index` | Make field searchable | No (default: true) |
+| `null_value` | Value to use for null inputs | No |
+| `store` | Store field separately from _source | No (default: false) |
+
+### Usage Example
+
+```json
+// Create index with scaled_float field
+PUT products
+{
+  "mappings": {
+    "properties": {
+      "price": {
+        "type": "scaled_float",
+        "scaling_factor": 100
+      }
+    }
+  }
+}
+
+// Index a document
+PUT products/_doc/1
+{
+  "price": 19.99
+}
+
+// The value 19.99 is stored as 1999 (19.99 * 100)
+
+// Range query
+POST products/_search
+{
+  "query": {
+    "range": {
+      "price": {
+        "gte": 10.00,
+        "lte": 20.00
+      }
+    }
+  }
+}
+
+// Term query
+POST products/_search
+{
+  "query": {
+    "term": {
+      "price": 19.99
+    }
+  }
+}
+```
+
+### Choosing a Scaling Factor
+
+| Use Case | Recommended Factor | Precision |
+|----------|-------------------|-----------|
+| Currency (cents) | 100 | 2 decimal places |
+| Percentages | 100 or 1000 | 2-3 decimal places |
+| Scientific data | 1000000 | 6 decimal places |
+
+Higher scaling factors provide more precision but require more storage space.
+
+## Limitations
+
+- **Floating-point precision**: Due to IEEE 754 floating-point representation, some values may have minor precision loss (e.g., `79.99 * 100` may compute as `7998.999...`)
+- **Range**: Values must fit within a long integer after scaling (approximately ±9.2 × 10¹⁸)
+- **No exact decimal arithmetic**: Unlike BigDecimal, scaled_float uses native floating-point multiplication
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19188](https://github.com/opensearch-project/OpenSearch/pull/19188) | Fix precision issue between indexing and querying |
+
+## References
+
+- [Issue #12433](https://github.com/opensearch-project/OpenSearch/issues/12433): Bug report for precision mismatch
+- [Numeric field types](https://docs.opensearch.org/3.0/field-types/supported-field-types/numeric/): Official documentation
+
+## Change History
+
+- **v3.3.0**: Fixed precision issue where `match` queries failed for certain values due to inconsistent scaling between indexing and querying. The `scale()` method now uses direct multiplication for both operations.

--- a/docs/releases/v3.3.0/features/opensearch/scaled-float-field.md
+++ b/docs/releases/v3.3.0/features/opensearch/scaled-float-field.md
@@ -1,0 +1,122 @@
+# Scaled Float Field Precision Fix
+
+## Summary
+
+This release fixes a precision issue in the `scaled_float` field type where `match` queries on certain values (especially large numbers) would fail to return expected results. The fix ensures consistent behavior between indexing and querying by using the same multiplication method for both operations.
+
+## Details
+
+### What's New in v3.3.0
+
+The `scaled_float` field type had an inconsistency between how values were scaled during indexing versus querying:
+
+- **Indexing**: Used direct floating-point multiplication (`doubleValue * scalingFactor`)
+- **Querying**: Used `BigDecimal` multiplication for precision
+
+This mismatch caused queries to fail for certain values, particularly large numbers like `92233720368547750` with a scaling factor of `100`.
+
+### Technical Changes
+
+#### Root Cause
+
+The `scale()` method in `ScaledFloatFieldMapper` used `BigDecimal` for query-time scaling:
+
+```java
+// Before (problematic)
+private double scale(Object input) {
+    return new BigDecimal(Double.toString(parse(input)))
+        .multiply(BigDecimal.valueOf(scalingFactor))
+        .doubleValue();
+}
+```
+
+This produced different scaled values than the direct multiplication used at index time, causing term mismatches.
+
+#### The Fix
+
+The `scale()` method now uses direct multiplication, matching the indexing behavior:
+
+```java
+// After (fixed)
+private double scale(Object input) {
+    return parse(input) * scalingFactor;
+}
+```
+
+#### Range Query Changes
+
+The range query logic was also simplified to properly pass through `includeLower` and `includeUpper` parameters instead of manually adjusting bounds:
+
+```java
+// Before: Manual bound adjustment
+if (includeLower == false) {
+    dValue = Math.nextUp(dValue);
+}
+lo = Math.round(Math.ceil(dValue));
+
+// After: Direct delegation
+lo = Math.round(scale(lowerTerm));
+Query query = NumberFieldMapper.NumberType.LONG.rangeQuery(
+    name(), lo, hi, includeLower, includeUpper, ...);
+```
+
+### Usage Example
+
+The fix ensures this scenario now works correctly:
+
+```json
+// Create index with scaled_float field
+PUT test-index
+{
+  "mappings": {
+    "properties": {
+      "price": {
+        "type": "scaled_float",
+        "scaling_factor": 100
+      }
+    }
+  }
+}
+
+// Index a document
+PUT test-index/_doc/1
+{
+  "price": 92233720368547750
+}
+
+// Query now returns the document (was broken before)
+POST test-index/_search
+{
+  "query": {
+    "match": {
+      "price": "92233720368547750"
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- No reindexing required - the fix only affects query-time behavior
+- Existing indices will work correctly after upgrading
+- No configuration changes needed
+
+## Limitations
+
+- Floating-point precision limitations still apply (e.g., `79.99 * 100 = 7998.999...`)
+- The fix prioritizes consistency over precision - both indexing and querying now use the same (potentially imprecise) multiplication
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19188](https://github.com/opensearch-project/OpenSearch/pull/19188) | Fix the `scaled_float` precision issue |
+
+## References
+
+- [Issue #12433](https://github.com/opensearch-project/OpenSearch/issues/12433): Bug report - `match` query on `scaled_float` no longer matches for some values
+- [Numeric field types documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/numeric/): Official docs for scaled_float
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/scaled-float-field.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -12,6 +12,7 @@
 - [Reactor Netty Transport](features/opensearch/reactor-netty-transport.md)
 - [Reindex API](features/opensearch/reindex-api.md)
 - [Request Cache](features/opensearch/request-cache.md)
+- [Scaled Float Field Precision Fix](features/opensearch/scaled-float-field.md)
 - [Search Stats - Negative Value Handling](features/opensearch/search-stats.md)
 - [Store Subdirectory Module](features/opensearch/store-subdirectory-module.md)
 - [Terms Query Rewriting](features/opensearch/terms-query-rewriting.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the `scaled_float` field precision fix in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/scaled-float-field.md`
- Feature report: `docs/features/opensearch/scaled-float-field.md`

### Key Changes in v3.3.0
- Fixed precision mismatch between indexing and querying for `scaled_float` fields
- The `scale()` method now uses direct multiplication for both operations
- Range query logic simplified to properly pass through include/exclude bounds

### Related
- Closes #1431
- OpenSearch PR: opensearch-project/OpenSearch#19188
- OpenSearch Issue: opensearch-project/OpenSearch#12433