### PR TITLE
docs: add Index Insight report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -368,6 +368,7 @@
 
 - [Agent Framework](ml-commons/ml-commons-agent-framework.md)
 - [Batch Ingestion](ml-commons/batch-ingestion.md)
+- [Index Insight](ml-commons/index-insight.md)
 - [Metrics Framework](ml-commons/metrics-framework.md)
 - [ML Commons Bugfixes](ml-commons/ml-commons-bugfixes.md)
 - [ML Commons CI/CD](ml-commons/ml-commons-ci-cd.md)

--- a/docs/features/ml-commons/index-insight.md
+++ b/docs/features/ml-commons/index-insight.md
@@ -1,0 +1,244 @@
+# Index Insight
+
+## Summary
+
+Index Insight is a centralized feature in ML Commons that provides AI-powered analysis of OpenSearch indices. It generates comprehensive insights including statistical data, field descriptions, and log-related index checks to enhance downstream AI features like Query Assistant, T2Viz, and Anomaly Detection Suggestion.
+
+The feature addresses the challenge of providing sufficient context to LLMs about index structure and semantics, which was previously limited to basic schema and occasional document samples.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Client Layer"
+        REST[REST API]
+        Tool[IndexInsightTool]
+    end
+    
+    subgraph "Task Execution Layer"
+        Executor[Task Executor]
+        STAT[StatisticalDataTask]
+        FIELD[FieldDescriptionTask]
+        LOG[LogRelatedIndexCheckTask]
+    end
+    
+    subgraph "Storage Layer"
+        ConfigIdx[Config Index]
+        StorageIdx[Storage Index]
+    end
+    
+    subgraph "External Dependencies"
+        LLM[LLM Agent]
+        TargetIdx[Target Index]
+    end
+    
+    REST --> Executor
+    Tool --> Executor
+    
+    Executor --> STAT
+    Executor --> FIELD
+    Executor --> LOG
+    
+    STAT --> TargetIdx
+    STAT --> StorageIdx
+    
+    FIELD --> STAT
+    FIELD --> LLM
+    FIELD --> StorageIdx
+    
+    LOG --> TargetIdx
+    LOG --> LLM
+    LOG --> StorageIdx
+    
+    REST --> ConfigIdx
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    Request[API Request] --> CheckCache{Cache Valid?}
+    CheckCache -->|Yes| ReturnCache[Return Cached Result]
+    CheckCache -->|No| CheckPattern{Pattern Match?}
+    
+    CheckPattern -->|Yes| FilterPattern[Filter Pattern Result]
+    FilterPattern --> ReturnResult[Return Result]
+    
+    CheckPattern -->|No| CheckPrereq{Has Prerequisites?}
+    CheckPrereq -->|Yes| RunPrereq[Run Prerequisites]
+    RunPrereq --> RunTask[Run Task]
+    CheckPrereq -->|No| RunTask
+    
+    RunTask --> SaveCache[Save to Cache]
+    SaveCache --> ReturnResult
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `IndexInsight` | Core data model containing index name, content, status, task type, and timestamp |
+| `IndexInsightConfig` | Configuration model for feature enablement |
+| `IndexInsightTask` | Interface defining task execution contract |
+| `AbstractIndexInsightTask` | Base implementation with caching, prerequisite handling, and LLM integration |
+| `StatisticalDataTask` | Collects index mapping, data distribution, and sample documents using DSL aggregations |
+| `FieldDescriptionTask` | Generates semantic descriptions for fields using LLM with batch processing |
+| `LogRelatedIndexCheckTask` | Analyzes index to determine log/trace relevance and identify key fields |
+| `IndexInsightTool` | Agent tool wrapper for integration with ML Commons agent framework |
+| `MergeRuleHelper` | Utility for merging index mappings from multiple shards |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ml_commons.index_insight_feature_enabled` | Enable/disable the feature | `false` |
+| `INDEX_INSIGHT_UPDATE_INTERVAL` | Cache refresh interval | 24 hours |
+| `INDEX_INSIGHT_GENERATING_TIMEOUT` | Task generation timeout | 3 minutes |
+
+### System Indices
+
+| Index | Purpose | Mapping |
+|-------|---------|---------|
+| `.plugins-ml-index-insight-config` | Feature configuration | `is_enable`, `tenant_id` |
+| `.plugins-ml-index-insight-storage` | Insight cache | `index_name`, `status`, `task_type`, `content`, `last_updated_time`, `tenant_id` |
+
+### API Reference
+
+#### Enable/Disable Index Insight
+
+```json
+PUT /_plugins/_ml/index_insight_config
+{
+    "is_enable": true
+}
+```
+
+#### Get Configuration
+
+```json
+GET /_plugins/_ml/index_insight_config
+```
+
+#### Get Index Insight
+
+```json
+GET /_plugins/_ml/insights/{index_name}/{task_type}
+```
+
+Task types: `STATISTICAL_DATA`, `FIELD_DESCRIPTION`, `LOG_RELATED_INDEX_CHECK`, `ALL`
+
+### Task Types
+
+#### StatisticalDataTask
+
+Collects comprehensive statistical information about an index:
+
+- **Index Mapping**: Field names and types
+- **Data Distribution**: Unique terms, cardinality, min/max values for numeric fields
+- **Sample Documents**: Representative documents from the index
+
+Uses sampler aggregation (100,000 documents) with terms, cardinality, min, max, and top_hits aggregations.
+
+#### FieldDescriptionTask
+
+Generates semantic descriptions for index fields using LLM:
+
+- Depends on `StatisticalDataTask` for context
+- Processes fields in batches of 50
+- Filters to important columns (>0.1% non-null rate)
+- Uses LLM to filter to top 30 most relevant fields
+
+#### LogRelatedIndexCheckTask
+
+Analyzes index to determine:
+
+- Whether the index contains log data
+- Which field contains full log messages
+- Which field serves as trace ID for correlating logs
+
+### Usage Example
+
+```json
+// 1. Enable feature
+PUT /_plugins/_ml/index_insight_config
+{
+    "is_enable": true
+}
+
+// 2. Configure LLM agent
+POST /_plugins/_ml/agents/_register
+{
+  "name": "GENERAL_TOOL",
+  "type": "flow",
+  "tools": [
+    {
+      "type": "MLModelTool",
+      "parameters": {
+        "model_id": "<model_id>"
+      }
+    }
+  ]
+}
+
+PUT /.plugins-ml-config/_doc/os_index_insight_agent
+{
+    "type": "os_index_insight_agent",
+    "configuration": {
+        "agent_id": "<agent_id>"
+    }
+}
+
+// 3. Get statistical data
+GET /_plugins/_ml/insights/my-logs-2024.01/STATISTICAL_DATA
+
+// 4. Get field descriptions
+GET /_plugins/_ml/insights/my-logs-2024.01/FIELD_DESCRIPTION
+
+// 5. Check if log-related
+GET /_plugins/_ml/insights/my-logs-2024.01/LOG_RELATED_INDEX_CHECK
+```
+
+### Agent Tool Integration
+
+```json
+POST /_plugins/_ml/agents/_register
+{
+  "name": "Index Analysis Agent",
+  "type": "flow",
+  "tools": [
+    {
+      "type": "IndexInsightTool",
+      "name": "IndexInsightTool",
+      "description": "Get index details including statistical data, field descriptions, and log-related checks",
+      "attributes": {
+        "input_schema": "{\"type\":\"object\",\"properties\":{\"indexName\":{\"type\":\"string\"},\"taskType\":{\"type\":\"string\"}}}"
+      }
+    }
+  ]
+}
+```
+
+## Limitations
+
+- Feature is disabled by default and requires explicit enablement
+- LLM-based tasks (`FIELD_DESCRIPTION`, `LOG_RELATED_INDEX_CHECK`) require a configured agent
+- Only admin users can modify the index insight configuration
+- Large indices may experience longer generation times
+- Pattern matching for similar indices is limited to 100 patterns
+- Batch processing timeout is 60 seconds per batch
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#4088](https://github.com/opensearch-project/ml-commons/pull/4088) | Initial implementation |
+
+## References
+
+- [Issue #3993](https://github.com/opensearch-project/ml-commons/issues/3993): RFC: Index insight: A feature to enhance indices related AI features
+
+## Change History
+
+- **v3.3.0** (2026-01-11): Initial implementation with StatisticalDataTask, FieldDescriptionTask, and LogRelatedIndexCheckTask

--- a/docs/releases/v3.3.0/features/ml-commons/index-insight.md
+++ b/docs/releases/v3.3.0/features/ml-commons/index-insight.md
@@ -1,0 +1,194 @@
+# Index Insight
+
+## Summary
+
+Index Insight is a new feature in ML Commons that provides centralized, AI-powered analysis of OpenSearch indices. It helps downstream AI features (Query Assistant, T2Viz, AD Suggestion) better understand index structure and semantics by generating statistical data, field descriptions, and log-related index checks using LLM integration.
+
+## Details
+
+### What's New in v3.3.0
+
+This release introduces the Index Insight feature as a centralized API for extracting and caching insights about OpenSearch indices. The feature addresses the limitation of providing only index schema and occasional document samples to LLMs by creating a purpose-built mechanism for comprehensive index understanding.
+
+### Technical Changes
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph "Index Insight API"
+        API[REST API]
+        Config[Config API]
+    end
+    
+    subgraph "Task Types"
+        STAT[StatisticalDataTask]
+        FIELD[FieldDescriptionTask]
+        LOG[LogRelatedIndexCheckTask]
+    end
+    
+    subgraph "Storage"
+        ConfigIdx[.plugins-ml-index-insight-config]
+        StorageIdx[.plugins-ml-index-insight-storage]
+    end
+    
+    subgraph "External"
+        LLM[LLM Agent]
+        TargetIdx[Target Index]
+    end
+    
+    API --> STAT
+    API --> FIELD
+    API --> LOG
+    
+    STAT --> TargetIdx
+    FIELD --> STAT
+    FIELD --> LLM
+    LOG --> LLM
+    
+    STAT --> StorageIdx
+    FIELD --> StorageIdx
+    LOG --> StorageIdx
+    
+    Config --> ConfigIdx
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `IndexInsight` | Core data model for storing insight results |
+| `IndexInsightConfig` | Configuration model for enabling/disabling the feature |
+| `AbstractIndexInsightTask` | Base class for all insight task implementations |
+| `StatisticalDataTask` | Collects mapping, data distribution, and sample documents |
+| `FieldDescriptionTask` | Generates LLM-based field descriptions |
+| `LogRelatedIndexCheckTask` | Determines if index is log-related with trace/message fields |
+| `IndexInsightTool` | Agent tool wrapper for index insight actions |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ml_commons.index_insight_feature_enabled` | Enable/disable index insight feature | `false` |
+
+#### New System Indices
+
+| Index | Purpose |
+|-------|---------|
+| `.plugins-ml-index-insight-config` | Stores feature configuration |
+| `.plugins-ml-index-insight-storage` | Stores generated insights |
+
+#### API Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `PUT` | `/_plugins/_ml/index_insight_config` | Enable/disable index insight |
+| `GET` | `/_plugins/_ml/index_insight_config` | Get current configuration |
+| `GET` | `/_plugins/_ml/insights/{index}/{task_type}` | Get insight for an index |
+
+### Usage Example
+
+1. Enable Index Insight:
+```json
+PUT /_plugins/_ml/index_insight_config
+{
+    "is_enable": true
+}
+```
+
+2. Configure the LLM agent for field descriptions:
+```json
+POST /_plugins/_ml/agents/_register
+{
+  "name": "GENERAL_TOOL",
+  "type": "flow",
+  "tools": [
+    {
+      "type": "MLModelTool",
+      "description": "A general tool to answer any question",
+      "parameters": {
+        "model_id": "<model_id>"
+      }
+    }
+  ]
+}
+
+PUT /.plugins-ml-config/_doc/os_index_insight_agent
+{
+    "type": "os_index_insight_agent",
+    "configuration": {
+        "agent_id": "<agent_id>"
+    }
+}
+```
+
+3. Get index insight:
+```json
+GET /_plugins/_ml/insights/my-index/STATISTICAL_DATA
+```
+
+Response:
+```json
+{
+    "index_insight": {
+        "index_name": "my-index",
+        "content": "{\"important_column_and_distribution\":{...},\"example_docs\":[...]}",
+        "status": "COMPLETED",
+        "task_type": "STATISTICAL_DATA",
+        "last_updated_time": 1754888310420
+    }
+}
+```
+
+4. Use as an agent tool:
+```json
+POST /_plugins/_ml/agents/_register
+{
+  "name": "flow agent with index insight tool",
+  "type": "flow",
+  "tools": [
+    {
+      "type": "IndexInsightTool",
+      "name": "IndexInsightTool",
+      "description": "Get index details including statistical data, field descriptions, and log-related checks"
+    }
+  ]
+}
+```
+
+### Task Types
+
+| Task Type | Description | Prerequisites | Uses LLM |
+|-----------|-------------|---------------|----------|
+| `STATISTICAL_DATA` | Index mapping, data distribution, sample documents | None | Optional (for filtering) |
+| `FIELD_DESCRIPTION` | LLM-generated descriptions for each field | `STATISTICAL_DATA` | Yes |
+| `LOG_RELATED_INDEX_CHECK` | Determines if index is log/trace related | None | Yes |
+
+### Caching Behavior
+
+- Insights are cached in `.plugins-ml-index-insight-storage`
+- Cache key: SHA-256 hash of `{index_name}_{task_type}`
+- Update interval: 24 hours (configurable via `INDEX_INSIGHT_UPDATE_INTERVAL`)
+- Generation timeout: 3 minutes (configurable via `INDEX_INSIGHT_GENERATING_TIMEOUT`)
+- Pattern matching: Supports wildcard patterns for similar indices
+
+## Limitations
+
+- Feature is disabled by default; requires explicit enablement
+- LLM-based tasks require a configured agent in ML config
+- Only admin users can modify index insight configuration
+- Large indices may experience longer generation times for statistical data
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4088](https://github.com/opensearch-project/ml-commons/pull/4088) | Add Index Insight Feature |
+
+## References
+
+- [Issue #3993](https://github.com/opensearch-project/ml-commons/issues/3993): RFC: Index insight: A feature to enhance indices related AI features
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/index-insight.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -102,6 +102,7 @@
 
 ### ML Commons
 
+- [Index Insight](features/ml-commons/index-insight.md)
 - [MCP Connector - Streamable HTTP Support](features/ml-commons/mcp-connector.md)
 - [ML Commons Agent Enhancements](features/ml-commons/ml-commons-agent-enhancements.md)
 - [ML Commons Bug Fixes](features/ml-commons/ml-commons-bug-fixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Index Insight feature introduced in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/ml-commons/index-insight.md`
- Feature report: `docs/features/ml-commons/index-insight.md`

### Key Changes in v3.3.0
- New centralized API for extracting AI-powered insights about OpenSearch indices
- Three task types: StatisticalDataTask, FieldDescriptionTask, LogRelatedIndexCheckTask
- LLM integration for generating field descriptions and log-related index checks
- Caching mechanism with 24-hour refresh interval
- New system indices for configuration and storage
- IndexInsightTool for agent framework integration

### Resources Used
- PR: [#4088](https://github.com/opensearch-project/ml-commons/pull/4088)
- Issue: [#3993](https://github.com/opensearch-project/ml-commons/issues/3993)

Closes #1317