### PR TITLE
docs: add search-relevance-fixes report for v3.3.0

### DIFF
--- a/docs/features/search-relevance/search-relevance-workbench.md
+++ b/docs/features/search-relevance/search-relevance-workbench.md
@@ -195,6 +195,7 @@ The plugin includes test data based on Amazon's ESCI (Shopping Queries Dataset):
 | v3.1.0 | [#99](https://github.com/opensearch-project/search-relevance/pull/99) | Change model for Experiment and Evaluation Result entities |
 | v3.1.0 | [#116](https://github.com/opensearch-project/search-relevance/pull/116) | Add text validation and query set file size check |
 | v3.1.0 | [#124](https://github.com/opensearch-project/search-relevance/pull/124) | Fixed missing variants in Hybrid Optimizer |
+| v3.3.0 | [#230](https://github.com/opensearch-project/search-relevance/pull/230) | Fix ImportJudgmentsProcessor to handle numeric ratings |
 
 ## References
 
@@ -216,9 +217,11 @@ The plugin includes test data based on Amazon's ESCI (Shopping Queries Dataset):
 - [Issue #543](https://github.com/opensearch-project/dashboards-search-relevance/issues/543): Backend plugin disabled messaging
 - [Issue #557](https://github.com/opensearch-project/dashboards-search-relevance/issues/557): Pipeline error when no pipelines exist
 - [Issue #584](https://github.com/opensearch-project/dashboards-search-relevance/issues/584): Validation results overflow
+- [Issue #229](https://github.com/opensearch-project/search-relevance/issues/229): Numeric rating type casting bug
 
 ## Change History
 
+- **v3.3.0** (2026-01-11): Bug fix - ImportJudgmentsProcessor now handles numeric ratings (integers, floats) in addition to strings, and preserves original judgment order
 - **v3.2.0** (2026-01-11): Major enhancements - new default SRW UI, dashboard visualization for experiments, polling mechanism for status updates, date filtering for implicit judgments, task scheduling for experiments
 - **v3.2.0** (2026-01-10): Bug fixes - backend plugin disabled messaging, pipeline error suppression, validation results overflow, Venn diagram statistics, REST API error status, input validation, pipeline parameter fix
 - **v3.2.0** (2026-01-10): Fixed toast notification error messages not rendering correctly across multiple UI components

--- a/docs/releases/v3.3.0/features/search-relevance/search-relevance-fixes.md
+++ b/docs/releases/v3.3.0/features/search-relevance/search-relevance-fixes.md
@@ -1,0 +1,105 @@
+# Search Relevance Fixes
+
+## Summary
+
+This bugfix improves the `ImportJudgmentsProcessor` in the Search Relevance plugin to handle ratings provided in numeric formats (integers, floats) in addition to strings. Previously, passing numeric ratings caused a `ClassCastException` that crashed the OpenSearch process. The fix also ensures imported judgments maintain their original order.
+
+## Details
+
+### What's New in v3.3.0
+
+The `ImportJudgmentsProcessor` now properly handles ratings data in any numeric format, converting them to strings internally before processing. This fix addresses a critical bug where importing judgments with numeric ratings would cause OpenSearch to crash.
+
+### Technical Changes
+
+#### Bug Description
+
+When importing judgments via the Search Relevance API, users could provide ratings as either strings or numbers:
+
+```json
+// String format (worked)
+{"docId": "doc1", "rating": "1.0"}
+
+// Numeric format (caused crash)
+{"docId": "doc1", "rating": 1.0}
+```
+
+The numeric format caused a `ClassCastException`:
+```
+java.lang.ClassCastException: class java.lang.Integer cannot be cast to class java.lang.String
+    at org.opensearch.searchrelevance.judgments.ImportJudgmentsProcessor.generateJudgmentRating
+```
+
+#### Fix Implementation
+
+The fix modifies `ImportJudgmentsProcessor.java` to:
+
+1. Accept ratings as `Object` instead of `String`
+2. Convert any numeric type to String using `String.valueOf()`
+3. Preserve the original order of imported judgments using a `List` instead of `HashMap`
+
+```java
+// Before (caused ClassCastException)
+String rating = (String) ratingInfo.get("rating");
+
+// After (handles any type)
+Object ratingObj = ratingInfo.get("rating");
+String rating = String.valueOf(ratingObj);
+```
+
+#### Order Preservation
+
+The fix also addresses a secondary issue where imported judgments could be returned in a different order than submitted. The implementation now uses an `ArrayList` to maintain insertion order:
+
+```java
+// Before: HashMap lost ordering
+Map<String, String> docRatings = new HashMap<>();
+
+// After: ArrayList preserves order
+List<Map<String, String>> docIdRatings = new ArrayList<>();
+```
+
+### Usage Example
+
+Import judgments with mixed rating formats:
+
+```json
+PUT _plugins/_search_relevance/judgments
+{
+  "name": "Product Search Judgments",
+  "type": "IMPORT_JUDGMENT",
+  "judgmentRatings": [
+    {
+      "query": "laptop",
+      "ratings": [
+        {"docId": "doc1", "rating": 1},
+        {"docId": "doc2", "rating": "0.5"},
+        {"docId": "doc3", "rating": 0.75}
+      ]
+    }
+  ]
+}
+```
+
+All rating formats (integer `1`, string `"0.5"`, float `0.75`) are now handled correctly.
+
+## Limitations
+
+- Ratings must still be valid numeric values (parseable as float)
+- Non-numeric strings like `"high"` or `"relevant"` will still fail validation
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#230](https://github.com/opensearch-project/search-relevance/pull/230) | Improve ImportJudgmentsProcessor handling of ratings data types |
+
+## References
+
+- [Issue #229](https://github.com/opensearch-project/search-relevance/issues/229): Bug report - Posting rating as integer causes class cast issues
+- [Search Relevance Plugin Repository](https://github.com/opensearch-project/search-relevance)
+- [Search Relevance Workbench Documentation](https://docs.opensearch.org/3.0/search-plugins/search-relevance/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/search-relevance/search-relevance-workbench.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -120,6 +120,10 @@
 
 - [Reporting CVE Fixes](features/reporting/reporting-cve-fixes.md)
 
+### Search Relevance
+
+- [Search Relevance Fixes](features/search-relevance/search-relevance-fixes.md)
+
 ### CI/CD
 
 - [CI/CD Workflow Updates](features/ci/cd-workflow-updates.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Search Relevance Fixes bugfix in v3.3.0.

### Changes

**Release Report** (`docs/releases/v3.3.0/features/search-relevance/search-relevance-fixes.md`):
- Documents the `ImportJudgmentsProcessor` fix that handles numeric ratings (integers, floats) in addition to strings
- Explains the order preservation fix for imported judgments
- Includes usage examples and technical details

**Feature Report Update** (`docs/features/search-relevance/search-relevance-workbench.md`):
- Added v3.3.0 entry to Change History
- Added PR #230 to Related PRs table
- Added Issue #229 to References

**Release Index Update** (`docs/releases/v3.3.0/index.md`):
- Added Search Relevance section with link to the new report

### Related Issue
Closes #1359

### Related PRs
- [opensearch-project/search-relevance#230](https://github.com/opensearch-project/search-relevance/pull/230): Improve ImportJudgmentsProcessor handling of ratings data types