### PR TITLE
docs: add pull-based ingestion report for v3.3.0

### DIFF
--- a/docs/features/opensearch/pull-based-ingestion.md
+++ b/docs/features/opensearch/pull-based-ingestion.md
@@ -198,6 +198,11 @@ GET /<index>/ingestion/_state
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#19316](https://github.com/opensearch-project/OpenSearch/pull/19316) | Support all-active mode in pull-based ingestion |
+| v3.3.0 | [#19320](https://github.com/opensearch-project/OpenSearch/pull/19320) | Fix ingestion state XContent serialization and fail fast on parsing errors |
+| v3.3.0 | [#19393](https://github.com/opensearch-project/OpenSearch/pull/19393) | Fix lag metric when streaming source is empty |
+| v3.3.0 | [#19212](https://github.com/opensearch-project/OpenSearch/pull/19212) | Fix ingestion pause state initialization on replica promotion |
+| v3.3.0 | [#19380](https://github.com/opensearch-project/OpenSearch/pull/19380) | Fix flaky test IngestFromKinesisIT.testAllActiveIngestion |
 | v3.2.0 | [#18591](https://github.com/opensearch-project/OpenSearch/pull/18591) | File-based ingestion plugin (ingestion-fs) for local testing |
 | v3.1.0 | [#17977](https://github.com/opensearch-project/OpenSearch/pull/17977) | Lag metrics for polling |
 | v3.1.0 | [#18088](https://github.com/opensearch-project/OpenSearch/pull/18088) | Error metrics and configurable queue size |
@@ -208,6 +213,9 @@ GET /<index>/ingestion/_state
 
 ## References
 
+- [Issue #19287](https://github.com/opensearch-project/OpenSearch/issues/19287): All-active mode feature request
+- [Issue #19286](https://github.com/opensearch-project/OpenSearch/issues/19286): XContent serialization bug
+- [Issue #17077](https://github.com/opensearch-project/OpenSearch/issues/17077): Metrics for pull-based ingestion
 - [Issue #17442](https://github.com/opensearch-project/OpenSearch/issues/17442): Ingestion management APIs
 - [Issue #18279](https://github.com/opensearch-project/OpenSearch/issues/18279): Cluster write block support
 - [Issue #18590](https://github.com/opensearch-project/OpenSearch/issues/18590): File-based ingestion plugin request
@@ -216,6 +224,7 @@ GET /<index>/ingestion/_state
 
 ## Change History
 
+- **v3.3.0**: Added all-active ingestion mode enabling replica shards to independently ingest from streaming sources. Fixed ingestion state XContent serialization for remote cluster state compatibility. Fixed lag metric calculation when streaming source is empty. Fixed pause state initialization during replica promotion. Added fail-fast behavior for mapper/parsing errors.
 - **v3.2.0**: Added `ingestion-fs` plugin for file-based ingestion, enabling local testing without Kafka/Kinesis setup. Files follow `${base_directory}/${stream}/${shard_id}.ndjson` convention.
 - **v3.1.0**: Added lag metrics, error metrics, configurable queue size, transient failure retries, create mode, cluster write block support, consumer reset in Resume API. Breaking change: renamed `REWIND_BY_OFFSET`/`REWIND_BY_TIMESTAMP` to `RESET_BY_OFFSET`/`RESET_BY_TIMESTAMP`.
 - **v3.0.0**: Initial implementation with Kafka and Kinesis support, pause/resume APIs, basic metrics.

--- a/docs/releases/v3.3.0/features/opensearch/pull-based-ingestion.md
+++ b/docs/releases/v3.3.0/features/opensearch/pull-based-ingestion.md
@@ -1,0 +1,144 @@
+# Pull-based Ingestion Enhancements
+
+## Summary
+
+OpenSearch v3.3.0 introduces the all-active ingestion mode for pull-based ingestion, enabling replica shards to independently ingest from streaming sources. This release also includes bug fixes for ingestion state serialization, lag metrics, and pause state initialization during replica promotion.
+
+## Details
+
+### What's New in v3.3.0
+
+#### All-Active Ingestion Mode
+
+The primary enhancement in v3.3.0 is the all-active ingestion mode, which provides a document replication equivalent for pull-based ingestion. Previously, pull-based ingestion only supported segment replication mode with remote store dependency. The all-active mode enables both primary and replica shards to consume from the same streaming source partition independently.
+
+```mermaid
+graph TB
+    subgraph "Streaming Source"
+        Partition[Kafka Partition / Kinesis Shard]
+    end
+    
+    subgraph "OpenSearch Cluster"
+        subgraph "Primary Shard"
+            P_Poller[Poller]
+            P_Engine[Ingestion Engine]
+            P_Index[Lucene Index]
+        end
+        
+        subgraph "Replica Shard"
+            R_Poller[Poller]
+            R_Engine[Ingestion Engine]
+            R_Index[Lucene Index]
+        end
+    end
+    
+    Partition --> P_Poller
+    Partition --> R_Poller
+    P_Poller --> P_Engine --> P_Index
+    R_Poller --> R_Engine --> R_Index
+```
+
+**Key characteristics:**
+- Both primary and replica shards ingest from the same partition independently
+- No coordination or replication between primary and replicas
+- Removes segment replication and remote store dependency
+- Better throughput compared to traditional document replication
+- Better freshness as all replicas directly ingest from the source
+- Replicas use peer recovery during shard reinitialization
+
+#### Bug Fixes
+
+| Fix | Description |
+|-----|-------------|
+| XContent Serialization | Added `ingestionStatus` field to `IndexMetadata.toXContent()` for remote cluster state compatibility |
+| Lag Metric | Fixed lag calculation when streaming source is empty by setting lag to 0 |
+| Pause State | Fixed ingestion pause state initialization during replica promotion |
+| Replication Validation | Added validation for all-active ingestion to validate replication type |
+| Fail Fast | Added fail-fast behavior for mapper/parsing errors to avoid unnecessary retries |
+
+### Technical Changes
+
+#### GetIngestionState API Enhancement
+
+The `GetIngestionState` API response now includes additional fields to differentiate between primary and replica shards:
+
+```json
+{
+  "ingestion_state": {
+    "my-index": [
+      {
+        "shard": 0,
+        "primary": true,
+        "node_name": "node-1",
+        "poller_state": "POLLING",
+        "error_policy": "DROP",
+        "poller_paused": false
+      },
+      {
+        "shard": 0,
+        "primary": false,
+        "node_name": "node-2",
+        "poller_state": "POLLING",
+        "error_policy": "DROP",
+        "poller_paused": false
+      }
+    ]
+  }
+}
+```
+
+#### Lag Metric Fix
+
+Previously, lag was computed as the difference between system time and last processed message timestamp. When no messages were consumed for a long time, the lag kept increasing incorrectly. The fix:
+- Sets lag to 0 when an empty batch is read from the streaming source
+- Explicitly sets lag to 0 when the poller is paused
+
+### Usage Example
+
+All-active mode is automatically enabled when using pull-based ingestion without segment replication:
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "ingestion_source": {
+      "type": "kafka",
+      "pointer.init.reset": "earliest",
+      "param": {
+        "topic": "my-topic",
+        "bootstrap_servers": "localhost:9092"
+      }
+    },
+    "index.number_of_shards": 3,
+    "index.number_of_replicas": 1
+  }
+}
+```
+
+## Limitations
+
+- Primary and replicas can process events at different rates (no coordination)
+- All-active mode requires document replication type (not segment replication)
+- Recovery logic does not yet consider `batchStartPointer` for optimized recovery
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19316](https://github.com/opensearch-project/OpenSearch/pull/19316) | Support all-active mode in pull-based ingestion |
+| [#19320](https://github.com/opensearch-project/OpenSearch/pull/19320) | Fix ingestion state XContent serialization and fail fast on parsing errors |
+| [#19393](https://github.com/opensearch-project/OpenSearch/pull/19393) | Fix lag metric when streaming source is empty |
+| [#19212](https://github.com/opensearch-project/OpenSearch/pull/19212) | Fix ingestion pause state initialization on replica promotion |
+| [#19380](https://github.com/opensearch-project/OpenSearch/pull/19380) | Fix flaky test IngestFromKinesisIT.testAllActiveIngestion |
+
+## References
+
+- [Issue #19287](https://github.com/opensearch-project/OpenSearch/issues/19287): Feature request for all-active mode
+- [Issue #19286](https://github.com/opensearch-project/OpenSearch/issues/19286): Bug report for XContent serialization
+- [Issue #17077](https://github.com/opensearch-project/OpenSearch/issues/17077): Metrics for pull-based ingestion
+- [Documentation](https://docs.opensearch.org/3.0/api-reference/document-apis/pull-based-ingestion/): Pull-based ingestion
+- [Documentation](https://docs.opensearch.org/3.0/api-reference/document-apis/pull-based-ingestion-management/): Pull-based ingestion management
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/pull-based-ingestion.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -26,6 +26,7 @@
 - [OOM Prevention](features/opensearch/oom-prevention.md)
 - [Painless Scripting](features/opensearch/painless-scripting.md)
 - [Plugin Installation](features/opensearch/plugin-installation.md)
+- [Pull-based Ingestion](features/opensearch/pull-based-ingestion.md)
 - [Query Phase Fixes](features/opensearch/query-phase-fixes.md)
 - [Reactor Netty Transport](features/opensearch/reactor-netty-transport.md)
 - [Reindex API](features/opensearch/reindex-api.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for Pull-based Ingestion enhancements in OpenSearch v3.3.0.

### Key Changes in v3.3.0

- **All-Active Ingestion Mode**: Enables replica shards to independently ingest from streaming sources (Kafka/Kinesis), providing a document replication equivalent for pull-based ingestion
- **XContent Serialization Fix**: Added `ingestionStatus` field to `IndexMetadata.toXContent()` for remote cluster state compatibility
- **Lag Metric Fix**: Fixed lag calculation when streaming source is empty
- **Pause State Fix**: Fixed ingestion pause state initialization during replica promotion
- **Fail Fast**: Added fail-fast behavior for mapper/parsing errors

### Reports Created

- Release report: `docs/releases/v3.3.0/features/opensearch/pull-based-ingestion.md`
- Feature report: `docs/features/opensearch/pull-based-ingestion.md` (updated)

### Related PRs

- #19316: Support all-active mode in pull-based ingestion
- #19320: Fix ingestion state XContent serialization
- #19393: Fix lag metric when streaming source is empty
- #19212: Fix ingestion pause state initialization on replica promotion
- #19380: Fix flaky test IngestFromKinesisIT.testAllActiveIngestion