### PR TITLE
docs: add ML Commons Agent Enhancements report for v3.3.0

### DIFF
--- a/docs/features/ml-commons/ml-commons-agent-framework.md
+++ b/docs/features/ml-commons/ml-commons-agent-framework.md
@@ -112,6 +112,8 @@ flowchart TB
 | LLM Connector | Connects to external LLM services (Bedrock, OpenAI, etc.) |
 | Function Calling | Native function/tool calling support for compatible LLMs |
 | MCP Server | Model Context Protocol server for tool integration |
+| Metrics Collector | Collects adoption and operational metrics via OpenTelemetry |
+| ML Client Get Agent | Programmatic API to retrieve agent configurations |
 | Metrics Collector | Collects adoption and operational metrics |
 
 ### Agent Types
@@ -231,6 +233,9 @@ PUT /_plugins/_ml/agents/{agent_id}
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#4180](https://github.com/opensearch-project/ml-commons/pull/4180) | Add Get Agent to ML Client |
+| v3.3.0 | [#4221](https://github.com/opensearch-project/ml-commons/pull/4221) | Introduce agent metrics & Add is_hidden tag for model metrics |
+| v3.3.0 | [#4198](https://github.com/opensearch-project/ml-commons/pull/4198) | Update interaction with failure message on agent execution failure |
 | v3.3.0 | [#4173](https://github.com/opensearch-project/ml-commons/pull/4173) | Move common string to common package |
 | v3.2.0 | [#4035](https://github.com/opensearch-project/ml-commons/pull/4035) | Add Execute Tool API |
 | v3.2.0 | [#4050](https://github.com/opensearch-project/ml-commons/pull/4050) | Implement create and add memory container API |
@@ -256,8 +261,10 @@ PUT /_plugins/_ml/agents/{agent_id}
 ## References
 
 - [Agent APIs Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/api/agent-apis/index/)
+- [Get Agent API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/agent-apis/get-agent/)
 - [Plan-Execute-Reflect Agents](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/agents/plan-execute-reflect/)
 - [ML Commons Cluster Settings](https://docs.opensearch.org/3.0/ml-commons-plugin/cluster-settings/)
+- [Issue #4197](https://github.com/opensearch-project/ml-commons/issues/4197): Failure message update feature request
 - [Issue #3748](https://github.com/opensearch-project/ml-commons/issues/3748): Update Agent API feature request
 - [Issue #2172](https://github.com/opensearch-project/ml-commons/issues/2172): Original Update Agent API request
 - [Issue #3841](https://github.com/opensearch-project/ml-commons/issues/3841): MCP tools persistence
@@ -266,7 +273,7 @@ PUT /_plugins/_ml/agents/{agent_id}
 
 ## Change History
 
-- **v3.3.0** (2026-01-14): Code refactoring - moved `NO_ESCAPE_PARAMS` constant from `AgentUtils` to `ToolUtils` in common package for skills plugin accessibility
+- **v3.3.0** (2026-01-14): Get Agent API in ML Client, agent metrics collection via OpenTelemetry (type, memory_type, is_hidden, _llm_interface, model info), interaction failure message updates, code refactoring for common package
 - **v3.2.0** (2025-09-16): Execute Tool API, AI-oriented memory container system (create, add, search, update, delete, get), QueryPlanningTool for agentic search, date/time injection for agents, message history limit for PER Agent, output filter support, SearchIndexTool improvements, feature flags for agentic search/memory, multiple bug fixes (class cast exception, connector URL exposure, async status, max iterations handling)
 - **v3.1.0** (2025-07-15): Update Agent API, MCP tools persistence, function calling for LLM interfaces, custom SSE endpoint, metrics framework integration, PlanExecuteReflect memory tracking, error handling improvements, multiple bug fixes (private IP validation, circuit breaker bypass, Python MCP client)
 - **v3.0.0** (2025-05-13): Plan-Execute-Reflect agent type, MCP server integration

--- a/docs/releases/v3.3.0/features/ml-commons/ml-commons-agent-enhancements.md
+++ b/docs/releases/v3.3.0/features/ml-commons/ml-commons-agent-enhancements.md
@@ -1,0 +1,136 @@
+# ML Commons Agent Enhancements
+
+## Summary
+
+OpenSearch v3.3.0 introduces several enhancements to the ML Commons agent framework, including a new Get Agent API in the ML Client, agent metrics collection via OpenTelemetry, and improved error handling for agent execution failures. These changes improve observability, debugging capabilities, and developer experience when working with ML agents.
+
+## Details
+
+### What's New in v3.3.0
+
+This release adds three key enhancements to the ML Commons agent framework:
+
+1. **Get Agent API in ML Client** - Programmatic access to retrieve agent configurations
+2. **Agent Metrics via OpenTelemetry** - Telemetry data collection for agent monitoring
+3. **Failure Message Updates** - Improved error handling with interaction updates on failures
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `MachineLearningClient.getAgent()` | New method to retrieve agent by ID |
+| `MLAgentGetRequest` | Request class for Get Agent API |
+| `MLAgentGetResponse` | Response class containing agent details |
+| `MLAgent.getTags()` | Method to generate telemetry tags for agents |
+| `AdoptionMetric.AGENT_COUNT` | New metric for tracking agent counts |
+
+#### Agent Metrics Collection
+
+The agent metrics feature captures the following telemetry data via OpenTelemetry:
+
+```
+{
+  _llm_interface: "bedrock/converse/claude",
+  model_deployment: "remote",
+  is_hidden: false,
+  model_service_provider: "bedrock",
+  model_type: "llm",
+  memory_type: "conversation_index",
+  model: "us.anthropic.claude-3-7-sonnet-20250219-v1:0",
+  type: "CONVERSATIONAL"
+}
+```
+
+Tags captured include:
+- `is_hidden` - Whether the agent is hidden
+- `type` - Agent type (e.g., CONVERSATIONAL, FLOW)
+- `memory_type` - Memory configuration type if configured
+- `_llm_interface` - LLM interface parameter if specified
+- Model information (model, provider, deployment type) from linked models
+
+#### Failure Message Handling
+
+When an agent execution fails, the interaction is now updated with the failure message:
+
+**Before (v3.2.x):**
+```json
+{
+    "memory_id": "Uw_ufZkBE5GN_tuwO2KT",
+    "message_id": "Wg_yfZkBE5GN_tuwuGI9",
+    "create_time": "2025-09-24T22:58:02.939633Z",
+    "input": "give me index mapping of any index"
+}
+```
+
+**After (v3.3.0):**
+```json
+{
+    "memory_id": "Uw_ufZkBE5GN_tuwO2KT",
+    "message_id": "Wg_yfZkBE5GN_tuwuGI9",
+    "create_time": "2025-09-24T22:58:02.939633Z",
+    "input": "give me index mapping of any index",
+    "response": "Agent execution failed: failed to run"
+}
+```
+
+### Usage Example
+
+#### Get Agent API
+
+```java
+// Using the ML Client to get an agent
+MachineLearningNodeClient mlClient = new MachineLearningNodeClient(client);
+
+// Synchronous call
+MLAgentGetResponse response = mlClient.getAgent("agent-id").actionGet();
+MLAgent agent = response.getMlAgent();
+
+// Asynchronous call
+mlClient.getAgent("agent-id", ActionListener.wrap(
+    response -> {
+        MLAgent agent = response.getMlAgent();
+        // Process agent
+    },
+    error -> {
+        // Handle error
+    }
+));
+```
+
+#### REST API
+
+```bash
+GET /_plugins/_ml/agents/<agent_id>
+```
+
+### Migration Notes
+
+- No breaking changes - all enhancements are additive
+- Existing agent workflows continue to work without modification
+- Agent metrics collection is automatic when the metrics framework is enabled
+
+## Limitations
+
+- Agent metrics are collected periodically via the stats job processor, not in real-time
+- Model tags cache is cleared on each metrics collection run
+- Batch size for agent metrics collection is limited to 10,000 agents
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4180](https://github.com/opensearch-project/ml-commons/pull/4180) | Add Get Agent to ML Client |
+| [#4221](https://github.com/opensearch-project/ml-commons/pull/4221) | Introduce agent metrics & Add is_hidden tag for model metrics |
+| [#4198](https://github.com/opensearch-project/ml-commons/pull/4198) | Update interaction with failure message on agent execution failure |
+
+## References
+
+- [Issue #4197](https://github.com/opensearch-project/ml-commons/issues/4197): Feature request for failure message updates
+- [Agent APIs Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/api/agent-apis/index/): Official agent API documentation
+- [Get Agent API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/agent-apis/get-agent/): Get agent endpoint documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/ml-commons/ml-commons-agent-framework.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -100,6 +100,7 @@
 
 ### ML Commons
 
+- [ML Commons Agent Enhancements](features/ml-commons/ml-commons-agent-enhancements.md)
 - [ML Commons Bug Fixes](features/ml-commons/ml-commons-bug-fixes.md)
 - [ML Commons Connector Enhancements](features/ml-commons/ml-commons-connector-enhancements.md)
 - [ML Commons Multi-tenancy](features/ml-commons/ml-commons-multi-tenancy.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for ML Commons Agent Enhancements in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/ml-commons/ml-commons-agent-enhancements.md`
- Feature report: `docs/features/ml-commons/ml-commons-agent-framework.md` (updated)

### Key Changes in v3.3.0
- **Get Agent API in ML Client** - New `MachineLearningClient.getAgent()` method for programmatic agent retrieval
- **Agent Metrics via OpenTelemetry** - Telemetry data collection including agent type, memory type, is_hidden, _llm_interface, and linked model information
- **Failure Message Updates** - Interaction records now updated with failure messages when agent execution fails

### PRs Investigated
- [#4180](https://github.com/opensearch-project/ml-commons/pull/4180) - Add Get Agent to ML Client
- [#4221](https://github.com/opensearch-project/ml-commons/pull/4221) - Introduce agent metrics & Add is_hidden tag for model metrics
- [#4198](https://github.com/opensearch-project/ml-commons/pull/4198) - Update interaction with failure message on agent execution failure

Closes #1337