### PR TITLE
docs: add CI/CD workflow updates report for v3.3.0

### DIFF
--- a/docs/features/ci/cd-build-improvements.md
+++ b/docs/features/ci/cd-build-improvements.md
@@ -85,6 +85,8 @@ CI/CD improvements typically involve changes to:
 
 | Version | PR | Repository | Description |
 |---------|-----|------------|-------------|
+| v3.3.0 | [#5548](https://github.com/opensearch-project/security/pull/5548) | security | Update delete_backport_branch workflow to include release-chores branches |
+| v3.3.0 | [#4090](https://github.com/opensearch-project/ml-commons/pull/4090) | ml-commons | Update delete_backport_branch workflow to include release-chores branches |
 | v2.18.0 | [#1276](https://github.com/opensearch-project/index-management/pull/1276) | index-management | Update baseline JDK to JDK-21 |
 | v2.18.0 | [#1263](https://github.com/opensearch-project/index-management/pull/1263) | index-management | Move non-active maintainer to emeritus |
 | v2.18.0 | [#1251](https://github.com/opensearch-project/index-management/pull/1251) | index-management | Remove wildcard imports |
@@ -103,4 +105,5 @@ CI/CD improvements typically involve changes to:
 
 ## Change History
 
+- **v3.3.0** (2025-08-25): Update delete_backport_branch workflow to include release-chores branches in security and ml-commons, modernize workflow to use actions/github-script
 - **v2.18.0** (2024-11-05): JDK-21 baseline for index-management, CI workflow fixes for notifications, observability, and query-insights, test security improvements for ml-commons, backport process improvements

--- a/docs/releases/v3.3.0/features/ci/cd-workflow-updates.md
+++ b/docs/releases/v3.3.0/features/ci/cd-workflow-updates.md
@@ -1,0 +1,97 @@
+# CI/CD Workflow Updates
+
+## Summary
+
+This release updates the `delete_backport_branch` workflow in the security and ml-commons plugins to automatically delete `release-chores/` branches after merge, in addition to the existing `backport/` branch cleanup. The workflow implementation is also modernized by replacing the deprecated `SvanBoxel/delete-merged-branch` action with the official `actions/github-script` action.
+
+## Details
+
+### What's New in v3.3.0
+
+The `delete_backport_branch` workflow is enhanced to handle two types of automatically-created branches:
+
+1. **backport/** branches - Created by the backport automation for cherry-picking changes to release branches
+2. **release-chores/** branches - Created automatically for individual release notes
+
+Previously, only `backport/` branches were automatically deleted after merge, leaving `release-chores/` branches to accumulate in the repository.
+
+### Technical Changes
+
+#### Workflow Condition Update
+
+The workflow trigger condition is updated to match both branch prefixes:
+
+```yaml
+# Before
+if: startsWith(github.event.pull_request.head.ref,'backport/')
+
+# After
+if: startsWith(github.event.pull_request.head.ref,'backport/') || startsWith(github.event.pull_request.head.ref,'release-chores/')
+```
+
+#### Action Modernization
+
+The deprecated `SvanBoxel/delete-merged-branch` action is replaced with `actions/github-script@v7`:
+
+```yaml
+# Before
+- name: Delete merged branch
+  uses: SvanBoxel/delete-merged-branch@main
+  env:
+    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# After
+- name: Delete merged branch
+  uses: actions/github-script@v7
+  with:
+    script: |
+      github.rest.git.deleteRef({
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        ref: `heads/${context.payload.pull_request.head.ref}`,
+      })
+```
+
+#### Permissions Update
+
+Explicit permissions are added to the workflow job:
+
+| Repository | Permission |
+|------------|------------|
+| security | `contents: write` |
+| ml-commons | `pull-requests: write` |
+
+### Usage Example
+
+The workflow triggers automatically when a PR is merged. No manual intervention is required.
+
+```mermaid
+flowchart LR
+    A[PR Merged] --> B{Branch Prefix?}
+    B -->|backport/| C[Delete Branch]
+    B -->|release-chores/| C
+    B -->|Other| D[No Action]
+```
+
+## Limitations
+
+- The workflow only runs on PR merge events
+- Branch deletion requires appropriate permissions (contents:write or pull-requests:write)
+- The ml-commons PR (#4090) is still open and not yet merged
+
+## Related PRs
+
+| PR | Repository | Description | Status |
+|----|------------|-------------|--------|
+| [#5548](https://github.com/opensearch-project/security/pull/5548) | security | Update delete_backport_branch workflow | Merged |
+| [#4090](https://github.com/opensearch-project/ml-commons/pull/4090) | ml-commons | Update delete_backport_branch workflow | Open |
+
+## References
+
+- [security PR #5548](https://github.com/opensearch-project/security/pull/5548): Main implementation for security plugin
+- [ml-commons PR #4090](https://github.com/opensearch-project/ml-commons/pull/4090): Implementation for ml-commons plugin
+- [actions/github-script](https://github.com/actions/github-script): Official GitHub Action for running scripts
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ci/cd-build-improvements.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -96,3 +96,7 @@
 ### Query Insights
 
 - [Query Plugin Dependencies](features/query-insights/query-plugin-dependencies.md)
+
+### CI/CD
+
+- [CI/CD Workflow Updates](features/ci/cd-workflow-updates.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the CI/CD workflow updates in OpenSearch v3.3.0.

### Changes

- **Release Report**: `docs/releases/v3.3.0/features/ci/cd-workflow-updates.md`
  - Documents the update to `delete_backport_branch` workflow to include `release-chores/` branches
  - Covers modernization from deprecated `SvanBoxel/delete-merged-branch` to `actions/github-script@v7`

- **Feature Report Update**: `docs/features/ci/cd-build-improvements.md`
  - Added v3.3.0 PRs to Related PRs table
  - Added v3.3.0 entry to Change History

- **Release Index Update**: `docs/releases/v3.3.0/index.md`
  - Added CI/CD section with link to the new report

### Related PRs

- [security#5548](https://github.com/opensearch-project/security/pull/5548) - Merged
- [ml-commons#4090](https://github.com/opensearch-project/ml-commons/pull/4090) - Open

Closes #1376