### PR TITLE
docs: add Docker Image Updates report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -60,6 +60,7 @@
 - [Derived Fields](opensearch/derived-fields.md)
 - [Derived Source](opensearch/derived-source.md)
 - [Docker Compose v2 Support](opensearch/docker-compose-v2-support.md)
+- [Docker Image Base](opensearch/docker-image-base.md)
 - [Dynamic Threadpool Resize](opensearch/dynamic-threadpool-resize.md)
 - [Engine API](opensearch/engine-api.md)
 - [Engine Optimization Fixes](opensearch/engine-optimization-fixes.md)

--- a/docs/features/opensearch/docker-image-base.md
+++ b/docs/features/opensearch/docker-image-base.md
@@ -1,0 +1,98 @@
+# Docker Image Base
+
+## Summary
+
+OpenSearch Docker images are built on a Linux base image that provides the foundation for running OpenSearch in containerized environments. The base image selection impacts security updates, package availability, and long-term support. OpenSearch has migrated from CentOS 8 to AlmaLinux 8 to ensure continued maintenance and security patches.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Docker Build Process"
+        A[DockerBase.java] --> B[build.gradle]
+        B --> C[Dockerfile]
+        C --> D[Base Image]
+        D --> E[OpenSearch Docker Image]
+    end
+    
+    subgraph "Base Image Selection"
+        D --> F[almalinux:8]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `DockerBase.java` | Enum defining available base images for Docker builds |
+| `build.gradle` | Gradle build configuration for Docker image creation |
+| `Dockerfile` | Docker build instructions using the selected base image |
+
+### Supported Base Images
+
+| Base Image | Status | Notes |
+|------------|--------|-------|
+| AlmaLinux 8 | Current | RHEL 8 compatible, actively maintained |
+| CentOS 8 | Deprecated | EOL, no longer supported |
+
+### Configuration
+
+The Docker base image is configured in the build system:
+
+```java
+// buildSrc/src/main/java/org/opensearch/gradle/DockerBase.java
+public enum DockerBase {
+    ALMALINUX("almalinux:8");
+    
+    private final String image;
+}
+```
+
+### Installed Packages
+
+The Docker image includes these essential packages:
+
+| Package | Purpose |
+|---------|---------|
+| `nmap-ncat` | Network connectivity testing |
+| `shadow-utils` | User/group management |
+| `zip` | Archive creation |
+| `unzip` | Archive extraction |
+
+### Usage Example
+
+```bash
+# Pull the official OpenSearch Docker image
+docker pull opensearchproject/opensearch:latest
+
+# Run OpenSearch container
+docker run -d -p 9200:9200 -p 9600:9600 \
+  -e "discovery.type=single-node" \
+  opensearchproject/opensearch:latest
+```
+
+## Limitations
+
+- Only AlmaLinux 8 is supported as the base image for official builds
+- Custom base images require modifications to the build system
+- ARM64 and x64 architectures are supported
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19154](https://github.com/opensearch-project/OpenSearch/pull/19154) | Replace centos:8 with almalinux:8 |
+
+## References
+
+- [OpenSearch Docker Installation](https://docs.opensearch.org/3.3/install-and-configure/install-opensearch/docker/)
+- [Compatible Operating Systems](https://docs.opensearch.org/3.3/install-and-configure/os-comp/)
+- [CentOS Docker Hub Deprecation](https://hub.docker.com/_/centos)
+- [AlmaLinux](https://almalinux.org/)
+- [opensearch-build Issue #4573](https://github.com/opensearch-project/opensearch-build/issues/4573): OS compatibility changes
+
+## Change History
+
+- **v3.3.0** (2025-08-27): Migrated from CentOS 8 to AlmaLinux 8 base image

--- a/docs/releases/v3.3.0/features/opensearch/docker-image-updates.md
+++ b/docs/releases/v3.3.0/features/opensearch/docker-image-updates.md
@@ -1,0 +1,97 @@
+# Docker Image Updates
+
+## Summary
+
+OpenSearch v3.3.0 replaces the deprecated CentOS 8 base image with AlmaLinux 8 for Docker builds. This change ensures continued support and security updates for the Docker distribution, as CentOS 8 reached end-of-life and its Docker images are no longer maintained.
+
+## Details
+
+### What's New in v3.3.0
+
+The Docker build infrastructure has been updated to use AlmaLinux 8 as the base image instead of CentOS 8. This migration was necessary because CentOS Docker images are deprecated and no longer receiving updates.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.3.0"
+        A1[Dockerfile] --> B1[centos:8]
+        B1 --> C1[OpenSearch Image]
+    end
+    subgraph "v3.3.0+"
+        A2[Dockerfile] --> B2[almalinux:8]
+        B2 --> C2[OpenSearch Image]
+    end
+```
+
+#### Changed Components
+
+| Component | Before | After |
+|-----------|--------|-------|
+| Base Image | `centos:8` | `almalinux:8` |
+| Package Manager | `yum` with mirror workarounds | `dnf` |
+| Network Tools | `nc` | `nmap-ncat` |
+
+#### Build System Changes
+
+| File | Change |
+|------|--------|
+| `DockerBase.java` | Renamed `CENTOS` enum to `ALMALINUX` |
+| `distribution/docker/build.gradle` | Updated references from `DockerBase.CENTOS` to `DockerBase.ALMALINUX` |
+| `Dockerfile` | Simplified package installation using `dnf` |
+
+### Dockerfile Changes
+
+The Dockerfile was simplified by removing CentOS-specific mirror workarounds:
+
+**Before (CentOS 8):**
+```dockerfile
+RUN sed -i 's/mirrorlist/#mirrorlist/g' /etc/yum.repos.d/CentOS-Linux-* && \
+    sed -i 's|#baseurl=http://mirror.centos.org|baseurl=http://vault.epel.cloud|g' /etc/yum.repos.d/CentOS-Linux-* && \
+    for iter in {1..10}; do \
+      ${package_manager} update --setopt=tsflags=nodocs -y && \
+      ${package_manager} install --setopt=tsflags=nodocs -y nc shadow-utils zip unzip && \
+      ${package_manager} clean all && exit_code=0 && break || ...
+    done
+```
+
+**After (AlmaLinux 8):**
+```dockerfile
+RUN set -e \
+    && dnf -y update \
+    && dnf -y install --setopt=tsflags=nodocs nmap-ncat shadow-utils zip unzip \
+    && dnf clean all \
+    && rm -rf /var/cache/dnf
+```
+
+### Migration Notes
+
+This change is transparent to users. The OpenSearch Docker images will continue to work the same way, but are now built on a supported base image.
+
+- No changes required for existing Docker deployments
+- No changes to exposed ports, volumes, or environment variables
+- AlmaLinux 8 is binary-compatible with RHEL 8 and CentOS 8
+
+## Limitations
+
+- This change only affects the official OpenSearch Docker images
+- Custom Docker builds using CentOS 8 should migrate to AlmaLinux 8 or another supported base
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19154](https://github.com/opensearch-project/OpenSearch/pull/19154) | Replace centos:8 with almalinux:8 since centos docker images are deprecated |
+
+## References
+
+- [CentOS Docker Hub Deprecation Notice](https://hub.docker.com/_/centos)
+- [AlmaLinux Official Site](https://almalinux.org/)
+- [OpenSearch Compatible Operating Systems](https://docs.opensearch.org/3.3/install-and-configure/os-comp/)
+- [opensearch-build Issue #4573](https://github.com/opensearch-project/opensearch-build/issues/4573): Remove CentOS8, add Almalinux8/Rockylinux8
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/docker-image-base.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -10,6 +10,7 @@
 - [Concurrent Segment Search](features/opensearch/concurrent-segment-search.md)
 - [Cross-Cluster Settings](features/opensearch/cross-cluster-settings.md)
 - [Derived Fields](features/opensearch/derived-fields.md)
+- [Docker Image Updates](features/opensearch/docker-image-updates.md)
 - [Engine API](features/opensearch/engine-api.md)
 - [Flaky Test Fixes](features/opensearch/flaky-test-fixes.md)
 - [Index Output](features/opensearch/index-output.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Docker Image Updates feature in OpenSearch v3.3.0.

### Changes
- **Release report**: `docs/releases/v3.3.0/features/opensearch/docker-image-updates.md`
- **Feature report**: `docs/features/opensearch/docker-image-base.md`
- Updated release and feature indexes

### Key Changes in v3.3.0
- Replaced deprecated CentOS 8 base image with AlmaLinux 8
- Simplified Dockerfile by removing CentOS mirror workarounds
- Updated package manager from `yum` to `dnf`
- Changed network tools package from `nc` to `nmap-ncat`

### Related
- Closes #1414
- PR: opensearch-project/OpenSearch#19154