### PR TITLE
docs: add Engine API report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -61,6 +61,7 @@
 - [Derived Source](opensearch/derived-source.md)
 - [Docker Compose v2 Support](opensearch/docker-compose-v2-support.md)
 - [Dynamic Threadpool Resize](opensearch/dynamic-threadpool-resize.md)
+- [Engine API](opensearch/engine-api.md)
 - [Engine Optimization Fixes](opensearch/engine-optimization-fixes.md)
 - [Locale Provider](opensearch/locale-provider.md)
 - [HTTP API](opensearch/http-api.md)

--- a/docs/features/opensearch/engine-api.md
+++ b/docs/features/opensearch/engine-api.md
@@ -1,0 +1,141 @@
+# Engine API
+
+## Summary
+
+The Engine API provides the core abstraction for OpenSearch's storage engine layer. The `Engine` class and its inner classes (`Result`, `IndexResult`, `DeleteResult`, `NoOpResult`) define the interface for document operations including indexing, deletion, and no-op operations. This API enables custom storage engine implementations and extensions.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Engine Layer"
+        Engine["Engine (abstract)"]
+        InternalEngine["InternalEngine"]
+        ReadOnlyEngine["ReadOnlyEngine"]
+        NRTReplicationEngine["NRTReplicationEngine"]
+    end
+    
+    subgraph "Engine.Result Hierarchy"
+        Result["Result (abstract)"]
+        IndexResult["IndexResult"]
+        DeleteResult["DeleteResult"]
+        NoOpResult["NoOpResult"]
+    end
+    
+    subgraph "Operations"
+        Index["Index Operation"]
+        Delete["Delete Operation"]
+        NoOp["NoOp Operation"]
+    end
+    
+    Engine --> Result
+    InternalEngine --> Engine
+    ReadOnlyEngine --> Engine
+    NRTReplicationEngine --> Engine
+    
+    Result --> IndexResult
+    Result --> DeleteResult
+    Result --> NoOpResult
+    
+    Index --> IndexResult
+    Delete --> DeleteResult
+    NoOp --> NoOpResult
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `Engine` | Abstract base class for all storage engine implementations |
+| `Engine.Result` | Base class for operation results containing version, sequence number, and timing |
+| `Engine.IndexResult` | Result of an index operation, includes `created` flag |
+| `Engine.DeleteResult` | Result of a delete operation, includes `found` flag |
+| `Engine.NoOpResult` | Result of a no-op operation for replication |
+| `Engine.Operation` | Base class for operations (Index, Delete, NoOp) |
+
+### Engine.Result Methods
+
+| Method | Description | Visibility |
+|--------|-------------|------------|
+| `getVersion()` | Returns the document version | `public` |
+| `getSeqNo()` | Returns the sequence number | `public` |
+| `getTerm()` | Returns the primary term | `public` |
+| `getResultType()` | Returns SUCCESS, FAILURE, or MAPPING_UPDATE_REQUIRED | `public` |
+| `getTranslogLocation()` | Returns the translog location | `public` |
+| `getFailure()` | Returns the exception if operation failed | `public` |
+| `getTook()` | Returns operation time in nanoseconds | `public` |
+| `setTranslogLocation()` | Sets the translog location | `public` |
+| `setTook()` | Sets the operation time | `public` |
+| `freeze()` | Freezes the result to prevent modifications | `public` |
+
+### Usage Example
+
+```java
+// Custom Engine implementation
+public class CustomEngine extends Engine {
+    
+    @Override
+    public IndexResult index(Index index) throws IOException {
+        long startTime = System.nanoTime();
+        
+        // Perform the indexing operation
+        long version = /* computed version */;
+        long term = /* primary term */;
+        long seqNo = /* sequence number */;
+        boolean created = /* true if new document */;
+        
+        IndexResult result = new IndexResult(version, term, seqNo, created);
+        
+        // Set translog location and timing
+        Translog.Location location = /* write to translog */;
+        result.setTranslogLocation(location);
+        result.setTook(System.nanoTime() - startTime);
+        result.freeze();
+        
+        return result;
+    }
+    
+    @Override
+    public DeleteResult delete(Delete delete) throws IOException {
+        // Similar pattern for delete operations
+        DeleteResult result = new DeleteResult(version, term, seqNo, found);
+        result.setTranslogLocation(location);
+        result.setTook(took);
+        result.freeze();
+        return result;
+    }
+}
+```
+
+### Result Types
+
+```java
+public enum Type {
+    SUCCESS,              // Operation completed successfully
+    FAILURE,              // Operation failed with exception
+    MAPPING_UPDATE_REQUIRED  // Operation needs mapping update first
+}
+```
+
+## Limitations
+
+- `freeze()` can only be called once; subsequent modifications throw `IllegalStateException`
+- Result objects are not thread-safe during construction
+- Custom engines must properly manage the result lifecycle
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19275](https://github.com/opensearch-project/OpenSearch/pull/19275) | Make all methods in Engine.Result public |
+
+## References
+
+- [Issue #19276](https://github.com/opensearch-project/OpenSearch/issues/19276): Feature request for public Engine.Result methods
+- [Engine.java](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/engine/Engine.java): Source code
+
+## Change History
+
+- **v3.3.0** (2025-09-12): Made `setTranslogLocation()`, `setTook()`, and `freeze()` methods public to enable custom Engine implementations

--- a/docs/releases/v3.3.0/features/opensearch/engine-api.md
+++ b/docs/releases/v3.3.0/features/opensearch/engine-api.md
@@ -1,0 +1,97 @@
+# Engine API
+
+## Summary
+
+This release makes all methods in `Engine.Result` public, enabling custom Engine implementations to properly set translog location, timing information, and freeze results. This change improves extensibility for developers building custom storage engines.
+
+## Details
+
+### What's New in v3.3.0
+
+The `Engine.Result` class methods have been changed from package-private to public visibility:
+
+- `setTranslogLocation(Translog.Location)` - Sets the translog location after an operation
+- `setTook(long)` - Sets the time taken for the operation in nanoseconds
+- `freeze()` - Freezes the result to prevent further modifications
+
+### Technical Changes
+
+#### API Visibility Changes
+
+| Method | Previous Visibility | New Visibility |
+|--------|---------------------|----------------|
+| `setTranslogLocation()` | package-private | `public` |
+| `setTook()` | package-private | `public` |
+| `freeze()` | package-private | `public` |
+
+#### Architecture Context
+
+```mermaid
+graph TB
+    subgraph "Engine Hierarchy"
+        Engine["Engine (abstract)"]
+        InternalEngine["InternalEngine"]
+        CustomEngine["Custom Engine Extensions"]
+    end
+    
+    subgraph "Engine.Result"
+        Result["Result (abstract)"]
+        IndexResult["IndexResult"]
+        DeleteResult["DeleteResult"]
+        NoOpResult["NoOpResult"]
+    end
+    
+    Engine --> Result
+    InternalEngine --> Engine
+    CustomEngine --> Engine
+    Result --> IndexResult
+    Result --> DeleteResult
+    Result --> NoOpResult
+```
+
+### Usage Example
+
+Custom Engine implementations can now properly manage result state:
+
+```java
+public class CustomEngine extends Engine {
+    
+    @Override
+    public IndexResult index(Index index) throws IOException {
+        long startTime = System.nanoTime();
+        
+        // Perform indexing operation
+        IndexResult result = new IndexResult(version, term, seqNo, created);
+        
+        // Now accessible from custom Engine implementations
+        result.setTranslogLocation(translogLocation);
+        result.setTook(System.nanoTime() - startTime);
+        result.freeze();
+        
+        return result;
+    }
+}
+```
+
+### Migration Notes
+
+No migration required. This is a backward-compatible change that only increases API visibility.
+
+## Limitations
+
+- The `freeze()` method can only be called once per result; subsequent calls to `setTranslogLocation()` or `setTook()` after freezing will throw `IllegalStateException`
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19275](https://github.com/opensearch-project/OpenSearch/pull/19275) | Make all methods in Engine.Result public |
+
+## References
+
+- [Issue #19276](https://github.com/opensearch-project/OpenSearch/issues/19276): Feature request to make Engine.Result methods public
+- [Engine.java](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/engine/Engine.java): Source code
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/engine-api.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -10,6 +10,7 @@
 - [Concurrent Segment Search](features/opensearch/concurrent-segment-search.md)
 - [Cross-Cluster Settings](features/opensearch/cross-cluster-settings.md)
 - [Derived Fields](features/opensearch/derived-fields.md)
+- [Engine API](features/opensearch/engine-api.md)
 - [Flaky Test Fixes](features/opensearch/flaky-test-fixes.md)
 - [Index Output](features/opensearch/index-output.md)
 - [Index Refresh](features/opensearch/index-refresh.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Engine API feature in OpenSearch v3.3.0.

### Changes
- **Release report**: `docs/releases/v3.3.0/features/opensearch/engine-api.md`
- **Feature report**: `docs/features/opensearch/engine-api.md`
- Updated release index and features index

### Key Changes in v3.3.0
- Made `Engine.Result#setTranslogLocation()`, `setTook()`, and `freeze()` methods public
- Enables custom Engine implementations to properly manage result state

### Related
- Closes #1416
- PR: [opensearch-project/OpenSearch#19275](https://github.com/opensearch-project/OpenSearch/pull/19275)
- Issue: [opensearch-project/OpenSearch#19276](https://github.com/opensearch-project/OpenSearch/issues/19276)