### PR TITLE
docs: add doc-request report for v3.3.0

### DIFF
--- a/docs/features/opensearch/docrequest-refactoring.md
+++ b/docs/features/opensearch/docrequest-refactoring.md
@@ -159,6 +159,8 @@ sequenceDiagram
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [opensearch#19313](https://github.com/opensearch-project/OpenSearch/pull/19313) | Add new extensible method to DocRequest to specify type |
+| v3.3.0 | [anomaly-detection#1566](https://github.com/opensearch-project/anomaly-detection/pull/1566) | Adds resource types to DocRequests in Anomaly Detection |
 | v3.1.0 | [#18269](https://github.com/opensearch-project/OpenSearch/pull/18269) | Create generic DocRequest to better categorize ActionRequests |
 
 ## References
@@ -168,4 +170,5 @@ sequenceDiagram
 
 ## Change History
 
+- **v3.3.0** (2026-01-10): Added `type()` method to DocRequest interface for resource sharing; Anomaly Detection plugin implements resource types for detectors and forecasters
 - **v3.1.0** (2025-05-15): Initial implementation - introduced `DocRequest` interface, updated `DocWriteRequest` to extend it, and made `GetRequest` implement it

--- a/docs/releases/v3.3.0/features/anomaly-detection/doc-request.md
+++ b/docs/releases/v3.3.0/features/anomaly-detection/doc-request.md
@@ -1,0 +1,102 @@
+# Doc Request Resource Type Support
+
+## Summary
+
+This release adds resource type support to `DocRequest` implementations in the Anomaly Detection plugin and OpenSearch core. The `type()` method enables the Security plugin's resource sharing framework to identify and authorize access to specific resource types (anomaly detectors, forecasters) rather than treating all document operations uniformly.
+
+## Details
+
+### What's New in v3.3.0
+
+The `DocRequest` interface now includes a `type()` method that plugins can override to specify the resource type for authorization purposes. This change enables:
+
+1. **Resource-level authorization**: The Security plugin can now distinguish between different resource types within the same index
+2. **Plugin onboarding to resource sharing**: Anomaly Detection plugin requests now return appropriate resource types (`anomaly-detector` or `forecaster`)
+3. **Multiple resource types per index**: Different resource types can coexist in the same system index with separate access controls
+
+### Technical Changes
+
+#### Core OpenSearch Change
+
+The `DocRequest` interface adds a new default method:
+
+```java
+public interface DocRequest {
+    String index();
+    String id();
+    
+    /**
+     * Get the type of the request for resource sharing context.
+     * Plugins override this to specify their resource type.
+     * @return the type (default: "indices")
+     */
+    default String type() {
+        return "indices";
+    }
+}
+```
+
+#### Anomaly Detection Plugin Changes
+
+The following request classes now override `type()`:
+
+| Request Class | Resource Type |
+|---------------|---------------|
+| `IndexAnomalyDetectorRequest` | `anomaly-detector` |
+| `PreviewAnomalyDetectorRequest` | `anomaly-detector` |
+| `IndexForecasterRequest` | `forecaster` |
+| `DeleteConfigRequest` | `anomaly-detector` or `forecaster` (based on index) |
+| `GetConfigRequest` | `anomaly-detector` or `forecaster` (based on index) |
+| `JobRequest` | `anomaly-detector` or `forecaster` (based on index) |
+| `SuggestConfigParamRequest` | `anomaly-detector` or `forecaster` (based on context) |
+
+#### Resource Type Constants
+
+```java
+// ADCommonName.java
+public static final String AD_RESOURCE_TYPE = "anomaly-detector";
+
+// ForecastCommonName.java  
+public static final String FORECAST_RESOURCE_TYPE = "forecaster";
+```
+
+### Usage Example
+
+When the Security plugin intercepts a request, it can now determine the resource type:
+
+```java
+// Security plugin evaluation
+DocRequest request = (DocRequest) actionRequest;
+String resourceType = request.type();  // Returns "anomaly-detector"
+String resourceId = request.id();
+
+// Evaluate access based on resource type and sharing configuration
+boolean hasAccess = resourceAccessEvaluator.evaluate(user, resourceType, resourceId, action);
+```
+
+### Migration Notes
+
+- No migration required for existing anomaly detectors or forecasters
+- Resource sharing must be explicitly enabled via Security plugin settings
+- Existing `filter_by_backend_role` behavior remains available as fallback
+
+## Limitations
+
+- Resource sharing requires Security plugin with experimental feature enabled
+- Only single-document operations are supported (not bulk operations)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [opensearch#19313](https://github.com/opensearch-project/OpenSearch/pull/19313) | Add new extensible method to DocRequest to specify type |
+| [anomaly-detection#1566](https://github.com/opensearch-project/anomaly-detection/pull/1566) | Adds resource types to DocRequests |
+
+## References
+
+- [Issue #4500](https://github.com/opensearch-project/security/issues/4500): Resource Permissions and Sharing
+- [Blog: Introducing resource sharing](https://opensearch.org/blog/introducing-resource-sharing-a-new-access-control-model-for-opensearch/): A new access control model for OpenSearch
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/docrequest-refactoring.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -78,3 +78,7 @@
 - [PPL/Query Enhancements](features/opensearch-dashboards/ppl-query-enhancements.md)
 - [OpenSearch Dashboards Keyboard Shortcuts](features/opensearch-dashboards/opensearch-dashboards-keyboard-shortcuts.md)
 - [OpenSearch Dashboards Plugin Compatibility](features/opensearch-dashboards/opensearch-dashboards-plugin-compatibility.md)
+
+### Anomaly Detection
+
+- [Doc Request Resource Type Support](features/anomaly-detection/doc-request.md)


### PR DESCRIPTION
## Summary

Adds documentation for the DocRequest resource type support feature in v3.3.0.

### Changes
- **Release report**: `docs/releases/v3.3.0/features/anomaly-detection/doc-request.md`
  - Documents the new `type()` method added to `DocRequest` interface
  - Covers Anomaly Detection plugin integration with resource types
- **Feature report update**: `docs/features/opensearch/docrequest-refactoring.md`
  - Added v3.3.0 PRs to Related PRs table
  - Updated Change History with v3.3.0 changes

### Key Changes in v3.3.0
- OpenSearch core adds `type()` method to `DocRequest` interface (default: "indices")
- Anomaly Detection plugin implements resource types for detectors and forecasters
- Enables Security plugin's resource sharing framework to authorize access by resource type

### Related PRs
- opensearch-project/OpenSearch#19313: Add new extensible method to DocRequest to specify type
- opensearch-project/anomaly-detection#1566: Adds resource types to DocRequests

Closes #1382