### PR TITLE
docs: add security client certificate authentication report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -226,6 +226,7 @@
 - [Alerting Comments Security](security/alerting-comments-security.md)
 - [Argon2 Password Hashing](security/argon2-password-hashing.md)
 - [Auxiliary Transport SSL](security/auxiliary-transport-ssl.md)
+- [Client Certificate Authentication](security/client-certificate-authentication.md)
 - [Correlation Alerts](security/correlation-alerts.md)
 - [Protobufs Version Synchronization](security/protobufs-version-sync.md)
 - [Security Auth Enhancements](security/security-auth-enhancements.md)

--- a/docs/features/security/client-certificate-authentication.md
+++ b/docs/features/security/client-certificate-authentication.md
@@ -1,0 +1,217 @@
+# Client Certificate Authentication
+
+## Summary
+
+Client Certificate Authentication enables users to authenticate to OpenSearch using X.509 client certificates instead of or in addition to username/password credentials. This provides stronger security through mutual TLS (mTLS) authentication, where both the server and client verify each other's identity using certificates. The feature supports extracting usernames and roles from certificate attributes (DN or SAN) and allows selective bypass for specific users via the `skip_users` configuration.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "TLS Handshake"
+        Client[Client] -->|1. ClientHello| Server[OpenSearch]
+        Server -->|2. ServerHello + Cert| Client
+        Client -->|3. Client Certificate| Server
+        Server -->|4. Verify Certificate| CA[Trusted CA]
+    end
+    
+    subgraph "Authentication Flow"
+        Server --> SSLContext[SSL Context]
+        SSLContext --> Principal[Extract Principal DN]
+        Principal --> SkipCheck{DN in skip_users?}
+        SkipCheck -->|Yes| NextAuth[Next Auth Backend]
+        SkipCheck -->|No| Authenticator[HTTPClientCertAuthenticator]
+        Authenticator --> UsernameAttr{username_attribute?}
+        UsernameAttr -->|DN| ExtractDN[Extract from DN]
+        UsernameAttr -->|SAN| ExtractSAN[Extract from SAN]
+        ExtractDN --> RolesAttr{roles_attribute?}
+        ExtractSAN --> RolesAttr
+        RolesAttr -->|DN| RolesDN[Extract Roles from DN]
+        RolesAttr -->|SAN| RolesSAN[Extract Roles from SAN]
+        RolesDN --> AuthCreds[AuthCredentials]
+        RolesSAN --> AuthCreds
+        AuthCreds --> Authenticated[User Authenticated]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Certificate Processing"
+        Cert[X.509 Certificate] --> DN[Distinguished Name]
+        Cert --> SAN[Subject Alternative Names]
+        
+        DN --> CNExtract[Extract CN]
+        DN --> OUExtract[Extract OU]
+        
+        SAN --> EmailSAN[Email SAN]
+        SAN --> DNSSAN[DNS SAN]
+        SAN --> URISAN[URI SAN]
+        
+        CNExtract --> Username[Username]
+        EmailSAN --> Username
+        
+        OUExtract --> Roles[Backend Roles]
+        DNSSAN --> Roles
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `HTTPClientCertAuthenticator` | Main authenticator class that extracts credentials from client certificates |
+| `WildcardMatcher` | Utility for matching DNs against `skip_users` patterns |
+| `ParsedAttribute` | Internal record for parsed username/roles attribute configuration |
+| `SANType` | Enum defining supported Subject Alternative Name types |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.ssl.http.clientauth_mode` | Client authentication mode (`NONE`, `OPTIONAL`, `REQUIRE`) | `OPTIONAL` |
+| `username_attribute` | Attribute to extract username from (e.g., `cn`, `san:EMAIL`) | Full DN |
+| `roles_attribute` | Attribute to extract roles from (e.g., `ou`, `san:DNS`) | None |
+| `skip_users` | List of DNs to skip certificate authentication | `[]` |
+
+### Supported SAN Types
+
+| SAN Type | Config Value | Description |
+|----------|--------------|-------------|
+| OTHER_NAME | `san:othername` | OtherName (type 0) |
+| EMAIL | `san:rfc822name` | RFC822 email address (type 1) |
+| DNS | `san:dnsname` | DNS name (type 2) |
+| X400_ADDRESS | `san:x400address` | X.400 address (type 3) |
+| DIRECTORY_NAME | `san:directoryname` | Directory name (type 4) |
+| EDI_PARTY_NAME | `san:edipartyname` | EDI party name (type 5) |
+| URI | `san:uniformresourceidentifier` | URI (type 6) |
+| IP_ADDRESS | `san:ipaddress` | IP address (type 7) |
+| REGISTERED_ID | `san:registeredid` | Registered ID (type 8) |
+
+### Usage Examples
+
+#### Basic Client Certificate Authentication
+
+```yaml
+# opensearch.yml
+plugins.security.ssl.http.clientauth_mode: OPTIONAL
+
+# config.yml
+config:
+  dynamic:
+    authc:
+      clientcert_auth_domain:
+        description: "Authenticate via SSL client certificates"
+        http_enabled: true
+        transport_enabled: true
+        order: 1
+        http_authenticator:
+          type: clientcert
+          config:
+            username_attribute: cn
+          challenge: false
+        authentication_backend:
+          type: noop
+```
+
+#### Using SAN for Username Extraction
+
+```yaml
+# config.yml - Extract username from email SAN
+config:
+  dynamic:
+    authc:
+      clientcert_auth_domain:
+        http_enabled: true
+        order: 1
+        http_authenticator:
+          type: clientcert
+          config:
+            username_attribute: "san:rfc822name"
+            roles_attribute: "san:dnsname:*.admin.example.com"
+          challenge: false
+        authentication_backend:
+          type: noop
+```
+
+#### Skip Users for Dashboard Integration
+
+```yaml
+# config.yml - Skip certificate auth for dashboard server
+config:
+  dynamic:
+    authc:
+      basic_internal_auth_domain:
+        authentication_backend:
+          type: intern
+        http_authenticator:
+          challenge: true
+          type: basic
+        http_enabled: true
+        order: 4
+        transport_enabled: true
+      
+      clientcert_auth_domain:
+        authentication_backend:
+          type: noop
+        http_authenticator:
+          challenge: false
+          type: clientcert
+          config:
+            username_attribute: cn
+            skip_users:
+              - "DC=de,L=test,O=users,OU=bridge,CN=dashboard"
+        http_enabled: true
+        order: 2
+        transport_enabled: false
+```
+
+#### Python Client Example
+
+```python
+import requests
+
+base_url = 'https://localhost:9200/'
+cert_file_path = "/path/to/client-cert.pem"
+key_file_path = "/path/to/client-cert-key.pem"
+root_ca_path = "/path/to/root-ca.pem"
+
+response = requests.get(
+    f"{base_url}movies/_search",
+    cert=(cert_file_path, key_file_path),
+    verify=root_ca_path
+)
+print(response.json())
+```
+
+## Limitations
+
+- Certificate DN must be properly formatted according to RFC 2253
+- SAN extraction supports only specific types (see table above)
+- Wildcard patterns in `skip_users` use simple glob matching, not regex
+- Maximum 16 SAN values are extracted per certificate
+- SAN values are truncated at 8192 characters for safety
+- When `skip_users` matches, the user must have valid credentials for another auth backend
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#5525](https://github.com/opensearch-project/security/pull/5525) | Added new option skip_users to client cert authenticator |
+
+## References
+
+- [Issue #4378](https://github.com/opensearch-project/security/issues/4378): Client certificate setting bypasses password requirements
+- [Client Certificate Authentication Documentation](https://docs.opensearch.org/3.0/security/authentication-backends/client-auth/): Official documentation
+- [Configuring TLS Certificates](https://docs.opensearch.org/3.0/security/configuration/tls/): TLS configuration guide
+- [Generating Self-Signed Certificates](https://docs.opensearch.org/3.0/security/configuration/generate-certificates/): Certificate generation guide
+
+## Change History
+
+- **v3.3.0** (2026-01-14): Added `skip_users` configuration option
+  - Allows specific certificate DNs to bypass client certificate authentication
+  - Enables OpenSearch Dashboards with basic auth when client cert is required
+  - Uses WildcardMatcher for flexible DN pattern matching

--- a/docs/releases/v3.3.0/features/security/security-client-certificate-authentication.md
+++ b/docs/releases/v3.3.0/features/security/security-client-certificate-authentication.md
@@ -1,0 +1,106 @@
+# Security Client Certificate Authentication
+
+## Summary
+
+This bugfix adds a new `skip_users` configuration option to the client certificate authenticator, allowing specific users to bypass certificate-based authentication and fall back to other authentication backends. This resolves an issue where OpenSearch Dashboards with basic authentication could not work properly when client certificate authentication was set to required mode.
+
+## Details
+
+### What's New in v3.3.0
+
+The `skip_users` option enables administrators to specify a list of Distinguished Names (DNs) that should skip client certificate authentication. When a user's certificate DN matches an entry in the `skip_users` list, the client certificate authenticator returns `null`, allowing the authentication chain to continue to the next authentication backend (e.g., basic authentication).
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Client Certificate Authentication Flow"
+        Request[HTTPS Request] --> SSLHandler[SSL Handler]
+        SSLHandler --> ExtractCert[Extract Client Certificate]
+        ExtractCert --> GetPrincipal[Get Certificate Principal/DN]
+        GetPrincipal --> SkipCheck{DN in skip_users?}
+        SkipCheck -->|Yes| ReturnNull[Return null]
+        SkipCheck -->|No| ExtractUsername[Extract Username]
+        ExtractUsername --> ExtractRoles[Extract Roles]
+        ExtractRoles --> CreateCreds[Create AuthCredentials]
+        ReturnNull --> NextBackend[Try Next Auth Backend]
+        NextBackend --> BasicAuth[Basic Auth]
+        BasicAuth --> Authenticated[User Authenticated]
+        CreateCreds --> Authenticated
+    end
+```
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `skip_users` | List of certificate DNs to skip client cert authentication | `[]` |
+
+The `skip_users` setting supports wildcard matching using the `WildcardMatcher` class, allowing patterns like `*dashboard*` to match multiple DNs.
+
+### Usage Example
+
+```yaml
+# config.yml - Security plugin configuration
+config:
+  dynamic:
+    authc:
+      basic_internal_auth_domain:
+        authentication_backend:
+          type: intern
+        description: Authenticate via HTTP Basic against internal users database
+        http_authenticator:
+          challenge: true
+          type: basic
+        http_enabled: true
+        order: 4
+        transport_enabled: true
+      
+      clientcert_auth_domain:
+        authentication_backend:
+          type: noop
+        description: Authenticate via SSL client certificates
+        http_authenticator:
+          challenge: false
+          type: clientcert
+          config:
+            username_attribute: cn
+            # Skip certificate authentication for dashboard server
+            skip_users:
+              - "DC=de,L=test,O=users,OU=bridge,CN=dashboard"
+        http_enabled: true
+        order: 2
+        transport_enabled: false
+```
+
+### Migration Notes
+
+If you have OpenSearch Dashboards configured with `alwaysPresentCertificate: true` and want to use basic authentication for dashboard users while requiring client certificates for other clients:
+
+1. Add the dashboard server's certificate DN to the `skip_users` list
+2. Ensure basic authentication domain has a higher order number (lower priority) than the client certificate domain
+3. The dashboard server will fall back to basic authentication while other clients must present valid certificates
+
+## Limitations
+
+- The `skip_users` list matches against the full certificate DN (Distinguished Name)
+- Wildcard patterns are supported but regex patterns are not
+- Users in the `skip_users` list must have valid credentials for another authentication backend
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5525](https://github.com/opensearch-project/security/pull/5525) | Added new option skip_users to client cert authenticator |
+
+## References
+
+- [Issue #4378](https://github.com/opensearch-project/security/issues/4378): Client certificate setting bypasses password requirements
+- [PR #5278](https://github.com/opensearch-project/security/pull/5278): Initial implementation attempt (closed)
+- [Client Certificate Authentication Documentation](https://docs.opensearch.org/3.0/security/authentication-backends/client-auth/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/client-certificate-authentication.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -87,6 +87,7 @@
 
 ### Security
 
+- [Client Certificate Authentication - skip_users](features/security/security-client-certificate-authentication.md)
 - [Resource Access Control Documentation](features/security/resource-access-control-documentation.md)
 - [Security Plugin Bug Fixes](features/security/security-plugin-bug-fixes.md)
 - [SSL/TLS Compatibility Fix](features/security/ssl-tls.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security Client Certificate Authentication bugfix in v3.3.0.

### Changes
- **Release Report**: `docs/releases/v3.3.0/features/security/security-client-certificate-authentication.md`
  - Documents the new `skip_users` configuration option
  - Explains the use case for OpenSearch Dashboards with basic auth when client cert is required
  
- **Feature Report**: `docs/features/security/client-certificate-authentication.md`
  - Comprehensive documentation of client certificate authentication
  - Covers DN and SAN-based username/role extraction
  - Documents all supported SAN types
  - Includes usage examples and configuration options

### Related
- Closes #1360
- PR: [opensearch-project/security#5525](https://github.com/opensearch-project/security/pull/5525)
- Issue: [opensearch-project/security#4378](https://github.com/opensearch-project/security/issues/4378)