### PR TITLE
docs: add query-phase-fixes report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -98,6 +98,7 @@
 - [Query Coordinator Context](opensearch/query-coordinator-context.md)
 - [Query Optimization](opensearch/query-optimization.md)
 - [Query Phase Plugin Extension](opensearch/query-phase-plugin-extension.md)
+- [Query Phase Result Consumer](opensearch/query-phase-result-consumer.md)
 - [Query String & Regex Queries](opensearch/query-string-regex.md)
 - [Randomness](opensearch/randomness.md)
 - [Reactor Netty Transport](opensearch/reactor-netty-transport.md)

--- a/docs/features/opensearch/query-phase-result-consumer.md
+++ b/docs/features/opensearch/query-phase-result-consumer.md
@@ -1,0 +1,131 @@
+# Query Phase Result Consumer
+
+## Summary
+
+The `QueryPhaseResultConsumer` is a core component in OpenSearch's distributed search architecture that handles incremental reduction of aggregation results as shard-level query results are consumed. It manages memory through circuit breaker accounting and coordinates partial reduce operations to efficiently process search results from multiple shards.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Coordinating Node"
+        A[Search Request] --> B[QueryPhaseResultConsumer]
+        B --> C[PendingReduces]
+        C --> D{Buffer Full?}
+        D -->|Yes| E[ReduceTask Queue]
+        D -->|No| F[Buffer Results]
+        E --> G[Executor]
+        G --> H[partialReduce]
+        H --> I[MergeResult]
+        I --> J[Final Reduce]
+    end
+    
+    subgraph "Data Nodes"
+        K[Shard 1] --> B
+        L[Shard 2] --> B
+        M[Shard N] --> B
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Shard Query Result] --> B[consumeResult]
+    B --> C{Check Circuit Breaker}
+    C -->|OK| D[Add to Buffer]
+    C -->|Break| E[onFailure]
+    D --> F{Buffer >= BatchSize?}
+    F -->|Yes| G[Create ReduceTask]
+    F -->|No| H[Wait for More Results]
+    G --> I[Queue Task]
+    I --> J[tryExecuteNext]
+    J --> K[partialReduce]
+    K --> L[Update MergeResult]
+    L --> M[Callback]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `QueryPhaseResultConsumer` | Main class that extends `ArraySearchPhaseResults` and implements incremental reduction |
+| `PendingReduces` | Inner class managing buffered results, reduce task queue, and circuit breaker accounting |
+| `ReduceTask` | Encapsulates a batch of query results to be reduced along with callback |
+| `ReduceResult` | Immutable record holding partial reduce outcome (TopDocs, Aggregations, estimated size) |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `search.batched_reduce_size` | Number of shard results to buffer before triggering partial reduce | 512 |
+| `indices.breaker.request.limit` | Circuit breaker limit for request memory | 60% of JVM heap |
+
+### Key Methods
+
+| Method | Description |
+|--------|-------------|
+| `consumeResult()` | Receives shard query result, buffers it, triggers reduce if threshold reached |
+| `reduce()` | Performs final reduction after all shards respond |
+| `partialReduce()` | Reduces buffered results into intermediate MergeResult |
+| `tryExecuteNext()` | Executes next queued reduce task if none running |
+
+### Usage Example
+
+The `QueryPhaseResultConsumer` is used internally by the search coordinator. Users interact with it indirectly through the Search API:
+
+```json
+POST /my-index/_search
+{
+  "size": 10,
+  "aggs": {
+    "my_terms": {
+      "terms": {
+        "field": "category",
+        "size": 100
+      }
+    }
+  }
+}
+```
+
+For large aggregations across many shards, the consumer incrementally reduces results to manage memory:
+
+```json
+POST /my-index/_search?batched_reduce_size=256
+{
+  "size": 0,
+  "aggs": {
+    "large_agg": {
+      "terms": {
+        "field": "user_id",
+        "size": 10000
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Partial reduces add CPU overhead; for simple queries without aggregations, the overhead may not be beneficial
+- Circuit breaker estimation is approximate and may over/under-estimate actual memory usage
+- Concurrent reduce tasks are serialized (only one running at a time) to maintain result ordering
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19231](https://github.com/opensearch-project/OpenSearch/pull/19231) | Fix incomplete callback loops in QueryPhaseResultConsumer |
+
+## References
+
+- [Issue #19094](https://github.com/opensearch-project/OpenSearch/issues/19094): Flaky Test Report for SearchPhaseControllerTests
+- [Search API Documentation](https://docs.opensearch.org/3.0/api-reference/search-apis/search/): OpenSearch Search API reference
+- [Search Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/search-settings/): Search configuration options
+
+## Change History
+
+- **v3.3.0** (2025-09-04): Fixed incomplete callback loops by adding graceful failure handling, clearing pending merge tasks on failure, and properly canceling tasks when failures are detected

--- a/docs/releases/v3.3.0/features/opensearch/query-phase-fixes.md
+++ b/docs/releases/v3.3.0/features/opensearch/query-phase-fixes.md
@@ -1,0 +1,119 @@
+# Query Phase Fixes
+
+## Summary
+
+This release fixes incomplete callback loops in `QueryPhaseResultConsumer`, addressing flaky test failures in `SearchPhaseControllerTests`. The fix ensures graceful handling of failures during shard-level query result consumption by properly clearing pending merge tasks and stopping partial reduces when failures or cancellations occur.
+
+## Details
+
+### What's New in v3.3.0
+
+The `QueryPhaseResultConsumer` class handles incremental reduction of aggregation results as shard results are consumed during the query phase. Prior to this fix, callback loops could remain incomplete when errors occurred during partial reduce execution, leading to test flakiness and potential resource leaks.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Query Phase Result Consumer"
+        A[consumeResult] --> B{Buffer Full?}
+        B -->|Yes| C[Create ReduceTask]
+        C --> D[tryExecuteNext]
+        D --> E{hasFailure?}
+        E -->|Yes| F[clearPendingMerges]
+        E -->|No| G[Execute Partial Reduce]
+        G --> H{Success?}
+        H -->|Yes| I[onAfterReduce]
+        H -->|No| J[onFailure]
+        J --> F
+        I --> K[consumeListener]
+        F --> K
+    end
+```
+
+#### Key Fixes
+
+| Fix | Description |
+|-----|-------------|
+| Early failure check in `partialReduce` | Returns early if `pendingMerges.hasFailure()` is true, preventing unnecessary processing |
+| Clear pending merges on failure | New `clearPendingMerges()` method properly cancels all queued and running tasks |
+| Task cancellation in `onAfterReduce` | Cancels task and returns early when failure detected after merge completion |
+| Failure check in `tryExecuteNext` | Clears pending merges and returns when failure detected before executing next task |
+| Null buffer handling | Cancels task when `consumeBuffer()` returns null |
+
+#### Code Changes
+
+The fix modifies `QueryPhaseResultConsumer.java` with the following key changes:
+
+1. **Early exit on failure in `partialReduce`**:
+```java
+if (pendingMerges.hasFailure()) {
+    return lastMerge;
+}
+```
+
+2. **New `clearPendingMerges` method** to properly clean up queued tasks:
+```java
+void clearPendingMerges(MergeTask task) {
+    List<MergeTask> toCancels = new ArrayList<>();
+    if (task != null) {
+        toCancels.add(task);
+    }
+    toCancels.addAll(queue);
+    queue.clear();
+    for (MergeTask toCancel : toCancels) {
+        toCancel.cancel();
+    }
+}
+```
+
+3. **Improved `onAfterMerge` handling**:
+```java
+private void onAfterMerge(MergeTask task, MergeResult newResult, long estimatedSize) {
+    synchronized (this) {
+        runningTask.compareAndSet(task, null);
+        if (hasFailure()) {
+            task.cancel();
+            return;
+        }
+        // ... rest of processing
+    }
+}
+```
+
+4. **Enhanced `tryExecuteNext` with failure check**:
+```java
+if (hasFailure()) {
+    clearPendingMerges(null);
+    return;
+}
+```
+
+### Usage Example
+
+No user-facing API changes. The fix is internal to the search query phase execution.
+
+### Migration Notes
+
+No migration required. This is a bug fix that improves reliability of search operations.
+
+## Limitations
+
+- This fix addresses callback loop issues but does not change the fundamental architecture of incremental aggregation reduction
+- The fix is specific to the `QueryPhaseResultConsumer` class and does not affect other search phase consumers
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19231](https://github.com/opensearch-project/OpenSearch/pull/19231) | Add graceful handling of failures in QueryPhaseResultConsumer |
+
+## References
+
+- [Issue #19094](https://github.com/opensearch-project/OpenSearch/issues/19094): Flaky Test Report for SearchPhaseControllerTests
+- [Search API Documentation](https://docs.opensearch.org/3.0/api-reference/search-apis/search/): OpenSearch Search API reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/query-phase-result-consumer.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -9,6 +9,7 @@
 - [Cluster State Caching](features/opensearch/cluster-state-caching.md)
 - [Derived Fields](features/opensearch/derived-fields.md)
 - [Netty Arena Settings](features/opensearch/netty-arena-settings.md)
+- [Query Phase Fixes](features/opensearch/query-phase-fixes.md)
 - [Reactor Netty Transport](features/opensearch/reactor-netty-transport.md)
 - [Reindex API](features/opensearch/reindex-api.md)
 - [Request Cache](features/opensearch/request-cache.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Query Phase Fixes feature in OpenSearch v3.3.0.

### Changes
- **Release report**: `docs/releases/v3.3.0/features/opensearch/query-phase-fixes.md`
- **Feature report**: `docs/features/opensearch/query-phase-result-consumer.md`
- Updated release and feature indexes

### Key Points
- Fixes incomplete callback loops in `QueryPhaseResultConsumer`
- Addresses flaky test failures in `SearchPhaseControllerTests`
- Adds graceful failure handling by clearing pending merge tasks and stopping partial reduces on failure/cancellation

### Related
- Resolves investigation Issue #1430
- Based on PR [opensearch-project/OpenSearch#19231](https://github.com/opensearch-project/OpenSearch/pull/19231)