### PR TITLE
docs: add file cache threshold report for v3.3.0

### DIFF
--- a/docs/releases/v3.3.0/features/opensearch/file-cache-threshold.md
+++ b/docs/releases/v3.3.0/features/opensearch/file-cache-threshold.md
@@ -1,0 +1,139 @@
+# File Cache Active Usage Guard Rails
+
+## Summary
+
+This release adds file cache active usage threshold monitoring to the DiskThresholdMonitor for warm nodes. When file cache active usage exceeds configurable thresholds, OpenSearch automatically applies index blocks to prevent resource exhaustion. This provides guard rails for warm nodes using searchable snapshots, ensuring cluster stability under high cache pressure.
+
+## Details
+
+### What's New in v3.3.0
+
+OpenSearch v3.3.0 introduces a new `FileCacheEvaluator` component that monitors file cache active usage on warm nodes and triggers protective actions when thresholds are exceeded:
+
+- **Indexing Threshold (90% default)**: When active usage reaches this level, indices on the affected warm node are marked read-only (INDEX_READ_ONLY_ALLOW_DELETE_BLOCK)
+- **Search Threshold (100% default)**: When active usage reaches this level, indices also receive a read block (INDEX_READ_BLOCK), preventing both reads and writes
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "DiskThresholdMonitor"
+        DTM[DiskThresholdMonitor]
+        NDE[NodeDiskEvaluator]
+        FCE[FileCacheEvaluator]
+    end
+    
+    subgraph "Settings"
+        DTS[DiskThresholdSettings]
+        FCTS[FileCacheThresholdSettings]
+    end
+    
+    subgraph "Actions"
+        RO[Read-Only Block]
+        RB[Read Block]
+        AR[Auto-Release]
+    end
+    
+    subgraph "Data Sources"
+        CI[ClusterInfo]
+        AFCS[AggregateFileCacheStats]
+    end
+    
+    DTM --> NDE
+    DTM --> FCE
+    NDE --> DTS
+    FCE --> FCTS
+    
+    CI --> DTM
+    AFCS --> FCE
+    
+    FCE -->|Indexing Threshold| RO
+    FCE -->|Search Threshold| RB
+    FCE -->|Below Threshold| AR
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `FileCacheEvaluator` | Evaluates file cache active usage against configured thresholds |
+| `FileCacheThresholdSettings` | Manages cluster settings for file cache thresholds |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.filecache.activeusage.threshold.enabled` | Enable/disable file cache threshold monitoring | `true` |
+| `cluster.filecache.activeusage.indexing.threshold` | Threshold for applying read-only block (percentage or bytes) | `90%` |
+| `cluster.filecache.activeusage.search.threshold` | Threshold for applying read block (percentage or bytes) | `100%` |
+
+#### API Changes
+
+New method added to `AggregateFileCacheStats`:
+- `getOverallActivePercent()`: Returns active usage as a percentage of total cache size (with decimal precision)
+
+### Usage Example
+
+**Configure file cache thresholds:**
+
+```yaml
+# opensearch.yml or via cluster settings API
+cluster.filecache.activeusage.threshold.enabled: true
+cluster.filecache.activeusage.indexing.threshold: 90%
+cluster.filecache.activeusage.search.threshold: 100%
+```
+
+**Using absolute byte values:**
+
+```bash
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.filecache.activeusage.indexing.threshold": "900mb",
+    "cluster.filecache.activeusage.search.threshold": "1000mb"
+  }
+}
+```
+
+**Disable threshold monitoring:**
+
+```bash
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.filecache.activeusage.threshold.enabled": false
+  }
+}
+```
+
+### Migration Notes
+
+- This feature is enabled by default; no action required for new deployments
+- Existing warm node deployments will automatically benefit from the new guard rails
+- If you experience unexpected index blocks, check file cache usage via `GET _nodes/stats/file_cache`
+- Adjust thresholds if default values are too aggressive for your workload
+
+## Limitations
+
+- Only applies to warm nodes with file cache enabled
+- Thresholds are evaluated per-node, not cluster-wide
+- Index blocks are applied at the index level, affecting all shards on the node
+- Auto-release of blocks requires cache pressure to drop below the threshold
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19071](https://github.com/opensearch-project/OpenSearch/pull/19071) | Addition of fileCache activeUsage guard rails to DiskThresholdMonitor |
+
+## References
+
+- [Searchable Snapshots Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot/)
+- [Clear Cache API](https://docs.opensearch.org/3.0/api-reference/index-apis/clear-index-cache/)
+- [Nodes Stats API](https://docs.opensearch.org/3.0/api-reference/nodes-apis/nodes-stats/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/file-cache.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -15,6 +15,7 @@
 - [Date Format](features/opensearch/date-format.md)
 - [Derived Fields](features/opensearch/derived-fields.md)
 - [Field Data Cache](features/opensearch/field-data-cache.md)
+- [File Cache Threshold](features/opensearch/file-cache-threshold.md)
 - [Docker Image Updates](features/opensearch/docker-image-updates.md)
 - [Engine API](features/opensearch/engine-api.md)
 - [Field Collapsing with search_after](features/opensearch/field-collapsing-search-after.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the File Cache Active Usage Guard Rails feature introduced in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/file-cache-threshold.md`
- Feature report: `docs/features/opensearch/file-cache.md` (updated)

### Key Changes in v3.3.0
- Added `FileCacheEvaluator` component to monitor file cache active usage on warm nodes
- New cluster settings for configuring indexing and search thresholds
- Automatic index blocking when thresholds are exceeded
- Auto-release of blocks when cache pressure drops

### Resources Used
- PR: [#19071](https://github.com/opensearch-project/OpenSearch/pull/19071)
- Docs: [Searchable Snapshots](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot/)

Closes #1393