### PR TITLE
docs: add S3 repository compatibility fix report for v3.3.0

### DIFF
--- a/docs/features/opensearch/s3-repository.md
+++ b/docs/features/opensearch/s3-repository.md
@@ -208,6 +208,7 @@ graph TB
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#19220](https://github.com/opensearch-project/OpenSearch/pull/19220) | Fix S3-compatible repository checksum trailing headers issue |
 | v3.1.0 | [#18312](https://github.com/opensearch-project/OpenSearch/pull/18312) | Add support for SSE-KMS and S3 bucket owner verification |
 | v2.18.0 | [#15621](https://github.com/opensearch-project/OpenSearch/pull/15621) | Add support for async deletion in S3BlobContainer |
 | v2.18.0 | [#15978](https://github.com/opensearch-project/OpenSearch/pull/15978) | Change default retry mechanism to Standard Mode |
@@ -215,6 +216,9 @@ graph TB
 
 ## References
 
+- [PR #19220](https://github.com/opensearch-project/OpenSearch/pull/19220): S3-compatible repository checksum fix
+- [Issue #18240](https://github.com/opensearch-project/OpenSearch/issues/18240): S3 compatible storage broken in 3.0.0
+- [Issue #19124](https://github.com/opensearch-project/OpenSearch/issues/19124): repository-s3 x-amz-trailer error
 - [PR #18312](https://github.com/opensearch-project/OpenSearch/pull/18312): SSE-KMS and bucket owner verification
 - [Issue #14606](https://github.com/opensearch-project/OpenSearch/issues/14606): Feature request for SSE-KMS support
 - [PR #15621](https://github.com/opensearch-project/OpenSearch/pull/15621): Async deletion implementation
@@ -226,5 +230,6 @@ graph TB
 
 ## Change History
 
+- **v3.3.0** (2025-09): Fixed S3-compatible repository compatibility by making checksum trailing headers conditional
 - **v3.1.0** (2025-07): Added SSE-KMS support, bucket owner verification, removed legacy server_side_encryption setting
 - **v2.18.0** (2024-10-22): Added async deletion support, changed default retry mechanism to Standard Mode, fixed SLF4J warnings

--- a/docs/releases/v3.3.0/features/opensearch/s3-repository.md
+++ b/docs/releases/v3.3.0/features/opensearch/s3-repository.md
@@ -1,0 +1,96 @@
+# S3 Repository Compatibility Fix
+
+## Summary
+
+This release fixes a critical compatibility issue with S3-compatible storage providers (such as Outscale, MinIO, and others) that was introduced in OpenSearch 3.0.0 due to the AWS SDK v2 upgrade. The fix ensures that checksum trailing headers are only sent when required by the storage provider, restoring compatibility with S3-compatible repositories.
+
+## Details
+
+### What's New in v3.3.0
+
+The `repository-s3` plugin now properly handles checksum requirements for S3-compatible storage providers by:
+
+1. Setting `RequestChecksumCalculation.WHEN_REQUIRED` - only calculates checksums when the storage provider requires them
+2. Setting `ResponseChecksumValidation.WHEN_REQUIRED` - only validates response checksums when required
+3. Adding `LegacyMd5Plugin` support for providers that require MD5 checksums instead of trailing headers
+
+### Technical Changes
+
+#### Root Cause
+
+AWS SDK v2.30.31+ introduced mandatory checksum trailing headers by default. Many S3-compatible storage providers don't support these new trailing headers, causing errors like:
+
+- `trailing checksum is not supported`
+- `Invalid trailing header names in x-amz-trailer`
+- `The Content-MD5 you specified did not match what we received`
+
+#### Solution
+
+The fix modifies `S3Service` and `S3AsyncService` to build S3 clients with conditional checksum behavior:
+
+```java
+final S3ClientBuilder builder = S3Client.builder()
+    .requestChecksumCalculation(RequestChecksumCalculation.WHEN_REQUIRED)
+    .responseChecksumValidation(ResponseChecksumValidation.WHEN_REQUIRED);
+
+if (clientSettings.legacyMd5ChecksumCalculation) {
+    builder.addPlugin(LegacyMd5Plugin.create());
+}
+```
+
+#### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `legacyMd5ChecksumCalculation` | Enable legacy MD5 checksum calculation for providers that require it | `false` |
+
+### Usage Example
+
+For S3-compatible storage that requires MD5 checksums:
+
+```yaml
+# opensearch.yml
+s3.client.default.legacy_md5_checksum_calculation: true
+```
+
+Register repository as usual:
+
+```json
+PUT _snapshot/my-s3-compatible-repo
+{
+  "type": "s3",
+  "settings": {
+    "bucket": "my-bucket",
+    "endpoint": "s3.my-provider.com",
+    "protocol": "https"
+  }
+}
+```
+
+### Migration Notes
+
+- Users of S3-compatible storage providers who experienced issues after upgrading to OpenSearch 3.0.0+ should upgrade to v3.3.0
+- No configuration changes required for standard AWS S3 usage
+- For providers requiring MD5 checksums, enable `legacy_md5_checksum_calculation`
+
+## Limitations
+
+- Some S3-compatible providers may still have compatibility issues depending on their specific implementation
+- The `LegacyMd5Plugin` adds overhead for MD5 calculation when enabled
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19220](https://github.com/opensearch-project/OpenSearch/pull/19220) | Fix issue with s3-compatible repositories due to missing checksum trailing headers |
+
+## References
+
+- [Issue #18240](https://github.com/opensearch-project/OpenSearch/issues/18240): Snapshot repositories don't work with S3 compatible storage in 3.0.0
+- [Issue #19124](https://github.com/opensearch-project/OpenSearch/issues/19124): repository-s3 error x-amz-trailer
+- [AWS SDK Discussion #5802](https://github.com/aws/aws-sdk-java-v2/discussions/5802): Workaround for checksum trailing headers
+- [Register Snapshot Repository](https://docs.opensearch.org/3.0/api-reference/snapshots/create-repository/): OpenSearch documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/s3-repository.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -14,6 +14,7 @@
 - [Reactor Netty Transport](features/opensearch/reactor-netty-transport.md)
 - [Reindex API](features/opensearch/reindex-api.md)
 - [Request Cache](features/opensearch/request-cache.md)
+- [S3 Repository Compatibility Fix](features/opensearch/s3-repository.md)
 - [Scaled Float Field Precision Fix](features/opensearch/scaled-float-field.md)
 - [Search Stats - Negative Value Handling](features/opensearch/search-stats.md)
 - [Store Subdirectory Module](features/opensearch/store-subdirectory-module.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the S3 repository compatibility fix in OpenSearch v3.3.0.

### Changes
- Created release report: `docs/releases/v3.3.0/features/opensearch/s3-repository.md`
- Updated feature report: `docs/features/opensearch/s3-repository.md`
- Updated release index: `docs/releases/v3.3.0/index.md`

### Key Points
- Fixes critical compatibility issue with S3-compatible storage providers (Outscale, MinIO, etc.)
- Issue was introduced in OpenSearch 3.0.0 due to AWS SDK v2 upgrade
- Fix makes checksum trailing headers conditional using `RequestChecksumCalculation.WHEN_REQUIRED`
- Adds `LegacyMd5Plugin` support for providers requiring MD5 checksums

### Related
- PR: opensearch-project/OpenSearch#19220
- Issue: opensearch-project/OpenSearch#18240
- Issue: opensearch-project/OpenSearch#19124
- Tracking Issue: #1428