### PR TITLE
docs: add Java 17 Modernization report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -52,6 +52,7 @@
 - [Flaky Test Fixes](opensearch/flaky-test-fixes.md)
 - [gRPC Transport & Services](opensearch/grpc-transport--services.md)
 - [Index Settings](opensearch/index-settings.md)
+- [Java 17 Modernization](opensearch/java-17-modernization.md)
 - [List APIs (Paginated)](opensearch/list-apis-paginated.md)
 - [Mapping Transformer](opensearch/mapping-transformer.md)
 - [Cluster Manager Task Throttling](opensearch/cluster-manager-throttling.md)

--- a/docs/features/opensearch/java-17-modernization.md
+++ b/docs/features/opensearch/java-17-modernization.md
@@ -1,0 +1,170 @@
+# Java 17 Modernization
+
+## Summary
+
+Java 17 Modernization is an ongoing effort to update OpenSearch codebase to leverage modern Java language features introduced in Java 17. This includes adopting pattern matching switch expressions, replacing deprecated APIs with their modern equivalents, and ensuring proper enforcement of Java deprecation warnings through build tooling updates.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Java 17 Language Features"
+        PM[Pattern Matching Switch]
+        SE[Switch Expressions]
+        NPC[Null Pattern Case]
+    end
+    
+    subgraph "Build Tooling"
+        FA[Forbidden APIs Plugin]
+        GR[Gradle Build]
+        DC[Deprecation Checks]
+    end
+    
+    subgraph "Code Areas"
+        CORE[Core Libraries]
+        SERVER[Server Module]
+        PLUGINS[Plugins]
+        TESTS[Test Framework]
+    end
+    
+    PM --> CORE
+    PM --> SERVER
+    SE --> CORE
+    SE --> SERVER
+    NPC --> CORE
+    
+    FA --> DC
+    GR --> FA
+    DC --> CORE
+    DC --> SERVER
+    DC --> PLUGINS
+    DC --> TESTS
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Pattern Matching Switch | Java 17 feature allowing type patterns in switch cases |
+| Switch Expressions | Expression form of switch returning values with `yield` |
+| Forbidden APIs Plugin | Gradle plugin enforcing API usage rules and deprecation warnings |
+| Deprecation Enforcement | Build-time checks for deprecated Java API usage |
+
+### Key Language Features Used
+
+#### Pattern Matching for Switch
+
+Pattern matching allows combining type checking and casting in a single operation:
+
+```java
+// Type pattern with binding variable
+case TermQuery tq -> mightMatchNestedDocs(tq.getTerm().field());
+
+// Guarded pattern (when clause)
+case TermInSetQuery tisq -> tisq.getTermsCount() > 0 && mightMatchNestedDocs(tisq.getField());
+
+// Null handling
+case null, default -> true;
+
+// Block with yield for complex logic
+case BooleanQuery bq -> {
+    boolean hasRequired = bq.clauses().stream().anyMatch(BooleanClause::isRequired);
+    yield hasRequired ? checkRequired(bq) : checkShould(bq);
+}
+```
+
+#### Ignored Pattern Variables
+
+When the matched value is not needed, use `ignored` as the variable name:
+
+```java
+case MatchAllDocsQuery ignored -> true;
+case Float ignored -> sortValue;  // sort by _score
+```
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `targetCompatibility` | Java version for forbidden APIs checks | Runtime Java version |
+| `bundledSignatures` | Built-in API signature sets | `jdk-unsafe`, `jdk-deprecated`, `jdk-non-portable`, `jdk-system-out` |
+| `signaturesWithSeverityWarn` | APIs that generate warnings instead of errors | Security Manager APIs |
+
+### Deprecated APIs and Replacements
+
+| Deprecated API | Replacement | Since |
+|----------------|-------------|-------|
+| `new URL(String)` | `URI.create(String).toURL()` | Java 20 |
+| `X509Certificate.getSubjectDN()` | `X509Certificate.getSubjectX500Principal()` | Java 16 |
+| `X509Certificate.getIssuerDN()` | `X509Certificate.getIssuerX500Principal()` | Java 16 |
+| `Thread.getId()` | `Thread.threadId()` | Java 19 |
+| `new Locale(String, String, String)` | `new Locale.Builder().setLanguage().setRegion().setVariant().build()` | Java 19 |
+| `Runtime.exec(String)` | `Runtime.exec(String[])` | Java 18 |
+| `AccessController.doPrivileged()` | Direct calls (Security Manager removal) | Java 17 |
+
+### Usage Example
+
+```java
+// Exception handling with pattern matching
+public static RestStatus status(Throwable t) {
+    return switch (t) {
+        case OpenSearchException ose -> ose.status();
+        case IllegalArgumentException ignored -> RestStatus.BAD_REQUEST;
+        case InputCoercionException ignored -> RestStatus.BAD_REQUEST;
+        case JsonParseException ignored -> RestStatus.BAD_REQUEST;
+        case NotXContentException ignored -> RestStatus.BAD_REQUEST;
+        case OpenSearchRejectedExecutionException ignored -> RestStatus.TOO_MANY_REQUESTS;
+        case null, default -> RestStatus.INTERNAL_SERVER_ERROR;
+    };
+}
+
+// Value conversion with pattern matching
+public static ValueSource wrap(Object value, ScriptService scriptService) {
+    return switch (value) {
+        case Map<?, ?> mapValue -> {
+            @SuppressWarnings("unchecked")
+            Map<Object, Object> castedMap = (Map<Object, Object>) mapValue;
+            Map<ValueSource, ValueSource> valueTypeMap = new HashMap<>(castedMap.size());
+            for (Map.Entry<Object, Object> entry : castedMap.entrySet()) {
+                valueTypeMap.put(wrap(entry.getKey(), scriptService), wrap(entry.getValue(), scriptService));
+            }
+            yield new MapValue(valueTypeMap);
+        }
+        case List<?> listValue -> {
+            // ... list handling
+        }
+        case byte[] byteArray -> new ByteValue(byteArray);
+        case String stringValue -> handleString(stringValue, scriptService);
+        case null -> new ObjectValue(null);
+        case Number number -> new ObjectValue(number);
+        case Boolean bool -> new ObjectValue(bool);
+        default -> throw new IllegalArgumentException("unexpected value type [" + value.getClass() + "]");
+    };
+}
+```
+
+## Limitations
+
+- Requires Java 17 or later runtime
+- Pattern matching switch is a language feature, not a runtime feature - compiled code requires Java 17+ bytecode
+- Some deprecated APIs (Security Manager related) are set to warn rather than error due to pervasive usage
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#18965](https://github.com/opensearch-project/OpenSearch/pull/18965) | Refactor if-else chains to pattern matching switch |
+| v3.3.0 | [#19163](https://github.com/opensearch-project/OpenSearch/pull/19163) | Remove Java version cap on forbidden APIs |
+
+## References
+
+- [Issue #17874](https://github.com/opensearch-project/OpenSearch/issues/17874): Original feature request
+- [JEP 406](https://openjdk.org/jeps/406): Pattern Matching for switch (Preview)
+- [JEP 441](https://openjdk.org/jeps/441): Pattern Matching for switch (Final)
+- [Forbidden APIs Plugin](https://github.com/policeman-tools/forbidden-apis): Build plugin documentation
+
+## Change History
+
+- **v3.3.0** (2025-09): Initial Java 17 modernization with pattern matching switch refactoring and forbidden APIs update

--- a/docs/releases/v3.3.0/features/opensearch/java-17-modernization.md
+++ b/docs/releases/v3.3.0/features/opensearch/java-17-modernization.md
@@ -1,0 +1,174 @@
+# Java 17 Modernization
+
+## Summary
+
+OpenSearch v3.3.0 introduces Java 17 language modernization improvements, refactoring legacy `if-else` chains to use Java 17 pattern matching switch expressions and removing the outdated Java version cap on forbidden APIs enforcement. These changes improve code readability, maintainability, and ensure proper enforcement of Java deprecation warnings.
+
+## Details
+
+### What's New in v3.3.0
+
+This release includes two key improvements for Java 17 modernization:
+
+1. **Pattern Matching Switch Expressions**: Refactored multiple `if-else` chains using `instanceof` checks to modern Java 17 pattern matching `switch` statements
+2. **Forbidden APIs Update**: Removed the Java 14 version cap on forbidden APIs plugin, enabling proper deprecation enforcement for Java 15+
+
+### Technical Changes
+
+#### Pattern Matching Switch Refactoring
+
+The following core files were refactored to use Java 17 pattern matching:
+
+| File | Changes |
+|------|---------|
+| `Numbers.java` | `toLongExact`, `toBigIntegerExact` methods |
+| `ExceptionsHelper.java` | Exception handling methods (`convertToRuntime`, `status`, `summaryMessage`) |
+| `NestedHelper.java` | Query matching methods (`mightMatchNestedDocs`, `mightMatchNonNestedDocs`) |
+| `ValueSource.java` | Value wrapping logic in `wrap()` method |
+| `SearchSortValuesAndFormats.java` | Sort value formatting |
+| `BulkItemResponse.java` | Response type serialization |
+| `DocWriteRequest.java` | Request serialization methods |
+| `BytesReference.java` | Stream type handling |
+| `LoggerMessageFormat.java` | Primitive array type handling |
+| `NioSelectorGroup.java` | Exception handling |
+| `SocketChannelContext.java` | Connection exception handling |
+
+#### Code Example: Before and After
+
+**Before (if-else chain):**
+```java
+public static long toLongExact(Number n) {
+    if (n instanceof Byte || n instanceof Short || n instanceof Integer || n instanceof Long) {
+        return n.longValue();
+    } else if (n instanceof Float || n instanceof Double) {
+        double d = n.doubleValue();
+        if (d != Math.round(d)) {
+            throw new IllegalArgumentException(n + " is not an integer value");
+        }
+        return n.longValue();
+    } else if (n instanceof BigDecimal) {
+        return ((BigDecimal) n).toBigIntegerExact().longValueExact();
+    } else if (n instanceof BigInteger) {
+        return ((BigInteger) n).longValueExact();
+    } else {
+        throw new IllegalArgumentException("Cannot check whether [" + n + "] ...");
+    }
+}
+```
+
+**After (pattern matching switch):**
+```java
+public static long toLongExact(Number n) {
+    return switch (n) {
+        case Byte b -> b.longValue();
+        case Short s -> s.longValue();
+        case Integer i -> i.longValue();
+        case Long l -> l;
+        case Float f -> {
+            double d = f.doubleValue();
+            if (d != Math.round(d)) {
+                throw new IllegalArgumentException(f + " is not an integer value");
+            }
+            yield f.longValue();
+        }
+        case Double d -> {
+            if (d != Math.round(d)) {
+                throw new IllegalArgumentException(d + " is not an integer value");
+            }
+            yield d.longValue();
+        }
+        case BigDecimal bd -> bd.toBigIntegerExact().longValueExact();
+        case BigInteger bi -> bi.longValueExact();
+        default -> throw new IllegalArgumentException("Cannot check whether [" + n + "] ...");
+    };
+}
+```
+
+#### Forbidden APIs Plugin Update
+
+| Change | Details |
+|--------|---------|
+| Plugin version | Updated from 3.8 to 3.9 |
+| Java version cap | Removed Java 14 cap that prevented deprecation enforcement |
+| Security Manager APIs | Added warnings for deprecated `AccessController`, `SecurityManager`, `Policy` usage |
+
+The forbidden APIs plugin now properly enforces Java deprecations for all Java versions, including Java 15+. Previously, a check capped the target compatibility at Java 14, meaning deprecation warnings from the past 5 years were not being enforced.
+
+#### Deprecated API Warnings
+
+The following deprecated Security Manager APIs are now set to warn globally:
+
+- `java.security.AccessController`
+- `java.security.AccessControlContext`
+- `java.lang.System#getSecurityManager()`
+- `java.lang.SecurityManager`
+- `java.security.Policy`
+
+#### Additional Deprecation Fixes
+
+Several deprecated API usages were fixed across the codebase:
+
+| Deprecated API | Replacement |
+|----------------|-------------|
+| `new URL(String)` | `URI.create(String).toURL()` |
+| `X509Certificate.getSubjectDN()` | `X509Certificate.getSubjectX500Principal()` |
+| `X509Certificate.getIssuerDN()` | `X509Certificate.getIssuerX500Principal()` |
+| `Thread.getId()` | `Thread.threadId()` |
+| `new Locale(String...)` | `new Locale.Builder().setLanguage(...).build()` |
+| `Runtime.exec(String)` | `Runtime.exec(String[])` |
+
+### Usage Example
+
+Pattern matching switch expressions provide cleaner, more readable code:
+
+```java
+// Query type matching in NestedHelper
+public boolean mightMatchNestedDocs(Query query) {
+    return switch (query) {
+        case ConstantScoreQuery csq -> mightMatchNestedDocs(csq.getQuery());
+        case BoostQuery bq -> mightMatchNestedDocs(bq.getQuery());
+        case MatchAllDocsQuery ignored -> true;
+        case MatchNoDocsQuery ignored -> false;
+        case TermQuery tq -> mightMatchNestedDocs(tq.getTerm().field());
+        case TermInSetQuery tisq -> tisq.getTermsCount() > 0 && mightMatchNestedDocs(tisq.getField());
+        case BooleanQuery bq -> {
+            // Complex logic with yield
+            yield bq.clauses().stream()
+                .filter(BooleanClause::isRequired)
+                .map(BooleanClause::query)
+                .allMatch(this::mightMatchNestedDocs);
+        }
+        case null, default -> true;
+    };
+}
+```
+
+### Migration Notes
+
+These changes are internal refactoring and do not affect the public API. No migration is required for users.
+
+For plugin developers:
+- If extending OpenSearch classes that were refactored, ensure your code is compatible with Java 17+
+- Consider adopting pattern matching switch expressions in your own code for improved readability
+
+## Limitations
+
+- Pattern matching switch expressions require Java 17 or later
+- The `ignored` pattern variable is used for cases where the matched value is not needed
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18965](https://github.com/opensearch-project/OpenSearch/pull/18965) | Refactor if-else chains to use Java 17 pattern matching switch expressions |
+| [#19163](https://github.com/opensearch-project/OpenSearch/pull/19163) | Remove cap on Java version used by forbidden APIs |
+
+## References
+
+- [Issue #17874](https://github.com/opensearch-project/OpenSearch/issues/17874): Feature request for Java 17 pattern matching
+- [JEP 406](https://openjdk.org/jeps/406): Pattern Matching for switch (Preview)
+- [JEP 441](https://openjdk.org/jeps/441): Pattern Matching for switch (Final)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/java-17-modernization.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -17,6 +17,7 @@
 - [Flaky Test Fixes](features/opensearch/flaky-test-fixes.md)
 - [Index Output](features/opensearch/index-output.md)
 - [Index Refresh](features/opensearch/index-refresh.md)
+- [Java 17 Modernization](features/opensearch/java-17-modernization.md)
 - [Lucene Migration](features/opensearch/lucene-migration.md)
 - [Netty Arena Settings](features/opensearch/netty-arena-settings.md)
 - [NRT Replication Engine](features/opensearch/nrt-replication-engine.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Java 17 Modernization feature in OpenSearch v3.3.0.

### Changes
- **Release report**: `docs/releases/v3.3.0/features/opensearch/java-17-modernization.md`
- **Feature report**: `docs/features/opensearch/java-17-modernization.md`
- Updated release and feature indexes

### Key Changes in v3.3.0
- Refactored `if-else` chains to use Java 17 pattern matching switch expressions
- Removed Java 14 version cap on forbidden APIs plugin
- Updated forbidden APIs plugin from 3.8 to 3.9
- Fixed deprecated API usages across the codebase

### Related PRs
- opensearch-project/OpenSearch#18965: Pattern matching switch refactoring
- opensearch-project/OpenSearch#19163: Forbidden APIs update

Closes #1409