### PR TITLE
docs: add move-common-string report for v3.3.0

### DIFF
--- a/docs/features/ml-commons/ml-commons-agent-framework.md
+++ b/docs/features/ml-commons/ml-commons-agent-framework.md
@@ -231,6 +231,7 @@ PUT /_plugins/_ml/agents/{agent_id}
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#4173](https://github.com/opensearch-project/ml-commons/pull/4173) | Move common string to common package |
 | v3.2.0 | [#4035](https://github.com/opensearch-project/ml-commons/pull/4035) | Add Execute Tool API |
 | v3.2.0 | [#4050](https://github.com/opensearch-project/ml-commons/pull/4050) | Implement create and add memory container API |
 | v3.2.0 | [#4055](https://github.com/opensearch-project/ml-commons/pull/4055) | Enable AI-Oriented memory operations |
@@ -265,6 +266,7 @@ PUT /_plugins/_ml/agents/{agent_id}
 
 ## Change History
 
+- **v3.3.0** (2026-01-14): Code refactoring - moved `NO_ESCAPE_PARAMS` constant from `AgentUtils` to `ToolUtils` in common package for skills plugin accessibility
 - **v3.2.0** (2025-09-16): Execute Tool API, AI-oriented memory container system (create, add, search, update, delete, get), QueryPlanningTool for agentic search, date/time injection for agents, message history limit for PER Agent, output filter support, SearchIndexTool improvements, feature flags for agentic search/memory, multiple bug fixes (class cast exception, connector URL exposure, async status, max iterations handling)
 - **v3.1.0** (2025-07-15): Update Agent API, MCP tools persistence, function calling for LLM interfaces, custom SSE endpoint, metrics framework integration, PlanExecuteReflect memory tracking, error handling improvements, multiple bug fixes (private IP validation, circuit breaker bypass, Python MCP client)
 - **v3.0.0** (2025-05-13): Plan-Execute-Reflect agent type, MCP server integration

--- a/docs/releases/v3.3.0/features/ml-commons/move-common-string.md
+++ b/docs/releases/v3.3.0/features/ml-commons/move-common-string.md
@@ -1,0 +1,67 @@
+# Move Common String
+
+## Summary
+
+This bugfix moves the `NO_ESCAPE_PARAMS` constant from `AgentUtils.java` in the ml-algorithms module to `ToolUtils.java` in the common package. This refactoring enables the skills plugin to access this constant, improving code reusability across ML Commons components.
+
+## Details
+
+### What's New in v3.3.0
+
+The `NO_ESCAPE_PARAMS` constant has been relocated to make it accessible from the common package, allowing other plugins (specifically the skills plugin) to use this shared string constant.
+
+### Technical Changes
+
+#### Code Relocation
+
+| Before | After |
+|--------|-------|
+| `ml-algorithms/.../agent/AgentUtils.java` | `common/.../utils/ToolUtils.java` |
+
+#### Changed Files
+
+| File | Change |
+|------|--------|
+| `common/src/main/java/org/opensearch/ml/common/utils/ToolUtils.java` | Added `NO_ESCAPE_PARAMS` constant |
+| `ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/agent/AgentUtils.java` | Removed `NO_ESCAPE_PARAMS` constant |
+| `ml-algorithms/src/main/java/org/opensearch/ml/engine/algorithms/remote/ConnectorUtils.java` | Updated import |
+| `ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/BedrockConverseDeepseekR1FunctionCalling.java` | Updated import |
+| `ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/BedrockConverseFunctionCalling.java` | Updated import |
+| `ml-algorithms/src/main/java/org/opensearch/ml/engine/function_calling/OpenaiV1ChatCompletionsFunctionCalling.java` | Updated import |
+
+#### New Constant Location
+
+```java
+// common/src/main/java/org/opensearch/ml/common/utils/ToolUtils.java
+public static final String NO_ESCAPE_PARAMS = "no_escape_params";
+```
+
+### Migration Notes
+
+If you have custom code that imports `NO_ESCAPE_PARAMS` from `AgentUtils`, update the import:
+
+```java
+// Before
+import static org.opensearch.ml.engine.algorithms.agent.AgentUtils.NO_ESCAPE_PARAMS;
+
+// After
+import static org.opensearch.ml.common.utils.ToolUtils.NO_ESCAPE_PARAMS;
+```
+
+## Limitations
+
+None. This is a backward-compatible refactoring change.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4173](https://github.com/opensearch-project/ml-commons/pull/4173) | Move common string |
+
+## References
+
+- [PR #4173](https://github.com/opensearch-project/ml-commons/pull/4173): Implementation PR
+
+## Related Feature Report
+
+- [ML Commons Agent Framework](../../../features/ml-commons/ml-commons-agent-framework.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -91,6 +91,7 @@
 
 ### ML Commons
 
+- [Move Common String](features/ml-commons/move-common-string.md)
 - [Updating Gson Version to Resolve Conflict Coming from Core](features/ml-commons/updating-gson-version-to-resolve-conflict-coming-from-core.md)
 
 ### Neural Search


### PR DESCRIPTION
## Summary

Adds documentation for the "Move common string" bugfix in ML Commons v3.3.0.

### Changes
- **Release report**: `docs/releases/v3.3.0/features/ml-commons/move-common-string.md`
- **Feature report update**: Added v3.3.0 entry to `docs/features/ml-commons/ml-commons-agent-framework.md`

### PR Investigated
- [ml-commons#4173](https://github.com/opensearch-project/ml-commons/pull/4173): Moves `NO_ESCAPE_PARAMS` constant from `AgentUtils` to `ToolUtils` in common package for skills plugin accessibility

Closes #1374