### PR TITLE
docs: add k-NN Engine Enhancements report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -459,6 +459,7 @@
 - [k-NN AVX512 SIMD Support](k-nn/k-nn-avx512-support.md)
 - [k-NN Bug Fixes](k-nn/k-nn-bug-fixes.md)
 - [k-NN Byte Vector Support](k-nn/k-nn-byte-vector-support.md)
+- [k-NN Engine Enhancements](k-nn/k-nn-engine-enhancements.md)
 - [k-NN Performance & Engine](k-nn/k-nn-performance-engine.md)
 - [Vector Search (k-NN)](k-nn/vector-search-k-nn.md)
 - [k-NN Explain API](k-nn/explain-api.md)

--- a/docs/features/k-nn/k-nn-engine-enhancements.md
+++ b/docs/features/k-nn/k-nn-engine-enhancements.md
@@ -1,0 +1,176 @@
+# k-NN Engine Enhancements
+
+## Summary
+
+The k-NN plugin provides flexible engine configuration options for vector search workloads. Users can specify the k-NN engine (Lucene, FAISS, or NMSLIB) at either the top level of the field mapping or within the method definition. Additionally, the plugin supports gRPC transport for high-performance k-NN queries using Protocol Buffers.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "k-NN Engine Configuration"
+        A[Index Mapping] --> B{Engine Specification}
+        B -->|Top-Level| C[engine: lucene/faiss]
+        B -->|Method-Level| D[method.engine: lucene/faiss]
+        C --> E[EngineResolver]
+        D --> E
+        E --> F[Resolved KNNEngine]
+        F --> G[Vector Index Creation]
+    end
+    
+    subgraph "gRPC Transport"
+        H[gRPC Client] --> I[SearchService.Search]
+        I --> J[KNNQueryBuilderProtoConverter]
+        J --> K[KNNQueryBuilder]
+        K --> L[k-NN Search Execution]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User Request] --> B{Request Type}
+    B -->|REST API| C[HTTP Handler]
+    B -->|gRPC| D[gRPC SearchService]
+    C --> E[Query Parser]
+    D --> F[Proto Converter]
+    F --> E
+    E --> G[KNNQueryBuilder]
+    G --> H[Engine-Specific Search]
+    H --> I[Results]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `EngineResolver` | Resolves the k-NN engine from top-level and method-level configurations |
+| `KNNEngine` | Enum representing supported engines: LUCENE, FAISS, NMSLIB (deprecated), UNDEFINED |
+| `KNNVectorFieldMapper` | Field mapper that processes engine configuration during index creation |
+| `KNNQueryBuilderProtoConverter` | Converts Protocol Buffer k-NN queries to OpenSearch query builders |
+| `QueryBuilderProtoConverterRegistry` | SPI registry for extensible query conversion |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `engine` (top-level) | k-NN engine at field mapping level | `undefined` (resolved based on context) |
+| `method.engine` | k-NN engine within method definition | `undefined` |
+| `compression_level` | Vector compression level (affects engine selection) | `1x` |
+| `mode` | Vector workload mode (`in_memory` or `on_disk`) | `in_memory` |
+
+### Engine Resolution Rules
+
+The `EngineResolver` applies the following logic:
+
+1. **User-configured engine takes precedence**: If specified at top-level or method-level
+2. **Conflict detection**: If both are specified with different values, throws error
+3. **Training requirement**: Training operations require FAISS engine
+4. **Compression constraint**: 4x compression requires Lucene engine
+5. **Default fallback**: FAISS is the default engine when not specified
+
+### Usage Example
+
+**Top-level engine configuration:**
+```json
+PUT my-index
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 128,
+        "engine": "lucene",
+        "space_type": "cosinesimil"
+      }
+    }
+  }
+}
+```
+
+**Method-level engine configuration:**
+```json
+PUT my-index
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 128,
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "space_type": "l2",
+          "parameters": {
+            "ef_construction": 128,
+            "m": 16
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**gRPC k-NN query:**
+```json
+{
+  "index": "my-index",
+  "request_body": {
+    "query": {
+      "knn": {
+        "my_vector": {
+          "vector": [0.1, 0.2, 0.3, ...],
+          "k": 10,
+          "filter": {
+            "term": { "category": "electronics" }
+          }
+        }
+      }
+    },
+    "size": 10
+  }
+}
+```
+
+## Limitations
+
+- NMSLIB engine is deprecated since v2.19.0 and will be removed in v3.0.0
+- Top-level engine parameter requires OpenSearch v3.2.0+
+- gRPC k-NN queries are experimental
+- 4x compression only supports Lucene engine
+- Training operations only support FAISS engine
+- Conflicting engine specifications (top-level vs method-level) cause mapping errors
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#2736](https://github.com/opensearch-project/k-NN/pull/2736) | Added engine as a top-level optional parameter |
+| v3.3.0 | [#2833](https://github.com/opensearch-project/k-NN/pull/2833) | Migrate k-NN plugin to use GRPC transport-grpc SPI interface |
+
+## References
+
+- [Issue #2534](https://github.com/opensearch-project/k-NN/issues/2534): Make engine top level field mapping parameter
+- [Issue #2816](https://github.com/opensearch-project/k-NN/issues/2816): Add GRPC support for k-NN queries
+- [k-NN Vector Documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/knn-vector/): Official k-NN vector field documentation
+- [Methods and Engines](https://docs.opensearch.org/3.0/field-types/supported-field-types/knn-methods-engines/): k-NN methods and engines reference
+- [gRPC Search API](https://docs.opensearch.org/3.0/api-reference/grpc-apis/search/): gRPC Search API documentation
+- [gRPC APIs Overview](https://docs.opensearch.org/3.0/api-reference/grpc-apis/index/): gRPC APIs overview
+
+## Change History
+
+- **v3.3.0** (2026-01-11): Added top-level engine parameter and gRPC transport support for k-NN queries

--- a/docs/releases/v3.3.0/features/k-nn/k-nn-engine-enhancements.md
+++ b/docs/releases/v3.3.0/features/k-nn/k-nn-engine-enhancements.md
@@ -1,0 +1,171 @@
+# k-NN Engine Enhancements
+
+## Summary
+
+OpenSearch v3.3.0 introduces two significant enhancements to the k-NN plugin: a top-level `engine` mapping parameter for simplified vector field configuration, and gRPC transport support for k-NN queries enabling high-performance binary protocol communication.
+
+## Details
+
+### What's New in v3.3.0
+
+#### 1. Top-Level Engine Parameter
+
+The `engine` parameter can now be specified at the top level of the `knn_vector` field mapping, similar to how `space_type` was moved in a previous release. This simplifies the mapping configuration by separating the engine selection from the method definition.
+
+**Before (engine in method):**
+```json
+{
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 4,
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss",
+          "parameters": {}
+        }
+      }
+    }
+  }
+}
+```
+
+**After (top-level engine):**
+```json
+{
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 4,
+        "engine": "lucene",
+        "method": {
+          "name": "hnsw",
+          "parameters": {}
+        }
+      }
+    }
+  }
+}
+```
+
+#### 2. gRPC Transport Support for k-NN Queries
+
+The k-NN plugin now integrates with OpenSearch's gRPC transport layer through the `transport-grpc-spi` interface. This enables k-NN queries to be executed via gRPC, providing performance benefits over REST API.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "k-NN Plugin v3.3.0"
+        A[KNNVectorFieldMapper] --> B[EngineResolver]
+        B --> C{Engine Source}
+        C -->|Top-Level| D[topLevelEngine Parameter]
+        C -->|Method| E[KNNMethodContext.engine]
+        D --> F[Resolved KNNEngine]
+        E --> F
+        
+        G[KNNQueryBuilderProtoConverter] --> H[QueryBuilderProtoConverterRegistry]
+        H --> I[gRPC Search Service]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `KNNEngine.UNDEFINED` | New enum value representing unset engine state |
+| `TOP_LEVEL_PARAMETER_ENGINE` | Constant for the top-level engine field name |
+| `KNNQueryBuilderProtoConverter` | Converts Protocol Buffer k-NN queries to OpenSearch query builders |
+| `QueryBuilderProtoConverterRegistry` | SPI registry for query converter extensions |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `engine` (top-level) | Specifies the k-NN engine at field mapping level | `undefined` (resolved to `faiss`) |
+
+#### Engine Resolution Logic
+
+The `EngineResolver` now handles multiple engine specification scenarios:
+
+1. **Top-level only**: Uses the top-level engine value
+2. **Method only**: Uses the method-level engine value
+3. **Both specified (same)**: Accepts if values match
+4. **Both specified (different)**: Throws `MapperParsingException`
+5. **Neither specified**: Defaults to `FAISS`
+
+### Usage Example
+
+**Simple mapping with top-level engine:**
+```json
+PUT test-index
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "vector1": {
+        "type": "knn_vector",
+        "dimension": 4,
+        "space_type": "l2",
+        "engine": "lucene"
+      }
+    }
+  }
+}
+```
+
+**gRPC k-NN query (Protocol Buffer format):**
+```json
+{
+  "request_body": {
+    "query": {
+      "knn": {
+        "my_vector": {
+          "vector": [1.0, 2.0, 3.0],
+          "k": 10
+        }
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- Existing mappings with `engine` in the `method` section continue to work
+- New mappings can use either top-level or method-level engine specification
+- If both are specified, they must have the same value
+- The feature requires OpenSearch v3.2.0+ for cluster compatibility
+
+## Limitations
+
+- Top-level engine parameter requires minimum version v3.2.0
+- gRPC k-NN queries are experimental and require the `transport-grpc` plugin
+- When using 4x compression, only Lucene engine is supported
+- Training operations require FAISS engine regardless of top-level setting
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2736](https://github.com/opensearch-project/k-NN/pull/2736) | Added engine as a top-level optional parameter while creating vector field |
+| [#2833](https://github.com/opensearch-project/k-NN/pull/2833) | Migrate k-NN plugin to use GRPC transport-grpc SPI interface |
+
+## References
+
+- [Issue #2534](https://github.com/opensearch-project/k-NN/issues/2534): Make engine top level field mapping parameter
+- [Issue #2816](https://github.com/opensearch-project/k-NN/issues/2816): Add GRPC support for k-NN queries
+- [k-NN Vector Documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/knn-vector/): Official k-NN vector field documentation
+- [gRPC Search API](https://docs.opensearch.org/3.0/api-reference/grpc-apis/search/): gRPC Search API documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/k-nn/k-nn-engine-enhancements.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -119,6 +119,7 @@
 ### k-NN
 
 - [k-NN Bug Fixes](features/k-nn/k-nn-bug-fixes.md)
+- [k-NN Engine Enhancements](features/k-nn/k-nn-engine-enhancements.md)
 
 ### Geospatial
 


### PR DESCRIPTION
## Summary

This PR adds documentation for k-NN Engine Enhancements in OpenSearch v3.3.0.

### Changes

- **Release Report**: `docs/releases/v3.3.0/features/k-nn/k-nn-engine-enhancements.md`
- **Feature Report**: `docs/features/k-nn/k-nn-engine-enhancements.md`
- Updated release index and features index

### Key Features Documented

1. **Top-Level Engine Parameter** (PR #2736)
   - Engine can now be specified at the top level of knn_vector field mapping
   - Simplifies configuration by separating engine selection from method definition

2. **gRPC Transport Support** (PR #2833)
   - k-NN plugin now integrates with OpenSearch's gRPC transport layer
   - Enables high-performance k-NN queries via Protocol Buffers

### Related Issue

Closes #1336