### PR TITLE
docs: add circuit-breaker report for v3.3.0

### DIFF
--- a/docs/features/opensearch/query-phase-result-consumer.md
+++ b/docs/features/opensearch/query-phase-result-consumer.md
@@ -118,14 +118,17 @@ POST /my-index/_search?batched_reduce_size=256
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#19396](https://github.com/opensearch-project/OpenSearch/pull/19396) | Harden the circuit breaker and failure handle logic in query result consumer |
 | v3.3.0 | [#19231](https://github.com/opensearch-project/OpenSearch/pull/19231) | Fix incomplete callback loops in QueryPhaseResultConsumer |
 
 ## References
 
+- [Circuit Breaker Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/circuit-breaker/): OpenSearch circuit breaker configuration
 - [Issue #19094](https://github.com/opensearch-project/OpenSearch/issues/19094): Flaky Test Report for SearchPhaseControllerTests
 - [Search API Documentation](https://docs.opensearch.org/3.0/api-reference/search-apis/search/): OpenSearch Search API reference
 - [Search Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/search-settings/): Search configuration options
 
 ## Change History
 
+- **v3.3.0** (2025-10-02): Hardened circuit breaker logic with proactive memory checks before consuming results; centralized failure handling in `onFailure` method; renamed classes for clarity (`PendingMerges` → `PendingReduces`, `MergeTask` → `ReduceTask`, `MergeResult` → `ReduceResult`)
 - **v3.3.0** (2025-09-04): Fixed incomplete callback loops by adding graceful failure handling, clearing pending merge tasks on failure, and properly canceling tasks when failures are detected

--- a/docs/releases/v3.3.0/features/opensearch/circuit-breaker.md
+++ b/docs/releases/v3.3.0/features/opensearch/circuit-breaker.md
@@ -1,0 +1,121 @@
+# Circuit Breaker Hardening in Query Result Consumer
+
+## Summary
+
+This release hardens the circuit breaker and failure handling logic in `QueryPhaseResultConsumer`, improving memory protection during distributed search operations. The changes ensure circuit breaker checks occur before consuming query results and provide more robust failure handling with proper cleanup of pending reduce tasks.
+
+## Details
+
+### What's New in v3.3.0
+
+The main enhancement is adding `addEstimateAndMaybeBreak(aggsSize)` in `consumeResult` before performing any actual consume logic. This ensures memory limits are checked proactively rather than reactively.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Enhanced Circuit Breaker Flow"
+        A[Query Result Received] --> B{Check Circuit Breaker}
+        B -->|OK| C[Add to Buffer]
+        B -->|Break| D[onFailure]
+        D --> E[Reset Circuit Breaker]
+        E --> F[Clear Reduce Queue]
+        F --> G[Cancel Search Task]
+        C --> H{Buffer Full?}
+        H -->|Yes| I[Create ReduceTask]
+        H -->|No| J[Wait]
+        I --> K[tryExecuteNext]
+        K --> L{Check CB Before Reduce}
+        L -->|OK| M[partialReduce]
+        L -->|Break| D
+    end
+```
+
+#### Key Changes
+
+| Change | Before | After |
+|--------|--------|-------|
+| Circuit breaker check timing | After buffering | Before consuming result |
+| Failure handling | Scattered logic | Centralized `onFailure` method |
+| Class naming | `PendingMerges`, `MergeTask`, `MergeResult` | `PendingReduces`, `ReduceTask`, `ReduceResult` |
+| Memory estimation | `1.5d * size - size` | `0.5d * size` |
+
+#### Refactored Components
+
+| Component | Description |
+|-----------|-------------|
+| `PendingReduces` | Renamed from `PendingMerges`; manages buffered results and reduce task coordination |
+| `ReduceTask` | Renamed from `MergeTask`; encapsulates batch of results with callback |
+| `ReduceResult` | Renamed from `MergeResult`; now a Java record for immutability |
+| `onFailure` | New centralized failure handler with idempotent, thread-safe cleanup |
+
+#### Circuit Breaker Usage Points
+
+1. **Before consume**: Query result received at coordinator transport layer; estimate heap size and check REQUEST circuit breaker
+2. **During tryExecuteNext**: Before partial reduce on buffered results; estimate extra heap for reduction and check circuit breaker
+
+### Code Changes
+
+The `consumeResult` method now checks circuit breaker before processing:
+
+```java
+private synchronized boolean consumeResult(QuerySearchResult result, Runnable callback) {
+    if (hasFailure()) {
+        result.consumeAll(); // release memory
+        return true;
+    }
+    // Check circuit breaker before consuming
+    if (hasAggs) {
+        long aggsSize = ramBytesUsedQueryResult(result);
+        try {
+            addEstimateAndMaybeBreak(aggsSize);
+            aggsCurrentBufferSize += aggsSize;
+        } catch (CircuitBreakingException e) {
+            onFailure(e);
+            return true;
+        }
+    }
+    // Process result...
+}
+```
+
+The new `onFailure` method provides centralized, idempotent failure handling:
+
+```java
+private synchronized void onFailure(Exception exc) {
+    if (hasFailure()) {
+        assert circuitBreakerBytes == 0;
+        return;
+    }
+    resetCircuitBreaker();
+    failure.compareAndSet(null, exc);
+    clearReduceTaskQueue();
+    cancelTaskOnFailure.accept(exc);
+}
+```
+
+### Performance Implication
+
+TermsReduceBenchmark shows no regression from these changes.
+
+## Limitations
+
+- Circuit breaker estimation remains approximate
+- The hardened checks add minimal overhead to each result consumption
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19396](https://github.com/opensearch-project/OpenSearch/pull/19396) | Harden the circuit breaker and failure handle logic in query result consumer |
+
+## References
+
+- [Circuit Breaker Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/circuit-breaker/): OpenSearch circuit breaker configuration
+- [Search Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/search-settings/): Search configuration options
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/query-phase-result-consumer.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -7,6 +7,7 @@
 - [Alias Write Index Policy](features/opensearch/alias-write-index-policy.md)
 - [Client API Enhancements](features/opensearch/client-api-enhancements.md)
 - [Cardinality Aggregation](features/opensearch/cardinality-aggregation.md)
+- [Circuit Breaker Hardening](features/opensearch/circuit-breaker.md)
 - [Cluster State Caching](features/opensearch/cluster-state-caching.md)
 - [Concurrent Segment Search](features/opensearch/concurrent-segment-search.md)
 - [Cross-Cluster Settings](features/opensearch/cross-cluster-settings.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the circuit breaker hardening changes in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/circuit-breaker.md`
- Feature report: `docs/features/opensearch/query-phase-result-consumer.md` (updated)

### Key Changes in v3.3.0
- Proactive circuit breaker checks before consuming query results
- Centralized failure handling in `onFailure` method
- Class renaming for clarity (`PendingMerges` → `PendingReduces`, etc.)
- Improved memory estimation formula

### Resources Used
- PR: #19396 (opensearch-project/OpenSearch)
- Docs: https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/circuit-breaker/

Closes #1408