### PR TITLE
docs: add observability-fixes report for v3.3.0

### DIFF
--- a/docs/features/observability/trace-analytics-bug-fixes.md
+++ b/docs/features/observability/trace-analytics-bug-fixes.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-This feature tracks bug fixes for the Trace Analytics functionality in OpenSearch Dashboards Observability plugin, including time filter processing for Jaeger trace data and visualization warning handling for integrations.
+This feature tracks bug fixes for the Trace Analytics functionality in OpenSearch Dashboards Observability plugin, including error handling improvements, time filter processing for Jaeger trace data, visualization warning handling, and test infrastructure fixes.
 
 ## Details
 
@@ -16,7 +16,10 @@ graph TB
         TF --> |Data Prepper Mode| DP[Data Prepper Processor]
         JP --> DSL[DSL Query Builder]
         DP --> DSL
-        DSL --> OS[OpenSearch]
+        DSL --> REQ[DSL Request Handler]
+        REQ --> |Success| OS[OpenSearch]
+        REQ --> |Error| EH[Error Handler]
+        EH --> Toast[Toast Notification]
     end
     
     subgraph "Integrations"
@@ -32,8 +35,11 @@ graph TB
 |-----------|-------------|
 | `processTimeStamp()` | Converts time picker values to appropriate format for Jaeger (microseconds) or Data Prepper |
 | `dateMath.parse()` | OpenSearch date math parser with optional `roundUp` for end times |
+| `handleError()` | Centralized error handler that parses various error formats and displays appropriate toast messages |
+| `safeJsonParse()` | Safe JSON parsing utility for error response bodies |
 | Vega Configuration | Visualization config supporting `hideWarnings` option |
 | NFW MV SQL | Materialized view creation SQL with `COALESCE()` defaults |
+| Jest path mappings | Module resolution configuration for OpenSearch Dashboards core paths |
 
 ### Configuration
 
@@ -52,6 +58,22 @@ flowchart LR
     C --> E[Convert to Microseconds]
     D --> E
     E --> F[DSL Query]
+```
+
+### Error Handling Flow
+
+```mermaid
+flowchart TB
+    A[DSL Request] --> B{Error?}
+    B -->|No| C[Display Data]
+    B -->|Yes| D[handleError]
+    D --> E[Parse Error Response]
+    E --> F{Status Code}
+    F -->|429| G[Rate Limit Toast]
+    F -->|503| H[Service Unavailable Toast]
+    F -->|504| I[Timeout Toast]
+    F -->|500 + too_many_buckets| J[Bucket Limit Toast]
+    F -->|Other| K[Generic Error Toast]
 ```
 
 ### Usage Example
@@ -82,11 +104,15 @@ processTimeStamp('now/d', 'jaeger', true)
 - Jaeger time fix only applies to Jaeger mode trace analytics
 - NFW default values are placeholders indicating missing data
 - Warning suppression hides all Vega warnings, not just empty data warnings
+- Error messages are generic and may not provide specific troubleshooting steps for all error types
+- The 25-second timeout toast is triggered independently of the actual request timeout
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#2463](https://github.com/opensearch-project/dashboards-observability/pull/2463) | Toast Error handling - Improved error display for trace analytics |
+| v3.3.0 | [#2492](https://github.com/opensearch-project/dashboards-observability/pull/2492) | Test fixes - Fixed Jest configuration for module resolution |
 | v3.1.0 | [#2460](https://github.com/opensearch-project/dashboards-observability/pull/2460) | Fix Jaeger end time processing |
 | v3.1.0 | [#2452](https://github.com/opensearch-project/dashboards-observability/pull/2452) | NFW Integration Vega Vis Warning Msg Fix |
 
@@ -94,7 +120,9 @@ processTimeStamp('now/d', 'jaeger', true)
 
 - [Analyzing Jaeger trace data](https://docs.opensearch.org/3.1/observing-your-data/trace/trace-analytics-jaeger/): Official Jaeger trace analytics documentation
 - [Trace Analytics](https://docs.opensearch.org/3.1/observing-your-data/trace/index/): Trace Analytics overview
+- [Trace Analytics plugin for OpenSearch Dashboards](https://docs.opensearch.org/3.3/observing-your-data/trace/ta-dashboards/): Dashboard plugin documentation
 
 ## Change History
 
+- **v3.3.0** (2025-08-21): Improved toast error handling for trace analytics requests; Fixed Jest test configuration for OpenSearch Dashboards module resolution
 - **v3.1.0** (2025-06-13): Fix Jaeger end time processing for "Today/This month/This year/This day" time picker options; Fix NFW integration Vega visualization warnings with empty MV indexes

--- a/docs/releases/v3.3.0/features/observability/observability-fixes.md
+++ b/docs/releases/v3.3.0/features/observability/observability-fixes.md
@@ -1,0 +1,105 @@
+# Observability Fixes
+
+## Summary
+
+This release includes bug fixes for the OpenSearch Dashboards Observability plugin, focusing on improved error handling in Trace Analytics and test infrastructure fixes. The changes ensure users receive informative error messages instead of silent failures, and fix Jest test configuration issues.
+
+## Details
+
+### What's New in v3.3.0
+
+Two key improvements were made to the dashboards-observability plugin:
+
+1. **Toast Error Handling for Traces**: Enhanced error handling to always display informative toast messages when trace analytics requests fail, replacing previous silent failures.
+
+2. **Test Infrastructure Fixes**: Fixed Jest test configuration to properly resolve OpenSearch Dashboards module paths, enabling tests to run successfully.
+
+### Technical Changes
+
+#### Error Handling Architecture
+
+```mermaid
+graph TB
+    subgraph "Before v3.3.0"
+        A1[DSL Request] --> B1{Error?}
+        B1 -->|Yes| C1[Silent Failure]
+        B1 -->|No| D1[Display Data]
+    end
+    
+    subgraph "After v3.3.0"
+        A2[DSL Request] --> B2{Error?}
+        B2 -->|Yes| C2[handleError]
+        C2 --> E2{Status Code}
+        E2 -->|429| F2[Rate Limit Toast]
+        E2 -->|503| G2[Service Unavailable Toast]
+        E2 -->|504| H2[Timeout Toast]
+        E2 -->|Other| I2[Generic Error Toast]
+        B2 -->|No| D2[Display Data]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `handleError()` | Centralized error handler that parses various error formats and displays appropriate toast messages |
+| `safeJsonParse()` | Safe JSON parsing utility for error response bodies |
+| Jest path mappings | Module resolution configuration for OpenSearch Dashboards core paths |
+
+#### Error Status Code Handling
+
+| Status Code | Error Type | User Message |
+|-------------|------------|--------------|
+| 429 | Rate Limit / Circuit Breaker | "Too many requests. The system is currently overloaded, please try again later." |
+| 503 | Service Unavailable | "Service temporarily unavailable. The system might be under maintenance or overloaded." |
+| 504 | Gateway Timeout | "Request timed out. The operation took too long to complete." |
+| 500 | Too Many Buckets | "Too many buckets in aggregation. Try using a shorter time range..." |
+
+### Usage Example
+
+**Error Toast Display** (automatic):
+```typescript
+// Errors are now automatically caught and displayed
+try {
+  const response = await handleDslRequest(http, {}, query, mode);
+} catch (error) {
+  // handleError() is called internally, displaying appropriate toast
+}
+```
+
+**Server-side Error Response** (improved):
+```typescript
+// Server now returns structured error responses
+return response.custom({
+  statusCode: error.statusCode || 400,
+  body: {
+    message: error.message || error.reason || 'Unknown error occurred',
+    error: error.response || error.body || error,
+  },
+});
+```
+
+### Migration Notes
+
+No migration required. These are internal improvements that enhance user experience automatically.
+
+## Limitations
+
+- Error messages are generic and may not provide specific troubleshooting steps for all error types
+- The 25-second timeout toast is triggered independently of the actual request timeout
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2463](https://github.com/opensearch-project/dashboards-observability/pull/2463) | [Traces] Toast Error handling - Improved error display for trace analytics |
+| [#2492](https://github.com/opensearch-project/dashboards-observability/pull/2492) | Test fixes - Fixed Jest configuration for module resolution |
+
+## References
+
+- [Trace Analytics](https://docs.opensearch.org/3.3/observing-your-data/trace/index/): Trace Analytics overview
+- [Trace Analytics plugin for OpenSearch Dashboards](https://docs.opensearch.org/3.3/observing-your-data/trace/ta-dashboards/): Dashboard plugin documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/observability/trace-analytics-bug-fixes.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -144,6 +144,7 @@
 ### Observability
 
 - [Observability Cypress Updates](features/observability/observability-cypress-updates.md)
+- [Observability Fixes](features/observability/observability-fixes.md)
 
 ### Multi-Plugin
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Observability Fixes in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/observability/observability-fixes.md`
- Feature report: `docs/features/observability/trace-analytics-bug-fixes.md` (updated)

### Key Changes in v3.3.0
- **Toast Error Handling**: Improved error handling in Trace Analytics to display informative toast messages instead of silent failures
- **Test Infrastructure Fixes**: Fixed Jest test configuration for OpenSearch Dashboards module resolution

### PRs Investigated
- [#2463](https://github.com/opensearch-project/dashboards-observability/pull/2463): [Traces] Toast Error handling
- [#2492](https://github.com/opensearch-project/dashboards-observability/pull/2492): Test fixes

Closes #1349