### PR TITLE
docs: add sync protobufs version report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -226,6 +226,7 @@
 - [Argon2 Password Hashing](security/argon2-password-hashing.md)
 - [Auxiliary Transport SSL](security/auxiliary-transport-ssl.md)
 - [Correlation Alerts](security/correlation-alerts.md)
+- [Protobufs Version Synchronization](security/protobufs-version-sync.md)
 - [Security Auth Enhancements](security/security-auth-enhancements.md)
 - [Security Bugfixes](security/security-bugfixes.md)
 - [Security Cache Management](security/security-cache-management.md)

--- a/docs/features/security/protobufs-version-sync.md
+++ b/docs/features/security/protobufs-version-sync.md
@@ -1,0 +1,76 @@
+# Protobufs Version Synchronization
+
+## Summary
+
+The OpenSearch Security plugin synchronizes its `org.opensearch:protobufs` dependency version with OpenSearch core to ensure compatibility and reduce maintenance overhead. This eliminates the need for manual version updates when core updates the protobufs library.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Core"
+        TOML[gradle/libs.versions.toml]
+        TOML -->|defines| VER[opensearchprotobufs version]
+    end
+    
+    subgraph "Security Plugin"
+        BUILD[build.gradle]
+        BUILD -->|references| VER
+        BUILD -->|resolves| DEP[org.opensearch:protobufs]
+    end
+    
+    subgraph "Build Process"
+        DEP -->|used by| TEST[Integration Tests]
+        TEST -->|validates| GRPC[gRPC Transport]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `gradle/libs.versions.toml` | OpenSearch core version catalog defining `opensearchprotobufs` |
+| `build.gradle` | Security plugin build configuration referencing core's version |
+| `org.opensearch:protobufs` | Protocol Buffers library for gRPC communication |
+
+### Configuration
+
+| Setting | Location | Description |
+|---------|----------|-------------|
+| `opensearchprotobufs` | `gradle/libs.versions.toml` (core) | Protobufs library version |
+| `versions.opensearchprotobufs` | `build.gradle` (security) | Reference to core's version |
+
+### Usage
+
+The protobufs library is used in integration tests for gRPC transport testing:
+
+```groovy
+dependencies {
+    integrationTestImplementation "org.opensearch:protobufs:${versions.opensearchprotobufs}"
+    integrationTestImplementation "io.grpc:grpc-stub:${versions.grpc}"
+    integrationTestImplementation "io.grpc:grpc-netty-shaded:${versions.grpc}"
+    integrationTestImplementation "org.opensearch.plugin:transport-grpc:${opensearch_version}"
+}
+```
+
+## Limitations
+
+- Breaking changes in protobufs require coordinated updates between core and Security plugin
+- Security plugin must be built against a compatible OpenSearch core version
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#5659](https://github.com/opensearch-project/security/pull/5659) | Initial implementation of version sync |
+
+## References
+
+- [OpenSearch core libs.versions.toml](https://github.com/opensearch-project/OpenSearch/blob/main/gradle/libs.versions.toml): Version catalog
+- [Security plugin build.gradle](https://github.com/opensearch-project/security/blob/main/build.gradle): Build configuration
+
+## Change History
+
+- **v3.3.0** (2026-01-11): Initial implementation - synchronized protobufs version with core

--- a/docs/releases/v3.3.0/features/security/sync-protobufs-version.md
+++ b/docs/releases/v3.3.0/features/security/sync-protobufs-version.md
@@ -1,0 +1,68 @@
+# Sync `org.opensearch:protobufs` Version with Core
+
+## Summary
+
+This bugfix synchronizes the `org.opensearch:protobufs` dependency version in the Security plugin with the version defined in OpenSearch core. Previously, the Security plugin maintained its own hardcoded protobufs version, requiring manual PRs to update it whenever core updated the dependency. This change automates version synchronization, reducing maintenance overhead and ensuring compatibility.
+
+## Details
+
+### What's New in v3.3.0
+
+The Security plugin now dynamically references the protobufs version from OpenSearch core's version catalog (`versions.opensearchprotobufs`) instead of maintaining a separate `protobuf_plugin_version` variable.
+
+### Technical Changes
+
+#### Build Configuration Changes
+
+| Before | After |
+|--------|-------|
+| `protobuf_plugin_version = '0.13.0'` (hardcoded) | Uses `versions.opensearchprotobufs` from core |
+| Manual PR required for each version update | Automatic sync with core |
+
+#### Modified Files
+
+| File | Change |
+|------|--------|
+| `build.gradle` | Removed `protobuf_plugin_version` variable, updated dependency reference |
+
+#### Dependency Reference Change
+
+```groovy
+// Before
+integrationTestImplementation "org.opensearch:protobufs:${protobuf_plugin_version}"
+
+// After
+integrationTestImplementation "org.opensearch:protobufs:${versions.opensearchprotobufs}"
+```
+
+### Benefits
+
+1. **Reduced maintenance**: No manual PRs needed when core updates protobufs version
+2. **Guaranteed compatibility**: Security plugin always uses the same protobufs version as core
+3. **Build consistency**: Eliminates version mismatch issues between core and Security plugin
+
+### Version Reference
+
+The protobufs version is defined in OpenSearch core at:
+- File: `gradle/libs.versions.toml`
+- Key: `opensearchprotobufs`
+- Current value: `1.1.0` (as of OpenSearch 3.x)
+
+## Limitations
+
+- If a breaking change is introduced in protobufs, the Security plugin build will fail until compatibility is restored
+- Requires the Security plugin to be built against a compatible OpenSearch core version
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5659](https://github.com/opensearch-project/security/pull/5659) | Sync `org.opensearch:protobufs` version with core |
+
+## References
+
+- [OpenSearch core libs.versions.toml](https://github.com/opensearch-project/OpenSearch/blob/main/gradle/libs.versions.toml#L25): Protobufs version definition
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/protobufs-version-sync.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -83,3 +83,7 @@
 
 - [Anomaly Detection Resource Authorization](features/anomaly-detection/anomaly-detection-resource-authorization.md)
 - [Doc Request Resource Type Support](features/anomaly-detection/doc-request.md)
+
+### Security
+
+- [Sync Protobufs Version with Core](features/security/sync-protobufs-version.md)


### PR DESCRIPTION
## Summary

Adds documentation for the Security plugin bugfix that synchronizes `org.opensearch:protobufs` version with OpenSearch core.

## Reports Created
- Release report: `docs/releases/v3.3.0/features/security/sync-protobufs-version.md`
- Feature report: `docs/features/security/protobufs-version-sync.md`

## Key Changes in v3.3.0
- Security plugin now references `versions.opensearchprotobufs` from core instead of hardcoded version
- Eliminates need for manual PRs when core updates protobufs version
- Ensures compatibility between Security plugin and OpenSearch core

## Related Issue
- Closes #1380

## Source PR
- [opensearch-project/security#5659](https://github.com/opensearch-project/security/pull/5659)