### PR TITLE
docs: add PPL patterns command report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -311,6 +311,7 @@
 - [Flint Index Operations](sql/flint-index-operations.md)
 - [Flint Query Scheduler](sql/flint-query-scheduler.md)
 - [PPL Documentation](sql/ppl-documentation.md)
+- [PPL Patterns Command](sql/ppl-patterns-command.md)
 - [PPL Rename Command](sql/ppl-rename-command.md)
 - [PPL Spath Command](sql/ppl-spath-command.md)
 - [Security Lake Data Source](sql/security-lake-data-source.md)

--- a/docs/features/sql/ppl-patterns-command.md
+++ b/docs/features/sql/ppl-patterns-command.md
@@ -1,0 +1,149 @@
+# PPL Patterns Command
+
+## Summary
+
+The PPL `patterns` command extracts and identifies recurring structural patterns from log messages. It supports two algorithms (simple_pattern and brain) and two modes (label and aggregation), enabling users to analyze log data for pattern discovery, anomaly detection, and log categorization.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph Input
+        LOG[Log Messages]
+    end
+    
+    subgraph "Patterns Command"
+        PARSE[Parse Field]
+        METHOD{Method}
+        SIMPLE[Simple Pattern<br/>Regex-based]
+        BRAIN[Brain Algorithm<br/>ML-based]
+        MODE{Mode}
+        LABEL[Label Mode<br/>Per-document]
+        AGG[Aggregation Mode<br/>Grouped results]
+    end
+    
+    subgraph Output
+        PATTERN[patterns_field]
+        COUNT[pattern_count]
+        TOKENS[tokens]
+        SAMPLES[sample_logs]
+    end
+    
+    LOG --> PARSE
+    PARSE --> METHOD
+    METHOD -->|simple_pattern| SIMPLE
+    METHOD -->|brain| BRAIN
+    SIMPLE --> MODE
+    BRAIN --> MODE
+    MODE -->|label| LABEL
+    MODE -->|aggregation| AGG
+    LABEL --> PATTERN
+    LABEL --> TOKENS
+    AGG --> PATTERN
+    AGG --> COUNT
+    AGG --> TOKENS
+    AGG --> SAMPLES
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Source Index] --> B[patterns command]
+    B --> C{Mode}
+    C -->|label| D[Per-document patterns]
+    C -->|aggregation| E[Grouped patterns]
+    D --> F[patterns_field per row]
+    E --> G[pattern + count + samples]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `BrainLogParser` | ML-based log pattern extraction using the Brain algorithm |
+| `PatternUtils` | Utility functions for pattern parsing and variable extraction |
+| `LogPatternAggFunction` | Aggregation function for pattern grouping |
+| `PatternParserFunctionImpl` | UDF implementation for pattern parsing |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ppl.pattern.method` | Default pattern extraction method | `simple_pattern` |
+| `plugins.ppl.pattern.mode` | Default output mode | `label` |
+| `plugins.ppl.pattern.max.sample.count` | Max sample logs per pattern in aggregation | `10` |
+| `plugins.ppl.pattern.buffer.limit` | Buffer limit for Brain algorithm | `100000` |
+| `plugins.ppl.pattern.show.numbered.token` | Show numbered tokens in output | `false` |
+
+### Syntax
+
+```
+patterns <field> [by byClause...] [method=simple_pattern|brain] [mode=label|aggregation] 
+         [max_sample_count=N] [buffer_limit=N] [show_numbered_token=true|false] 
+         [new_field=<alias>] [pattern=<regex>] [variable_count_threshold=N] 
+         [frequency_threshold_percentage=N]
+```
+
+### Usage Examples
+
+**Label mode with simple pattern**:
+```sql
+source=logs | patterns message | fields message, patterns_field
+```
+
+**Aggregation mode with Brain algorithm**:
+```sql
+source=logs | patterns message method=brain mode=aggregation | fields patterns_field, pattern_count, sample_logs
+```
+
+**With numbered tokens**:
+```sql
+source=logs | patterns message mode=aggregation show_numbered_token=true | fields patterns_field, tokens
+```
+
+**With custom regex pattern**:
+```sql
+source=logs | patterns message pattern='[0-9]+' new_field='no_numbers' | fields message, no_numbers
+```
+
+**With group by clause**:
+```sql
+source=logs | patterns message by level mode=aggregation | fields level, patterns_field, pattern_count
+```
+
+### Output Fields
+
+| Field | Mode | Description |
+|-------|------|-------------|
+| `patterns_field` | Both | The extracted pattern with variables replaced by placeholders |
+| `tokens` | Both (when show_numbered_token=true) | Map of token names to extracted values |
+| `pattern_count` | Aggregation | Number of logs matching the pattern |
+| `sample_logs` | Aggregation | Sample log messages matching the pattern |
+
+## Limitations
+
+- The `patterns` command is not rewritten to OpenSearch DSL; it executes on the coordination node
+- Brain algorithm requires sufficient memory for large datasets (controlled by `buffer_limit`)
+- V2 engine does not support `show_numbered_token` option
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#4155](https://github.com/opensearch-project/sql/pull/4155) | Add sample_logs output field |
+| v3.3.0 | [#4402](https://github.com/opensearch-project/sql/pull/4402) | Add show_numbered_token option, fix continuous wildcards bug |
+
+## References
+
+- [Issue #4139](https://github.com/opensearch-project/sql/issues/4139): Feature request for sample_logs field
+- [Issue #4364](https://github.com/opensearch-project/sql/issues/4364): Feature request for optional numbered tokens
+- [PPL Commands Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/ppl/functions/): Official PPL commands reference
+
+## Change History
+
+- **v3.3.0** (2026-01-14): Added `sample_logs` output field, `show_numbered_token` option, fixed continuous wildcards bug
+- **v3.1.0**: Added aggregation mode, Brain algorithm support
+- **v3.0.0**: Initial patterns command implementation

--- a/docs/releases/v3.3.0/features/sql/ppl-patterns-command.md
+++ b/docs/releases/v3.3.0/features/sql/ppl-patterns-command.md
@@ -1,0 +1,98 @@
+# PPL Patterns Command Enhancements
+
+## Summary
+
+OpenSearch v3.3.0 enhances the PPL `patterns` command with two key improvements: adding `sample_logs` output field to aggregation results for backward compatibility with V2 engine, and introducing a `show_numbered_token` option to control the output format of variable placeholders. These changes improve usability and provide more flexibility in log pattern analysis.
+
+## Details
+
+### What's New in v3.3.0
+
+1. **sample_logs Output Field**: The `patterns` command in aggregation mode now includes `sample_logs` in the output, matching the V2 engine behavior. This field contains sample log messages that match each detected pattern.
+
+2. **show_numbered_token Option**: A new `show_numbered_token` parameter allows users to choose between numbered token format (`<token1>`, `<token2>`) and standard wildcard format (`<*>`).
+
+3. **Bug Fix for Continuous Wildcards**: Fixed an issue where the Brain algorithm could generate patterns with continuous variable placeholders like `<*><*><*>` instead of merging them into a single `<*>`.
+
+### Technical Changes
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `show_numbered_token` | Controls whether to output numbered tokens (`<token1>`) or standard wildcards (`<*>`) | `false` |
+| `plugins.ppl.pattern.show.numbered.token` | Cluster setting for default show_numbered_token value | `false` |
+
+#### Output Format Changes
+
+**Default Output (show_numbered_token=false)**:
+- Pattern field uses `<*>` placeholders
+- No `tokens` field in output
+- Compatible with V2 engine format
+
+**Numbered Token Output (show_numbered_token=true)**:
+- Pattern field uses `<token1>`, `<token2>`, etc.
+- Includes `tokens` field mapping token names to extracted values
+- Useful for detailed variable extraction
+
+### Usage Example
+
+**Basic aggregation mode (default format)**:
+```sql
+source=logs | patterns message mode=aggregation | fields patterns_field, pattern_count, sample_logs
+```
+
+Output:
+```
++-----------------------------------------------+---------------+---------------------------+
+| patterns_field                                | pattern_count | sample_logs               |
++-----------------------------------------------+---------------+---------------------------+
+| <*IP*> - <*> [<*>/Sep/<*>:<*>:<*>:<*> <*>]... | 4             | [log1, log2, log3, log4]  |
++-----------------------------------------------+---------------+---------------------------+
+```
+
+**With numbered tokens**:
+```sql
+source=logs | patterns message mode=aggregation show_numbered_token=true | fields patterns_field, pattern_count, tokens
+```
+
+Output:
+```
++-------------------------------------------------------+---------------+----------------------------------+
+| patterns_field                                        | pattern_count | tokens                           |
++-------------------------------------------------------+---------------+----------------------------------+
+| <token1> - <token2> [<token3>/Sep/<token4>:...]       | 4             | {'<token1>': ['ip1', 'ip2',...]} |
++-------------------------------------------------------+---------------+----------------------------------+
+```
+
+### Migration Notes
+
+- Existing queries using `patterns` command will continue to work
+- The default output format now uses `<*>` placeholders (V2-compatible)
+- To get numbered tokens (previous Calcite default), add `show_numbered_token=true`
+- The `sample_logs` field is now automatically included in aggregation mode
+
+## Limitations
+
+- The `show_numbered_token` option only affects Calcite engine output
+- V2 engine always uses the standard `<*>` format
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4155](https://github.com/opensearch-project/sql/pull/4155) | Add sample_logs output field to patterns command aggregation result |
+| [#4402](https://github.com/opensearch-project/sql/pull/4402) | Fix numbered token bug and make it optional output |
+
+## References
+
+- [Issue #4139](https://github.com/opensearch-project/sql/issues/4139): Feature request for sample_logs field
+- [Issue #4364](https://github.com/opensearch-project/sql/issues/4364): Feature request for optional numbered tokens
+- [Issue #4363](https://github.com/opensearch-project/sql/issues/4363): Bug report for continuous wildcards
+- [Issue #4362](https://github.com/opensearch-project/sql/issues/4362): Related bug fix
+- [Issue #4366](https://github.com/opensearch-project/sql/issues/4366): Related bug fix
+- [PPL Commands Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/ppl/functions/): Official PPL commands reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/sql/ppl-patterns-command.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -136,6 +136,7 @@
 
 ### SQL
 
+- [PPL Patterns Command Enhancements](features/sql/ppl-patterns-command.md)
 - [PPL Rename Command - Wildcard Support](features/sql/ppl-rename-command.md)
 - [PPL Rex and Regex Commands](features/sql/ppl-rex-and-regex-commands.md)
 - [PPL Spath Command](features/sql/ppl-spath-command.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the PPL patterns command enhancements in OpenSearch v3.3.0.

### Changes in v3.3.0

1. **sample_logs Output Field**: The `patterns` command in aggregation mode now includes `sample_logs` in the output, matching the V2 engine behavior.

2. **show_numbered_token Option**: A new `show_numbered_token` parameter allows users to choose between numbered token format (`<token1>`, `<token2>`) and standard wildcard format (`<*>`).

3. **Bug Fix for Continuous Wildcards**: Fixed an issue where the Brain algorithm could generate patterns with continuous variable placeholders.

### Reports Created

- Release report: `docs/releases/v3.3.0/features/sql/ppl-patterns-command.md`
- Feature report: `docs/features/sql/ppl-patterns-command.md`

### Related PRs

- [opensearch-project/sql#4155](https://github.com/opensearch-project/sql/pull/4155): Add sample_logs output field
- [opensearch-project/sql#4402](https://github.com/opensearch-project/sql/pull/4402): Add show_numbered_token option, fix continuous wildcards bug

Closes #1329