### PR TITLE
docs: add OOM Prevention report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -86,6 +86,7 @@
 - [Numeric Terms Aggregation Optimization](opensearch/numeric-terms-aggregation-optimization.md)
 - [Numeric Field Skip List](opensearch/numeric-field-skip-list.md)
 - [Offline Nodes (Background Tasks)](opensearch/offline-nodes.md)
+- [OOM Prevention](opensearch/oom-prevention.md)
 - [OpenSearch Core Dependencies](opensearch/opensearch-core-dependencies.md)
 - [Parallel Shard Refresh](opensearch/parallel-shard-refresh.md)
 - [Parent-Child Query](opensearch/parent-child-query.md)

--- a/docs/features/opensearch/oom-prevention.md
+++ b/docs/features/opensearch/oom-prevention.md
@@ -1,0 +1,142 @@
+# OOM Prevention
+
+## Summary
+
+OOM Prevention is a memory protection mechanism that prevents coordinator nodes from running out of memory during search operations. When searching across indexes with many shards, the coordinator node buffers shard-level query results before performing batched reduce operations. Without proper memory management, this buffering can cause OutOfMemoryError (OOM) conditions. This feature integrates circuit breaker checks into the query result consumption process to detect and prevent memory exhaustion before it occurs.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Search Request Flow"
+        Client[Client] --> Coord[Coordinator Node]
+        Coord --> |Fan out| DN1[Data Node 1]
+        Coord --> |Fan out| DN2[Data Node 2]
+        Coord --> |Fan out| DN3[Data Node N]
+    end
+    
+    subgraph "Coordinator Processing"
+        DN1 --> |Shard Result| QPC[QueryPhaseResultConsumer]
+        DN2 --> |Shard Result| QPC
+        DN3 --> |Shard Result| QPC
+        QPC --> CB{Circuit Breaker}
+        CB -->|OK| Buffer[Result Buffer]
+        CB -->|Trip| Fail[Fail Request]
+        Buffer -->|Full| Reduce[Partial Reduce]
+        Reduce --> Buffer
+        Buffer -->|All received| Final[Final Reduce]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Shard Result Arrives] --> B{Task Cancelled?}
+    B -->|Yes| C[Discard Result]
+    B -->|No| D{Check Circuit Breaker}
+    D -->|Pass| E[Add to Buffer]
+    D -->|Trip| F[Set Failure]
+    F --> G[Cancel Task]
+    G --> H[Cancel Child Tasks]
+    E --> I{Buffer Full?}
+    I -->|Yes| J[Submit Partial Reduce]
+    I -->|No| K[Wait for More Results]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `QueryPhaseResultConsumer` | Manages buffering and incremental reduction of shard query results |
+| `PendingMerges` | Inner class that handles result buffering and circuit breaker integration |
+| `SearchPhaseController` | Factory for creating `QueryPhaseResultConsumer` instances |
+| `TransportSearchAction` | Coordinates search execution and passes task cancellation status |
+| `AbstractSearchAsyncAction` | Base class for async search actions with result handling |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `indices.breaker.request.limit` | Memory limit for request circuit breaker | 60% of JVM heap |
+| `indices.breaker.request.overhead` | Multiplier for request estimations | 1.0 |
+| `search.default_batched_reduce_size` | Number of shard results to buffer before partial reduce | 512 |
+
+### Usage Example
+
+The OOM prevention is automatic and requires no configuration. When memory limits are exceeded:
+
+```json
+GET /my-index-*/_search
+{
+  "size": 100,
+  "aggs": {
+    "large_agg": {
+      "terms": {
+        "field": "category",
+        "size": 10000
+      }
+    }
+  }
+}
+```
+
+Response when circuit breaker trips:
+
+```json
+{
+  "error": {
+    "root_cause": [
+      {
+        "type": "circuit_breaking_exception",
+        "reason": "[request] Data too large, data for [<reduce_aggs>] would be [1234567890/1.1gb], which is larger than the limit of [1073741824/1gb]",
+        "bytes_wanted": 1234567890,
+        "bytes_limit": 1073741824,
+        "durability": "TRANSIENT"
+      }
+    ],
+    "type": "search_phase_execution_exception",
+    "reason": "all shards failed"
+  },
+  "status": 503
+}
+```
+
+### Tuning Recommendations
+
+To reduce memory pressure during large searches:
+
+1. **Reduce `batched_reduce_size`**: Lower values reduce peak memory but increase reduce operations
+   ```
+   GET /my-index/_search?batched_reduce_size=64
+   ```
+
+2. **Increase circuit breaker limit** (if sufficient heap available):
+   ```yaml
+   indices.breaker.request.limit: 70%
+   ```
+
+3. **Optimize aggregations**: Use smaller `size` values or filter data before aggregating
+
+## Limitations
+
+- Circuit breaker checks add minimal overhead per shard result
+- Very memory-intensive queries may still fail; this is by design to protect cluster stability
+- The `batched_reduce_size` parameter affects both memory usage and reduce performance
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19066](https://github.com/opensearch-project/OpenSearch/pull/19066) | Add circuit breaking logic for shard level results |
+
+## References
+
+- [Issue #18999](https://github.com/opensearch-project/OpenSearch/issues/18999): Original bug report
+- [Circuit Breaker Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/circuit-breaker/): Official documentation
+
+## Change History
+
+- **v3.3.0**: Initial implementation - Added circuit breaker checks for shard result buffering with automatic task cancellation

--- a/docs/releases/v3.3.0/features/opensearch/oom-prevention.md
+++ b/docs/releases/v3.3.0/features/opensearch/oom-prevention.md
@@ -1,0 +1,121 @@
+# OOM Prevention
+
+## Summary
+
+This release adds circuit breaker protection for shard-level query results buffering on coordinator nodes. Previously, when searching across indexes with many shards, the coordinator node could run out of memory while buffering shard results before the batched reduce phase. The new implementation checks the circuit breaker on each shard result arrival and cancels the search task if memory limits are exceeded.
+
+## Details
+
+### What's New in v3.3.0
+
+The `QueryPhaseResultConsumer` class now integrates with the request circuit breaker to prevent OOM conditions during the query phase. Key changes include:
+
+1. **Circuit breaker check on each shard result**: Before buffering a new shard result, the system evaluates the circuit breaker to ensure memory limits are not exceeded
+2. **Immediate task cancellation**: When the circuit breaker trips, the coordinator task and all child tasks are cancelled immediately
+3. **Result discarding after cancellation**: New shard results are discarded after task cancellation, preventing further memory accumulation
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Coordinator Node"
+        SR[Shard Results] --> CB{Circuit Breaker Check}
+        CB -->|Pass| Buffer[Result Buffer]
+        CB -->|Trip| Cancel[Cancel Task]
+        Buffer -->|batched_reduce_size reached| Reduce[Partial Reduce]
+        Cancel --> Discard[Discard Results]
+        Cancel --> ChildCancel[Cancel Child Tasks]
+    end
+    
+    subgraph "Data Nodes"
+        S1[Shard 1] --> SR
+        S2[Shard 2] --> SR
+        S3[Shard N] --> SR
+    end
+```
+
+#### Modified Components
+
+| Component | Description |
+|-----------|-------------|
+| `QueryPhaseResultConsumer` | Added circuit breaker check in `consume()` method and task cancellation support |
+| `SearchPhaseController` | Extended `newSearchPhaseResults()` to accept `isTaskCancelled` supplier |
+| `TransportSearchAction` | Passes task cancellation status to the result consumer |
+| `AbstractSearchAsyncAction` | Added exception handling for shard result consumption failures |
+
+#### Key Code Changes
+
+The `QueryPhaseResultConsumer.PendingMerges.consume()` method now includes:
+
+```java
+private void checkCircuitBreaker(Runnable next) throws CircuitBreakingException {
+    try {
+        // Force the CircuitBreaker eval to ensure during buffering 
+        // we did not hit the circuit breaker limit
+        addEstimateAndMaybeBreak(0);
+    } catch (CircuitBreakingException e) {
+        resetCircuitBreakerForCurrentRequest();
+        if (!hasFailure()) {
+            failure.set(e);
+            onPartialMergeFailure.accept(e);
+        }
+    }
+}
+```
+
+### Configuration
+
+This feature uses the existing request circuit breaker settings:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `indices.breaker.request.limit` | Memory limit for request circuit breaker | 60% of JVM heap |
+| `indices.breaker.request.overhead` | Multiplier for request estimations | 1.0 |
+
+### Usage Example
+
+No configuration changes are required. The protection is automatically enabled. When the circuit breaker trips during a search:
+
+```json
+{
+  "error": {
+    "root_cause": [
+      {
+        "type": "circuit_breaking_exception",
+        "reason": "[request] Data too large, data for [<reduce_aggs>] would be [...]"
+      }
+    ],
+    "type": "search_phase_execution_exception",
+    "reason": "all shards failed"
+  },
+  "status": 503
+}
+```
+
+### Migration Notes
+
+- No migration required - this is a transparent improvement
+- Queries that previously caused OOM will now fail gracefully with a `CircuitBreakingException`
+- Consider adjusting `batched_reduce_size` for queries spanning many shards if you encounter circuit breaker errors
+
+## Limitations
+
+- The circuit breaker check adds minimal overhead to each shard result processing
+- Very large aggregation results may still trigger circuit breaker errors; consider using `batched_reduce_size` to control memory usage
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19066](https://github.com/opensearch-project/OpenSearch/pull/19066) | Add circuit breaking logic for shard level results |
+
+## References
+
+- [Issue #18999](https://github.com/opensearch-project/OpenSearch/issues/18999): Original bug report for OOM during large shard searches
+- [Circuit Breaker Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/circuit-breaker/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/oom-prevention.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -13,6 +13,7 @@
 - [Flaky Test Fixes](features/opensearch/flaky-test-fixes.md)
 - [Netty Arena Settings](features/opensearch/netty-arena-settings.md)
 - [NRT Replication Engine](features/opensearch/nrt-replication-engine.md)
+- [OOM Prevention](features/opensearch/oom-prevention.md)
 - [Query Phase Fixes](features/opensearch/query-phase-fixes.md)
 - [Reactor Netty Transport](features/opensearch/reactor-netty-transport.md)
 - [Reindex API](features/opensearch/reindex-api.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the OOM Prevention feature introduced in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/oom-prevention.md`
- Feature report: `docs/features/opensearch/oom-prevention.md`

### Feature Overview

OOM Prevention adds circuit breaker protection for shard-level query results buffering on coordinator nodes. When searching across indexes with many shards, the coordinator node could previously run out of memory while buffering shard results before the batched reduce phase. The new implementation:

- Checks the circuit breaker on each shard result arrival
- Cancels the search task immediately if memory limits are exceeded
- Discards new shard results after task cancellation

### Key Changes in v3.3.0
- Added circuit breaker check in `QueryPhaseResultConsumer.consume()` method
- Extended `SearchPhaseController.newSearchPhaseResults()` to accept task cancellation supplier
- Integrated task cancellation with circuit breaker trips

### Resources Used
- PR: [#19066](https://github.com/opensearch-project/OpenSearch/pull/19066)
- Issue: [#18999](https://github.com/opensearch-project/OpenSearch/issues/18999)
- Docs: [Circuit Breaker Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/circuit-breaker/)