### PR TITLE
docs: add SQL/PPL Aggregation Pushdown report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -311,6 +311,7 @@
 - [Flint Index Operations](sql/flint-index-operations.md)
 - [Flint Query Scheduler](sql/flint-query-scheduler.md)
 - [PPL Aggregate Functions](sql/ppl-aggregate-functions.md)
+- [PPL Aggregation Pushdown](sql/ppl-aggregation-pushdown.md)
 - [PPL Documentation](sql/ppl-documentation.md)
 - [PPL Patterns Command](sql/ppl-patterns-command.md)
 - [PPL Rename Command](sql/ppl-rename-command.md)

--- a/docs/features/sql/ppl-aggregation-pushdown.md
+++ b/docs/features/sql/ppl-aggregation-pushdown.md
@@ -1,0 +1,244 @@
+# PPL Aggregation Pushdown
+
+## Summary
+
+PPL Aggregation Pushdown is a query optimization feature that translates PPL (Piped Processing Language) aggregation operations directly into efficient OpenSearch DSL queries. Instead of fetching raw data and computing aggregations on the coordination node, pushdown optimization leverages OpenSearch's native aggregation capabilities, resulting in significant performance improvements—up to 100x faster for certain query patterns.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "PPL Query Processing"
+        Q[PPL Query] --> Parser[PPL Parser]
+        Parser --> LP[Logical Plan]
+        LP --> Calcite[Calcite Optimizer]
+    end
+    
+    subgraph "Pushdown Analysis"
+        Calcite --> PA[Pushdown Analyzer]
+        PA --> AFA[AggregateFilterAnalyzer]
+        PA --> LPA[LimitPushdownAnalyzer]
+        PA --> SGA[SingleGroupByOptimizer]
+        PA --> SLA[SumLiteralAnalyzer]
+        PA --> THA[TopHitsAnalyzer]
+        PA --> ADH[AutoDateHistogramAnalyzer]
+    end
+    
+    subgraph "DSL Generation"
+        AFA --> DSL[OpenSearch DSL Builder]
+        LPA --> DSL
+        SGA --> DSL
+        SLA --> DSL
+        THA --> DSL
+        ADH --> DSL
+    end
+    
+    subgraph "OpenSearch Execution"
+        DSL --> ES[OpenSearch Engine]
+        ES --> AGG[Aggregation Results]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Without Pushdown"
+        Q1[PPL Query] --> F1[Fetch All Documents]
+        F1 --> C1[Coordination Node]
+        C1 --> A1[Compute Aggregation]
+        A1 --> R1[Results]
+    end
+    
+    subgraph "With Pushdown"
+        Q2[PPL Query] --> T2[Translate to DSL]
+        T2 --> E2[Execute on Data Nodes]
+        E2 --> R2[Aggregated Results]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `AggregateFilterAnalyzer` | Translates `count(eval(...))` to OpenSearch filter aggregations |
+| `LimitPushdownRule` | Pushes LIMIT operators into aggregation bucket sizes |
+| `SingleGroupByOptimizer` | Converts single group-by to terms aggregation instead of composite |
+| `SumLiteralOptimizer` | Rewrites `SUM(field + literal)` to `SUM(field) + literal * COUNT()` |
+| `TopHitsAggregationBuilder` | Builds `top_hits` aggregations for earliest/latest functions |
+| `AutoDateHistogramBuilder` | Builds `auto_date_histogram` for time-based binning |
+| `PredicateAnalyzer` | Handles `IS_TRUE` operator for proper null handling in filters |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.calcite.enabled` | Enable Calcite engine for advanced PPL optimizations | `false` |
+| `plugins.ppl.syntax.legacy.preferred` | Use legacy PPL behavior for backward compatibility | `true` |
+
+### Pushdown Optimizations
+
+#### 1. Single Group-By Optimization
+
+Replaces expensive composite aggregations with faster terms aggregations when there is only one group-by expression.
+
+**Before (Composite Aggregation):**
+```json
+{
+  "aggregations": {
+    "composite_buckets": {
+      "composite": {
+        "size": 1000,
+        "sources": [{ "field": { "terms": { "field": "state" } } }]
+      }
+    }
+  }
+}
+```
+
+**After (Terms Aggregation):**
+```json
+{
+  "aggregations": {
+    "state": {
+      "terms": { "field": "state", "size": 1000 }
+    }
+  }
+}
+```
+
+#### 2. Filtered Aggregation Pushdown
+
+Translates `count(eval(...))` expressions into OpenSearch filter aggregations.
+
+```ppl
+source=accounts | stats count(eval(status="200")) as success_count
+```
+
+Generated DSL:
+```json
+{
+  "aggregations": {
+    "success_count": {
+      "filter": { "term": { "status": "200" } },
+      "aggregations": {
+        "success_count": { "value_count": { "field": "_index" } }
+      }
+    }
+  }
+}
+```
+
+#### 3. Limit Pushdown
+
+Pushes LIMIT operators into aggregation bucket sizes.
+
+```ppl
+source=accounts | stats avg(age) by state | head 10
+```
+
+The `head 10` is pushed into the aggregation's bucket size parameter.
+
+#### 4. SUM with Literal Optimization
+
+Optimizes `SUM(field + literal)` by rewriting to `SUM(field) + literal * COUNT()`.
+
+```ppl
+source=data | stats sum(price + 10) as total
+# Optimized to: sum(price) + 10 * count()
+```
+
+#### 5. Earliest/Latest Pushdown
+
+Pushes `earliest`/`latest` aggregate functions to `top_hits` aggregation.
+
+```ppl
+source=logs | stats earliest(message), latest(status) by host
+```
+
+Generated DSL uses `top_hits` with sort by timestamp.
+
+#### 6. Auto Date Histogram
+
+Pushes `stats` with `bins` on time fields into `auto_date_histogram`.
+
+```ppl
+source=logs | stats count() by bins(@timestamp, 20)
+```
+
+Generated DSL:
+```json
+{
+  "aggregations": {
+    "date": {
+      "auto_date_histogram": {
+        "field": "@timestamp",
+        "buckets": 20
+      }
+    }
+  }
+}
+```
+
+### Usage Examples
+
+#### Basic Aggregation with Pushdown
+```ppl
+# Pushed down to OpenSearch
+source=accounts | stats avg(age), sum(balance) by state
+```
+
+#### Conditional Counting
+```ppl
+# Uses filter aggregation pushdown
+source=logs | stats count(eval(http_status LIKE "2%")) as success,
+                    count(eval(http_status LIKE "5%")) as errors
+```
+
+#### Time-Series Aggregation
+```ppl
+# Uses date_histogram pushdown
+source=metrics | stats avg(cpu) by span(@timestamp, 1h)
+```
+
+#### Top N Results
+```ppl
+# Limit pushed to bucket size
+source=sales | stats sum(amount) by product | sort -sum(amount) | head 10
+```
+
+## Limitations
+
+- Pushdown requires `plugins.calcite.enabled=true`
+- Single group-by optimization only applies with exactly one group-by expression
+- Complex expressions may fall back to coordination node execution
+- Some functions are not pushdown-compatible and execute post-aggregation
+- `bucket_nullable` setting affects null bucket handling in results
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#3550](https://github.com/opensearch-project/sql/pull/3550) | Speed up aggregation pushdown for single group-by expression |
+| v3.3.0 | [#3971](https://github.com/opensearch-project/sql/pull/3971) | SUM aggregation enhancement on operations with literal |
+| v3.3.0 | [#4166](https://github.com/opensearch-project/sql/pull/4166) | Pushdown earliest/latest aggregate functions |
+| v3.3.0 | [#4213](https://github.com/opensearch-project/sql/pull/4213) | Enable pushdown optimization for filtered aggregation |
+| v3.3.0 | [#4228](https://github.com/opensearch-project/sql/pull/4228) | Push down limit operator into aggregation bucket size |
+| v3.3.0 | [#4329](https://github.com/opensearch-project/sql/pull/4329) | Push down stats with bins on time field into auto_date_histogram |
+
+## References
+
+- [Issue #3528](https://github.com/opensearch-project/sql/issues/3528): Span query in PPL is slower than date histogram aggregation
+- [Issue #3949](https://github.com/opensearch-project/sql/issues/3949): Support eval-style expressions inside stats command
+- [Issue #3961](https://github.com/opensearch-project/sql/issues/3961): Support Limit pushdown through aggregation
+- [Issue #3967](https://github.com/opensearch-project/sql/issues/3967): Aggregation enhancement for SUM on FIELD + NUMBER
+- [Issue #3639](https://github.com/opensearch-project/sql/issues/3639): PPL earliest/latest aggregation function support
+- [Issue #4210](https://github.com/opensearch-project/sql/issues/4210): Span()/bin should support auto_date_histogram aggregation
+- [PPL Commands Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/ppl/functions/)
+- [OpenSearch Aggregations](https://docs.opensearch.org/3.0/aggregations/)
+
+## Change History
+
+- **v3.3.0** (2026-01-11): Added single group-by optimization, filtered aggregation pushdown, limit pushdown, SUM literal optimization, earliest/latest pushdown, and auto_date_histogram support

--- a/docs/releases/v3.3.0/features/sql/ppl-aggregation-pushdown.md
+++ b/docs/releases/v3.3.0/features/sql/ppl-aggregation-pushdown.md
@@ -1,0 +1,157 @@
+# SQL/PPL Aggregation Pushdown
+
+## Summary
+
+OpenSearch v3.3.0 introduces significant performance improvements to PPL (Piped Processing Language) aggregation queries through enhanced pushdown optimizations. These changes translate PPL aggregation operations directly into efficient OpenSearch DSL queries, achieving up to 100x performance improvements for certain query patterns.
+
+## Details
+
+### What's New in v3.3.0
+
+This release adds multiple aggregation pushdown optimizations:
+
+1. **Single group-by optimization**: Replaces expensive composite aggregations with faster terms aggregations for single group-by expressions
+2. **Filtered aggregation pushdown**: Translates `count(eval(...))` expressions into OpenSearch filter aggregations
+3. **Limit pushdown to aggregation bucket size**: Pushes LIMIT operators into aggregation bucket sizes
+4. **SUM with literal optimization**: Optimizes `SUM(field + literal)` to `SUM(field) + literal * COUNT()`
+5. **Earliest/Latest function pushdown**: Pushes `earliest`/`latest` aggregate functions to `top_hits` aggregation
+6. **Auto date histogram support**: Pushes `stats` with `bins` on time fields into `auto_date_histogram`
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "PPL Query"
+        Q[PPL Query] --> Parser[PPL Parser]
+        Parser --> AST[Logical Plan]
+    end
+    
+    subgraph "Calcite Optimization"
+        AST --> Calcite[Calcite Optimizer]
+        Calcite --> Rules[Pushdown Rules]
+    end
+    
+    subgraph "Pushdown Rules"
+        Rules --> AFA[AggregateFilterAnalyzer]
+        Rules --> LPA[LimitPushdownAnalyzer]
+        Rules --> SGA[SingleGroupByOptimizer]
+        Rules --> SUM[SumLiteralOptimizer]
+        Rules --> ADH[AutoDateHistogramPushdown]
+    end
+    
+    subgraph "OpenSearch DSL"
+        AFA --> Filter[Filter Aggregation]
+        LPA --> Bucket[Bucket Size]
+        SGA --> Terms[Terms Aggregation]
+        SUM --> Script[Script Aggregation]
+        ADH --> AutoHist[auto_date_histogram]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `AggregateFilterAnalyzer` | Analyzes and pushes filtered aggregations to OpenSearch filter aggregations |
+| `LimitPushdownRule` | Pushes LIMIT operators into aggregation bucket sizes |
+| `SingleGroupByOptimizer` | Optimizes single group-by queries to use terms aggregation instead of composite |
+| `SumLiteralOptimizer` | Rewrites `SUM(field + literal)` to `SUM(field) + literal * COUNT()` |
+| `AutoDateHistogramBuilder` | Builds `auto_date_histogram` aggregations for time-based binning |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ppl.syntax.legacy.preferred` | Controls default PPL behavior for backward compatibility | `true` |
+| `bucket_nullable` | Controls whether null buckets are included in group-by results | `true` (legacy) / `false` (new) |
+
+### Usage Examples
+
+#### Filtered Aggregation Pushdown
+
+```ppl
+# Before: Executed on coordination node
+source=accounts | stats count(eval(age = 31)) as cnt
+
+# After: Pushed down to OpenSearch DSL
+# Generates filter aggregation with term query
+```
+
+Generated DSL:
+```json
+{
+  "aggregations": {
+    "cnt": {
+      "filter": {
+        "term": { "age": { "value": 31 } }
+      },
+      "aggregations": {
+        "cnt": { "value_count": { "field": "_index" } }
+      }
+    }
+  }
+}
+```
+
+#### Single Group-By Optimization
+
+```ppl
+# Before: Uses composite aggregation (slow)
+source=logs | stats count() by span(@timestamp, 12h)
+
+# After: Uses date_histogram aggregation (100x faster)
+```
+
+#### Limit Pushdown
+
+```ppl
+# LIMIT is pushed into aggregation bucket size
+source=accounts | stats avg(age) by state, city | head 100
+```
+
+#### Auto Date Histogram
+
+```ppl
+# Uses auto_date_histogram for dynamic bucket sizing
+source=logs | stats count() by bins(@timestamp, 20)
+```
+
+### Migration Notes
+
+- Set `plugins.ppl.syntax.legacy.preferred=false` to enable new optimizations by default
+- The `bucket_nullable` argument in `stats` command controls null bucket handling
+- Existing queries continue to work with legacy behavior when `plugins.ppl.syntax.legacy.preferred=true`
+
+## Limitations
+
+- Single group-by optimization only applies when there is exactly one group-by expression
+- Filtered aggregation pushdown requires Calcite engine (`plugins.calcite.enabled=true`)
+- Auto date histogram pushdown only works with time/date fields
+- Some complex expressions may not be pushed down and will execute on the coordination node
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3550](https://github.com/opensearch-project/sql/pull/3550) | Speed up aggregation pushdown for single group-by expression |
+| [#3971](https://github.com/opensearch-project/sql/pull/3971) | SUM aggregation enhancement on operations with literal |
+| [#4166](https://github.com/opensearch-project/sql/pull/4166) | Pushdown earliest/latest aggregate functions |
+| [#4213](https://github.com/opensearch-project/sql/pull/4213) | Enable pushdown optimization for filtered aggregation |
+| [#4228](https://github.com/opensearch-project/sql/pull/4228) | Push down limit operator into aggregation bucket size |
+| [#4329](https://github.com/opensearch-project/sql/pull/4329) | Push down stats with bins on time field into auto_date_histogram |
+
+## References
+
+- [Issue #3528](https://github.com/opensearch-project/sql/issues/3528): Span query in PPL is slower than date histogram aggregation
+- [Issue #3949](https://github.com/opensearch-project/sql/issues/3949): Support eval-style expressions inside stats command
+- [Issue #3961](https://github.com/opensearch-project/sql/issues/3961): Support Limit pushdown through aggregation
+- [Issue #3967](https://github.com/opensearch-project/sql/issues/3967): Aggregation enhancement for SUM on FIELD + NUMBER
+- [Issue #3639](https://github.com/opensearch-project/sql/issues/3639): PPL earliest/latest aggregation function support
+- [Issue #4210](https://github.com/opensearch-project/sql/issues/4210): Span()/bin should support auto_date_histogram aggregation
+- [PPL Commands Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/ppl/functions/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/sql/ppl-aggregation-pushdown.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -137,6 +137,7 @@
 ### SQL
 
 - [PPL Aggregate Functions](features/sql/ppl-aggregate-functions.md)
+- [PPL Aggregation Pushdown](features/sql/ppl-aggregation-pushdown.md)
 - [PPL Patterns Command Enhancements](features/sql/ppl-patterns-command.md)
 - [PPL Rename Command - Wildcard Support](features/sql/ppl-rename-command.md)
 - [PPL Rex and Regex Commands](features/sql/ppl-rex-and-regex-commands.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the SQL/PPL Aggregation Pushdown feature in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/sql/ppl-aggregation-pushdown.md`
- Feature report: `docs/features/sql/ppl-aggregation-pushdown.md`

### Key Changes in v3.3.0

- **Single group-by optimization**: Replaces expensive composite aggregations with faster terms aggregations (up to 100x performance improvement)
- **Filtered aggregation pushdown**: Translates `count(eval(...))` expressions into OpenSearch filter aggregations
- **Limit pushdown**: Pushes LIMIT operators into aggregation bucket sizes
- **SUM with literal optimization**: Optimizes `SUM(field + literal)` to `SUM(field) + literal * COUNT()`
- **Earliest/Latest pushdown**: Pushes `earliest`/`latest` aggregate functions to `top_hits` aggregation
- **Auto date histogram support**: Pushes `stats` with `bins` on time fields into `auto_date_histogram`

### Related PRs
- #3550: Speed up aggregation pushdown for single group-by expression
- #3971: SUM aggregation enhancement on operations with literal
- #4166: Pushdown earliest/latest aggregate functions
- #4213: Enable pushdown optimization for filtered aggregation
- #4228: Push down limit operator into aggregation bucket size
- #4329: Push down stats with bins on time field into auto_date_histogram

Closes #1327