### PR TITLE
docs: add S3 Performance report for v3.3.0

### DIFF
--- a/docs/features/opensearch/s3-repository.md
+++ b/docs/features/opensearch/s3-repository.md
@@ -40,10 +40,11 @@ graph TB
 | Component | Description |
 |-----------|-------------|
 | `S3Service` | Manages synchronous S3 client operations |
-| `S3AsyncService` | Manages asynchronous S3 client operations |
+| `S3AsyncService` | Manages asynchronous S3 client operations with configurable HTTP client |
 | `S3Repository` | Implements the repository interface for S3 storage |
 | `S3BlobStore` | Handles blob storage operations in S3 |
 | `S3BlobContainer` | Manages blob containers within S3 |
+| `AwsCrtAsyncHttpClient` | AWS CRT-based async HTTP client for improved throughput (v3.3.0+) |
 
 ### Configuration
 
@@ -69,6 +70,7 @@ graph TB
 | `max_restore_bytes_per_sec` | Maximum restore rate | `40mb` |
 | `max_snapshot_bytes_per_sec` | Maximum snapshot rate | `40mb` |
 | `readonly` | Whether repository is read-only | `false` |
+| `s3_async_client_type` | Async HTTP client type: `crt` (default) or `netty` | `crt` (v3.3.0+) |
 
 #### Client Settings
 
@@ -208,6 +210,7 @@ graph TB
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#18800](https://github.com/opensearch-project/OpenSearch/pull/18800) | Switch default async HTTP client to AWS CRT for improved throughput |
 | v3.3.0 | [#19220](https://github.com/opensearch-project/OpenSearch/pull/19220) | Fix S3-compatible repository checksum trailing headers issue |
 | v3.1.0 | [#18312](https://github.com/opensearch-project/OpenSearch/pull/18312) | Add support for SSE-KMS and S3 bucket owner verification |
 | v2.18.0 | [#15621](https://github.com/opensearch-project/OpenSearch/pull/15621) | Add support for async deletion in S3BlobContainer |
@@ -216,6 +219,8 @@ graph TB
 
 ## References
 
+- [PR #18800](https://github.com/opensearch-project/OpenSearch/pull/18800): AWS CRT async HTTP client implementation
+- [Issue #18535](https://github.com/opensearch-project/OpenSearch/issues/18535): Feature request for S3CrtClient support
 - [PR #19220](https://github.com/opensearch-project/OpenSearch/pull/19220): S3-compatible repository checksum fix
 - [Issue #18240](https://github.com/opensearch-project/OpenSearch/issues/18240): S3 compatible storage broken in 3.0.0
 - [Issue #19124](https://github.com/opensearch-project/OpenSearch/issues/19124): repository-s3 x-amz-trailer error
@@ -230,6 +235,7 @@ graph TB
 
 ## Change History
 
+- **v3.3.0** (2025-09): Switched default async HTTP client to AWS CRT for ~5-7% throughput improvement; added `s3_async_client_type` setting
 - **v3.3.0** (2025-09): Fixed S3-compatible repository compatibility by making checksum trailing headers conditional
 - **v3.1.0** (2025-07): Added SSE-KMS support, bucket owner verification, removed legacy server_side_encryption setting
 - **v2.18.0** (2024-10-22): Added async deletion support, changed default retry mechanism to Standard Mode, fixed SLF4J warnings

--- a/docs/releases/v3.3.0/features/opensearch/s3-performance.md
+++ b/docs/releases/v3.3.0/features/opensearch/s3-performance.md
@@ -1,0 +1,140 @@
+# S3 Performance
+
+## Summary
+
+OpenSearch v3.3.0 introduces AWS CRT (Common Runtime) async HTTP client as the default for S3 repository operations, replacing the previous Netty-based client. This change delivers approximately 5-7% throughput improvement for file uploads to S3, benefiting Remote Store and snapshot operations. The Netty client remains available as a configurable fallback option.
+
+## Details
+
+### What's New in v3.3.0
+
+This release switches the default async HTTP client used by the S3 repository plugin from `NettyNioAsyncHttpClient` to `AwsCrtAsyncHttpClient`. The AWS CRT client is optimized for high-throughput S3 operations and provides better performance for uploading translog and segment files in Remote Store configurations.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "S3AsyncService"
+        Settings[Repository Settings]
+        ClientCache[HTTP Client Type Cache]
+        
+        subgraph "HTTP Client Selection"
+            CRT[AwsCrtAsyncHttpClient<br/>Default]
+            Netty[NettyNioAsyncHttpClient<br/>Fallback]
+        end
+    end
+    
+    subgraph "S3 Operations"
+        Upload[Segment/Translog Upload]
+        Download[Restore Operations]
+    end
+    
+    Settings -->|s3_async_client_type| ClientCache
+    ClientCache -->|crt| CRT
+    ClientCache -->|netty| Netty
+    CRT --> Upload
+    CRT --> Download
+    Netty --> Upload
+    Netty --> Download
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `AwsCrtAsyncHttpClient` | AWS CRT-based async HTTP client for improved S3 throughput |
+| `EventLoopThreadFilter` | Thread filter for CRT event loop threads in tests |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `s3_async_client_type` | Type of async HTTP client: `crt` or `netty` | `crt` |
+
+#### Client Cache Changes
+
+The `S3AsyncService` now maintains separate client caches for each HTTP client type:
+
+```mermaid
+graph TB
+    subgraph "Client Cache Structure"
+        TypeCache[s3HttpClientTypesClientsCache]
+        
+        subgraph "CRT Cache"
+            CRTSettings1[ClientSettings 1]
+            CRTSettings2[ClientSettings 2]
+        end
+        
+        subgraph "Netty Cache"
+            NettySettings1[ClientSettings 1]
+            NettySettings2[ClientSettings 2]
+        end
+    end
+    
+    TypeCache -->|crt| CRTSettings1
+    TypeCache -->|crt| CRTSettings2
+    TypeCache -->|netty| NettySettings1
+    TypeCache -->|netty| NettySettings2
+```
+
+### Usage Example
+
+#### Using Default CRT Client (Recommended)
+
+```json
+PUT _snapshot/my-s3-repo
+{
+  "type": "s3",
+  "settings": {
+    "bucket": "my-opensearch-snapshots",
+    "base_path": "snapshots"
+  }
+}
+```
+
+#### Using Netty Client (Fallback)
+
+```json
+PUT _snapshot/my-s3-repo
+{
+  "type": "s3",
+  "settings": {
+    "bucket": "my-opensearch-snapshots",
+    "base_path": "snapshots",
+    "s3_async_client_type": "netty"
+  }
+}
+```
+
+### Performance Impact
+
+- **Upload Throughput**: ~5-7% improvement for Remote Store segment and translog uploads
+- **Use Case**: Most beneficial for clusters with high write throughput using Remote Store
+
+### Migration Notes
+
+- No action required for existing repositories - they will automatically use the new CRT client
+- To revert to the previous behavior, explicitly set `s3_async_client_type` to `netty`
+- Both client types support the same proxy configuration options
+
+## Limitations
+
+- CRT client event loop threads may appear in thread dumps (filtered in tests)
+- Known issue with CRT thread cleanup tracked in [aws-crt-java#905](https://github.com/awslabs/aws-crt-java/issues/905)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18800](https://github.com/opensearch-project/OpenSearch/pull/18800) | Move async HTTP client to CRT from Netty and add configurability |
+
+## References
+
+- [Issue #18535](https://github.com/opensearch-project/OpenSearch/issues/18535): Feature request for S3CrtClient support
+- [AWS CRT HTTP Client Documentation](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/http-configuration-crt.html): AWS SDK CRT client guide
+
+## Related Feature Report
+
+- [Full S3 Repository documentation](../../../../features/opensearch/s3-repository.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -38,6 +38,7 @@
 - [Reindex API](features/opensearch/reindex-api.md)
 - [Request Cache](features/opensearch/request-cache.md)
 - [Rule-based Auto-tagging](features/opensearch/rule-based-auto-tagging.md)
+- [S3 Performance](features/opensearch/s3-performance.md)
 - [S3 Repository Compatibility Fix](features/opensearch/s3-repository.md)
 - [Scaled Float Field Precision Fix](features/opensearch/scaled-float-field.md)
 - [Scroll API Error Handling](features/opensearch/scroll-api.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the S3 Performance enhancement in OpenSearch v3.3.0.

### Changes

- **Release Report**: `docs/releases/v3.3.0/features/opensearch/s3-performance.md`
  - Documents the switch from Netty to AWS CRT async HTTP client
  - Explains the ~5-7% throughput improvement for S3 uploads
  - Covers the new `s3_async_client_type` configuration setting

- **Feature Report Update**: `docs/features/opensearch/s3-repository.md`
  - Added `AwsCrtAsyncHttpClient` component
  - Added `s3_async_client_type` configuration option
  - Updated Related PRs and References sections
  - Updated Change History

### Key Changes in v3.3.0

- Default async HTTP client changed from `NettyNioAsyncHttpClient` to `AwsCrtAsyncHttpClient`
- New `s3_async_client_type` setting allows switching between `crt` (default) and `netty`
- ~5-7% throughput improvement for Remote Store segment/translog uploads

### Related Issue

Closes #1390