### PR TITLE
docs: add Query Rewriting report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -114,6 +114,7 @@
 - [Query Optimization](opensearch/query-optimization.md)
 - [Query Phase Plugin Extension](opensearch/query-phase-plugin-extension.md)
 - [Query Phase Result Consumer](opensearch/query-phase-result-consumer.md)
+- [Query Rewriting](opensearch/query-rewriting.md)
 - [Query String & Regex Queries](opensearch/query-string-regex.md)
 - [Randomness](opensearch/randomness.md)
 - [Reactor Netty Transport](opensearch/reactor-netty-transport.md)

--- a/docs/features/opensearch/query-rewriting.md
+++ b/docs/features/opensearch/query-rewriting.md
@@ -1,0 +1,218 @@
+# Query Rewriting
+
+## Summary
+
+Query Rewriting is an automatic query optimization feature that transforms user queries into more efficient forms before execution. It applies multiple optimization strategies including boolean flattening, terms merging, must-to-filter conversion, and match_all removal to reduce query complexity by 60-70% for typical filtered queries while preserving exact query semantics.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Query Execution Flow"
+        A[Search Request] --> B[QueryBuilder Tree]
+        B --> C[QueryRewriterRegistry]
+        
+        subgraph "Rewriter Chain"
+            D[BooleanFlatteningRewriter]
+            E[MustToFilterRewriter]
+            F[MustNotToShouldRewriter]
+            G[TermsMergingRewriter]
+            H[MatchAllRemovalRewriter]
+        end
+        
+        C --> D
+        D --> E
+        E --> F
+        F --> G
+        G --> H
+        
+        H --> I[Optimized QueryBuilder]
+        I --> J[Lucene Query]
+        J --> K[Query Execution]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "SearchService.parseSource()"
+        A[source.query()] --> B{Rewriting Enabled?}
+        B -->|Yes| C[QueryRewriterRegistry.rewrite]
+        B -->|No| D[Original Query]
+        C --> E[Sorted Rewriters by Priority]
+        E --> F[Apply Each Rewriter]
+        F --> G[Optimized Query]
+        G --> H[toQuery via QueryShardContext]
+        D --> H
+    end
+```
+
+### Components
+
+| Component | Priority | Description |
+|-----------|----------|-------------|
+| `QueryRewriter` | - | Interface defining `rewrite(QueryBuilder, QueryShardContext)` method |
+| `QueryRewriterRegistry` | - | Singleton managing rewriter registration and execution chain |
+| `BooleanFlatteningRewriter` | 100 | Flattens nested boolean queries with single clause types |
+| `MustToFilterRewriter` | 150 | Moves scoring-irrelevant queries from must to filter |
+| `MustNotToShouldRewriter` | 175 | Converts must_not to should for complement-aware queries |
+| `TermsMergingRewriter` | 200 | Merges multiple term queries into terms query |
+| `MatchAllRemovalRewriter` | 300 | Removes redundant match_all queries |
+
+### Configuration
+
+| Setting | Description | Default | Dynamic |
+|---------|-------------|---------|---------|
+| `search.query_rewriting.enabled` | Enable/disable query rewriting globally | `true` | Yes |
+| `search.query_rewriting.terms_threshold` | Minimum number of term queries to trigger merging | `16` | Yes |
+
+### Rewriter Details
+
+#### BooleanFlatteningRewriter
+
+Flattens unnecessary nested boolean queries:
+
+```json
+// Before
+{"bool": {"filter": [{"bool": {"filter": [{"term": {"field": "value"}}]}}]}}
+
+// After
+{"bool": {"filter": [{"term": {"field": "value"}}]}}
+```
+
+#### MustToFilterRewriter
+
+Moves scoring-irrelevant clauses from must to filter for better caching:
+
+```json
+// Before
+{"bool": {"must": [{"range": {"date": {"gte": "2024-01-01"}}}, {"match": {"title": "search"}}]}}
+
+// After
+{"bool": {"filter": [{"range": {"date": {"gte": "2024-01-01"}}}], "must": [{"match": {"title": "search"}}]}}
+```
+
+Applies to:
+- Range queries (always)
+- GeoBoundingBox queries (always)
+- Term/Terms/Match queries on numeric fields (requires QueryShardContext)
+
+#### MustNotToShouldRewriter
+
+Converts must_not range queries to should clauses for single-valued numeric fields:
+
+```json
+// Before
+{"bool": {"must_not": [{"range": {"age": {"gte": 18, "lte": 65}}}]}}
+
+// After
+{"bool": {"must": [{"bool": {"should": [
+  {"range": {"age": {"lt": 18}}},
+  {"range": {"age": {"gt": 65}}}
+], "minimum_should_match": 1}}]}}
+```
+
+Requirements:
+- Field must be numeric with point values
+- All documents must have exactly one value for the field
+- Only one complement-aware query per field
+
+#### TermsMergingRewriter
+
+Merges multiple term queries on the same field into a single terms query:
+
+```json
+// Before (with 16+ terms)
+{"bool": {"filter": [
+  {"term": {"status": "active"}},
+  {"term": {"status": "pending"}},
+  // ... 14+ more terms
+]}}
+
+// After
+{"bool": {"filter": [{"terms": {"status": ["active", "pending", ...]}}]}}
+```
+
+Only merges in filter and should contexts (not must or must_not).
+
+#### MatchAllRemovalRewriter
+
+Removes redundant match_all queries from boolean contexts:
+
+```json
+// Before
+{"bool": {"filter": [{"match_all": {}}, {"term": {"status": "active"}}]}}
+
+// After
+{"bool": {"filter": [{"term": {"status": "active"}}]}}
+```
+
+### Usage Example
+
+```bash
+# Disable query rewriting
+PUT /_cluster/settings
+{
+  "persistent": {
+    "search.query_rewriting.enabled": false
+  }
+}
+
+# Adjust terms merging threshold
+PUT /_cluster/settings
+{
+  "persistent": {
+    "search.query_rewriting.terms_threshold": 8
+  }
+}
+```
+
+### Custom Rewriter Registration
+
+```java
+// Register a custom rewriter
+QueryRewriterRegistry.INSTANCE.registerRewriter(new QueryRewriter() {
+    @Override
+    public QueryBuilder rewrite(QueryBuilder query, QueryShardContext context) {
+        // Custom rewriting logic
+        return query;
+    }
+    
+    @Override
+    public int priority() {
+        return 500; // Execute after built-in rewriters
+    }
+    
+    @Override
+    public String name() {
+        return "custom_rewriter";
+    }
+});
+```
+
+## Limitations
+
+- Terms merging only triggers when term count meets threshold (default: 16)
+- Must-not-to-should requires single-valued numeric fields with complete coverage
+- Rewriters execute in priority order; later rewriters see results of earlier ones
+- Custom rewriters must be registered programmatically (no plugin API yet)
+- Query names and boosts are preserved but may affect flattening eligibility
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#19060](https://github.com/opensearch-project/OpenSearch/pull/19060) | Initial implementation of query rewriting infrastructure |
+
+## References
+
+- [Issue #18906](https://github.com/opensearch-project/OpenSearch/issues/18906): RFC for Query Rewriting, Logical Planning, and Cost-Based Execution
+- [Issue #12390](https://github.com/opensearch-project/OpenSearch/issues/12390): RFC for Query Planning and Rewriting
+- [Documentation](https://docs.opensearch.org/3.0/search-plugins/search-relevance/query-rewriting/): Query rewriting overview
+
+## Change History
+
+- **v3.3.0** (2026-01): Initial implementation with five built-in rewriters (boolean flattening, must-to-filter, must-not-to-should, terms merging, match-all removal)

--- a/docs/releases/v3.3.0/features/opensearch/query-rewriting.md
+++ b/docs/releases/v3.3.0/features/opensearch/query-rewriting.md
@@ -1,0 +1,127 @@
+# Query Rewriting Infrastructure
+
+## Summary
+
+OpenSearch v3.3.0 introduces a comprehensive query rewriting infrastructure that automatically optimizes query structure before execution. This feature achieves 60-70% reduction in query nodes for typical filtered queries by applying multiple optimization strategies including boolean flattening, terms merging, and must-to-filter clause conversion.
+
+## Details
+
+### What's New in v3.3.0
+
+This release implements a pluggable query rewriting framework that transforms queries into more efficient forms while preserving exact query semantics and results. The infrastructure operates at the QueryBuilder level before conversion to Lucene queries.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Query Processing Pipeline"
+        DSL[DSL Query] --> QB[QueryBuilder Tree]
+        QB --> QRR[QueryRewriterRegistry]
+        
+        subgraph "Rewriters (Priority Order)"
+            BF[BooleanFlatteningRewriter<br/>priority: 100]
+            MTF[MustToFilterRewriter<br/>priority: 150]
+            MNS[MustNotToShouldRewriter<br/>priority: 175]
+            TM[TermsMergingRewriter<br/>priority: 200]
+            MAR[MatchAllRemovalRewriter<br/>priority: 300]
+        end
+        
+        QRR --> BF --> MTF --> MNS --> TM --> MAR
+        MAR --> OQB[Optimized QueryBuilder]
+        OQB --> LQ[Lucene Query]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `QueryRewriter` | Interface for query rewriting implementations |
+| `QueryRewriterRegistry` | Singleton registry managing rewriter chain execution |
+| `BooleanFlatteningRewriter` | Flattens unnecessary nested boolean queries |
+| `MustToFilterRewriter` | Moves scoring-irrelevant clauses from must to filter |
+| `MustNotToShouldRewriter` | Transforms must_not to should for complement-aware queries |
+| `TermsMergingRewriter` | Merges multiple term queries into single terms query |
+| `MatchAllRemovalRewriter` | Removes redundant match_all queries |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `search.query_rewriting.enabled` | Enable/disable query rewriting | `true` |
+| `search.query_rewriting.terms_threshold` | Minimum terms to trigger merging | `16` |
+
+### Usage Example
+
+Query rewriting is enabled by default. The following query:
+
+```json
+{
+  "bool": {
+    "filter": [
+      {"bool": {"filter": [{"term": {"status": "active"}}]}},
+      {"term": {"category": "A"}},
+      {"term": {"category": "B"}},
+      {"term": {"category": "C"}},
+      // ... 16+ category terms
+      {"match_all": {}}
+    ],
+    "must": [
+      {"range": {"price": {"gte": 100}}}
+    ]
+  }
+}
+```
+
+Is automatically rewritten to:
+
+```json
+{
+  "bool": {
+    "filter": [
+      {"term": {"status": "active"}},
+      {"terms": {"category": ["A", "B", "C", ...]}},
+      {"range": {"price": {"gte": 100}}}
+    ]
+  }
+}
+```
+
+### Optimization Strategies
+
+1. **Boolean Flattening**: Removes unnecessary nesting like `bool.filter[bool.filter[...]]`
+2. **Must-to-Filter**: Moves range queries and numeric term queries from must to filter (no scoring impact)
+3. **Must-Not-to-Should**: Converts must_not range queries to should clauses for single-valued numeric fields
+4. **Terms Merging**: Combines 16+ term queries on same field into single terms query
+5. **Match-All Removal**: Eliminates redundant match_all in filter/must contexts
+
+### Migration Notes
+
+- Query rewriting is enabled by default
+- To disable: `PUT /_cluster/settings {"persistent": {"search.query_rewriting.enabled": false}}`
+- Existing queries continue to work with potential performance improvements
+- Query semantics and results are preserved exactly
+
+## Limitations
+
+- Terms merging only applies when 16+ terms target the same field (configurable)
+- Must-not-to-should rewriting requires single-valued numeric fields with values in all documents
+- Custom rewriters must be registered programmatically
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19060](https://github.com/opensearch-project/OpenSearch/pull/19060) | Implement Query Rewriting Infrastructure |
+
+## References
+
+- [Issue #18906](https://github.com/opensearch-project/OpenSearch/issues/18906): RFC for Query Rewriting, Logical Planning, and Cost-Based Execution
+- [Issue #12390](https://github.com/opensearch-project/OpenSearch/issues/12390): RFC for Query Planning and Rewriting
+- [Documentation](https://docs.opensearch.org/3.0/search-plugins/search-relevance/query-rewriting/): Query rewriting overview
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/query-rewriting.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -36,6 +36,7 @@
 - [Pull-based Ingestion](features/opensearch/pull-based-ingestion.md)
 - [Query Cache Dynamic Settings](features/opensearch/query-cache.md)
 - [Query Phase Fixes](features/opensearch/query-phase-fixes.md)
+- [Query Rewriting Infrastructure](features/opensearch/query-rewriting.md)
 - [Reactor Netty Transport](features/opensearch/reactor-netty-transport.md)
 - [Reindex API](features/opensearch/reindex-api.md)
 - [Request Cache](features/opensearch/request-cache.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Query Rewriting Infrastructure feature introduced in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/query-rewriting.md`
- Feature report: `docs/features/opensearch/query-rewriting.md`

### Key Changes in v3.3.0
- New `QueryRewriterRegistry` for managing query rewriting chain
- Five built-in rewriters: BooleanFlattening, MustToFilter, MustNotToShould, TermsMerging, MatchAllRemoval
- 60-70% reduction in query nodes for typical filtered queries
- Configurable via `search.query_rewriting.enabled` and `search.query_rewriting.terms_threshold`

### Resources Used
- PR: opensearch-project/OpenSearch#19060
- RFC: opensearch-project/OpenSearch#18906
- Docs: https://docs.opensearch.org/3.0/search-plugins/search-relevance/query-rewriting/

Related to #1386