### PR TITLE
docs: add dynamic mapping false_allow_templates report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -46,6 +46,7 @@
 - [Deprecated Code Cleanup](opensearch/deprecated-code-cleanup.md)
 - [DocRequest Refactoring](opensearch/docrequest-refactoring.md)
 - [Dynamic Settings](opensearch/dynamic-settings.md)
+- [Dynamic Mapping](opensearch/dynamic-mapping.md)
 - [Field Collapsing](opensearch/field-collapsing.md)
 - [Field Data Cache](opensearch/field-data-cache.md)
 - [Field Mapping](opensearch/field-mapping.md)

--- a/docs/features/opensearch/dynamic-mapping.md
+++ b/docs/features/opensearch/dynamic-mapping.md
@@ -1,0 +1,203 @@
+# Dynamic Mapping
+
+## Summary
+
+Dynamic mapping in OpenSearch controls how new fields are handled when indexing documents. The `dynamic` parameter determines whether unmapped fields are automatically added to the index mapping, ignored, or cause an error. This feature is essential for managing schema evolution and controlling index mapping growth.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Document Indexing"
+        DOC[Incoming Document]
+        PARSER[DocumentParser]
+        MAPPER[ObjectMapper]
+    end
+    
+    subgraph "Dynamic Mapping Decision"
+        CHECK{Check dynamic setting}
+        TRUE[dynamic: true]
+        FALSE[dynamic: false]
+        STRICT[dynamic: strict]
+        SAT[dynamic: strict_allow_templates]
+        FAT[dynamic: false_allow_templates]
+    end
+    
+    subgraph "Template Matching"
+        TEMPLATE[Dynamic Templates]
+        MATCH{Template matches?}
+    end
+    
+    subgraph "Outcomes"
+        INDEX[Index field]
+        IGNORE[Ignore field]
+        ERROR[Throw exception]
+        SOURCE[Store in _source only]
+    end
+    
+    DOC --> PARSER
+    PARSER --> MAPPER
+    MAPPER --> CHECK
+    
+    CHECK --> TRUE
+    CHECK --> FALSE
+    CHECK --> STRICT
+    CHECK --> SAT
+    CHECK --> FAT
+    
+    TRUE --> INDEX
+    FALSE --> SOURCE
+    STRICT --> ERROR
+    
+    SAT --> TEMPLATE
+    FAT --> TEMPLATE
+    
+    TEMPLATE --> MATCH
+    MATCH -->|Yes| INDEX
+    MATCH -->|No, strict_allow_templates| ERROR
+    MATCH -->|No, false_allow_templates| SOURCE
+```
+
+### Dynamic Mapping Options
+
+| Option | New Fields Indexed | Template Support | Unknown Fields |
+|--------|-------------------|------------------|----------------|
+| `true` | Yes | Yes | Auto-mapped |
+| `false` | No | No | Stored in `_source` only |
+| `strict` | No | No | Throws exception |
+| `strict_allow_templates` | Template matches only | Yes | Throws exception |
+| `false_allow_templates` | Template matches only | Yes | Stored in `_source` only |
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ObjectMapper.Dynamic` | Enum defining dynamic mapping options |
+| `DocumentParser` | Parses documents and applies dynamic mapping rules |
+| `RootObjectMapper` | Root-level mapper handling document-wide dynamic settings |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `dynamic` | Controls dynamic field mapping behavior | `true` |
+| `dynamic_templates` | Array of templates for pattern-based field mapping | `[]` |
+| `date_detection` | Enable automatic date field detection | `true` |
+| `numeric_detection` | Enable automatic numeric field detection | `false` |
+
+### Usage Examples
+
+#### Basic false_allow_templates Usage
+
+```json
+PUT my-index
+{
+  "mappings": {
+    "dynamic": "false_allow_templates",
+    "dynamic_templates": [
+      {
+        "dates": {
+          "match": "date_*",
+          "mapping": { "type": "date" }
+        }
+      },
+      {
+        "metrics": {
+          "match": "metric_*",
+          "mapping": { "type": "double" }
+        }
+      }
+    ],
+    "properties": {
+      "id": { "type": "keyword" },
+      "name": { "type": "text" }
+    }
+  }
+}
+```
+
+#### Nested Object with Dynamic Templates
+
+```json
+PUT my-index
+{
+  "mappings": {
+    "dynamic": "false_allow_templates",
+    "dynamic_templates": [
+      {
+        "nested_strings": {
+          "path_match": "metadata.*",
+          "match_mapping_type": "string",
+          "mapping": { "type": "keyword" }
+        }
+      }
+    ],
+    "properties": {
+      "title": { "type": "text" }
+    }
+  }
+}
+```
+
+#### Combining Multiple Template Types
+
+```json
+PUT my-index
+{
+  "mappings": {
+    "dynamic": "false_allow_templates",
+    "dynamic_templates": [
+      {
+        "strings": {
+          "match": "str_*",
+          "match_mapping_type": "string",
+          "mapping": { "type": "keyword" }
+        }
+      },
+      {
+        "longs": {
+          "match": "long_*",
+          "match_mapping_type": "long",
+          "mapping": { "type": "long" }
+        }
+      },
+      {
+        "objects": {
+          "match": "obj_*",
+          "match_mapping_type": "object",
+          "mapping": { "type": "object" }
+        }
+      }
+    ]
+  }
+}
+```
+
+## Limitations
+
+- Dynamic mapping settings are applied at index creation and cannot be changed for existing fields
+- `false_allow_templates` requires OpenSearch 3.3.0 or later
+- Fields ignored by dynamic mapping are still stored in `_source` but cannot be searched
+- Template matching is evaluated in order; first match wins
+- Deeply nested objects require templates for each level of the hierarchy
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19065](https://github.com/opensearch-project/OpenSearch/pull/19065) | Add `false_allow_templates` as a dynamic mapping option |
+
+## References
+
+- [Issue #18617](https://github.com/opensearch-project/OpenSearch/issues/18617): Feature request for `false_allow_templates`
+- [Issue #11276](https://github.com/opensearch-project/OpenSearch/issues/11276): Related feature request
+- [Documentation: Dynamic mapping parameter](https://docs.opensearch.org/3.0/field-types/mapping-parameters/dynamic/): Official documentation
+- [Documentation: Mappings and field types](https://docs.opensearch.org/3.0/field-types/): Field types overview
+- [API Specification PR #944](https://github.com/opensearch-project/opensearch-api-specification/pull/944): API spec update
+- [Documentation PR #10388](https://github.com/opensearch-project/documentation-website/pull/10388): Documentation update
+
+## Change History
+
+- **v3.3.0** (2025): Added `false_allow_templates` dynamic mapping option

--- a/docs/releases/v3.3.0/features/opensearch/dynamic-mapping.md
+++ b/docs/releases/v3.3.0/features/opensearch/dynamic-mapping.md
@@ -1,0 +1,119 @@
+# Dynamic Mapping: false_allow_templates Option
+
+## Summary
+
+OpenSearch v3.3.0 introduces a new `dynamic` mapping parameter value: `false_allow_templates`. This option provides a middle ground between `dynamic: false` and `dynamic: true`, allowing fields that match predefined `dynamic_templates` to be indexed while silently ignoring fields that don't match any template or explicit mapping.
+
+## Details
+
+### What's New in v3.3.0
+
+The `false_allow_templates` option addresses a common use case where users want to:
+- Define explicit mappings for known fields
+- Use dynamic templates for predictable naming patterns (e.g., `date_*`, `metric_*`)
+- Silently ignore unexpected fields without throwing errors
+
+Previously, users had to choose between:
+- `dynamic: true` - indexes all fields (including unwanted ones)
+- `dynamic: false` - disables dynamic templates entirely
+- `dynamic: strict` - throws errors on unknown fields
+- `dynamic: strict_allow_templates` - throws errors on fields not matching templates
+
+### Technical Changes
+
+#### New Dynamic Mapping Option
+
+| Option | Behavior |
+|--------|----------|
+| `true` | All new fields are dynamically mapped |
+| `false` | New fields are ignored, not indexed, but stored in `_source` |
+| `strict` | Throws exception on unknown fields |
+| `strict_allow_templates` | Maps fields matching templates, throws exception on others |
+| `false_allow_templates` | Maps fields matching templates, silently ignores others |
+
+#### Implementation Details
+
+The feature modifies the `DocumentParser` class to handle the new dynamic option:
+- When a field matches a `dynamic_template`, it creates the mapping as defined
+- When a field doesn't match any template or explicit property, it skips indexing but preserves the field in `_source`
+- Supports all field types: objects, arrays, strings, numbers, booleans, dates, and binary data
+
+### Usage Example
+
+```json
+PUT my-index
+{
+  "mappings": {
+    "dynamic": "false_allow_templates",
+    "dynamic_templates": [
+      {
+        "dates": {
+          "match": "date_*",
+          "mapping": {
+            "type": "date"
+          }
+        }
+      }
+    ],
+    "properties": {
+      "url": { "type": "keyword" }
+    }
+  }
+}
+```
+
+Index a document with mixed fields:
+
+```json
+POST my-index/_doc/1
+{
+  "url": "https://example.com",
+  "date_timestamp": "2024-01-01T00:00:00Z",
+  "date_timezone": "2024-01-02T00:00:00Z",
+  "author": "John Doe"
+}
+```
+
+Resulting mapping:
+
+```json
+{
+  "properties": {
+    "url": { "type": "keyword" },
+    "date_timestamp": { "type": "date" },
+    "date_timezone": { "type": "date" }
+  }
+}
+```
+
+The `author` field is stored in `_source` but not indexed or searchable.
+
+### Migration Notes
+
+To adopt this feature:
+1. Update index mappings to use `"dynamic": "false_allow_templates"`
+2. Define `dynamic_templates` for fields that should be dynamically mapped
+3. Existing indexes require reindexing to apply the new mapping behavior
+
+## Limitations
+
+- Fields not matching templates are stored in `_source` but cannot be searched or aggregated
+- The feature requires OpenSearch 3.3.0 or later
+- Cannot be combined with other dynamic values on the same mapping level
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19065](https://github.com/opensearch-project/OpenSearch/pull/19065) | Add `false_allow_templates` as a dynamic mapping option |
+
+## References
+
+- [Issue #18617](https://github.com/opensearch-project/OpenSearch/issues/18617): Feature request for `false_allow_templates`
+- [Documentation: Dynamic mapping parameter](https://docs.opensearch.org/3.0/field-types/mapping-parameters/dynamic/): Official docs on dynamic mapping
+- [API Specification PR #944](https://github.com/opensearch-project/opensearch-api-specification/pull/944): API spec update
+- [Documentation PR #10388](https://github.com/opensearch-project/documentation-website/pull/10388): Documentation update
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/dynamic-mapping.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -14,6 +14,7 @@
 - [Cross-Cluster Settings](features/opensearch/cross-cluster-settings.md)
 - [Date Format](features/opensearch/date-format.md)
 - [Derived Fields](features/opensearch/derived-fields.md)
+- [Dynamic Mapping: false_allow_templates](features/opensearch/dynamic-mapping.md)
 - [Field Data Cache](features/opensearch/field-data-cache.md)
 - [File Cache Threshold](features/opensearch/file-cache-threshold.md)
 - [Docker Image Updates](features/opensearch/docker-image-updates.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the new `false_allow_templates` dynamic mapping option introduced in OpenSearch v3.3.0.

## Changes

### Release Report
- `docs/releases/v3.3.0/features/opensearch/dynamic-mapping.md`: Documents the new `false_allow_templates` option

### Feature Report
- `docs/features/opensearch/dynamic-mapping.md`: Comprehensive documentation of dynamic mapping including the new option

## Key Points

The `false_allow_templates` option provides a middle ground between `dynamic: false` and `dynamic: true`:
- Fields matching `dynamic_templates` are indexed
- Fields not matching any template are silently ignored (stored in `_source` only)
- No exceptions are thrown for unknown fields

## Related

- PR: [opensearch-project/OpenSearch#19065](https://github.com/opensearch-project/OpenSearch/pull/19065)
- Issue: [opensearch-project/OpenSearch#18617](https://github.com/opensearch-project/OpenSearch/issues/18617)