### PR TITLE
docs: add segment warmer metrics report for v3.3.0

### DIFF
--- a/docs/features/opensearch/segment-warmer.md
+++ b/docs/features/opensearch/segment-warmer.md
@@ -79,6 +79,27 @@ flowchart TB
 | `index.replication.type` | Must be set to `SEGMENT` for segment warmer to activate | `DOCUMENT` |
 | `max_remote_low_priority_download_bytes_per_sec` | Rate limit for low-priority downloads (merged segments) | `0` (unlimited) |
 
+### Metrics (v3.3.0+)
+
+The segment warmer exposes comprehensive metrics under `merges.warmer` in stats APIs:
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `total_invocations_count` | Cumulative | Total number of warm operations invoked |
+| `total_time_millis` | Cumulative | Total wallclock time spent in warming operations |
+| `total_failure_count` | Cumulative | Number of failed warming attempts |
+| `total_bytes_sent` | Cumulative | Total data volume uploaded by primary shards |
+| `total_bytes_received` | Cumulative | Total data volume downloaded by replica shards |
+| `total_send_time_millis` | Cumulative | Time spent uploading segments |
+| `total_receive_time_millis` | Cumulative | Time spent downloading segments |
+| `ongoing_count` | Point-in-time | Current number of active warming operations |
+
+Access metrics via:
+- Node Stats: `GET /_nodes/stats/indices/merge`
+- Index Stats: `GET /_stats/merge`
+- CAT Shards: `GET /_cat/shards?h=merges.warmer.*`
+- CAT Nodes: `GET /_cat/nodes?h=merges.warmer.*`
+
 ### Usage Example
 
 Enable the feature flag in `opensearch.yml`:
@@ -127,6 +148,7 @@ PUT /my-index
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#18929](https://github.com/opensearch-project/OpenSearch/pull/18929) | Add metrics for merged segment warmer operations |
 | v3.2.0 | [#18683](https://github.com/opensearch-project/OpenSearch/pull/18683) | Remote store support for merged segment warming |
 | v3.0.0 | [#18255](https://github.com/opensearch-project/OpenSearch/pull/18255) | Local merged segment warmer implementation |
 | v3.0.0 | [#17881](https://github.com/opensearch-project/OpenSearch/pull/17881) | Initial implementation - MergedSegmentWarmerFactory infrastructure |
@@ -141,5 +163,6 @@ PUT /my-index
 
 ## Change History
 
+- **v3.3.0** (2025-10-14): Added comprehensive metrics for monitoring segment warmer operations - `MergedSegmentTransferTracker` and `MergedSegmentWarmerStats` expose invocation counts, timing, bytes transferred, and failure counts via stats APIs
 - **v3.2.0** (2025-08-05): Added remote store support - merged segments are uploaded to remote store and replicated to replicas via `RemoteStorePublishMergedSegmentAction`
 - **v3.0.0** (2025-05-06): Initial implementation - introduced `MergedSegmentWarmerFactory` with `LocalMergedSegmentWarmer` and `RemoteStoreMergedSegmentWarmer` infrastructure

--- a/docs/releases/v3.3.0/features/opensearch/segment-warmer.md
+++ b/docs/releases/v3.3.0/features/opensearch/segment-warmer.md
@@ -1,0 +1,136 @@
+# Segment Warmer Metrics
+
+## Summary
+
+OpenSearch v3.3.0 introduces comprehensive metrics for monitoring merged segment warming operations. These metrics provide visibility into the pre-copy process that transfers merged segments to replica shards before refresh, enabling operators to monitor warming performance, data transfer volumes, and identify potential issues.
+
+## Details
+
+### What's New in v3.3.0
+
+This release adds a new `warmer` section under `merges` statistics, exposing metrics at node, index, and shard levels. The metrics track both cumulative totals and point-in-time state of warming operations.
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `MergedSegmentTransferTracker` | Tracks statistics for merged segment replication operations including invocations, failures, bytes transferred, and timing |
+| `MergedSegmentWarmerStats` | Stores and serializes warmer statistics for API responses |
+
+#### New Metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `total_invocations_count` | Cumulative | Total number of warm operations invoked |
+| `total_time_millis` | Cumulative | Total wallclock time spent in warming operations |
+| `total_failure_count` | Cumulative | Number of failed warming attempts |
+| `total_bytes_sent` | Cumulative | Total data volume uploaded by primary shards |
+| `total_bytes_received` | Cumulative | Total data volume downloaded by replica shards |
+| `total_send_time_millis` | Cumulative | Time spent uploading segments |
+| `total_receive_time_millis` | Cumulative | Time spent downloading segments |
+| `ongoing_count` | Point-in-time | Current number of active warming operations |
+
+#### API Changes
+
+The warmer metrics are exposed through existing stats APIs:
+
+**Node Stats API** (`/_nodes/stats/indices/merge`):
+```json
+{
+  "indices": {
+    "merges": {
+      "warmer": {
+        "total_invocations_count": 23,
+        "total_time_millis": 4217,
+        "total_failure_count": 0,
+        "total_bytes_sent": 12107729,
+        "total_bytes_received": 0,
+        "total_send_time_millis": 1459,
+        "total_receive_time_millis": 0,
+        "ongoing_count": 0
+      }
+    }
+  }
+}
+```
+
+**Index Stats API** (`/_stats/merge`):
+```json
+{
+  "_all": {
+    "primaries": {
+      "merges": {
+        "warmer": {
+          "total_invocations_count": 19,
+          "total_time_millis": 3589,
+          "total_failure_count": 0,
+          "total_bytes_sent": 9071479,
+          "total_bytes_received": 0,
+          "total_send_time_millis": 1271,
+          "total_receive_time_millis": 0,
+          "ongoing_count": 0
+        }
+      }
+    }
+  }
+}
+```
+
+**CAT Shards API** (`/_cat/shards?v&h=index,shard,prirep,merges.warmer.*`):
+```
+index       shard prirep merges.warmer.total_invocations merges.warmer.total_time ...
+test-index  0     p      23                              4.2s
+test-index  0     r      0                               0s
+```
+
+**CAT Nodes API** (`/_cat/nodes?v&h=id,merges.warmer.*`):
+```
+id   merges.warmer.total_invocations merges.warmer.total_time ...
+n3zT 23                              4.2s
+2-by 0                               0s
+```
+
+### Usage Example
+
+Monitor segment warmer performance across the cluster:
+
+```bash
+# Get warmer stats for all nodes
+GET /_nodes/stats/indices/merge?filter_path=**.warmer
+
+# Get warmer stats per shard
+GET /_stats/merge?level=shards&filter_path=**.warmer
+
+# Monitor ongoing warming operations
+GET /_cat/shards?v&h=index,shard,prirep,merges.warmer.ongoing_count
+```
+
+### Interpreting Metrics
+
+- **Primary shards**: Show `total_bytes_sent` and `total_send_time_millis` (uploading merged segments)
+- **Replica shards**: Show `total_bytes_received` and `total_receive_time_millis` (downloading merged segments)
+- **High `total_failure_count`**: Indicates issues with segment warming; segments fall back to standard replication
+- **Non-zero `ongoing_count`**: Active warming operations in progress
+
+## Limitations
+
+- Metrics are only populated when merged segment warmer feature is enabled
+- Requires segment replication (`replication.type: SEGMENT`)
+- Experimental feature requiring feature flag: `opensearch.experimental.feature.merged_segment_warmer.enabled: true`
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18929](https://github.com/opensearch-project/OpenSearch/pull/18929) | Add metrics for the merged segment warmer feature |
+
+## References
+
+- [Issue #17528](https://github.com/opensearch-project/OpenSearch/issues/17528): RFC - Introduce Pre-copy Merged Segment into Segment Replication
+- [PR #18683](https://github.com/opensearch-project/OpenSearch/pull/18683): Remote store support for merged segment warming
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/segment-warmer.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -43,6 +43,7 @@
 - [Search Stats - Negative Value Handling](features/opensearch/search-stats.md)
 - [Search Tie-breaking](features/opensearch/search-tie-breaking.md)
 - [Segment Replication](features/opensearch/segment-replication.md)
+- [Segment Warmer Metrics](features/opensearch/segment-warmer.md)
 - [Skip List](features/opensearch/skip-list.md)
 - [Star Tree Index](features/opensearch/star-tree-index.md)
 - [Store Subdirectory Module](features/opensearch/store-subdirectory-module.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Segment Warmer Metrics feature introduced in OpenSearch v3.3.0.

### Changes

**Release Report** (`docs/releases/v3.3.0/features/opensearch/segment-warmer.md`):
- Documents new `MergedSegmentTransferTracker` and `MergedSegmentWarmerStats` components
- Lists all new metrics: `total_invocations_count`, `total_time_millis`, `total_failure_count`, `total_bytes_sent`, `total_bytes_received`, `total_send_time_millis`, `total_receive_time_millis`, `ongoing_count`
- Provides API examples for Node Stats, Index Stats, CAT Shards, and CAT Nodes
- Explains how to interpret metrics for primary vs replica shards

**Feature Report Update** (`docs/features/opensearch/segment-warmer.md`):
- Added new Metrics section documenting all available metrics
- Added PR #18929 to Related PRs table
- Added v3.3.0 entry to Change History

**Release Index Update** (`docs/releases/v3.3.0/index.md`):
- Added link to segment warmer metrics report

### Related Issue
Closes #1395

### Key Changes in v3.3.0
- New `MergedSegmentTransferTracker` component for tracking segment warming statistics
- New `MergedSegmentWarmerStats` class for serializing warmer metrics
- Metrics exposed via `/_nodes/stats`, `/_stats`, `/_cat/shards`, `/_cat/nodes` APIs
- Tracks invocations, timing, bytes transferred, failures, and ongoing operations