### PR TITLE
docs: add ML Commons Tools Enhancements report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -377,6 +377,7 @@
 - [ML Commons Sparse Encoding](ml-commons/ml-commons-sparse-encoding.md)
 - [ML Commons Stability and Reliability](ml-commons/ml-commons-stability.md)
 - [ML Commons Test Fixes](ml-commons/ml-commons-test-fixes.md)
+- [ML Commons Tools](ml-commons/ml-commons-tools.md)
 - [ML Config API](ml-commons/ml-config-api.md)
 - [ML Inference Processor](ml-commons/ml-inference-processor.md)
 - [PlanExecuteReflect Agent](ml-commons/planexecutereflect-agent.md)

--- a/docs/features/ml-commons/ml-commons-tools.md
+++ b/docs/features/ml-commons/ml-commons-tools.md
@@ -1,0 +1,127 @@
+# ML Commons Tools
+
+## Summary
+
+ML Commons Tools provide a framework for AI agents to interact with OpenSearch data and services. Tools like SearchIndexTool, ListIndexTool, and IndexMappingTool enable agents to search indexes, list available indexes, and retrieve index mappings. The Execute Tool API allows direct tool execution independent of agents.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "ML Commons Tools Framework"
+        API[Execute Tool API]
+        Agent[Agent Framework]
+    end
+    
+    subgraph "Available Tools"
+        SIT[SearchIndexTool]
+        LIT[ListIndexTool]
+        IMT[IndexMappingTool]
+        Other[Other Tools...]
+    end
+    
+    subgraph "Data Layer"
+        Index[(OpenSearch Index)]
+        Mapping[Index Mappings]
+    end
+    
+    API --> SIT
+    API --> LIT
+    API --> IMT
+    Agent --> SIT
+    Agent --> LIT
+    Agent --> IMT
+    
+    SIT --> Index
+    LIT --> Index
+    IMT --> Mapping
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SearchIndexTool` | Searches an index using Query DSL and returns results |
+| `ListIndexTool` | Lists available indexes in the cluster |
+| `IndexMappingTool` | Retrieves index mappings |
+| `Execute Tool API` | REST API for direct tool execution |
+| `PlainNumberAdapter` | Gson adapter for numeric serialization without scientific notation |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ml_commons.execute_tools_enabled` | Enable/disable Execute Tool API | `true` (v3.3.0+) |
+| `plugins.ml_commons.agent_framework_enabled` | Enable/disable agent framework | `true` |
+
+### Usage Example
+
+#### Using SearchIndexTool with an Agent
+
+```json
+POST /_plugins/_ml/agents/_register
+{
+  "name": "Search Agent",
+  "type": "flow",
+  "tools": [
+    {
+      "type": "SearchIndexTool"
+    }
+  ]
+}
+```
+
+#### Direct Tool Execution
+
+```json
+POST /_plugins/_ml/tools/SearchIndexTool/_execute
+{
+  "parameters": {
+    "input": "{\"index\": \"my-index\", \"query\": {\"match_all\": {}}}"
+  }
+}
+```
+
+### JSON Number Handling
+
+SearchIndexTool uses `PLAIN_NUMBER_GSON` for query serialization to avoid scientific notation issues:
+
+```java
+// Input with scientific notation
+{"range": {"price": {"gte": 1e-6}}}
+
+// Serialized output (plain format)
+{"range": {"price": {"gte": 0.000001}}}
+```
+
+Special value handling:
+- `NaN` → `null`
+- `Infinity` → `null`
+- `-Infinity` → `null`
+
+## Limitations
+
+- Execute Tool API requires `plugins.ml_commons.execute_tools_enabled` to be `true`
+- `NaN` and `Infinity` values are converted to `null` in SearchIndexTool queries
+- Tools must be registered before use with agents
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#4296](https://github.com/opensearch-project/ml-commons/pull/4296) | Enable execute tool feature flag by default |
+| v3.3.0 | [#4133](https://github.com/opensearch-project/ml-commons/pull/4133) | Add PlainNumberAdapter for Gson in SearchIndexTool |
+| v3.3.0 | [#4215](https://github.com/opensearch-project/ml-commons/pull/4215) | Standardize setting naming convention |
+
+## References
+
+- [SearchIndexTool Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/tools/search-index-tool/)
+- [Tools Overview](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/tools/index/)
+- [ML Commons Cluster Settings](https://docs.opensearch.org/3.0/ml-commons-plugin/cluster-settings/)
+- [Execute Agent API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/agent-apis/execute-agent/)
+
+## Change History
+
+- **v3.3.0** (2026-01): Execute Tool API enabled by default, PlainNumberAdapter added for SearchIndexTool, setting naming standardization

--- a/docs/releases/v3.3.0/features/ml-commons/ml-commons-tools-enhancements.md
+++ b/docs/releases/v3.3.0/features/ml-commons/ml-commons-tools-enhancements.md
@@ -1,0 +1,102 @@
+# ML Commons Tools Enhancements
+
+## Summary
+
+OpenSearch v3.3.0 introduces several enhancements to ML Commons tools, including enabling the Execute Tool API by default, improved JSON number serialization in SearchIndexTool, and standardized setting naming conventions. These changes improve usability and consistency for agent-based workflows.
+
+## Details
+
+### What's New in v3.3.0
+
+#### Execute Tool API Enabled by Default
+
+The `plugins.ml_commons.execute_tools_enabled` setting now defaults to `true`, making the Execute Tool API available out-of-the-box without requiring manual configuration.
+
+| Setting | Old Default | New Default |
+|---------|-------------|-------------|
+| `plugins.ml_commons.execute_tools_enabled` | `false` | `true` |
+
+This change allows users to immediately use the Execute Tool API for running tools independently of agents.
+
+#### PlainNumberAdapter for SearchIndexTool
+
+A new `PlainNumberAdapter` has been added to improve JSON serialization of numeric values in SearchIndexTool queries. This addresses issues with scientific notation in query parameters.
+
+```mermaid
+flowchart LR
+    A[Query Input] --> B[PLAIN_NUMBER_GSON]
+    B --> C{Number Type}
+    C -->|Double/Float| D[PlainDoubleAdapter]
+    C -->|Other| E[Standard Gson]
+    D --> F[Plain String Output]
+    E --> F
+    F --> G[SearchIndexTool]
+```
+
+Key improvements:
+- Avoids binary float artifacts using `BigDecimal.valueOf`
+- Strips trailing zeros and writes integers when safe
+- Handles `NaN` and `Infinity` by writing `null`
+- Ensures no scientific notation in output (e.g., `1e30` becomes `1000000000000000000000000000000`)
+
+#### Setting Name Standardization
+
+All ML Commons settings now use a consistent naming convention with the `plugins.ml_commons.` prefix defined as a constant `ML_PLUGIN_SETTING_PREFIX`.
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `PlainDoubleAdapter` | Custom Gson TypeAdapter for Double serialization without scientific notation |
+| `PlainFloatAdapter` | Custom Gson TypeAdapter for Float serialization without scientific notation |
+| `PLAIN_NUMBER_GSON` | Pre-configured Gson instance with number adapters registered |
+
+#### Configuration Changes
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ml_commons.execute_tools_enabled` | Enable/disable Execute Tool API | `true` |
+
+### Usage Example
+
+With the Execute Tool API now enabled by default, you can directly execute tools:
+
+```json
+POST /_plugins/_ml/tools/SearchIndexTool/_execute
+{
+  "parameters": {
+    "input": "{\"index\": \"my-index\", \"query\": {\"range\": {\"price\": {\"gte\": 0.001}}}}"
+  }
+}
+```
+
+The PlainNumberAdapter ensures that numeric values like `0.001` are serialized correctly without scientific notation.
+
+### Migration Notes
+
+- No migration required - changes are backward compatible
+- The Execute Tool API is now enabled by default; to disable, set `plugins.ml_commons.execute_tools_enabled: false`
+
+## Limitations
+
+- `PlainDoubleAdapter` and `PlainFloatAdapter` write `null` for `NaN` and `Infinity` values
+- The adapters are only applied to SearchIndexTool query processing
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4296](https://github.com/opensearch-project/ml-commons/pull/4296) | Enable execute tool feature flag by default |
+| [#4133](https://github.com/opensearch-project/ml-commons/pull/4133) | Add PlainNumberAdapter and corresponding tests for Gson in SearchIndexTool |
+| [#4215](https://github.com/opensearch-project/ml-commons/pull/4215) | Change the setting name to same naming convention with others |
+
+## References
+
+- [SearchIndexTool Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/tools/search-index-tool/)
+- [ML Commons Cluster Settings](https://docs.opensearch.org/3.0/ml-commons-plugin/cluster-settings/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/ml-commons-tools.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -101,6 +101,7 @@
 ### ML Commons
 
 - [ML Commons Bug Fixes](features/ml-commons/ml-commons-bug-fixes.md)
+- [ML Commons Tools Enhancements](features/ml-commons/ml-commons-tools-enhancements.md)
 - [Metrics Framework Bug Fix](features/ml-commons/metrics-framework.md)
 - [Move Common String](features/ml-commons/move-common-string.md)
 - [Updating Gson Version to Resolve Conflict Coming from Core](features/ml-commons/updating-gson-version-to-resolve-conflict-coming-from-core.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for ML Commons Tools Enhancements in OpenSearch v3.3.0.

### Changes in v3.3.0

1. **Execute Tool API Enabled by Default** - The `plugins.ml_commons.execute_tools_enabled` setting now defaults to `true`
2. **PlainNumberAdapter for SearchIndexTool** - Improved JSON number serialization to avoid scientific notation issues
3. **Setting Name Standardization** - All ML Commons settings now use consistent `plugins.ml_commons.` prefix

### Reports Created

- Release report: `docs/releases/v3.3.0/features/ml-commons/ml-commons-tools-enhancements.md`
- Feature report: `docs/features/ml-commons/ml-commons-tools.md`

### Related PRs

- [#4296](https://github.com/opensearch-project/ml-commons/pull/4296) - Enable execute tool feature flag by default
- [#4133](https://github.com/opensearch-project/ml-commons/pull/4133) - Add PlainNumberAdapter for Gson in SearchIndexTool
- [#4215](https://github.com/opensearch-project/ml-commons/pull/4215) - Change setting name to same naming convention

Closes #1340