### PR TITLE
docs: add flow-framework-fixes report for v3.3.0

### DIFF
--- a/docs/features/flow-framework/flow-framework.md
+++ b/docs/features/flow-framework/flow-framework.md
@@ -190,6 +190,7 @@ POST /_plugins/_flow_framework/workflow/<id>/_deprovision
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#1217](https://github.com/opensearch-project/flow-framework/pull/1217) | Pre-create ML Commons indices for Tenant Aware tests |
 | v3.2.0 | [#1185](https://github.com/opensearch-project/flow-framework/pull/1185) | Fix ApiSpecFetcher Memory Issues and Exception Handling |
 | v3.2.0 | [#1190](https://github.com/opensearch-project/flow-framework/pull/1190) | Better handling of Workflow Steps with Bad Request status |
 | v3.2.0 | [#1194](https://github.com/opensearch-project/flow-framework/pull/1194) | Update RegisterLocalCustomModelStep for 3.1+ compatibility |
@@ -223,6 +224,7 @@ POST /_plugins/_flow_framework/workflow/<id>/_deprovision
 - [Workflow Template Security](https://docs.opensearch.org/3.0/automating-configurations/workflow-security/)
 - [Register Agent API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/agent-apis/register-agent/)
 - [Flow Agents](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/agents/flow/)
+- [Issue #1216](https://github.com/opensearch-project/flow-framework/issues/1216): Tenant Aware Integ Tests failing because indices aren't being created
 - [Issue #1180](https://github.com/opensearch-project/flow-framework/issues/1180): Migrate workflow custom model registration to 3.1
 - [Issue #1189](https://github.com/opensearch-project/flow-framework/issues/1189): Error message for CreateIndexStep when index exists is unhelpful
 - [Issue #1197](https://github.com/opensearch-project/flow-framework/issues/1197): create_connector issue with connector name validation in 3.1.0
@@ -237,6 +239,7 @@ POST /_plugins/_flow_framework/workflow/<id>/_deprovision
 
 ## Change History
 
+- **v3.3.0** (2025-10-07): Fixed tenant-aware integration test failures by pre-creating ML Commons indices; Added `createMLCommonsIndices()` helper method to test infrastructure
 - **v3.2.0** (2025-08-06): Bug fixes for ApiSpecFetcher memory issues and exception handling; Improved error messages for workflow steps with Bad Request status; Updated RegisterLocalCustomModelStep for OpenSearch 3.1+ API compatibility with model_config nesting and space_type support; Fixed encryption key race condition during concurrent template creation; Fixed connector name substitution in default use case templates
 - **v3.1.0** (2025-07-15): Bug fixes for RegisterAgentStep LLM field processing, exception type in WorkflowState error messages, and LLM spec parameter passing; Conditional DynamoDB client dependency inclusion via environment variable; New data summary with log pattern agent template for query assist
 - **v3.0.0** (2025-05-06): OpenSearch 3.0 compatibility fixes, per-tenant provisioning throttling, REST status code corrections, config parser fix for tenant_id, synchronous provisioning action listener fix, reprovision timeout response fix, ToolStep attributes field, text-to-visualization templates

--- a/docs/releases/v3.3.0/features/flow-framework/flow-framework-fixes.md
+++ b/docs/releases/v3.3.0/features/flow-framework/flow-framework-fixes.md
@@ -1,0 +1,134 @@
+# Flow Framework Fixes
+
+## Summary
+
+This release fixes integration test failures in Flow Framework when running with tenant awareness enabled. The fix ensures ML Commons indices are pre-created before running tenant-aware integration tests, addressing a compatibility issue introduced by changes in ML Commons that assume indices are pre-populated in multi-tenant environments.
+
+## Details
+
+### What's New in v3.3.0
+
+The fix addresses failing tenant-aware integration tests caused by ML Commons no longer automatically creating indices when tenant awareness is enabled. In production multi-tenant environments, external setup scripts are expected to create these indices, but integration tests require them to be created programmatically.
+
+### Technical Changes
+
+#### Problem Background
+
+When tenant awareness is enabled in OpenSearch:
+1. ML Commons assumes indices are pre-populated by external setup scripts
+2. Flow Framework's tenant-aware integration tests validate tenant ID handling with ML Commons
+3. Tests were failing because required ML Commons indices (like the config index) didn't exist
+
+```mermaid
+flowchart TB
+    subgraph "Before Fix"
+        TA1[Tenant Awareness Enabled]
+        MLC1[ML Commons]
+        FF1[Flow Framework Tests]
+        FAIL[Tests Fail - Missing Indices]
+        
+        TA1 --> MLC1
+        MLC1 -->|No Auto-Create| FF1
+        FF1 --> FAIL
+    end
+    
+    subgraph "After Fix"
+        TA2[Tenant Awareness Enabled]
+        PRE[Pre-create ML Indices]
+        MLC2[ML Commons]
+        FF2[Flow Framework Tests]
+        PASS[Tests Pass]
+        
+        TA2 --> PRE
+        PRE --> MLC2
+        MLC2 --> FF2
+        FF2 --> PASS
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `createMLCommonsIndices()` | New helper method in `FlowFrameworkTenantAwareRestTestCase` that iterates through `MLIndex` enum and creates each index with default settings |
+
+#### Implementation Details
+
+The fix adds a new method `createMLCommonsIndices()` to the base test class that:
+1. Iterates through all `MLIndex` enum values from ML Commons
+2. Creates each index using its defined mapping
+3. Handles `resource_already_exists_exception` gracefully to allow idempotent execution
+
+```java
+protected static void createMLCommonsIndices() throws Exception {
+    for (MLIndex mlIndex : MLIndex.values()) {
+        String requestPath = "/" + mlIndex.getIndexName();
+        String requestBody = "{\"mappings\":" + mlIndex.getMapping() + "}";
+        try {
+            TestHelpers.makeRequest(client(), "PUT", requestPath, null, requestBody, null);
+        } catch (ResponseException e) {
+            if (e.getMessage().contains("resource_already_exists_exception")) {
+                continue;
+            }
+            throw e;
+        }
+    }
+}
+```
+
+#### Modified Test Classes
+
+| Test Class | Change |
+|------------|--------|
+| `RestWorkflowProvisionTenantAwareIT` | Added `createMLCommonsIndices()` call before `createFlowFrameworkIndices()` |
+| `RestWorkflowStateTenantAwareIT` | Added `createMLCommonsIndices()` call before `createFlowFrameworkIndices()` |
+| `RestWorkflowTenantAwareIT` | Added `createMLCommonsIndices()` call before `createFlowFrameworkIndices()` |
+
+#### Build Configuration
+
+Added `json-schema-validator` as a `compileOnly` dependency to access `MLIndex` class mappings at test runtime:
+
+```gradle
+compileOnly('com.networknt:json-schema-validator:1.4.0') {
+    exclude group: 'com.fasterxml.jackson.core', module: 'jackson-databind'
+    exclude group: 'com.fasterxml.jackson.dataformat', module: 'jackson-dataformat-yaml'
+    exclude group: 'org.yml', module: 'snakeyaml'
+    exclude group: 'org.slf4j', module: 'slf4j-api'
+}
+```
+
+### Usage Example
+
+The fix is automatically applied when running tenant-aware integration tests. No user action is required.
+
+```bash
+# Run tenant-aware integration tests (fix is applied automatically)
+./gradlew integTestTenantAware
+```
+
+### Migration Notes
+
+No migration required. This is an internal test infrastructure fix that does not affect production deployments.
+
+## Limitations
+
+- This fix only applies to integration test environments
+- Production multi-tenant deployments still require external index setup scripts
+- The fix assumes ML Commons is available and the `MLIndex` enum is accessible
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1217](https://github.com/opensearch-project/flow-framework/pull/1217) | Pre-create ML Commons indices for Tenant Aware tests |
+
+## References
+
+- [Issue #1216](https://github.com/opensearch-project/flow-framework/issues/1216): Tenant Aware Integ Tests failing because indices aren't being created
+- [ML Commons PR #4089](https://github.com/opensearch-project/ml-commons/pull/4089): Related ML Commons change that assumes pre-populated indices
+- [ML Commons Issue #3860](https://github.com/opensearch-project/ml-commons/issues/3860): Related ML Commons issue
+- [Flow Framework Documentation](https://docs.opensearch.org/3.0/automating-configurations/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/flow-framework/flow-framework.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -161,6 +161,10 @@
 
 - [Notifications Plugin Fixes](features/notifications/notifications-plugin-fixes.md)
 
+### Flow Framework
+
+- [Flow Framework Fixes](features/flow-framework/flow-framework-fixes.md)
+
 ### Dependencies
 
 - [Dependency Updates](features/dependency-updates.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Flow Framework Fixes release item in v3.3.0.

### Changes

- Created release report: `docs/releases/v3.3.0/features/flow-framework/flow-framework-fixes.md`
- Updated feature report: `docs/features/flow-framework/flow-framework.md`
- Updated release index: `docs/releases/v3.3.0/index.md`

### Key Changes in v3.3.0

- Fixed tenant-aware integration test failures by pre-creating ML Commons indices
- Added `createMLCommonsIndices()` helper method to test infrastructure
- Addresses compatibility with ML Commons changes that assume pre-populated indices in multi-tenant environments

### Related

- Fixes Issue #1350
- PR: [opensearch-project/flow-framework#1217](https://github.com/opensearch-project/flow-framework/pull/1217)
- Issue: [opensearch-project/flow-framework#1216](https://github.com/opensearch-project/flow-framework/issues/1216)