### PR TITLE
docs: add Security SSL/TLS report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -242,6 +242,7 @@
 - [Security Role Mapping](security/security-role-mapping.md)
 - [Security Testing Framework](security/security-testing-framework.md)
 - [Security CI/CD](security/security-ci-cd.md)
+- [SSL/TLS Compatibility](security/ssl-tls-compatibility.md)
 - [JWT Authentication](security/jwt-authentication.md)
 - [Multi-Tenancy](security/multi-tenancy.md)
 - [Resource Access Control Framework](security/resource-access-control-framework.md)

--- a/docs/features/security/ssl-tls-compatibility.md
+++ b/docs/features/security/ssl-tls-compatibility.md
@@ -1,0 +1,134 @@
+# Security SSL/TLS Compatibility
+
+## Summary
+
+The Security plugin provides SSL/TLS encryption for both transport layer (node-to-node) and REST layer (client-to-node) communication in OpenSearch. This feature ensures secure communication and enables client certificate authentication. The SSL/TLS implementation must be compatible with different HTTP transport implementations, including the standard netty4 transport and the reactor-netty4 transport used for HTTP/2 and MCP server support.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph "Client Request"
+        C[Client] -->|HTTPS| R[REST Layer]
+    end
+    
+    subgraph "OpenSearch Node"
+        R --> T[HTTP Transport]
+        T --> |"netty4 or reactor-netty4"| H[HttpChannel]
+        H --> S[Security Plugin]
+        S -->|"get SSLEngine"| SSL[SSL/TLS Info]
+        SSL --> Auth[Authentication]
+    end
+    
+    subgraph "SSL Attribute Resolution"
+        H -->|"ssl_http"| SH[SslHandler]
+        H -->|"ssl_engine"| SE[SSLEngine]
+        SH -->|".engine()"| SE
+        SE --> S
+    end
+```
+
+### Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant Transport as HTTP Transport
+    participant Channel as HttpChannel
+    participant Security as Security Plugin
+    
+    Client->>Transport: HTTPS Request
+    Transport->>Channel: Create HttpChannel
+    Security->>Channel: get("ssl_http", SslHandler.class)
+    alt SslHandler found and compatible
+        Channel-->>Security: SslHandler
+        Security->>Security: handler.engine()
+    else SslHandler not found or incompatible
+        Security->>Channel: get("ssl_engine", SSLEngine.class)
+        Channel-->>Security: SSLEngine
+    end
+    Security->>Security: Extract client certificate
+    Security->>Client: Authenticated response
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `OpenSearchRequest` | Wrapper for REST requests that extracts SSL information |
+| `ReactorNetty4BaseHttpChannel` | Base class for reactor-netty4 HTTP channels with SSL attribute support |
+| `ReactorNetty4NonStreamingHttpChannel` | Non-streaming HTTP channel implementation |
+| `ReactorNetty4StreamingHttpChannel` | Streaming HTTP channel implementation |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.ssl.http.enabled` | Enable TLS on REST layer | `false` |
+| `plugins.security.ssl.http.pemcert_filepath` | Path to node certificate (PEM) | Required |
+| `plugins.security.ssl.http.pemkey_filepath` | Path to private key (PKCS#8) | Required |
+| `plugins.security.ssl.http.pemtrustedcas_filepath` | Path to root CA (PEM) | Required |
+| `plugins.security.ssl.http.clientauth_mode` | Client auth mode: NONE, OPTIONAL, REQUIRE | `OPTIONAL` |
+| `http.type` | HTTP transport type | `netty4` |
+
+### Usage Example
+
+```yaml
+# opensearch.yml - Using reactor-netty4 transport with security
+http.type: reactor-netty4-secure
+
+# REST layer TLS
+plugins.security.ssl.http.enabled: true
+plugins.security.ssl.http.pemcert_filepath: node.pem
+plugins.security.ssl.http.pemkey_filepath: node-key.pem
+plugins.security.ssl.http.pemtrustedcas_filepath: root-ca.pem
+plugins.security.ssl.http.clientauth_mode: OPTIONAL
+
+# Transport layer TLS
+plugins.security.ssl.transport.pemcert_filepath: node.pem
+plugins.security.ssl.transport.pemkey_filepath: node-key.pem
+plugins.security.ssl.transport.pemtrustedcas_filepath: root-ca.pem
+plugins.security.ssl.transport.enforce_hostname_verification: true
+```
+
+### SSL Attribute Resolution
+
+The Security plugin retrieves SSL information from the HTTP channel using a fallback mechanism:
+
+```java
+// Primary: Try to get SslHandler (standard netty4)
+httpChannel.get("ssl_http", SslHandler.class)
+    .map(SslHandler::engine)
+    // Fallback: Get SSLEngine directly (reactor-netty4)
+    .or(() -> httpChannel.get("ssl_engine", SSLEngine.class))
+    .orElse(null);
+```
+
+This approach handles:
+1. **Different naming conventions**: reactor-netty4 uses `NettyPipeline.SslHandler` instead of `ssl_http`
+2. **Classloader isolation**: Returning `SSLEngine` directly avoids classloader conflicts between plugins
+
+## Limitations
+
+- Custom HTTP transport implementations must expose either `ssl_http` (SslHandler) or `ssl_engine` (SSLEngine) attributes
+- Client certificate authentication requires `clientauth_mode` to be `OPTIONAL` or `REQUIRE`
+- The `ssl_engine` fallback is only available in OpenSearch 3.3.0+
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [security#5667](https://github.com/opensearch-project/security/pull/5667) | Add fallback logic for ssl_engine attribute |
+| v3.3.0 | [OpenSearch#19458](https://github.com/opensearch-project/OpenSearch/pull/19458) | Implement SslHandler retrieval for reactor-netty4 |
+
+## References
+
+- [TLS Configuration Documentation](https://docs.opensearch.org/3.0/security/configuration/tls/): Official TLS configuration guide
+- [Forum Discussion](https://forum.opensearch.org/t/pods-not-coming-up-after-using-transport-reactor-netty4-plugin-for-mcp-server/26990): Original issue report and workarounds
+- [Network Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/network-settings/): HTTP transport configuration
+
+## Change History
+
+- **v3.3.0** (2025-09-29): Added fallback logic to use `ssl_engine` attribute when `ssl_handler` is unavailable or incompatible with reactor-netty4 transport

--- a/docs/releases/v3.3.0/features/security/ssl-tls.md
+++ b/docs/releases/v3.3.0/features/security/ssl-tls.md
@@ -1,0 +1,116 @@
+# Security SSL/TLS
+
+## Summary
+
+This bugfix resolves SSL/TLS compatibility issues between the Security plugin and the `transport-reactor-netty4` plugin. When using the reactor-netty4 transport (required for MCP server support and HTTP/2), the Security plugin failed to retrieve SSL information due to different naming conventions and classloader conflicts. The fix adds fallback logic to use the `ssl_engine` attribute directly when the `ssl_handler` attribute is unavailable or incompatible.
+
+## Details
+
+### What's New in v3.3.0
+
+The fix addresses two related issues that occurred when using the `transport-reactor-netty4` plugin:
+
+1. **SslHandler naming mismatch**: The reactor-netty4 plugin uses a different naming convention for the SSL handler in the Netty pipeline, causing the Security plugin to fail when looking up `ssl_http`
+2. **ClassCastException due to classloader isolation**: Even when the SslHandler was found, classloader differences between plugins caused `ClassCastException` errors
+
+### Technical Changes
+
+#### Problem Scenario
+
+```mermaid
+flowchart TB
+    subgraph "Before Fix"
+        A[Security Plugin] -->|"get('ssl_http', SslHandler.class)"| B[HttpChannel]
+        B -->|"Not found or ClassCastException"| C[403 Forbidden / 500 Error]
+    end
+    
+    subgraph "After Fix"
+        D[Security Plugin] -->|"get('ssl_http', SslHandler.class)"| E[HttpChannel]
+        E -->|"Not found?"| F["Fallback: get('ssl_engine', SSLEngine.class)"]
+        F -->|"SSLEngine"| G[Success]
+    end
+```
+
+#### Security Plugin Changes
+
+The `OpenSearchRequest.java` was modified to add fallback logic:
+
+```java
+final HttpChannel httpChannel = underlyingRequest.getHttpChannel();
+return httpChannel.get("ssl_http", SslHandler.class)
+    .map(SslHandler::engine)
+    .or(() -> httpChannel.get("ssl_engine", SSLEngine.class))
+    .orElse(null);
+```
+
+#### Transport Plugin Changes
+
+A new `ReactorNetty4BaseHttpChannel` class was added to properly expose SSL attributes:
+
+| Attribute | Type | Description |
+|-----------|------|-------------|
+| `ssl_http` | `SslHandler` | Standard SSL handler (if compatible) |
+| `ssl_engine` | `SSLEngine` | Direct SSLEngine access (fallback) |
+| `channel` | `Channel` | Netty channel reference |
+
+### Error Messages Before Fix
+
+Users encountered these errors when using `securityadmin.sh` or REST API calls:
+
+```
+ERR: An unexpected ResponseException occured: method [GET], host [https://localhost:9200], 
+URI [/_plugins/_security/whoami], status line [HTTP/2.0 403 Forbidden]
+```
+
+Or classloader conflicts:
+
+```
+class io.netty.handler.ssl.SslHandler cannot be cast to class io.netty.handler.ssl.SslHandler 
+(io.netty.handler.ssl.SslHandler is in unnamed module of loader java.net.URLClassLoader @58164e9a; 
+io.netty.handler.ssl.SslHandler is in unnamed module of loader java.net.URLClassLoader @2d74cbbd)
+```
+
+### Usage Example
+
+After the fix, the reactor-netty4 transport works correctly with the Security plugin:
+
+```yaml
+# opensearch.yml
+http.type: reactor-netty4-secure
+
+# Security plugin configuration remains unchanged
+plugins.security.ssl.http.enabled: true
+plugins.security.ssl.http.pemcert_filepath: node.pem
+plugins.security.ssl.http.pemkey_filepath: node-key.pem
+plugins.security.ssl.http.pemtrustedcas_filepath: root-ca.pem
+```
+
+### Migration Notes
+
+No migration required. Users who previously had to work around this issue by:
+1. Starting the cluster without `http.type` configuration
+2. Initializing the security index
+3. Adding the `http.type` setting and restarting
+
+Can now use the standard installation process with `http.type: reactor-netty4-secure` from the start.
+
+## Limitations
+
+- The fix is specific to the `transport-reactor-netty4` plugin; other custom transport implementations may need similar updates
+- Client authentication mode must be properly configured in `opensearch.yml`
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#5667](https://github.com/opensearch-project/security/pull/5667) | security | Add fallback logic to use 'ssl_engine' if 'ssl_handler' attribute is not available/compatible |
+| [#19458](https://github.com/opensearch-project/OpenSearch/pull/19458) | OpenSearch | Implement SslHandler retrieval logic for transport-reactor-netty4 plugin |
+
+## References
+
+- [Forum Discussion](https://forum.opensearch.org/t/pods-not-coming-up-after-using-transport-reactor-netty4-plugin-for-mcp-server/26990): Original issue report
+- [TLS Configuration Documentation](https://docs.opensearch.org/3.0/security/configuration/tls/): Official TLS configuration guide
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/security/ssl-tls-compatibility.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -88,6 +88,7 @@
 ### Security
 
 - [Resource Access Control Documentation](features/security/resource-access-control-documentation.md)
+- [SSL/TLS Compatibility Fix](features/security/ssl-tls.md)
 - [Sync Protobufs Version with Core](features/security/sync-protobufs-version.md)
 - [Security Plugin Dependencies](features/security/security-plugin-dependencies.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security SSL/TLS compatibility bugfix in OpenSearch v3.3.0.

### Issue Investigated
- GitHub Issue: #1362 - [bugfix] Security SSL/TLS

### Problem
When using the `transport-reactor-netty4` plugin (required for MCP server support and HTTP/2), the Security plugin failed to retrieve SSL information due to:
1. Different naming conventions for the SSL handler in the Netty pipeline
2. Classloader conflicts causing `ClassCastException`

### Solution
Added fallback logic to use `ssl_engine` attribute directly (returning `SSLEngine`) when `ssl_handler` is unavailable or incompatible.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/security/ssl-tls.md`
- Feature report: `docs/features/security/ssl-tls-compatibility.md`

### Related PRs
- [security#5667](https://github.com/opensearch-project/security/pull/5667): Add fallback logic for ssl_engine
- [OpenSearch#19458](https://github.com/opensearch-project/OpenSearch/pull/19458): Implement SslHandler retrieval for reactor-netty4