### PR TITLE
docs: add Lucene 10.3 Update report for v3.3.0

### DIFF
--- a/docs/features/opensearch/lucene-upgrade.md
+++ b/docs/features/opensearch/lucene-upgrade.md
@@ -69,6 +69,9 @@ GET /_nodes?filter_path=nodes.*.version
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#19296](https://github.com/opensearch-project/OpenSearch/pull/19296) | Bump Apache Lucene from 10.2.2 to 10.3.0 |
+| v3.3.0 | [k-NN#2878](https://github.com/opensearch-project/k-NN/pull/2878) | Fix KNN build due to Lucene 10.3 upgrade |
+| v3.3.0 | [custom-codecs#277](https://github.com/opensearch-project/custom-codecs/pull/277) | Update for Lucene 10.3 |
 | v3.3.0 | [#19397](https://github.com/opensearch-project/OpenSearch/pull/19397) | Migrate deprecated usages of Operations#union |
 | v3.1.0 | [#17961](https://github.com/opensearch-project/OpenSearch/pull/17961) | Upgrade to Lucene 10.2.1 |
 | v3.1.0 | [#18395](https://github.com/opensearch-project/OpenSearch/pull/18395) | Replace deprecated TopScoreDocCollectorManager construction |
@@ -79,6 +82,7 @@ GET /_nodes?filter_path=nodes.*.version
 
 ## References
 
+- [Lucene 10.3.0 Changelog](https://lucene.apache.org/core/10_3_0/changes/Changes.html): Official Lucene 10.3.0 release notes
 - [Lucene 10.2.1 Changelog](https://lucene.apache.org/core/10_2_1/changes/Changes.html): Official Lucene 10.2.1 release notes
 - [Lucene 10.2.0 Changelog](https://lucene.apache.org/core/10_2_0/changes/Changes.html): Official Lucene 10.2.0 release notes
 - [Lucene 9.12.0 Changelog](https://lucene.apache.org/core/9_12_0/changes/Changes.html): Official Lucene 9.12.0 release notes
@@ -89,6 +93,7 @@ GET /_nodes?filter_path=nodes.*.version
 
 ## Change History
 
+- **v3.3.0**: Upgrade to Apache Lucene 10.3.0. New KNN1030Codec for k-NN plugin, Lucene103 codecs for custom-codecs plugin. API changes include new `AcceptDocs` interface replacing `Bits` in vector search, and `IOContext` hints for optimized file access.
 - **v3.3.0**: Migrate deprecated `Operations#union(Automaton, Automaton)` usages to `Operations#union(Collection<Automaton>)` in AutomatonQueries, XContentMapValues, and SystemIndices classes.
 - **v3.1.0**: Upgrade to Apache Lucene 10.2.1 with SeededKnnVectorQuery, binary quantized vector codecs, TopDocs#rrf, and API changes (DisiPriorityQueue, TopScoreDocCollectorManager). Plugin updates: neural-search hybrid query refactoring, learning-to-rank RankerQuery fix.
 - **v3.0.0**: Upgrade to Apache Lucene 10

--- a/docs/releases/v3.3.0/features/opensearch/lucene-10.3-update.md
+++ b/docs/releases/v3.3.0/features/opensearch/lucene-10.3-update.md
@@ -1,0 +1,95 @@
+# Lucene 10.3 Update
+
+## Summary
+
+OpenSearch v3.3.0 upgrades Apache Lucene from 10.2.2 to 10.3.0. This update brings performance improvements, new features, and API changes that required coordinated updates across multiple OpenSearch repositories including core, k-NN, and custom-codecs plugins.
+
+## Details
+
+### What's New in v3.3.0
+
+The Lucene 10.3.0 upgrade introduces several key changes:
+
+1. **Core OpenSearch**: Version bump from Lucene 10.2.2 to 10.3.0 with updated JAR dependencies
+2. **k-NN Plugin**: New KNN1030Codec for Lucene 10.3, API changes for `AcceptDocs` interface
+3. **Custom Codecs Plugin**: New Lucene103 codec classes for ZSTD and QAT compression
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "OpenSearch v3.3.0"
+        OS[OpenSearch Core]
+        KNN[k-NN Plugin]
+        CC[Custom Codecs]
+    end
+    
+    subgraph "Lucene 10.3.0"
+        L103[Lucene103Codec]
+        AcceptDocs[AcceptDocs Interface]
+        IOContext[IOContext Hints]
+    end
+    
+    OS --> L103
+    KNN --> L103
+    KNN --> AcceptDocs
+    CC --> L103
+```
+
+#### New Components
+
+| Component | Repository | Description |
+|-----------|------------|-------------|
+| KNN1030Codec | k-NN | New codec wrapping Lucene103Codec for k-NN vector indexing |
+| Lucene103CustomCodec | custom-codecs | ZSTD compression codec for Lucene 10.3 |
+| Lucene103QatCodec | custom-codecs | QAT hardware-accelerated compression codec for Lucene 10.3 |
+| AcceptDocs | k-NN | New interface replacing `Bits` for accepted documents in vector search |
+
+#### API Changes
+
+| Change | Description |
+|--------|-------------|
+| `AcceptDocs` interface | Replaces `Bits` parameter in `KnnVectorsReader.search()` methods |
+| `IOContext` hints | New `FileTypeHint`, `FileDataHint`, `DataAccessHint` for optimized file access |
+| Backward codecs | Lucene101Codec moved to `backward_codecs` package |
+
+### Usage Example
+
+No user-facing configuration changes are required. The Lucene version is automatically bundled with OpenSearch.
+
+Verify the Lucene version:
+```bash
+GET /_nodes?filter_path=nodes.*.version
+```
+
+### Migration Notes
+
+- **Automatic**: The upgrade is transparent for most users
+- **Plugin developers**: Update to new `AcceptDocs` interface if implementing custom `KnnVectorsReader`
+- **Custom codec users**: Existing indices using Lucene 10.1/10.2 codecs remain readable via backward compatibility
+
+## Limitations
+
+- Indices created with Lucene 10.3 cannot be read by older OpenSearch versions
+- Some deprecated Lucene APIs have been removed
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#19296](https://github.com/opensearch-project/OpenSearch/pull/19296) | OpenSearch | Bump Apache Lucene from 10.2.2 to 10.3.0 |
+| [#2878](https://github.com/opensearch-project/k-NN/pull/2878) | k-NN | Fix KNN build due to Lucene 10.3 upgrade |
+| [#277](https://github.com/opensearch-project/custom-codecs/pull/277) | custom-codecs | Update for Lucene 10.3 |
+
+## References
+
+- [Issue #18638](https://github.com/opensearch-project/OpenSearch/issues/18638): Feature request for Lucene 10.3 upgrade
+- [Issue #2888](https://github.com/opensearch-project/k-NN/issues/2888): Fix KNN build after Lucene 10.3 upgrade
+- [Issue #276](https://github.com/opensearch-project/custom-codecs/issues/276): Distribution build failed for custom-codecs-3.3.0
+- [Lucene 10.3.0 Changelog](https://lucene.apache.org/core/10_3_0/changes/Changes.html): Official Lucene 10.3.0 release notes
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/lucene-upgrade.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -28,6 +28,7 @@
 - [Index Output](features/opensearch/index-output.md)
 - [Index Refresh](features/opensearch/index-refresh.md)
 - [Java 17 Modernization](features/opensearch/java-17-modernization.md)
+- [Lucene 10.3 Update](features/opensearch/lucene-10.3-update.md)
 - [Lucene Migration](features/opensearch/lucene-migration.md)
 - [Netty Arena Settings](features/opensearch/netty-arena-settings.md)
 - [NRT Replication Engine](features/opensearch/nrt-replication-engine.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Lucene 10.3 update in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/opensearch/lucene-10.3-update.md`
- Feature report updated: `docs/features/opensearch/lucene-upgrade.md`

### Key Changes in v3.3.0
- Apache Lucene upgraded from 10.2.2 to 10.3.0
- New KNN1030Codec for k-NN plugin
- New Lucene103 codecs for custom-codecs plugin (ZSTD and QAT compression)
- API changes: `AcceptDocs` interface replacing `Bits` in vector search

### Related PRs
- OpenSearch #19296: Bump Apache Lucene from 10.2.2 to 10.3.0
- k-NN #2878: Fix KNN build due to Lucene 10.3 upgrade
- custom-codecs #277: Update for Lucene 10.3

Closes #1370