### PR TITLE
docs: add search tie-breaking report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -132,6 +132,7 @@
 - [Search Settings](opensearch/search-settings.md)
 - [Scripted Metric Aggregation](opensearch/scripted-metric-aggregation.md)
 - [Search Shard Routing](opensearch/search-shard-routing.md)
+- [Search Tie-breaking](opensearch/search-tie-breaking.md)
 - [Secure Aux Transport Settings](opensearch/secure-aux-transport-settings.md)
 - [Secure Transport Settings](opensearch/secure-transport-settings.md)
 - [Segment Replication](opensearch/segment-replication.md)

--- a/docs/features/opensearch/search-tie-breaking.md
+++ b/docs/features/opensearch/search-tie-breaking.md
@@ -1,0 +1,146 @@
+# Search Tie-breaking (_shard_doc)
+
+## Summary
+
+The `_shard_doc` pseudo-field provides deterministic tie-breaking for search result pagination in OpenSearch. When paginating through search results using `search_after` with Point in Time (PIT), documents with identical sort values can appear in inconsistent order across pages, leading to duplicates or missing results. The `_shard_doc` field solves this by providing a unique sort key for every document, computed as a composite of the shard ID and global document ID.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Query Processing"
+        A[Search Request] --> B[SearchRequest.validate]
+        B --> C{_shard_doc in sort?}
+        C -->|Yes| D{PIT present?}
+        C -->|No| E[Continue normal flow]
+        D -->|Yes| F[Build ShardDocSortBuilder]
+        D -->|No| G[Reject: PIT required]
+    end
+    
+    subgraph "Sort Field Construction"
+        F --> H[ShardDocSortBuilder.build]
+        H --> I[Create SortField with ShardDocFieldComparatorSource]
+        I --> J[Pass shardId to comparator]
+    end
+    
+    subgraph "Document Comparison"
+        J --> K[ShardDocFieldComparatorSource]
+        K --> L[LeafFieldComparator per segment]
+        L --> M["computeGlobalDocKey(doc)"]
+        M --> N["shardKeyPrefix | (docBase + doc)"]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Document] --> B[Shard ID]
+    A --> C[Segment docBase]
+    A --> D[Local doc ID]
+    B --> E["shardId << 32"]
+    C --> F[docBase + doc]
+    D --> F
+    E --> G["shardKeyPrefix | globalDocId"]
+    F --> G
+    G --> H[64-bit sort key]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ShardDocSortBuilder` | Parses `_shard_doc` from JSON/XContent and builds the Lucene `SortField` |
+| `ShardDocFieldComparatorSource` | Custom `FieldComparatorSource` that computes composite keys for comparison |
+| `SearchRequest.validate` | Validates that `_shard_doc` is only used with PIT and not with scroll |
+| `SortBuilders.shardDocSort()` | Factory method for creating `ShardDocSortBuilder` programmatically |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `sort._shard_doc.order` | Sort order for _shard_doc | `asc` |
+
+### Usage Example
+
+#### Basic Usage with PIT
+
+```json
+// Create PIT
+POST /my-index/_search/point_in_time?keep_alive=5m
+
+// First page
+GET /_search
+{
+  "size": 10,
+  "pit": { "id": "<pit_id>", "keep_alive": "5m" },
+  "sort": [
+    { "score": "desc" },
+    { "_shard_doc": "asc" }
+  ]
+}
+
+// Response includes sort values
+{
+  "hits": {
+    "hits": [
+      {
+        "_id": "doc1",
+        "sort": [0.95, 4294967296]
+      }
+    ]
+  }
+}
+
+// Next page using search_after
+GET /_search
+{
+  "size": 10,
+  "pit": { "id": "<pit_id>", "keep_alive": "5m" },
+  "sort": [
+    { "score": "desc" },
+    { "_shard_doc": "asc" }
+  ],
+  "search_after": [0.95, 4294967296]
+}
+```
+
+#### Java API Usage
+
+```java
+// Create _shard_doc sort
+ShardDocSortBuilder shardDocSort = SortBuilders.shardDocSort()
+    .order(SortOrder.ASC);
+
+// Build search request with PIT
+SearchSourceBuilder sourceBuilder = new SearchSourceBuilder()
+    .size(100)
+    .pointInTimeBuilder(new PointInTimeBuilder(pitId))
+    .sort(SortBuilders.fieldSort("timestamp").order(SortOrder.DESC))
+    .sort(shardDocSort);
+```
+
+## Limitations
+
+- **PIT Required**: `_shard_doc` can only be used with Point in Time (PIT). Attempting to use it without PIT results in a validation error.
+- **No Scroll Support**: Cannot be combined with the scroll API. Use PIT + `search_after` instead.
+- **Single Instance**: Only one `_shard_doc` sort field is allowed per query.
+- **No Bucketed Sort**: Bucketed sort operations are not supported for `_shard_doc`.
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#18924](https://github.com/opensearch-project/OpenSearch/pull/18924) | Initial implementation of _shard_doc sort |
+
+## References
+
+- [Issue #17064](https://github.com/opensearch-project/OpenSearch/issues/17064): Original feature request
+- [Point in Time Documentation](https://docs.opensearch.org/3.0/search-plugins/searching-data/point-in-time/): PIT usage guide
+- [Paginate Results](https://docs.opensearch.org/3.0/search-plugins/searching-data/paginate/): Pagination methods comparison
+
+## Change History
+
+- **v3.3.0** (2025-09-30): Initial implementation - Added `_shard_doc` pseudo-field for deterministic tie-breaking with PIT pagination

--- a/docs/releases/v3.3.0/features/opensearch/search-tie-breaking.md
+++ b/docs/releases/v3.3.0/features/opensearch/search-tie-breaking.md
@@ -1,0 +1,117 @@
+# Search Tie-breaking
+
+## Summary
+
+OpenSearch v3.3.0 introduces the `_shard_doc` sort field, enabling deterministic tie-breaking for search result pagination. This feature allows users to sort by a composite key of shard ID and document ID, ensuring consistent ordering when paginating through results with `search_after` and Point in Time (PIT). This addresses a common issue where documents with identical scores could appear in inconsistent order across pages.
+
+## Details
+
+### What's New in v3.3.0
+
+The `_shard_doc` pseudo-field provides a unique, deterministic sort key for each document by combining the shard ID and global document ID into a single 64-bit value: `(shardId << 32) | globalDocId`. This ensures that every document has a unique sort value, eliminating duplicates and gaps when paginating through search results.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Search Request"
+        A[Search Query] --> B{Has _shard_doc sort?}
+        B -->|Yes| C[Validate PIT present]
+        B -->|No| D[Standard Sort]
+        C -->|Valid| E[ShardDocSortBuilder]
+        C -->|Invalid| F[Validation Error]
+    end
+    
+    subgraph "Sort Execution"
+        E --> G[ShardDocFieldComparatorSource]
+        G --> H[Compute: shardId << 32 | docBase + doc]
+        H --> I[Long comparison for ordering]
+    end
+    
+    subgraph "Pagination"
+        I --> J[Return sort values in response]
+        J --> K[Use in search_after for next page]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ShardDocSortBuilder` | Sort builder for the `_shard_doc` pseudo-field, handles JSON parsing and sort field construction |
+| `ShardDocFieldComparatorSource` | Lucene `FieldComparatorSource` that computes the composite key `(shardId << 32) \| globalDocId` |
+
+#### Validation Rules
+
+| Rule | Description |
+|------|-------------|
+| PIT Required | `_shard_doc` can only be used with Point in Time (PIT) |
+| No Scroll | `_shard_doc` cannot be used with scroll API |
+| No Duplicates | Only one `_shard_doc` sort can be specified per query |
+
+### Usage Example
+
+```json
+// Step 1: Create a Point in Time
+POST /my-index/_search/point_in_time?keep_alive=5m
+
+// Step 2: Search with _shard_doc sort
+GET /_search
+{
+  "size": 100,
+  "pit": {
+    "id": "<pit_id>",
+    "keep_alive": "5m"
+  },
+  "sort": [
+    { "timestamp": "desc" },
+    { "_shard_doc": "asc" }
+  ]
+}
+
+// Step 3: Paginate using search_after with the last document's sort values
+GET /_search
+{
+  "size": 100,
+  "pit": {
+    "id": "<pit_id>",
+    "keep_alive": "5m"
+  },
+  "sort": [
+    { "timestamp": "desc" },
+    { "_shard_doc": "asc" }
+  ],
+  "search_after": ["2024-01-15T10:30:00Z", 4294967296]
+}
+```
+
+### Migration Notes
+
+- If you're currently using `search_after` with PIT and experiencing duplicate results, add `_shard_doc` as a tie-breaker sort field
+- Replace scroll-based pagination with PIT + `search_after` + `_shard_doc` for more consistent results
+- The `_shard_doc` sort value is a `Long` type in the response
+
+## Limitations
+
+- Requires Point in Time (PIT) - cannot be used without PIT
+- Cannot be combined with scroll API
+- Only one `_shard_doc` sort field allowed per query
+- Bucketed sort is not supported for `_shard_doc`
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18924](https://github.com/opensearch-project/OpenSearch/pull/18924) | Add support for search tie-breaking by _shard_doc |
+
+## References
+
+- [Issue #17064](https://github.com/opensearch-project/OpenSearch/issues/17064): Original feature request for _shard_doc equivalent
+- [Point in Time Documentation](https://docs.opensearch.org/3.0/search-plugins/searching-data/point-in-time/): Official PIT documentation
+- [Paginate Results Documentation](https://docs.opensearch.org/3.0/search-plugins/searching-data/paginate/): Pagination methods in OpenSearch
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/search-tie-breaking.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -37,6 +37,7 @@
 - [Scroll API Error Handling](features/opensearch/scroll-api.md)
 - [Search Settings](features/opensearch/search-settings.md)
 - [Search Stats - Negative Value Handling](features/opensearch/search-stats.md)
+- [Search Tie-breaking](features/opensearch/search-tie-breaking.md)
 - [Segment Replication](features/opensearch/segment-replication.md)
 - [Skip List](features/opensearch/skip-list.md)
 - [Star Tree Index](features/opensearch/star-tree-index.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Search Tie-breaking feature introduced in OpenSearch v3.3.0.

### Feature Overview

The `_shard_doc` pseudo-field provides deterministic tie-breaking for search result pagination. When paginating through search results using `search_after` with Point in Time (PIT), documents with identical sort values can appear in inconsistent order across pages. The `_shard_doc` field solves this by providing a unique sort key for every document, computed as `(shardId << 32) | globalDocId`.

### Reports Created

- Release report: `docs/releases/v3.3.0/features/opensearch/search-tie-breaking.md`
- Feature report: `docs/features/opensearch/search-tie-breaking.md`

### Key Changes in v3.3.0

- New `ShardDocSortBuilder` for parsing `_shard_doc` sort field
- New `ShardDocFieldComparatorSource` for computing composite sort keys
- Validation to ensure `_shard_doc` is only used with PIT
- Support for both ascending and descending sort order

### Resources Used

- PR: #18924 (opensearch-project/OpenSearch)
- Issue: #17064 (opensearch-project/OpenSearch)
- Docs: https://docs.opensearch.org/3.0/search-plugins/searching-data/point-in-time/