### PR TITLE
docs: add aggregation-optimizations report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -16,6 +16,7 @@
 
 ## opensearch
 
+- [Aggregation Optimizations](opensearch/aggregation-optimizations.md)
 - [Alias Write Index Policy](opensearch/alias-write-index-policy.md)
 - [Approximation Framework](opensearch/approximation-framework.md)
 - [BooleanQuery Rewrite Optimizations](opensearch/booleanquery-rewrite-optimizations.md)

--- a/docs/features/opensearch/aggregation-optimizations.md
+++ b/docs/features/opensearch/aggregation-optimizations.md
@@ -1,0 +1,197 @@
+# Aggregation Optimizations
+
+## Summary
+
+OpenSearch provides various performance optimizations for aggregation operations. These optimizations reduce query latency and memory consumption by using smarter algorithms for bucket selection, precomputation techniques, and object reuse patterns. The optimizations target three key aggregation types: rare terms, string terms, and date histogram aggregations.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Aggregation Request"
+        Query[Search Query]
+        Agg[Aggregation Definition]
+    end
+    
+    subgraph "Optimization Layer"
+        PreComp[Precomputation Check]
+        Strategy[Strategy Selection]
+        Rounding[Rounding Optimization]
+    end
+    
+    subgraph "Aggregation Types"
+        RareTerms[Rare Terms Aggregator]
+        StringTerms[String Terms Aggregator]
+        DateHist[Date Histogram Aggregator]
+    end
+    
+    Query --> PreComp
+    Agg --> Strategy
+    
+    PreComp --> RareTerms
+    Strategy --> StringTerms
+    Rounding --> DateHist
+    
+    RareTerms --> |"Term Frequency"| Result[Aggregation Result]
+    StringTerms --> |"Bucket Selection"| Result
+    DateHist --> |"Object Reuse"| Result
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Rare Terms Optimization"
+        RT1[Check Weight.count] --> RT2{Match All?}
+        RT2 -->|Yes| RT3[Use TermsEnum.docFreq]
+        RT2 -->|No| RT4[Standard Collection]
+        RT3 --> RT5[Direct Bucket Count]
+    end
+    
+    subgraph "String Terms Optimization"
+        ST1[Calculate Bucket Count] --> ST2{Size vs Buckets}
+        ST2 -->|"buckets ≤ size"| ST3[Select All]
+        ST2 -->|"buckets ≤ 5×size"| ST4[Priority Queue]
+        ST2 -->|"buckets > 5×size"| ST5[QuickSelect]
+    end
+    
+    subgraph "Date Histogram Optimization"
+        DH1[Rounding Request] --> DH2[Reuse Rounding Object]
+        DH2 --> DH3[Compute Bucket Key]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `StringRareTermsAggregator` | Aggregator for rare terms with precomputation support |
+| `GlobalOrdinalsStringTermsAggregator` | String terms aggregator with adaptive bucket selection |
+| `BucketSelectionStrategy` | Strategy enum for selecting bucket selection algorithm |
+| `Rounding` | Date rounding utilities with object reuse optimization |
+| `TimeUnitPreparedRounding` | Prepared rounding implementations for time units |
+| `TimeIntervalPreparedRounding` | Prepared rounding implementations for time intervals |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `search.bucket_selection_strategy_factor` | Threshold factor for quickselect vs priority queue | 5 |
+
+### Optimization Strategies
+
+#### Rare Terms Precomputation
+
+When the following conditions are met, rare terms aggregation can skip document iteration:
+
+1. `Weight.count(leafContext) == leafContext.reader().maxDoc()` (match-all query)
+2. No deleted documents in the segment
+3. No sub-aggregations defined
+4. No `_doc_count` field present
+
+The aggregator then uses `TermsEnum.docFreq()` to get bucket counts directly from the index.
+
+#### String Terms Bucket Selection
+
+Three strategies are available based on the ratio of requested size to total buckets:
+
+| Strategy | Algorithm | Time Complexity | When Used |
+|----------|-----------|-----------------|-----------|
+| `select_all` | Direct copy | O(n) | buckets ≤ size |
+| `priority_queue` | Heap-based selection | O(n log k) | buckets ≤ 5×size |
+| `quick_select` | Partition-based selection | O(n) average | buckets > 5×size |
+
+#### Date Histogram Object Reuse
+
+Rounding utility classes are instantiated once and reused:
+
+```java
+// Before: Created new object for each call
+return new JavaTimeToMidnightRounding().nextRoundingValue(utcMillis);
+
+// After: Reuses single instance
+private final JavaTimeToMidnightRounding MIDNIGHT_ROUNDING = new JavaTimeToMidnightRounding();
+return MIDNIGHT_ROUNDING.nextRoundingValue(utcMillis);
+```
+
+### Usage Example
+
+```json
+// Rare terms aggregation
+GET /logs/_search
+{
+  "size": 0,
+  "aggs": {
+    "rare_errors": {
+      "rare_terms": {
+        "field": "error_code.keyword",
+        "max_doc_count": 10,
+        "precision": 0.001
+      }
+    }
+  }
+}
+
+// String terms with large bucket count
+GET /events/_search
+{
+  "size": 0,
+  "aggs": {
+    "by_user": {
+      "terms": {
+        "field": "user_id.keyword",
+        "size": 10000
+      }
+    }
+  }
+}
+
+// Date histogram with sub-aggregation
+GET /metrics/_search
+{
+  "size": 0,
+  "aggs": {
+    "by_hour": {
+      "date_histogram": {
+        "field": "@timestamp",
+        "calendar_interval": "hour"
+      },
+      "aggs": {
+        "avg_value": {
+          "avg": { "field": "value" }
+        }
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Rare terms precomputation requires specific conditions (match-all, no deletions, no sub-aggs)
+- String terms quickselect does not apply to significant terms aggregations
+- Date histogram optimization benefits are most visible with sub-aggregations
+- Precomputation does not work with documents containing `_doc_count` field
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#18978](https://github.com/opensearch-project/OpenSearch/pull/18978) | Rare terms aggregation precomputation |
+| v3.3.0 | [#18732](https://github.com/opensearch-project/OpenSearch/pull/18732) | String terms aggregation optimization |
+| v3.3.0 | [#19088](https://github.com/opensearch-project/OpenSearch/pull/19088) | Date histogram rounding optimization |
+
+## References
+
+- [Issue #13122](https://github.com/opensearch-project/OpenSearch/issues/13122): Rare Terms Aggregation Performance Optimization
+- [Issue #18704](https://github.com/opensearch-project/OpenSearch/issues/18704): Optimize String terms agg
+- [Issue #10954](https://github.com/opensearch-project/OpenSearch/issues/10954): Use Collector.setWeight to improve aggregation performance
+- [Rare Terms Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/rare-terms/)
+- [Terms Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/terms/)
+- [Date Histogram Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/date-histogram/)
+
+## Change History
+
+- **v3.3.0** (2026-01): Added precomputation for rare terms, quickselect for string terms, object reuse for date histogram

--- a/docs/releases/v3.3.0/features/opensearch/aggregation-optimizations.md
+++ b/docs/releases/v3.3.0/features/opensearch/aggregation-optimizations.md
@@ -1,0 +1,147 @@
+# Aggregation Optimizations
+
+## Summary
+
+OpenSearch v3.3.0 introduces performance optimizations for three aggregation types: rare terms, string terms, and date histogram aggregations. These improvements reduce latency and memory usage by using smarter algorithms for bucket selection and eliminating unnecessary object allocations.
+
+## Details
+
+### What's New in v3.3.0
+
+This release includes three distinct aggregation optimizations:
+
+1. **Rare Terms Aggregation Precomputation**: Uses Lucene term frequency data to avoid iterating through individual documents
+2. **String Terms Aggregation Optimization**: Implements quickselect algorithm for large bucket counts
+3. **Date Histogram Optimization**: Reuses rounding utility objects to prevent unnecessary memory allocations
+
+### Technical Changes
+
+#### Rare Terms Aggregation Precomputation
+
+The `StringRareTermsAggregator` now supports precomputation using `Weight.count()` and Lucene's term frequency data. When conditions are met (match-all query, no deletions, no sub-aggregations), the aggregator can compute bucket counts directly from the index without iterating through documents.
+
+Key implementation details:
+- Added `tryPrecomputeAggregationForLeaf()` method to `StringRareTermsAggregator`
+- Uses `Weight.setWeight()` to access query weight for count optimization
+- Iterates over `TermsEnum` to get document frequencies directly
+- Handles missing values through `ValuesSourceConfig`
+
+#### String Terms Aggregation Optimization
+
+The `GlobalOrdinalsStringTermsAggregator` now uses adaptive bucket selection strategies:
+
+| Strategy | Condition | Description |
+|----------|-----------|-------------|
+| `priority_queue` | buckets ≤ 5× size | Traditional PriorityQueue for top-N selection |
+| `quick_select` | buckets > 5× size | Lucene's ArrayUtil.select() for faster selection |
+| `select_all` | buckets ≤ size | Returns all buckets without selection |
+
+The threshold factor (default: 5) is configurable via `SearchContext.bucketSelectionStrategyFactor()`.
+
+#### Date Histogram Optimization
+
+Refactored `Rounding.java` to reuse rounding utility objects:
+
+| Class | Change |
+|-------|--------|
+| `FixedToMidnightRounding` | Reuses single `JavaTimeToMidnightRounding` instance |
+| `ToMidnightRounding` | Reuses single `JavaTimeToMidnightRounding` instance |
+| `FixedRounding` | Reuses single `JavaTimeRounding` instance |
+| `VariableRounding` | Reuses single `JavaTimeRounding` instance |
+
+Additional improvements:
+- Converted if-else chains to Java 17 switch expressions
+- Replaced `ChronoUnit` methods with direct `LocalDateTime` methods (e.g., `plusDays()`)
+- Converted `ArrayRounding` to a record class
+
+### Usage Example
+
+```json
+// Rare terms aggregation (benefits from precomputation)
+GET /logs/_search
+{
+  "size": 0,
+  "aggs": {
+    "rare_errors": {
+      "rare_terms": {
+        "field": "error_code",
+        "max_doc_count": 5
+      }
+    }
+  }
+}
+
+// String terms aggregation (benefits from quickselect)
+GET /logs/_search
+{
+  "size": 0,
+  "aggs": {
+    "top_users": {
+      "terms": {
+        "field": "user_id",
+        "size": 1000
+      }
+    }
+  }
+}
+
+// Date histogram (benefits from object reuse)
+GET /logs/_search
+{
+  "size": 0,
+  "aggs": {
+    "by_day": {
+      "date_histogram": {
+        "field": "@timestamp",
+        "calendar_interval": "day"
+      },
+      "aggs": {
+        "total_size": {
+          "sum": { "field": "size" }
+        }
+      }
+    }
+  }
+}
+```
+
+### Performance Impact
+
+**Date Histogram Optimization Benchmarks:**
+
+| Metric | Before | After | Improvement |
+|--------|--------|-------|-------------|
+| 50th percentile latency | 26.5 ms | 12.2 ms | ~2.2x faster |
+| 90th percentile latency | 31.2 ms | 16.2 ms | ~1.9x faster |
+| 50th percentile service time | 24.4 ms | 9.6 ms | ~2.5x faster |
+
+## Limitations
+
+- Rare terms precomputation only works when:
+  - Top-level query matches all documents in the segment
+  - No deleted documents exist in the segment
+  - No sub-aggregations are present
+  - No `_doc_count` field is present
+- String terms quickselect optimization does not apply to significant terms aggregations
+- Date histogram optimization benefits are most visible with sub-aggregations that prevent precomputation
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18978](https://github.com/opensearch-project/OpenSearch/pull/18978) | Rare terms aggregation precomputation |
+| [#18732](https://github.com/opensearch-project/OpenSearch/pull/18732) | String terms aggregation optimization for large bucket counts |
+| [#19088](https://github.com/opensearch-project/OpenSearch/pull/19088) | Date histogram optimization with rounding utility refactoring |
+
+## References
+
+- [Issue #13122](https://github.com/opensearch-project/OpenSearch/issues/13122): Rare Terms Aggregation Performance Optimization
+- [Issue #18704](https://github.com/opensearch-project/OpenSearch/issues/18704): Optimize String terms agg
+- [Issue #10954](https://github.com/opensearch-project/OpenSearch/issues/10954): Use Collector.setWeight to improve aggregation performance
+- [Rare Terms Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/rare-terms/)
+- [Terms Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/terms/)
+- [Date Histogram Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/date-histogram/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/aggregation-optimizations.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -4,6 +4,7 @@
 
 ### OpenSearch
 
+- [Aggregation Optimizations](features/opensearch/aggregation-optimizations.md)
 - [Alias Write Index Policy](features/opensearch/alias-write-index-policy.md)
 - [Client API Enhancements](features/opensearch/client-api-enhancements.md)
 - [Cardinality Aggregation](features/opensearch/cardinality-aggregation.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Aggregation Optimizations feature in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/aggregation-optimizations.md`
- Feature report: `docs/features/opensearch/aggregation-optimizations.md`

### Key Changes in v3.3.0

1. **Rare Terms Aggregation Precomputation** (PR #18978)
   - Uses Lucene term frequency data to avoid document iteration
   - Leverages `Weight.count()` for match-all query optimization

2. **String Terms Aggregation Optimization** (PR #18732)
   - Implements quickselect algorithm for large bucket counts
   - Adaptive strategy selection: priority_queue, quick_select, or select_all

3. **Date Histogram Optimization** (PR #19088)
   - Reuses rounding utility objects to prevent memory allocations
   - ~1.5-2x latency improvement for date histogram with sub-aggregations

### Related Issue
Closes #1406