### PR TITLE
docs: add wildcard-field-mapper report for v3.3.0

### DIFF
--- a/docs/features/opensearch/wildcard-field.md
+++ b/docs/features/opensearch/wildcard-field.md
@@ -142,6 +142,7 @@ GET logs/_search
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#18568](https://github.com/opensearch-project/OpenSearch/pull/18568) | Fix sorting bug by disabling pruning for doc_values |
 | v3.0.0 | [#17349](https://github.com/opensearch-project/OpenSearch/pull/17349) | Optimize to 3-gram only indexing |
 | v2.18.0 | [#15737](https://github.com/opensearch-project/OpenSearch/pull/15737) | Fix wildcard query containing escaped character |
 | v2.18.0 | [#15882](https://github.com/opensearch-project/OpenSearch/pull/15882) | Fix case-insensitive query on wildcard field |
@@ -150,6 +151,7 @@ GET logs/_search
 ## References
 
 - [Wildcard Field Documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/wildcard/): Official documentation
+- [Issue #18461](https://github.com/opensearch-project/OpenSearch/issues/18461): Bug report for wildcard sort error with doc_values
 - [Issue #17099](https://github.com/opensearch-project/OpenSearch/issues/17099): 3-gram optimization feature request with benchmarks
 - [Issue #15555](https://github.com/opensearch-project/OpenSearch/issues/15555): Bug report for escaped wildcard character handling
 - [Issue #15855](https://github.com/opensearch-project/OpenSearch/issues/15855): Bug report for case-insensitive query issue
@@ -157,6 +159,7 @@ GET logs/_search
 
 ## Change History
 
+- **v3.3.0** (2025-09-10): Fixed sorting bug when `doc_values` enabled by disabling Lucene's dynamic pruning optimization
 - **v3.0.0** (2025-05-06): Changed indexing strategy from 1-3 gram to 3-gram only, reducing index size by ~20% and improving write throughput by 5-30%
 - **v2.18.0** (2024-11-05): Fixed escaped wildcard character handling and case-insensitive query behavior
 - **v2.15.0** (2024-06-25): Initial introduction of wildcard field type with 1-3 gram indexing

--- a/docs/releases/v3.3.0/features/opensearch/wildcard-field-mapper.md
+++ b/docs/releases/v3.3.0/features/opensearch/wildcard-field-mapper.md
@@ -1,0 +1,118 @@
+# Wildcard Field Mapper
+
+## Summary
+
+OpenSearch v3.3.0 fixes a critical sorting bug in the wildcard field type when `doc_values` is enabled. Previously, sorting on wildcard fields with doc values would throw an `IllegalStateException` when the result size was less than the total document count. This fix disables Lucene's dynamic pruning optimization for wildcard fields, ensuring correct sorting behavior.
+
+## Details
+
+### What's New in v3.3.0
+
+This release resolves a bug where sorting on wildcard fields with `doc_values: true` would fail with an `IllegalStateException`. The issue occurred because Lucene's dynamic pruning optimization expected the term dictionary to contain the same values as doc values, but wildcard fields use n-gram tokenization for terms while storing full values in doc values.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.3.0"
+        A1[Wildcard Field] --> B1[SortedSetOrdinalsIndexFieldData]
+        B1 --> C1[Lucene Pruning Enabled]
+        C1 --> D1[IllegalStateException]
+    end
+    
+    subgraph "After v3.3.0"
+        A2[Wildcard Field] --> B2[NonPruningSortedSetOrdinalsIndexFieldData]
+        B2 --> C2[Pruning Disabled]
+        C2 --> D2[Correct Sort Results]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `NonPruningSortedSetOrdinalsIndexFieldData` | Wrapper for `SortedSetOrdinalsIndexFieldData` that disables pruning optimization |
+| `NonPruningSortField` | Custom `SortField` implementation that explicitly sets `Pruning.NONE` |
+| `FilteredSortField` | Abstract base class for delegating sort field operations |
+
+#### Root Cause
+
+The wildcard field type uses `SortedSetDocValues` for doc values, which triggers Lucene's dynamic pruning during sorting. Lucene's `TermOrdValComparator` expects the term dictionary to contain the same values as doc values. However, wildcard fields:
+
+- **Term dictionary**: Contains n-gram tokens (e.g., `tes`, `est` for "test")
+- **Doc values**: Contains full original values (e.g., "test")
+
+This mismatch caused `IllegalStateException` when pruning tried to look up doc values in the term dictionary.
+
+### Usage Example
+
+Sorting on wildcard fields now works correctly:
+
+```json
+PUT test
+{
+  "mappings": {
+    "properties": {
+      "my_field": {
+        "type": "wildcard",
+        "fields": {
+          "doc_values": {
+            "type": "wildcard",
+            "doc_values": true
+          }
+        }
+      }
+    }
+  }
+}
+
+POST test/_bulk
+{"index": {"_id": "1"}}
+{"my_field": "zebra"}
+{"index": {"_id": "2"}}
+{"my_field": "apple"}
+{"index": {"_id": "3"}}
+{"my_field": "banana"}
+
+GET test/_search
+{
+  "query": {
+    "wildcard": {
+      "my_field": "*"
+    }
+  },
+  "sort": [
+    { "my_field.doc_values": { "order": "asc" } }
+  ],
+  "size": 2
+}
+```
+
+Before v3.3.0, this query would fail. Now it correctly returns documents sorted alphabetically.
+
+### Migration Notes
+
+No migration is required. The fix is transparent and automatically applies to all wildcard fields with doc values enabled.
+
+## Limitations
+
+- Sorting performance on wildcard fields may be slightly slower than keyword fields due to disabled pruning optimization
+- This is a necessary trade-off to ensure correctness given the n-gram indexing strategy
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18568](https://github.com/opensearch-project/OpenSearch/pull/18568) | Disable pruning for `doc_values` for the wildcard field mapper |
+
+## References
+
+- [Issue #18461](https://github.com/opensearch-project/OpenSearch/issues/18461): Bug report for wildcard sort error
+- [Lucene TermOrdValComparator](https://github.com/apache/lucene/blob/485141dd34ea866ad9dc59843770969d1b0c8fa2/lucene/core/src/java/org/apache/lucene/search/comparators/TermOrdValComparator.java#L569-L572): Source of the pruning logic
+- [Wildcard Field Documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/wildcard/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/wildcard-field.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -31,6 +31,7 @@
 - [Terms Query Rewriting](features/opensearch/terms-query-rewriting.md)
 - [Test Infrastructure](features/opensearch/test-infrastructure.md)
 - [Tiered Caching](features/opensearch/tiered-caching.md)
+- [Wildcard Field Mapper](features/opensearch/wildcard-field-mapper.md)
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the wildcard field mapper fix in OpenSearch v3.3.0.

### Changes

- **Release report**: `docs/releases/v3.3.0/features/opensearch/wildcard-field-mapper.md`
  - Documents the fix for sorting bug when `doc_values` is enabled
  - Explains the root cause (n-gram vs full value mismatch)
  - Describes the new `NonPruningSortedSetOrdinalsIndexFieldData` component

- **Feature report update**: `docs/features/opensearch/wildcard-field.md`
  - Added v3.3.0 entry to Change History
  - Added PR #18568 to Related PRs table
  - Added Issue #18461 to References

### Key Technical Details

The fix introduces `NonPruningSortedSetOrdinalsIndexFieldData` which wraps the standard field data and explicitly disables Lucene's dynamic pruning optimization. This is necessary because wildcard fields store n-gram tokens in the term dictionary but full values in doc values, causing a mismatch that triggers `IllegalStateException` during sorting.

### Related

- Resolves investigation for Issue #1415
- PR: [opensearch-project/OpenSearch#18568](https://github.com/opensearch-project/OpenSearch/pull/18568)
- Issue: [opensearch-project/OpenSearch#18461](https://github.com/opensearch-project/OpenSearch/issues/18461)