### PR TITLE
docs: add concurrent segment search report for v3.3.0

### DIFF
--- a/docs/features/opensearch/concurrent-segment-search.md
+++ b/docs/features/opensearch/concurrent-segment-search.md
@@ -117,17 +117,21 @@ PUT _cluster/settings
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#19053](https://github.com/opensearch-project/OpenSearch/pull/19053) | Fix assertion error when collapsing search results with concurrent segment search |
 | v3.2.0 | [#18451](https://github.com/opensearch-project/OpenSearch/pull/18451) | Optimize grouping for segment concurrent search |
 
 ## References
 
 - [Concurrent Segment Search Documentation](https://docs.opensearch.org/3.0/search-plugins/concurrent-segment-search/): Official documentation
 - [Issue #7358](https://github.com/opensearch-project/OpenSearch/issues/7358): Original issue discussing slice computation mechanisms
+- [Issue #19051](https://github.com/opensearch-project/OpenSearch/issues/19051): Assertion error with field collapsing
+- [Issue #19111](https://github.com/opensearch-project/OpenSearch/issues/19111): Inconsistent field collapsing results
 - [Introducing concurrent segment search in OpenSearch](https://opensearch.org/blog/concurrent_segment_search/): Introduction blog post
 - [Exploring concurrent segment search performance](https://opensearch.org/blog/concurrent-search-follow-up/): Performance analysis blog
 
 ## Change History
 
+- **v3.3.0** (2025-10-30): Fixed assertion error when using field collapsing with concurrent segment search by removing setShardIndex parameter from CollapseTopFieldDocs.merge()
 - **v3.2.0** (2025-07-31): Optimized segment grouping algorithm using priority queue for better load balancing
 - **v3.0.0**: Concurrent segment search enabled by default in `auto` mode
 - **v2.12.0**: Initial experimental release of concurrent segment search

--- a/docs/releases/v3.3.0/features/opensearch/concurrent-segment-search.md
+++ b/docs/releases/v3.3.0/features/opensearch/concurrent-segment-search.md
@@ -1,0 +1,94 @@
+# Concurrent Segment Search
+
+## Summary
+
+This release fixes an assertion error that occurred when using field collapsing with concurrent segment search enabled. The bug caused inconsistent search results and could crash nodes when collapsing search results across multiple segments searched in parallel.
+
+## Details
+
+### What's New in v3.3.0
+
+This release addresses a critical bug where the `shardIndex` was being set twice during field collapsing operations with concurrent segment search enabled, causing an assertion error and inconsistent results.
+
+### Technical Changes
+
+#### Root Cause
+
+When concurrent segment search is enabled, segments are searched in parallel and results are merged. The `CollapseTopFieldDocs.merge()` method had a `setShardIndex` parameter that would set the shard index on score documents during the merge. However, when concurrent segment search was enabled, the shard index was already being set in the query phase (`TopDocsCollectorContext`), causing a double-set that triggered an assertion error:
+
+```
+java.lang.AssertionError: shardIndex is already set
+    at org.opensearch.action.search.SearchPhaseController.setShardIndex
+```
+
+#### Fix Implementation
+
+The fix removes the `setShardIndex` parameter from `CollapseTopFieldDocs.merge()`, aligning it with the Lucene 9.0.0 change that removed this capability from `TopDocs.merge()`. The key changes include:
+
+1. **Removed `setShardIndex` parameter**: The merge method no longer accepts or uses this parameter
+2. **Updated tie-breaking logic**: Uses a default comparator that handles both set and unset shard indices
+3. **Added consistency validation**: Throws `IllegalArgumentException` if shard indices are inconsistent across documents
+
+#### Modified Components
+
+| Component | Change |
+|-----------|--------|
+| `CollapseTopFieldDocs.java` | Removed `setShardIndex` parameter, added default tie-breaker comparators |
+| `SearchPhaseController.java` | Updated merge call to remove `setShardIndex` argument |
+| `TopDocsCollectorContext.java` | Updated merge call to remove `setShardIndex` argument |
+
+#### New Tie-Breaking Logic
+
+```java
+private static final Comparator<ScoreDoc> SHARD_INDEX_TIE_BREAKER = 
+    Comparator.comparingInt(d -> d.shardIndex);
+private static final Comparator<ScoreDoc> DOC_ID_TIE_BREAKER = 
+    Comparator.comparingInt(d -> d.doc);
+private static final Comparator<ScoreDoc> DEFAULT_TIE_BREAKER = 
+    SHARD_INDEX_TIE_BREAKER.thenComparing(DOC_ID_TIE_BREAKER);
+```
+
+### Usage Example
+
+Field collapsing with concurrent segment search now works correctly:
+
+```json
+PUT test_index/_settings
+{
+    "index.search.concurrent_segment_search.mode": "all"
+}
+
+GET test_index/_search
+{
+  "collapse": {
+    "field": "category"
+  },
+  "sort": [{ "timestamp": "desc" }]
+}
+```
+
+### Migration Notes
+
+No migration required. This is a bug fix that makes field collapsing work correctly with concurrent segment search. Users who previously disabled concurrent segment search to work around this issue can now re-enable it.
+
+## Limitations
+
+- The fix ensures consistent behavior between concurrent and non-concurrent search paths
+- When documents have the same sort value, tie-breaking uses shard index first, then document ID
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19053](https://github.com/opensearch-project/OpenSearch/pull/19053) | Remove the setShardIndex parameter in CollapseTopFieldDocs.merge() |
+
+## References
+
+- [Issue #19051](https://github.com/opensearch-project/OpenSearch/issues/19051): Collapsing search results with concurrent segment search enabled triggers assertion error
+- [Issue #19111](https://github.com/opensearch-project/OpenSearch/issues/19111): Inconsistent field collapsing search results with concurrent segment search
+- [Lucene PR #757](https://github.com/apache/lucene-solr/pull/757): Original Lucene change that removed setShardIndex from TopDocs.merge()
+- [Concurrent Segment Search Documentation](https://docs.opensearch.org/3.0/search-plugins/concurrent-segment-search/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/concurrent-segment-search.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -7,6 +7,7 @@
 - [Alias Write Index Policy](features/opensearch/alias-write-index-policy.md)
 - [Cardinality Aggregation](features/opensearch/cardinality-aggregation.md)
 - [Cluster State Caching](features/opensearch/cluster-state-caching.md)
+- [Concurrent Segment Search](features/opensearch/concurrent-segment-search.md)
 - [Cross-Cluster Settings](features/opensearch/cross-cluster-settings.md)
 - [Derived Fields](features/opensearch/derived-fields.md)
 - [Netty Arena Settings](features/opensearch/netty-arena-settings.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Concurrent Segment Search bug fix in OpenSearch v3.3.0.

### Changes

**Release Report** (`docs/releases/v3.3.0/features/opensearch/concurrent-segment-search.md`):
- Documents the fix for assertion error when using field collapsing with concurrent segment search
- Explains the root cause (double-setting of shardIndex)
- Details the technical changes to `CollapseTopFieldDocs.merge()`

**Feature Report Update** (`docs/features/opensearch/concurrent-segment-search.md`):
- Added v3.3.0 to change history
- Added references to related issues (#19051, #19111)
- Added PR #19053 to related PRs table

**Release Index Update** (`docs/releases/v3.3.0/index.md`):
- Added link to the new release report

### Related Issue
Closes #1426

### Key Changes in v3.3.0
- Fixed assertion error when collapsing search results with concurrent segment search enabled
- Removed `setShardIndex` parameter from `CollapseTopFieldDocs.merge()` to align with Lucene 9.0.0 changes
- Ensures consistent behavior between concurrent and non-concurrent search paths