### PR TITLE
docs: add NRT Replication Engine report for v3.3.0

### DIFF
--- a/docs/features/opensearch/segment-replication.md
+++ b/docs/features/opensearch/segment-replication.md
@@ -122,6 +122,7 @@ GET _cat/segment_replication?v
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#19214](https://github.com/opensearch-project/OpenSearch/pull/19214) | Add reference count control in NRTReplicationEngine#acquireLastIndexCommit |
 | v3.2.0 | [#18602](https://github.com/opensearch-project/OpenSearch/pull/18602) | Fix bugs in replication lag computation |
 
 ## References
@@ -129,9 +130,11 @@ GET _cat/segment_replication?v
 - [Segment Replication Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/segment-replication/index/): Official documentation
 - [Segment Replication Backpressure](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/segment-replication/backpressure/): Backpressure mechanism
 - [CAT Segment Replication API](https://docs.opensearch.org/3.0/api-reference/cat/cat-segment-replication/): API for viewing metrics
+- [Issue #19213](https://github.com/opensearch-project/OpenSearch/issues/19213): Bug report for NRTReplicationEngine file deletion issue
 - [Issue #18437](https://github.com/opensearch-project/OpenSearch/issues/18437): Bug report for lag metric issue
 - [Segment Replication Blog](https://opensearch.org/blog/segment-replication/): Introduction blog post
 
 ## Change History
 
+- **v3.3.0** (2025-09-09): Fixed reference count control in NRTReplicationEngine#acquireLastIndexCommit to prevent NoSuchFileException
 - **v3.2.0** (2025-07-01): Fixed replication lag computation to use epoch-based timestamps and corrected checkpoint pruning logic

--- a/docs/releases/v3.3.0/features/opensearch/nrt-replication-engine.md
+++ b/docs/releases/v3.3.0/features/opensearch/nrt-replication-engine.md
@@ -1,0 +1,115 @@
+# NRT Replication Engine
+
+## Summary
+
+This release fixes a critical bug in `NRTReplicationEngine#acquireLastIndexCommit` where files contained in the returned `GatedCloseable<IndexCommit>` could be deleted before the commit was closed. The fix adds proper reference count control to prevent `NoSuchFileException` errors during segment replication operations.
+
+## Details
+
+### What's New in v3.3.0
+
+This bug fix addresses a race condition in the NRT (Near Real-Time) Replication Engine that could cause replica shards to fail with `NoSuchFileException` when accessing segment files.
+
+### Technical Changes
+
+#### Problem
+
+In production clusters with segment replication enabled, replica shards using `NRTReplicationEngine` could encounter `NoSuchFileException` when traversing files from `acquireLastIndexCommit`. This occurred because:
+
+1. `NRTReplicationEngine#acquireLastIndexCommit` returned an `IndexCommit` without incrementing reference counts on the underlying segment files
+2. Concurrent operations (like force merge) could delete these files before the `IndexCommit` was closed
+3. Unlike `InternalEngine`, which uses `combinedDeletionPolicy` to protect files, `NRTReplicationEngine` had no such protection
+
+#### Solution
+
+The fix introduces proper reference counting in `NRTReplicationEngine`:
+
+```java
+// Before (vulnerable to file deletion)
+final IndexCommit indexCommit = Lucene.getIndexCommit(lastCommittedSegmentInfos, store.directory());
+return new GatedCloseable<>(indexCommit, () -> {});
+
+// After (files protected until close)
+synchronized (lastCommittedSegmentInfosMutex) {
+    final IndexCommit indexCommit = Lucene.getIndexCommit(lastCommittedSegmentInfos, store.directory());
+    final Collection<String> files = indexCommit.getFileNames();
+    replicaFileTracker.incRef(files);
+    return new GatedCloseable<>(indexCommit, () -> { replicaFileTracker.decRef(files); });
+}
+```
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "NRTReplicationEngine"
+        ALI[acquireLastIndexCommit]
+        RFT[ReplicaFileTracker]
+        LCSI[lastCommittedSegmentInfos]
+        MUT[lastCommittedSegmentInfosMutex]
+    end
+    
+    subgraph "IndexCommit Lifecycle"
+        IC[IndexCommit]
+        FILES[Segment Files]
+        GC[GatedCloseable]
+    end
+    
+    ALI --> |synchronized| MUT
+    MUT --> |read| LCSI
+    LCSI --> IC
+    IC --> |getFileNames| FILES
+    FILES --> |incRef| RFT
+    IC --> GC
+    GC --> |on close| RFT
+    RFT --> |decRef| FILES
+```
+
+#### Key Changes
+
+| Component | Change |
+|-----------|--------|
+| `NRTReplicationEngine` | Added `lastCommittedSegmentInfosMutex` for thread-safe access |
+| `acquireLastIndexCommit` | Now increments reference count on segment files |
+| `GatedCloseable` close handler | Now decrements reference count when closed |
+| `commitSegmentInfos` | Synchronized access to `lastCommittedSegmentInfos` |
+
+### Usage Example
+
+The fix is transparent to users. Segment replication continues to work as before, but without the risk of `NoSuchFileException`:
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "replication.type": "SEGMENT",
+      "number_of_replicas": 1
+    }
+  }
+}
+```
+
+### Migration Notes
+
+No migration required. The fix is automatically applied when upgrading to v3.3.0.
+
+## Limitations
+
+- This fix specifically addresses `NRTReplicationEngine` (used by replica shards in segment replication)
+- Primary shards using `InternalEngine` were not affected by this bug
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19214](https://github.com/opensearch-project/OpenSearch/pull/19214) | Add reference count control in NRTReplicationEngine#acquireLastIndexCommit |
+
+## References
+
+- [Issue #19213](https://github.com/opensearch-project/OpenSearch/issues/19213): Bug report - NoSuchFileException when traversing files from acquireLastIndexCommit
+- [Segment Replication Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/segment-replication/index/): Official segment replication docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/segment-replication.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -9,6 +9,7 @@
 - [Cluster State Caching](features/opensearch/cluster-state-caching.md)
 - [Derived Fields](features/opensearch/derived-fields.md)
 - [Netty Arena Settings](features/opensearch/netty-arena-settings.md)
+- [NRT Replication Engine](features/opensearch/nrt-replication-engine.md)
 - [Query Phase Fixes](features/opensearch/query-phase-fixes.md)
 - [Reactor Netty Transport](features/opensearch/reactor-netty-transport.md)
 - [Reindex API](features/opensearch/reindex-api.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the NRT Replication Engine bug fix in OpenSearch v3.3.0.

### Changes

- **Release report**: `docs/releases/v3.3.0/features/opensearch/nrt-replication-engine.md`
  - Documents the fix for reference count control in `NRTReplicationEngine#acquireLastIndexCommit`
  - Explains the bug that caused `NoSuchFileException` in segment replication
  - Includes architecture diagram and code changes

- **Feature report update**: `docs/features/opensearch/segment-replication.md`
  - Added v3.3.0 entry to Related PRs table
  - Added v3.3.0 entry to Change History
  - Added reference to Issue #19213

### Related

- Closes #1429
- PR: [opensearch-project/OpenSearch#19214](https://github.com/opensearch-project/OpenSearch/pull/19214)
- Issue: [opensearch-project/OpenSearch#19213](https://github.com/opensearch-project/OpenSearch/issues/19213)