### PR TITLE
docs: add Query Cache report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -107,6 +107,7 @@
 - [Profiler](opensearch/profiler.md)
 - [Pull-based Ingestion](opensearch/pull-based-ingestion.md)
 - [Query Bug Fixes](opensearch/query-bug-fixes.md)
+- [Query Cache](opensearch/query-cache.md)
 - [Query Coordinator Context](opensearch/query-coordinator-context.md)
 - [Query Optimization](opensearch/query-optimization.md)
 - [Query Phase Plugin Extension](opensearch/query-phase-plugin-extension.md)

--- a/docs/features/opensearch/query-cache.md
+++ b/docs/features/opensearch/query-cache.md
@@ -1,0 +1,124 @@
+# Query Cache
+
+## Summary
+
+The Query Cache (also known as the filter cache) is a node-level cache that stores the results of filter queries to improve search performance. When a filter query is executed multiple times, OpenSearch can return cached results instead of re-evaluating the filter, significantly reducing query latency for repeated searches.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Search Request"
+        SR[Search Request] --> QP[Query Parser]
+        QP --> BQ[Boolean Query]
+        BQ --> FC[Filter Context]
+        BQ --> QC[Query Context]
+    end
+    
+    subgraph "Filter Processing"
+        FC --> CCP[QueryCachingPolicy]
+        CCP --> |"Check eligibility"| EC{Eligible?}
+        EC --> |"Yes"| LRU[LRU Query Cache]
+        EC --> |"No"| Direct[Direct Execution]
+        LRU --> |"Hit"| Result[Cached Result]
+        LRU --> |"Miss"| Exec[Execute & Cache]
+    end
+    
+    subgraph "Cache Management"
+        CS[Cluster Settings] --> |"Dynamic update"| CCP
+        CS --> |"Dynamic update"| LRU
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    Q[Filter Query] --> P{Policy Check}
+    P --> |"frequency >= threshold"| C{Cache Lookup}
+    P --> |"frequency < threshold"| E[Execute Query]
+    C --> |"Hit"| R[Return Cached]
+    C --> |"Miss"| E
+    E --> S{Should Cache?}
+    S --> |"Yes"| Store[Store in Cache]
+    S --> |"No"| Return[Return Result]
+    Store --> Return
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `IndicesQueryCache` | Node-level LRU cache implementation that stores query results |
+| `OpenseachUsageTrackingQueryCachingPolicy` | Custom caching policy with configurable frequency thresholds |
+| `LRUQueryCache` | Lucene's underlying cache implementation with configurable skip factor |
+
+### Configuration
+
+| Setting | Description | Default | Dynamic |
+|---------|-------------|---------|---------|
+| `indices.queries.cache.size` | Cache size as percentage of heap | `10%` | No |
+| `indices.queries.cache.count` | Maximum number of cached queries | `10000` | No |
+| `indices.queries.cache.all_segments` | Cache all segments regardless of size | `false` | No |
+| `indices.queries.cache.skip_cache_factor` | Skip cache factor for segment size ratio | `10` | Yes |
+| `indices.queries.cache.min_frequency` | Minimum query frequency before caching | `5` | Yes |
+| `indices.queries.cache.costly_min_frequency` | Minimum frequency for costly queries | `2` | Yes |
+
+### Usage Example
+
+```json
+// Check query cache statistics
+GET _nodes/stats/indices/query_cache
+
+// Clear query cache
+POST _cache/clear?query=true
+
+// Configure dynamic settings
+PUT _cluster/settings
+{
+  "persistent": {
+    "indices.queries.cache.skip_cache_factor": 15,
+    "indices.queries.cache.min_frequency": 3,
+    "indices.queries.cache.costly_min_frequency": 1
+  }
+}
+```
+
+### Query Eligibility
+
+Queries are eligible for caching when:
+1. They are in filter context (not query context)
+2. The segment has at least 10,000 documents
+3. The query has been seen at least `min_frequency` times (or `costly_min_frequency` for costly queries)
+4. The segment size ratio passes the skip cache factor check
+
+Costly queries include:
+- `MultiTermQuery` (wildcard, prefix, regexp)
+- Point queries (range queries on numeric fields)
+- `MultiTermQueryConstantScoreWrapper` variants
+
+## Limitations
+
+- Only filter context queries are cached; query context queries are not cached
+- Segments with fewer than 10,000 documents are never cached
+- Cache is invalidated on index refresh (document updates/deletes)
+- Node-level cache; not shared across nodes in a cluster
+- Dynamic settings are cluster-wide; per-index configuration not supported
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#18351](https://github.com/opensearch-project/OpenSearch/pull/18351) | Add dynamic settings for skip_cache_factor and min_frequency |
+
+## References
+
+- [Issue #17736](https://github.com/opensearch-project/OpenSearch/issues/17736): Feature request for dynamic query cache settings
+- [Lucene PR #14412](https://github.com/apache/lucene/pull/14412): Upstream Lucene change for dynamic skip cache factor
+- [Query and filter context](https://docs.opensearch.org/3.0/query-dsl/query-filter-context/): OpenSearch documentation
+
+## Change History
+
+- **v3.3.0** (2025-08-21): Added dynamic cluster settings for `skip_cache_factor`, `min_frequency`, and `costly_min_frequency`

--- a/docs/releases/v3.3.0/features/opensearch/query-cache.md
+++ b/docs/releases/v3.3.0/features/opensearch/query-cache.md
@@ -1,0 +1,104 @@
+# Query Cache Dynamic Settings
+
+## Summary
+
+This release adds dynamic cluster settings to control query cache behavior, allowing administrators to tune cache utilization at runtime without restarting nodes. Three new settings enable dynamic adjustment of the skip cache factor and minimum frequency thresholds for query caching.
+
+## Details
+
+### What's New in v3.3.0
+
+OpenSearch v3.3.0 introduces dynamic cluster settings for the query cache (also known as the filter cache), which caches the results of filter queries to improve search performance. Previously, these settings were static and required a node restart to change. Now they can be modified at runtime.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Query Execution"
+        Q[Query] --> QCP[QueryCachingPolicy]
+        QCP --> |"Check frequency"| FC{Frequency Check}
+        FC --> |"≥ minFrequency"| Cache[LRU Query Cache]
+        FC --> |"< minFrequency"| NoCache[Skip Cache]
+    end
+    
+    subgraph "Dynamic Settings"
+        CS[ClusterSettings] --> |"Update"| QCP
+        CS --> |"Update"| Cache
+    end
+    
+    subgraph "Settings"
+        SKF[skip_cache_factor] --> Cache
+        MF[min_frequency] --> QCP
+        CMF[costly_min_frequency] --> QCP
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `OpenseachUsageTrackingQueryCachingPolicy` | Custom caching policy that extends Lucene's `UsageTrackingQueryCachingPolicy` with dynamic frequency thresholds |
+| Dynamic settings consumers | Listeners that update cache behavior when cluster settings change |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `indices.queries.cache.skip_cache_factor` | Controls when to skip caching based on segment size ratio. Higher values allow more caching. | `10` |
+| `indices.queries.cache.min_frequency` | Minimum number of times a query must be seen before caching (for regular queries) | `5` |
+| `indices.queries.cache.costly_min_frequency` | Minimum frequency for costly queries (MultiTermQuery, Point queries) | `2` |
+
+All settings are:
+- **Scope**: Node-level (cluster-wide)
+- **Type**: Dynamic (can be changed at runtime)
+
+### Usage Example
+
+```json
+// Update skip_cache_factor to increase cache utilization
+PUT _cluster/settings
+{
+  "persistent": {
+    "indices.queries.cache.skip_cache_factor": 20
+  }
+}
+
+// Adjust minimum frequency thresholds
+PUT _cluster/settings
+{
+  "persistent": {
+    "indices.queries.cache.min_frequency": 3,
+    "indices.queries.cache.costly_min_frequency": 1
+  }
+}
+```
+
+### Migration Notes
+
+- Existing clusters will use the default values after upgrade
+- No action required; settings can be tuned based on workload characteristics
+- Higher `skip_cache_factor` values can improve cache hit rates for workloads with many repeated filter queries
+
+## Limitations
+
+- Settings apply cluster-wide; per-index configuration is not supported
+- The query cache only caches filter context queries, not query context queries
+- Segments with fewer than 10,000 documents are not cached regardless of settings
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18351](https://github.com/opensearch-project/OpenSearch/pull/18351) | Add a dynamic setting to change skip_cache_factor and min_frequency for querycache |
+
+## References
+
+- [Issue #17736](https://github.com/opensearch-project/OpenSearch/issues/17736): Original feature request
+- [Lucene PR #14412](https://github.com/apache/lucene/pull/14412): Upstream Lucene change enabling dynamic skip cache factor
+- [Query and filter context](https://docs.opensearch.org/3.0/query-dsl/query-filter-context/): OpenSearch documentation on filter caching
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/query-cache.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -32,6 +32,7 @@
 - [Painless Scripting](features/opensearch/painless-scripting.md)
 - [Plugin Installation](features/opensearch/plugin-installation.md)
 - [Pull-based Ingestion](features/opensearch/pull-based-ingestion.md)
+- [Query Cache Dynamic Settings](features/opensearch/query-cache.md)
 - [Query Phase Fixes](features/opensearch/query-phase-fixes.md)
 - [Reactor Netty Transport](features/opensearch/reactor-netty-transport.md)
 - [Reindex API](features/opensearch/reindex-api.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Query Cache dynamic settings feature introduced in OpenSearch v3.3.0.

## Changes

### Release Report
- `docs/releases/v3.3.0/features/opensearch/query-cache.md`: Documents the new dynamic cluster settings for query cache tuning

### Feature Report
- `docs/features/opensearch/query-cache.md`: Comprehensive documentation of the Query Cache feature

## Key Changes in v3.3.0

Three new dynamic cluster settings were added:
- `indices.queries.cache.skip_cache_factor` (default: 10)
- `indices.queries.cache.min_frequency` (default: 5)
- `indices.queries.cache.costly_min_frequency` (default: 2)

These settings allow administrators to tune query cache behavior at runtime without restarting nodes.

## Related

- Resolves investigation Issue #1391
- OpenSearch PR: [#18351](https://github.com/opensearch-project/OpenSearch/pull/18351)
- OpenSearch Issue: [#17736](https://github.com/opensearch-project/OpenSearch/issues/17736)