### PR TITLE
docs: add notifications-plugin-fixes report for v3.3.0

### DIFF
--- a/docs/features/notifications/notifications-plugin.md
+++ b/docs/features/notifications/notifications-plugin.md
@@ -97,6 +97,8 @@ POST _plugins/_notifications/configs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#1074](https://github.com/opensearch-project/notifications/pull/1074) | Fix issue publishing maven snapshots by forcing slf4j version |
+| v3.3.0 | [#1069](https://github.com/opensearch-project/notifications/pull/1069) | Fix: Update System.env syntax for Gradle 9 compatibility |
 | v3.2.0 | [#1057](https://github.com/opensearch-project/notifications/pull/1057) | Updated gradle, jdk and other dependencies |
 | v3.1.0 | [#1036](https://github.com/opensearch-project/notifications/pull/1036) | Upgrade javax to jakarta mail |
 | v3.1.0 | [#1027](https://github.com/opensearch-project/notifications/pull/1027) | Version increment to 3.1.0-SNAPSHOT |
@@ -109,5 +111,6 @@ POST _plugins/_notifications/configs
 
 ## Change History
 
+- **v3.3.0** (2026-01-11): Build infrastructure fixes - Gradle 9 compatibility for environment variable syntax, SLF4J version conflict resolution for Maven snapshot publication
 - **v3.2.0** (2026-01-11): Infrastructure updates - Gradle 8.14, JaCoCo 0.8.13, nebula.ospackage 12.0.0, JDK 24 CI support
 - **v3.1.0** (2026-01-10): Migrated from javax.mail to jakarta.mail APIs to avoid version conflicts; updated greenmail test dependency to 2.0.1

--- a/docs/releases/v3.3.0/features/notifications/notifications-plugin-fixes.md
+++ b/docs/releases/v3.3.0/features/notifications/notifications-plugin-fixes.md
@@ -1,0 +1,77 @@
+# Notifications Plugin Fixes
+
+## Summary
+
+This release includes two build infrastructure fixes for the OpenSearch Notifications plugin that resolve Maven snapshot publication issues. These fixes ensure compatibility with Gradle 9 and resolve SLF4J version conflicts that were preventing successful snapshot builds.
+
+## Details
+
+### What's New in v3.3.0
+
+Two critical build fixes were merged to restore snapshot publication functionality:
+
+1. **Gradle 9 Compatibility**: Updated environment variable access syntax from deprecated `$System.env.VARIABLE_NAME` to `System.getenv("VARIABLE_NAME")`
+2. **SLF4J Version Conflict Resolution**: Forced SLF4J version from Gradle version catalog to resolve dependency conflicts
+
+### Technical Changes
+
+#### Gradle 9 Environment Variable Syntax Fix
+
+The previous syntax for accessing environment variables in Gradle build files was incompatible with Gradle 9:
+
+```gradle
+// Before (incompatible with Gradle 9)
+credentials {
+    username "$System.env.SONATYPE_USERNAME"
+    password "$System.env.SONATYPE_PASSWORD"
+}
+
+// After (Gradle 9 compatible)
+credentials {
+    username System.getenv("SONATYPE_USERNAME")
+    password System.getenv("SONATYPE_PASSWORD")
+}
+```
+
+This change was applied to both `notifications/core/build.gradle` and `notifications/notifications/build.gradle`.
+
+#### SLF4J Version Conflict Resolution
+
+A version conflict between SLF4J 2.0.17 and 1.7.36 was causing build failures when publishing Maven snapshots. The fix forces the SLF4J version from the Gradle version catalog:
+
+```gradle
+configurations.all {
+    resolutionStrategy {
+        force "org.slf4j:slf4j-api:${versions.slf4j}"
+    }
+}
+```
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `notifications/core/build.gradle` | Updated Sonatype credentials syntax |
+| `notifications/notifications/build.gradle` | Updated Sonatype credentials syntax, added SLF4J version forcing |
+
+## Limitations
+
+- These are build infrastructure fixes only; no runtime behavior changes
+- Requires Gradle version catalog to define `versions.slf4j`
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1069](https://github.com/opensearch-project/notifications/pull/1069) | Fix: Update System.env syntax for Gradle 9 compatibility |
+| [#1074](https://github.com/opensearch-project/notifications/pull/1074) | Fix issue publishing maven snapshots by forcing slf4j version |
+
+## References
+
+- [Failed workflow example](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/actions/runs/17023398832/job/48255946880#step:5:74): Gradle 9 syntax failure
+- [Related fix in opensearch-remote-metadata-sdk](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/245): Similar Gradle 9 fix
+- [Snapshot publication failure](https://github.com/opensearch-project/notifications/actions/runs/17410029596/job/50618172116): SLF4J conflict error
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/notifications/notifications-plugin.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -149,6 +149,10 @@
 
 - [Learning to Rank Fixes](features/learning/learning-to-rank-fixes.md)
 
+### Notifications
+
+- [Notifications Plugin Fixes](features/notifications/notifications-plugin-fixes.md)
+
 ### Dependencies
 
 - [Dependency Updates](features/dependency-updates.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Notifications Plugin bug fixes in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/notifications/notifications-plugin-fixes.md`
- Feature report: `docs/features/notifications/notifications-plugin.md` (updated)

### Key Changes in v3.3.0
- **Gradle 9 Compatibility**: Updated environment variable access syntax from `$System.env.VARIABLE_NAME` to `System.getenv(\"VARIABLE_NAME\")`
- **SLF4J Version Conflict Resolution**: Forced SLF4J version from Gradle version catalog to resolve dependency conflicts during Maven snapshot publication

### Related PRs
- [opensearch-project/notifications#1069](https://github.com/opensearch-project/notifications/pull/1069): Gradle 9 syntax fix
- [opensearch-project/notifications#1074](https://github.com/opensearch-project/notifications/pull/1074): SLF4J version forcing

Closes #1356"