### PR TITLE
docs: add field-data-cache report for v3.3.0

### DIFF
--- a/docs/features/opensearch/field-data-cache.md
+++ b/docs/features/opensearch/field-data-cache.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-The Field Data Cache is a node-level cache in OpenSearch that stores field data used for sorting, aggregations, and scripting on text fields. It loads field values into memory for efficient access during search operations. The cache uses a composite key structure and provides mechanisms for cache clearing during index operations.
+The Field Data Cache is a node-level cache in OpenSearch that stores field data used for sorting, aggregations, and scripting on text fields. It loads field values into memory for efficient access during search operations. Starting from v3.3.0, the cache has a default size limit of 35% of heap and supports dynamic configuration.
 
 ## Details
 
@@ -13,6 +13,7 @@ graph TB
     subgraph "Node Level"
         IFC[IndicesFieldDataCache]
         IFC --> Cache[(Cache Store)]
+        IFC --> Cleaner[Scheduled Cleaner Thread]
     end
     
     subgraph "Index Level"
@@ -29,6 +30,12 @@ graph TB
         IF --> IDX[Index Details]
     end
     
+    subgraph "Cleanup Tracking"
+        indicesToClear[indicesToClear Set]
+        fieldsToClear[fieldsToClear Map]
+        cacheKeysToClear[cacheKeysToClear Set]
+    end
+    
     subgraph "Operations"
         Load[Load Field Data]
         Clear[Clear Cache]
@@ -38,6 +45,9 @@ graph TB
     IFDS --> Load
     IFDS --> Clear
     IFDS --> Invalidate
+    Cleaner --> indicesToClear
+    Cleaner --> fieldsToClear
+    Cleaner --> cacheKeysToClear
 ```
 
 ### Data Flow
@@ -52,9 +62,11 @@ flowchart TB
         Store --> Return
     end
     
-    subgraph "Cache Invalidation"
-        Refresh[Index Refresh] --> Inv[Invalidate Stale Keys]
-        Remove[Index Removal] --> Clear[Clear Index Entries]
+    subgraph "Cache Invalidation (v3.3.0+)"
+        Refresh[Index Refresh] --> Mark[Mark Keys for Cleanup]
+        Remove[Index Removal] --> Mark
+        Mark --> Cleaner[Scheduled Cleaner Thread]
+        Cleaner --> Clear[Clear Marked Entries]
     end
 ```
 
@@ -66,20 +78,22 @@ flowchart TB
 | `IndexFieldDataService` | Index-level service managing field data operations |
 | `IndexFieldCache` | Per-index cache wrapper containing field name and index details |
 | `CircuitBreakerService` | Memory protection to prevent OOM from excessive cache growth |
+| `Scheduled Cleaner Thread` | Background thread for asynchronous cache cleanup (v3.3.0+) |
 
 ### Configuration
 
-| Setting | Description | Default |
-|---------|-------------|---------|
-| `indices.fielddata.cache.size` | Maximum size of the field data cache | Unbounded |
-| `indices.breaker.fielddata.limit` | Circuit breaker limit for field data | 40% of JVM heap |
-| `indices.breaker.fielddata.overhead` | Multiplier for field data memory estimation | 1.03 |
+| Setting | Description | Default | Dynamic |
+|---------|-------------|---------|---------|
+| `indices.fielddata.cache.size` | Maximum size of the field data cache | 35% of heap (v3.3.0+), unbounded (pre-v3.3.0) | Yes (v3.3.0+) |
+| `indices.breaker.fielddata.limit` | Circuit breaker limit for field data | 40% of JVM heap | Yes |
+| `indices.breaker.fielddata.overhead` | Multiplier for field data memory estimation | 1.03 | Yes |
 
 ### Cache Clearing Scenarios
 
-1. **Index Refresh**: During shard refresh, stale cache entries are invalidated synchronously
-2. **Index Removal**: When an index is deleted, all associated cache entries are cleared
+1. **Index Refresh**: During shard refresh, stale cache entries are marked for cleanup
+2. **Index Removal**: When an index is deleted, all associated cache entries are marked for cleanup
 3. **Manual Clear**: Using the Clear Cache API to explicitly clear field data
+4. **Segment Close**: When index reader segments close, associated entries are invalidated
 
 ### Usage Example
 
@@ -93,24 +107,37 @@ Clear field data cache for specific index:
 POST /my-index/_cache/clear?fielddata=true
 ```
 
+Update cache size dynamically (v3.3.0+):
+```bash
+PUT _cluster/settings
+{
+  "persistent": {
+    "indices.fielddata.cache.size": "30%"
+  }
+}
+```
+
 ## Limitations
 
-- Field data cache size is unbounded by default, controlled only by circuit breakers
-- Cache clearing during index removal iterates over all cache keys (inefficient for large caches)
-- No integration with tiered caching (heap + disk) as of v3.2.0
+- No integration with tiered caching (heap + disk) as of v3.3.0
+- Cache size changes trigger eviction asynchronously (not immediate)
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#19152](https://github.com/opensearch-project/OpenSearch/pull/19152) | Make field data cache size setting dynamic and add default limit |
+| v3.3.0 | [#19116](https://github.com/opensearch-project/OpenSearch/pull/19116) | Remove unnecessary looping in field data cache clear |
 | v3.2.0 | [#18888](https://github.com/opensearch-project/OpenSearch/pull/18888) | Close IndexFieldDataService asynchronously |
 
 ## References
 
+- [Issue #19104](https://github.com/opensearch-project/OpenSearch/issues/19104): Change default settings for field data cache size
 - [Issue #13862](https://github.com/opensearch-project/OpenSearch/issues/13862): Optimize FieldDataCache removal flow
 - [CAT Field Data API](https://docs.opensearch.org/3.0/api-reference/cat/cat-field-data/): View field data cache memory usage
 - [Clear Cache API](https://docs.opensearch.org/3.0/api-reference/index-apis/clear-index-cache/): Clear index caches including field data
 
 ## Change History
 
+- **v3.3.0** (2025-09): Added default 35% heap limit, made cache size setting dynamic, optimized cache clearing from O(FN) to O(N) with scheduled cleaner thread
 - **v3.2.0** (2025-08): Changed `IndexFieldDataService.close()` to clear cache asynchronously, preventing cluster applier thread blocking during index removal

--- a/docs/releases/v3.3.0/features/opensearch/field-data-cache.md
+++ b/docs/releases/v3.3.0/features/opensearch/field-data-cache.md
@@ -1,0 +1,107 @@
+# Field Data Cache
+
+## Summary
+
+OpenSearch v3.3.0 introduces significant improvements to the Field Data Cache, including a new default size limit of 35% of heap, dynamic cache size configuration, and optimized cache clearing performance. These changes prevent unexpected CircuitBreakingExceptions and improve cluster stability during index operations.
+
+## Details
+
+### What's New in v3.3.0
+
+1. **Default Cache Size Limit**: The `indices.fielddata.cache.size` setting now defaults to 35% of heap instead of unbounded (-1)
+2. **Dynamic Setting**: Cache size can now be changed at runtime without node restart
+3. **Optimized Cache Clearing**: Removed O(FN) looping during cache clear, reducing clear time from minutes to milliseconds for large caches
+4. **Asynchronous Cleanup**: Cache clearing now uses a scheduled cleaner thread instead of blocking the cluster applier thread
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "v3.3.0 Field Data Cache"
+        IFC[IndicesFieldDataCache]
+        IFC --> Cache[(Cache Store<br/>Default: 35% heap)]
+        IFC --> Cleaner[Scheduled Cleaner Thread]
+        
+        subgraph "Clear Operations"
+            MarkClear[Mark for Cleanup]
+            MarkClear --> indicesToClear[indicesToClear Set]
+            MarkClear --> fieldsToClear[fieldsToClear Map]
+            MarkClear --> cacheKeysToClear[cacheKeysToClear Set]
+        end
+        
+        Cleaner --> |"Periodic cleanup"| Cache
+    end
+    
+    subgraph "Settings"
+        Size[indices.fielddata.cache.size<br/>Default: 35%]
+        Breaker[indices.breaker.fielddata.limit<br/>Default: 40%]
+    end
+    
+    Size --> IFC
+    Breaker --> |"Circuit breaker"| IFC
+```
+
+#### New Configuration
+
+| Setting | Description | Default | Dynamic |
+|---------|-------------|---------|---------|
+| `indices.fielddata.cache.size` | Maximum cache size | 35% of heap | Yes (v3.3.0+) |
+| `indices.breaker.fielddata.limit` | Circuit breaker limit | 40% of heap | Yes |
+
+#### Behavior Changes
+
+**Before v3.3.0:**
+- Cache size unlimited by default, only controlled by circuit breaker
+- Queries exceeding breaker limit caused `CircuitBreakingException`
+- Cache clearing iterated through all N keys once per field (O(FN) complexity)
+- Clearing could take minutes for large caches, causing node drops
+
+**After v3.3.0:**
+- Cache evicts LRU entries when exceeding 35% limit
+- Circuit breaker only triggers for extremely large single entries (>5% heap)
+- Cache clearing uses O(N) iteration with scheduled cleanup thread
+- Clearing completes in milliseconds even for large caches
+
+### Usage Example
+
+Update cache size dynamically:
+```bash
+PUT _cluster/settings
+{
+  "persistent": {
+    "indices.fielddata.cache.size": "30%"
+  }
+}
+```
+
+### Migration Notes
+
+- **Breaking Change**: Default cache behavior changed from unbounded to 35% limit
+- Existing clusters upgrading to v3.3.0 will see automatic LRU eviction when cache exceeds 35%
+- To restore previous behavior: `indices.fielddata.cache.size: -1` (not recommended)
+- Cache clearing is now asynchronous; use `assertBusy()` in tests that verify cache state
+
+## Limitations
+
+- Cache size changes trigger eviction asynchronously (not immediate)
+- No tiered caching support (heap + disk) for field data cache yet
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19152](https://github.com/opensearch-project/OpenSearch/pull/19152) | Make field data cache size setting dynamic and add default limit |
+| [#19116](https://github.com/opensearch-project/OpenSearch/pull/19116) | Remove unnecessary looping in field data cache clear |
+
+## References
+
+- [Issue #19104](https://github.com/opensearch-project/OpenSearch/issues/19104): Change default settings for field data cache size
+- [Issue #13862](https://github.com/opensearch-project/OpenSearch/issues/13862): Optimize FieldDataCache removal flow
+- [CAT Field Data API](https://docs.opensearch.org/3.0/api-reference/cat/cat-field-data/): View field data cache memory usage
+- [Clear Cache API](https://docs.opensearch.org/3.0/api-reference/index-apis/clear-index-cache/): Clear index caches
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/field-data-cache.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -10,6 +10,7 @@
 - [Concurrent Segment Search](features/opensearch/concurrent-segment-search.md)
 - [Cross-Cluster Settings](features/opensearch/cross-cluster-settings.md)
 - [Derived Fields](features/opensearch/derived-fields.md)
+- [Field Data Cache](features/opensearch/field-data-cache.md)
 - [Docker Image Updates](features/opensearch/docker-image-updates.md)
 - [Engine API](features/opensearch/engine-api.md)
 - [Flaky Test Fixes](features/opensearch/flaky-test-fixes.md)


### PR DESCRIPTION
## Summary

Adds documentation for Field Data Cache improvements in OpenSearch v3.3.0.

### Key Changes in v3.3.0

- **Default Cache Size Limit**: `indices.fielddata.cache.size` now defaults to 35% of heap instead of unbounded
- **Dynamic Setting**: Cache size can be changed at runtime without node restart
- **Optimized Cache Clearing**: Reduced cache clear time from O(FN) to O(N) complexity
- **Asynchronous Cleanup**: Cache clearing uses scheduled cleaner thread instead of blocking cluster applier thread

### Reports Created

- Release report: `docs/releases/v3.3.0/features/opensearch/field-data-cache.md`
- Feature report: `docs/features/opensearch/field-data-cache.md` (updated)

### Related PRs

- opensearch-project/OpenSearch#19152: Make field data cache size setting dynamic and add default limit
- opensearch-project/OpenSearch#19116: Remove unnecessary looping in field data cache clear

Closes #1413