### PR TITLE
docs: add index-output report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -71,6 +71,7 @@
 - [Gradle Build System](opensearch/gradle-build-system.md)
 - [HTTP Client](opensearch/http-client.md)
 - [Identity Feature Flag Removal](opensearch/identity-feature-flag-removal.md)
+- [Index Output Optimization](opensearch/index-output.md)
 - [Index Refresh](opensearch/index-refresh.md)
 - [Java Runtime & JPMS](opensearch/java-runtime-and-jpms.md)
 - [Lucene 10 Upgrade](opensearch/lucene-10-upgrade.md)

--- a/docs/features/opensearch/index-output.md
+++ b/docs/features/opensearch/index-output.md
@@ -1,0 +1,103 @@
+# Index Output Optimization
+
+## Summary
+
+OpenSearch uses `ByteSizeCachingDirectory` to wrap the underlying Lucene directory and cache byte size calculations for efficient storage management. This feature ensures that primitive write methods (`writeInt`, `writeShort`, `writeLong`) in the wrapped `IndexOutput` are properly delegated to the underlying output stream, enabling optimized bulk writes instead of byte-by-byte operations.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Store Layer"
+        Store[Store] --> BSCD[ByteSizeCachingDirectory]
+        BSCD --> Dir[Underlying Directory]
+    end
+    
+    subgraph "IndexOutput Wrapping"
+        BSCD --> |createOutput| WIO[Wrapped IndexOutput]
+        WIO --> |delegates| UIO[Underlying IndexOutput]
+    end
+    
+    subgraph "Write Operations"
+        App[Application] --> WIO
+        WIO --> |writeBytes| UIO
+        WIO --> |writeByte| UIO
+        WIO --> |writeInt| UIO
+        WIO --> |writeShort| UIO
+        WIO --> |writeLong| UIO
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Indexing Operation] --> B[Store.createOutput]
+    B --> C[ByteSizeCachingDirectory]
+    C --> D[Wrapped IndexOutput]
+    D --> E{Write Method}
+    E --> |writeInt/Short/Long| F[Direct Delegation]
+    E --> |writeBytes/Byte| G[Tracked Write]
+    F --> H[Underlying IndexOutput]
+    G --> H
+    H --> I[Disk/Storage]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ByteSizeCachingDirectory` | Directory wrapper that caches byte size calculations and tracks modifications |
+| `FilterIndexOutput` | Anonymous inner class that wraps `IndexOutput` to track writes and delegate operations |
+| `SingleObjectCache` | Cache for storing computed directory size with refresh logic |
+
+### How It Works
+
+1. **Directory Wrapping**: `Store` wraps the underlying directory with `ByteSizeCachingDirectory` to track storage size
+2. **Output Wrapping**: When `createOutput()` or `createTempOutput()` is called, the returned `IndexOutput` is wrapped
+3. **Write Tracking**: The wrapper tracks open outputs and modification counts for cache invalidation
+4. **Method Delegation**: Write methods delegate to the underlying `IndexOutput`:
+   - `writeBytes()` and `writeByte()` - tracked for size caching
+   - `writeInt()`, `writeShort()`, `writeLong()` - direct delegation for performance
+
+### Configuration
+
+This is an internal optimization with no user-configurable settings. The behavior is automatically applied to all index operations.
+
+### Usage Example
+
+The optimization is transparent to users. Any indexing operation benefits automatically:
+
+```json
+PUT /my-index/_doc/1
+{
+  "numeric_field": 12345,
+  "timestamp": 1704067200000
+}
+```
+
+Numeric fields and timestamps use primitive writes internally, which now benefit from optimized delegation.
+
+## Limitations
+
+- Internal optimization only - no user-facing configuration
+- Performance improvement varies based on workload (more benefit for numeric-heavy indices)
+- Only affects primitive write methods; byte array writes were already optimized
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19432](https://github.com/opensearch-project/OpenSearch/pull/19432) | Delegate primitive write methods with ByteSizeCachingDirectory wrapped IndexOutput |
+
+## References
+
+- [Issue #19420](https://github.com/opensearch-project/OpenSearch/issues/19420): Original bug report
+- [Lucene PR #321](https://github.com/apache/lucene/pull/321): Lucene optimization for primitive writes
+- [ByteSizeCachingDirectory.java](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/store/ByteSizeCachingDirectory.java): Source code
+
+## Change History
+
+- **v3.3.0** (2025-09-28): Added delegation for `writeInt`, `writeShort`, `writeLong` methods to improve BKD merge performance

--- a/docs/releases/v3.3.0/features/opensearch/index-output.md
+++ b/docs/releases/v3.3.0/features/opensearch/index-output.md
@@ -1,0 +1,97 @@
+# Index Output Primitive Write Delegation
+
+## Summary
+
+This release improves indexing performance by delegating primitive write methods (`writeInt`, `writeShort`, `writeLong`) in `ByteSizeCachingDirectory`'s wrapped `IndexOutput`. Previously, these methods fell back to byte-by-byte writing, which was inefficient. This optimization speeds up BKD tree merges and other index operations that use primitive writes.
+
+## Details
+
+### What's New in v3.3.0
+
+The `ByteSizeCachingDirectory` class wraps the underlying directory to cache byte size calculations. When creating `IndexOutput` instances, it wraps them with `FilterIndexOutput` to track modifications. However, the wrapper did not delegate primitive write methods, causing them to use the default `DataOutput` implementation that writes byte-by-byte.
+
+This change adds direct delegation for:
+- `writeInt(int i)`
+- `writeShort(short i)`
+- `writeLong(long i)`
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.3.0"
+        A1[Application] --> B1[FilterIndexOutput]
+        B1 --> C1[writeLong/writeInt/writeShort]
+        C1 --> D1[Default: writeByte loop]
+        D1 --> E1[Underlying IndexOutput]
+    end
+    
+    subgraph "After v3.3.0"
+        A2[Application] --> B2[FilterIndexOutput]
+        B2 --> C2[writeLong/writeInt/writeShort]
+        C2 --> E2[Underlying IndexOutput directly]
+    end
+```
+
+#### Modified Components
+
+| Component | Description |
+|-----------|-------------|
+| `ByteSizeCachingDirectory` | Added delegation for `writeInt`, `writeShort`, `writeLong` in the wrapped `IndexOutput` |
+
+#### Code Changes
+
+The following methods were added to the anonymous `FilterIndexOutput` class in `ByteSizeCachingDirectory.wrapIndexOutput()`:
+
+```java
+@Override
+public void writeInt(int i) throws IOException {
+    out.writeInt(i);
+}
+
+@Override
+public void writeShort(short i) throws IOException {
+    out.writeShort(i);
+}
+
+@Override
+public void writeLong(long i) throws IOException {
+    out.writeLong(i);
+}
+```
+
+### Performance Impact
+
+This optimization benefits operations that write primitive types frequently, particularly:
+- **BKD tree merges**: BKD trees (used for numeric and geo fields) write many primitive values during merge operations
+- **Segment merges**: General segment merge operations that write structured data
+- **Index creation**: Initial indexing of documents with numeric fields
+
+The improvement aligns with Lucene's optimization in [apache/lucene#321](https://github.com/apache/lucene/pull/321), which introduced optimized primitive writes in `IndexOutput`.
+
+### Usage Example
+
+No configuration changes required. The optimization is automatically applied to all index operations using `ByteSizeCachingDirectory`.
+
+## Limitations
+
+- This is an internal optimization with no user-facing configuration
+- Performance gains depend on workload characteristics (more benefit for numeric-heavy indices)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19432](https://github.com/opensearch-project/OpenSearch/pull/19432) | Delegate primitive write methods with ByteSizeCachingDirectory wrapped IndexOutput |
+
+## References
+
+- [Issue #19420](https://github.com/opensearch-project/OpenSearch/issues/19420): Bug report identifying the missing delegation
+- [Lucene PR #321](https://github.com/apache/lucene/pull/321): Original Lucene optimization for primitive writes
+- [RateLimitedIndexOutput](https://github.com/apache/lucene/blob/main/lucene/core/src/java/org/apache/lucene/store/RateLimitedIndexOutput.java): Lucene reference implementation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/index-output.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -11,6 +11,7 @@
 - [Cross-Cluster Settings](features/opensearch/cross-cluster-settings.md)
 - [Derived Fields](features/opensearch/derived-fields.md)
 - [Flaky Test Fixes](features/opensearch/flaky-test-fixes.md)
+- [Index Output](features/opensearch/index-output.md)
 - [Index Refresh](features/opensearch/index-refresh.md)
 - [Netty Arena Settings](features/opensearch/netty-arena-settings.md)
 - [NRT Replication Engine](features/opensearch/nrt-replication-engine.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Index Output optimization feature in OpenSearch v3.3.0.

## Changes

- **Release report**: `docs/releases/v3.3.0/features/opensearch/index-output.md`
- **Feature report**: `docs/features/opensearch/index-output.md`
- Updated release and feature indexes

## Feature Overview

This release improves indexing performance by delegating primitive write methods (`writeInt`, `writeShort`, `writeLong`) in `ByteSizeCachingDirectory`'s wrapped `IndexOutput`. Previously, these methods fell back to byte-by-byte writing, which was inefficient. This optimization speeds up BKD tree merges and other index operations.

## Related

- PR: [opensearch-project/OpenSearch#19432](https://github.com/opensearch-project/OpenSearch/pull/19432)
- Issue: [opensearch-project/OpenSearch#19420](https://github.com/opensearch-project/OpenSearch/issues/19420)
- Closes #1420