### PR TITLE
docs: add security configuration enhancements report for v3.3.0

### DIFF
--- a/docs/features/security/security-configuration.md
+++ b/docs/features/security/security-configuration.md
@@ -92,11 +92,14 @@ OIDC providers may send usernames with special characters. The plugin handles pi
 
 ### Configuration
 
-| Setting | Description | Default |
-|---------|-------------|---------|
-| `plugins.security.config_index_name` | Name of the security index | `.opendistro_security` |
-| `plugins.security.allow_default_init_securityindex` | Allow default initialization | `false` |
-| `plugins.security.audit.type` | Audit log type | `internal_opensearch` |
+| Setting | Description | Default | Dynamic |
+|---------|-------------|---------|---------|
+| `plugins.security.config_index_name` | Name of the security index | `.opendistro_security` | No |
+| `plugins.security.allow_default_init_securityindex` | Allow default initialization | `false` | No |
+| `plugins.security.audit.type` | Audit log type | `internal_opensearch` | No |
+| `plugins.security.user_attribute_serialization.enabled` | Enable user attribute serialization | `false` | Yes |
+| `plugins.security.experimental.resource_sharing.enabled` | Enable resource sharing framework | `false` | No |
+| `plugins.security.experimental.resource_sharing.protected_types` | List of resource types to protect | `[]` | No |
 
 ### Usage Example
 
@@ -130,6 +133,8 @@ config:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#5671](https://github.com/opensearch-project/security/pull/5671) | Adds protected resource types setting |
+| v3.3.0 | [#5673](https://github.com/opensearch-project/security/pull/5673) | Make user attribute serialization dynamic |
 | v3.0.0 | [#5193](https://github.com/opensearch-project/security/pull/5193) | Default to v7 models if _meta not present |
 | v3.0.0 | [#5175](https://github.com/opensearch-project/security/pull/5175) | Escape pipe character for injected users |
 | v3.0.0 | [#5157](https://github.com/opensearch-project/security/pull/5157) | Fix version matcher in demo config installer |
@@ -145,5 +150,6 @@ config:
 
 ## Change History
 
+- **v3.3.0** (2025-10-01): Added protected resource types setting, made user attribute serialization dynamic
 - **v3.0.0** (2025-05-06): Default to v7 models, escape pipe characters in usernames, fix demo config version matcher
 - **v2.18.0** (2024-11-05): Auto-convert security config models from v6 to v7

--- a/docs/releases/v3.3.0/features/security/security-configuration-enhancements.md
+++ b/docs/releases/v3.3.0/features/security/security-configuration-enhancements.md
@@ -1,0 +1,124 @@
+# Security Configuration Enhancements
+
+## Summary
+
+OpenSearch v3.3.0 introduces two configuration enhancements to the Security plugin: a new setting to explicitly specify which resource types should be protected by the resource sharing framework, and making the user attribute serialization setting dynamically configurable without requiring a cluster restart.
+
+## Details
+
+### What's New in v3.3.0
+
+#### 1. Protected Resource Types Setting
+
+A new list setting allows cluster administrators to explicitly specify which resource types should be protected by the resource sharing framework:
+
+```yaml
+plugins.security.experimental.resource_sharing.protected_types: [sample-resource]
+```
+
+**Key behaviors:**
+- Default value: `[]` (empty list - no resources protected by default)
+- Only resource types listed in this setting will have resource-level authorization applied
+- Resources not in the list behave as if the resource sharing feature is disabled for them
+- Provides granular control over which plugin resources receive access protection
+
+#### 2. Dynamic User Attribute Serialization Setting
+
+The `plugins.security.user_attribute_serialization.enabled` setting is now dynamic and can be updated at runtime:
+
+```bash
+PUT _cluster/settings
+{
+  "persistent": {
+    "plugins.security.user_attribute_serialization.enabled": true
+  }
+}
+```
+
+**Previous behavior:** Required static configuration in `opensearch.yml` and cluster restart.
+
+**New behavior:** Can be dynamically updated via the Cluster Settings API.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Resource Sharing Framework"
+        Setting[protected_types Setting]
+        Evaluator[ResourceAccessEvaluator]
+        Client[ResourceAccessControlClient]
+    end
+    
+    subgraph "Request Flow"
+        Request[DocRequest]
+        Check{Is type protected?}
+        Authorize[Apply Authorization]
+        Allow[Allow Access]
+    end
+    
+    Request --> Check
+    Setting --> Check
+    Check -->|Yes| Authorize
+    Check -->|No| Allow
+    Evaluator --> Authorize
+    Client --> Authorize
+```
+
+#### New Configuration
+
+| Setting | Description | Default | Dynamic |
+|---------|-------------|---------|---------|
+| `plugins.security.experimental.resource_sharing.protected_types` | List of resource types to protect | `[]` | No |
+| `plugins.security.user_attribute_serialization.enabled` | Enable user attribute serialization | `false` | Yes |
+
+#### Settings Filter Updates
+
+The settings filter was updated to be more granular, explicitly listing security setting prefixes instead of using a broad `plugins.security.*` pattern. This allows the user attribute serialization setting to be visible in cluster settings responses while keeping sensitive settings filtered.
+
+### Usage Example
+
+```yaml
+# opensearch.yml - Enable resource sharing with specific protected types
+plugins.security.experimental.resource_sharing.enabled: true
+plugins.security.experimental.resource_sharing.protected_types:
+  - sample-resource
+  - anomaly-detector
+```
+
+```bash
+# Dynamically enable user attribute serialization
+PUT _cluster/settings
+{
+  "persistent": {
+    "plugins.security.user_attribute_serialization.enabled": true
+  }
+}
+```
+
+### Migration Notes
+
+- Existing clusters using resource sharing should add their resource types to `protected_types` to maintain current behavior
+- The user attribute serialization setting can now be changed without cluster restart
+
+## Limitations
+
+- The `protected_types` setting is static and requires a cluster restart to change
+- Resource types must be explicitly listed; there is no wildcard support
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5671](https://github.com/opensearch-project/security/pull/5671) | Adds a list setting to explicitly specify resources to be protected |
+| [#5673](https://github.com/opensearch-project/security/pull/5673) | Make user attribute serialization property dynamic |
+
+## References
+
+- [PR #5657](https://github.com/opensearch-project/security/pull/5657): Original PR for dynamic user attribute serialization (superseded by #5673)
+- [Documentation: Security Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/security-settings/)
+
+## Related Feature Report
+
+- [Security Configuration](../../../features/security/security-configuration.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -89,6 +89,7 @@
 
 - [Client Certificate Authentication - skip_users](features/security/security-client-certificate-authentication.md)
 - [Resource Access Control Documentation](features/security/resource-access-control-documentation.md)
+- [Security Configuration Enhancements](features/security/security-configuration-enhancements.md)
 - [Security Plugin Bug Fixes](features/security/security-plugin-bug-fixes.md)
 - [SSL/TLS Compatibility Fix](features/security/ssl-tls.md)
 - [Sync Protobufs Version with Core](features/security/sync-protobufs-version.md)


### PR DESCRIPTION
## Summary

Adds documentation for Security Configuration Enhancements in OpenSearch v3.3.0.

### Changes in v3.3.0

1. **Protected Resource Types Setting** (PR #5671)
   - New `plugins.security.experimental.resource_sharing.protected_types` setting
   - Allows explicit specification of which resource types should be protected
   - Default: empty list (no resources protected by default)

2. **Dynamic User Attribute Serialization** (PR #5673)
   - `plugins.security.user_attribute_serialization.enabled` is now dynamic
   - Can be updated via Cluster Settings API without restart

### Reports Created
- Release report: `docs/releases/v3.3.0/features/security/security-configuration-enhancements.md`
- Feature report updated: `docs/features/security/security-configuration.md`

### Related Issue
Closes #1346