### PR TITLE
docs: add Store Factory report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -146,6 +146,7 @@
 - [Skip List](opensearch/skip-list.md)
 - [Snapshot Restore Enhancements](opensearch/snapshot-restore-enhancements.md)
 - [Star Tree Index](opensearch/star-tree-index.md)
+- [Store Factory](opensearch/store-factory.md)
 - [Store Subdirectory Module](opensearch/store-subdirectory-module.md)
 - [Streaming Indexing](opensearch/streaming-indexing.md)
 - [Streaming Transport & Aggregation](opensearch/streaming-transport-aggregation.md)

--- a/docs/features/opensearch/store-factory.md
+++ b/docs/features/opensearch/store-factory.md
@@ -1,0 +1,178 @@
+# Store Factory
+
+## Summary
+
+Store Factory is an extensibility feature that enables OpenSearch plugins to provide custom `Store` implementations per index. The `Store` class is responsible for managing the Lucene directory and file operations for each shard. By making Store pluggable, plugins can customize how shard data is stored, managed, and recovered.
+
+This feature addresses the limitation that OpenSearch's Store assumes all files are in a flat `index` directory. With Store Factory, plugins can implement stores that handle files in subdirectories, use custom storage backends, or add specialized file handling logic.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Plugin Registration"
+        Plugin[IndexStorePlugin]
+        GSF[getStoreFactories]
+        SFMap["Map<String, StoreFactory>"]
+    end
+    
+    subgraph "Node Initialization"
+        Node[Node]
+        PS[PluginsService]
+        IndS[IndicesService]
+    end
+    
+    subgraph "Index Creation"
+        IM[IndexModule]
+        IS[IndexService]
+        Shard[IndexShard]
+    end
+    
+    subgraph "Store Layer"
+        SF[StoreFactory]
+        Store[Store]
+        Dir[Directory]
+    end
+    
+    Plugin -->|implements| GSF
+    GSF -->|returns| SFMap
+    
+    Node -->|collects| PS
+    PS -->|aggregates| SFMap
+    SFMap -->|passed to| IndS
+    
+    IndS -->|creates| IM
+    IM -->|resolves factory| SF
+    IM -->|creates| IS
+    IS -->|creates shard| Shard
+    Shard -->|uses| SF
+    SF -->|newStore| Store
+    Store -->|wraps| Dir
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Index Creation Flow"
+        A[Create Index Request] --> B{index.store.factory set?}
+        B -->|Yes| C[Lookup StoreFactory by key]
+        B -->|No| D[Use default Store::new]
+        C --> E{Factory found?}
+        E -->|Yes| F[Use custom StoreFactory]
+        E -->|No| G[Throw IllegalArgumentException]
+        D --> H[Create IndexService]
+        F --> H
+    end
+    
+    subgraph "Shard Creation Flow"
+        H --> I[Create IndexShard]
+        I --> J[StoreFactory.newStore]
+        J --> K[Custom Store Instance]
+        K --> L[Shard Operations]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `IndexStorePlugin` | Plugin interface extended with store factory support |
+| `IndexStorePlugin.StoreFactory` | Functional interface for creating Store instances |
+| `IndexModule` | Resolves and passes store factory to IndexService |
+| `IndexService` | Uses store factory when creating shards |
+| `IndicesService` | Aggregates store factories from all plugins |
+| `Node` | Collects store factories during initialization |
+
+### Configuration
+
+| Setting | Description | Default | Scope |
+|---------|-------------|---------|-------|
+| `index.store.factory` | Key identifying the StoreFactory to use | `""` (empty) | Index, Node |
+
+When empty or not set, the default `Store` implementation is used.
+
+### StoreFactory Interface
+
+```java
+@FunctionalInterface
+@ExperimentalApi
+interface StoreFactory {
+    Store newStore(
+        ShardId shardId,
+        IndexSettings indexSettings,
+        Directory directory,
+        ShardLock shardLock,
+        Store.OnClose onClose,
+        ShardPath shardPath
+    ) throws IOException;
+}
+```
+
+### Public APIs for Plugin Developers
+
+| Class | Description |
+|-------|-------------|
+| `Store.MetadataSnapshot.LoadedMetadata` | Container for file metadata, user data, and document count |
+| `Store.OnClose` | Callback interface invoked when store is closed |
+
+### Usage Example
+
+#### Plugin Implementation
+
+```java
+public class CustomStorePlugin extends Plugin implements IndexStorePlugin {
+    
+    @Override
+    public Map<String, StoreFactory> getStoreFactories() {
+        return Collections.singletonMap("custom_store", 
+            (shardId, indexSettings, directory, shardLock, onClose, shardPath) -> 
+                new CustomStore(shardId, indexSettings, directory, shardLock, onClose, shardPath)
+        );
+    }
+}
+```
+
+#### Index Configuration
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index.store.factory": "custom_store"
+  }
+}
+```
+
+### Built-in Implementations
+
+| Factory Key | Module | Description |
+|-------------|--------|-------------|
+| `subdirectory_store` | store-subdirectory | Handles files in subdirectories with peer recovery support |
+
+## Limitations
+
+- The `StoreFactory` interface is marked as `@ExperimentalApi` and may change in future versions
+- Store factory selection is immutable after index creation
+- Custom stores must implement all Store methods correctly for proper operation
+- Recovery operations depend on correct metadata handling in custom stores
+- Only one store factory can be active per index
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19091](https://github.com/opensearch-project/OpenSearch/pull/19091) | Add StoreFactory plugin interface for custom Store implementations |
+| v3.3.0 | [#19132](https://github.com/opensearch-project/OpenSearch/pull/19132) | Add subdirectory-aware store module (first implementation using StoreFactory) |
+
+## References
+
+- [Issue #19090](https://github.com/opensearch-project/OpenSearch/issues/19090): Feature request for custom Store implementations through plugin
+- [Issue #19131](https://github.com/opensearch-project/OpenSearch/issues/19131): Store module/plugin to handle subdirectory copying during recovery
+- [Store Subdirectory Module](store-subdirectory-module.md): First implementation using StoreFactory
+
+## Change History
+
+- **v3.3.0** (2026-01-11): Initial implementation with StoreFactory interface, index.store.factory setting, and public API exposure for Store.LoadedMetadata and Store.OnClose

--- a/docs/releases/v3.3.0/features/opensearch/store-factory.md
+++ b/docs/releases/v3.3.0/features/opensearch/store-factory.md
@@ -1,0 +1,145 @@
+# Store Factory
+
+## Summary
+
+Store Factory introduces a plugin interface (`StoreFactory`) that enables plugins to provide custom `Store` implementations per index. This extensibility point allows plugins to customize how shard data is stored and managed, supporting use cases like handling files in subdirectories or implementing custom storage backends.
+
+The feature adds a new index setting `index.store.factory` that selects which custom store factory to use, with fallback to the default Store when not specified.
+
+## Details
+
+### What's New in v3.3.0
+
+This release introduces the `StoreFactory` plugin interface as part of the `IndexStorePlugin` extension point:
+
+1. **New `StoreFactory` Interface**: A functional interface for creating custom Store instances per shard
+2. **New Index Setting**: `index.store.factory` setting to select a custom store factory
+3. **Public API Exposure**: `Store.LoadedMetadata` and `Store.OnClose` are now public APIs for plugin developers
+4. **Plugin Integration**: Plugins can register store factories via `getStoreFactories()` method
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Plugin Layer"
+        ISP[IndexStorePlugin]
+        SF[StoreFactory]
+        CS[Custom Store]
+    end
+    
+    subgraph "OpenSearch Core"
+        IM[IndexModule]
+        IS[IndexService]
+        Store[Store]
+    end
+    
+    subgraph "Configuration"
+        Setting["index.store.factory"]
+    end
+    
+    ISP -->|implements| SF
+    SF -->|creates| CS
+    CS -->|extends| Store
+    
+    Setting -->|selects| SF
+    IM -->|resolves| SF
+    IS -->|uses| SF
+    SF -->|newStore| CS
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `IndexStorePlugin.StoreFactory` | Functional interface for creating custom Store instances |
+| `IndexStorePlugin.getStoreFactories()` | Method to register store factories with unique keys |
+| `INDEX_STORE_FACTORY_SETTING` | Index setting to select a custom store factory |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.store.factory` | Selects a custom StoreFactory provided by plugins | `""` (empty, uses default Store) |
+
+#### API Changes
+
+The following classes are now public API for plugin developers:
+
+| Class | Since | Description |
+|-------|-------|-------------|
+| `Store.MetadataSnapshot.LoadedMetadata` | v3.2.0 | Metadata container for store files |
+| `Store.OnClose` | v3.2.0 | Callback interface for store close events |
+
+### Usage Example
+
+#### Implementing a Custom Store Factory
+
+```java
+public class MyStorePlugin extends Plugin implements IndexStorePlugin {
+    
+    @Override
+    public Map<String, StoreFactory> getStoreFactories() {
+        return Map.of("my_store", new MyStoreFactory());
+    }
+    
+    static class MyStoreFactory implements StoreFactory {
+        @Override
+        public Store newStore(
+            ShardId shardId,
+            IndexSettings indexSettings,
+            Directory directory,
+            ShardLock shardLock,
+            Store.OnClose onClose,
+            ShardPath shardPath
+        ) throws IOException {
+            return new MyCustomStore(shardId, indexSettings, directory, 
+                                     shardLock, onClose, shardPath);
+        }
+    }
+}
+```
+
+#### Using a Custom Store Factory
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "store": {
+        "factory": "my_store"
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- Existing indices continue to use the default Store
+- To use a custom store factory, the plugin providing it must be installed
+- The setting is applied at index creation time
+
+## Limitations
+
+- Store factory selection is immutable after index creation
+- Custom stores must properly implement all Store methods for compatibility
+- The `StoreFactory` interface is marked as `@ExperimentalApi`
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19091](https://github.com/opensearch-project/OpenSearch/pull/19091) | Add StoreFactory plugin interface for custom Store implementations |
+| [#19132](https://github.com/opensearch-project/OpenSearch/pull/19132) | Add subdirectory-aware store module with recovery support (first implementation) |
+
+## References
+
+- [Issue #19090](https://github.com/opensearch-project/OpenSearch/issues/19090): Feature request for custom Store implementations through plugin
+- [Issue #19131](https://github.com/opensearch-project/OpenSearch/issues/19131): Store module/plugin to handle subdirectory copying during recovery
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/store-factory.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -50,6 +50,7 @@
 - [Segment Warmer Metrics](features/opensearch/segment-warmer.md)
 - [Skip List](features/opensearch/skip-list.md)
 - [Star Tree Index](features/opensearch/star-tree-index.md)
+- [Store Factory](features/opensearch/store-factory.md)
 - [Store Subdirectory Module](features/opensearch/store-subdirectory-module.md)
 - [Streaming Aggregation](features/opensearch/streaming-aggregation.md)
 - [Terms Query Rewriting](features/opensearch/terms-query-rewriting.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Store Factory feature introduced in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/store-factory.md`
- Feature report: `docs/features/opensearch/store-factory.md`

### Feature Overview

Store Factory introduces a plugin interface (`StoreFactory`) that enables plugins to provide custom `Store` implementations per index. Key changes:

- New `IndexStorePlugin.StoreFactory` interface for creating custom Store instances
- New `index.store.factory` setting to select a custom store factory
- Public API exposure for `Store.LoadedMetadata` and `Store.OnClose`

### Related PRs
- [#19091](https://github.com/opensearch-project/OpenSearch/pull/19091): Add StoreFactory plugin interface
- [#19132](https://github.com/opensearch-project/OpenSearch/pull/19132): Add subdirectory-aware store module (first implementation)

### Related Issues
- [#19090](https://github.com/opensearch-project/OpenSearch/issues/19090): Feature request
- Closes #1389