### PR TITLE
docs: add test-infrastructure report for v3.3.0

### DIFF
--- a/docs/features/opensearch/code-coverage-gradle.md
+++ b/docs/features/opensearch/code-coverage-gradle.md
@@ -167,6 +167,8 @@ $buildDir/build/reports/jacoco/test/html/
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#19165](https://github.com/opensearch-project/OpenSearch/pull/19165) | Include internalClusterTests and yamlRestTest in code coverage report |
+| v3.3.0 | [#19085](https://github.com/opensearch-project/OpenSearch/pull/19085) | Grant access to testclusters dir for tests |
 | v3.2.0 | [#18509](https://github.com/opensearch-project/OpenSearch/pull/18509) | Initial implementation - local code coverage with Gradle |
 
 ## References
@@ -174,9 +176,11 @@ $buildDir/build/reports/jacoco/test/html/
 - [PR #18509](https://github.com/opensearch-project/OpenSearch/pull/18509): Main implementation
 - [PR #18358](https://github.com/opensearch-project/OpenSearch/pull/18358): Related coverage improvement work
 - [PR #18376](https://github.com/opensearch-project/OpenSearch/pull/18376): javaRestTest coverage addition
+- [Issue #19140](https://github.com/opensearch-project/OpenSearch/issues/19140): Bug report - Code coverage report does not include internalClusterTests
 - [JaCoCo Gradle Plugin](https://docs.gradle.org/current/userguide/jacoco_plugin.html): Official Gradle documentation
 - [Issue #850](https://github.com/opensearch-project/OpenSearch/issues/850): Original feature request for test coverage reporting
 
 ## Change History
 
+- **v3.3.0** (2025-10-14): Expanded coverage to include internalClusterTest and yamlRestTest; added testclusters directory permissions
 - **v3.2.0** (2025-06-13): Initial implementation - ability to run code coverage locally with Gradle and produce JaCoCo reports

--- a/docs/releases/v3.3.0/features/opensearch/test-infrastructure.md
+++ b/docs/releases/v3.3.0/features/opensearch/test-infrastructure.md
@@ -1,0 +1,144 @@
+# Test Infrastructure
+
+## Summary
+
+OpenSearch v3.3.0 enhances the test infrastructure with expanded code coverage reporting and improved security manager permissions for test clusters. These changes ensure more comprehensive test coverage metrics and enable plugins to properly access test cluster directories during integration tests.
+
+## Details
+
+### What's New in v3.3.0
+
+1. **Expanded Code Coverage Reports**: The Gradle check task now includes coverage reports for `internalClusterTest` and `yamlRestTest` in addition to existing unit tests and `javaRestTest`.
+
+2. **Test Clusters Directory Access**: Fixed security manager permissions to allow tests to read/write to the testclusters directory, resolving issues with cross-cluster replication and other plugin tests.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Gradle Check Task"
+        CT[check task]
+    end
+    
+    subgraph "Coverage Report Tasks"
+        TCR[testCodeCoverageReport<br/>Unit Tests]
+        TCRI[testCodeCoverageReportInternalClusterTest<br/>NEW in v3.3.0]
+        TCRJ[testCodeCoverageReportJavaRestTest]
+        TCRY[testCodeCoverageReportYamlRestTest<br/>NEW in v3.3.0]
+    end
+    
+    subgraph "Execution Data Files"
+        ED1[test.exec]
+        ED2[internalClusterTest.exec]
+        ED3[javaRestTest.exec]
+        ED4[yamlRestTest.exec]
+    end
+    
+    CT --> TCR
+    CT --> TCRI
+    CT --> TCRJ
+    CT --> TCRY
+    
+    ED1 --> TCR
+    ED2 --> TCRI
+    ED3 --> TCRJ
+    ED4 --> TCRY
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `testCodeCoverageReportInternalClusterTest` | New JaCoCo report task for internal cluster tests |
+| `testCodeCoverageReportYamlRestTest` | New JaCoCo report task for YAML REST tests |
+| `testclusters.dir` permission | Security manager permission for test cluster directory access |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `testclusters.dir` | System property specifying the test clusters directory path | `$buildDir/testclusters` |
+
+### Code Changes
+
+#### gradle/code-coverage.gradle
+
+The coverage configuration now includes yamlRestTest source sets and execution data:
+
+```groovy
+// Added yamlRestTest support
+if (tasks.findByName('yamlRestTest')) {
+  executionDataFiles.add("$buildDir/jacoco/yamlRestTest.exec")
+  sourceSetsList.add(sourceSets.yamlRestTest)
+}
+
+// New report tasks attached to check
+project.getTasks().named(JavaBasePlugin.CHECK_TASK_NAME).configure {
+  dependsOn(
+    tasks.named('testCodeCoverageReport', JacocoReport),
+    tasks.named('testCodeCoverageReportInternalClusterTest', JacocoReport),
+    tasks.named('testCodeCoverageReportJavaRestTest', JacocoReport),
+    tasks.named('testCodeCoverageReportYamlRestTest', JacocoReport)
+  )
+}
+```
+
+#### BootstrapForTesting.java
+
+Added permission for testclusters directory:
+
+```java
+String testclustersDir = System.getProperty("testclusters.dir");
+if (testclustersDir != null) {
+    FilePermissionUtils.addDirectoryPath(
+        perms,
+        "testclusters.dir",
+        PathUtils.get(testclustersDir),
+        "read,readlink,write,delete",
+        false
+    );
+}
+```
+
+### Usage Example
+
+```bash
+# Run all tests with coverage enabled (now includes internalClusterTest and yamlRestTest)
+./gradlew check -Dtests.coverage=true
+
+# For plugins using testclusters, add the system property
+systemProperty 'testclusters.dir', project.layout.buildDirectory.get().file("testclusters").asFile.absolutePath
+```
+
+### Migration Notes
+
+For plugins that copy files to test cluster config directories (like cross-cluster-replication), add the following to your `build.gradle`:
+
+```groovy
+integTest {
+    systemProperty 'testclusters.dir', project.layout.buildDirectory.get().file("testclusters").asFile.absolutePath
+}
+```
+
+## Limitations
+
+- The `testclusters.dir` system property must be explicitly set for plugins that need to write to test cluster directories
+- Coverage reports are only generated when `tests.coverage=true` is set
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19165](https://github.com/opensearch-project/OpenSearch/pull/19165) | Include internalClusterTests and yamlRestTest in code coverage report |
+| [#19085](https://github.com/opensearch-project/OpenSearch/pull/19085) | Grant access to testclusters dir for tests |
+
+## References
+
+- [Issue #19140](https://github.com/opensearch-project/OpenSearch/issues/19140): Bug report - Code coverage report does not include internalClusterTests
+- [PR #1571](https://github.com/opensearch-project/cross-cluster-replication/pull/1571): CCR issue that triggered testclusters fix
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/code-coverage-gradle.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -28,6 +28,7 @@
 - [Segment Replication](features/opensearch/segment-replication.md)
 - [Store Subdirectory Module](features/opensearch/store-subdirectory-module.md)
 - [Terms Query Rewriting](features/opensearch/terms-query-rewriting.md)
+- [Test Infrastructure](features/opensearch/test-infrastructure.md)
 - [Tiered Caching](features/opensearch/tiered-caching.md)
 
 ### OpenSearch Dashboards


### PR DESCRIPTION
## Summary

This PR adds documentation for the Test Infrastructure improvements in OpenSearch v3.3.0.

### Changes in v3.3.0

1. **Expanded Code Coverage Reports** (PR #19165)
   - Added `testCodeCoverageReportInternalClusterTest` task
   - Added `testCodeCoverageReportYamlRestTest` task
   - All coverage reports now attached to Gradle check task

2. **Test Clusters Directory Access** (PR #19085)
   - Added security manager permission for `testclusters.dir`
   - Fixes issues with plugins writing to test cluster config directories

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/test-infrastructure.md`
- Feature report updated: `docs/features/opensearch/code-coverage-gradle.md`

### Related Issue
Closes #1417