### PR TITLE
docs: add JWT Authentication JWKS support report for v3.3.0

### DIFF
--- a/docs/features/security/jwt-authentication.md
+++ b/docs/features/security/jwt-authentication.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-JWT (JSON Web Token) authentication in OpenSearch Security allows users to authenticate using signed tokens issued by an identity provider. JWTs are self-contained tokens that carry user identity and role information, enabling single sign-on (SSO) scenarios. The Security plugin validates JWT signatures and extracts user credentials and backend roles from token claims.
+JWT (JSON Web Token) authentication in OpenSearch Security allows users to authenticate using signed tokens issued by an identity provider. JWTs are self-contained tokens that carry user identity and role information, enabling single sign-on (SSO) scenarios. The Security plugin validates JWT signatures and extracts user credentials and backend roles from token claims. Starting with v3.3.0, direct JWKS endpoint support enables JWT authentication without requiring full OpenID Connect infrastructure.
 
 ## Details
 
@@ -14,22 +14,30 @@ graph TB
         A[Client] -->|JWT Token| B[OpenSearch]
         B --> C[Security Plugin]
         C --> D[JWT Authenticator]
-        D --> E{Validate Signature}
-        E -->|Valid| F[Extract Claims]
-        E -->|Invalid| G[Reject]
-        F --> H[Extract Subject]
-        F --> I[Extract Roles]
-        H --> J[Create AuthCredentials]
+        D --> E{Key Source}
+        E -->|Static Key| F[signing_key config]
+        E -->|JWKS URI| G[KeySetRetriever]
+        E -->|OIDC| H[OIDC Discovery]
+        G --> I[JWKS Endpoint]
+        H --> I
+        F --> J[JwtVerifier]
         I --> J
-        J --> K[Grant Access]
+        J --> K{Validate Signature}
+        K -->|Valid| L[Extract Claims]
+        K -->|Invalid| M[Reject]
+        L --> N[Extract Subject]
+        L --> O[Extract Roles]
+        N --> P[Create AuthCredentials]
+        O --> P
+        P --> Q[Grant Access]
     end
     
     subgraph "JWT Structure"
-        L[Header] --> M[Algorithm]
-        N[Payload] --> O[Subject]
-        N --> P[Roles]
-        N --> Q[Nested Claims]
-        R[Signature] --> S[Verification]
+        R[Header] --> S[Algorithm + kid]
+        T[Payload] --> U[Subject]
+        T --> V[Roles]
+        T --> W[Nested Claims]
+        X[Signature] --> Y[Verification]
     end
 ```
 
@@ -40,13 +48,17 @@ flowchart LR
     A[JWT Token] --> B[Base64 Decode]
     B --> C[Parse Header]
     B --> D[Parse Payload]
-    B --> E[Verify Signature]
-    D --> F[Extract subject_key]
-    D --> G[Extract roles_key]
-    F --> H[Username]
-    G --> I[Backend Roles]
-    H --> J[AuthCredentials]
-    I --> J
+    C --> E{Get kid}
+    E -->|Has kid| F[Lookup Key by kid]
+    E -->|No kid| G[Use Default Key]
+    F --> H[Verify Signature]
+    G --> H
+    D --> I[Extract subject_key]
+    D --> J[Extract roles_key]
+    I --> K[Username]
+    J --> L[Backend Roles]
+    K --> M[AuthCredentials]
+    L --> M
 ```
 
 ### Components
@@ -54,16 +66,21 @@ flowchart LR
 | Component | Description |
 |-----------|-------------|
 | `AbstractHTTPJwtAuthenticator` | Base class providing common JWT authentication logic |
-| `HTTPJwtAuthenticator` | Standard JWT authenticator for HTTP requests |
+| `HTTPJwtAuthenticator` | Standard JWT authenticator for HTTP requests with static keys |
+| `HTTPJwtKeyByJWKSAuthenticator` | JWT authenticator with direct JWKS endpoint support (v3.3.0+) |
 | `HTTPJwtKeyByOpenIdConnectAuthenticator` | JWT authenticator using OIDC JWKS endpoint for key retrieval |
 | `JwtVerifier` | Validates JWT signatures using configured keys |
 | `KeyProvider` | Interface for providing signing keys |
+| `KeySetRetriever` | Retrieves and caches JWKS from endpoints |
+| `SelfRefreshingKeySet` | Manages automatic key refresh with rate limiting |
 
 ### Configuration
 
+#### Core Settings
+
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `signing_key` | Base64-encoded signing key(s) for signature verification | Required |
+| `signing_key` | Base64-encoded signing key(s) for signature verification | Required (if no jwks_uri) |
 | `jwt_header` | HTTP header containing the JWT token | `Authorization` |
 | `jwt_url_parameter` | URL parameter name for JWT (alternative to header) | `null` |
 | `subject_key` | Claim path for extracting username | `sub` (subject claim) |
@@ -72,9 +89,43 @@ flowchart LR
 | `required_issuer` | Required issuer claim value | `null` |
 | `jwt_clock_skew_tolerance_seconds` | Clock skew tolerance for token validation | `30` |
 
+#### JWKS Settings (v3.3.0+)
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `jwks_uri` | Direct JWKS endpoint URL | `null` |
+| `cache_jwks_endpoint` | Enable caching for JWKS responses | `true` |
+| `jwks_request_timeout_ms` | HTTP request timeout for JWKS endpoint | `5000` |
+| `jwks_queued_thread_timeout_ms` | Queued thread timeout | `2500` |
+| `refresh_rate_limit_time_window_ms` | Rate limit window for key refresh | `10000` |
+| `refresh_rate_limit_count` | Max refresh attempts per window | `10` |
+| `max_jwks_keys` | Maximum allowed keys in JWKS (hard limit) | `-1` (unlimited) |
+| `max_jwks_response_size_bytes` | Maximum HTTP response size | `1048576` (1MB) |
+
 ### Usage Example
 
-**Basic JWT Configuration:**
+**Direct JWKS Configuration (v3.3.0+):**
+```yaml
+jwt_auth_domain:
+  http_enabled: true
+  transport_enabled: true
+  order: 0
+  http_authenticator:
+    type: jwt
+    challenge: false
+    config:
+      jwks_uri: 'https://your-jwks-endpoint.com/.well-known/jwks.json'
+      jwt_header: "Authorization"
+      subject_key: "preferred_username"
+      roles_key: "roles"
+      cache_jwks_endpoint: true
+      jwks_request_timeout_ms: 5000
+      max_jwks_keys: 10
+  authentication_backend:
+    type: noop
+```
+
+**Static Key Configuration:**
 ```yaml
 jwt_auth_domain:
   http_enabled: true
@@ -128,19 +179,25 @@ jwt_auth_domain:
 - Only symmetric (HMAC) and asymmetric (RSA, ECDSA) algorithms are supported
 - Token expiration is enforced; expired tokens are rejected
 - Nested claim paths require all intermediate keys to be JSON objects
+- JWKS endpoints must return valid JSON Web Key Set format
+- SSL/TLS configuration for JWKS endpoints uses the `jwks` prefix in settings
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#5578](https://github.com/opensearch-project/security/pull/5578) | Direct JWKS (JSON Web Key Set) support in the JWT authentication backend |
 | v3.1.0 | [#5355](https://github.com/opensearch-project/security/pull/5355) | Handle roles in nested claim for JWT auth backends |
 
 ## References
 
+- [Issue #4974](https://github.com/opensearch-project/security/issues/4974): Feature request for JWKS with JWT without OIDC
 - [Issue #5343](https://github.com/opensearch-project/security/issues/5343): Support roles in nested JWT claims
 - [JWT Authentication Documentation](https://docs.opensearch.org/3.0/security/authentication-backends/jwt/): Official docs
 - [OpenID Connect Documentation](https://docs.opensearch.org/3.0/security/authentication-backends/openid-connect/): OIDC integration
+- [JSON Web Key (JWK) Specification](https://datatracker.ietf.org/doc/html/rfc7517): RFC 7517
 
 ## Change History
 
+- **v3.3.0** (2026-01-11): Added direct JWKS endpoint support with `jwks_uri` configuration, security validation features, and automatic fallback to static key authentication
 - **v3.1.0** (2025-06-06): Added support for nested claim paths in `roles_key` configuration

--- a/docs/releases/v3.3.0/features/security/jwt-authentication.md
+++ b/docs/releases/v3.3.0/features/security/jwt-authentication.md
@@ -1,0 +1,133 @@
+# JWT Authentication - Direct JWKS Support
+
+## Summary
+
+OpenSearch v3.3.0 adds direct JWKS (JSON Web Key Set) endpoint support to the JWT authentication backend. This enhancement allows JWT authentication with JWKS endpoints without requiring OpenID Connect (OIDC) infrastructure, simplifying configuration for environments that have JWKS endpoints but don't use full OIDC discovery.
+
+## Details
+
+### What's New in v3.3.0
+
+This release introduces a new `HTTPJwtKeyByJWKSAuthenticator` class that enables direct JWKS endpoint access within the JWT authentication backend. Previously, JWKS support was only available through the OIDC authenticator (`HTTPJwtKeyByOpenIdConnectAuthenticator`), which required an `openid_connect_url` for OIDC discovery.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "New: Direct JWKS Flow"
+        A[Client] -->|JWT Token| B[OpenSearch]
+        B --> C[HTTPJwtKeyByJWKSAuthenticator]
+        C --> D{jwks_uri configured?}
+        D -->|Yes| E[KeySetRetriever]
+        D -->|No| F[HTTPJwtAuthenticator<br/>Static Key Fallback]
+        E -->|Fetch| G[JWKS Endpoint]
+        G -->|JWKSet| H[SelfRefreshingKeySet]
+        H --> I[JwtVerifier]
+        I --> J[Validate Signature]
+        J --> K[Extract Claims]
+        K --> L[Grant Access]
+    end
+    
+    subgraph "Security Features"
+        M[Response Size Validation]
+        N[Key Count Limit]
+        O[Rate Limiting]
+        P[Caching]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `HTTPJwtKeyByJWKSAuthenticator` | New authenticator extending `AbstractHTTPJwtAuthenticator` for direct JWKS support |
+| `KeySetRetriever.createForJwksUri()` | Factory method for creating secure JWKS retrievers with validation |
+| `MockJwksServer` | Test utility for JWKS endpoint testing |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `jwks_uri` | Direct JWKS endpoint URL | `null` |
+| `cache_jwks_endpoint` | Enable caching for JWKS responses | `true` |
+| `jwks_request_timeout_ms` | HTTP request timeout for JWKS endpoint | `5000` |
+| `jwks_queued_thread_timeout_ms` | Queued thread timeout | `2500` |
+| `refresh_rate_limit_time_window_ms` | Rate limit window for key refresh | `10000` |
+| `refresh_rate_limit_count` | Max refresh attempts per window | `10` |
+| `max_jwks_keys` | Maximum allowed keys in JWKS (hard limit) | `-1` (unlimited) |
+| `max_jwks_response_size_bytes` | Maximum HTTP response size | `1048576` (1MB) |
+
+### Usage Example
+
+**Direct JWKS Configuration (New in v3.3.0):**
+```yaml
+jwt_auth_domain:
+  http_enabled: true
+  transport_enabled: true
+  order: 0
+  http_authenticator:
+    type: jwt
+    challenge: false
+    config:
+      jwks_uri: 'https://your-jwks-endpoint.com/.well-known/jwks.json'
+      jwt_header: "Authorization"
+      subject_key: "preferred_username"
+      roles_key: "roles"
+      cache_jwks_endpoint: true
+      jwks_request_timeout_ms: 5000
+      max_jwks_keys: 10
+  authentication_backend:
+    type: noop
+```
+
+**Backward Compatible - Static Key (Still Supported):**
+```yaml
+jwt_auth_domain:
+  http_enabled: true
+  http_authenticator:
+    type: jwt
+    config:
+      signing_key: "base64 encoded HMAC key or PEM public key"
+      jwt_header: "Authorization"
+  authentication_backend:
+    type: noop
+```
+
+### Migration Notes
+
+- **No breaking changes**: Existing configurations using `signing_key` continue to work
+- **Automatic fallback**: If `jwks_uri` is not configured, the authenticator falls back to static key authentication
+- **OIDC still supported**: The `openid` type with `openid_connect_url` remains available for full OIDC discovery
+
+### Security Features
+
+The new JWKS implementation includes built-in security protections:
+
+1. **Response Size Validation**: Prevents memory exhaustion from oversized JWKS responses
+2. **Key Count Limit**: Rejects JWKS with excessive keys (configurable hard limit)
+3. **Rate Limiting**: Prevents excessive refresh attempts
+4. **Caching**: Reduces network calls with configurable HTTP caching
+
+## Limitations
+
+- The `jwks_uri` must return a valid JWKS JSON response
+- SSL/TLS configuration for JWKS endpoints uses the `jwks` prefix in settings
+- Key rotation requires the JWKS endpoint to be accessible
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5578](https://github.com/opensearch-project/security/pull/5578) | Direct JWKS (JSON Web Key Set) support in the JWT authentication backend |
+
+## References
+
+- [Issue #4974](https://github.com/opensearch-project/security/issues/4974): Feature request for JWKS with JWT without OIDC
+- [JWT Authentication Documentation](https://docs.opensearch.org/3.0/security/authentication-backends/jwt/): Official docs
+- [JSON Web Key (JWK) Specification](https://datatracker.ietf.org/doc/html/rfc7517): RFC 7517
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/security/jwt-authentication.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -88,6 +88,7 @@
 ### Security
 
 - [Client Certificate Authentication - skip_users](features/security/security-client-certificate-authentication.md)
+- [JWT Authentication - Direct JWKS Support](features/security/jwt-authentication.md)
 - [Resource Access Control Documentation](features/security/resource-access-control-documentation.md)
 - [Security Configuration Enhancements](features/security/security-configuration-enhancements.md)
 - [Security Plugin Bug Fixes](features/security/security-plugin-bug-fixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the JWT Authentication enhancement in OpenSearch v3.3.0 that introduces direct JWKS (JSON Web Key Set) endpoint support.

## Changes

### Release Report Created
- `docs/releases/v3.3.0/features/security/jwt-authentication.md`

### Feature Report Updated
- `docs/features/security/jwt-authentication.md` - Added v3.3.0 JWKS support details

### Release Index Updated
- `docs/releases/v3.3.0/index.md` - Added link to new report

## Key Changes in v3.3.0

- **Direct JWKS Support**: New `jwks_uri` configuration parameter enables JWT authentication with JWKS endpoints without requiring OpenID Connect infrastructure
- **New Authenticator**: `HTTPJwtKeyByJWKSAuthenticator` class for direct JWKS endpoint access
- **Security Features**: Response size validation, key count limits, rate limiting, and caching
- **Backward Compatible**: Existing `signing_key` configurations continue to work with automatic fallback

## Related Issue
Closes #1345

## PR Reference
- [opensearch-project/security#5578](https://github.com/opensearch-project/security/pull/5578)