### PR TITLE
docs: add plugin-installation report for v3.3.0

### DIFF
--- a/docs/features/opensearch/plugin-installation.md
+++ b/docs/features/opensearch/plugin-installation.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-OpenSearch provides a command-line tool (`opensearch-plugin`) for managing plugins. This tool allows users to install, list, and remove plugins from their OpenSearch installation. Plugin installation includes signature verification using PGP keys to ensure artifact integrity and authenticity.
+OpenSearch provides a command-line tool (`opensearch-plugin`) for managing plugins. This tool allows users to install, list, and remove plugins from their OpenSearch installation. Plugin installation includes signature verification using PGP keys to ensure artifact integrity and authenticity. Starting from v3.3.0, plugins can also include directory structures in their config folder.
 
 ## Details
 
@@ -15,6 +15,7 @@ graph TB
         Download[Download Plugin]
         Verify[Verify Signature]
         Install[Install Plugin]
+        Config[Copy Config Files/Dirs]
     end
     
     subgraph "Signature Verification"
@@ -23,9 +24,22 @@ graph TB
         SIG[Signature File]
     end
     
+    subgraph "Config Processing v3.3.0+"
+        Check{Is Directory?}
+        CopyDir[Copy Recursively]
+        CopyFile[Copy File]
+        Perms[Set Permissions]
+    end
+    
     CLI --> Download
     Download --> Verify
     Verify --> Install
+    Install --> Config
+    Config --> Check
+    Check -->|Yes| CopyDir
+    Check -->|No| CopyFile
+    CopyDir --> Perms
+    CopyFile --> Perms
     
     PGP --> Verify
     BC --> Verify
@@ -40,6 +54,8 @@ graph TB
 | `PluginCli` | Entry point for the plugin CLI tool |
 | `public_key.sig` | PGP public key for signature verification |
 | BouncyCastle FIPS | Cryptographic provider for PGP operations |
+| `copyDirectoryRecursively()` | Recursively copies directory structures (v3.3.0+) |
+| `copyWithPermissions()` | Copies files/dirs with proper permissions (v3.3.0+) |
 
 ### Configuration
 
@@ -98,6 +114,7 @@ The verification process:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#19343](https://github.com/opensearch-project/OpenSearch/pull/19343) | Allow plugins to copy folders into their config dir during installation |
 | v3.1.0 | [#18147](https://github.com/opensearch-project/OpenSearch/pull/18147) | Fix native plugin installation error caused by PGP public key change |
 
 ## References
@@ -107,4 +124,5 @@ The verification process:
 
 ## Change History
 
+- **v3.3.0** (2026-01-11): Added support for copying directories to plugin config folder during installation
 - **v3.1.0** (2026-01-10): Fixed signature verification failure caused by PGP public key change; added BouncyCastle FIPS provider initialization

--- a/docs/releases/v3.3.0/features/opensearch/plugin-installation.md
+++ b/docs/releases/v3.3.0/features/opensearch/plugin-installation.md
@@ -1,0 +1,115 @@
+# Plugin Installation: Directory Support in Config
+
+## Summary
+
+OpenSearch v3.3.0 relaxes the plugin installation CLI to allow plugins to copy directories (not just files) to their config folder during installation. This enables plugins like security-analytics to maintain their existing folder structure for bundled resources such as sigma rules.
+
+## Details
+
+### What's New in v3.3.0
+
+Previously, the `opensearch-plugin install` command only allowed plugins to copy individual files from `src/main/config` to their config folder (`config/{plugin-name}`). Directories were explicitly rejected with an error.
+
+With this change:
+- Plugins can now include subdirectories in their config folder
+- Directory structures are recursively copied during installation
+- Proper permissions are applied to both directories and files
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Plugin Installation (v3.3.0)"
+        CLI[opensearch-plugin install]
+        Extract[Extract Plugin ZIP]
+        Config[Process Config Dir]
+        
+        subgraph "Config Processing"
+            Check{Is Directory?}
+            CopyDir[Copy Directory Recursively]
+            CopyFile[Copy File]
+            Perms[Set Permissions]
+        end
+    end
+    
+    CLI --> Extract
+    Extract --> Config
+    Config --> Check
+    Check -->|Yes| CopyDir
+    Check -->|No| CopyFile
+    CopyDir --> Perms
+    CopyFile --> Perms
+```
+
+#### Modified Components
+
+| Component | Change |
+|-----------|--------|
+| `InstallPluginCommand.installConfig()` | Removed directory rejection; added recursive copy support |
+| `InstallPluginCommand.copyWithPermissions()` | New helper method for copying with permissions |
+| `InstallPluginCommand.copyDirectoryRecursively()` | New method for recursive directory copying |
+
+#### Behavior Change
+
+| Aspect | Before v3.3.0 | v3.3.0+ |
+|--------|---------------|---------|
+| Directories in config | Rejected with `UserException` | Recursively copied |
+| Directory permissions | N/A | `CONFIG_DIR_PERMS` applied |
+| File permissions | `CONFIG_FILES_PERMS` | `CONFIG_FILES_PERMS` (unchanged) |
+| Ownership | Inherited from parent | Explicitly set from destination config dir |
+
+### Usage Example
+
+Plugin developers can now structure their config like this:
+
+```
+my-plugin/
+├── src/main/config/
+│   ├── settings.yml
+│   └── rules/
+│       ├── category1/
+│       │   └── rule1.yml
+│       └── category2/
+│           └── rule2.yml
+```
+
+After installation, the config folder will be:
+
+```
+config/my-plugin/
+├── settings.yml
+└── rules/
+    ├── category1/
+    │   └── rule1.yml
+    └── category2/
+        └── rule2.yml
+```
+
+### Migration Notes
+
+- No migration required for existing plugins
+- Plugin developers can now move resources from JAR classpath to config folder
+- Existing config files are not overwritten during reinstallation
+
+## Limitations
+
+- Config directories are only copied if they don't already exist at the destination
+- Existing files/directories are preserved (not overwritten)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19343](https://github.com/opensearch-project/OpenSearch/pull/19343) | Allow plugins to copy folders into their config dir during installation |
+
+## References
+
+- [PR #19343](https://github.com/opensearch-project/OpenSearch/pull/19343): Main implementation
+- [security-analytics sigma rules](https://github.com/opensearch-project/security-analytics/tree/main/src/main/resources/rules): Motivation for this change
+- [Documentation](https://docs.opensearch.org/3.0/install-and-configure/plugins/): Installing plugins
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/plugin-installation.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -17,6 +17,7 @@
 - [Netty Arena Settings](features/opensearch/netty-arena-settings.md)
 - [NRT Replication Engine](features/opensearch/nrt-replication-engine.md)
 - [OOM Prevention](features/opensearch/oom-prevention.md)
+- [Plugin Installation](features/opensearch/plugin-installation.md)
 - [Query Phase Fixes](features/opensearch/query-phase-fixes.md)
 - [Reactor Netty Transport](features/opensearch/reactor-netty-transport.md)
 - [Reindex API](features/opensearch/reindex-api.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Plugin Installation enhancement in OpenSearch v3.3.0.

### Changes in v3.3.0
- Plugins can now copy directories (not just files) to their config folder during installation
- Enables plugins like security-analytics to maintain folder structure for bundled resources (e.g., sigma rules)
- Recursive directory copying with proper permissions

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/plugin-installation.md`
- Feature report: `docs/features/opensearch/plugin-installation.md` (updated)

### Related PR
- [opensearch-project/OpenSearch#19343](https://github.com/opensearch-project/OpenSearch/pull/19343)