### PR TITLE
docs: add flaky-test-fixes report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -48,6 +48,7 @@
 - [File Cache](opensearch/file-cache.md)
 - [Cluster Permissions](opensearch/cluster-permissions.md)
 - [Flat Object Field](opensearch/flat-object-field.md)
+- [Flaky Test Fixes](opensearch/flaky-test-fixes.md)
 - [gRPC Transport & Services](opensearch/grpc-transport--services.md)
 - [Index Settings](opensearch/index-settings.md)
 - [List APIs (Paginated)](opensearch/list-apis-paginated.md)

--- a/docs/features/opensearch/flaky-test-fixes.md
+++ b/docs/features/opensearch/flaky-test-fixes.md
@@ -1,0 +1,95 @@
+# Flaky Test Fixes
+
+## Summary
+
+OpenSearch maintains a robust test suite to ensure code quality and reliability. Flaky tests—tests that pass or fail intermittently without code changes—can undermine CI/CD reliability and developer productivity. This feature tracks fixes for flaky tests across the OpenSearch codebase, improving test stability and build reliability.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Test Execution"
+        TC[Test Case] --> TF[Test Framework]
+        TF --> RS[Random Seed]
+        TF --> LC[Locale/Timezone]
+    end
+    
+    subgraph "Flaky Test Detection"
+        CI[CI Pipeline] --> FD[Failure Detection]
+        FD --> AR[AUTOCUT Report]
+        AR --> GH[GitHub Issue]
+    end
+    
+    subgraph "Fix Categories"
+        GH --> TI[Timing Issues]
+        GH --> LD[Locale Dependencies]
+        GH --> RL[Resource Limits]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `IntervalBuilder` | Builds interval queries with disjunction limit checking |
+| `IntervalsSourceProvider` | Provides interval sources with early validation |
+| `AbstractQueryTestCase` | Base test class with improved exception handling |
+| `KeyStoreUtils` | Certificate generation utilities with locale-independent behavior |
+
+### Common Flaky Test Patterns
+
+| Pattern | Cause | Solution |
+|---------|-------|----------|
+| Random seed sensitivity | Test behavior varies with random input | Add bounds checking, handle edge cases |
+| Locale/timezone dependency | Date/string formatting varies by locale | Use `Locale.ROOT` and explicit formatting |
+| Resource limits | Queries exceed Lucene clause limits | Add early validation before execution |
+| Timing issues | Race conditions in async operations | Use proper synchronization, increase timeouts |
+
+### Configuration
+
+No user configuration required. These are internal test framework improvements.
+
+### Usage Example
+
+```java
+// Example: Checking disjunction count before combining interval sources
+public static boolean canCombineSources(List<IntervalsSource> sources) {
+    int sourceIndex = 0;
+    long disjunctionCount = 1;
+
+    while (sourceIndex < sources.size()) {
+        disjunctionCount = disjunctionCount 
+            * sources.get(sourceIndex).pullUpDisjunctions().size();
+        if (disjunctionCount > IndexSearcher.getMaxClauseCount()) {
+            return false;
+        }
+        sourceIndex += 1;
+    }
+    return true;
+}
+```
+
+## Limitations
+
+- Flaky test fixes are reactive—new flaky tests may emerge as code evolves
+- Some timing-related flakiness may require environment-specific tuning
+- Random seed reproduction may not always capture the exact failure conditions
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19332](https://github.com/opensearch-project/OpenSearch/pull/19332) | Fix Flaky IntervalQueryBuilderTests |
+| v3.3.0 | [#19327](https://github.com/opensearch-project/OpenSearch/pull/19327) | Fix flaky test in SecureReactorNetty4HttpServerTransportTests |
+
+## References
+
+- [Issue #19167](https://github.com/opensearch-project/OpenSearch/issues/19167): IntervalQueryBuilderTests flaky test report
+- [Issue #17486](https://github.com/opensearch-project/OpenSearch/issues/17486): SecureReactorNetty4HttpServerTransportTests flaky test report
+- [OpenSearch Gradle Check Metrics](https://metrics.opensearch.org/_dashboards/app/dashboards#/view/e5e64d40-ed31-11ee-be99-69d1dbc75083): Flaky test tracking dashboard
+
+## Change History
+
+- **v3.3.0**: Fixed IntervalQueryBuilderTests disjunction limit and SecureReactorNetty4HttpServerTransportTests locale issues

--- a/docs/releases/v3.3.0/features/opensearch/flaky-test-fixes.md
+++ b/docs/releases/v3.3.0/features/opensearch/flaky-test-fixes.md
@@ -1,0 +1,81 @@
+# Flaky Test Fixes
+
+## Summary
+
+OpenSearch v3.3.0 includes fixes for several flaky tests that were causing intermittent CI failures. These fixes improve test reliability by addressing timing issues, locale-dependent behavior, and query complexity limits in the test framework.
+
+## Details
+
+### What's New in v3.3.0
+
+This release addresses three categories of flaky test failures:
+
+1. **IntervalQueryBuilderTests** - Fixed excessive disjunction expansion causing test failures
+2. **SecureReactorNetty4HttpServerTransportTests** - Fixed locale-dependent certificate generation issues
+
+### Technical Changes
+
+#### IntervalQuery Disjunction Fix
+
+The `IntervalQueryBuilderTests.testToQuery` test was failing intermittently when randomly generated interval queries exceeded Lucene's maximum clause count limit during disjunction expansion.
+
+**Root Cause**: When combining multiple `IntervalsSource` objects with `maxGaps=0` and `ORDERED` mode, the number of disjunctions can grow exponentially. Lucene enforces a limit via `IndexSearcher.getMaxClauseCount()`.
+
+**Solution**: Added early detection of disjunction count before attempting to combine sources:
+
+| Component | Change |
+|-----------|--------|
+| `IntervalBuilder` | Added `canCombineSources()` method to check disjunction count |
+| `IntervalsSourceProvider.Combine` | Throws `IllegalArgumentException` when disjunction limit exceeded |
+| `AbstractQueryTestCase` | Catches and handles the expected exception in test framework |
+
+#### SecureReactorNetty4HttpServerTransportTests Fix
+
+Multiple tests in `SecureReactorNetty4HttpServerTransportTests` were failing with specific random seeds due to locale-dependent certificate generation.
+
+**Root Cause**: The `JcaX509v1CertificateBuilder` class used locale-dependent date formatting, causing certificate generation to fail with certain locale/timezone combinations.
+
+**Solution**: Replaced `JcaX509v1CertificateBuilder` with `X509v1CertificateBuilder` and explicitly specified `Locale.ROOT` for consistent behavior across all test environments.
+
+| Component | Change |
+|-----------|--------|
+| `KeyStoreUtils` | Use `X509v1CertificateBuilder` with explicit `Locale.ROOT` |
+| Certificate generation | Use `SubjectPublicKeyInfo.getInstance()` for public key encoding |
+
+### Usage Example
+
+The fixes are internal to the test framework and require no user action. Tests now handle edge cases gracefully:
+
+```java
+// IntervalBuilder now checks disjunction count before combining
+if (maxGaps == 0 && mode == IntervalMode.ORDERED 
+    && IntervalBuilder.canCombineSources(ss) == false) {
+    throw new IllegalArgumentException("Too many disjunctions to expand");
+}
+```
+
+### Migration Notes
+
+No migration required. These are internal test framework improvements.
+
+## Limitations
+
+- The disjunction limit check only applies to `maxGaps=0` with `ORDERED` mode
+- Other interval query combinations may still hit Lucene limits in edge cases
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19332](https://github.com/opensearch-project/OpenSearch/pull/19332) | Fix Flaky IntervalQueryBuilderTests |
+| [#19327](https://github.com/opensearch-project/OpenSearch/pull/19327) | Fix flaky test in SecureReactorNetty4HttpServerTransportTests |
+
+## References
+
+- [Issue #19167](https://github.com/opensearch-project/OpenSearch/issues/19167): IntervalQueryBuilderTests flaky test report
+- [Issue #17486](https://github.com/opensearch-project/OpenSearch/issues/17486): SecureReactorNetty4HttpServerTransportTests flaky test report
+- [Lucene Disjunctions](https://github.com/apache/lucene/blob/main/lucene/queries/src/java/org/apache/lucene/queries/intervals/Disjunctions.java): Lucene disjunction limit implementation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/flaky-test-fixes.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -10,6 +10,7 @@
 - [Concurrent Segment Search](features/opensearch/concurrent-segment-search.md)
 - [Cross-Cluster Settings](features/opensearch/cross-cluster-settings.md)
 - [Derived Fields](features/opensearch/derived-fields.md)
+- [Flaky Test Fixes](features/opensearch/flaky-test-fixes.md)
 - [Netty Arena Settings](features/opensearch/netty-arena-settings.md)
 - [NRT Replication Engine](features/opensearch/nrt-replication-engine.md)
 - [Query Phase Fixes](features/opensearch/query-phase-fixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Flaky Test Fixes feature in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/flaky-test-fixes.md`
- Feature report: `docs/features/opensearch/flaky-test-fixes.md`

### Key Changes in v3.3.0
- Fixed IntervalQueryBuilderTests by adding disjunction count validation before combining interval sources
- Fixed SecureReactorNetty4HttpServerTransportTests by using locale-independent certificate generation

### Related PRs
- [#19332](https://github.com/opensearch-project/OpenSearch/pull/19332): Fix Flaky IntervalQueryBuilderTests
- [#19327](https://github.com/opensearch-project/OpenSearch/pull/19327): Fix flaky test in SecureReactorNetty4HttpServerTransportTests

Closes #1424