### PR TITLE
docs: add star-tree-index report for v3.3.0

### DIFF
--- a/docs/features/opensearch/star-tree-index.md
+++ b/docs/features/opensearch/star-tree-index.md
@@ -104,8 +104,10 @@ Star-tree search statistics are available (v3.2.0+) through the stats APIs:
 | `startree_query_total` | Total queries resolved using star-tree |
 | `startree_query_time_in_millis` | Time spent in star-tree queries |
 | `startree_query_current` | Currently running star-tree queries |
+| `query_failed` | Total failed query phase operations (v3.3.0+) |
+| `startree_query_failed` | Failed star-tree query operations (v3.3.0+) |
 
-Access via `/_nodes/stats/indices/search`, `/_stats/search`, or `/_stats/search?level=shards`.
+Access via `/_nodes/stats/indices/search`, `/_stats/search`, `/_cat/shards`, `/_cat/nodes`, `/_cat/indices`, or `/_stats/search?level=shards`.
 
 ### Supported Features
 
@@ -128,6 +130,7 @@ Access via `/_nodes/stats/indices/search`, `/_stats/search`, or `/_stats/search?
 - Terms aggregations (keyword and numeric)
 - Range aggregations with metric sub-aggregations
 - Nested bucket aggregations (v3.1.0+): terms → terms → metric, date_histogram → terms → metric, etc.
+- Multi-terms aggregations (v3.3.0+): group by multiple dimension fields simultaneously
 
 ### Usage Example
 
@@ -201,6 +204,8 @@ POST /logs/_search
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#19284](https://github.com/opensearch-project/OpenSearch/pull/19284) | Support for multi-terms aggregations |
+| v3.3.0 | [#19209](https://github.com/opensearch-project/OpenSearch/pull/19209) | Add search & star-tree search query failure count metrics |
 | v3.2.0 | [security#5492](https://github.com/opensearch-project/security/pull/5492) | Restrict star-tree for users with DLS/FLS/Field Masking |
 | v3.2.0 | [#18707](https://github.com/opensearch-project/OpenSearch/pull/18707) | Add star-tree search statistics |
 | v3.2.0 | [#18671](https://github.com/opensearch-project/OpenSearch/pull/18671) | Add IP field search support |
@@ -215,6 +220,8 @@ POST /logs/_search
 
 ## References
 
+- [Issue #18398](https://github.com/opensearch-project/OpenSearch/issues/18398): Multi-terms aggregation feature request
+- [Issue #19210](https://github.com/opensearch-project/OpenSearch/issues/19210): Query failure stats feature request
 - [Issue #17443](https://github.com/opensearch-project/OpenSearch/issues/17443): Date range query support
 - [Issue #17274](https://github.com/opensearch-project/OpenSearch/issues/17274): Nested bucket aggregations
 - [Issue #16551](https://github.com/opensearch-project/OpenSearch/issues/16551): Bucket terms aggregation feature request
@@ -229,6 +236,7 @@ POST /logs/_search
 
 ## Change History
 
+- **v3.3.0** (2025-10-28): Added multi-terms aggregation support (up to 40x performance improvement), search query failure statistics (query_failed, startree_query_failed)
 - **v3.2.0** (2025-09-16): Added DLS/FLS/Field Masking security integration (disables star-tree for restricted users), IP field search support, star-tree search statistics (query count, time, current)
 - **v3.1.0** (2025-06-10): Production-ready status, removed feature flag, added index-level setting, date range query support, nested bucket aggregations
 - **v3.0.0** (2025-05-12): Added boolean query support, terms aggregations, range aggregations, unsigned-long support

--- a/docs/releases/v3.3.0/features/opensearch/star-tree-index.md
+++ b/docs/releases/v3.3.0/features/opensearch/star-tree-index.md
@@ -1,0 +1,132 @@
+# Star Tree Index
+
+## Summary
+
+OpenSearch v3.3.0 enhances the star-tree index with two key improvements: support for multi-terms aggregations and new search failure statistics. Multi-terms aggregations allow grouping by multiple fields simultaneously using the star-tree index, delivering significant performance gains (up to 40x faster). The new failure metrics provide better observability for star-tree query operations.
+
+## Details
+
+### What's New in v3.3.0
+
+#### Multi-Terms Aggregation Support
+
+Star-tree index now supports multi-terms aggregations, enabling efficient grouping by multiple dimension fields in a single query. This feature generates the cartesian product of dimension values within star-tree entries to form composite keys.
+
+**Performance Improvements** (based on ~12GB http_logs dataset):
+- keyword × numeric field: ~6s → ~2s (3x faster)
+- numeric × numeric field: ~6s → ~150ms (40x faster)
+
+#### Search Query Failure Statistics
+
+New metrics capture failure counts for search queries:
+- `search.query_failed`: Total failed query phase operations
+- `search.startree_query_failed`: Failed star-tree query operations
+
+These metrics are available through:
+- `/_nodes/stats/indices/search`
+- `/_stats/search`
+- `/_cat/shards`
+- `/_cat/nodes`
+- `/_cat/indices`
+
+### Technical Changes
+
+#### Multi-Terms Aggregation Implementation
+
+```mermaid
+graph TB
+    subgraph "Multi-Terms with Star-Tree"
+        Query[Multi-Terms Query<br/>fields: keyword, numeric] --> Validate{Fields in<br/>Dimensions?}
+        Validate -->|Yes| Iterators[Open Dimension<br/>Value Iterators]
+        Validate -->|No| Fallback[Standard Aggregation]
+        
+        Iterators --> Collect[Collect Star-Tree Entries]
+        Collect --> Cartesian[Generate Cartesian<br/>Product of Values]
+        Cartesian --> Buckets[Collect Buckets<br/>with Doc Counts]
+        Buckets --> SubAgg[Process Sub-Aggregations]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `MultiTermsAggregator.getStarTreeBucketCollector()` | Creates star-tree bucket collector for multi-terms |
+| `StarTreeValuesIterator.entryValueCount()` | Returns value count for current star-tree entry |
+| `StatsHolder.queryFailed` | Counter for failed query operations |
+| `StatsHolder.starTreeQueryFailed` | Counter for failed star-tree query operations |
+
+#### API Changes
+
+New fields in search stats response:
+
+```json
+{
+  "search": {
+    "query_total": 1000,
+    "query_time_in_millis": 5000,
+    "query_current": 0,
+    "query_failed": 5,
+    "startree_query_total": 500,
+    "startree_query_time_in_millis": 100,
+    "startree_query_current": 0,
+    "startree_query_failed": 1
+  }
+}
+```
+
+### Usage Example
+
+```json
+// Multi-terms aggregation using star-tree
+POST /logs/_search
+{
+  "size": 0,
+  "aggs": {
+    "by_status_and_method": {
+      "multi_terms": {
+        "terms": [
+          { "field": "status" },
+          { "field": "method" }
+        ]
+      },
+      "aggs": {
+        "max_latency": {
+          "max": { "field": "latency" }
+        }
+      }
+    }
+  }
+}
+```
+
+### Requirements
+
+For multi-terms aggregations to use star-tree:
+1. All fields in `terms` must be part of star-tree `ordered_dimensions`
+2. Sub-aggregation metrics must be configured in star-tree `metrics`
+3. Index must have `index.composite_index: true` and `index.append_only.enabled: true`
+
+## Limitations
+
+- Multi-terms aggregation fields must all be star-tree dimensions
+- Nested metric sub-aggregations (metric inside metric) not supported with star-tree
+- Unsupported sub-aggregations fall back to standard aggregation path
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19284](https://github.com/opensearch-project/OpenSearch/pull/19284) | Support for multi-terms aggregations using star-tree |
+| [#19209](https://github.com/opensearch-project/OpenSearch/pull/19209) | Add search & star-tree search query failure count metrics |
+
+## References
+
+- [Issue #18398](https://github.com/opensearch-project/OpenSearch/issues/18398): Multi-terms aggregation feature request
+- [Issue #19210](https://github.com/opensearch-project/OpenSearch/issues/19210): Query failure stats feature request
+- [Documentation](https://docs.opensearch.org/3.0/search-plugins/star-tree-index/): Star-tree index documentation
+- [Multi-terms Aggregation](https://docs.opensearch.org/3.0/aggregations/bucket/multi-terms/): Multi-terms aggregation reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/star-tree-index.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -36,6 +36,7 @@
 - [Search Settings](features/opensearch/search-settings.md)
 - [Search Stats - Negative Value Handling](features/opensearch/search-stats.md)
 - [Segment Replication](features/opensearch/segment-replication.md)
+- [Star Tree Index](features/opensearch/star-tree-index.md)
 - [Store Subdirectory Module](features/opensearch/store-subdirectory-module.md)
 - [Streaming Aggregation](features/opensearch/streaming-aggregation.md)
 - [Terms Query Rewriting](features/opensearch/terms-query-rewriting.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for Star Tree Index enhancements in OpenSearch v3.3.0.

### Changes in v3.3.0

1. **Multi-Terms Aggregation Support** (PR #19284)
   - Enables grouping by multiple dimension fields simultaneously using star-tree index
   - Performance improvements: up to 40x faster (numeric × numeric: ~6s → ~150ms)

2. **Search Query Failure Statistics** (PR #19209)
   - New metrics: `query_failed` and `startree_query_failed`
   - Available through stats APIs, cat shards, cat nodes, cat indices

### Files Changed

- Created: `docs/releases/v3.3.0/features/opensearch/star-tree-index.md`
- Updated: `docs/features/opensearch/star-tree-index.md`
- Updated: `docs/releases/v3.3.0/index.md`

### Related Issue

Closes #1404