### PR TITLE
docs: add ppl-rename-command report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -311,6 +311,7 @@
 - [Flint Index Operations](sql/flint-index-operations.md)
 - [Flint Query Scheduler](sql/flint-query-scheduler.md)
 - [PPL Documentation](sql/ppl-documentation.md)
+- [PPL Rename Command](sql/ppl-rename-command.md)
 - [Security Lake Data Source](sql/security-lake-data-source.md)
 - [SQL Error Handling](sql/sql-error-handling.md)
 - [SQL Pagination](sql/sql-pagination.md)

--- a/docs/features/sql/ppl-rename-command.md
+++ b/docs/features/sql/ppl-rename-command.md
@@ -1,0 +1,145 @@
+# PPL Rename Command
+
+## Summary
+
+The PPL `rename` command renames one or more fields in search results. Starting from v3.3.0, it supports wildcard patterns using `*` to batch rename multiple fields at once, enabling efficient field name transformations across datasets with similarly-named fields.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "PPL Query Processing"
+        A[PPL Query] --> B[Parser/Lexer]
+        B --> C[AST Builder]
+        C --> D[Query Analyzer]
+        D --> E{Calcite Enabled?}
+        E -->|Yes| F[CalciteRelNodeVisitor]
+        E -->|No| G[Legacy Visitor]
+        F --> H[WildcardRenameUtils]
+        H --> I[Field Transformation]
+        G --> J[Simple Rename]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Source Fields] --> B[Pattern Matching]
+    B --> C{Wildcard?}
+    C -->|Yes| D[Match Fields]
+    C -->|No| E[Direct Rename]
+    D --> F[Apply Transformation]
+    E --> G[Rename Single Field]
+    F --> H[Output Fields]
+    G --> H
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `WildcardRenameUtils` | Utility class for wildcard pattern matching and transformation |
+| `CalciteRelNodeVisitor.visitRename()` | Handles rename command processing with wildcard support |
+| `AstExpressionBuilder.visitRenameFieldExpression()` | Parses rename field expressions including wildcards |
+| `OpenSearchPPLParser.renameFieldExpression` | Grammar rule for rename field expressions |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.calcite.enabled` | Enable Calcite query engine (required for wildcards) | `false` |
+
+### Syntax
+
+```
+rename <source-field> AS <target-field>[, <source-field> AS <target-field>]...
+```
+
+- `source-field`: Field name to rename. Supports wildcard patterns (`*`) since v3.3.0.
+- `target-field`: New field name. Must have same number of wildcards as source.
+
+### Wildcard Patterns
+
+| Pattern | Description | Example |
+|---------|-------------|---------|
+| `*name` | Match fields ending with "name" | `firstname`, `lastname` |
+| `old_*` | Match fields starting with "old_" | `old_id`, `old_value` |
+| `*_*` | Match fields with underscore | `user_name`, `first_name` |
+| `*` | Match all fields | All fields |
+
+### Field Rename Behavior (v3.3.0+)
+
+| Scenario | Behavior |
+|----------|----------|
+| Non-existent → Non-existent | No change to result set |
+| Non-existent → Existing | Target field is removed |
+| Existing → Existing | Target field removed, source renamed to target |
+
+### Usage Examples
+
+**Basic rename:**
+```ppl
+source=accounts | rename account_number as an | fields an
+```
+
+**Multiple field rename:**
+```ppl
+source=accounts | rename account_number as an, employer as emp | fields an, emp
+```
+
+**Wildcard rename (v3.3.0+):**
+```ppl
+source=accounts | rename *name as *_name | fields first_name, last_name
+```
+
+**Add prefix to all fields (v3.3.0+):**
+```ppl
+source=accounts | fields name, age | rename * as old_* | fields old_name, old_age
+```
+
+**Remove prefix (v3.3.0+):**
+```ppl
+source=data | rename old_* as * | fields name, value
+```
+
+**Multiple wildcards (v3.3.0+):**
+```ppl
+source=accounts | rename m*n*h as M*N*H | fields MoNtH
+```
+
+**Chained renames (v3.3.0+):**
+```ppl
+source=accounts | rename *ame as *_ame, *_ame as *_AME | fields n_AME
+```
+
+**Space-delimited syntax (v3.3.0+):**
+```ppl
+source=accounts | rename name as user_name age as user_age country as location
+```
+
+## Limitations
+
+- The `rename` command is not rewritten to OpenSearch DSL; it executes only on the coordination node
+- Wildcard patterns require `plugins.calcite.enabled=true`
+- Source and target patterns must have the same number of wildcards
+- Literal asterisk (`*`) characters in field names cannot be matched
+- Consecutive wildcards (e.g., `**`) in non-full patterns are not supported
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#4019](https://github.com/opensearch-project/sql/pull/4019) | Add wildcard support for rename command |
+
+## References
+
+- [Issue #4008](https://github.com/opensearch-project/sql/issues/4008): Feature request for wildcard rename support
+- [PPL Commands Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/ppl/functions/): Official PPL commands reference
+
+## Change History
+
+- **v3.3.0** (2026): Added wildcard pattern support for batch field renaming, space-delimited syntax, and updated field rename behavior for non-existent/existing field scenarios
+- **v1.0.0**: Initial implementation with basic single and multiple field rename support

--- a/docs/releases/v3.3.0/features/sql/ppl-rename-command.md
+++ b/docs/releases/v3.3.0/features/sql/ppl-rename-command.md
@@ -1,0 +1,122 @@
+# SQL/PPL Rename Command - Wildcard Support
+
+## Summary
+
+OpenSearch v3.3.0 adds wildcard pattern support to the PPL `rename` command, enabling batch field renaming using `*` wildcards. This enhancement allows users to rename multiple fields at once using pattern matching, significantly improving productivity when working with datasets that have many similarly-named fields.
+
+## Details
+
+### What's New in v3.3.0
+
+The `rename` command now supports wildcard patterns using `*` to match and transform multiple field names in a single operation. This feature requires the Calcite query engine to be enabled.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "PPL Query Processing"
+        A[PPL Parser] --> B[AST Builder]
+        B --> C[CalciteRelNodeVisitor]
+        C --> D[WildcardRenameUtils]
+        D --> E[Field Transformation]
+    end
+    
+    subgraph "WildcardRenameUtils"
+        D --> F[isWildcardPattern]
+        D --> G[matchFieldNames]
+        D --> H[applyWildcardTransformation]
+        D --> I[validatePatternCompatibility]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `WildcardRenameUtils` | Utility class for wildcard pattern matching and field name transformation |
+| `renameFieldExpression` | New grammar rule in PPL parser supporting wildcard expressions |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.calcite.enabled` | Must be `true` to use wildcard rename | `false` |
+
+#### Parser Changes
+
+The PPL parser grammar was updated to:
+- Accept `*` in rename field expressions
+- Allow space-delimited rename clauses (comma is now optional)
+
+#### Field Rename Behavior
+
+| Scenario | Behavior |
+|----------|----------|
+| Non-existent → Non-existent | No change to result set |
+| Non-existent → Existing | Target field is removed |
+| Existing → Existing | Target field removed, source renamed to target |
+
+### Usage Examples
+
+**Basic wildcard rename:**
+```ppl
+source=accounts | rename *name as *_name
+```
+- `firstname` → `first_name`
+- `lastname` → `last_name`
+
+**Add prefix to all fields:**
+```ppl
+source=accounts | rename * as old_*
+```
+- `id` → `old_id`
+- `email` → `old_email`
+
+**Remove prefix:**
+```ppl
+source=data | rename old_* as *
+```
+- `old_name` → `name`
+- `old_date` → `date`
+
+**Multiple wildcards:**
+```ppl
+source=accounts | rename *_*_field as *_*
+```
+- `user_profile_field` → `user_profile`
+
+**Chained renames:**
+```ppl
+source=accounts | rename *ame as *_ame, *_ame as *_AME
+```
+- `name` → `n_ame` → `n_AME`
+
+### Migration Notes
+
+- Wildcard rename only works with the Calcite query engine enabled
+- Source and target patterns must have the same number of wildcards
+- Literal asterisk (`*`) characters in field names cannot be matched as they are interpreted as wildcards
+
+## Limitations
+
+- Requires `plugins.calcite.enabled=true`
+- Consecutive wildcards (e.g., `**`) in non-full patterns are not supported
+- Cannot match literal `*` characters in field names
+- The `rename` command is executed on the coordination node, not rewritten to OpenSearch DSL
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4019](https://github.com/opensearch-project/sql/pull/4019) | Add wildcard support for rename command |
+
+## References
+
+- [Issue #4008](https://github.com/opensearch-project/sql/issues/4008): Feature request for wildcard rename support
+- [PPL Commands Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/ppl/functions/): Official PPL commands reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/sql/ppl-rename-command.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -136,6 +136,7 @@
 
 ### SQL
 
+- [PPL Rename Command - Wildcard Support](features/sql/ppl-rename-command.md)
 - [SQL/PPL Bug Fixes](features/sql/sql-ppl-bug-fixes.md)
 
 ### Reporting


### PR DESCRIPTION
## Summary

Add documentation for the PPL rename command wildcard support feature introduced in OpenSearch v3.3.0.

## Changes

### Release Report
- `docs/releases/v3.3.0/features/sql/ppl-rename-command.md`: Documents the wildcard pattern support added to the PPL rename command

### Feature Report
- `docs/features/sql/ppl-rename-command.md`: Comprehensive documentation of the PPL rename command including the new wildcard functionality

## Key Features Documented

- Wildcard pattern matching using `*` for batch field renaming
- New field rename behavior for non-existent/existing field scenarios
- Space-delimited syntax support
- Chained rename operations
- Performance benchmarks from PR #4019

## Related Issue

Closes #1332