### PR TITLE
docs: add Security Plugin Health Check report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -240,6 +240,7 @@
 - [Security Performance Improvements](security/security-performance-improvements.md)
 - [Security Plugin](security/security-plugin.md)
 - [Security Plugin Dependencies](security/security-plugin-dependencies.md)
+- [Security Plugin Health Check](security/security-plugin-health-check.md)
 - [Security Role Mapping](security/security-role-mapping.md)
 - [Security Testing Framework](security/security-testing-framework.md)
 - [Security CI/CD](security/security-ci-cd.md)

--- a/docs/features/security/security-plugin-health-check.md
+++ b/docs/features/security/security-plugin-health-check.md
@@ -1,0 +1,124 @@
+# Security Plugin Health Check
+
+## Summary
+
+The Security plugin health check API (`GET _plugins/_security/health`) provides a way to verify whether the Security plugin is fully initialized and operational. This is particularly useful for load balancers and orchestration systems that need to determine node readiness before routing traffic.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Security Plugin Initialization"
+        A[Plugin Start] --> B[Create Security Index]
+        B --> C[Index Security Docs]
+        C --> D[Initialize BackendRegistry]
+        D --> E[Initialize PrivilegesEvaluator]
+        E --> F[Security Ready]
+    end
+    
+    subgraph "Health Check Components"
+        G[SecurityHealthAction] --> H[BackendRegistry]
+        G --> I[PrivilegesEvaluator]
+    end
+    
+    subgraph "Health Check Logic"
+        J[Request] --> K{Mode?}
+        K -->|strict| L{BackendRegistry.isInitialized?}
+        L -->|Yes| M{PrivilegesEvaluator.isInitialized?}
+        L -->|No| N[DOWN]
+        M -->|Yes| O[UP]
+        M -->|No| N
+        K -->|lenient| O
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SecurityHealthAction` | REST handler for the health check endpoint |
+| `BackendRegistry` | Manages authentication backends; must be initialized for AuthN |
+| `PrivilegesEvaluator` | Evaluates user privileges; must be initialized for AuthZ |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.cache.ttl_minutes` | Cache TTL reported in health response | 60 |
+
+The health check mode is determined by the Security plugin's operational mode:
+- **strict**: Full initialization checks (both AuthN and AuthZ)
+- **lenient**: Bypasses initialization checks
+
+### API Endpoint
+
+```
+GET _plugins/_security/health
+```
+
+### Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `status` | String | `UP` if fully initialized, `DOWN` otherwise |
+| `mode` | String | Current security mode (`strict` or `lenient`) |
+| `message` | String | Error message if status is `DOWN`, null otherwise |
+| `settings` | Object | Current security settings |
+
+### Usage Example
+
+```bash
+# Check security plugin health
+curl -XGET "https://localhost:9200/_plugins/_security/health"
+
+# Successful response
+{
+  "message": null,
+  "mode": "strict",
+  "status": "UP",
+  "settings": {
+    "plugins.security.cache.ttl_minutes": 60
+  }
+}
+
+# Not initialized response (HTTP 503)
+{
+  "message": "Not initialized",
+  "mode": "strict",
+  "status": "DOWN",
+  "settings": {
+    "plugins.security.cache.ttl_minutes": 60
+  }
+}
+```
+
+### Load Balancer Integration
+
+The health check endpoint is designed for use with load balancers:
+
+- Returns HTTP 200 when status is `UP`
+- Returns HTTP 503 (Service Unavailable) when status is `DOWN`
+- Does not require authentication, making it suitable for external health probes
+
+## Limitations
+
+- Only checks initialization status, not ongoing operational health
+- Does not validate connectivity to external authentication backends (LDAP, SAML, etc.)
+- In lenient mode, always reports `UP` regardless of actual initialization state
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#5626](https://github.com/opensearch-project/security/pull/5626) | Add AuthZ initialization completion check |
+
+## References
+
+- [Issue #5603](https://github.com/opensearch-project/security/issues/5603): Security Initialization Issues
+- [Security API Documentation](https://docs.opensearch.org/3.0/security/access-control/api/): Official API docs
+
+## Change History
+
+- **v3.3.0**: Added PrivilegesEvaluator (AuthZ) initialization check to health API. Previously only checked BackendRegistry (AuthN) initialization.

--- a/docs/releases/v3.3.0/features/security/security-plugin-health-check.md
+++ b/docs/releases/v3.3.0/features/security/security-plugin-health-check.md
@@ -1,0 +1,102 @@
+# Security Plugin Health Check
+
+## Summary
+
+This enhancement improves the Security plugin's health check API to include Authorization (AuthZ) initialization status. Previously, the health check only verified Authentication (AuthN) initialization via BackendRegistry. Now it also verifies that PrivilegesEvaluator is initialized, providing a more accurate health status for the Security plugin.
+
+## Details
+
+### What's New in v3.3.0
+
+The health check API (`GET _plugins/_security/health`) now validates both authentication and authorization subsystems are fully initialized before reporting `UP` status.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Health Check Flow"
+        A[Health Check Request] --> B{Mode Check}
+        B -->|strict| C{BackendRegistry Initialized?}
+        C -->|Yes| D{PrivilegesEvaluator Initialized?}
+        C -->|No| E[Status: DOWN]
+        D -->|Yes| F[Status: UP]
+        D -->|No| E
+        B -->|lenient| F
+    end
+    
+    subgraph "Security Initialization"
+        G[Security Plugin Start] --> H[BackendRegistry Init]
+        H --> I[PrivilegesEvaluator Init]
+        I --> J[Security Ready]
+    end
+```
+
+#### Modified Components
+
+| Component | Description |
+|-----------|-------------|
+| `SecurityHealthAction` | Now accepts `PrivilegesEvaluator` in constructor and checks its initialization status |
+| `OpenSearchSecurityPlugin` | Updated to pass `PrivilegesEvaluator` to `SecurityHealthAction` |
+
+#### Behavior Change
+
+| Scenario | Old Behavior | New Behavior |
+|----------|--------------|--------------|
+| BackendRegistry initialized, PrivilegesEvaluator not initialized | `UP` | `DOWN` |
+| Both BackendRegistry and PrivilegesEvaluator initialized | `UP` | `UP` |
+| BackendRegistry not initialized | `DOWN` | `DOWN` |
+
+### Usage Example
+
+```bash
+# Health check request
+curl -XGET "https://localhost:9200/_plugins/_security/health"
+
+# Response when fully initialized
+{
+  "message": null,
+  "mode": "strict",
+  "status": "UP",
+  "settings": {
+    "plugins.security.cache.ttl_minutes": 60
+  }
+}
+
+# Response when not fully initialized
+{
+  "message": "Not initialized",
+  "mode": "strict",
+  "status": "DOWN",
+  "settings": {
+    "plugins.security.cache.ttl_minutes": 60
+  }
+}
+```
+
+### Migration Notes
+
+- No configuration changes required
+- Load balancers using the health check endpoint will now correctly detect partial initialization states
+- Applications relying on the health check should expect `DOWN` status during the brief period between AuthN and AuthZ initialization
+
+## Limitations
+
+- The health check only validates initialization status, not ongoing operational health
+- In `lenient` mode, the initialization checks are bypassed
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5626](https://github.com/opensearch-project/security/pull/5626) | Add AuthZ initialization completion check in health check API |
+
+## References
+
+- [Issue #5603](https://github.com/opensearch-project/security/issues/5603): Security Initialization Issues (bug report)
+- [Security API Documentation](https://docs.opensearch.org/3.0/security/access-control/api/): Official Security plugin API docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/security-plugin-health-check.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -92,6 +92,7 @@
 - [Resource Access Control Documentation](features/security/resource-access-control-documentation.md)
 - [Security Configuration Enhancements](features/security/security-configuration-enhancements.md)
 - [Security Plugin Bug Fixes](features/security/security-plugin-bug-fixes.md)
+- [Security Plugin Health Check](features/security/security-plugin-health-check.md)
 - [SSL/TLS Compatibility Fix](features/security/ssl-tls.md)
 - [Sync Protobufs Version with Core](features/security/sync-protobufs-version.md)
 - [Security Plugin Dependencies](features/security/security-plugin-dependencies.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security Plugin Health Check enhancement in OpenSearch v3.3.0.

## Changes

### Release Report
- `docs/releases/v3.3.0/features/security/security-plugin-health-check.md`

### Feature Report (new)
- `docs/features/security/security-plugin-health-check.md`

### Index Updates
- Updated `docs/releases/v3.3.0/index.md`
- Updated `docs/features/index.md`

## Key Changes in v3.3.0

The health check API (`GET _plugins/_security/health`) now validates both authentication (BackendRegistry) and authorization (PrivilegesEvaluator) subsystems are fully initialized before reporting `UP` status.

**Behavior Change:**
| Scenario | Old Behavior | New Behavior |
|----------|--------------|--------------|
| BackendRegistry initialized, PrivilegesEvaluator not initialized | `UP` | `DOWN` |

## Related

- PR: [opensearch-project/security#5626](https://github.com/opensearch-project/security/pull/5626)
- Issue: [opensearch-project/security#5603](https://github.com/opensearch-project/security/issues/5603)
- Investigation Issue: #1344