### PR TITLE
docs: add lucene-migration report for v3.3.0

### DIFF
--- a/docs/features/opensearch/lucene-upgrade.md
+++ b/docs/features/opensearch/lucene-upgrade.md
@@ -69,6 +69,7 @@ GET /_nodes?filter_path=nodes.*.version
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#19397](https://github.com/opensearch-project/OpenSearch/pull/19397) | Migrate deprecated usages of Operations#union |
 | v3.1.0 | [#17961](https://github.com/opensearch-project/OpenSearch/pull/17961) | Upgrade to Lucene 10.2.1 |
 | v3.1.0 | [#18395](https://github.com/opensearch-project/OpenSearch/pull/18395) | Replace deprecated TopScoreDocCollectorManager construction |
 | v3.1.0 | [neural-search#1336](https://github.com/opensearch-project/neural-search/pull/1336) | Update Lucene dependencies for hybrid query |
@@ -88,6 +89,7 @@ GET /_nodes?filter_path=nodes.*.version
 
 ## Change History
 
+- **v3.3.0**: Migrate deprecated `Operations#union(Automaton, Automaton)` usages to `Operations#union(Collection<Automaton>)` in AutomatonQueries, XContentMapValues, and SystemIndices classes.
 - **v3.1.0**: Upgrade to Apache Lucene 10.2.1 with SeededKnnVectorQuery, binary quantized vector codecs, TopDocs#rrf, and API changes (DisiPriorityQueue, TopScoreDocCollectorManager). Plugin updates: neural-search hybrid query refactoring, learning-to-rank RankerQuery fix.
 - **v3.0.0**: Upgrade to Apache Lucene 10
 - **v2.18.0**: Upgrade to Apache Lucene 9.12.0 with new Lucene912PostingsFormat, JDK 23 Panama Vectorization support, dynamic range facets, and various performance optimizations

--- a/docs/releases/v3.3.0/features/opensearch/lucene-migration.md
+++ b/docs/releases/v3.3.0/features/opensearch/lucene-migration.md
@@ -1,0 +1,104 @@
+# Lucene Migration
+
+## Summary
+
+This release migrates deprecated usages of Lucene's `Operations#union(Automaton, Automaton)` method to the non-deprecated `Operations#union(Collection<Automaton>)` variant. This is a code maintenance change that ensures OpenSearch remains compatible with future Lucene versions while preserving existing behavior.
+
+## Details
+
+### What's New in v3.3.0
+
+The deprecated two-argument `Operations#union` method from Apache Lucene's automaton utilities has been replaced with the collection-based variant across multiple OpenSearch components.
+
+### Technical Changes
+
+#### API Migration
+
+The Lucene `Operations` class provides automaton manipulation utilities. The two-argument union method was deprecated in favor of a more flexible collection-based approach:
+
+| Old API (Deprecated) | New API |
+|---------------------|---------|
+| `Operations.union(Automaton, Automaton)` | `Operations.union(Collection<Automaton>)` |
+
+#### Modified Components
+
+| Component | File | Change |
+|-----------|------|--------|
+| AutomatonQueries | `server/src/main/java/org/opensearch/common/lucene/search/AutomatonQueries.java` | Updated `toCaseInsensitiveChar()` to use `Arrays.asList()` wrapper |
+| XContentMapValues | `server/src/main/java/org/opensearch/common/xcontent/support/XContentMapValues.java` | Refactored `makeMatchDotsInFieldNames()` to use collection-based union |
+| SystemIndices | `server/src/main/java/org/opensearch/indices/SystemIndices.java` | Simplified `buildCharacterRunAutomaton()` using stream collection |
+
+### Code Changes
+
+#### AutomatonQueries.java
+
+```java
+// Before (deprecated)
+result = Operations.union(case1, Automata.makeChar(altCase));
+
+// After
+result = Operations.union(Arrays.asList(case1, Automata.makeChar(altCase)));
+```
+
+#### XContentMapValues.java
+
+```java
+// Before (deprecated)
+return Operations.determinize(
+    Operations.union(automaton, Operations.concatenate(...)),
+    Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
+);
+
+// After
+Automaton automatonMatchingFields = Operations.concatenate(
+    Arrays.asList(automaton, Automata.makeChar('.'), Automata.makeAnyString())
+);
+return Operations.determinize(
+    Operations.union(Arrays.asList(automaton, automatonMatchingFields)),
+    Operations.DEFAULT_DETERMINIZE_WORK_LIMIT
+);
+```
+
+#### SystemIndices.java
+
+```java
+// Before (deprecated)
+Optional<Automaton> automaton = descriptors.stream()
+    .map(descriptor -> Regex.simpleMatchToAutomaton(descriptor.getIndexPattern()))
+    .reduce(Operations::union);
+return new CharacterRunAutomaton(
+    Operations.determinize(automaton.orElse(Automata.makeEmpty()), ...)
+);
+
+// After
+List<Automaton> automatons = descriptors.stream()
+    .map(descriptor -> Regex.simpleMatchToAutomaton(descriptor.getIndexPattern()))
+    .collect(Collectors.toList());
+return new CharacterRunAutomaton(
+    Operations.determinize(Operations.union(automatons), ...)
+);
+```
+
+### Migration Notes
+
+This is an internal code change with no user-facing impact. No migration steps are required.
+
+## Limitations
+
+- This is a code maintenance change only
+- No functional changes to automaton behavior
+- No configuration changes required
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19397](https://github.com/opensearch-project/OpenSearch/pull/19397) | Migrate deprecated usages of Operations#union |
+
+## References
+
+- [Apache Lucene Operations API](https://lucene.apache.org/core/10_0_0/core/org/apache/lucene/util/automaton/Operations.html): Lucene automaton operations documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/lucene-upgrade.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -13,6 +13,7 @@
 - [Flaky Test Fixes](features/opensearch/flaky-test-fixes.md)
 - [Index Output](features/opensearch/index-output.md)
 - [Index Refresh](features/opensearch/index-refresh.md)
+- [Lucene Migration](features/opensearch/lucene-migration.md)
 - [Netty Arena Settings](features/opensearch/netty-arena-settings.md)
 - [NRT Replication Engine](features/opensearch/nrt-replication-engine.md)
 - [OOM Prevention](features/opensearch/oom-prevention.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Lucene Migration feature in OpenSearch v3.3.0.

### Changes

- **Release report**: `docs/releases/v3.3.0/features/opensearch/lucene-migration.md`
- **Feature report update**: `docs/features/opensearch/lucene-upgrade.md` (added v3.3.0 entry)
- **Release index update**: Added link to new report

### Key Changes in v3.3.0

- Migrated deprecated `Operations#union(Automaton, Automaton)` usages to `Operations#union(Collection<Automaton>)`
- Updated components: AutomatonQueries, XContentMapValues, SystemIndices
- Code maintenance change with no user-facing impact

### Related Issue

Closes #1419