### PR TITLE
docs: add semantic field multifields fix report for v3.3.0

### DIFF
--- a/docs/features/neural-search/semantic-field.md
+++ b/docs/features/neural-search/semantic-field.md
@@ -240,6 +240,7 @@ GET /my-nlp-index/_search
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#1572](https://github.com/opensearch-project/neural-search/pull/1572) | Fix not able to index the multiFields for the rawFieldType |
 | v3.2.0 | [#1420](https://github.com/opensearch-project/neural-search/pull/1420) | Support configuring the auto-generated knn_vector field through the semantic field |
 | v3.2.0 | [#1438](https://github.com/opensearch-project/neural-search/pull/1438) | Support configuring the ingest batch size for the semantic field |
 | v3.2.0 | [#1434](https://github.com/opensearch-project/neural-search/pull/1434) | Allow configuring prune strategies for sparse encoding in semantic fields |
@@ -259,6 +260,7 @@ GET /my-nlp-index/_search
 ## References
 
 - [Issue #803](https://github.com/opensearch-project/neural-search/issues/803): Neural Search field type proposal
+- [Issue #1571](https://github.com/opensearch-project/neural-search/issues/1571): MultiFields doesn't work for semantic field type
 - [Documentation: Semantic Field Type](https://docs.opensearch.org/3.1/field-types/supported-field-types/semantic/)
 - [Documentation: Semantic Search](https://docs.opensearch.org/3.1/vector-search/ai-search/semantic-search/)
 - [Blog: The new semantic field](https://opensearch.org/blog/the-new-semantic-field-simplifying-semantic-search-in-opensearch/)
@@ -268,6 +270,7 @@ GET /my-nlp-index/_search
 
 | Version | Date | Changes |
 |---------|------|---------|
+| v3.3.0 | 2025-12 | Bug fix: MultiFields now properly indexed for semantic fields with supported raw field types |
 | v3.2.0 | 2025-09 | knn_vector field configuration, ingest batch size setting, sparse encoding prune strategies, chunking strategies configuration, embedding reuse option, remote dense model handling fix, neural sparse analyzer version fix |
 | v3.1.0 | 2025-06 | Semantic mapping transformer, ingest processor, query logic, chunking support, search analyzer support, stats tracking |
 | v3.0.0 | 2025-03 | Initial semantic field mapper implementation (feature-flagged) |

--- a/docs/releases/v3.3.0/features/neural-search/semantic-field-multifields-fix.md
+++ b/docs/releases/v3.3.0/features/neural-search/semantic-field-multifields-fix.md
@@ -1,0 +1,109 @@
+# Semantic Field MultiFields Fix
+
+## Summary
+
+This bug fix resolves an issue where multiFields defined within a semantic field type were not being indexed. When users configured multiFields (such as a keyword subfield) on a semantic field with a text raw field type, the multiFields were silently ignored during indexing, causing searches against those subfields to fail.
+
+## Details
+
+### What's New in v3.3.0
+
+Fixed the `SemanticFieldMapper` to properly delegate multiFields iteration to the underlying delegate field mapper, enabling multiFields to be indexed correctly.
+
+### Technical Changes
+
+#### Root Cause
+
+The `SemanticFieldMapper` wraps a delegate field mapper (e.g., `TextFieldMapper`) but did not override the `iterator()` method. OpenSearch uses this iterator during indexing to discover and process multiFields. Without the override, the semantic field mapper returned an empty iterator, causing multiFields to be skipped.
+
+#### Fix Implementation
+
+Added an `iterator()` method override in `SemanticFieldMapper` that delegates to the underlying field mapper:
+
+```java
+@Override
+public Iterator<Mapper> iterator() {
+    return delegateFieldMapper.iterator();
+}
+```
+
+This ensures that when OpenSearch iterates over the semantic field's child mappers during indexing, it correctly discovers and processes any configured multiFields.
+
+### Usage Example
+
+```json
+// Create index with semantic field containing multiFields
+PUT /my-semantic-index
+{
+  "settings": {
+    "index.knn": true
+  },
+  "mappings": {
+    "properties": {
+      "products": {
+        "type": "nested",
+        "properties": {
+          "product_description": {
+            "type": "semantic",
+            "model_id": "<model_id>",
+            "fields": {
+              "keyword": {
+                "type": "keyword"
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+// Index document
+PUT /my-semantic-index/_doc/1
+{
+  "products": [
+    {
+      "product_description": "High-quality wireless headphones"
+    }
+  ]
+}
+
+// Search against multiField (now works correctly)
+GET /my-semantic-index/_search
+{
+  "query": {
+    "nested": {
+      "path": "products",
+      "query": {
+        "match": {
+          "products.product_description": "headphones"
+        }
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+No migration required. After upgrading to v3.3.0, existing indices with semantic fields containing multiFields will work correctly for new documents. Existing documents may need to be reindexed to populate the multiFields.
+
+## Limitations
+
+- Existing documents indexed before this fix will not have multiFields populated; reindexing is required
+- MultiFields are only supported when the raw field type supports them (e.g., `text`, `keyword`)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1572](https://github.com/opensearch-project/neural-search/pull/1572) | Fix not able to index the multiFields for the rawFieldType |
+
+## References
+
+- [Issue #1571](https://github.com/opensearch-project/neural-search/issues/1571): MultiFields doesn't work for semantic field type
+- [Related Issue #3950](https://github.com/opensearch-project/ml-commons/issues/3950): Original user report
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/neural-search/semantic-field.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -104,6 +104,7 @@
 
 - [Neural Search Bug Fixes](features/neural-search/neural-search-bug-fixes.md)
 - [Neural Search Dependencies](features/neural-search/neural-search-dependencies.md)
+- [Semantic Field MultiFields Fix](features/neural-search/semantic-field-multifields-fix.md)
 
 ### Geospatial
 


### PR DESCRIPTION
## Summary

Documents the bug fix for semantic field multiFields support in OpenSearch v3.3.0.

### Bug Fix Details
- **Issue**: MultiFields defined within a semantic field type were not being indexed
- **Root Cause**: `SemanticFieldMapper` didn't override `iterator()` method to delegate to underlying field mapper
- **Fix**: Added `iterator()` override to properly delegate multiFields iteration

### Reports Created
- Release report: `docs/releases/v3.3.0/features/neural-search/semantic-field-multifields-fix.md`
- Feature report updated: `docs/features/neural-search/semantic-field.md`

### Related
- PR: opensearch-project/neural-search#1572
- Issue: opensearch-project/neural-search#1571