### PR TITLE
docs: add ML Commons Multi-tenancy report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -374,6 +374,7 @@
 - [ML Commons Memory Metadata](ml-commons/ml-commons-memory-metadata.md)
 - [ML Commons Model & Inference](ml-commons/ml-commons-model-inference.md)
 - [ML Commons Model Deployment](ml-commons/ml-commons-model-deployment.md)
+- [ML Commons Multi-tenancy](ml-commons/ml-commons-multi-tenancy.md)
 - [ML Commons Sparse Encoding](ml-commons/ml-commons-sparse-encoding.md)
 - [ML Commons Stability and Reliability](ml-commons/ml-commons-stability.md)
 - [ML Commons Test Fixes](ml-commons/ml-commons-test-fixes.md)

--- a/docs/features/ml-commons/ml-commons-multi-tenancy.md
+++ b/docs/features/ml-commons/ml-commons-multi-tenancy.md
@@ -1,0 +1,145 @@
+# ML Commons Multi-tenancy
+
+## Summary
+
+ML Commons multi-tenancy enables multiple tenants to share a single OpenSearch instance while maintaining data isolation and security. This feature ensures that ML resources such as models, connectors, agents, and guardrails are properly isolated between tenants, making ML Commons suitable for cloud service environments.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Multi-tenant ML Commons"
+        subgraph "Tenant A"
+            A1[Models] --> SDK1[SdkClient]
+            A2[Connectors] --> SDK1
+            A3[Agents] --> SDK1
+            A4[Guardrails] --> SDK1
+        end
+        
+        subgraph "Tenant B"
+            B1[Models] --> SDK2[SdkClient]
+            B2[Connectors] --> SDK2
+            B3[Agents] --> SDK2
+            B4[Guardrails] --> SDK2
+        end
+        
+        SDK1 --> Store[(OpenSearch Indices)]
+        SDK2 --> Store
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    Request[API Request] --> Auth[Authentication]
+    Auth --> TenantId[Extract Tenant ID]
+    TenantId --> Resource[ML Resource Operation]
+    Resource --> SdkClient[SdkClient with Tenant Context]
+    SdkClient --> Index[Tenant-Filtered Index Access]
+```
+
+### Components
+
+| Component | Description | Multi-tenancy Support |
+|-----------|-------------|----------------------|
+| `MLModel` | Machine learning model metadata | Tenant ID stored with model |
+| `Connector` | External model service connector | Tenant-aware access control |
+| `Agent` | Conversational AI agent | Tenant isolation for agent data |
+| `Guardrail` | Input/output validation | Tenant-aware stop word validation |
+| `LocalRegexGuardrail` | Regex-based guardrail | Uses SdkClient for tenant-aware searches |
+| `ModelGuardrail` | Model-based guardrail | Stores tenant context |
+| `MLGuard` | Guardrail orchestrator | Passes tenant context to guardrails |
+
+### Configuration
+
+Multi-tenancy is configured at the cluster level:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ml_commons.multi_tenancy_enabled` | Enable multi-tenancy | `false` |
+
+### Guardrail Multi-tenancy
+
+The guardrail system validates model inputs and outputs against stop words stored in indices. With multi-tenancy support:
+
+1. Each tenant can have their own stop word indices
+2. Stop word validation is performed within tenant context
+3. The `SdkClient` ensures tenant isolation during searches
+
+```java
+// Guardrail initialization with tenant context
+guardrail.init(xContentRegistry, client, sdkClient, tenantId);
+
+// Tenant-aware stop word search
+SearchDataObjectRequest request = SearchDataObjectRequest.builder()
+    .indices(indexName)
+    .searchSourceBuilder(searchSourceBuilder)
+    .tenantId(tenantId)
+    .build();
+```
+
+### Usage Example
+
+```yaml
+# Model registration with guardrails in multi-tenant environment
+POST /_plugins/_ml/models/_register?deploy=true
+{
+  "name": "Claude Model with Guardrails",
+  "function_name": "remote",
+  "connector_id": "<connector_id>",
+  "guardrails": {
+    "type": "local_regex",
+    "input_guardrail": {
+      "stop_words": [
+        {
+          "index_name": "tenant_stop_words",
+          "source_fields": ["title"]
+        }
+      ],
+      "regex": [".*prohibited.*"]
+    },
+    "output_guardrail": {
+      "stop_words": [
+        {
+          "index_name": "tenant_stop_words",
+          "source_fields": ["title"]
+        }
+      ]
+    }
+  }
+}
+```
+
+## Limitations
+
+- Multi-tenancy must be enabled at cluster startup
+- All ML resources must be migrated when enabling multi-tenancy on existing clusters
+- `ModelGuardrail` stores tenant context but does not yet use it for model-based validation
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#4120](https://github.com/opensearch-project/ml-commons/pull/4120) | Support multi-tenancy for LocalRegexGuardrail |
+| v3.3.0 | [#4196](https://github.com/opensearch-project/ml-commons/pull/4196) | Fixing validate access for multi-tenancy |
+| v3.0.0 | [#3700](https://github.com/opensearch-project/ml-commons/pull/3700) | Fix config index masterkey for multi-tenancy |
+| v2.19.0 | [#3432](https://github.com/opensearch-project/ml-commons/pull/3432) | Multi-tenancy support for ML components |
+| v2.19.0 | [#3416](https://github.com/opensearch-project/ml-commons/pull/3416) | Multi-tenancy support additions |
+| v2.19.0 | [#3399](https://github.com/opensearch-project/ml-commons/pull/3399) | Multi-tenancy support additions |
+| v2.19.0 | [#3382](https://github.com/opensearch-project/ml-commons/pull/3382) | Multi-tenancy support additions |
+| v2.19.0 | [#3307](https://github.com/opensearch-project/ml-commons/pull/3307) | Primary setup for multi-tenancy |
+
+## References
+
+- [Issue #4119](https://github.com/opensearch-project/ml-commons/issues/4119): Add multi-tenancy support to Guardrails
+- [Guardrails Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/guardrails/): Official guardrails configuration guide
+- [Multi-tenancy Configuration](https://docs.opensearch.org/3.0/security/multi-tenancy/multi-tenancy-config/): OpenSearch multi-tenancy setup
+
+## Change History
+
+- **v3.3.0**: Added multi-tenancy support for LocalRegexGuardrail using SdkClient
+- **v3.0.0**: Fixed config index masterkey for multi-tenancy
+- **v2.19.0**: Initial multi-tenancy implementation for connectors, models, agents

--- a/docs/releases/v3.3.0/features/ml-commons/ml-commons-multi-tenancy.md
+++ b/docs/releases/v3.3.0/features/ml-commons/ml-commons-multi-tenancy.md
@@ -1,0 +1,113 @@
+# ML Commons Multi-tenancy
+
+## Summary
+
+This release adds multi-tenancy support to the LocalRegexGuardrail component in ML Commons. The change enables guardrails to work correctly in multi-tenant environments where multiple tenants share a single OpenSearch instance, ensuring proper tenant isolation when validating model inputs and outputs against stop words.
+
+## Details
+
+### What's New in v3.3.0
+
+The LocalRegexGuardrail component now supports multi-tenancy through the integration of the SDK client (`SdkClient`) for performing search requests. This allows guardrails to properly isolate stop word validation per tenant.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.3.0"
+        A1[LocalRegexGuardrail] --> B1[Client]
+        B1 --> C1[Stop Words Index]
+    end
+    
+    subgraph "After v3.3.0"
+        A2[LocalRegexGuardrail] --> B2[SdkClient]
+        B2 --> C2[SearchDataObjectRequest]
+        C2 --> D2[Stop Words Index]
+        C2 -.-> E2[tenantId]
+    end
+```
+
+#### Modified Components
+
+| Component | Change | Description |
+|-----------|--------|-------------|
+| `Guardrail` | Interface updated | `init()` method now accepts `SdkClient` and `tenantId` parameters |
+| `LocalRegexGuardrail` | Multi-tenancy support | Uses `SdkClient` for tenant-aware stop word searches |
+| `ModelGuardrail` | Interface updated | Stores `SdkClient` and `tenantId` for future use |
+| `MLGuard` | Constructor updated | Passes `SdkClient` and `tenantId` to guardrails |
+| `MLModelManager` | Integration | Passes tenant context when setting up guardrails |
+
+#### API Changes
+
+The `Guardrail.init()` method signature changed:
+
+```java
+// Before
+void init(NamedXContentRegistry xContentRegistry, Client client);
+
+// After
+void init(NamedXContentRegistry xContentRegistry, Client client, SdkClient sdkClient, String tenantId);
+```
+
+#### New Dependencies
+
+| Dependency | Purpose |
+|------------|---------|
+| `SdkClient` | Remote metadata client for tenant-aware operations |
+| `SearchDataObjectRequest` | Tenant-aware search request builder |
+| `SdkClientUtils` | Utility for wrapping search completion callbacks |
+
+### Usage Example
+
+When registering a model with guardrails in a multi-tenant environment, the guardrails automatically inherit the tenant context:
+
+```json
+POST /_plugins/_ml/models/_register?deploy=true
+{
+  "name": "Model with Guardrails",
+  "function_name": "remote",
+  "connector_id": "<connector_id>",
+  "guardrails": {
+    "type": "local_regex",
+    "input_guardrail": {
+      "stop_words": [
+        {
+          "index_name": "stop_words_index",
+          "source_fields": ["title"]
+        }
+      ],
+      "regex": [".*prohibited.*"]
+    }
+  }
+}
+```
+
+The tenant ID is automatically propagated from the model's tenant context to the guardrail's stop word validation.
+
+### Migration Notes
+
+- No configuration changes required for existing single-tenant deployments
+- Multi-tenant deployments will automatically benefit from tenant isolation
+- Stop word indices should be properly configured with tenant-aware access controls
+
+## Limitations
+
+- Only `LocalRegexGuardrail` has been updated for multi-tenancy in this release
+- `ModelGuardrail` stores tenant context but does not yet use it for validation
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4120](https://github.com/opensearch-project/ml-commons/pull/4120) | Support multi-tenancy for LocalRegexGuardrail |
+
+## References
+
+- [Issue #4119](https://github.com/opensearch-project/ml-commons/issues/4119): Feature request for multi-tenancy support in Guardrails
+- [Guardrails Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/guardrails/): Official guardrails configuration guide
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/ml-commons-multi-tenancy.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -101,6 +101,7 @@
 ### ML Commons
 
 - [ML Commons Bug Fixes](features/ml-commons/ml-commons-bug-fixes.md)
+- [ML Commons Multi-tenancy](features/ml-commons/ml-commons-multi-tenancy.md)
 - [ML Commons Tools Enhancements](features/ml-commons/ml-commons-tools-enhancements.md)
 - [Metrics Framework Bug Fix](features/ml-commons/metrics-framework.md)
 - [Move Common String](features/ml-commons/move-common-string.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the ML Commons Multi-tenancy enhancement in v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/ml-commons/ml-commons-multi-tenancy.md`
- Feature report: `docs/features/ml-commons/ml-commons-multi-tenancy.md`

### Key Changes in v3.3.0
- Added multi-tenancy support for LocalRegexGuardrail using SdkClient
- Updated `Guardrail.init()` interface to accept `SdkClient` and `tenantId` parameters
- Enables tenant-isolated stop word validation in multi-tenant environments

### Related Issue
- Closes #1339

### Source PR
- [opensearch-project/ml-commons#4120](https://github.com/opensearch-project/ml-commons/pull/4120): Support multi-tenancy for LocalRegexGuardrail