### PR TITLE
docs: add common-utils-release-notes report for v3.3.0

### DIFF
--- a/docs/features/common-utils/common-utils.md
+++ b/docs/features/common-utils/common-utils.md
@@ -128,6 +128,7 @@ ReplicationPluginInterface.stopReplication(client, request, listener)
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#869](https://github.com/opensearch-project/common-utils/pull/869) | Backport release notes for 2.13 to main branch |
 | v3.2.0 | [#850](https://github.com/opensearch-project/common-utils/pull/850) | Pinned commons-beanutils dependency to fix CVE-2025-48734 |
 | v3.2.0 | [#847](https://github.com/opensearch-project/common-utils/pull/847) | Revert PublishFindingsRequest to use a list of findings |
 | v3.2.0 | [#848](https://github.com/opensearch-project/common-utils/pull/848) | Switch gradle to 8.14 and JDK to 24 |
@@ -144,5 +145,6 @@ ReplicationPluginInterface.stopReplication(client, request, listener)
 
 ## Change History
 
+- **v3.3.0** (2025-10-16): Added release notes for version 2.13.0.0 (backported to main branch)
 - **v3.2.0** (2025-07-17): Security fix for CVE-2025-48734, reverted batch findings API, upgraded to Gradle 8.14 and JDK 24
 - **v3.0.0** (2025-03-19): Added replication plugin interface, fixed transport package imports, added pipe character escaping in user info

--- a/docs/releases/v3.3.0/features/common-utils/common-utils-release-notes.md
+++ b/docs/releases/v3.3.0/features/common-utils/common-utils-release-notes.md
@@ -1,0 +1,75 @@
+# Common Utils Release Notes
+
+## Summary
+
+This release item adds release notes documentation for common-utils version 2.13.0.0. The release notes document the changes, enhancements, and maintenance updates included in the 2.13.0.0 release of the common-utils library.
+
+## Details
+
+### What's New in v3.3.0
+
+PR #869 backports the release notes for common-utils 2.13.0.0 from the 2.13 branch to the main branch. This ensures the release notes are available in the main branch for reference.
+
+### Technical Changes
+
+#### Release Notes Content
+
+The release notes for version 2.13.0.0 document the following changes:
+
+| Category | Description | PR |
+|----------|-------------|-----|
+| Maintenance | Increment version to 2.13.0-SNAPSHOT | [#591](https://github.com/opensearch-project/common-utils/pull/591) |
+| Enhancement | Add queryFieldNames field in Doc Level Queries | [#582](https://github.com/opensearch-project/common-utils/pull/582), [#597](https://github.com/opensearch-project/common-utils/pull/597) |
+| Feature | Fix findings API enhancements | [#611](https://github.com/opensearch-project/common-utils/pull/611), [#617](https://github.com/opensearch-project/common-utils/pull/617) |
+| Feature | Feature findings enhancement | [#596](https://github.com/opensearch-project/common-utils/pull/596), [#606](https://github.com/opensearch-project/common-utils/pull/606) |
+| Documentation | Added 2.13.0.0 release notes | [#622](https://github.com/opensearch-project/common-utils/pull/622) |
+
+#### File Added
+
+| File | Description |
+|------|-------------|
+| `release-notes/opensearch-common-utils.release-notes-2.13.0.0.md` | Release notes for version 2.13.0.0 |
+
+### Usage Example
+
+The release notes file follows the standard OpenSearch release notes format:
+
+```markdown
+## Version 2.13.0.0 2023-03-21
+
+Compatible with OpenSearch 2.13.0
+
+### Maintenance
+* Increment version to 2.13.0-SNAPSHOT ([#591](url))
+
+### Enhancement
+* add queryFieldNames field in Doc Level Queries ([#582](url)) ([#597](url))
+
+# Features
+* fix findings API enhancemnts ([#611](url)) ([#617](url))
+* Feature findings enhancemnt ([#596](url)) ([#606](url))
+
+### Documentation
+* Added 2.13.0.0 release notes ([#622](url))
+```
+
+## Limitations
+
+- This is a documentation-only change with no functional impact
+- The release notes document changes from the 2.13.0.0 release cycle
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#869](https://github.com/opensearch-project/common-utils/pull/869) | Backport release notes for 2.13 to main branch |
+| [#623](https://github.com/opensearch-project/common-utils/pull/623) | Original PR adding release notes for 2.13 |
+
+## References
+
+- [Common Utils Repository](https://github.com/opensearch-project/common-utils)
+- [Release Notes File](https://github.com/opensearch-project/common-utils/blob/main/release-notes/opensearch-common-utils.release-notes-2.13.0.0.md)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/common-utils/common-utils.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -115,6 +115,10 @@
 
 - [CI/CD Workflow Updates](features/ci/cd-workflow-updates.md)
 
+### Common Utils
+
+- [Common Utils Release Notes](features/common-utils/common-utils-release-notes.md)
+
 ### Observability
 
 - [Observability Cypress Updates](features/observability/observability-cypress-updates.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the common-utils release notes item in v3.3.0.

### Changes
- Created release report: `docs/releases/v3.3.0/features/common-utils/common-utils-release-notes.md`
- Updated feature report: `docs/features/common-utils/common-utils.md` (added v3.3.0 change history)
- Updated release index: `docs/releases/v3.3.0/index.md`

### Related Issue
Closes #1367

### PR Details
- PR #869 backports release notes for common-utils 2.13.0.0 from the 2.13 branch to main
- Original PR #623 added the release notes documentation