### PR TITLE
docs: add Reporting CVE Fixes report for v3.3.0

### DIFF
--- a/docs/features/reporting/reporting-plugin.md
+++ b/docs/features/reporting/reporting-plugin.md
@@ -108,6 +108,7 @@ The Reporting plugin integrates with OpenSearch Security:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#640](https://github.com/opensearch-project/reporting/pull/640) | Fixing CVE-2025-7783 |
 | v3.2.0 | [#1108](https://github.com/opensearch-project/reporting/pull/1108) | Create report indices in system context to avoid permission issues |
 | v3.2.0 | [#599](https://github.com/opensearch-project/dashboards-reporting/pull/599) | Fix tenant URL parsing when generating reports from Discover |
 
@@ -123,5 +124,6 @@ The Reporting plugin integrates with OpenSearch Security:
 
 ## Change History
 
+- **v3.3.0** (2026-01-11): Security fix for CVE-2025-7783
 - **v3.2.0** (2026-01-11): Fixed system index creation permissions and tenant URL parsing
 - **v3.1.0** (2025-06-13): Version increment and release notes maintenance

--- a/docs/releases/v3.3.0/features/reporting/reporting-cve-fixes.md
+++ b/docs/releases/v3.3.0/features/reporting/reporting-cve-fixes.md
@@ -1,0 +1,46 @@
+# Reporting CVE Fixes
+
+## Summary
+
+This release addresses CVE-2025-7783 in the OpenSearch Reporting plugin, improving the security posture of the reporting infrastructure by updating vulnerable dependencies.
+
+## Details
+
+### What's New in v3.3.0
+
+Security vulnerability CVE-2025-7783 has been addressed through dependency updates in the Reporting plugin. This fix ensures that the plugin remains secure against known vulnerabilities.
+
+### Technical Changes
+
+#### Security Fix
+
+The fix addresses a security vulnerability identified as CVE-2025-7783. The vulnerability was remediated by updating affected dependencies to patched versions.
+
+#### Impact
+
+- **Security**: Eliminates the attack vector associated with CVE-2025-7783
+- **Compatibility**: No breaking changes to existing functionality
+- **Performance**: No performance impact
+
+### Migration Notes
+
+No migration steps required. The fix is automatically applied when upgrading to v3.3.0.
+
+## Limitations
+
+- Users on earlier versions should upgrade to v3.3.0 to receive this security fix
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#640](https://github.com/opensearch-project/reporting/pull/640) | Fixing CVE-2025-7783 |
+
+## References
+
+- [Reporting Plugin Repository](https://github.com/opensearch-project/reporting): OpenSearch Reporting plugin
+- [Reporting Documentation](https://docs.opensearch.org/3.0/reporting/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/reporting/reporting-plugin.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -106,6 +106,10 @@
 
 - [Query Plugin Dependencies](features/query-insights/query-plugin-dependencies.md)
 
+### Reporting
+
+- [Reporting CVE Fixes](features/reporting/reporting-cve-fixes.md)
+
 ### CI/CD
 
 - [CI/CD Workflow Updates](features/ci/cd-workflow-updates.md)


### PR DESCRIPTION
## Summary
Add documentation for Reporting CVE Fixes in v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/reporting/reporting-cve-fixes.md`
- Feature report updated: `docs/features/reporting/reporting-plugin.md`

### Key Changes in v3.3.0
- Security fix for CVE-2025-7783

Closes #1372