### PR TITLE
docs: add Query Insights Bug Fixes report for v3.3.0

### DIFF
--- a/docs/features/query-insights/query-insights.md
+++ b/docs/features/query-insights/query-insights.md
@@ -185,6 +185,17 @@ GET /_insights/live_queries?sort=latency&size=5
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#426](https://github.com/opensearch-project/query-insights/pull/426) | Change matchQuery to termQuery for query ID matching |
+| v3.3.0 | [#420](https://github.com/opensearch-project/query-insights/pull/420) | Filter out shard-level tasks from live queries |
+| v3.3.0 | [#413](https://github.com/opensearch-project/query-insights/pull/413) | Fix time range validation (from < to) |
+| v3.3.0 | [#414](https://github.com/opensearch-project/query-insights/pull/414) | Fix positive size parameter validation |
+| v3.3.0 | [#430](https://github.com/opensearch-project/query-insights/pull/430) | Fix flaky test by clearing stale queue records |
+| v3.3.0 | [#435](https://github.com/opensearch-project/query-insights/pull/435) | Add unit tests for queue clearing |
+| v3.3.0 | [#366](https://github.com/opensearch-project/query-insights-dashboards/pull/366) | Fix Group By selector on Configuration page |
+| v3.3.0 | [#367](https://github.com/opensearch-project/query-insights-dashboards/pull/367) | Fix query ID matching in retrieveQueryById |
+| v3.3.0 | [#338](https://github.com/opensearch-project/query-insights-dashboards/pull/338) | Fix filter and date picker bugs |
+| v3.3.0 | [#329](https://github.com/opensearch-project/query-insights-dashboards/pull/329) | Cypress workflow fix |
+| v3.3.0 | [#327](https://github.com/opensearch-project/query-insights-dashboards/pull/327) | Update delete-backport-branch workflow |
 | v3.2.0 | [#381](https://github.com/opensearch-project/query-insights/pull/381) | Increase reader search limit to 500 and fix sort by metric type |
 | v3.2.0 | [#392](https://github.com/opensearch-project/query-insights/pull/392) | Update Maven endpoint and bump Gradle/Java versions |
 | v3.2.0 | [#393](https://github.com/opensearch-project/query-insights/pull/393) | Fix codecov configuration |
@@ -254,6 +265,7 @@ GET /_insights/live_queries?sort=latency&size=5
 
 ## Change History
 
+- **v3.3.0**: Bug fixes for query ID matching (changed from matchQuery to termQuery with keyword field mapping); fixed Live Queries API to filter out shard-level tasks; added time range validation (from < to); fixed positive size parameter validation; fixed flaky test by clearing stale queue records when disabling metrics; **Dashboards**: fixed Group By selector showing "None" after refresh by correcting settings path; fixed retrieveQueryById to explicitly match by ID; fixed indices filter, Query Count display for non-grouped queries, metric headers toggle, and date picker for relative ranges; CI/CD improvements for Cypress tests and branch cleanup workflows
 - **v3.2.0**: Increased reader search limit to 500 and fixed sort by metric type; infrastructure updates including Maven endpoint migration, Gradle and Java version bumps; codecov configuration fixes; **Dashboards**: replaced Vega with react-vis for Live Queries visualizations to fix build errors; fixed search bar on Top N Queries page to properly filter by query ID; fixed table sorting with ID-based deduplication; added MDS support for Inflight Queries; changed default auto-refresh interval from 5s to 30s for better performance; multiple UI bug fixes including number formatting, validation messages, refresh button, and box plot updates; removed flaky Cypress tests for search bar
 - **v3.1.0**: Added metric labels to historical data for filtering by metric type; consolidated grouping settings under `grouping.*` namespace; added `excluded_indices` setting to filter indices from insights; refactored local index reader to use asynchronous operations; added `is_cancelled` field to Live Queries API; new Live Queries Dashboard with real-time monitoring, auto-refresh, visual breakdowns, and query cancellation; new Workload Management Dashboard for query group management; fixed duplicate API requests on overview page; fixed node-level top queries request parameter serialization bug; improved Cypress test stability; fixed CI version mismatch; added multi-node cluster integration tests
 - **v3.0.0**: Added Live Queries API, default index template, verbose parameter, profile query filtering, strict hash check

--- a/docs/releases/v3.3.0/features/query-insights/query-insights-bug-fixes.md
+++ b/docs/releases/v3.3.0/features/query-insights/query-insights-bug-fixes.md
@@ -1,0 +1,142 @@
+# Query Insights Bug Fixes
+
+## Summary
+
+OpenSearch v3.3.0 includes multiple bug fixes for the Query Insights plugin and its Dashboards component. These fixes address issues with query ID matching, live queries filtering, time range validation, flaky tests, and UI problems in the Configuration page and Top N Queries page.
+
+## Details
+
+### What's New in v3.3.0
+
+This release focuses on stability and correctness improvements across both the backend plugin and the Dashboards UI.
+
+### Technical Changes
+
+#### Backend Plugin Fixes
+
+**Query ID Matching Fix (PR #426)**
+
+Changed from `matchQuery` to `termQuery` for query ID lookups. The previous implementation used `matchQuery` with OR logic, which could return incorrect results when query IDs contained similar numeric patterns (e.g., numbers between dashes). The fix also changes the `id` field mapping from `text` to `keyword` for exact matching.
+
+```java
+// Before: matchQuery with OR logic could match similar IDs
+QueryBuilders.matchQuery("id", queryId)
+
+// After: termQuery for exact matching
+QueryBuilders.termQuery("id", queryId)
+```
+
+**Live Queries Shard Task Filtering (PR #420)**
+
+Fixed the Live Queries API to filter out shard-level tasks. Previously, the pattern `indices:data/read/search*` matched both request-level and shard-level tasks. The fix removes the trailing wildcard to only match request-level search tasks.
+
+```java
+// Before: matched both search and shard tasks
+"indices:data/read/search*"
+
+// After: matches only search tasks
+"indices:data/read/search"
+```
+
+**Time Range Validation (PR #413)**
+
+Added validation to ensure the `from` timestamp is before the `to` timestamp in Top N queries API requests. Previously, invalid time ranges were accepted without error.
+
+**Size Parameter Validation (PR #414)**
+
+Fixed validation for the `size` parameter in Live Queries API to ensure it's a positive integer.
+
+**Flaky Test Fix (PR #430)**
+
+Fixed intermittent test failures in `TopQueriesRestIT.testTopQueriesResponses` caused by stale records in the shared queue. When metrics were disabled, the `queryRecordsQueue` wasn't cleared, causing old records to be processed alongside new ones.
+
+```java
+// Fix: Clear shared queue when disabling metrics
+public void setEnabled(boolean enabled) {
+    if (!enabled) {
+        queryRecordsQueue.clear();
+    }
+    this.enabled = enabled;
+}
+```
+
+#### Dashboards UI Fixes
+
+**Group By Selector Fix (PR #366)**
+
+Fixed the Configuration page where the "Group By" dropdown always showed "None" after page refresh, even when "Similarity" was enabled. The issue was reading from incorrect settings paths:
+
+```typescript
+// Before: incorrect path
+persistentSettings?.group_by
+
+// After: correct path
+persistentSettings?.grouping?.group_by
+```
+
+Also fixed validation to hide the Save button when values exceed the maximum allowed (180 days).
+
+**Query ID Matching in Detail Page (PR #367)**
+
+Fixed `retrieveQueryById` function that was returning the first record from API response instead of filtering for the exact ID match. This caused users to be directed to incorrect query detail pages.
+
+```typescript
+// Before: returned first record blindly
+return top_queries[0];
+
+// After: explicitly filter by ID
+return top_queries.find(q => q.id === id);
+```
+
+**Filter and Date Picker Fixes (PR #338)**
+
+Fixed multiple UI bugs on the Top N Queries page:
+1. Indices filter not filtering the table
+2. Query Count shown for non-grouped (individual) queries
+3. Metric headers not updating when toggling grouping mode
+4. Date picker not working for relative ranges (Today, Yesterday, Last week, etc.)
+
+#### CI/CD Improvements
+
+**Cypress Workflow Fix (PR #329)**
+
+Fixed Cypress tests by dynamically checking plugin versions to ensure consistency between plugin and core, and enabled WLM mode for tests.
+
+**Delete Backport Branch Workflow (PR #327)**
+
+Updated workflow to automatically delete `release-chores/` branches after merge, in addition to `backport/` branches.
+
+### Migration Notes
+
+No migration required. These are bug fixes that improve existing functionality.
+
+## Limitations
+
+- The query ID field mapping change from `text` to `keyword` only affects new indices; existing indices retain the old mapping
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#426](https://github.com/opensearch-project/query-insights/pull/426) | query-insights | Change matchQuery to termQuery for query ID matching |
+| [#420](https://github.com/opensearch-project/query-insights/pull/420) | query-insights | Filter out shard-level tasks from live queries |
+| [#413](https://github.com/opensearch-project/query-insights/pull/413) | query-insights | Fix time range validation (from < to) |
+| [#414](https://github.com/opensearch-project/query-insights/pull/414) | query-insights | Fix positive size parameter validation |
+| [#430](https://github.com/opensearch-project/query-insights/pull/430) | query-insights | Fix flaky test by clearing stale queue records |
+| [#435](https://github.com/opensearch-project/query-insights/pull/435) | query-insights | Add unit tests for queue clearing |
+| [#366](https://github.com/opensearch-project/query-insights-dashboards/pull/366) | query-insights-dashboards | Fix Group By selector on Configuration page |
+| [#367](https://github.com/opensearch-project/query-insights-dashboards/pull/367) | query-insights-dashboards | Fix query ID matching in retrieveQueryById |
+| [#338](https://github.com/opensearch-project/query-insights-dashboards/pull/338) | query-insights-dashboards | Fix filter and date picker bugs |
+| [#329](https://github.com/opensearch-project/query-insights-dashboards/pull/329) | query-insights-dashboards | Cypress workflow fix |
+| [#327](https://github.com/opensearch-project/query-insights-dashboards/pull/327) | query-insights-dashboards | Update delete-backport-branch workflow |
+
+## References
+
+- [Issue #425](https://github.com/opensearch-project/query-insights/issues/425): Query ID matching returns incorrect results
+- [Issue #350](https://github.com/opensearch-project/query-insights-dashboards/issues/350): Group By selector shows "None" after refresh
+- [Issue #351](https://github.com/opensearch-project/query-insights-dashboards/issues/351): Configuration page validation issues
+- [Query Insights Documentation](https://docs.opensearch.org/3.0/observing-your-data/query-insights/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/query-insights/query-insights.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -110,6 +110,7 @@
 
 ### Query Insights
 
+- [Query Insights Bug Fixes](features/query-insights/query-insights-bug-fixes.md)
 - [Query Plugin Dependencies](features/query-insights/query-plugin-dependencies.md)
 
 ### SQL


### PR DESCRIPTION
## Summary

This PR adds documentation for Query Insights bug fixes in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/query-insights/query-insights-bug-fixes.md`
- Feature report: `docs/features/query-insights/query-insights.md` (updated)

### Key Changes in v3.3.0

**Backend Plugin Fixes:**
- Query ID matching: Changed from matchQuery to termQuery with keyword field mapping
- Live Queries API: Filter out shard-level tasks
- Time range validation: Ensure from timestamp is before to timestamp
- Size parameter validation: Ensure positive integer
- Flaky test fix: Clear stale queue records when disabling metrics

**Dashboards UI Fixes:**
- Group By selector showing "None" after refresh
- Query ID matching in retrieveQueryById
- Indices filter, Query Count display, metric headers toggle
- Date picker for relative ranges

**CI/CD:**
- Cypress workflow fixes
- Branch cleanup workflow updates

### PRs Investigated
- query-insights: #426, #420, #413, #414, #430, #435
- query-insights-dashboards: #366, #367, #338, #329, #327