### PR TITLE
docs: add observability-cypress-updates report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -392,6 +392,7 @@
 
 ## observability
 
+- [Observability Cypress Updates](observability/observability-cypress-updates.md)
 - [Observability Infrastructure](observability/observability-infrastructure.md)
 - [Observability Integrations](observability/observability-integrations.md)
 - [Release Maintenance](observability/release-maintenance.md)

--- a/docs/features/observability/observability-cypress-updates.md
+++ b/docs/features/observability/observability-cypress-updates.md
@@ -1,0 +1,70 @@
+# Observability Cypress Test Dependencies
+
+## Summary
+
+The OpenSearch Dashboards Observability plugin uses Cypress for end-to-end testing. This feature tracks maintenance updates to Cypress-related dependencies to address security advisories and keep the test infrastructure current.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Development Environment"
+        Dev[Developer] --> Cypress[Cypress Test Runner]
+        Cypress --> Request[@cypress/request]
+        Request --> Deps[Transient Dependencies]
+    end
+    subgraph "Transient Dependencies"
+        Deps --> FormData[form-data]
+        Deps --> HttpSig[http-signature]
+        Deps --> QS[qs]
+        Deps --> Cookie[tough-cookie]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| @cypress/request | HTTP request library used by Cypress for network operations |
+| form-data | Library for creating multipart form data |
+| http-signature | HTTP signature authentication |
+| qs | Query string parsing and stringifying |
+| tough-cookie | Cookie handling library |
+
+### Configuration
+
+This is a development dependency and requires no production configuration.
+
+### Usage
+
+Cypress tests are run during development and CI/CD pipelines:
+
+```bash
+# Run Cypress tests
+yarn cypress run
+
+# Open Cypress test runner
+yarn cypress open
+```
+
+## Limitations
+
+- These dependencies are development-only and do not affect production deployments
+- Security advisories in transient dependencies may require periodic updates
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#2507](https://github.com/opensearch-project/dashboards-observability/pull/2507) | Update @cypress/request to 3.0.9 |
+
+## References
+
+- [Cypress Documentation](https://docs.cypress.io/): Official Cypress documentation
+- [dashboards-observability Repository](https://github.com/opensearch-project/dashboards-observability): Source repository
+
+## Change History
+
+- **v3.3.0** (2025-10-02): Updated @cypress/request from 3.0.1 to 3.0.9 to address security advisories

--- a/docs/releases/v3.3.0/features/observability/observability-cypress-updates.md
+++ b/docs/releases/v3.3.0/features/observability/observability-cypress-updates.md
@@ -1,0 +1,56 @@
+# Observability Cypress Updates
+
+## Summary
+
+This maintenance update addresses security advisories in the Cypress test framework dependencies used by the OpenSearch Dashboards Observability plugin. The `@cypress/request` package was updated to resolve vulnerabilities in transient development dependencies.
+
+## Details
+
+### What's New in v3.3.0
+
+The `@cypress/request` dependency was updated from version 3.0.1 to 3.0.9 to address security advisories flagged by dependency scanning tools. This is a development-only change that does not affect production functionality.
+
+### Technical Changes
+
+#### Dependency Updates
+
+| Package | Previous Version | New Version |
+|---------|------------------|-------------|
+| @cypress/request | 3.0.1 | 3.0.9 |
+| form-data | 2.3.3 | 4.0.4 |
+| http-signature | 1.3.6 | 1.4.0 |
+| qs | 6.10.4 | 6.14.0 |
+| tough-cookie | 4.1.3 | 5.0.0 |
+| sshpk | 1.17.0 | 1.18.0 |
+
+#### Changes Made
+
+1. Removed explicit `@cypress/request` override from `package.json` resolutions
+2. Updated `yarn.lock` with new dependency versions
+3. Added newline at end of `package.json` file
+
+### Impact
+
+- **Production**: No impact - these are development dependencies only
+- **Development**: Resolves security advisory warnings during dependency installation
+- **Testing**: No functional changes to Cypress test execution
+
+## Limitations
+
+- This update only addresses transient development dependencies
+- The vulnerabilities were in dependencies never directly called by the codebase
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2507](https://github.com/opensearch-project/dashboards-observability/pull/2507) | Update cypress/requests |
+
+## References
+
+- [PR #2507](https://github.com/opensearch-project/dashboards-observability/pull/2507): Main implementation
+- [Observability Documentation](https://docs.opensearch.org/3.3/observing-your-data/): Official docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/observability/observability-cypress-updates.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -113,3 +113,7 @@
 ### CI/CD
 
 - [CI/CD Workflow Updates](features/ci/cd-workflow-updates.md)
+
+### Observability
+
+- [Observability Cypress Updates](features/observability/observability-cypress-updates.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Observability Cypress Updates bugfix in OpenSearch v3.3.0.

### Changes

- **Release Report**: `docs/releases/v3.3.0/features/observability/observability-cypress-updates.md`
- **Feature Report**: `docs/features/observability/observability-cypress-updates.md`
- Updated release and feature indexes

### Related Issue

Closes #1371

### PR Investigated

- [opensearch-project/dashboards-observability#2507](https://github.com/opensearch-project/dashboards-observability/pull/2507): Update cypress/requests

### Summary of Changes

This maintenance update addresses security advisories in the Cypress test framework dependencies. The `@cypress/request` package was updated from 3.0.1 to 3.0.9 to resolve vulnerabilities in transient development dependencies. This is a development-only change with no impact on production functionality.