### PR TITLE
docs: add segment-replication report for v3.3.0

### DIFF
--- a/docs/features/opensearch/segment-replication.md
+++ b/docs/features/opensearch/segment-replication.md
@@ -123,6 +123,7 @@ GET _cat/segment_replication?v
 | Version | PR | Description |
 |---------|-----|-------------|
 | v3.3.0 | [#19214](https://github.com/opensearch-project/OpenSearch/pull/19214) | Add reference count control in NRTReplicationEngine#acquireLastIndexCommit |
+| v3.3.0 | [#18997](https://github.com/opensearch-project/OpenSearch/pull/18997) | Fix NullPointerException in segment replicator |
 | v3.2.0 | [#18602](https://github.com/opensearch-project/OpenSearch/pull/18602) | Fix bugs in replication lag computation |
 
 ## References
@@ -136,5 +137,5 @@ GET _cat/segment_replication?v
 
 ## Change History
 
-- **v3.3.0** (2025-09-09): Fixed reference count control in NRTReplicationEngine#acquireLastIndexCommit to prevent NoSuchFileException
+- **v3.3.0** (2025-09-09): Fixed NullPointerException in SegmentReplicator.getSegmentReplicationStats() caused by race condition; Fixed reference count control in NRTReplicationEngine#acquireLastIndexCommit to prevent NoSuchFileException
 - **v3.2.0** (2025-07-01): Fixed replication lag computation to use epoch-based timestamps and corrected checkpoint pruning logic

--- a/docs/releases/v3.3.0/features/opensearch/segment-replication.md
+++ b/docs/releases/v3.3.0/features/opensearch/segment-replication.md
@@ -1,0 +1,70 @@
+# Segment Replication
+
+## Summary
+
+This release fixes a NullPointerException (NPE) in the `SegmentReplicator` class that occurred during concurrent indexing and stats requests. The bug caused intermittent test failures in `IndexStatsIT.testConcurrentIndexingAndStatsRequests` when using segment replication strategy.
+
+## Details
+
+### What's New in v3.3.0
+
+Fixed a race condition in `SegmentReplicator.getSegmentReplicationStats()` that could throw a NullPointerException when retrieving replication checkpoint statistics.
+
+### Technical Changes
+
+#### Bug Fix
+
+The issue occurred in the `getSegmentReplicationStats()` method of `SegmentReplicator.java`. The original code checked if the concurrent map was empty using `isEmpty()`, but entries could be removed between the check and subsequent `firstEntry()`/`lastEntry()` calls, resulting in null values.
+
+**Before (vulnerable to race condition):**
+```java
+if (existingCheckpointStats == null || existingCheckpointStats.isEmpty()) {
+    return ReplicationStats.empty();
+}
+Map.Entry<Long, ReplicationCheckpointStats> lowestEntry = existingCheckpointStats.firstEntry();
+Map.Entry<Long, ReplicationCheckpointStats> highestEntry = existingCheckpointStats.lastEntry();
+// NPE if entries removed between isEmpty() check and here
+```
+
+**After (thread-safe):**
+```java
+if (existingCheckpointStats == null) {
+    return ReplicationStats.empty();
+}
+Map.Entry<Long, ReplicationCheckpointStats> lowestEntry = existingCheckpointStats.firstEntry();
+Map.Entry<Long, ReplicationCheckpointStats> highestEntry = existingCheckpointStats.lastEntry();
+if (lowestEntry == null || highestEntry == null) {
+    return ReplicationStats.empty();
+}
+```
+
+#### Root Cause
+
+The `ConcurrentNavigableMap` used for storing checkpoint stats is modified concurrently:
+- Entries are added when new checkpoints arrive
+- Entries are pruned when old checkpoints are cleaned up
+
+The `isEmpty()` check was not atomic with the subsequent `firstEntry()`/`lastEntry()` calls, creating a time-of-check to time-of-use (TOCTOU) race condition.
+
+### Migration Notes
+
+No migration required. This is a bug fix that improves stability when using segment replication with concurrent stats requests.
+
+## Limitations
+
+None specific to this fix.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18997](https://github.com/opensearch-project/OpenSearch/pull/18997) | Fix NPE in segment replicator |
+
+## References
+
+- [Issue #15836](https://github.com/opensearch-project/OpenSearch/issues/15836): Flaky test report for IndexStatsIT
+- [Segment Replication Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/segment-replication/index/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/segment-replication.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -21,6 +21,7 @@
 - [S3 Repository Compatibility Fix](features/opensearch/s3-repository.md)
 - [Scaled Float Field Precision Fix](features/opensearch/scaled-float-field.md)
 - [Search Stats - Negative Value Handling](features/opensearch/search-stats.md)
+- [Segment Replication](features/opensearch/segment-replication.md)
 - [Store Subdirectory Module](features/opensearch/store-subdirectory-module.md)
 - [Terms Query Rewriting](features/opensearch/terms-query-rewriting.md)
 - [Tiered Caching](features/opensearch/tiered-caching.md)


### PR DESCRIPTION
## Summary

Add release report for Segment Replication NPE fix in v3.3.0.

### Changes
- Created release report: `docs/releases/v3.3.0/features/opensearch/segment-replication.md`
- Updated feature report: `docs/features/opensearch/segment-replication.md`
- Updated release index

### Key Fix
Fixed a NullPointerException in `SegmentReplicator.getSegmentReplicationStats()` caused by a race condition when entries are removed from the concurrent map between the `isEmpty()` check and subsequent `firstEntry()`/`lastEntry()` calls.

### Related
- PR: opensearch-project/OpenSearch#18997
- Issue: #1422