### PR TITLE
docs: add fetch phase profiling report for v3.3.0

### DIFF
--- a/docs/features/opensearch/profiler.md
+++ b/docs/features/opensearch/profiler.md
@@ -159,6 +159,18 @@ flowchart LR
 | `HighlightPhase` | Generates search highlights |
 | `FetchScorePhase` | Retrieves document scores when sorting |
 
+### Fetch Phase Types (v3.3.0+)
+
+Starting in v3.3.0, the fetch profiler supports multiple fetch phase types:
+
+| Type | Description |
+|------|-------------|
+| `fetch` | Standard fetch phase for top-level search results |
+| `fetch_inner_hits[<name>]` | Fetch phase for inner hits with the specified name |
+| `fetch_top_hits_aggregation[<name>]` | Fetch phase for top hits aggregation with the specified name |
+
+Each fetch type appears as a separate entry in the `fetch` array of the profile response, allowing developers to identify performance bottlenecks in complex queries involving nested documents and aggregations.
+
 ### Configuration
 
 The Profile API is enabled per-request using the `profile` parameter:
@@ -253,13 +265,12 @@ When concurrent segment search is enabled, the profiler provides additional slic
 - Does not measure network latency
 - Does not measure queue wait time
 - Plugin metrics are only included in the query breakdown, not as separate sections (v3.2.0+)
-- Inner hits fetch operations are not profiled (v3.2.0+)
-- Top hits aggregation fetch operations use a separate description (v3.2.0+)
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#18936](https://github.com/opensearch-project/OpenSearch/pull/18936) | Expand fetch phase profiling to support inner hits and top hits aggregation phases |
 | v3.2.0 | [#18664](https://github.com/opensearch-project/OpenSearch/pull/18664) | Add fetch phase profiling |
 | v3.2.0 | [#18656](https://github.com/opensearch-project/OpenSearch/pull/18656) | Extend profile capabilities to plugins |
 | v3.2.0 | [#18887](https://github.com/opensearch-project/OpenSearch/pull/18887) | Expand fetch phase profiling to multi-shard queries |
@@ -269,11 +280,16 @@ When concurrent segment search is enabled, the profiler provides additional slic
 
 - [Profile API Documentation](https://docs.opensearch.org/3.0/api-reference/search-apis/profile/): Official API reference
 - [Concurrent Segment Search](https://docs.opensearch.org/3.0/search-plugins/concurrent-segment-search/): Related feature
+- [Inner Hits Documentation](https://docs.opensearch.org/3.0/search-plugins/searching-data/inner-hits/): Inner hits usage
+- [Top Hits Aggregation](https://docs.opensearch.org/3.0/aggregations/metric/top-hits/): Top hits aggregation usage
 - [Issue #18460](https://github.com/opensearch-project/OpenSearch/issues/18460): RFC for Profiling Extensibility
 - [Issue #1764](https://github.com/opensearch-project/OpenSearch/issues/1764): Original fetch phase profiling request
+- [Issue #18862](https://github.com/opensearch-project/OpenSearch/issues/18862): Feature request for inner hits and top hits profiling
+- [Issue #18864](https://github.com/opensearch-project/OpenSearch/issues/18864): META issue for fetch phase profiling
 
 ## Change History
 
+- **v3.3.0** (2025-08-12): Expanded fetch phase profiling to support inner hits and top hits aggregation phases
 - **v3.2.0** (2025-07-31): Added comprehensive fetch phase profiling with detailed timing breakdowns for fetch operations and sub-phases
 - **v3.2.0** (2025-08-05): Added plugin profiling extensibility and multi-shard fetch phase profiling
 - **v3.2.0** (2025-06-21): Fixed incorrect timing values for concurrent segment search when timers have zero invocations

--- a/docs/releases/v3.3.0/features/opensearch/fetch-phase-profiling.md
+++ b/docs/releases/v3.3.0/features/opensearch/fetch-phase-profiling.md
@@ -1,0 +1,140 @@
+# Fetch Phase Profiling
+
+## Summary
+
+OpenSearch v3.3.0 expands fetch phase profiling to support inner hits and top hits aggregation phases. Previously (v3.2.0), fetch phase profiling only supported the standard fetch phase. This enhancement provides complete visibility into all fetch operations, enabling developers to identify performance bottlenecks in complex queries involving nested documents and aggregations.
+
+## Details
+
+### What's New in v3.3.0
+
+This release extends the fetch phase profiler to capture timing information for:
+
+1. **Inner Hits Fetch**: Profiling for fetch operations triggered by `inner_hits` in nested or parent-child queries
+2. **Top Hits Aggregation Fetch**: Profiling for fetch operations within `top_hits` aggregations
+
+Each fetch type appears as a separate entry in the profile response with a descriptive label indicating its source.
+
+### Technical Changes
+
+#### Profile Response Structure
+
+The fetch profile array now contains multiple entries when inner hits or top hits aggregations are used:
+
+```json
+{
+  "profile": {
+    "shards": [{
+      "fetch": [
+        {
+          "type": "fetch",
+          "description": "fetch",
+          "time_in_nanos": 500000,
+          "breakdown": { ... },
+          "children": [...]
+        },
+        {
+          "type": "fetch_inner_hits[nested_field]",
+          "description": "fetch_inner_hits[nested_field]",
+          "time_in_nanos": 150000,
+          "breakdown": { ... },
+          "children": [...]
+        },
+        {
+          "type": "fetch_top_hits_aggregation[top_hits_agg1]",
+          "description": "fetch_top_hits_aggregation[top_hits_agg1]",
+          "time_in_nanos": 200000,
+          "breakdown": { ... },
+          "children": [...]
+        }
+      ]
+    }]
+  }
+}
+```
+
+#### New Profile Types
+
+| Type | Description |
+|------|-------------|
+| `fetch_inner_hits[<name>]` | Fetch profile for inner hits with the specified name |
+| `fetch_top_hits_aggregation[<name>]` | Fetch profile for top hits aggregation with the specified name |
+
+#### Implementation Changes
+
+| Component | Change |
+|-----------|--------|
+| `FetchPhase.java` | Removed restriction that limited profiling to standard fetch phase only |
+| `InnerHitsPhase.java` | Updated to pass descriptive profile name `fetch_inner_hits[<name>]` |
+| `TopHitsAggregator.java` | Updated to pass descriptive profile name `fetch_top_hits_aggregation[<name>]` |
+| `FlatFetchProfileTree.java` | Added consolidation logic for concurrent slices and reference counting |
+
+#### Consolidation Behavior
+
+When multiple fetch operations of the same type occur (common with top hits aggregations across many buckets), they are consolidated under a single breakdown entry. This prevents verbose and crowded profiles while still providing accurate timing information.
+
+### Usage Example
+
+Query with inner hits:
+
+```json
+GET /my_index/_search
+{
+  "profile": true,
+  "query": {
+    "nested": {
+      "path": "nested_field",
+      "query": { "match_all": {} },
+      "inner_hits": { "name": "my_inner_hits" }
+    }
+  }
+}
+```
+
+Query with top hits aggregation:
+
+```json
+GET /my_index/_search
+{
+  "profile": true,
+  "size": 0,
+  "aggs": {
+    "by_category": {
+      "terms": { "field": "category" },
+      "aggs": {
+        "top_products": {
+          "top_hits": { "size": 3 }
+        }
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+No migration required. The enhanced profiling is automatically available when using `"profile": true` in search requests.
+
+## Limitations
+
+- Profiling adds overhead to search operations
+- Each inner hit definition and top hits aggregation creates a separate fetch profile entry
+- Concurrent segment search slice statistics are included for all fetch types
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18936](https://github.com/opensearch-project/OpenSearch/pull/18936) | Expand fetch phase profiling to support inner hits and top hits aggregation phases |
+
+## References
+
+- [Issue #18862](https://github.com/opensearch-project/OpenSearch/issues/18862): Feature request for inner hits and top hits profiling
+- [Issue #18864](https://github.com/opensearch-project/OpenSearch/issues/18864): META issue for fetch phase profiling
+- [Profile API Documentation](https://docs.opensearch.org/3.0/api-reference/search-apis/profile/): Official API reference
+- [Inner Hits Documentation](https://docs.opensearch.org/3.0/search-plugins/searching-data/inner-hits/): Inner hits usage
+- [Top Hits Aggregation](https://docs.opensearch.org/3.0/aggregations/metric/top-hits/): Top hits aggregation usage
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/profiler.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -20,6 +20,7 @@
 - [Docker Image Updates](features/opensearch/docker-image-updates.md)
 - [Engine API](features/opensearch/engine-api.md)
 - [Engine Config toBuilder](features/opensearch/engine-config.md)
+- [Fetch Phase Profiling](features/opensearch/fetch-phase-profiling.md)
 - [Field Collapsing with search_after](features/opensearch/field-collapsing-search-after.md)
 - [Flaky Test Fixes](features/opensearch/flaky-test-fixes.md)
 - [Grok Processor](features/opensearch/grok-processor.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Fetch Phase Profiling enhancement in OpenSearch v3.3.0.

### Changes

**Release Report** (`docs/releases/v3.3.0/features/opensearch/fetch-phase-profiling.md`):
- Documents the expansion of fetch phase profiling to support inner hits and top hits aggregation phases
- Includes profile response structure examples
- Lists new profile types: `fetch_inner_hits[<name>]` and `fetch_top_hits_aggregation[<name>]`
- Documents implementation changes and consolidation behavior

**Feature Report Update** (`docs/features/opensearch/profiler.md`):
- Added new "Fetch Phase Types (v3.3.0+)" section
- Updated Related PRs table with PR #18936
- Updated References with inner hits and top hits documentation links
- Updated Change History with v3.3.0 entry
- Removed outdated limitations about inner hits and top hits profiling

**Release Index Update** (`docs/releases/v3.3.0/index.md`):
- Added link to fetch phase profiling report

### Related Issue

Closes #1383

### Key Changes in v3.3.0

- Inner hits fetch operations are now profiled with descriptive labels
- Top hits aggregation fetch operations are now profiled with descriptive labels
- Multiple fetch operations of the same type are consolidated under a single breakdown entry