### PR TITLE
docs: add search-settings report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -129,6 +129,7 @@
 - [Search Pipeline](opensearch/search-pipeline.md)
 - [Search Request Stats](opensearch/search-request-stats.md)
 - [Search Scoring](opensearch/search-scoring.md)
+- [Search Settings](opensearch/search-settings.md)
 - [Scripted Metric Aggregation](opensearch/scripted-metric-aggregation.md)
 - [Search Shard Routing](opensearch/search-shard-routing.md)
 - [Secure Aux Transport Settings](opensearch/secure-aux-transport-settings.md)

--- a/docs/features/opensearch/search-settings.md
+++ b/docs/features/opensearch/search-settings.md
@@ -1,0 +1,118 @@
+# Search Settings
+
+## Summary
+
+OpenSearch provides configurable search settings that control query behavior, resource limits, and performance characteristics. These cluster-level settings allow administrators to tune search operations for security, performance, and resource management. The `search.query.max_query_string_length` setting specifically limits the maximum length of query strings to prevent resource exhaustion from excessively long queries.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Search Request Flow"
+        Client[Client] --> Coordinator[Coordinator Node]
+        Coordinator --> Parser[Query Parser]
+        Parser --> Validator{Length Check}
+        Validator -->|Pass| Lucene[Lucene Query]
+        Validator -->|Fail| Error[ParseException]
+        Lucene --> Shards[Data Shards]
+    end
+    
+    subgraph "Settings Management"
+        ClusterSettings[Cluster Settings] --> SearchService[SearchService]
+        SearchService --> QueryStringQueryParser[QueryStringQueryParser]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SearchService` | Manages search settings and registers setting update consumers |
+| `QueryStringQueryParser` | Parses query strings and enforces length limits |
+| `ClusterSettings` | Stores and propagates dynamic cluster settings |
+
+### Configuration
+
+| Setting | Description | Default | Dynamic |
+|---------|-------------|---------|---------|
+| `search.query.max_query_string_length` | Maximum allowed length for query strings | 32,000 | Yes |
+| `search.max_buckets` | Maximum aggregation buckets per response | 65,535 | Yes |
+| `search.default_search_timeout` | Default timeout for search requests | -1 (none) | Yes |
+| `search.allow_expensive_queries` | Allow expensive query types | true | Yes |
+| `search.low_level_cancellation` | Enable low-level request cancellation | true | Yes |
+
+### Usage Example
+
+#### Setting Query String Length Limit
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "search.query.max_query_string_length": 10000
+  }
+}
+```
+
+#### Query String Query Example
+
+```json
+GET my-index/_search
+{
+  "query": {
+    "query_string": {
+      "query": "status:active AND (title:opensearch OR content:search)"
+    }
+  }
+}
+```
+
+If the query string exceeds the configured limit, the request fails with:
+
+```json
+{
+  "error": {
+    "type": "search_phase_execution_exception",
+    "reason": "Query string length exceeds max allowed length 10000 (search.query.max_query_string_length); actual length: 15000"
+  }
+}
+```
+
+### Security Considerations
+
+The query string length limit helps protect against:
+
+1. **Denial of Service**: Extremely long query strings can consume excessive memory and CPU
+2. **Resource Exhaustion**: Complex queries with many terms can overwhelm the query parser
+3. **Untrusted Input**: User-provided search queries should be bounded to prevent abuse
+
+### Best Practices
+
+- Set limits appropriate for your use case (default 32,000 is generous)
+- Monitor query patterns to identify appropriate thresholds
+- Combine with other search settings for comprehensive protection
+- Use `search.allow_expensive_queries: false` in production for additional safety
+
+## Limitations
+
+- Query string length limit only applies to `query_string` and `simple_query_string` queries
+- Does not limit other query types or overall request body size
+- Length check occurs at parse time, not at request receipt
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19491](https://github.com/opensearch-project/OpenSearch/pull/19491) | Introduced search.query.max_query_string_length setting |
+
+## References
+
+- [PR #19491](https://github.com/opensearch-project/OpenSearch/pull/19491): Initial implementation
+- [Query String Query](https://docs.opensearch.org/latest/query-dsl/full-text/query-string/): Query string syntax documentation
+- [Search Settings](https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/search-settings/): Search configuration reference
+
+## Change History
+
+- **v3.3.0** (2025-10-01): Added `search.query.max_query_string_length` setting to limit query string length

--- a/docs/releases/v3.3.0/features/opensearch/search-settings.md
+++ b/docs/releases/v3.3.0/features/opensearch/search-settings.md
@@ -1,0 +1,84 @@
+# Search Settings
+
+## Summary
+
+OpenSearch v3.3.0 introduces a new cluster-wide setting `search.query.max_query_string_length` that limits the maximum length of query strings in `query_string` and `simple_query_string` queries. This provides a simple but robust mechanism to control inputs from potentially untrusted sources and prevent resource exhaustion from excessively long query strings.
+
+## Details
+
+### What's New in v3.3.0
+
+A new dynamic cluster setting has been added to limit the maximum allowed length of query strings used in Lucene-style query string queries.
+
+### Technical Changes
+
+#### New Configuration
+
+| Setting | Description | Default | Min | Max |
+|---------|-------------|---------|-----|-----|
+| `search.query.max_query_string_length` | Maximum allowed length for query strings in `query_string` and `simple_query_string` queries | 32,000 | 1 | Integer.MAX_VALUE |
+
+#### Setting Properties
+
+- **Scope**: Node-level (applies cluster-wide)
+- **Dynamic**: Yes (can be updated without restart)
+- **Type**: Integer
+
+#### Implementation Details
+
+The setting is enforced in `QueryStringQueryParser.parse()` method. When a query string exceeds the configured limit, a `ParseException` is thrown with a descriptive error message:
+
+```
+Query string length exceeds max allowed length {limit} (search.query.max_query_string_length); actual length: {actual}
+```
+
+### Usage Example
+
+Update the setting dynamically via the Cluster Settings API:
+
+```json
+PUT _cluster/settings
+{
+  "transient": {
+    "search.query.max_query_string_length": 10000
+  }
+}
+```
+
+Or configure in `opensearch.yml`:
+
+```yaml
+search.query.max_query_string_length: 10000
+```
+
+### Use Cases
+
+- **Security hardening**: Prevent denial-of-service attacks via extremely long query strings
+- **Resource protection**: Limit memory and CPU usage from parsing complex queries
+- **Input validation**: Enforce reasonable limits on user-provided search queries
+
+### Migration Notes
+
+No migration required. The default value of 32,000 characters is generous enough for most use cases. Adjust only if you need stricter limits or have legitimate use cases requiring longer query strings.
+
+## Limitations
+
+- Only applies to `query_string` and `simple_query_string` query types
+- Does not limit other query types or the overall request body size
+- The check occurs at parse time, so invalid queries may still consume some resources before being rejected
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19491](https://github.com/opensearch-project/OpenSearch/pull/19491) | Introduced new setting search.query.max_query_string_length |
+
+## References
+
+- [PR #19491](https://github.com/opensearch-project/OpenSearch/pull/19491): Main implementation
+- [Query String Query Documentation](https://docs.opensearch.org/latest/query-dsl/full-text/query-string/): Official query string query docs
+- [Search Settings Documentation](https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/search-settings/): Search configuration reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/search-settings.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -32,6 +32,7 @@
 - [S3 Repository Compatibility Fix](features/opensearch/s3-repository.md)
 - [Scaled Float Field Precision Fix](features/opensearch/scaled-float-field.md)
 - [Scroll API Error Handling](features/opensearch/scroll-api.md)
+- [Search Settings](features/opensearch/search-settings.md)
 - [Search Stats - Negative Value Handling](features/opensearch/search-stats.md)
 - [Segment Replication](features/opensearch/segment-replication.md)
 - [Store Subdirectory Module](features/opensearch/store-subdirectory-module.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the new `search.query.max_query_string_length` cluster setting introduced in OpenSearch v3.3.0.

## Changes

### Release Report
- `docs/releases/v3.3.0/features/opensearch/search-settings.md`: Documents the new setting, its configuration, and use cases

### Feature Report
- `docs/features/opensearch/search-settings.md`: Comprehensive documentation of search settings including architecture diagram and configuration reference

## Key Points

- New cluster setting `search.query.max_query_string_length` limits query string length (default: 32,000)
- Dynamic setting that can be updated without cluster restart
- Helps prevent DoS attacks and resource exhaustion from excessively long query strings
- Applies to `query_string` and `simple_query_string` query types

## Related

- Closes #1407
- PR: opensearch-project/OpenSearch#19491