### PR TITLE
docs: add metrics-framework report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -358,6 +358,7 @@
 
 - [Agent Framework](ml-commons/ml-commons-agent-framework.md)
 - [Batch Ingestion](ml-commons/batch-ingestion.md)
+- [Metrics Framework](ml-commons/metrics-framework.md)
 - [ML Commons Bugfixes](ml-commons/ml-commons-bugfixes.md)
 - [ML Commons CI/CD](ml-commons/ml-commons-ci-cd.md)
 - [ML Commons Configuration](ml-commons/ml-commons-configuration.md)

--- a/docs/features/ml-commons/metrics-framework.md
+++ b/docs/features/ml-commons/metrics-framework.md
@@ -1,0 +1,84 @@
+# Metrics Framework (ML Commons)
+
+## Summary
+
+The Metrics Framework in ML Commons provides comprehensive metrics collection and monitoring capabilities for machine learning workloads in OpenSearch. It enables cluster-wide statistics collection for ML operations, helping operators monitor model performance, resource usage, and system health.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "ML Commons Plugin"
+        Listener[MLCommonsClusterEventListener]
+        TaskManager[MLTaskManager]
+        Settings[MLFeatureEnabledSetting]
+    end
+    
+    subgraph "Cluster Events"
+        NodeJoin[Data Node Join]
+        ClusterChange[Cluster State Change]
+    end
+    
+    subgraph "Jobs"
+        StatsCollector[Stats Collector Job]
+        TaskPolling[Task Polling Job]
+    end
+    
+    NodeJoin --> Listener
+    ClusterChange --> Listener
+    Listener --> |Check Version >= 3.1| TaskManager
+    Settings --> |isMetricCollectionEnabled| Listener
+    TaskManager --> StatsCollector
+    TaskManager --> TaskPolling
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `MLCommonsClusterEventListener` | Listens for cluster events and triggers stats collection jobs |
+| `MLTaskManager` | Manages ML task lifecycle including stats collector and task polling jobs |
+| `MLFeatureEnabledSetting` | Configuration settings for enabling/disabling metric collection |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ml_commons.enable_metric_collection` | Enable/disable metric collection | `true` |
+| `plugins.ml_commons.enable_static_metric_collection` | Enable/disable static metric collection | `true` |
+
+### Version Requirements
+
+The Metrics Framework requires OpenSearch version 3.1.0 or later. The stats collector job only starts on data nodes running compatible versions.
+
+### How It Works
+
+1. When a data node joins the cluster, `MLCommonsClusterEventListener` receives a cluster change event
+2. The listener checks if the joining node is running version 3.1.0 or later
+3. If metric collection is enabled in settings, the `MLTaskManager` starts the stats collector job
+4. The stats collector job periodically collects and indexes ML-related metrics
+
+## Limitations
+
+- Only available on OpenSearch 3.1.0 and later
+- Requires data nodes to be running compatible versions
+- Metric collection adds some overhead to cluster operations
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#4220](https://github.com/opensearch-project/ml-commons/pull/4220) | Fix version checking logic for starting the stats collector job |
+
+## References
+
+- [Metrics Framework Documentation](https://docs.opensearch.org/3.0/monitoring-your-cluster/metrics/getting-started/)
+- [ML Commons Cluster Settings](https://docs.opensearch.org/3.0/ml-commons-plugin/cluster-settings/)
+- [ML Commons APIs](https://docs.opensearch.org/3.0/ml-commons-plugin/api/index/)
+
+## Change History
+
+- **v3.3.0** (2026-01-11): Fixed version checking logic bug that prevented stats collector from starting on nodes > v3.1.0
+- **v3.1.0**: Initial implementation of Metrics Framework

--- a/docs/releases/v3.3.0/features/ml-commons/metrics-framework.md
+++ b/docs/releases/v3.3.0/features/ml-commons/metrics-framework.md
@@ -1,0 +1,77 @@
+# Metrics Framework Bug Fix
+
+## Summary
+
+This release fixes a critical bug in the ML Commons Metrics Framework where the version checking logic for starting the stats collector job was inverted. The bug prevented the stats collector job from starting on nodes running OpenSearch versions newer than 3.1.0.
+
+## Details
+
+### What's New in v3.3.0
+
+Fixed the version comparison logic in `MLCommonsClusterEventListener` that determines whether to start the stats collector job when a data node joins the cluster.
+
+### Technical Changes
+
+#### Bug Description
+
+The original code incorrectly checked:
+```java
+Version.V_3_1_0.onOrAfter(node.getVersion())
+```
+
+This condition evaluated to `true` only when the node version was 3.1.0 or **older**, which is the opposite of the intended behavior.
+
+#### Fix Applied
+
+The corrected code now properly checks:
+```java
+node.getVersion().onOrAfter(Version.V_3_1_0)
+```
+
+This ensures the stats collector job starts for nodes running version 3.1.0 or **newer**.
+
+#### Impact
+
+| Scenario | Before Fix | After Fix |
+|----------|------------|-----------|
+| Node v3.0.0 joins | Stats collector started ❌ | Stats collector NOT started ✓ |
+| Node v3.1.0 joins | Stats collector started ✓ | Stats collector started ✓ |
+| Node v3.2.0+ joins | Stats collector NOT started ❌ | Stats collector started ✓ |
+
+### Code Change
+
+```java
+// File: MLCommonsClusterEventListener.java
+// Before:
+if (node.isDataNode() && Version.V_3_1_0.onOrAfter(node.getVersion())) {
+
+// After:
+if (node.isDataNode() && node.getVersion().onOrAfter(Version.V_3_1_0)) {
+```
+
+### Test Coverage
+
+New test cases were added to `MLCommonsClusterEventListenerTests.java` to verify:
+- Stats collector starts for v3.1.0 data nodes
+- Stats collector starts for v3.2.0+ data nodes
+- Stats collector does NOT start for pre-v3.1.0 data nodes
+
+## Limitations
+
+- This fix is backported to 3.1 and 3.2 branches
+- Clusters that were affected by this bug may need to restart nodes to trigger the stats collector job
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4220](https://github.com/opensearch-project/ml-commons/pull/4220) | Fix version checking logic for starting the stats collector job |
+
+## References
+
+- [Metrics Framework Documentation](https://docs.opensearch.org/3.0/monitoring-your-cluster/metrics/getting-started/)
+- [ML Commons Cluster Settings](https://docs.opensearch.org/3.0/ml-commons-plugin/cluster-settings/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/metrics-framework.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -96,6 +96,7 @@
 
 ### ML Commons
 
+- [Metrics Framework Bug Fix](features/ml-commons/metrics-framework.md)
 - [Move Common String](features/ml-commons/move-common-string.md)
 - [Updating Gson Version to Resolve Conflict Coming from Core](features/ml-commons/updating-gson-version-to-resolve-conflict-coming-from-core.md)
 - [ML Commons Tutorials and Blueprints](features/ml-commons/ml-commons-tutorials-and-blueprints.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Metrics Framework bug fix in ML Commons for v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/ml-commons/metrics-framework.md`
- Feature report: `docs/features/ml-commons/metrics-framework.md`

### Key Changes in v3.3.0
- Fixed version checking logic in `MLCommonsClusterEventListener` that prevented stats collector job from starting on nodes running OpenSearch > v3.1.0
- The bug was in the condition `Version.V_3_1_0.onOrAfter(node.getVersion())` which should have been `node.getVersion().onOrAfter(Version.V_3_1_0)`

### Resources Used
- PR: [opensearch-project/ml-commons#4220](https://github.com/opensearch-project/ml-commons/pull/4220)
- Docs: [Metrics Framework](https://docs.opensearch.org/3.0/monitoring-your-cluster/metrics/getting-started/)