### PR TITLE
docs: add date-format report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -42,6 +42,7 @@
 - [Concurrent Segment Search](opensearch/concurrent-segment-search.md)
 - [Crypto KMS Plugin](opensearch/crypto-kms-plugin.md)
 - [Custom Index Name Resolver](opensearch/custom-index-name-resolver.md)
+- [Date Format](opensearch/date-format.md)
 - [Deprecated Code Cleanup](opensearch/deprecated-code-cleanup.md)
 - [DocRequest Refactoring](opensearch/docrequest-refactoring.md)
 - [Dynamic Settings](opensearch/dynamic-settings.md)

--- a/docs/features/opensearch/date-format.md
+++ b/docs/features/opensearch/date-format.md
@@ -1,0 +1,117 @@
+# Date Format
+
+## Summary
+
+OpenSearch provides flexible date formatting options for date fields, allowing users to specify how date values are parsed during indexing and formatted during retrieval. The date format system supports built-in formats (like `epoch_millis`, `epoch_second`, `epoch_micros`, and ISO 8601 variants) as well as custom patterns using Java's DateTimeFormatter syntax.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Date Parsing Flow"
+        Input[Date String/Number] --> Parser[DateFormatter]
+        Parser --> Instant[Java Instant]
+        Instant --> Storage[Lucene Storage]
+    end
+    
+    subgraph "Date Formatters"
+        FormatNames[FormatNames Enum] --> DateFormatters[DateFormatters Factory]
+        DateFormatters --> EpochTime[EpochTime Formatters]
+        DateFormatters --> JavaDateFormatter[Java Date Formatters]
+    end
+    
+    subgraph "Epoch Formatters"
+        EpochTime --> SECONDS[epoch_second]
+        EpochTime --> MILLIS[epoch_millis]
+        EpochTime --> MICROS[epoch_micros]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `FormatNames` | Enum defining all supported date format names |
+| `DateFormatters` | Factory class that creates formatters for given patterns |
+| `EpochTime` | Provides epoch-based formatters (seconds, millis, micros) |
+| `JavaDateFormatter` | Wrapper for Java's DateTimeFormatter |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `format` | Date format(s) for the field | `strict_date_time_no_millis\|\|strict_date_optional_time\|\|epoch_millis` |
+
+Multiple formats can be specified using `||` as a separator.
+
+### Supported Epoch Formats
+
+| Format | Unit | Precision | Example |
+|--------|------|-----------|---------|
+| `epoch_second` | Seconds | 1 second | `1680000430` |
+| `epoch_millis` | Milliseconds | 1 millisecond | `1680000430768` |
+| `epoch_micros` | Microseconds | 1 microsecond | `1680000430768123` |
+
+All epoch formats support:
+- Positive and negative values
+- Fractional precision (e.g., `123.456789` for sub-unit precision)
+- Nanosecond resolution in fractional part
+
+### Usage Example
+
+```json
+PUT my-index
+{
+  "mappings": {
+    "properties": {
+      "created_at": {
+        "type": "date",
+        "format": "epoch_micros"
+      },
+      "updated_at": {
+        "type": "date",
+        "format": "strict_date_optional_time||epoch_millis"
+      },
+      "custom_date": {
+        "type": "date",
+        "format": "yyyy-MM-dd HH:mm:ss"
+      }
+    }
+  }
+}
+```
+
+Index documents with different date formats:
+
+```json
+POST my-index/_doc/1
+{
+  "created_at": 1680000430768123,
+  "updated_at": "2023-03-28T12:00:30.768Z",
+  "custom_date": "2023-03-28 12:00:30"
+}
+```
+
+## Limitations
+
+- `epoch_micros` is not supported by Joda time (legacy date parsing)
+- Custom patterns must follow Java's DateTimeFormatter syntax
+- Maximum epoch values are constrained by Java's `Long.MAX_VALUE`
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19245](https://github.com/opensearch-project/OpenSearch/pull/19245) | Add `epoch_micros` date format |
+
+## References
+
+- [Issue #14669](https://github.com/opensearch-project/OpenSearch/issues/14669): Feature request for epoch_micros support
+- [Date field type documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/date/): Official date field documentation
+- [Format mapping parameter](https://docs.opensearch.org/3.0/field-types/mapping-parameters/format/): Date format configuration
+
+## Change History
+
+- **v3.3.0** (2025-09-12): Added `epoch_micros` date format for microsecond precision timestamps

--- a/docs/releases/v3.3.0/features/opensearch/date-format.md
+++ b/docs/releases/v3.3.0/features/opensearch/date-format.md
@@ -1,0 +1,110 @@
+# Date Format
+
+## Summary
+
+OpenSearch v3.3.0 adds support for the `epoch_micros` date format, enabling users to store and query timestamps with microsecond precision. This enhancement addresses use cases where millisecond precision is insufficient, such as high-frequency trading systems, scientific data analysis, and detailed event logging.
+
+## Details
+
+### What's New in v3.3.0
+
+The `epoch_micros` date format allows date fields to accept timestamps as the number of microseconds since the Unix epoch (January 1, 1970, 00:00:00 UTC). This complements the existing `epoch_millis` and `epoch_second` formats.
+
+### Technical Changes
+
+#### New Date Format
+
+| Format | Description | Example |
+|--------|-------------|---------|
+| `epoch_micros` | Microseconds since epoch | `1680000430768123` |
+
+The format supports:
+- Positive and negative timestamps
+- Fractional values with up to nanosecond precision (e.g., `123.456` for 123 microseconds and 456 nanoseconds)
+- Values ending with a decimal point (e.g., `123.`)
+
+#### Implementation Details
+
+The implementation follows the same approach as `epoch_millis`:
+
+1. Added `EPOCH_MICROS` to `FormatNames` enum
+2. Created `MICROS_FORMATTER` in `EpochTime` class with:
+   - `MICROS` field for absolute microsecond values
+   - `NANOS_OF_MICRO` field for sub-microsecond precision
+3. Registered the formatter in `DateFormatters.forPattern()`
+
+#### Changed Files
+
+| File | Change |
+|------|--------|
+| `FormatNames.java` | Added `EPOCH_MICROS` enum value |
+| `EpochTime.java` | Added `MICROS_FORMATTER` and supporting fields |
+| `DateFormatters.java` | Registered `epoch_micros` pattern |
+
+### Usage Example
+
+Create an index with a date field using `epoch_micros` format:
+
+```json
+PUT my-index
+{
+  "mappings": {
+    "properties": {
+      "timestamp": {
+        "type": "date",
+        "format": "epoch_micros"
+      }
+    }
+  }
+}
+```
+
+Index a document with a microsecond timestamp:
+
+```json
+PUT my-index/_doc/1
+{
+  "timestamp": 1680000430768123
+}
+```
+
+Use multiple formats including `epoch_micros`:
+
+```json
+PUT my-index
+{
+  "mappings": {
+    "properties": {
+      "timestamp": {
+        "type": "date",
+        "format": "strict_date_optional_time||epoch_micros"
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+No migration is required. The new format is additive and does not affect existing date fields or formats.
+
+## Limitations
+
+- The `epoch_micros` format is not supported by Joda time (used in legacy date parsing), only by the Java time API
+- Maximum value is constrained by Java's `Long.MAX_VALUE` divided by 1,000,000
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19245](https://github.com/opensearch-project/OpenSearch/pull/19245) | Add `epoch_micros` date format |
+
+## References
+
+- [Issue #14669](https://github.com/opensearch-project/OpenSearch/issues/14669): Feature request for epoch_micros support
+- [Date field type documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/date/): Official date field documentation
+- [Format mapping parameter](https://docs.opensearch.org/3.0/field-types/mapping-parameters/format/): Date format configuration
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/date-format.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -12,6 +12,7 @@
 - [Cluster State Caching](features/opensearch/cluster-state-caching.md)
 - [Concurrent Segment Search](features/opensearch/concurrent-segment-search.md)
 - [Cross-Cluster Settings](features/opensearch/cross-cluster-settings.md)
+- [Date Format](features/opensearch/date-format.md)
 - [Derived Fields](features/opensearch/derived-fields.md)
 - [Field Data Cache](features/opensearch/field-data-cache.md)
 - [Docker Image Updates](features/opensearch/docker-image-updates.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Date Format feature in OpenSearch v3.3.0.

### Changes
- Added release report: `docs/releases/v3.3.0/features/opensearch/date-format.md`
- Added feature report: `docs/features/opensearch/date-format.md`
- Updated release index and features index

### Key Changes in v3.3.0
- Added `epoch_micros` date format for microsecond precision timestamps
- Supports positive/negative values and fractional nanosecond precision

### Resources Used
- PR: [#19245](https://github.com/opensearch-project/OpenSearch/pull/19245)
- Issue: [#14669](https://github.com/opensearch-project/OpenSearch/issues/14669)
- Docs: https://docs.opensearch.org/3.0/field-types/supported-field-types/date/