### PR TITLE
docs: add ML Commons Connector Enhancements report for v3.3.0

### DIFF
--- a/docs/features/ml-commons/ml-commons-connector.md
+++ b/docs/features/ml-commons/ml-commons-connector.md
@@ -55,6 +55,7 @@ flowchart TB
 | `RemoteConnectorExecutor` | Interface defining the execution flow for remote connector invocations |
 | `AwsConnectorExecutor` | Implementation for AWS services using SigV4 authentication |
 | `HttpConnector` | Base connector implementation for HTTP-based services |
+| `MLHttpClientFactory` | HTTP client factory for creating async HTTP clients (moved to `common` module in v3.3.0) |
 
 ### Configuration
 
@@ -127,15 +128,19 @@ When `skip_validating_missing_parameters` is `true`, the `${parameters.role}` pl
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#4121](https://github.com/opensearch-project/ml-commons/pull/4121) | Parameter Passing for Predict via Remote Connector |
+| v3.3.0 | [#4175](https://github.com/opensearch-project/ml-commons/pull/4175) | Move HttpClientFactory to common to expose to other components |
 | v2.17.0 | [#2830](https://github.com/opensearch-project/ml-commons/pull/2830) | Backport: Support skip_validating_missing_parameters in connector |
 | v2.17.0 | [#2812](https://github.com/opensearch-project/ml-commons/pull/2812) | Support skip_validating_missing_parameters in connector |
 
 ## References
 
+- [Issue #4105](https://github.com/opensearch-project/ml-commons/issues/4105): Feature request for parameter passing in predict API
 - [Issue #2712](https://github.com/opensearch-project/ml-commons/issues/2712): KnowledgeBaseTool parameter placeholder error
-- [Connector Blueprints Documentation](https://docs.opensearch.org/2.17/ml-commons-plugin/remote-models/blueprints/): Official connector configuration guide
-- [Connectors Documentation](https://docs.opensearch.org/2.17/ml-commons-plugin/remote-models/connectors/): Connector overview and examples
+- [Connector Blueprints Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/blueprints/): Official connector configuration guide
+- [Connectors Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/connectors/): Connector overview and examples
 
 ## Change History
 
+- **v3.3.0** (2026-01-11): Added parameter passing support for predict operations via remote connectors; moved `MLHttpClientFactory` to common module for broader accessibility
 - **v2.17.0** (2024-09-17): Added `skip_validating_missing_parameters` parameter to allow bypassing payload validation for unfilled parameter placeholders

--- a/docs/releases/v3.3.0/features/ml-commons/ml-commons-connector-enhancements.md
+++ b/docs/releases/v3.3.0/features/ml-commons/ml-commons-connector-enhancements.md
@@ -1,0 +1,148 @@
+# ML Commons Connector Enhancements
+
+## Summary
+
+This release introduces two key enhancements to the ML Commons connector framework: parameter passing support for predict operations via remote connectors and improved code organization by moving `HttpClientFactory` to the common module. These changes enable more flexible remote model invocations and better code reusability across ML Commons components.
+
+## Details
+
+### What's New in v3.3.0
+
+#### Parameter Passing for Predict via Remote Connector
+
+Previously, when invoking the predict API with `text_embedding` function, user-defined parameters from the predict call were not fully propagated through the connector to the remote endpoint. This enhancement ensures that parameters supplied in the predict request are correctly merged into the connector's `request_body` template and included in the outgoing request.
+
+#### HttpClientFactory Relocation
+
+The `MLHttpClientFactory` class has been moved from the `ml-algorithms` module to the `common` module, making it accessible to other components such as skills. This refactoring also includes:
+- Simplified code using `ThreadContextAccess.doPrivileged()` instead of `AccessController.doPrivileged()`
+- Improved private IP validation logic
+- Better logging format using parameterized messages
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Predict Request Flow"
+        A[User Predict Request] --> B[MLInput with Parameters]
+        B --> C[RemoteConnectorExecutor]
+        C --> D[preparePayloadAndInvoke]
+        D --> E{MLAlgoParams present?}
+        E -->|Yes| F[getParams - Extract to Map]
+        E -->|No| G[Skip Parameter Extraction]
+        F --> H[Merge with Input Parameters]
+        G --> H
+        H --> I[Create Payload from Template]
+        I --> J[Send to Remote Service]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `RemoteConnectorExecutor.getParams()` | New static method that extracts `MLAlgoParams` to a `Map<String, String>` for parameter substitution |
+| `MLHttpClientFactory` (relocated) | HTTP client factory now in `common` module for broader accessibility |
+
+#### Code Changes
+
+The `RemoteConnectorExecutor` interface now includes logic to extract parameters from `MLInput.getParameters()`:
+
+```java
+MLAlgoParams algoParams = mlInput.getParameters();
+if (algoParams != null) {
+    Map<String, String> parametersMap = getParams(mlInput);
+    parameters.putAll(parametersMap);
+}
+```
+
+The `getParams()` method serializes `MLAlgoParams` to JSON and converts it to a parameter map:
+
+```java
+static Map<String, String> getParams(MLInput mlInput) throws IOException {
+    XContentBuilder builder = XContentFactory.jsonBuilder();
+    mlInput.getParameters().toXContent(builder, ToXContent.EMPTY_PARAMS);
+    builder.flush();
+    String json = builder.toString();
+    Map<String, Object> tempMap = StringUtils.MAPPER.readValue(json, Map.class);
+    return getParameterMap(tempMap);
+}
+```
+
+### Usage Example
+
+#### Connector with Parameter Placeholders
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "SageMaker Sparse Embedding Connector",
+  "description": "Connector with parameter support",
+  "version": 1,
+  "protocol": "aws_sigv4",
+  "parameters": {
+    "region": "us-west-2",
+    "service_name": "sagemaker"
+  },
+  "credential": {
+    "access_key": "<ACCESS_KEY>",
+    "secret_key": "<SECRET_KEY>"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://runtime.sagemaker.us-west-2.amazonaws.com/endpoints/<endpoint>/invocations",
+      "headers": {
+        "content-type": "application/json"
+      },
+      "request_body": "{ \"input\": ${parameters.input}, \"parameters\": {\"sparse_embedding_format\": \"${parameters.sparse_embedding_format}\" }}"
+    }
+  ]
+}
+```
+
+#### Predict Request with Parameters
+
+```json
+POST /_plugins/_ml/_predict/text_embedding/<model_id>
+{
+  "text_docs": ["hello world"],
+  "parameters": {
+    "sparse_embedding_format": "TOKEN_ID"
+  }
+}
+```
+
+The `sparse_embedding_format` parameter is now correctly passed through to the remote endpoint.
+
+### Migration Notes
+
+- No breaking changes; existing connectors continue to work
+- To use parameter passing, update connector `request_body` templates to include parameter placeholders (e.g., `${parameters.sparse_embedding_format}`)
+- Components using `MLHttpClientFactory` should update imports from `org.opensearch.ml.engine.httpclient` to `org.opensearch.ml.common.httpclient`
+
+## Limitations
+
+- Parameter passing requires the connector's `request_body` template to include appropriate placeholders
+- Parameters must be serializable to JSON via `toXContent()`
+- If a parameter placeholder is not filled and `skip_validating_missing_parameters` is `false`, the request will fail validation
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4121](https://github.com/opensearch-project/ml-commons/pull/4121) | Parameter Passing for Predict via Remote Connector |
+| [#4175](https://github.com/opensearch-project/ml-commons/pull/4175) | Move HttpClientFactory to common to expose to other components |
+
+## References
+
+- [Issue #4105](https://github.com/opensearch-project/ml-commons/issues/4105): Feature request for parameter passing
+- [Connector Blueprints Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/blueprints/): Official connector configuration guide
+- [Connectors Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/connectors/): Connector overview and examples
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/ml-commons-connector.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -101,6 +101,7 @@
 ### ML Commons
 
 - [ML Commons Bug Fixes](features/ml-commons/ml-commons-bug-fixes.md)
+- [ML Commons Connector Enhancements](features/ml-commons/ml-commons-connector-enhancements.md)
 - [ML Commons Multi-tenancy](features/ml-commons/ml-commons-multi-tenancy.md)
 - [ML Commons Tools Enhancements](features/ml-commons/ml-commons-tools-enhancements.md)
 - [Metrics Framework Bug Fix](features/ml-commons/metrics-framework.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for ML Commons Connector Enhancements in v3.3.0.

### Changes

1. **Release Report**: `docs/releases/v3.3.0/features/ml-commons/ml-commons-connector-enhancements.md`
   - Parameter passing support for predict operations via remote connectors
   - HttpClientFactory relocation to common module

2. **Feature Report Update**: `docs/features/ml-commons/ml-commons-connector.md`
   - Added v3.3.0 changes to Related PRs table
   - Added new references
   - Updated Change History

### Key Features in v3.3.0

- **Parameter Passing for Predict via Remote Connector** (PR #4121): User-defined parameters from predict calls are now correctly propagated through connectors to remote endpoints
- **HttpClientFactory Relocation** (PR #4175): Moved `MLHttpClientFactory` to common module for broader accessibility by other components like skills

### Related Issue

Closes #1338