### PR TITLE
docs: add updating-gson-version-to-resolve-conflict-coming-from-core report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -363,6 +363,7 @@
 - [ML Commons Connector Blueprints](ml-commons/ml-commons-blueprints.md)
 - [ML Commons Documentation & Tutorials](ml-commons/ml-commons-documentation-tutorials.md)
 - [ML Commons Error Handling](ml-commons/ml-commons-error-handling.md)
+- [ML Commons Dependencies](ml-commons/ml-commons-dependencies.md)
 - [ML Commons MCP (Model Context Protocol)](ml-commons/ml-commons-mcp.md)
 - [ML Commons Memory Metadata](ml-commons/ml-commons-memory-metadata.md)
 - [ML Commons Model & Inference](ml-commons/ml-commons-model-inference.md)

--- a/docs/features/ml-commons/ml-commons-dependencies.md
+++ b/docs/features/ml-commons/ml-commons-dependencies.md
@@ -1,0 +1,53 @@
+# ML Commons Dependencies
+
+## Summary
+
+ML Commons plugin manages various third-party dependencies to provide machine learning capabilities within OpenSearch. Keeping these dependencies aligned with OpenSearch core is essential to prevent runtime conflicts and ensure compatibility.
+
+## Details
+
+### Key Dependencies
+
+| Dependency | Purpose |
+|------------|---------|
+| Gson | JSON serialization/deserialization |
+| Guava | Core utilities |
+| Apache Commons | Text processing, math operations |
+| DJL (Deep Java Library) | ML model inference |
+
+### Dependency Management Strategy
+
+ML Commons uses Gradle's dependency management features to ensure version alignment:
+
+1. **compileOnly**: Dependencies provided by OpenSearch core at runtime
+2. **implementation**: Dependencies bundled with the plugin
+3. **resolutionStrategy.force**: Ensures consistent versions across transitive dependencies
+
+### Configuration Example
+
+```groovy
+configurations.all {
+    resolutionStrategy.force 'com.google.code.gson:gson:2.13.2'
+    resolutionStrategy.force "com.google.errorprone:error_prone_annotations:${versions.error_prone_annotations}"
+}
+```
+
+## Limitations
+
+- Dependency versions must be kept in sync with OpenSearch core to avoid conflicts
+- Major version upgrades may require code changes
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#4176](https://github.com/opensearch-project/ml-commons/pull/4176) | Update Gson from 2.11.0 to 2.13.2 |
+
+## References
+
+- [ML Commons Repository](https://github.com/opensearch-project/ml-commons)
+- [OpenSearch Dependency Management](https://github.com/opensearch-project/OpenSearch/blob/main/buildSrc/version.properties)
+
+## Change History
+
+- **v3.3.0**: Updated Gson from 2.11.0 to 2.13.2 to resolve conflict with OpenSearch core

--- a/docs/releases/v3.3.0/features/ml-commons/updating-gson-version-to-resolve-conflict-coming-from-core.md
+++ b/docs/releases/v3.3.0/features/ml-commons/updating-gson-version-to-resolve-conflict-coming-from-core.md
@@ -1,0 +1,52 @@
+# Updating Gson Version to Resolve Conflict Coming from Core
+
+## Summary
+
+This bugfix updates the Gson library version in ml-commons from 2.11.0 to 2.13.2 to resolve a dependency conflict with OpenSearch core. OpenSearch core upgraded Gson to 2.13.2 in September 2025, and ml-commons needed to align with this version to prevent runtime conflicts.
+
+## Details
+
+### What's New in v3.3.0
+
+The Gson dependency was updated across all ml-commons modules to version 2.13.2 to match the version used by OpenSearch core.
+
+### Technical Changes
+
+#### Dependency Updates
+
+| Module | Scope | Old Version | New Version |
+|--------|-------|-------------|-------------|
+| common | compileOnly | 2.11.0 | 2.13.2 |
+| memory | testImplementation | 2.11.0 | 2.13.2 |
+| ml-algorithms | implementation | 2.11.0 | 2.13.2 |
+| plugin | implementation | 2.11.0 | 2.13.2 |
+| search-processors | compileOnly | 2.11.0 | 2.13.2 |
+
+#### Additional Changes
+
+The plugin module also added:
+- `error_prone_annotations` API dependency
+- Resolution strategy force rules for both `gson:2.13.2` and `error_prone_annotations`
+
+### Migration Notes
+
+No migration required. This is a transparent dependency update that maintains backward compatibility.
+
+## Limitations
+
+None. Gson 2.13.2 is backward compatible with 2.11.0.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4176](https://github.com/opensearch-project/ml-commons/pull/4176) | Updating gson version to resolve conflict coming from core |
+
+## References
+
+- [OpenSearch PR #19290](https://github.com/opensearch-project/OpenSearch/pull/19290): Bump com.google.code.gson:gson from 2.13.1 to 2.13.2 in /plugins/repository-hdfs
+- [Gson 2.13.2 Release](https://github.com/google/gson/releases/tag/gson-parent-2.13.2): Improved JPMS module packaging
+
+## Related Feature Report
+
+- [ML Commons Dependencies](../../../features/ml-commons/ml-commons-dependencies.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -89,6 +89,10 @@
 - [Sync Protobufs Version with Core](features/security/sync-protobufs-version.md)
 - [Security Plugin Dependencies](features/security/security-plugin-dependencies.md)
 
+### ML Commons
+
+- [Updating Gson Version to Resolve Conflict Coming from Core](features/ml-commons/updating-gson-version-to-resolve-conflict-coming-from-core.md)
+
 ### Neural Search
 
 - [Neural Search Dependencies](features/neural-search/neural-search-dependencies.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Gson version update bugfix in ml-commons for OpenSearch v3.3.0.

### Changes
- **Release report**: `docs/releases/v3.3.0/features/ml-commons/updating-gson-version-to-resolve-conflict-coming-from-core.md`
- **Feature report**: `docs/features/ml-commons/ml-commons-dependencies.md` (new)
- Updated release and feature indexes

### Key Findings
- Gson updated from 2.11.0 to 2.13.2 across all ml-commons modules
- This aligns with OpenSearch core's Gson version (upgraded in PR #19290)
- Added resolution strategy force rules to ensure consistent versions

### Related
- Closes #1375
- ml-commons PR: https://github.com/opensearch-project/ml-commons/pull/4176