### PR TITLE
docs: add painless-scripting report for v3.3.0

### DIFF
--- a/docs/features/opensearch/scripted-metric-aggregation.md
+++ b/docs/features/opensearch/scripted-metric-aggregation.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Scripted metric aggregation is a multi-value metric aggregation that returns metrics calculated from user-defined scripts. It provides flexibility for custom aggregation logic through four script stages: init, map, combine, and reduce. In v3.2.0, support was added for using scripted metric aggregations when reducing `InternalValueCount` and `InternalAvg` aggregations, enabling seamless searches across rollup and raw indices.
+Scripted metric aggregation is a multi-value metric aggregation that returns metrics calculated from user-defined scripts. It provides flexibility for custom aggregation logic through four script stages: init, map, combine, and reduce. In v3.2.0, support was added for using scripted metric aggregations when reducing `InternalValueCount` and `InternalAvg` aggregations, enabling seamless searches across rollup and raw indices. In v3.3.0, the `ScriptedAvg` class was added to the Painless SPI allowlist, enabling plugins to use this class directly in Painless scripts.
 
 ## Details
 
@@ -35,6 +35,16 @@ graph TB
 | `ScriptedAvg` | Helper class containing sum and count for average calculations |
 | `InternalAvg` | Average aggregation with scripted metric support in reduce |
 | `InternalValueCount` | Value count aggregation with scripted metric support in reduce |
+
+### Painless SPI Allowlist (v3.3.0)
+
+The `ScriptedAvg` class is available in Painless scripts with the following methods:
+
+| Method | Description |
+|--------|-------------|
+| `ScriptedAvg(double sum, long count)` | Constructor to create a new ScriptedAvg instance |
+| `double getSum()` | Returns the sum value |
+| `long getCount()` | Returns the count value |
 
 ### Script Stages
 
@@ -119,6 +129,7 @@ GET rollup_index,raw_index/_search
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#19006](https://github.com/opensearch-project/OpenSearch/pull/19006) | Adding ScriptedAvg class to painless spi to allowlist usage from plugins |
 | v3.2.0 | [#18411](https://github.com/opensearch-project/OpenSearch/pull/18411) | Supporting Scripted Metric Aggregation when reducing aggregations in InternalValueCount and InternalAvg |
 
 ## References
@@ -129,4 +140,5 @@ GET rollup_index,raw_index/_search
 
 ## Change History
 
+- **v3.3.0** (2025-08-19): Added `ScriptedAvg` class to Painless SPI allowlist, enabling plugins to use scripted averages in Painless scripts; registered `ScriptedAvg` in `Streamables.java` with byte marker 28 for cross-node streaming
 - **v3.2.0** (2025-08-06): Added support for `InternalScriptedMetric` in `InternalValueCount` and `InternalAvg` reduce methods, enabling searches across rollup and raw indices

--- a/docs/releases/v3.3.0/features/opensearch/painless-scripting.md
+++ b/docs/releases/v3.3.0/features/opensearch/painless-scripting.md
@@ -1,0 +1,116 @@
+# Painless Scripting
+
+## Summary
+
+This release adds the `ScriptedAvg` class to the Painless SPI (Service Provider Interface) allowlist, enabling plugins to use this class in Painless scripts. This is a follow-up enhancement to the v3.2.0 changes that added scripted metric support for reducing aggregations, completing the integration by making `ScriptedAvg` accessible from external plugins.
+
+## Details
+
+### What's New in v3.3.0
+
+The `ScriptedAvg` class has been added to the Painless SPI allowlist, allowing plugins to instantiate and use `ScriptedAvg` objects within Painless scripts. This enables plugins like index-management to properly use scripted metrics when searching across rollup and raw indices together.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Painless SPI Integration"
+        A[Plugin Code] --> B[Painless Script]
+        B --> C[ScriptedAvg Class]
+        C --> D[InternalScriptedMetric]
+        D --> E[InternalAvg.reduce]
+    end
+    
+    subgraph "Streaming Support"
+        F[ScriptedAvg] --> G[Writeable Interface]
+        G --> H[StreamOutput byte 28]
+        H --> I[Cross-node Communication]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ScriptedAvg` in Painless SPI | Allowlisted class for use in Painless scripts |
+| `WriteableRegistry` entry | Registered `ScriptedAvg` with byte marker 28 for streaming |
+
+#### Painless SPI Allowlist Addition
+
+The following methods are now available in Painless scripts:
+
+```java
+class org.opensearch.search.aggregations.metrics.ScriptedAvg {
+  (double, long)    // Constructor with sum and count
+  double getSum()   // Get the sum value
+  long getCount()   // Get the count value
+}
+```
+
+#### Streaming Support
+
+`ScriptedAvg` is now registered in `Streamables.java` with byte marker 28, enabling proper serialization/deserialization across cluster nodes:
+
+```java
+WriteableRegistry.registerWriter(ScriptedAvg.class, (o, v) -> {
+    o.writeByte((byte) 28);
+    ((ScriptedAvg) v).writeTo(o);
+});
+WriteableRegistry.registerReader(Byte.valueOf((byte) 28), ScriptedAvg::new);
+```
+
+### Usage Example
+
+Plugins can now create `ScriptedAvg` objects in Painless scripts for use with rollup aggregations:
+
+```painless
+// In a combine script for rollup aggregations
+def scriptedAvg = new ScriptedAvg(state.sum, state.count);
+return scriptedAvg;
+```
+
+This enables the index-management plugin to properly handle average calculations when searching across rollup and raw indices:
+
+```json
+GET rollup_index,raw_index/_search
+{
+  "size": 0,
+  "aggs": {
+    "avg_value": {
+      "avg": {
+        "field": "numeric_field"
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+No migration required. This is an additive change that enables new functionality for plugins using Painless scripts with scripted metric aggregations.
+
+## Limitations
+
+- `ScriptedAvg` is specifically designed for average calculations with sum and count values
+- The class is intended for use with rollup aggregation scenarios
+- Scripts using `ScriptedAvg` must ensure proper handling in the reduce phase
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19006](https://github.com/opensearch-project/OpenSearch/pull/19006) | Adding ScriptedAvg class to painless spi to allowlist usage from plugins |
+| [#18411](https://github.com/opensearch-project/OpenSearch/pull/18411) | Supporting Scripted Metric in InternalValueCount and InternalAvg (prerequisite) |
+
+## References
+
+- [PR #19006](https://github.com/opensearch-project/OpenSearch/pull/19006): Main implementation
+- [PR #18411](https://github.com/opensearch-project/OpenSearch/pull/18411): Prerequisite PR for scripted metric support
+- [Script APIs Documentation](https://docs.opensearch.org/3.0/api-reference/script-apis/index/): Painless scripting documentation
+- [Scripted Metric Aggregation](https://docs.opensearch.org/3.0/aggregations/metric/scripted-metric/): Scripted metric aggregation documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/scripted-metric-aggregation.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -20,6 +20,7 @@
 - [Netty Arena Settings](features/opensearch/netty-arena-settings.md)
 - [NRT Replication Engine](features/opensearch/nrt-replication-engine.md)
 - [OOM Prevention](features/opensearch/oom-prevention.md)
+- [Painless Scripting](features/opensearch/painless-scripting.md)
 - [Plugin Installation](features/opensearch/plugin-installation.md)
 - [Query Phase Fixes](features/opensearch/query-phase-fixes.md)
 - [Reactor Netty Transport](features/opensearch/reactor-netty-transport.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Painless Scripting enhancement in OpenSearch v3.3.0.

### Changes

**Release Report** (`docs/releases/v3.3.0/features/opensearch/painless-scripting.md`):
- Documents the addition of `ScriptedAvg` class to Painless SPI allowlist
- Explains the streaming support with byte marker 28
- Provides usage examples for plugins using scripted averages

**Feature Report Update** (`docs/features/opensearch/scripted-metric-aggregation.md`):
- Added v3.3.0 entry to Change History
- Added Painless SPI Allowlist section
- Updated summary to include v3.3.0 changes
- Added PR #19006 to Related PRs table

### Key Changes in v3.3.0

- `ScriptedAvg` class added to Painless SPI allowlist
- Registered `ScriptedAvg` in `Streamables.java` with byte marker 28
- Enables plugins (like index-management) to use `ScriptedAvg` in Painless scripts

### Related

- PR: [opensearch-project/OpenSearch#19006](https://github.com/opensearch-project/OpenSearch/pull/19006)
- Issue: [tkykenmt/opensearch-feature-explorer#1412](https://github.com/tkykenmt/opensearch-feature-explorer/issues/1412)