### PR TITLE
docs: add field collapsing search_after report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -46,6 +46,7 @@
 - [Deprecated Code Cleanup](opensearch/deprecated-code-cleanup.md)
 - [DocRequest Refactoring](opensearch/docrequest-refactoring.md)
 - [Dynamic Settings](opensearch/dynamic-settings.md)
+- [Field Collapsing](opensearch/field-collapsing.md)
 - [Field Data Cache](opensearch/field-data-cache.md)
 - [Field Mapping](opensearch/field-mapping.md)
 - [File Cache](opensearch/file-cache.md)

--- a/docs/features/opensearch/field-collapsing.md
+++ b/docs/features/opensearch/field-collapsing.md
@@ -1,0 +1,139 @@
+# Field Collapsing
+
+## Summary
+
+Field collapsing groups search results by a specified field value, returning only the top document within each group. This reduces redundancy by eliminating duplicate entries based on a common field, making it useful for scenarios like showing one product per category or one article per author.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Search Request"
+        A[Query] --> B[Collapse Parameter]
+        B --> C[field: collapse field name]
+        B --> D[inner_hits: optional expanded results]
+        B --> E[max_concurrent_group_searches: optional]
+    end
+    
+    subgraph "Collapse Processing"
+        C --> F[CollapseContext]
+        F --> G{Field Type?}
+        G -->|Keyword| H[CollapsingDocValuesSource.Keyword]
+        G -->|Numeric| I[CollapsingDocValuesSource.Numeric]
+        H --> J[CollapsingTopDocsCollector]
+        I --> J
+    end
+    
+    subgraph "Result Collection"
+        J --> K[Group by field value]
+        K --> L[Keep top doc per group]
+        L --> M[CollapseTopFieldDocs]
+    end
+    
+    subgraph "Optional Inner Hits"
+        D --> N[Expand each collapsed group]
+        N --> O[Return additional docs per group]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Search Request] --> B[Parse collapse parameter]
+    B --> C[Validate field type]
+    C --> D[Create CollapseContext]
+    D --> E[Execute query with collapse collector]
+    E --> F[Group documents by collapse field]
+    F --> G[Select top document per group]
+    G --> H{Inner hits requested?}
+    H -->|Yes| I[Execute inner hit queries]
+    H -->|No| J[Return collapsed results]
+    I --> J
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `CollapseBuilder` | Builds collapse configuration from search request |
+| `CollapseContext` | Holds collapse field info and creates collectors |
+| `CollapsingTopDocsCollector` | Lucene collector that groups and collapses results |
+| `CollapsingDocValuesSource` | Extracts collapse field values from doc values |
+| `CollapseTopFieldDocs` | Result container with collapsed hits and field values |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `collapse.field` | Field to collapse on (required) | - |
+| `collapse.inner_hits` | Inner hits configuration for expanded results | null |
+| `collapse.inner_hits.name` | Name for inner hits group | - |
+| `collapse.inner_hits.size` | Number of inner hits per group | 3 |
+| `collapse.max_concurrent_group_searches` | Max concurrent inner hit searches | Based on data nodes and thread pool |
+
+### Usage Example
+
+```json
+// Basic collapse
+GET /products/_search
+{
+  "query": { "match": { "description": "laptop" } },
+  "collapse": { "field": "brand" },
+  "sort": [{ "price": "asc" }]
+}
+
+// Collapse with inner hits
+GET /products/_search
+{
+  "query": { "match": { "description": "laptop" } },
+  "collapse": {
+    "field": "brand",
+    "inner_hits": {
+      "name": "by_brand",
+      "size": 3,
+      "sort": [{ "price": "asc" }]
+    }
+  },
+  "sort": [{ "rating": "desc" }]
+}
+
+// Collapse with search_after (v3.3.0+)
+GET /products/_search
+{
+  "query": { "match_all": {} },
+  "collapse": { "field": "category" },
+  "sort": [{ "category": "asc" }],
+  "search_after": ["electronics"],
+  "size": 10
+}
+```
+
+## Limitations
+
+- Only `keyword` and `numeric` field types are supported for collapsing
+- Cannot be used with scroll context
+- Cannot be used with rescore
+- When using `search_after` (v3.3.0+):
+  - Collapse field and sort field must be the same
+  - Secondary sort fields are not supported
+- Total hits reflects all matching documents before collapsing, not the number of collapsed groups
+- Aggregations are not affected by collapse (computed on all matching documents)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19261](https://github.com/opensearch-project/OpenSearch/pull/19261) | Field collapsing supports search_after |
+
+## References
+
+- [Issue #3725](https://github.com/opensearch-project/OpenSearch/issues/3725): Feature request for search_after support
+- [Collapse search results documentation](https://docs.opensearch.org/3.0/search-plugins/searching-data/collapse-search/): Official documentation
+- [Collapse processor documentation](https://docs.opensearch.org/3.0/search-plugins/search-pipelines/collapse-processor/): Search pipeline collapse processor
+
+## Change History
+
+- **v3.3.0** (2026): Added `search_after` pagination support for field collapsing (requires collapse field = sort field)

--- a/docs/releases/v3.3.0/features/opensearch/field-collapsing-search-after.md
+++ b/docs/releases/v3.3.0/features/opensearch/field-collapsing-search-after.md
@@ -1,0 +1,105 @@
+# Field Collapsing with search_after Support
+
+## Summary
+
+OpenSearch v3.3.0 adds `search_after` pagination support for field collapsing queries. This enables efficient deep pagination through collapsed search results, which was previously not possible. The feature requires that the collapse field and sort field be the same, ensuring consistent pagination behavior.
+
+## Details
+
+### What's New in v3.3.0
+
+Field collapsing now supports the `search_after` parameter for pagination, allowing users to efficiently page through large collapsed result sets without the performance overhead of offset-based pagination.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Search Request"
+        A[Query] --> B[Collapse Parameter]
+        A --> C[Sort Parameter]
+        A --> D[search_after Parameter]
+    end
+    
+    subgraph "Validation"
+        B --> E{Collapse Field == Sort Field?}
+        C --> E
+        E -->|Yes| F[Create CollapsingTopDocsCollector with search_after]
+        E -->|No| G[Throw SearchException]
+    end
+    
+    subgraph "Collection"
+        F --> H[Filter docs after search_after value]
+        H --> I[Collapse by field value]
+        I --> J[Return top N collapsed groups]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `CollapsingTopDocsCollector` (updated) | Extended to accept `FieldDoc after` parameter for search_after support |
+| `CollapseContext.createTopDocs()` (overloaded) | New method signature accepting `searchAfter` parameter |
+| `CollapsingTopDocsCollectorContext` (updated) | Passes search_after to collector creation |
+
+#### Validation Rules
+
+| Condition | Behavior |
+|-----------|----------|
+| Collapse field ≠ Sort field | Throws `SearchException` with message: "collapse field and sort field must be the same when use `collapse` in conjunction with `search_after`" |
+| Multiple sort fields | Not supported with search_after |
+| Single sort field = collapse field | Allowed |
+
+### Usage Example
+
+```json
+// First page - get initial collapsed results
+GET /my-index/_search
+{
+  "query": { "match_all": {} },
+  "collapse": { "field": "category" },
+  "sort": [{ "category": "asc" }],
+  "size": 10
+}
+
+// Subsequent pages - use search_after with last sort value
+GET /my-index/_search
+{
+  "query": { "match_all": {} },
+  "collapse": { "field": "category" },
+  "sort": [{ "category": "asc" }],
+  "search_after": ["electronics"],
+  "size": 10
+}
+```
+
+### Migration Notes
+
+- Existing collapse queries without `search_after` continue to work unchanged
+- To use `search_after` with collapse, ensure the sort field matches the collapse field
+- Remove any secondary sort fields when using collapse with `search_after`
+
+## Limitations
+
+- Collapse field and sort field must be identical when using `search_after`
+- Secondary sort fields are not supported with collapse + `search_after`
+- Only `keyword` and `numeric` field types are supported for collapsing (unchanged from previous behavior)
+- Cannot be used with scroll context (unchanged)
+- Cannot be used with rescore (unchanged)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19261](https://github.com/opensearch-project/OpenSearch/pull/19261) | Field collapsing supports search_after |
+
+## References
+
+- [Issue #3725](https://github.com/opensearch-project/OpenSearch/issues/3725): Original feature request
+- [Collapse search results documentation](https://docs.opensearch.org/3.0/search-plugins/searching-data/collapse-search/): Official docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/field-collapsing.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -17,6 +17,7 @@
 - [Field Data Cache](features/opensearch/field-data-cache.md)
 - [Docker Image Updates](features/opensearch/docker-image-updates.md)
 - [Engine API](features/opensearch/engine-api.md)
+- [Field Collapsing with search_after](features/opensearch/field-collapsing-search-after.md)
 - [Flaky Test Fixes](features/opensearch/flaky-test-fixes.md)
 - [Grok Processor](features/opensearch/grok-processor.md)
 - [gRPC Transport](features/opensearch/grpc-transport.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Field Collapsing with `search_after` support feature introduced in OpenSearch v3.3.0.

## Changes

### Release Report
- `docs/releases/v3.3.0/features/opensearch/field-collapsing-search-after.md`: Documents the new `search_after` pagination support for field collapsing

### Feature Report
- `docs/features/opensearch/field-collapsing.md`: Comprehensive documentation of the field collapsing feature including the new v3.3.0 enhancement

## Key Findings

- PR [#19261](https://github.com/opensearch-project/OpenSearch/pull/19261) adds `search_after` support for field collapsing
- Resolves long-standing feature request [#3725](https://github.com/opensearch-project/OpenSearch/issues/3725) from 2022
- Key constraint: collapse field and sort field must be the same when using `search_after`
- Works with both keyword and numeric field types
- Compatible with concurrent segment search

## Related Issue
Closes #1394