### PR TITLE
docs: add Gradle 9 compatibility report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -336,6 +336,7 @@
 - [CI/Infrastructure Fixes](multi-plugin/ci-infrastructure-fixes.md)
 - [CVE Fixes & Dependency Updates](multi-plugin/cve-fixes-dependency-updates.md)
 - [Dependency Bumps](multi-plugin/dependency-bumps.md)
+- [Gradle 9 Compatibility](multi-plugin/gradle-9-compatibility.md)
 - [Header Redesign](multi-plugin/header-redesign.md)
 - [JDK 21 & Java Agent Migration](multi-plugin/jdk-21-java-agent-migration.md)
 - [Look & Feel UI Improvements](multi-plugin/look-and-feel-ui-improvements.md)

--- a/docs/features/multi-plugin/gradle-9-compatibility.md
+++ b/docs/features/multi-plugin/gradle-9-compatibility.md
@@ -1,0 +1,111 @@
+# Gradle 9 Compatibility
+
+## Summary
+
+Gradle 9 introduced breaking changes in how environment variables are accessed in Gradle build scripts. The `$System.env.VARIABLE_NAME` string interpolation syntax is no longer supported and must be replaced with the `System.getenv("VARIABLE_NAME")` method call. This affects OpenSearch plugin repositories that use environment variables for Sonatype credentials during SNAPSHOT publication.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Gradle Build Process"
+        A[build.gradle] --> B[Publishing Configuration]
+        B --> C[Sonatype Repository]
+        C --> D{Environment Variables}
+        D --> E[SONATYPE_USERNAME]
+        D --> F[SONATYPE_PASSWORD]
+    end
+    
+    subgraph "CI/CD Pipeline"
+        G[GitHub Actions] --> H[Set Environment Variables]
+        H --> A
+    end
+```
+
+### Problem
+
+The deprecated syntax using string interpolation for environment variables fails in Gradle 9:
+
+```gradle
+// This syntax fails in Gradle 9
+credentials {
+    username "$System.env.SONATYPE_USERNAME"
+    password "$System.env.SONATYPE_PASSWORD"
+}
+```
+
+Error message: The build fails during the `publishToSonatype` task when attempting to resolve credentials.
+
+### Solution
+
+Use the `System.getenv()` method which is compatible with all Gradle versions:
+
+```gradle
+// Gradle 9 compatible syntax
+credentials {
+    username System.getenv("SONATYPE_USERNAME")
+    password System.getenv("SONATYPE_PASSWORD")
+}
+```
+
+### Configuration
+
+| Setting | Description | Example |
+|---------|-------------|---------|
+| `SONATYPE_USERNAME` | Sonatype repository username | Set in CI environment |
+| `SONATYPE_PASSWORD` | Sonatype repository password/token | Set in CI environment |
+
+### Usage Example
+
+```gradle
+publishing {
+    repositories {
+        maven {
+            name = "Snapshots"
+            url = "https://central.sonatype.com/repository/maven-snapshots/"
+            credentials {
+                username System.getenv("SONATYPE_USERNAME")
+                password System.getenv("SONATYPE_PASSWORD")
+            }
+        }
+    }
+}
+```
+
+## Limitations
+
+- The fix is specific to Sonatype credentials; other environment variable usages may need similar updates
+- Requires Gradle wrapper update to Gradle 9+ for full compatibility testing
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [alerting#1920](https://github.com/opensearch-project/alerting/pull/1920) | alerting plugin fix |
+| v3.3.0 | [asynchronous-search#763](https://github.com/opensearch-project/asynchronous-search/pull/763) | asynchronous-search plugin fix |
+| v3.3.0 | [common-utils#867](https://github.com/opensearch-project/common-utils/pull/867) | common-utils fix |
+| v3.3.0 | [cross-cluster-replication#1575](https://github.com/opensearch-project/cross-cluster-replication/pull/1575) | CCR plugin fix |
+| v3.3.0 | [custom-codecs#273](https://github.com/opensearch-project/custom-codecs/pull/273) | custom-codecs plugin fix |
+| v3.3.0 | [geospatial#791](https://github.com/opensearch-project/geospatial/pull/791) | geospatial plugin fix |
+| v3.3.0 | [index-management#1474](https://github.com/opensearch-project/index-management/pull/1474) | index-management plugin fix |
+| v3.3.0 | [job-scheduler#821](https://github.com/opensearch-project/job-scheduler/pull/821) | job-scheduler plugin fix |
+| v3.3.0 | [opensearch-system-templates#95](https://github.com/opensearch-project/opensearch-system-templates/pull/95) | system-templates fix |
+| v3.3.0 | [query-insights#407](https://github.com/opensearch-project/query-insights/pull/407) | query-insights plugin fix |
+| v3.3.0 | [reporting#1120](https://github.com/opensearch-project/reporting/pull/1120) | reporting plugin fix |
+| v3.3.0 | [notifications#1069](https://github.com/opensearch-project/notifications/pull/1069) | notifications plugin fix |
+| v3.3.0 | [opensearch-learning-to-rank-base#219](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/219) | learning-to-rank plugin fix |
+| v3.3.0 | [user-behavior-insights#122](https://github.com/opensearch-project/user-behavior-insights/pull/122) | UBI plugin fix |
+| v3.3.0 | [dashboards-search-relevance#227](https://github.com/opensearch-project/dashboards-search-relevance/pull/227) | search-relevance fix |
+| v3.3.0 | [skills#630](https://github.com/opensearch-project/skills/pull/630) | skills plugin fix |
+
+## References
+
+- [Gradle 9 Release Notes](https://docs.gradle.org/9.0/release-notes.html): Official Gradle 9 documentation
+- [opensearch-remote-metadata-sdk#245](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/245): Original fix that restored successful snapshots
+- [Example failed workflow](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/actions/runs/17023398832/job/48255946880#step:5:74): CI failure demonstrating the issue
+
+## Change History
+
+- **v3.3.0** (2026-01): Fixed Gradle 9 compatibility across 16 plugin repositories by updating `$System.env` syntax to `System.getenv()`

--- a/docs/releases/v3.3.0/features/multi-plugin/gradle-9-compatibility.md
+++ b/docs/releases/v3.3.0/features/multi-plugin/gradle-9-compatibility.md
@@ -1,0 +1,83 @@
+# Gradle 9 Compatibility
+
+## Summary
+
+This bugfix updates Gradle build files across 16 OpenSearch plugin repositories to fix compatibility with Gradle 9. The change replaces the deprecated `$System.env.VARIABLE_NAME` syntax with the `System.getenv()` method for accessing environment variables, specifically for Sonatype credentials used in SNAPSHOT publication.
+
+## Details
+
+### What's New in v3.3.0
+
+Gradle 9 introduced breaking changes in how environment variables are accessed in build scripts. The previous syntax using string interpolation (`$System.env.VARIABLE_NAME`) no longer works and causes build failures during SNAPSHOT publication workflows.
+
+### Technical Changes
+
+#### Syntax Change
+
+| Before (Gradle 8 and earlier) | After (Gradle 9 compatible) |
+|-------------------------------|------------------------------|
+| `"$System.env.SONATYPE_USERNAME"` | `System.getenv("SONATYPE_USERNAME")` |
+| `"$System.env.SONATYPE_PASSWORD"` | `System.getenv("SONATYPE_PASSWORD")` |
+
+#### Code Change Example
+
+```gradle
+// Before (incompatible with Gradle 9)
+credentials {
+    username "$System.env.SONATYPE_USERNAME"
+    password "$System.env.SONATYPE_PASSWORD"
+}
+
+// After (Gradle 9 compatible)
+credentials {
+    username System.getenv("SONATYPE_USERNAME")
+    password System.getenv("SONATYPE_PASSWORD")
+}
+```
+
+### Affected Repositories
+
+| Repository | PR |
+|------------|-----|
+| alerting | [#1920](https://github.com/opensearch-project/alerting/pull/1920) |
+| asynchronous-search | [#763](https://github.com/opensearch-project/asynchronous-search/pull/763) |
+| common-utils | [#867](https://github.com/opensearch-project/common-utils/pull/867) |
+| cross-cluster-replication | [#1575](https://github.com/opensearch-project/cross-cluster-replication/pull/1575) |
+| custom-codecs | [#273](https://github.com/opensearch-project/custom-codecs/pull/273) |
+| geospatial | [#791](https://github.com/opensearch-project/geospatial/pull/791) |
+| index-management | [#1474](https://github.com/opensearch-project/index-management/pull/1474) |
+| job-scheduler | [#821](https://github.com/opensearch-project/job-scheduler/pull/821) |
+| opensearch-system-templates | [#95](https://github.com/opensearch-project/opensearch-system-templates/pull/95) |
+| query-insights | [#407](https://github.com/opensearch-project/query-insights/pull/407) |
+| reporting | [#1120](https://github.com/opensearch-project/reporting/pull/1120) |
+| notifications | [#1069](https://github.com/opensearch-project/notifications/pull/1069) |
+| opensearch-learning-to-rank-base | [#219](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/219) |
+| user-behavior-insights | [#122](https://github.com/opensearch-project/user-behavior-insights/pull/122) |
+| dashboards-search-relevance | [#227](https://github.com/opensearch-project/dashboards-search-relevance/pull/227) |
+| skills | [#630](https://github.com/opensearch-project/skills/pull/630) |
+
+### Migration Notes
+
+No user action required. This is an internal build system fix that ensures CI/CD pipelines continue to work with Gradle 9.
+
+## Limitations
+
+- This fix only addresses the Sonatype credentials syntax; other uses of `$System.env` may require similar updates in the future.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1920](https://github.com/opensearch-project/alerting/pull/1920) | alerting: Update System.env syntax |
+| [#763](https://github.com/opensearch-project/asynchronous-search/pull/763) | asynchronous-search: Update System.env syntax |
+| [#867](https://github.com/opensearch-project/common-utils/pull/867) | common-utils: Update System.env syntax |
+| [#245](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/245) | opensearch-remote-metadata-sdk: Original fix example |
+
+## References
+
+- [Gradle 9 Release Notes](https://docs.gradle.org/9.0/release-notes.html): Breaking changes in Gradle 9
+- [Example failed workflow](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/actions/runs/17023398832/job/48255946880#step:5:74): CI failure demonstrating the issue
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/multi-plugin/gradle-9-compatibility.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -148,6 +148,7 @@
 
 ### Multi-Plugin
 
+- [Gradle 9 Compatibility](features/multi-plugin/gradle-9-compatibility.md)
 - [Version Increment](features/multi-plugin/version-increment.md)
 
 ### User Behavior Insights


### PR DESCRIPTION
## Summary

This PR adds documentation for the Gradle 9 compatibility bugfix in OpenSearch v3.3.0.

### Changes

- **Release report**: `docs/releases/v3.3.0/features/multi-plugin/gradle-9-compatibility.md`
- **Feature report**: `docs/features/multi-plugin/gradle-9-compatibility.md`
- Updated release index and features index

### Key Points

- Fixes `$System.env.VARIABLE_NAME` syntax to `System.getenv("VARIABLE_NAME")` for Gradle 9 compatibility
- Affects 16 plugin repositories for Sonatype credentials in SNAPSHOT publication
- All PRs authored by @dbwiddis

Closes #1347