### PR TITLE
docs: add Performance Analyzer Enhancements report for v3.3.0

### DIFF
--- a/docs/features/performance-analyzer/performance-analyzer.md
+++ b/docs/features/performance-analyzer/performance-analyzer.md
@@ -115,6 +115,8 @@ GET localhost:9600/_plugins/_performanceanalyzer/rca?name=HighHeapUsageClusterRC
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#845](https://github.com/opensearch-project/performance-analyzer/pull/845) | Use Subclass method for Version and Channel type for security plugin compatibility |
+| v3.3.0 | [#846](https://github.com/opensearch-project/performance-analyzer/pull/846) | Increment to 3.3.0.0 and update SHA files |
 | v3.2.0 | [#826](https://github.com/opensearch-project/performance-analyzer/pull/826) | Bump SpotBugs to 6.2.2 and Checkstyle to 10.26.1 |
 | v2.17.0 | [#690](https://github.com/opensearch-project/performance-analyzer/pull/690) | Added CacheConfig Telemetry collectors |
 | v2.17.0 | [#712](https://github.com/opensearch-project/performance-analyzer/pull/712) | Bump PA to use 1.6.0 PA commons lib |
@@ -128,5 +130,6 @@ GET localhost:9600/_plugins/_performanceanalyzer/rca?name=HighHeapUsageClusterRC
 
 ## Change History
 
+- **v3.3.0** (2026-01-11): Transport channel wrapper improvements - delegate getProfileName(), getChannelType(), getVersion(), and get() to wrapped channel; removed getInnerChannel() method for better security plugin compatibility
 - **v3.2.0** (2025-07-18): Build infrastructure update - SpotBugs 6.2.2, Checkstyle 10.26.1; Removed CVE-2025-27820 workaround
 - **v2.17.0** (2024-09-17): Added RTFCacheConfigMetricsCollector for cache configuration telemetry; Updated PA Commons dependency to 1.6.0

--- a/docs/releases/v3.3.0/features/performance-analyzer/performance-analyzer-enhancements.md
+++ b/docs/releases/v3.3.0/features/performance-analyzer/performance-analyzer-enhancements.md
@@ -1,0 +1,98 @@
+# Performance Analyzer Enhancements
+
+## Summary
+
+This release improves the Performance Analyzer's transport channel wrapper classes to properly delegate method calls to the underlying wrapped channel, enhancing compatibility with the security plugin.
+
+## Details
+
+### What's New in v3.3.0
+
+The Performance Analyzer transport channel wrappers (`PerformanceAnalyzerTransportChannel` and `RTFPerformanceAnalyzerTransportChannel`) have been updated to delegate method calls to the wrapped channel instead of returning hardcoded values. This change improves interoperability with the security plugin.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.3.0"
+        TC1[TransportChannel]
+        PA1[PATransportChannel]
+        PA1 -->|wraps| TC1
+        PA1 -->|getChannelType| HV1[Hardcoded Value]
+        PA1 -->|getProfileName| HV2[Hardcoded Value]
+        PA1 -->|getInnerChannel| TC1
+    end
+    
+    subgraph "After v3.3.0"
+        TC2[TransportChannel]
+        PA2[PATransportChannel]
+        PA2 -->|wraps| TC2
+        PA2 -->|getChannelType| TC2
+        PA2 -->|getProfileName| TC2
+        PA2 -->|getVersion| TC2
+        PA2 -->|get| TC2
+    end
+```
+
+#### Key Changes
+
+| Method | Before | After |
+|--------|--------|-------|
+| `getProfileName()` | Returns hardcoded `"PerformanceAnalyzerTransportChannelProfile"` | Delegates to `original.getProfileName()` |
+| `getChannelType()` | Returns hardcoded `"PerformanceAnalyzerTransportChannelType"` | Delegates to `original.getChannelType()` |
+| `getVersion()` | Not implemented | Delegates to `original.getVersion()` |
+| `get(name, clazz)` | Not implemented | Delegates to `original.get(name, clazz)` |
+| `getInnerChannel()` | Returns wrapped channel | Removed (no longer needed) |
+
+#### New Method Implementations
+
+```java
+@Override
+public String getProfileName() {
+    return this.original == null ? null : this.original.getProfileName();
+}
+
+@Override
+public String getChannelType() {
+    return this.original == null ? null : this.original.getChannelType();
+}
+
+@Override
+public <T> Optional<T> get(String name, Class<T> clazz) {
+    return this.original == null ? Optional.empty() : this.original.get(name, clazz);
+}
+
+@Override
+public Version getVersion() {
+    return this.original == null ? null : this.original.getVersion();
+}
+```
+
+### Migration Notes
+
+- The `getInnerChannel()` method has been removed from both `PerformanceAnalyzerTransportChannel` and `RTFPerformanceAnalyzerTransportChannel`
+- Security plugin integration now uses standard `TransportChannel` interface methods instead of reflection-based access
+- No configuration changes required
+
+## Limitations
+
+- None specific to this release
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#845](https://github.com/opensearch-project/performance-analyzer/pull/845) | Use Subclass method for Version and Channel type which is understood by security plugin |
+| [#846](https://github.com/opensearch-project/performance-analyzer/pull/846) | Increment to 3.3.0.0 and update SHA files |
+
+## References
+
+- [Issue #606](https://github.com/opensearch-project/performance-analyzer/issues/606): Related issue for transport channel delegation
+- [PR #609](https://github.com/opensearch-project/performance-analyzer/pull/609): Earlier attempt to fix PATransportChannel delegation
+- [Performance Analyzer Documentation](https://docs.opensearch.org/3.0/monitoring-your-cluster/pa/index/): Official docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/performance-analyzer/performance-analyzer.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -167,6 +167,10 @@
 
 - [Notifications Plugin Fixes](features/notifications/notifications-plugin-fixes.md)
 
+### Performance Analyzer
+
+- [Performance Analyzer Enhancements](features/performance-analyzer/performance-analyzer-enhancements.md)
+
 ### Flow Framework
 
 - [Flow Framework Fixes](features/flow-framework/flow-framework-fixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for Performance Analyzer Enhancements in OpenSearch v3.3.0.

### Changes

**Release Report** (`docs/releases/v3.3.0/features/performance-analyzer/performance-analyzer-enhancements.md`):
- Documents transport channel wrapper improvements
- Explains the change from hardcoded values to delegation pattern
- Lists the new method implementations

**Feature Report Update** (`docs/features/performance-analyzer/performance-analyzer.md`):
- Added v3.3.0 PRs to Related PRs table
- Added v3.3.0 entry to Change History

**Release Index Update** (`docs/releases/v3.3.0/index.md`):
- Added Performance Analyzer section with link to the new report

### Key Changes in v3.3.0

- `getProfileName()` and `getChannelType()` now delegate to wrapped channel instead of returning hardcoded values
- Added `getVersion()` and `get(name, clazz)` method implementations
- Removed `getInnerChannel()` method (no longer needed for security plugin compatibility)

### Related PRs

- [#845](https://github.com/opensearch-project/performance-analyzer/pull/845): Use Subclass method for Version and Channel type
- [#846](https://github.com/opensearch-project/performance-analyzer/pull/846): Version increment to 3.3.0.0

Closes #1342