### PR TITLE
docs: add PPL spath command report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -312,6 +312,7 @@
 - [Flint Query Scheduler](sql/flint-query-scheduler.md)
 - [PPL Documentation](sql/ppl-documentation.md)
 - [PPL Rename Command](sql/ppl-rename-command.md)
+- [PPL Spath Command](sql/ppl-spath-command.md)
 - [Security Lake Data Source](sql/security-lake-data-source.md)
 - [SQL Error Handling](sql/sql-error-handling.md)
 - [SQL Pagination](sql/sql-pagination.md)

--- a/docs/features/sql/ppl-spath-command.md
+++ b/docs/features/sql/ppl-spath-command.md
@@ -1,0 +1,141 @@
+# PPL Spath Command
+
+## Summary
+
+The `spath` command is a PPL (Piped Processing Language) command that provides a simple, intuitive way to extract fields from structured JSON data stored in text fields. It offers a more user-friendly alternative to the `json_extract()` function, with plans for future XML support and additional structured data extraction capabilities.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "PPL Query Processing"
+        A[PPL Query] --> B[Lexer/Parser]
+        B --> C{Command Type}
+        C -->|spath| D[SPath AST Node]
+        D --> E[Rewrite Phase]
+        E --> F[Eval with json_extract]
+        F --> G[Calcite RelNode Visitor]
+        G --> H[Query Execution]
+    end
+    
+    subgraph "SPath Internals"
+        D --> I[Parse Parameters]
+        I --> J[input field]
+        I --> K[output field]
+        I --> L[path expression]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[JSON Text Field] --> B[spath command]
+    B --> C[json_extract function]
+    C --> D[Extracted Value]
+    D --> E[Output Field]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SPath` | AST node class representing the spath command in the query tree |
+| `AstBuilder.visitSpathCommand` | Parser visitor that constructs SPath nodes from PPL syntax |
+| `CalciteRelNodeVisitor.visitSpath` | Visitor that converts SPath to Calcite RelNode via eval rewrite |
+| `OpenSearchPPLLexer` | Extended with SPATH, INPUT, OUTPUT, PATH tokens |
+| `OpenSearchPPLParser` | Extended with spath command grammar rules |
+
+### Configuration
+
+| Parameter | Description | Required | Default |
+|-----------|-------------|----------|---------|
+| `input` | The field containing JSON data to scan | Yes | N/A |
+| `output` | The destination field for extracted data | No | Value of `path` |
+| `path` | The JSON path expression to extract | Yes | N/A |
+
+### Syntax
+
+```
+spath input=<field> [output=<field>] [path=]<path>
+```
+
+### Path Expression Syntax
+
+The path parameter supports various JSON path expressions:
+
+| Pattern | Description | Example |
+|---------|-------------|---------|
+| `field` | Simple field access | `n` |
+| `parent.child` | Nested field access | `nest_out.nest_in` |
+| `array{}` | All array elements | `list{}` |
+| `array{N}` | Specific array index | `list{0}` |
+| `['field']` | Escaped field names | `['a.b.c']` |
+
+### Usage Examples
+
+**Example 1: Simple Field Extraction**
+
+```sql
+source=logs | spath input=doc n
+```
+
+**Example 2: With Custom Output Field**
+
+```sql
+source=logs | spath input=doc output=user_id path=user.id
+```
+
+**Example 3: Array Element Extraction**
+
+```sql
+source=logs | spath input=doc output=first list{0}
+           | spath input=doc output=all list{}
+```
+
+**Example 4: Nested Field Extraction**
+
+```sql
+source=logs | spath input=doc output=nested nest_out.nest_in
+```
+
+**Example 5: With Type Casting and Aggregation**
+
+```sql
+source=logs | spath input=doc n 
+           | eval n=cast(n as int) 
+           | stats sum(n)
+```
+
+**Example 6: Escaped Path Names**
+
+```sql
+source=logs | spath output=a input=doc "['a fancy field name']"
+           | spath output=b input=doc "['a.b.c']"
+```
+
+## Limitations
+
+- **No pushdown optimization**: Extraction happens at the coordinating node, not pushed down to shards
+- **Performance on large datasets**: May be slow on large datasets; consider indexing frequently filtered fields
+- **JSON only**: Currently supports only JSON data (XML support planned for future)
+- **String output**: Always returns string values; explicit casting required for numeric operations
+- **No automatic type inference**: Unlike direct field indexing, types must be cast manually
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#4120](https://github.com/opensearch-project/sql/pull/4120) | Starter implementation for `spath` command |
+
+## References
+
+- [Issue #4119](https://github.com/opensearch-project/sql/issues/4119): RFC - Improved structured data extraction with `spath`
+- [PPL Commands Documentation](https://docs.opensearch.org/3.3/search-plugins/sql/ppl/functions/): Official PPL commands reference
+- [json_extract Function](https://github.com/opensearch-project/sql/blob/main/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLJsonBuiltinFunctionIT.java): Related JSON extraction tests
+
+## Change History
+
+- **v3.3.0** (2025-08-28): Initial implementation with JSON path support, rewriting to json_extract internally

--- a/docs/releases/v3.3.0/features/sql/ppl-spath-command.md
+++ b/docs/releases/v3.3.0/features/sql/ppl-spath-command.md
@@ -1,0 +1,130 @@
+# PPL Spath Command
+
+## Summary
+
+OpenSearch v3.3.0 introduces the `spath` command for PPL (Piped Processing Language), providing a simple and intuitive way to extract fields from structured JSON data stored in text fields. This command simplifies the extraction of nested data without requiring verbose function syntax.
+
+## Details
+
+### What's New in v3.3.0
+
+The `spath` command is a new PPL command that allows users to extract fields from JSON documents using path-based syntax. It serves as a more user-friendly alternative to the existing `json_extract()` function.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "PPL Query Processing"
+        A[PPL Query with spath] --> B[PPL Parser]
+        B --> C[SPath AST Node]
+        C --> D[Rewrite to Eval]
+        D --> E[json_extract Function]
+        E --> F[Calcite RelNode]
+        F --> G[Query Execution]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `SPath` | New AST node class representing the spath command |
+| `visitSpath` | Visitor method in `AbstractNodeVisitor` for processing spath nodes |
+| `CalcitePPLSpathCommandIT` | Integration tests for the spath command |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `input` | The field to scan for JSON data | Required |
+| `output` | The destination field for extracted data | Value of `path` |
+| `path` | The JSON path of the data to extract | Required |
+
+#### Syntax
+
+```
+spath input=<field> [output=<field>] [path=]<path>
+```
+
+### Usage Example
+
+**Example 1: Simple Field Extraction**
+
+Extract a single field from JSON data:
+
+```sql
+source=logs | spath input=doc n
+```
+
+Result:
+```
++----------+---+
+| doc      | n |
+|----------+---|
+| {"n": 1} | 1 |
+| {"n": 2} | 2 |
+| {"n": 3} | 3 |
++----------+---+
+```
+
+**Example 2: Nested Fields and Arrays**
+
+Extract nested fields and array elements:
+
+```sql
+source=logs | spath input=doc output=first_element list{0} 
+           | spath input=doc output=all_elements list{} 
+           | spath input=doc output=nested nest_out.nest_in
+```
+
+**Example 3: With Aggregation**
+
+Extract and aggregate inner values:
+
+```sql
+source=logs | spath input=doc n | eval n=cast(n as int) | stats sum(n)
+```
+
+### Implementation Details
+
+The `spath` command is implemented as a lightweight conversion that rewrites to a `json_extract` eval expression internally:
+
+```java
+public Eval rewriteAsEval() {
+    String outField = this.outField;
+    if (outField == null) {
+        outField = this.path;
+    }
+    return AstDSL.eval(
+        this.child,
+        AstDSL.let(
+            AstDSL.field(outField),
+            AstDSL.function("json_extract", AstDSL.field(inField), 
+                           AstDSL.stringLiteral(this.path))));
+}
+```
+
+## Limitations
+
+- **No pushdown optimization**: The `spath` command does not support pushdown behavior for extraction, which may result in slower performance on large datasets
+- **JSON only**: Currently only supports JSON data extraction (XML support planned for future releases)
+- **String output**: Always returns strings for inner types; explicit casting is required for numeric operations
+- **Indexing recommended**: For filtering on nested fields, it's generally better to index fields directly rather than using `spath`
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4120](https://github.com/opensearch-project/sql/pull/4120) | Starter implementation for `spath` command |
+
+## References
+
+- [Issue #4119](https://github.com/opensearch-project/sql/issues/4119): RFC - Improved structured data extraction with `spath`
+- [PPL Commands Documentation](https://docs.opensearch.org/3.3/search-plugins/sql/ppl/functions/): Official PPL commands reference
+- [json_extract Function](https://github.com/opensearch-project/sql/blob/main/integ-test/src/test/java/org/opensearch/sql/calcite/remote/CalcitePPLJsonBuiltinFunctionIT.java): Related JSON extraction functionality
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/sql/ppl-spath-command.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -137,6 +137,7 @@
 ### SQL
 
 - [PPL Rename Command - Wildcard Support](features/sql/ppl-rename-command.md)
+- [PPL Spath Command](features/sql/ppl-spath-command.md)
 - [SQL/PPL Bug Fixes](features/sql/sql-ppl-bug-fixes.md)
 
 ### Reporting


### PR DESCRIPTION
## Summary

Add documentation for the PPL `spath` command introduced in OpenSearch v3.3.0.

## Changes

- Created release report: `docs/releases/v3.3.0/features/sql/ppl-spath-command.md`
- Created feature report: `docs/features/sql/ppl-spath-command.md`
- Updated release index and features index

## Feature Overview

The `spath` command provides a simple way to extract fields from JSON data stored in text fields, serving as a user-friendly alternative to `json_extract()`.

### Key Points
- Syntax: `spath input=<field> [output=<field>] [path=]<path>`
- Supports nested fields, array access, and escaped paths
- Internally rewrites to `json_extract` eval expression
- No pushdown optimization (performance consideration for large datasets)

## Related
- PR: opensearch-project/sql#4120
- Issue: opensearch-project/sql#4119
- Tracking Issue: #1331