### PR TITLE
docs: add Grok Processor report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -74,6 +74,7 @@
 - [Source Field Matching](opensearch/source-field-matching.md)
 - [Cryptography & Security Libraries](opensearch/cryptography-security-libraries.md)
 - [Gradle Build System](opensearch/gradle-build-system.md)
+- [Grok Processor](opensearch/grok-processor.md)
 - [HTTP Client](opensearch/http-client.md)
 - [Identity Feature Flag Removal](opensearch/identity-feature-flag-removal.md)
 - [Index Output Optimization](opensearch/index-output.md)

--- a/docs/features/opensearch/grok-processor.md
+++ b/docs/features/opensearch/grok-processor.md
@@ -1,0 +1,138 @@
+# Grok Processor
+
+## Summary
+
+The Grok processor is an ingest processor that parses and structures unstructured data using pattern matching. It extracts fields from log messages, web server access logs, application logs, and other log data that follows a consistent format. The processor uses predefined patterns based on regular expressions to match parts of the input text and assign them to named fields.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Ingest Pipeline"
+        Doc[Document] --> Pipeline[Ingest Pipeline]
+        Pipeline --> GrokProcessor[Grok Processor]
+        GrokProcessor --> Grok[Grok Library]
+        Grok --> PatternBank[Pattern Bank]
+        Grok --> Regex[Oniguruma Regex Engine]
+        Regex --> Extracter[GrokCaptureExtracter]
+        Extracter --> Result[Extracted Fields]
+        Result --> Doc2[Processed Document]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Raw Log Line] --> B[Grok Pattern Matching]
+    B --> C{Match Found?}
+    C -->|Yes| D[Extract Named Captures]
+    C -->|No| E[Error/Ignore]
+    D --> F{capture_all_matches?}
+    F -->|true| G[Collect All Values as Array]
+    F -->|false| H[Keep First Value Only]
+    G --> I[Add Fields to Document]
+    H --> I
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `GrokProcessor` | Main processor class that handles pipeline integration |
+| `Grok` | Core pattern matching engine using Oniguruma regex |
+| `GrokCaptureExtracter` | Extracts matched values from regex regions |
+| `GrokCaptureType` | Handles type conversion (string, int, long, float, double) |
+| `GrokCaptureConfig` | Configuration for individual capture groups |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `field` | The field containing the text to parse | Required |
+| `patterns` | List of grok patterns to match against | Required |
+| `pattern_definitions` | Custom pattern definitions | `{}` |
+| `trace_match` | Add `_grok_match_index` to show which pattern matched | `false` |
+| `ignore_missing` | Ignore if the field doesn't exist | `false` |
+| `ignore_failure` | Continue even if processing fails | `false` |
+| `capture_all_matches` | Capture all values for repeated field names as array | `false` |
+
+### Usage Example
+
+**Basic grok pattern:**
+
+```json
+PUT _ingest/pipeline/apache_logs
+{
+  "description": "Parse Apache access logs",
+  "processors": [
+    {
+      "grok": {
+        "field": "message",
+        "patterns": ["%{IPORHOST:clientip} %{USER:ident} %{USER:auth} \\[%{HTTPDATE:timestamp}\\] \"%{WORD:method} %{URIPATHPARAM:request} HTTP/%{NUMBER:httpversion}\" %{NUMBER:response:int} %{NUMBER:bytes:int}"]
+      }
+    }
+  ]
+}
+```
+
+**With custom patterns:**
+
+```json
+PUT _ingest/pipeline/custom_logs
+{
+  "processors": [
+    {
+      "grok": {
+        "field": "message",
+        "patterns": ["Status: %{STATUS:status}"],
+        "pattern_definitions": {
+          "STATUS": "OK|ERROR|WARNING"
+        }
+      }
+    }
+  ]
+}
+```
+
+**Capturing multiple values (v3.3.0+):**
+
+```json
+PUT _ingest/pipeline/multi_ip
+{
+  "processors": [
+    {
+      "grok": {
+        "field": "message",
+        "patterns": ["%{IP:ip}, %{IP:ip}, %{IP:ip}"],
+        "capture_all_matches": true
+      }
+    }
+  ]
+}
+```
+
+## Limitations
+
+- Pattern matching can be CPU-intensive for complex patterns or large inputs
+- The `capture_all_matches` option applies globally to all fields in the pattern
+- Grok patterns are evaluated sequentially; only the first matching pattern is used
+- No built-in protection against catastrophic backtracking in regex patterns
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#18799](https://github.com/opensearch-project/OpenSearch/pull/18799) | Added `capture_all_matches` option for multi-value capture |
+
+## References
+
+- [Issue #18790](https://github.com/opensearch-project/OpenSearch/issues/18790): Feature request for multi-value capture
+- [Grok Processor Documentation](https://docs.opensearch.org/3.0/ingest-pipelines/processors/grok/): Official documentation
+- [Oniguruma Regex Library](https://github.com/kkos/oniguruma): Underlying regex engine
+
+## Change History
+
+- **v3.3.0** (2025-09-12): Added `capture_all_matches` option to capture multiple values for repeated field names into an array

--- a/docs/releases/v3.3.0/features/opensearch/grok-processor.md
+++ b/docs/releases/v3.3.0/features/opensearch/grok-processor.md
@@ -1,0 +1,115 @@
+# Grok Processor - Capture All Matches
+
+## Summary
+
+The Grok processor in OpenSearch v3.3.0 adds a new `capture_all_matches` option that allows capturing multiple values for the same field name into an array. Previously, when a grok pattern contained repeated field names (e.g., multiple IP addresses), only the first matched value was captured. This enhancement aligns behavior with Logstash's grok filter, which captures all matched values by default.
+
+## Details
+
+### What's New in v3.3.0
+
+The `capture_all_matches` parameter enables collecting all matched values for repeated field names into an array instead of only keeping the first match.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Grok Processor"
+        Input[Input Document] --> GrokProcessor[GrokProcessor]
+        GrokProcessor --> Grok[Grok Library]
+        Grok --> Extracter[GrokCaptureExtracter]
+        Extracter --> |captureAllMatches=false| FirstMatch[First Match Only]
+        Extracter --> |captureAllMatches=true| AllMatches[All Matches as Array]
+        FirstMatch --> Output[Output Document]
+        AllMatches --> Output
+    end
+```
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `capture_all_matches` | When `true`, all matched values for the same field name are collected into an array. When `false`, only the first matched value is captured. | `false` |
+
+#### Modified Components
+
+| Component | Description |
+|-----------|-------------|
+| `GrokProcessor` | Added `captureAllMatches` parameter to constructor and factory |
+| `Grok` | New constructor accepting `captureAllMatches` flag |
+| `GrokCaptureExtracter` | Modified `extract()` method to support array collection |
+| `GrokCaptureType` | Modified to continue capturing when `captureAllMatches` is true |
+
+### Usage Example
+
+**Pipeline with `capture_all_matches` enabled:**
+
+```json
+PUT _ingest/pipeline/log_pipeline
+{
+  "description": "Extract multiple IP addresses",
+  "processors": [
+    {
+      "grok": {
+        "field": "message",
+        "patterns": ["%{IP:x_forwarded_for}, %{IP:x_forwarded_for}, %{IP:x_forwarded_for}"],
+        "capture_all_matches": true
+      }
+    }
+  ]
+}
+```
+
+**Input document:**
+
+```json
+{
+  "message": "Request from 198.51.100.1, 203.0.113.5, 10.0.0.2"
+}
+```
+
+**Output with `capture_all_matches: true`:**
+
+```json
+{
+  "message": "Request from 198.51.100.1, 203.0.113.5, 10.0.0.2",
+  "x_forwarded_for": ["198.51.100.1", "203.0.113.5", "10.0.0.2"]
+}
+```
+
+**Output with `capture_all_matches: false` (default):**
+
+```json
+{
+  "message": "Request from 198.51.100.1, 203.0.113.5, 10.0.0.2",
+  "x_forwarded_for": "198.51.100.1"
+}
+```
+
+### Migration Notes
+
+- Existing pipelines are unaffected as `capture_all_matches` defaults to `false`
+- To enable multi-value capture, add `"capture_all_matches": true` to grok processor configuration
+- When enabled, fields with multiple matches become arrays; update downstream processing accordingly
+
+## Limitations
+
+- The `capture_all_matches` option applies to all fields in the pattern; selective per-field control is not supported
+- Type coercion (e.g., `:int`, `:long`) is applied to each captured value individually
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18799](https://github.com/opensearch-project/OpenSearch/pull/18799) | Grok processor supports capturing multiple values for same field name |
+
+## References
+
+- [Issue #18790](https://github.com/opensearch-project/OpenSearch/issues/18790): Bug report - Grok processor only extracts the first matched value for repeated field name
+- [Grok Processor Documentation](https://docs.opensearch.org/3.0/ingest-pipelines/processors/grok/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/grok-processor.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -17,6 +17,7 @@
 - [Docker Image Updates](features/opensearch/docker-image-updates.md)
 - [Engine API](features/opensearch/engine-api.md)
 - [Flaky Test Fixes](features/opensearch/flaky-test-fixes.md)
+- [Grok Processor](features/opensearch/grok-processor.md)
 - [Index Output](features/opensearch/index-output.md)
 - [Index Refresh](features/opensearch/index-refresh.md)
 - [Java 17 Modernization](features/opensearch/java-17-modernization.md)


### PR DESCRIPTION
## Summary

Adds documentation for the Grok Processor enhancement in OpenSearch v3.3.0.

### Key Changes in v3.3.0

- Added `capture_all_matches` option to the Grok processor
- When enabled, all matched values for repeated field names are collected into an array
- Previously, only the first matched value was captured (default behavior preserved)

### Reports Created

- Release report: `docs/releases/v3.3.0/features/opensearch/grok-processor.md`
- Feature report: `docs/features/opensearch/grok-processor.md`

### Related

- PR: [opensearch-project/OpenSearch#18799](https://github.com/opensearch-project/OpenSearch/pull/18799)
- Issue: [opensearch-project/OpenSearch#18790](https://github.com/opensearch-project/OpenSearch/issues/18790)
- Closes #1399