### PR TITLE
docs: add Learning to Rank Fixes report for v3.3.0

### DIFF
--- a/docs/features/learning/learning-to-rank.md
+++ b/docs/features/learning/learning-to-rank.md
@@ -146,6 +146,11 @@ POST my_index/_search
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#226](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/226) | Fix bad inclusion of log4j in plugin JAR |
+| v3.3.0 | [#219](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/219) | Update System.env syntax for Gradle 9 compatibility |
+| v3.3.0 | [#228](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/228) | Add code coverage report generation |
+| v3.3.0 | [#221](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/221) | Hybrid method for float comparison in assertions |
+| v3.3.0 | [#222](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/222) | Upgrade spotless plugin and address build deprecations |
 | v3.2.0 | [#206](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/206) | Add support to handle missing values for XGBoost models |
 | v3.2.0 | [#202](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/202) | Bump gradle to 8.14, codecov to v5 and support JDK24 |
 | v3.2.0 | [#205](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/205) | Fix flaky test with ULP tolerance adjustment |
@@ -165,5 +170,6 @@ POST my_index/_search
 
 ## Change History
 
+- **v3.3.0** (2026-01-14): Build infrastructure fixes - log4j exclusion from JAR, Gradle 9 compatibility, hybrid float comparison for tests, code coverage reporting, spotless plugin upgrade
 - **v3.2.0** (2025-09-16): Added XGBoost missing values support for correct NaN handling; Build infrastructure upgrade (Gradle 8.14, JDK 24 support); fixed flaky test with ULP tolerance adjustment
 - **v3.0.0** (2025-05-13): Added XGBoost raw JSON parser for proper `save_model` format support; fixed ApproximateScoreQuery test

--- a/docs/releases/v3.3.0/features/learning/learning-to-rank-fixes.md
+++ b/docs/releases/v3.3.0/features/learning/learning-to-rank-fixes.md
@@ -1,0 +1,121 @@
+# Learning to Rank Fixes
+
+## Summary
+
+OpenSearch v3.3.0 includes several build infrastructure and test stability improvements for the Learning to Rank plugin. These changes focus on Gradle 9 compatibility, improved floating-point comparison in tests, log4j dependency fixes, code coverage reporting, and spotless plugin upgrades.
+
+## Details
+
+### What's New in v3.3.0
+
+This release addresses build and test infrastructure issues that improve plugin stability and maintainability:
+
+1. **Log4j Dependency Fix** - Removed log4j from the plugin JAR to prevent "jar hell" conflicts when bundled with OpenSearch
+2. **Gradle 9 Compatibility** - Updated environment variable syntax for Sonatype credentials
+3. **Hybrid Float Comparison** - Improved test reliability with a hybrid approach to floating-point assertions
+4. **Code Coverage** - Added JaCoCo code coverage report generation to CI
+5. **Spotless Plugin Upgrade** - Updated to version 6.25.0 with build deprecation fixes
+
+### Technical Changes
+
+#### Log4j Exclusion (PR #226)
+
+The plugin was incorrectly bundling log4j in its JAR, causing conflicts when OpenSearch itself is bundled:
+
+```gradle
+configurations {
+  runtimeClasspath {
+    exclude group: 'org.apache.logging.log4j', module: 'log4j-core'
+    exclude group: 'org.apache.logging.log4j', module: 'log4j-api'
+    exclude group: 'org.apache.logging.log4j', module: 'log4j-jul'
+  }
+}
+```
+
+#### Gradle 9 Environment Variable Syntax (PR #219)
+
+Updated from deprecated `$System.env.VARIABLE` syntax to `System.getenv()`:
+
+```gradle
+// Before (deprecated in Gradle 9)
+credentials {
+    username "$System.env.SONATYPE_USERNAME"
+    password "$System.env.SONATYPE_PASSWORD"
+}
+
+// After (Gradle 9 compatible)
+credentials {
+    username System.getenv("SONATYPE_USERNAME")
+    password System.getenv("SONATYPE_PASSWORD")
+}
+```
+
+#### Hybrid Float Comparison (PR #221)
+
+Replaced simple ULP-based comparison with a hybrid approach for more reliable test assertions:
+
+```java
+// Tuned hybrid assertion parameters
+private static final double ABS_FLOOR = 1e-4;
+private static final double RELATIVE_TOLERANCE = 1e-2;
+private static final int ULP_MULTIPLIER = 128;
+
+// Hybrid comparison: max(ABS_FLOOR, max(REL_TOL * |mag|, ULP_MULT * ulp(expected)))
+final double mag = Math.max(Math.abs((double) modelScore), Math.abs((double) queryScore));
+final double ulp = Math.ulp((double) modelScore);
+final double delta = Math.max(ABS_FLOOR, Math.max(RELATIVE_TOLERANCE * mag, ULP_MULTIPLIER * ulp));
+```
+
+This approach is based on the [C++ Boost math library](https://www.boost.org/doc/libs/boost_1_75_0/libs/math/doc/html/math_toolkit/float_comparison.html) recommendations for floating-point comparison.
+
+#### Code Coverage (PR #228)
+
+Added JaCoCo plugin for code coverage reporting:
+
+```gradle
+plugins {
+    id 'jacoco'
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.required = true
+        html.required = true
+        csv.required = false
+    }
+}
+```
+
+CI workflow updated to generate and upload coverage reports to Codecov.
+
+#### Build Modernization (PR #222)
+
+- Upgraded spotless plugin from 6.23.0 to 6.25.0
+- Updated task definitions to use `tasks.register()` instead of deprecated syntax
+- Updated test cluster configuration to use `testClusters.register()`
+- Fixed deprecation warnings in Gradle build
+
+## Limitations
+
+- These are infrastructure changes only; no functional changes to the LTR plugin itself
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#226](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/226) | Fix bad inclusion of log4j in plugin JAR |
+| [#219](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/219) | Update System.env syntax for Gradle 9 compatibility |
+| [#228](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/228) | Add code coverage report generation |
+| [#221](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/221) | Hybrid method for float comparison in assertions |
+| [#222](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/222) | Upgrade spotless plugin and address build deprecations |
+
+## References
+
+- [GitHub Issue #227](https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/227): Code coverage request
+- [C++ Boost Float Comparison](https://www.boost.org/doc/libs/boost_1_75_0/libs/math/doc/html/math_toolkit/float_comparison.html): Reference for hybrid comparison approach
+- [Learning to Rank Documentation](https://docs.opensearch.org/3.0/search-plugins/ltr/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/learning/learning-to-rank.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -145,6 +145,10 @@
 
 - [User Plugin Fixes](features/user-behavior-insights/user-plugin-fixes.md)
 
+### Learning to Rank
+
+- [Learning to Rank Fixes](features/learning/learning-to-rank-fixes.md)
+
 ### Dependencies
 
 - [Dependency Updates](features/dependency-updates.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for Learning to Rank plugin fixes in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/learning/learning-to-rank-fixes.md`
- Feature report: `docs/features/learning/learning-to-rank.md` (updated)

### Key Changes in v3.3.0
- **Log4j Dependency Fix** (PR #226): Removed log4j from plugin JAR to prevent jar hell conflicts
- **Gradle 9 Compatibility** (PR #219): Updated System.env syntax for Sonatype credentials
- **Hybrid Float Comparison** (PR #221): Improved test reliability with hybrid approach to floating-point assertions
- **Code Coverage** (PR #228): Added JaCoCo code coverage report generation to CI
- **Spotless Plugin Upgrade** (PR #222): Updated to version 6.25.0 with build deprecation fixes

### Resources Used
- PRs: #226, #219, #228, #221, #222 from opensearch-learning-to-rank-base
- Docs: https://docs.opensearch.org/3.0/search-plugins/ltr/index/

Closes #1357