### PR TITLE
docs: add neural-search-dependencies report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -7,6 +7,7 @@
 - [Hybrid Query](neural-search/hybrid-query.md)
 - [Neural Search Bug Fixes](neural-search/neural-search-bug-fixes.md)
 - [Neural Search Compatibility](neural-search/neural-search-compatibility.md)
+- [Neural Search Dependencies](neural-search/neural-search-dependencies.md)
 - [Neural Search Rescore](neural-search/neural-search-rescore.md)
 - [Neural Search Reranking](neural-search/neural-search-reranking.md)
 - [Neural Search Stats](neural-search/neural-search-stats.md)

--- a/docs/features/neural-search/neural-search-dependencies.md
+++ b/docs/features/neural-search/neural-search-dependencies.md
@@ -1,0 +1,113 @@
+# Neural Search Dependencies
+
+## Summary
+
+The Neural Search plugin manages various third-party dependencies to provide neural search capabilities in OpenSearch. This includes Apache Commons libraries, Lucene codecs, and build tooling dependencies. Proper dependency management ensures compatibility with other OpenSearch plugins and prevents jar hell conflicts.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Neural Search Plugin"
+        NS[Neural Search Core]
+        QA[QA Module]
+    end
+    
+    subgraph "Dependencies"
+        CL3[commons-lang3]
+        LC[Lucene Codecs]
+        EP[error_prone_annotations]
+        GV[Guava]
+    end
+    
+    subgraph "OpenSearch Ecosystem"
+        KNN[k-NN Plugin]
+        OS[OpenSearch Core]
+    end
+    
+    NS --> CL3
+    NS --> LC
+    NS --> EP
+    NS --> GV
+    QA --> CL3
+    
+    KNN --> CL3
+    OS --> LC
+    OS --> GV
+
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `commons-lang3` | Apache Commons Lang library providing helper utilities for Java |
+| `Lucene Codecs` | Lucene codec implementations for index format compatibility |
+| `error_prone_annotations` | Google Error Prone annotations for static analysis |
+| `Guava` | Google core libraries for Java |
+
+### Configuration
+
+Dependencies are managed through Gradle build files:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `versions.commonslang` | commons-lang3 version from version catalog | Managed by OpenSearch |
+| `error_prone_annotations` | Forced version for conflict resolution | `2.21.1` |
+
+### Dependency Declaration Example
+
+```groovy
+// build.gradle
+dependencies {
+    compileOnly group: 'org.apache.commons', name: 'commons-lang3', version: "${versions.commonslang}"
+    compileOnly group: 'com.google.guava', name: 'guava', version: '32.1.3-jre'
+}
+
+configurations.all {
+    resolutionStrategy {
+        force("com.google.errorprone:error_prone_annotations:2.21.1")
+    }
+}
+```
+
+### Import Migration
+
+When migrating from commons-lang to commons-lang3:
+
+```java
+// Before (commons-lang 2.x)
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
+
+// After (commons-lang3)
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+```
+
+## Limitations
+
+- Version conflicts may occur when multiple plugins bundle different versions of the same dependency
+- Jar hell errors can occur if plugins include duplicate classes
+- Forced dependency versions are temporary workarounds until upstream fixes are available
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#1551](https://github.com/opensearch-project/neural-search/pull/1551) | Remove commons-lang dependency and use gradle version catalog for commons-lang3 |
+| v3.3.0 | [#1574](https://github.com/opensearch-project/neural-search/pull/1574) | Update Lucene101 codec path to backward path & force errorprone version |
+| v3.3.0 | [#1589](https://github.com/opensearch-project/neural-search/pull/1589) | Upgrade QA Gradle Dependency Version with commons-lang3 |
+
+## References
+
+- [k-NN PR #2863 Comment](https://github.com/opensearch-project/k-NN/pull/2863#issuecomment-3251945721): Original jar hell issue report
+- [Apache Commons Lang](https://commons.apache.org/proper/commons-lang/): Official documentation
+
+## Change History
+
+- **v3.3.0** (2026-01-10): Migrated from commons-lang to commons-lang3, updated Lucene codec paths, forced error_prone_annotations version

--- a/docs/releases/v3.3.0/features/neural-search/neural-search-dependencies.md
+++ b/docs/releases/v3.3.0/features/neural-search/neural-search-dependencies.md
@@ -1,0 +1,73 @@
+# Neural Search Dependencies
+
+## Summary
+
+This release item addresses dependency management issues in the Neural Search plugin for OpenSearch v3.3.0. The changes resolve jar hell conflicts, update Lucene codec paths for backward compatibility, and migrate from the deprecated `commons-lang` to `commons-lang3` library.
+
+## Details
+
+### What's New in v3.3.0
+
+Three key dependency-related fixes were implemented:
+
+1. **commons-lang Migration**: Removed the deprecated `commons-lang:commons-lang` (v2.6) dependency and migrated to `commons-lang3` using Gradle version catalog
+2. **Lucene Codec Path Update**: Updated Lucene101 codec imports from `org.apache.lucene.codecs.lucene101` to `org.apache.lucene.backward_codecs.lucene101` for backward compatibility
+3. **Error Prone Version Fix**: Forced `error_prone_annotations` to version 2.21.1 to resolve version conflicts with Guava
+
+### Technical Changes
+
+#### Dependency Updates
+
+| Change | Before | After |
+|--------|--------|-------|
+| commons-lang | `commons-lang:commons-lang:2.6` | `org.apache.commons:commons-lang3:${versions.commonslang}` |
+| Lucene codec path | `org.apache.lucene.codecs.lucene101` | `org.apache.lucene.backward_codecs.lucene101` |
+| error_prone_annotations | Conflicting versions | Forced to `2.21.1` |
+
+#### Files Modified
+
+**PR #1551 - commons-lang Migration**:
+- `build.gradle`: Updated dependency declarations
+- Multiple Java files updated imports from `org.apache.commons.lang.*` to `org.apache.commons.lang3.*`:
+  - Query builders (`NeuralQueryBuilder`, `NeuralSparseQueryBuilder`, `HybridQueryBuilder`, `AgenticSearchQueryBuilder`)
+  - Mapper DTOs (`ChunkingConfig`, `SparseEncodingConfig`)
+  - Stats classes (`EventStatName`, `InfoStatName`)
+  - Utility classes (`NeuralQueryValidationUtil`, `PruneType`)
+  - Test classes
+
+**PR #1574 - Lucene Codec Path Update**:
+- `build.gradle`: Added resolution strategy for error_prone_annotations
+- `ClusteredPostingTermsWriter.java`: Updated Lucene101PostingsFormat import
+- `SparseCodec.java`: Updated Lucene101Codec import
+- Test files updated accordingly
+
+**PR #1589 - QA Gradle Dependency**:
+- `qa/build.gradle`: Updated commons-lang dependency to commons-lang3
+
+### Migration Notes
+
+For plugin developers extending Neural Search:
+
+1. Update any imports from `org.apache.commons.lang.*` to `org.apache.commons.lang3.*`
+2. Note API differences between commons-lang 2.x and 3.x (e.g., `RandomUtils.nextFloat()` now requires parameters)
+3. If using Lucene101 codecs directly, update import paths to use `backward_codecs`
+
+## Limitations
+
+- The error_prone_annotations version is forced to 2.21.1 as a temporary workaround until upstream dependencies resolve the version conflict
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1551](https://github.com/opensearch-project/neural-search/pull/1551) | Remove commons-lang dependency and use gradle version catalog for commons-lang3 |
+| [#1574](https://github.com/opensearch-project/neural-search/pull/1574) | Update Lucene101 codec path to backward path & force errorprone version |
+| [#1589](https://github.com/opensearch-project/neural-search/pull/1589) | Upgrade QA Gradle Dependency Version with commons-lang3 |
+
+## References
+
+- [k-NN PR #2863 Comment](https://github.com/opensearch-project/k-NN/pull/2863#issuecomment-3251945721): Original jar hell issue report
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/neural-search/neural-search-dependencies.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -89,6 +89,10 @@
 - [Sync Protobufs Version with Core](features/security/sync-protobufs-version.md)
 - [Security Plugin Dependencies](features/security/security-plugin-dependencies.md)
 
+### Neural Search
+
+- [Neural Search Dependencies](features/neural-search/neural-search-dependencies.md)
+
 ### Query Insights
 
 - [Query Plugin Dependencies](features/query-insights/query-plugin-dependencies.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Neural Search Dependencies bugfix item in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/neural-search/neural-search-dependencies.md`
- Feature report: `docs/features/neural-search/neural-search-dependencies.md`

### Key Changes in v3.3.0
- Migrated from deprecated `commons-lang` to `commons-lang3` library
- Updated Lucene101 codec paths for backward compatibility
- Forced `error_prone_annotations` to version 2.21.1 to resolve conflicts

### Related PRs
- [#1551](https://github.com/opensearch-project/neural-search/pull/1551): Remove commons-lang dependency
- [#1574](https://github.com/opensearch-project/neural-search/pull/1574): Update Lucene101 codec path
- [#1589](https://github.com/opensearch-project/neural-search/pull/1589): Upgrade QA Gradle Dependency

Closes #1377