### PR TITLE
docs: add translog channel factory report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -155,6 +155,7 @@
 - [Test Fixes](opensearch/test-fixes.md)
 - [Thread Context Permissions](opensearch/thread-context-permissions.md)
 - [Tiered Caching](opensearch/tiered-caching.md)
+- [Translog](opensearch/translog.md)
 - [Transport Nodes Action Optimization](opensearch/transport-nodes-action-optimization.md)
 - [Unified Highlighter](opensearch/unified-highlighter.md)
 - [Warm Storage Tiering](opensearch/warm-storage-tiering.md)

--- a/docs/features/opensearch/translog.md
+++ b/docs/features/opensearch/translog.md
@@ -1,0 +1,151 @@
+# Translog
+
+## Summary
+
+The Translog (transaction log) is a core component in OpenSearch that provides durability for indexing operations. It records all non-committed index operations in a durable manner, ensuring that data is not lost in case of failures. Each index shard has its own translog instance that works alongside the Lucene index to guarantee data persistence.
+
+The translog serves as a write-ahead log (WAL) - operations are first written to the translog and flushed to disk before being acknowledged, ensuring durability even before the data is committed to Lucene segments.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Index Shard"
+        IE[InternalEngine]
+        TL[Translog]
+        LI[Lucene Index]
+    end
+    
+    subgraph "Translog Components"
+        TW[TranslogWriter<br/>Current Generation]
+        TR[TranslogReader<br/>Previous Generations]
+        CP[Checkpoint]
+        CF[ChannelFactory]
+    end
+    
+    IE --> TL
+    IE --> LI
+    TL --> TW
+    TL --> TR
+    TL --> CP
+    TW --> CF
+    TR --> CF
+    
+    subgraph "Translog Implementations"
+        LT[LocalTranslog]
+        RFT[RemoteFsTranslog]
+        RFTAT[RemoteFsTimestampAwareTranslog]
+    end
+    
+    TL --> LT
+    TL --> RFT
+    RFT --> RFTAT
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Index Request] --> B[Write to Translog]
+    B --> C[Fsync to Disk]
+    C --> D[Acknowledge Client]
+    D --> E[Buffer in Memory]
+    E --> F{Refresh?}
+    F -->|Yes| G[Create Lucene Segment]
+    F -->|No| E
+    G --> H{Flush?}
+    H -->|Yes| I[Fsync Segments]
+    I --> J[Purge Translog]
+    H -->|No| G
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `Translog` | Abstract base class for transaction log implementations |
+| `LocalTranslog` | Standard local translog implementation |
+| `RemoteFsTranslog` | Remote store-backed translog for remote-backed storage |
+| `RemoteFsTimestampAwareTranslog` | Timestamp-aware variant for remote translog |
+| `TranslogWriter` | Writes operations to the current translog generation |
+| `TranslogReader` | Reads operations from previous translog generations |
+| `Checkpoint` | Tracks translog state (generation, offset, operations count) |
+| `ChannelFactory` | Factory for creating file channels (customizable since v3.3.0) |
+| `TranslogDeletionPolicy` | Controls when translog files can be safely deleted |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.translog.durability` | Sync mode: `request` (per-request) or `async` (periodic) | `request` |
+| `index.translog.sync_interval` | Sync interval for async durability | `5s` |
+| `index.translog.flush_threshold_size` | Size threshold to trigger flush | `512mb` |
+| `index.translog.generation_threshold_size` | Size threshold to roll generation | `64mb` |
+| `index.translog.retention.size` | Maximum translog size to retain | `512mb` |
+| `index.translog.retention.age` | Maximum translog age to retain | `12h` |
+
+### Usage Example
+
+```yaml
+# Index settings for translog configuration
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "translog": {
+        "durability": "async",
+        "sync_interval": "10s",
+        "flush_threshold_size": "1gb"
+      }
+    }
+  }
+}
+```
+
+### Custom Channel Factory (v3.3.0+)
+
+```java
+// Create a custom channel factory for specialized storage
+ChannelFactory customFactory = (path, options) -> {
+    // Custom channel creation logic
+    return FileChannel.open(path, options);
+};
+
+// Use with translog constructor
+Translog translog = new LocalTranslog(
+    config,
+    translogUUID,
+    deletionPolicy,
+    globalCheckpointSupplier,
+    primaryTermSupplier,
+    persistedSequenceNumberConsumer,
+    TranslogOperationHelper.DEFAULT,
+    customFactory
+);
+```
+
+## Limitations
+
+- Translog operations are single-threaded per shard for write operations
+- Large translog sizes can impact recovery time
+- Custom channel factories must be compatible with all translog file operations
+- The channel factory cannot be changed after translog creation
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#18918](https://github.com/opensearch-project/OpenSearch/pull/18918) | Add Channel Factory parameter to Translog |
+
+## References
+
+- [OpenSearch Introduction - Translog](https://docs.opensearch.org/3.0/getting-started/intro/#translog): Official translog documentation
+- [Tuning for Indexing Speed](https://docs.opensearch.org/3.0/tuning-your-cluster/performance/): Translog tuning recommendations
+- [Remote-backed Storage](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/remote-store/index/): Remote translog configuration
+- [opensearch-storage-encryption#39](https://github.com/opensearch-project/opensearch-storage-encryption/pull/39): Related storage encryption use case
+
+## Change History
+
+- **v3.3.0** (2025-08-27): Added `ChannelFactory` parameter to Translog constructor, enabling custom file channel implementations for use cases like storage encryption

--- a/docs/releases/v3.3.0/features/opensearch/translog.md
+++ b/docs/releases/v3.3.0/features/opensearch/translog.md
@@ -1,0 +1,114 @@
+# Translog Channel Factory Parameter
+
+## Summary
+
+This release adds a new overload constructor to the Translog class that accepts a `ChannelFactory` parameter. Previously, the translog always used `FileChannel::open` as the default channel factory, which prevented customization of how file channels are opened. This enhancement enables plugins and extensions to provide their own channel factory implementations, supporting use cases like storage encryption.
+
+## Details
+
+### What's New in v3.3.0
+
+The Translog class now accepts an optional `ChannelFactory` parameter in its constructor, allowing callers to customize how file channels are created for translog operations.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.3.0"
+        T1[Translog] --> FC1[FileChannel::open]
+    end
+    
+    subgraph "v3.3.0+"
+        T2[Translog] --> CF[ChannelFactory]
+        CF --> FC2[FileChannel::open<br/>default]
+        CF --> Custom[Custom Implementation<br/>e.g., Encrypted Channel]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ChannelFactory` parameter | New constructor parameter in `Translog` class |
+| Overload constructors | Secondary constructors for backward compatibility |
+
+#### Constructor Changes
+
+The main `Translog` constructor now accepts a `ChannelFactory` parameter:
+
+```java
+public Translog(
+    final TranslogConfig config,
+    final String translogUUID,
+    TranslogDeletionPolicy deletionPolicy,
+    final LongSupplier globalCheckpointSupplier,
+    final LongSupplier primaryTermSupplier,
+    final LongConsumer persistedSequenceNumberConsumer,
+    final TranslogOperationHelper translogOperationHelper,
+    final ChannelFactory channelFactory  // NEW PARAMETER
+) throws IOException
+```
+
+When `channelFactory` is `null`, it defaults to `FileChannel::open`.
+
+#### Affected Classes
+
+| Class | Change |
+|-------|--------|
+| `Translog` | Added `channelFactory` field and constructor parameter |
+| `LocalTranslog` | Updated to pass channel factory to parent |
+| `RemoteFsTranslog` | Updated to pass channel factory to parent |
+| `RemoteFsTimestampAwareTranslog` | Updated to pass channel factory |
+| `InternalTranslogFactory` | Passes `null` for default behavior |
+| `RemoteBlobStoreInternalTranslogFactory` | Passes `null` for default behavior |
+| `TruncateTranslogAction` | Updated constructor call |
+
+### Usage Example
+
+```java
+// Custom channel factory for encrypted storage
+ChannelFactory encryptedChannelFactory = (path, options) -> {
+    FileChannel channel = FileChannel.open(path, options);
+    return new EncryptedFileChannel(channel, encryptionKey);
+};
+
+// Create translog with custom channel factory
+Translog translog = new LocalTranslog(
+    config,
+    translogUUID,
+    deletionPolicy,
+    globalCheckpointSupplier,
+    primaryTermSupplier,
+    persistedSequenceNumberConsumer,
+    TranslogOperationHelper.DEFAULT,
+    encryptedChannelFactory  // Custom factory
+);
+```
+
+### Migration Notes
+
+- Existing code using the old constructors will continue to work without changes
+- Secondary constructors without `ChannelFactory` parameter are provided for backward compatibility
+- To use a custom channel factory, use the new constructor with the `ChannelFactory` parameter
+
+## Limitations
+
+- The channel factory is set at translog creation time and cannot be changed afterward
+- Custom channel factories must be compatible with the translog's file operations (read, write, sync)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18918](https://github.com/opensearch-project/OpenSearch/pull/18918) | Add Channel Factory parameter to Translog |
+
+## References
+
+- [opensearch-storage-encryption#39](https://github.com/opensearch-project/opensearch-storage-encryption/pull/39): Related storage encryption PR
+- [Translog Documentation](https://docs.opensearch.org/3.0/getting-started/intro/#translog): Official translog documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/translog.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -53,6 +53,7 @@
 - [Terms Query Rewriting](features/opensearch/terms-query-rewriting.md)
 - [Test Infrastructure](features/opensearch/test-infrastructure.md)
 - [Tiered Caching](features/opensearch/tiered-caching.md)
+- [Translog Channel Factory](features/opensearch/translog.md)
 - [Wildcard Field Mapper](features/opensearch/wildcard-field-mapper.md)
 
 ### OpenSearch Dashboards


### PR DESCRIPTION
## Summary

This PR adds documentation for the Translog Channel Factory feature introduced in OpenSearch v3.3.0.

### Changes

- **Release Report**: `docs/releases/v3.3.0/features/opensearch/translog.md`
  - Documents the new `ChannelFactory` parameter added to Translog constructor
  - Explains the technical changes and affected classes
  - Provides usage examples for custom channel factories

- **Feature Report**: `docs/features/opensearch/translog.md`
  - Comprehensive documentation of the Translog component
  - Architecture diagrams showing translog structure and data flow
  - Configuration options and usage examples
  - Change history tracking the v3.3.0 enhancement

### Key Changes in v3.3.0

- Added `ChannelFactory` parameter to Translog constructor
- Enables custom file channel implementations (e.g., for storage encryption)
- Backward-compatible with existing code via overload constructors

### Related

- PR: [opensearch-project/OpenSearch#18918](https://github.com/opensearch-project/OpenSearch/pull/18918)
- Issue: #1392