### PR TITLE
docs: add query-plugin-dependencies report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -495,6 +495,7 @@
 ## query-insights
 
 - [Query Insights](query-insights/query-insights.md)
+- [Query Insights Dependencies](query-insights/query-insights-dependencies.md)
 
 ## skills
 

--- a/docs/features/query-insights/query-insights-dependencies.md
+++ b/docs/features/query-insights/query-insights-dependencies.md
@@ -1,0 +1,92 @@
+# Query Insights Plugin Dependencies
+
+## Summary
+
+The Query Insights plugin manages its dependencies through Gradle build configuration to ensure security and compatibility. This includes proactive updates to address CVEs in transitive dependencies like Apache HttpClient and Apache Commons BeanUtils.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Query Insights Plugin"
+        QI[Query Insights Core]
+        QI --> HTTP[HTTP Client Layer]
+        QI --> UTIL[Utility Libraries]
+    end
+    
+    subgraph "Dependencies"
+        HTTP --> HC5[httpclient5]
+        HTTP --> HCore[httpcore5]
+        HTTP --> HCore2[httpcore5-h2]
+        UTIL --> BU[commons-beanutils]
+        UTIL --> BU2[commons-beanutils2]
+    end
+    
+    subgraph "Security"
+        HC5 -.-> CVE1[CVE-2025-27820]
+        HCore -.-> CVE1
+        BU -.-> CVE2[CVE-2025-48734]
+        BU2 -.-> CVE2
+    end
+```
+
+### Dependency Management Strategy
+
+The plugin uses Gradle's `resolutionStrategy` to enforce specific versions of transitive dependencies:
+
+```groovy
+configurations.all {
+  resolutionStrategy {
+    force("org.apache.httpcomponents.client5:httpclient5:5.4.4")
+    force("org.apache.httpcomponents:httpcore:5.3.4")
+    force("org.apache.httpcomponents.core5:httpcore5-h2:5.3.4")
+    force("commons-beanutils:commons-beanutils:1.11.0")
+    force("org.apache.commons:commons-beanutils2:2.0.0-M2")
+
+    eachDependency { DependencyResolveDetails details ->
+      // Version enforcement rules
+    }
+  }
+}
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| httpclient5 | Apache HTTP client for making HTTP requests |
+| httpcore5 | Core HTTP transport components |
+| httpcore5-h2 | HTTP/2 support for httpcore5 |
+| commons-beanutils | JavaBeans utility library |
+| commons-beanutils2 | Next generation BeanUtils library |
+
+### Security Vulnerabilities Addressed
+
+| CVE | Severity | Component | Description |
+|-----|----------|-----------|-------------|
+| CVE-2025-27820 | High (7.5) | httpclient5 | PSL validation bug disables domain checks |
+| CVE-2025-48734 | High (8.8) | commons-beanutils | Improper access control via enum classloader |
+
+## Limitations
+
+- Dependency versions must be kept in sync with OpenSearch core requirements
+- Transitive dependency conflicts may require additional resolution rules
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#371](https://github.com/opensearch-project/query-insights/pull/371) | CVE-2025-27820 and CVE-2025-48734 fix |
+| v3.3.0 | [#375](https://github.com/opensearch-project/query-insights/pull/375) | Backport to 3.1 branch |
+
+## References
+
+- [CVE-2025-27820](https://github.com/advisories/GHSA-73m2-qfq3-56cx): Apache HttpClient domain check bypass
+- [CVE-2025-48734](https://github.com/advisories/GHSA-wxr5-93ph-8wr9): Apache Commons BeanUtils improper access control
+- [Query Insights Plugin](https://github.com/opensearch-project/query-insights): GitHub repository
+
+## Change History
+
+- **v3.3.0**: Fixed CVE-2025-27820 (httpclient5) and CVE-2025-48734 (commons-beanutils)

--- a/docs/releases/v3.3.0/features/query-insights/query-plugin-dependencies.md
+++ b/docs/releases/v3.3.0/features/query-insights/query-plugin-dependencies.md
@@ -1,0 +1,78 @@
+# Query Plugin Dependencies
+
+## Summary
+
+This release addresses critical security vulnerabilities in the Query Insights plugin by updating transitive dependencies. The fixes resolve CVE-2025-27820 (Apache HttpClient domain check bypass) and CVE-2025-48734 (Apache Commons BeanUtils improper access control).
+
+## Details
+
+### What's New in v3.3.0
+
+Security dependency updates to address high-severity CVEs affecting the Query Insights plugin's transitive dependencies.
+
+### Technical Changes
+
+#### Dependency Updates
+
+| Dependency | Previous Version | Updated Version | CVE Fixed |
+|------------|------------------|-----------------|-----------|
+| httpclient5 | 5.4.x | 5.4.4 | CVE-2025-27820 |
+| httpcore5 | - | 5.3.4 | CVE-2025-27820 |
+| httpcore5-h2 | - | 5.3.4 | CVE-2025-27820 |
+| commons-beanutils | < 1.11.0 | 1.11.0 | CVE-2025-48734 |
+| commons-beanutils2 | < 2.0.0-M2 | 2.0.0-M2 | CVE-2025-48734 |
+
+#### CVE-2025-27820: Apache HttpClient Domain Check Bypass
+
+- Severity: High (CVSS 7.5)
+- A bug in PSL validation logic in Apache HttpClient 5.4.x disables domain checks
+- Affects cookie management and host name verification
+- Fixed by upgrading to httpclient5 5.4.3+
+
+#### CVE-2025-48734: Apache Commons BeanUtils Improper Access Control
+
+- Severity: High (CVSS 8.8)
+- BeanIntrospector protection against classloader access via enum's declared class property was not enabled by default
+- Could allow attackers to access the classloader through Java enum objects
+- Fixed by upgrading to commons-beanutils 1.11.0 / commons-beanutils2 2.0.0-M2
+
+#### Build Configuration Changes
+
+The `build.gradle` file was updated to force specific dependency versions:
+
+```groovy
+configurations.all {
+  resolutionStrategy {
+    force("org.apache.httpcomponents.client5:httpclient5:5.4.4")
+    force("org.apache.httpcomponents:httpcore:5.3.4")
+    force("org.apache.httpcomponents.core5:httpcore5-h2:5.3.4")
+    force("commons-beanutils:commons-beanutils:1.11.0")
+    force("org.apache.commons:commons-beanutils2:2.0.0-M2")
+  }
+}
+```
+
+### Migration Notes
+
+No migration required. These are transparent dependency updates that do not change the plugin's API or behavior.
+
+## Limitations
+
+- These fixes address transitive dependencies; direct usage of affected libraries should also be reviewed in custom implementations
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#371](https://github.com/opensearch-project/query-insights/pull/371) | CVE-2025-27820 and CVE-2025-48734 fix (main) |
+| [#375](https://github.com/opensearch-project/query-insights/pull/375) | Backport to 3.1 branch |
+
+## References
+
+- [CVE-2025-27820](https://github.com/advisories/GHSA-73m2-qfq3-56cx): Apache HttpClient domain check bypass
+- [CVE-2025-48734](https://github.com/advisories/GHSA-wxr5-93ph-8wr9): Apache Commons BeanUtils improper access control
+- [Apache HttpClient 5.4.x](https://hc.apache.org/httpcomponents-client-5.4.x/index.html): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/query-insights/query-insights-dependencies.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -88,3 +88,7 @@
 
 - [Sync Protobufs Version with Core](features/security/sync-protobufs-version.md)
 - [Security Plugin Dependencies](features/security/security-plugin-dependencies.md)
+
+### Query Insights
+
+- [Query Plugin Dependencies](features/query-insights/query-plugin-dependencies.md)


### PR DESCRIPTION
## Summary

Add documentation for Query Plugin Dependencies bugfix in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/query-insights/query-plugin-dependencies.md`
- Feature report: `docs/features/query-insights/query-insights-dependencies.md`

### Key Changes in v3.3.0
- Fixed CVE-2025-27820 (Apache HttpClient domain check bypass) by upgrading httpclient5 to 5.4.4
- Fixed CVE-2025-48734 (Apache Commons BeanUtils improper access control) by upgrading to 1.11.0/2.0.0-M2

### Related PRs
- opensearch-project/query-insights#371: CVE-2025-27820 and CVE-2025-48734 fix
- opensearch-project/query-insights#375: Backport to 3.1 branch

Closes #1378