### PR TITLE
docs: add Remote Client Enhancements report for v3.3.0

### DIFF
--- a/docs/features/opensearch-remote-metadata-sdk/remote-metadata-sdk.md
+++ b/docs/features/opensearch-remote-metadata-sdk/remote-metadata-sdk.md
@@ -127,6 +127,11 @@ The following plugins support multi-tenancy with remote metadata storage:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#234](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/234) | Add SeqNo and PrimaryTerm support to Put and Delete requests |
+| v3.3.0 | [#244](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/244) | Add RefreshPolicy and timeout support to Put, Update, Delete, and Bulk requests |
+| v3.3.0 | [#236](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/236) | Throw exception on empty string for put request ID |
+| v3.3.0 | [#250](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/250) | Update argument type for ThreadContextAccess:doPrivileged |
+| v3.3.0 | [#254](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/254) | Use AccessController instead of ThreadContextAccess |
 | v3.0.0 | [#124](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/124) | Add a developer guide |
 | v3.0.0 | [#114](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/114) | Fix version conflict check for update |
 | v3.0.0 | [#121](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/121) | Use SdkClientDelegate's classloader for ServiceLoader |
@@ -147,9 +152,13 @@ The following plugins support multi-tenancy with remote metadata storage:
 - [Issue #127](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/issues/127): DDB getItem() eventually consistent bug
 - [Issue #132](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/issues/132): Aggregation API failure bug
 - [Issue #154](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/issues/154): DDBClient validation bug
+- [Issue #178](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/issues/178): RefreshPolicy support request
+- [Issue #191](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/issues/191): Empty string ID validation
+- [Issue #233](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/issues/233): SeqNo/PrimaryTerm support request
 - [Issue #1082](https://github.com/opensearch-project/flow-framework/issues/1082): Version conflict bug in flow-framework
 
 ## Change History
 
+- **v3.3.0** (2025-09-22): Added SeqNo/PrimaryTerm support for Put and Delete requests, RefreshPolicy and timeout configuration for write operations, empty string ID validation fix, and ThreadContextAccess API compatibility fixes (PRs #234, #244, #236, #250, #254)
 - **v3.0.0** (2025-05-06): Bug fixes for version conflict detection, DynamoDB consistency, error handling, response passthrough, URL encoding, and request validation (PRs #114, #121, #128, #130, #141, #156, #157, #158)
 - **v3.0.0** (2025-05-06): Added developer guide with migration instructions (PR #124)

--- a/docs/releases/v3.3.0/features/opensearch-remote-metadata-sdk/remote-client-enhancements.md
+++ b/docs/releases/v3.3.0/features/opensearch-remote-metadata-sdk/remote-client-enhancements.md
@@ -1,0 +1,142 @@
+# Remote Client Enhancements
+
+## Summary
+
+OpenSearch Remote Metadata SDK v3.3.0 introduces enhancements to write request handling and bug fixes for API compatibility. The release adds support for sequence number and primary term on Put and Delete requests for optimistic concurrency control, adds RefreshPolicy and timeout configuration for write operations, and fixes issues with empty string ID validation and ThreadContextAccess API compatibility.
+
+## Details
+
+### What's New in v3.3.0
+
+This release focuses on improving the write request API with better concurrency control and configuration options, along with critical bug fixes for API compatibility.
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `WriteDataObjectRequest` | New abstract parent class for Put, Update, and Delete requests with shared seqNo/primaryTerm handling |
+| `RefreshPolicy` support | Configurable refresh behavior for write operations (IMMEDIATE, WAIT_UNTIL, NONE) |
+| `timeout` support | Configurable timeout for write operations |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `refreshPolicy` | When to refresh written data (IMMEDIATE, WAIT_UNTIL, NONE) | `IMMEDIATE` |
+| `timeout` | Timeout for write operations | `1m` |
+| `ifSeqNo` | Sequence number for optimistic concurrency control | `null` |
+| `ifPrimaryTerm` | Primary term for optimistic concurrency control | `null` |
+
+#### API Changes
+
+**SeqNo and PrimaryTerm Support (PR #234)**
+
+Put and Delete requests now support optimistic concurrency control via sequence numbers and primary terms:
+
+```java
+// Put with version check
+PutDataObjectRequest request = PutDataObjectRequest.builder()
+    .index("my-index")
+    .id("doc-id")
+    .dataObject(myObject)
+    .ifSeqNo(5L)
+    .ifPrimaryTerm(2L)
+    .build();
+
+// Delete with version check
+DeleteDataObjectRequest request = DeleteDataObjectRequest.builder()
+    .index("my-index")
+    .id("doc-id")
+    .ifSeqNo(5L)
+    .ifPrimaryTerm(2L)
+    .build();
+```
+
+**RefreshPolicy and Timeout Support (PR #244)**
+
+Write operations now support configurable refresh policy and timeout:
+
+```java
+PutDataObjectRequest request = PutDataObjectRequest.builder()
+    .index("my-index")
+    .id("doc-id")
+    .dataObject(myObject)
+    .refreshPolicy(RefreshPolicy.WAIT_UNTIL)
+    .timeout("30s")
+    .build();
+
+// Bulk requests also support these settings
+BulkDataObjectRequest bulkRequest = BulkDataObjectRequest.builder()
+    .globalIndex("my-index")
+    .build()
+    .setRefreshPolicy(RefreshPolicy.WAIT_UNTIL)
+    .timeout("45s")
+    .add(putRequest)
+    .add(deleteRequest);
+```
+
+### Usage Example
+
+```java
+// Complete example with all new features
+PutDataObjectRequest putRequest = PutDataObjectRequest.builder()
+    .index("my-index")
+    .id("doc-id")
+    .tenantId("tenant-1")
+    .dataObject(myDataObject)
+    .ifSeqNo(currentSeqNo)        // Optimistic concurrency
+    .ifPrimaryTerm(currentTerm)   // Optimistic concurrency
+    .refreshPolicy(RefreshPolicy.IMMEDIATE)  // Refresh immediately
+    .timeout("30s")               // 30 second timeout
+    .build();
+
+sdkClient.putDataObjectAsync(putRequest)
+    .whenComplete((response, error) -> {
+        if (error != null) {
+            if (error.getCause() instanceof OpenSearchStatusException) {
+                OpenSearchStatusException ose = (OpenSearchStatusException) error.getCause();
+                if (ose.status() == RestStatus.CONFLICT) {
+                    // Handle version conflict
+                }
+            }
+        }
+    });
+```
+
+### Bug Fixes
+
+| PR | Issue | Description |
+|----|-------|-------------|
+| #236 | #191 | Throw exception on empty string for put request ID - aligns with OpenSearch behavior |
+| #250 | - | Update argument type for `ThreadContextAccess.doPrivileged()` to align with OpenSearch core changes |
+| #254 | - | Use `AccessController` instead of `ThreadContextAccess` for internal use to fix `NoSuchMethodError` in ml-commons integration tests |
+
+## Limitations
+
+- RefreshPolicy and timeout may not be applicable on all client implementations (e.g., DynamoDB doesn't have an equivalent concept for refresh)
+- Bulk request individual items always use `RefreshPolicy.NONE` - the refresh policy applies to the bulk request as a whole
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#234](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/234) | Add SeqNo and PrimaryTerm support to Put and Delete requests |
+| [#244](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/244) | Add RefreshPolicy and timeout support to Put, Update, Delete, and Bulk requests |
+| [#236](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/236) | Throw exception on empty string for put request ID |
+| [#250](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/250) | Update argument type for ThreadContextAccess:doPrivileged |
+| [#254](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/254) | Use AccessController instead of ThreadContextAccess as it's for internal use |
+
+## References
+
+- [Issue #233](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/issues/233): SeqNo/PrimaryTerm support request
+- [Issue #136](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/issues/136): Timeout support request
+- [Issue #178](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/issues/178): RefreshPolicy support request
+- [Issue #191](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/issues/191): Empty string ID validation
+- [OpenSearch PR #19239](https://github.com/opensearch-project/OpenSearch/pull/19239): ThreadContextAccess API change in OpenSearch core
+- [Plugin as a Service Documentation](https://docs.opensearch.org/3.0/developer-documentation/plugin-as-a-service/index/): Official OpenSearch documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-remote-metadata-sdk/remote-metadata-sdk.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -182,3 +182,7 @@
 ### Dependencies
 
 - [Dependency Updates](features/dependency-updates.md)
+
+### OpenSearch Remote Metadata SDK
+
+- [Remote Client Enhancements](features/opensearch-remote-metadata-sdk/remote-client-enhancements.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Remote Client Enhancements in OpenSearch Remote Metadata SDK v3.3.0.

### Changes

**Release Report Created:**
- `docs/releases/v3.3.0/features/opensearch-remote-metadata-sdk/remote-client-enhancements.md`

**Feature Report Updated:**
- `docs/features/opensearch-remote-metadata-sdk/remote-metadata-sdk.md`
  - Added v3.3.0 PRs to Related PRs table
  - Added v3.3.0 entry to Change History
  - Added new issue references

### Key Changes in v3.3.0

**Enhancements:**
- SeqNo and PrimaryTerm support for Put and Delete requests (PR #234)
- RefreshPolicy and timeout support for Put, Update, Delete, and Bulk requests (PR #244)

**Bug Fixes:**
- Throw exception on empty string for put request ID (PR #236)
- Update argument type for ThreadContextAccess:doPrivileged (PR #250)
- Use AccessController instead of ThreadContextAccess for internal use (PR #254)

### Related Issue
Closes #1341