### PR TITLE
docs: add Scroll API report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -121,6 +121,7 @@
 - [Remote Store Metrics](opensearch/remote-store-metrics.md)
 - [S3 Repository](opensearch/s3-repository.md)
 - [Scaled Float Field](opensearch/scaled-float-field.md)
+- [Scroll API](opensearch/scroll-api.md)
 - [Search Backpressure](opensearch/search-backpressure.md)
 - [Search API Enhancements](opensearch/search-api-enhancements.md)
 - [Search Pipeline](opensearch/search-pipeline.md)

--- a/docs/features/opensearch/scroll-api.md
+++ b/docs/features/opensearch/scroll-api.md
@@ -1,0 +1,150 @@
+# Scroll API
+
+## Summary
+
+The Scroll API enables retrieval of large numbers of results from a search query by maintaining a search context across multiple requests. It is designed for processing large datasets in batches, such as for machine learning jobs or data export operations, rather than for real-time user queries.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph Client
+        C[Client Application]
+    end
+    
+    subgraph OpenSearch Cluster
+        COORD[Coordinator Node]
+        subgraph Data Nodes
+            DN1[Data Node 1]
+            DN2[Data Node 2]
+            DN3[Data Node 3]
+        end
+    end
+    
+    C -->|1. Initial Search + scroll param| COORD
+    COORD -->|2. Create Search Context| DN1
+    COORD -->|2. Create Search Context| DN2
+    COORD -->|2. Create Search Context| DN3
+    DN1 -->|3. Results + Context ID| COORD
+    DN2 -->|3. Results + Context ID| COORD
+    DN3 -->|3. Results + Context ID| COORD
+    COORD -->|4. Results + Scroll ID| C
+    C -->|5. Subsequent scroll requests| COORD
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Initial Search Request] --> B{scroll parameter?}
+    B -->|Yes| C[Create Search Contexts on Shards]
+    B -->|No| D[Normal Search Response]
+    C --> E[Generate Scroll ID]
+    E --> F[Return Results + Scroll ID]
+    F --> G{More results needed?}
+    G -->|Yes| H[Send Scroll Request with ID]
+    H --> I[Retrieve Next Batch]
+    I --> F
+    G -->|No| J[Clear Scroll Context]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SearchScrollAsyncAction` | Handles asynchronous scroll search execution across nodes |
+| `ParsedScrollId` | Parses and validates scroll IDs containing node and context references |
+| `SearchContextIdForNode` | Stores search context ID and associated node information |
+| `InternalScrollSearchRequest` | Internal representation of scroll search requests |
+
+### Scroll ID Structure
+
+Scroll IDs are Base64-encoded payloads containing:
+- Target node references
+- Shard-local searcher context IDs
+- Cluster alias (for cross-cluster searches)
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `scroll` | Duration to keep the search context alive | Required parameter |
+| `size` | Number of results per batch | 10 |
+
+### Usage Example
+
+Initial search with scroll:
+
+```json
+GET /my-index/_search?scroll=10m
+{
+  "size": 1000,
+  "query": {
+    "match_all": {}
+  }
+}
+```
+
+Subsequent scroll requests:
+
+```json
+GET _search/scroll
+{
+  "scroll": "10m",
+  "scroll_id": "DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAUWdmpUZDhnRFBUcWFtV21nMmFwUGJEQQ=="
+}
+```
+
+Clear scroll context when done:
+
+```bash
+DELETE _search/scroll/DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAUWdmpUZDhnRFBUcWFtV21nMmFwUGJEQQ==
+```
+
+Clear all scroll contexts:
+
+```bash
+DELETE _search/scroll/_all
+```
+
+### Sliced Scroll
+
+For parallel processing of large datasets:
+
+```json
+GET /my-index/_search?scroll=10m
+{
+  "slice": {
+    "id": 0,
+    "max": 5
+  },
+  "query": {
+    "match_all": {}
+  }
+}
+```
+
+## Limitations
+
+- Search contexts consume memory; avoid using scroll for frequent user queries
+- Scroll results reflect a point-in-time snapshot; documents added after the initial search are not included
+- Scroll IDs become invalid when referenced nodes leave the cluster
+- For real-time pagination, consider using `search_after` with Point in Time (PIT) instead
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19031](https://github.com/opensearch-project/OpenSearch/pull/19031) | Improved error handling for invalid scroll IDs |
+
+## References
+
+- [Scroll API Documentation](https://docs.opensearch.org/3.0/api-reference/search-apis/scroll/)
+- [Point in Time API](https://docs.opensearch.org/3.0/search-plugins/searching-data/point-in-time/)
+- [Paginate Results](https://docs.opensearch.org/3.0/search-plugins/searching-data/paginate/)
+
+## Change History
+
+- **v3.3.0**: Improved error handling - scroll IDs referencing missing nodes now return HTTP 400 (Bad Request) with `IllegalArgumentException` instead of HTTP 500 (Internal Server Error) with `IllegalStateException`

--- a/docs/releases/v3.3.0/features/opensearch/scroll-api.md
+++ b/docs/releases/v3.3.0/features/opensearch/scroll-api.md
@@ -1,0 +1,94 @@
+# Scroll API Error Handling Improvement
+
+## Summary
+
+This release improves error handling for the Scroll API when a scroll ID references a node that is no longer part of the cluster. Previously, this scenario returned an HTTP 500 (Internal Server Error), but now correctly returns an HTTP 400 (Bad Request) with a clear error message indicating the scroll ID is invalid or stale.
+
+## Details
+
+### What's New in v3.3.0
+
+The Scroll API now provides more accurate HTTP status codes and error messages when processing scroll requests with outdated or invalid scroll IDs.
+
+### Technical Changes
+
+#### Error Response Change
+
+| Aspect | Before v3.3.0 | v3.3.0+ |
+|--------|---------------|---------|
+| Exception Type | `IllegalStateException` | `IllegalArgumentException` |
+| HTTP Status | 500 (Internal Server Error) | 400 (Bad Request) |
+| Error Message | `node [nodeId] is not available` | `scroll_id references node [nodeId] which was not found in the cluster` |
+
+#### Background
+
+Scroll IDs in OpenSearch are Base64-encoded payloads containing:
+- References to target nodes
+- Shard-local searcher context IDs
+
+When a client sends a scroll ID referencing a node that no longer exists (due to node replacement, cluster changes, or pointing to a different cluster), the coordinator now correctly identifies this as a client-side issue rather than a server-side error.
+
+### Usage Example
+
+When using an outdated scroll ID:
+
+```json
+GET _search/scroll
+{
+  "scroll": "1m",
+  "scroll_id": "DXF1ZXJ5QW5kRmV0Y2gBAAAAAAAAAAUWdmpUZDhnRFBUcWFtV21nMmFwUGJEQQ=="
+}
+```
+
+If the scroll ID references a node no longer in the cluster, the response is now:
+
+```json
+{
+  "error": {
+    "root_cause": [
+      {
+        "type": "illegal_argument_exception",
+        "reason": "scroll_id references node [node123] which was not found in the cluster"
+      }
+    ],
+    "type": "search_phase_execution_exception",
+    "reason": "all shards failed",
+    "phase": "query",
+    "grouped": true,
+    "failed_shards": [
+      {
+        "reason": {
+          "type": "illegal_argument_exception",
+          "reason": "scroll_id references node [node123] which was not found in the cluster"
+        }
+      }
+    ]
+  },
+  "status": 400
+}
+```
+
+### Migration Notes
+
+- Clients should update error handling logic to expect HTTP 400 instead of HTTP 500 for invalid scroll IDs
+- The error message format has changed - update any error parsing logic accordingly
+- No changes required for normal scroll operations with valid scroll IDs
+
+## Limitations
+
+- This change only affects the error response when a scroll ID references a missing node
+- Other scroll-related errors may still return different HTTP status codes
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19031](https://github.com/opensearch-project/OpenSearch/pull/19031) | IllegalArgumentException when scroll ID references a node not found in Cluster |
+
+## References
+
+- [Scroll API Documentation](https://docs.opensearch.org/3.0/api-reference/search-apis/scroll/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/scroll-api.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -28,6 +28,7 @@
 - [Request Cache](features/opensearch/request-cache.md)
 - [S3 Repository Compatibility Fix](features/opensearch/s3-repository.md)
 - [Scaled Float Field Precision Fix](features/opensearch/scaled-float-field.md)
+- [Scroll API Error Handling](features/opensearch/scroll-api.md)
 - [Search Stats - Negative Value Handling](features/opensearch/search-stats.md)
 - [Segment Replication](features/opensearch/segment-replication.md)
 - [Store Subdirectory Module](features/opensearch/store-subdirectory-module.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Scroll API error handling improvement in OpenSearch v3.3.0.

### Changes in v3.3.0

PR [#19031](https://github.com/opensearch-project/OpenSearch/pull/19031) improves error handling when a scroll ID references a node that is no longer part of the cluster:

- **Before**: `IllegalStateException` with HTTP 500 (Internal Server Error)
- **After**: `IllegalArgumentException` with HTTP 400 (Bad Request)

This provides more accurate feedback to clients, correctly identifying the issue as a client-side problem (stale/invalid scroll ID) rather than a server-side error.

### Reports Created

- Release report: `docs/releases/v3.3.0/features/opensearch/scroll-api.md`
- Feature report: `docs/features/opensearch/scroll-api.md`

Closes #1411