### PR TITLE
docs: add index-refresh report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -71,6 +71,7 @@
 - [Gradle Build System](opensearch/gradle-build-system.md)
 - [HTTP Client](opensearch/http-client.md)
 - [Identity Feature Flag Removal](opensearch/identity-feature-flag-removal.md)
+- [Index Refresh](opensearch/index-refresh.md)
 - [Java Runtime & JPMS](opensearch/java-runtime-and-jpms.md)
 - [Lucene 10 Upgrade](opensearch/lucene-10-upgrade.md)
 - [Lucene Similarity](opensearch/lucene-similarity.md)

--- a/docs/features/opensearch/index-refresh.md
+++ b/docs/features/opensearch/index-refresh.md
@@ -1,0 +1,136 @@
+# Index Refresh
+
+## Summary
+
+Index refresh is a core OpenSearch operation that makes newly indexed documents searchable by transferring them from the memory buffer to Lucene segments. OpenSearch provides configurable refresh policies (`IMMEDIATE`, `WAIT_UNTIL`, `NONE`) that control when and how refresh operations occur. This feature documentation covers the refresh mechanism and related optimizations.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph Indexing["Document Indexing"]
+        A[Document] --> B[Memory Buffer]
+        B --> C{Refresh Trigger}
+    end
+    
+    subgraph Refresh["Refresh Operation"]
+        C -->|Automatic| D[Create New Segment]
+        C -->|Manual| D
+        C -->|API Request| D
+        D --> E[Documents Searchable]
+    end
+    
+    subgraph Policies["Refresh Policies"]
+        F[IMMEDIATE] -->|Refresh after each operation| C
+        G[WAIT_UNTIL] -->|Wait for next refresh| C
+        H[NONE] -->|No automatic refresh| C
+    end
+```
+
+### Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant OpenSearch
+    participant Shard
+    participant Translog
+    participant Segment
+    
+    Client->>OpenSearch: Index Document
+    OpenSearch->>Shard: Route to Primary
+    Shard->>Translog: Write to Translog
+    Shard->>Shard: Add to Memory Buffer
+    
+    alt refresh=true
+        Shard->>Segment: Create New Segment
+        Segment-->>Client: Document Searchable
+    else refresh=wait_for
+        Shard-->>Client: Wait for Next Refresh
+        Note over Shard: Background refresh
+        Shard->>Segment: Create New Segment
+    else refresh=false
+        Shard-->>Client: Return Immediately
+        Note over Shard: Document not yet searchable
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `TransportShardBulkAction` | Handles bulk write operations and refresh policy enforcement |
+| `AsyncAfterWriteAction` | Executes post-replication actions including refresh |
+| `IndexShard` | Manages shard-level refresh operations |
+| `RefreshPolicy` | Enum defining refresh behavior (IMMEDIATE, WAIT_UNTIL, NONE) |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.refresh_interval` | How often the index should refresh automatically | `1s` |
+| `index.search.idle.after` | Time after which an index is considered idle | `30s` |
+| `refresh` (API parameter) | Per-request refresh policy | `false` |
+
+### Usage Example
+
+```bash
+# Set refresh interval for an index
+PUT /my-index/_settings
+{
+  "index": {
+    "refresh_interval": "30s"
+  }
+}
+
+# Index with immediate refresh
+POST /my-index/_doc?refresh=true
+{
+  "field": "value"
+}
+
+# Update with retry and refresh
+POST /my-index/_update/1?retry_on_conflict=5&refresh=true
+{
+  "doc": {
+    "counter": 1
+  }
+}
+
+# Manual refresh
+POST /my-index/_refresh
+
+# Disable automatic refresh (for bulk loading)
+PUT /my-index/_settings
+{
+  "index": {
+    "refresh_interval": "-1"
+  }
+}
+```
+
+## Limitations
+
+- Frequent refresh operations are resource-intensive (CPU, memory, I/O)
+- `refresh=true` adds latency to write operations
+- In high-conflict scenarios with `retry_on_conflict`, unnecessary refreshes could occur (fixed in v3.3.0)
+- Disabling refresh (`-1`) requires manual refresh to make documents searchable
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#18917](https://github.com/opensearch-project/OpenSearch/pull/18917) | Fix unnecessary refreshes during update retry conflicts |
+
+## References
+
+- [Issue #15261](https://github.com/opensearch-project/OpenSearch/issues/15261): Bug report for unnecessary refresh on update conflicts
+- [Refresh Index API](https://docs.opensearch.org/3.0/api-reference/index-apis/refresh/): Official API documentation
+- [Index Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/index-settings/): Configuration reference
+- [Optimize OpenSearch Refresh Interval](https://opensearch.org/blog/optimize-refresh-interval/): Best practices blog
+
+## Change History
+
+- **v3.3.0**: Fixed unnecessary refresh operations during update retry conflicts ([#18917](https://github.com/opensearch-project/OpenSearch/pull/18917))

--- a/docs/releases/v3.3.0/features/opensearch/index-refresh.md
+++ b/docs/releases/v3.3.0/features/opensearch/index-refresh.md
@@ -1,0 +1,96 @@
+# Index Refresh
+
+## Summary
+
+This release fixes a performance issue where unnecessary index refresh operations were triggered during update retry conflicts. When using the `_update` API with `retry_on_conflict` and `refresh=true`, OpenSearch was incorrectly triggering refresh operations for each failed retry attempt, causing significant performance degradation in high-conflict scenarios.
+
+## Details
+
+### What's New in v3.3.0
+
+The fix ensures that refresh operations are only triggered when actual writes occur, not when update preparation fails due to version conflicts.
+
+### Technical Changes
+
+#### Problem Background
+
+When using the `_update` API with:
+- `retry_on_conflict > 0` (to handle concurrent updates)
+- `refresh=true` or `refresh=wait_for` (to make changes immediately searchable)
+
+Each retry attempt that failed due to a version conflict was triggering a refresh operation. In high-concurrency scenarios with many conflicts, this could result in thousands of unnecessary refreshes per minute, severely impacting indexing performance.
+
+#### Architecture Changes
+
+```mermaid
+flowchart TB
+    subgraph Before["Before Fix"]
+        A1[Update Request] --> B1[Attempt Update]
+        B1 --> C1{Version Conflict?}
+        C1 -->|Yes| D1[Trigger Refresh]
+        D1 --> E1[Retry]
+        E1 --> B1
+        C1 -->|No| F1[Success + Refresh]
+    end
+    
+    subgraph After["After Fix"]
+        A2[Update Request] --> B2[Attempt Update]
+        B2 --> C2{Version Conflict?}
+        C2 -->|Yes| D2[Skip Refresh]
+        D2 --> E2[Retry]
+        E2 --> B2
+        C2 -->|No| F2[Success + Refresh]
+    end
+```
+
+#### Implementation Details
+
+The fix modifies `TransportShardBulkAction.java` to check if any actual writes occurred before triggering a refresh:
+
+| Component | Change |
+|-----------|--------|
+| `TransportShardBulkAction` | Added logic to suppress refresh when `locationToSync` is null |
+| `BulkShardRequest` | Creates modified request with `RefreshPolicy.NONE` when no writes occurred |
+
+The key change is in the `finishRequest()` method:
+- If `locationToSync` is null (no writes occurred), the refresh policy is changed to `NONE`
+- The original refresh policy is preserved for successful operations
+- Refresh still occurs once when the update eventually succeeds
+
+### Usage Example
+
+```json
+// Update with retry_on_conflict - refresh now only happens on success
+POST /my-index/_update/1?retry_on_conflict=5&refresh=true
+{
+  "doc": {
+    "counter": 1
+  }
+}
+```
+
+### Migration Notes
+
+No migration required. This is a transparent performance improvement that maintains the same API behavior while eliminating unnecessary refresh operations.
+
+## Limitations
+
+- The fix only applies to update operations with `retry_on_conflict`
+- Refresh behavior for successful operations remains unchanged
+- Does not affect bulk operations where some items succeed and others fail (refresh still occurs for successful items)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18917](https://github.com/opensearch-project/OpenSearch/pull/18917) | Fix unnecessary refreshes during update retry conflicts |
+
+## References
+
+- [Issue #15261](https://github.com/opensearch-project/OpenSearch/issues/15261): Original bug report - TransportUpdateAction trigger refresh for every failed retry attempt
+- [Refresh Index API](https://docs.opensearch.org/3.0/api-reference/index-apis/refresh/): Official documentation
+- [Optimize OpenSearch Refresh Interval](https://opensearch.org/blog/optimize-refresh-interval/): Blog post on refresh optimization
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/index-refresh.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -11,6 +11,7 @@
 - [Cross-Cluster Settings](features/opensearch/cross-cluster-settings.md)
 - [Derived Fields](features/opensearch/derived-fields.md)
 - [Flaky Test Fixes](features/opensearch/flaky-test-fixes.md)
+- [Index Refresh](features/opensearch/index-refresh.md)
 - [Netty Arena Settings](features/opensearch/netty-arena-settings.md)
 - [NRT Replication Engine](features/opensearch/nrt-replication-engine.md)
 - [OOM Prevention](features/opensearch/oom-prevention.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Index Refresh fix in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/index-refresh.md`
- Feature report: `docs/features/opensearch/index-refresh.md`

### Key Changes in v3.3.0
- Fixed unnecessary refresh operations during update retry conflicts
- When using `_update` API with `retry_on_conflict` and `refresh=true`, refresh now only triggers on successful writes
- Improves indexing performance in high-conflict scenarios

### Resources Used
- PR: [#18917](https://github.com/opensearch-project/OpenSearch/pull/18917)
- Issue: [#15261](https://github.com/opensearch-project/OpenSearch/issues/15261)
- Docs: [Refresh Index API](https://docs.opensearch.org/3.0/api-reference/index-apis/refresh/)
- Blog: [Optimize OpenSearch Refresh Interval](https://opensearch.org/blog/optimize-refresh-interval/)

Closes #1421