### PR TITLE
docs: add cross-cluster-settings report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -31,6 +31,7 @@
 - [Cluster Info & Resource Stats](opensearch/cluster-info-resource-stats.md)
 - [Cluster Manager Metrics](opensearch/cluster-manager-metrics.md)
 - [Cluster State Caching](opensearch/cluster-state-caching.md)
+- [Cross-Cluster Settings](opensearch/cross-cluster-settings.md)
 - [Code Cleanup](opensearch/code-cleanup.md)
 - [Code Coverage (Gradle)](opensearch/code-coverage-gradle.md)
 - [Combined Fields Query](opensearch/combined-fields-query.md)

--- a/docs/features/opensearch/cross-cluster-settings.md
+++ b/docs/features/opensearch/cross-cluster-settings.md
@@ -1,0 +1,138 @@
+# Cross-Cluster Settings
+
+## Summary
+
+Cross-cluster settings control how OpenSearch connects to and interacts with remote clusters for cross-cluster search (CCS) and cross-cluster replication (CCR). These settings include connection parameters, authentication, and behavior when remote clusters become unavailable.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Coordinating Cluster"
+        CC[Coordinating Node]
+        CS[ClusterSettings]
+        RCA[RemoteClusterAware]
+        RCS[RemoteClusterService]
+    end
+    
+    subgraph "Remote Cluster"
+        RC[Remote Node]
+    end
+    
+    CC --> CS
+    CS --> RCA
+    RCA --> RCS
+    RCS -->|Transport Connection| RC
+    
+    CS -->|Settings Update| RCA
+    RCA -->|validateAndUpdateRemoteCluster| RCS
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User Updates Settings] --> B[ClusterSettings]
+    B --> C[RemoteClusterAware.listenForUpdates]
+    C --> D{Setting Changed?}
+    D -->|Yes| E[validateAndUpdateRemoteCluster]
+    E --> F[RemoteClusterService.updateRemoteCluster]
+    F --> G[Reconnect to Remote]
+    D -->|No| H[No Action]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `RemoteClusterAware` | Base class that listens for remote cluster setting updates |
+| `RemoteClusterService` | Manages connections to remote clusters |
+| `RemoteConnectionStrategy` | Defines connection mode (sniff or proxy) |
+| `SniffConnectionStrategy` | Discovers remote cluster nodes via seed nodes |
+| `ProxyConnectionStrategy` | Connects through a proxy server |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.remote.<alias>.seeds` | Seed node addresses for remote cluster | - |
+| `cluster.remote.<alias>.skip_unavailable` | Return partial results if remote unavailable | `false` |
+| `cluster.remote.<alias>.mode` | Connection mode: `sniff` or `proxy` | `sniff` |
+| `cluster.remote.<alias>.proxy_address` | Proxy address (for proxy mode) | - |
+| `cluster.remote.<alias>.compress` | Enable compression for remote connections | `false` |
+| `cluster.remote.<alias>.ping_schedule` | Interval for keep-alive pings | `30s` |
+
+### Usage Example
+
+Configure a remote cluster connection:
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.remote": {
+      "my-remote-cluster": {
+        "seeds": ["remote-node1:9300", "remote-node2:9300"],
+        "skip_unavailable": true
+      }
+    }
+  }
+}
+```
+
+Verify remote cluster connection:
+
+```bash
+GET _remote/info
+```
+
+Response:
+
+```json
+{
+  "my-remote-cluster": {
+    "connected": true,
+    "mode": "sniff",
+    "seeds": ["remote-node1:9300", "remote-node2:9300"],
+    "num_nodes_connected": 2,
+    "max_connections_per_cluster": 3,
+    "initial_connect_timeout": "30s",
+    "skip_unavailable": true
+  }
+}
+```
+
+Execute cross-cluster search:
+
+```json
+GET my-remote-cluster:my-index/_search
+{
+  "query": {
+    "match_all": {}
+  }
+}
+```
+
+## Limitations
+
+- Remote cluster connections require transport layer connectivity (port 9300 by default)
+- `skip_unavailable` only affects search operations, not replication
+- Proxy mode requires additional infrastructure setup
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#18766](https://github.com/opensearch-project/OpenSearch/pull/18766) | Fix skip_unavailable setting changing to default during node drop |
+
+## References
+
+- [Issue #13798](https://github.com/opensearch-project/OpenSearch/issues/13798): Bug report for skip_unavailable reset issue
+- [Cross-cluster search documentation](https://docs.opensearch.org/3.0/search-plugins/cross-cluster-search/): Official docs
+- [Remote cluster information API](https://docs.opensearch.org/3.0/api-reference/cluster-api/remote-info/): API reference
+
+## Change History
+
+- **v3.3.0** (2025-08-20): Fixed `skip_unavailable` setting persistence during seed node updates

--- a/docs/releases/v3.3.0/features/opensearch/cross-cluster-settings.md
+++ b/docs/releases/v3.3.0/features/opensearch/cross-cluster-settings.md
@@ -1,0 +1,96 @@
+# Cross-Cluster Settings
+
+## Summary
+
+This release fixes a bug where the `skip_unavailable` setting for cross-cluster search (CCS) would reset to its default value when remote cluster seed nodes were updated. This fix ensures that the `skip_unavailable` setting is properly preserved during cluster configuration changes, allowing CCS to correctly return partial results when remote clusters become unavailable.
+
+## Details
+
+### What's New in v3.3.0
+
+The fix addresses a critical issue in cross-cluster search where updating the `cluster.remote.<alias>.seeds` setting would cause the `skip_unavailable` setting to revert to its default value (`false`). This caused CCS queries to fail with errors instead of returning partial results when remote clusters were unavailable.
+
+### Technical Changes
+
+#### Root Cause
+
+The `RemoteClusterAware.listenForUpdates()` method was not listening for changes to the `REMOTE_CLUSTER_SKIP_UNAVAILABLE` setting. When seed nodes were updated, the cluster settings update consumer would rebuild the remote cluster connection without preserving the `skip_unavailable` value.
+
+#### Fix Implementation
+
+Added `RemoteClusterService.REMOTE_CLUSTER_SKIP_UNAVAILABLE` to the list of settings monitored by the `listenForUpdates()` method in `RemoteClusterAware.java`:
+
+```java
+public void listenForUpdates(ClusterSettings clusterSettings) {
+    List<Setting.AffixSetting<?>> remoteClusterSettings = Arrays.asList(
+        RemoteClusterService.REMOTE_CLUSTER_COMPRESS,
+        RemoteClusterService.REMOTE_CLUSTER_PING_SCHEDULE,
+        RemoteConnectionStrategy.REMOTE_CONNECTION_MODE,
+        RemoteClusterService.REMOTE_CLUSTER_SKIP_UNAVAILABLE,  // Added
+        SniffConnectionStrategy.REMOTE_CLUSTERS_PROXY,
+        SniffConnectionStrategy.REMOTE_CLUSTER_SEEDS,
+        // ... other settings
+    );
+    clusterSettings.addAffixGroupUpdateConsumer(remoteClusterSettings, this::validateAndUpdateRemoteCluster);
+}
+```
+
+### Usage Example
+
+Configure cross-cluster search with `skip_unavailable` enabled:
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.remote": {
+      "remote-cluster": {
+        "seeds": ["172.31.0.3:9300"],
+        "skip_unavailable": true
+      }
+    }
+  }
+}
+```
+
+After this fix, updating the seed nodes will preserve the `skip_unavailable` setting:
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.remote": {
+      "remote-cluster": {
+        "seeds": ["172.31.0.4:9300"],
+        "skip_unavailable": true
+      }
+    }
+  }
+}
+```
+
+CCS queries will now correctly return partial results with `skipped: 1` when the remote cluster is unavailable, instead of failing with an error.
+
+### Migration Notes
+
+No migration required. This is a bug fix that improves the reliability of existing cross-cluster search configurations.
+
+## Limitations
+
+- The fix only affects the `skip_unavailable` setting persistence during configuration updates
+- Other cross-cluster settings behavior remains unchanged
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18766](https://github.com/opensearch-project/OpenSearch/pull/18766) | Fix skip_unavailable setting changing to default during node drop |
+
+## References
+
+- [Issue #13798](https://github.com/opensearch-project/OpenSearch/issues/13798): Original bug report
+- [Cross-cluster search documentation](https://docs.opensearch.org/3.0/search-plugins/cross-cluster-search/): Official docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/cross-cluster-settings.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -7,6 +7,7 @@
 - [Alias Write Index Policy](features/opensearch/alias-write-index-policy.md)
 - [Cardinality Aggregation](features/opensearch/cardinality-aggregation.md)
 - [Cluster State Caching](features/opensearch/cluster-state-caching.md)
+- [Cross-Cluster Settings](features/opensearch/cross-cluster-settings.md)
 - [Derived Fields](features/opensearch/derived-fields.md)
 - [Netty Arena Settings](features/opensearch/netty-arena-settings.md)
 - [NRT Replication Engine](features/opensearch/nrt-replication-engine.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Cross-Cluster Settings bug fix in OpenSearch v3.3.0.

### Changes

- **Release Report**: `docs/releases/v3.3.0/features/opensearch/cross-cluster-settings.md`
- **Feature Report**: `docs/features/opensearch/cross-cluster-settings.md`
- Updated release and feature indexes

### Bug Fix Details

Fixes a bug where the `skip_unavailable` setting for cross-cluster search would reset to its default value when remote cluster seed nodes were updated. The fix adds `REMOTE_CLUSTER_SKIP_UNAVAILABLE` to the list of settings monitored by `RemoteClusterAware.listenForUpdates()`.

### Related

- OpenSearch PR: [#18766](https://github.com/opensearch-project/OpenSearch/pull/18766)
- OpenSearch Issue: [#13798](https://github.com/opensearch-project/OpenSearch/issues/13798)
- Investigation Issue: #1427