### PR TITLE
docs: add Engine Config report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -68,6 +68,7 @@
 - [Docker Image Base](opensearch/docker-image-base.md)
 - [Dynamic Threadpool Resize](opensearch/dynamic-threadpool-resize.md)
 - [Engine API](opensearch/engine-api.md)
+- [Engine Config](opensearch/engine-config.md)
 - [Engine Optimization Fixes](opensearch/engine-optimization-fixes.md)
 - [Locale Provider](opensearch/locale-provider.md)
 - [HTTP API](opensearch/http-api.md)

--- a/docs/features/opensearch/engine-config.md
+++ b/docs/features/opensearch/engine-config.md
@@ -1,0 +1,153 @@
+# Engine Config
+
+## Summary
+
+`EngineConfig` is a configuration class that holds all settings required to create an OpenSearch `Engine` instance. It encapsulates over 25 configuration parameters including shard settings, thread pools, merge policies, translog configuration, and more. The class uses a Builder pattern for construction and provides a `toBuilder()` method for creating modified copies.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Engine Configuration"
+        EC[EngineConfig]
+        B[EngineConfig.Builder]
+    end
+    
+    subgraph "Core Components"
+        SI[ShardId]
+        TP[ThreadPool]
+        IS[IndexSettings]
+        ST[Store]
+        MP[MergePolicy]
+    end
+    
+    subgraph "Services"
+        CS[CodecService]
+        TC[TranslogConfig]
+        TF[TranslogFactory]
+        CBS[CircuitBreakerService]
+    end
+    
+    subgraph "Plugins"
+        P1[Storage Encryption Plugin]
+        P2[Custom Engine Plugin]
+    end
+    
+    B --> EC
+    EC --> SI
+    EC --> TP
+    EC --> IS
+    EC --> ST
+    EC --> MP
+    EC --> CS
+    EC --> TC
+    EC --> TF
+    EC --> CBS
+    
+    P1 -->|toBuilder| EC
+    P2 -->|toBuilder| EC
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `EngineConfig` | Immutable configuration holder for Engine creation |
+| `EngineConfig.Builder` | Fluent builder for constructing EngineConfig instances |
+| `toBuilder()` | Method to create a pre-populated Builder from existing config |
+| `CodecService` | Service for managing Lucene codecs |
+
+### Configuration Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `shardId` | `ShardId` | Identifier for the shard |
+| `threadPool` | `ThreadPool` | Thread pool for async operations |
+| `indexSettings` | `IndexSettings` | Index-level settings |
+| `warmer` | `Engine.Warmer` | Searcher warmer for new segments |
+| `store` | `Store` | Access to the Lucene directory |
+| `mergePolicy` | `MergePolicy` | Lucene merge policy |
+| `analyzer` | `Analyzer` | Default analyzer for indexing |
+| `similarity` | `Similarity` | Similarity for scoring |
+| `codecService` | `CodecService` | Codec management service |
+| `eventListener` | `Engine.EventListener` | Engine event callbacks |
+| `queryCache` | `QueryCache` | Query result cache |
+| `queryCachingPolicy` | `QueryCachingPolicy` | Policy for query caching |
+| `translogConfig` | `TranslogConfig` | Translog configuration |
+| `translogFactory` | `TranslogFactory` | Factory for creating translogs |
+| `flushMergesAfter` | `TimeValue` | Time after which to flush merges |
+| `circuitBreakerService` | `CircuitBreakerService` | Memory circuit breaker |
+| `globalCheckpointSupplier` | `LongSupplier` | Global checkpoint tracker |
+| `retentionLeasesSupplier` | `Supplier<RetentionLeases>` | Retention leases provider |
+| `primaryTermSupplier` | `LongSupplier` | Primary term supplier |
+| `isReadOnlyReplica` | `boolean` | Read-only replica flag |
+| `leafSorter` | `Comparator<LeafReader>` | Segment ordering comparator |
+
+### Usage Example
+
+#### Creating a New EngineConfig
+
+```java
+EngineConfig config = new EngineConfig.Builder()
+    .shardId(shardId)
+    .threadPool(threadPool)
+    .indexSettings(indexSettings)
+    .warmer(warmer)
+    .store(store)
+    .mergePolicy(mergePolicy)
+    .analyzer(analyzer)
+    .similarity(similarity)
+    .codecService(codecService)
+    .eventListener(eventListener)
+    .queryCache(queryCache)
+    .queryCachingPolicy(queryCachingPolicy)
+    .translogConfig(translogConfig)
+    .translogFactory(new InternalTranslogFactory())
+    .flushMergesAfter(flushMergesAfter)
+    .circuitBreakerService(circuitBreakerService)
+    .globalCheckpointSupplier(globalCheckpointSupplier)
+    .retentionLeasesSupplier(retentionLeasesSupplier)
+    .primaryTermSupplier(primaryTermSupplier)
+    .build();
+```
+
+#### Modifying an Existing Config (v3.3.0+)
+
+```java
+// Create a modified copy with a custom translog factory
+EngineConfig encryptedConfig = existingConfig.toBuilder()
+    .translogFactory(new EncryptedTranslogFactory())
+    .build();
+```
+
+### Index Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.codec` | Lucene codec for writing segments | `default` |
+| `index.codec.compression_level` | Compression level (1-6) for zstd codecs | `3` |
+| `index.optimize_auto_generated_id` | Optimize for auto-generated IDs | `true` |
+| `index.use_compound_file` | Use compound file format | `true` |
+
+## Limitations
+
+- `EngineConfig` is effectively immutable after construction
+- The `toBuilder()` method creates shallow copies of mutable objects
+- Some settings like `codecName` are derived from `IndexSettings` and cannot be directly modified
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19054](https://github.com/opensearch-project/OpenSearch/pull/19054) | Add toBuilder() method for easy config modification |
+
+## References
+
+- [opensearch-storage-encryption](https://github.com/opensearch-project/opensearch-storage-encryption): Plugin that motivated the toBuilder() addition
+- [EngineConfig.java](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/index/engine/EngineConfig.java): Source code
+
+## Change History
+
+- **v3.3.0**: Added `toBuilder()` method; promoted `EngineConfig.Builder` and `CodecService` to public API

--- a/docs/releases/v3.3.0/features/opensearch/engine-config.md
+++ b/docs/releases/v3.3.0/features/opensearch/engine-config.md
@@ -1,0 +1,94 @@
+# Engine Config toBuilder Method
+
+## Summary
+
+This release adds a `toBuilder()` method to the `EngineConfig` class, enabling plugin developers to easily create modified copies of engine configurations. This is particularly useful for plugins that need to customize specific engine settings (like translog factory) while preserving all other configuration values.
+
+## Details
+
+### What's New in v3.3.0
+
+The `EngineConfig` class now includes a `toBuilder()` method that creates a new `Builder` instance pre-populated with all values from the current configuration. This allows selective modification of specific fields while preserving all others.
+
+Additionally, both `EngineConfig.Builder` and `CodecService` have been promoted to public API status (`@PublicApi(since = "3.3.0")`).
+
+### Technical Changes
+
+#### New Method
+
+```java
+/**
+ * Creates a new Builder pre-populated with all values from this EngineConfig.
+ * This allows for easy modification of specific fields while preserving all others.
+ *
+ * @return a new Builder instance with all current configuration values
+ */
+public Builder toBuilder() {
+    return new Builder()
+        .shardId(this.shardId)
+        .threadPool(this.threadPool)
+        .indexSettings(this.indexSettings)
+        // ... all 28+ fields copied
+        .translogFactory(this.translogFactory)
+        .clusterApplierService(this.clusterApplierService);
+}
+```
+
+#### API Visibility Changes
+
+| Class | Previous Status | New Status |
+|-------|-----------------|------------|
+| `EngineConfig.Builder` | `@opensearch.internal` | `@PublicApi(since = "3.3.0")` |
+| `CodecService` | `@opensearch.internal` | `@PublicApi(since = "3.3.0")` |
+
+### Usage Example
+
+Before this change, modifying a single field required manually copying all 25+ fields:
+
+```java
+// Old approach - error-prone and verbose
+EngineConfig cryptoConfig = new EngineConfig.Builder()
+    .shardId(config.getShardId())
+    .threadPool(config.getThreadPool())
+    .indexSettings(config.getIndexSettings())
+    // ... 20+ more manual field copies
+    .translogFactory(cryptoTranslogFactory)  // The only field we want to change
+    .build();
+```
+
+With the new `toBuilder()` method:
+
+```java
+// New approach - clean and maintainable
+EngineConfig cryptoConfig = config.toBuilder()
+    .translogFactory(cryptoTranslogFactory)
+    .build();
+```
+
+### Motivation
+
+This change was driven by the [opensearch-storage-encryption](https://github.com/opensearch-project/opensearch-storage-encryption) plugin, which needed to create an `EngineConfig` identical to the original except for the `translogFactory` field to enable encrypted translogs.
+
+The previous approach of manually copying all fields was:
+- Error-prone: Easy to miss fields when copying
+- Maintenance burden: Any new fields added to `EngineConfig.Builder` would require updates to all plugins using this pattern
+- Verbose: Required 25+ lines of boilerplate code
+
+## Limitations
+
+- The `toBuilder()` method creates a shallow copy of all configuration values
+- Mutable objects within the configuration are shared between the original and the copy
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19054](https://github.com/opensearch-project/OpenSearch/pull/19054) | Add toBuilder() method in EngineConfig |
+
+## References
+
+- [opensearch-storage-encryption PR #39](https://github.com/opensearch-project/opensearch-storage-encryption/pull/39#discussion_r2257070134): Original discussion that motivated this change
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/engine-config.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -18,6 +18,7 @@
 - [File Cache Threshold](features/opensearch/file-cache-threshold.md)
 - [Docker Image Updates](features/opensearch/docker-image-updates.md)
 - [Engine API](features/opensearch/engine-api.md)
+- [Engine Config toBuilder](features/opensearch/engine-config.md)
 - [Field Collapsing with search_after](features/opensearch/field-collapsing-search-after.md)
 - [Flaky Test Fixes](features/opensearch/flaky-test-fixes.md)
 - [Grok Processor](features/opensearch/grok-processor.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Engine Config `toBuilder()` method introduced in OpenSearch v3.3.0.

### Changes
- **Release Report**: `docs/releases/v3.3.0/features/opensearch/engine-config.md`
- **Feature Report**: `docs/features/opensearch/engine-config.md`
- Updated release and feature indexes

### Key Points
- Adds `toBuilder()` method to `EngineConfig` for easy modification of specific fields
- Promotes `EngineConfig.Builder` and `CodecService` to public API (`@PublicApi(since = "3.3.0")`)
- Motivated by opensearch-storage-encryption plugin's need to customize translog factory

### Related
- OpenSearch PR: [#19054](https://github.com/opensearch-project/OpenSearch/pull/19054)
- Closes #1388