### PR TITLE
docs: add Resource Access Control report for v3.3.0

### DIFF
--- a/docs/features/security/resource-access-control-framework.md
+++ b/docs/features/security/resource-access-control-framework.md
@@ -278,39 +278,102 @@ client.share(
 - Resources must be stored in system indices with system index protection enabled
 - Currently supports single action group (`default`) - multiple action groups planned for future
 
+### Onboarded Plugins
+
+#### ML-Commons (v3.3.0+)
+
+ML-Commons is the first plugin to onboard to the centralized resource access control framework for model groups.
+
+**Integration Components:**
+
+| Component | Description |
+|-----------|-------------|
+| `ResourceSharingClientAccessor` | Singleton accessor for `ResourceSharingClient` |
+| `ML_MODEL_GROUP_RESOURCE_TYPE` | Resource type constant: `"ml-model-group"` |
+| `DocRequest` interface | Implemented by model group request classes |
+
+**Modified Request Classes:**
+
+- `MLModelGroupGetRequest` - implements `DocRequest`
+- `MLModelGroupDeleteRequest` - implements `DocRequest`
+- `MLUpdateModelGroupRequest` - implements `DocRequest`
+
+**Index Mapping (schema version 4):**
+
+```json
+{
+  "all_shared_principals": {
+    "type": "keyword"
+  }
+}
+```
+
+### Resource Access Management Dashboard (v3.3.0+)
+
+The Security Dashboards Plugin provides a UI for managing resource sharing.
+
+**Dashboard Configuration:**
+
+| Setting | Value |
+|---------|-------|
+| App ID | `resource_access_management` |
+| Route | `/app/resource_access_management` |
+| Feature Flag | `resource_sharing.enabled: true` |
+
+**Dashboard API Routes:**
+
+| Route | Method | Description |
+|-------|--------|-------------|
+| `/api/resource/types` | GET | List registered resource types |
+| `/api/resource/list` | GET | List accessible resources by type |
+| `/api/resource/view` | GET | Get sharing info for specific resource |
+| `/api/resource/share` | PUT | Share a resource |
+| `/api/resource/update_sharing` | PATCH | Update sharing (add/revoke) |
+
+**UI Features:**
+
+- Type selector dropdown for resource types
+- Table view of accessible resources with owner, tenant, and sharing info
+- Share/Update Access modal for managing permissions
+- Support for users, roles, and backend_roles at different access levels
+
 ## Related PRs
 
-| Version | PR | Description |
-|---------|-----|-------------|
-| v3.3.0 | [#5600](https://github.com/opensearch-project/security/pull/5600) | DLS-based automatic filtering using `all_shared_principals` |
-| v3.3.0 | [#5596](https://github.com/opensearch-project/security/pull/5596) | Track `all_shared_principals` for efficient searchability |
-| v3.3.0 | [#5588](https://github.com/opensearch-project/security/pull/5588) | Multi-tenancy support with tenant tracking |
-| v3.3.0 | [#5597](https://github.com/opensearch-project/security/pull/5597) | Dashboard APIs for resource access management |
-| v3.3.0 | [#5574](https://github.com/opensearch-project/security/pull/5574) | Fix case-sensitive user search |
-| v3.3.0 | [#5576](https://github.com/opensearch-project/security/pull/5576) | Revert @Inject to client accessor pattern |
-| v3.3.0 | [#5631](https://github.com/opensearch-project/security/pull/5631) | Fix GET _doc authorization on sharable indices |
-| v3.3.0 | [#5654](https://github.com/opensearch-project/security/pull/5654) | Fix PATCH API visibility update |
-| v3.3.0 | [#5658](https://github.com/opensearch-project/security/pull/5658) | Preserve `all_shared_principals` on resource updates |
-| v3.3.0 | [#5666](https://github.com/opensearch-project/security/pull/5666) | Make initial share map mutable |
-| v3.3.0 | [#5605](https://github.com/opensearch-project/security/pull/5605) | Match `.kibana` index settings |
-| v3.3.0 | [#5540](https://github.com/opensearch-project/security/pull/5540) | Comprehensive documentation for Resource Access Control |
-| v3.2.0 | [#5389](https://github.com/opensearch-project/security/pull/5389) | Migration API for existing sharing info |
-| v3.2.0 | [#5408](https://github.com/opensearch-project/security/pull/5408) | Resource Access Evaluator for standalone authorization |
-| v3.2.0 | [#5541](https://github.com/opensearch-project/security/pull/5541) | Client accessor pattern fix for optional security plugin |
-| v3.1.0 | [#5281](https://github.com/opensearch-project/security/pull/5281) | Introduces Centralized Resource Access Control Framework |
-| v3.1.0 | [#5358](https://github.com/opensearch-project/security/pull/5358) | Store resource sharing info in 1:1 backing indices |
+| Version | PR | Repository | Description |
+|---------|-----|------------|-------------|
+| v3.3.0 | [#3715](https://github.com/opensearch-project/ml-commons/pull/3715) | ml-commons | Onboards ML-Model-Group to centralized resource access control |
+| v3.3.0 | [#2304](https://github.com/opensearch-project/security-dashboards-plugin/pull/2304) | security-dashboards-plugin | Adds Resource Access Management Dashboard |
+| v3.3.0 | [#5600](https://github.com/opensearch-project/security/pull/5600) | security | DLS-based automatic filtering using `all_shared_principals` |
+| v3.3.0 | [#5596](https://github.com/opensearch-project/security/pull/5596) | security | Track `all_shared_principals` for efficient searchability |
+| v3.3.0 | [#5588](https://github.com/opensearch-project/security/pull/5588) | security | Multi-tenancy support with tenant tracking |
+| v3.3.0 | [#5597](https://github.com/opensearch-project/security/pull/5597) | security | Dashboard APIs for resource access management |
+| v3.3.0 | [#5574](https://github.com/opensearch-project/security/pull/5574) | security | Fix case-sensitive user search |
+| v3.3.0 | [#5576](https://github.com/opensearch-project/security/pull/5576) | security | Revert @Inject to client accessor pattern |
+| v3.3.0 | [#5631](https://github.com/opensearch-project/security/pull/5631) | security | Fix GET _doc authorization on sharable indices |
+| v3.3.0 | [#5654](https://github.com/opensearch-project/security/pull/5654) | security | Fix PATCH API visibility update |
+| v3.3.0 | [#5658](https://github.com/opensearch-project/security/pull/5658) | security | Preserve `all_shared_principals` on resource updates |
+| v3.3.0 | [#5666](https://github.com/opensearch-project/security/pull/5666) | security | Make initial share map mutable |
+| v3.3.0 | [#5605](https://github.com/opensearch-project/security/pull/5605) | security | Match `.kibana` index settings |
+| v3.3.0 | [#5540](https://github.com/opensearch-project/security/pull/5540) | security | Comprehensive documentation for Resource Access Control |
+| v3.2.0 | [#5389](https://github.com/opensearch-project/security/pull/5389) | security | Migration API for existing sharing info |
+| v3.2.0 | [#5408](https://github.com/opensearch-project/security/pull/5408) | security | Resource Access Evaluator for standalone authorization |
+| v3.2.0 | [#5541](https://github.com/opensearch-project/security/pull/5541) | security | Client accessor pattern fix for optional security plugin |
+| v3.1.0 | [#5281](https://github.com/opensearch-project/security/pull/5281) | security | Introduces Centralized Resource Access Control Framework |
+| v3.1.0 | [#5358](https://github.com/opensearch-project/security/pull/5358) | security | Store resource sharing info in 1:1 backing indices |
 
 ## References
 
 - [Issue #4500](https://github.com/opensearch-project/security/issues/4500): Resource Permissions and Sharing proposal
 - [Issue #5391](https://github.com/opensearch-project/security/issues/5391): Migration API tracking issue
 - [Issue #5442](https://github.com/opensearch-project/security/issues/5442): Resource Access Evaluator tracking issue
+- [Issue #3890](https://github.com/opensearch-project/ml-commons/issues/3890): Onboard ML plugin to Centralized Resource AuthZ framework
+- [Issue #2303](https://github.com/opensearch-project/security-dashboards-plugin/issues/2303): Resource Access Management Dashboard feature request
 - [Blog: Introducing resource sharing](https://opensearch.org/blog/introducing-resource-sharing-a-new-access-control-model-for-opensearch/): Official announcement
 - [RESOURCE_SHARING_AND_ACCESS_CONTROL.md](https://github.com/opensearch-project/security/blob/main/RESOURCE_SHARING_AND_ACCESS_CONTROL.md): Complete developer and user guide
 - [spi/README.md](https://github.com/opensearch-project/security/blob/main/spi/README.md): SPI implementation guide
 
 ## Change History
 
-- **v3.3.0** (2026-01): DLS-based automatic filtering with `all_shared_principals`, multi-tenancy support, dashboard APIs (`/resource/types`, `/resource/list`), bug fixes for case-sensitive search, PATCH visibility, resource updates, and multiple shares
+- **v3.3.0** (2026-01): ML-Commons model group onboarding, Resource Access Management Dashboard UI, DLS-based automatic filtering with `all_shared_principals`, multi-tenancy support, dashboard APIs (`/resource/types`, `/resource/list`), bug fixes for case-sensitive search, PATCH visibility, resource updates, and multiple shares
 - **v3.2.0** (2025): Migration API, Resource Access Evaluator for automatic authorization, client accessor pattern fix
 - **v3.1.0** (2025): Initial implementation with centralized SPI, 1:1 backing sharing indices, and automatic access evaluation

--- a/docs/releases/v3.3.0/features/multi-plugin/resource-access-control.md
+++ b/docs/releases/v3.3.0/features/multi-plugin/resource-access-control.md
@@ -1,0 +1,207 @@
+# Resource Access Control
+
+## Summary
+
+OpenSearch v3.3.0 extends the Resource Access Control framework with two major additions: ML-Commons plugin onboarding for model groups and a new Resource Access Management Dashboard in OpenSearch Dashboards. These changes enable ML model group owners to share their resources using the centralized authorization framework, and provide a user-friendly UI for managing resource sharing across all plugin-defined resources.
+
+## Details
+
+### What's New in v3.3.0
+
+This release includes two key components:
+
+1. **ML-Commons Model Group Onboarding**: The ML-Commons plugin now integrates with the Security plugin's centralized resource access control framework for model groups, replacing the legacy `filter_by_backend_role` approach.
+
+2. **Resource Access Management Dashboard**: A new UI in OpenSearch Dashboards allows users to view and manage sharing settings for their accessible resources without requiring backend plugin integration.
+
+### Technical Changes
+
+#### ML-Commons Integration
+
+```mermaid
+graph TB
+    subgraph ML-Commons["ML-Commons Plugin"]
+        MG[Model Group Requests]
+        RSC[ResourceSharingClientAccessor]
+        RSE[MLResourceSharingExtension]
+    end
+    
+    subgraph Security["Security Plugin"]
+        SPI[opensearch-security-spi]
+        RAE[ResourceAccessEvaluator]
+        RSH[ResourceSharingIndexHandler]
+    end
+    
+    subgraph Indices["System Indices"]
+        MGI[(.plugins-ml-model-group)]
+        MGSI[(.plugins-ml-model-group-sharing)]
+    end
+    
+    MG -->|implements DocRequest| RAE
+    RSE -->|registers on startup| SPI
+    RSC -->|share/revoke/verify| RSH
+    RAE -->|automatic authorization| MGI
+    RSH -->|manages sharing| MGSI
+```
+
+##### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ResourceSharingClientAccessor` | Singleton accessor for `ResourceSharingClient` in ML-Commons |
+| `ML_MODEL_GROUP_RESOURCE_TYPE` | Resource type constant: `"ml-model-group"` |
+| `DocRequest` interface | Implemented by `MLModelGroupGetRequest`, `MLModelGroupDeleteRequest`, `MLUpdateModelGroupRequest` |
+
+##### Index Mapping Changes
+
+The `ml_model_group` index mapping is updated to schema version 4 with a new field:
+
+```json
+{
+  "_meta": {
+    "schema_version": 4
+  },
+  "properties": {
+    "all_shared_principals": {
+      "type": "keyword"
+    }
+  }
+}
+```
+
+This field enables DLS-based automatic filtering of model groups based on user access.
+
+##### Modified Transport Actions
+
+All model group-related transport actions now pass the action name to `validateModelGroupAccess()`:
+
+| Transport Action | Action Name |
+|-----------------|-------------|
+| `GetModelGroupTransportAction` | `MLModelGroupGetAction.NAME` |
+| `DeleteModelGroupTransportAction` | `MLModelGroupDeleteAction.NAME` |
+| `TransportUpdateModelGroupAction` | `MLUpdateModelGroupAction.NAME` |
+| `SearchModelGroupTransportAction` | Uses `ResourceSharingClient.getAccessibleResourceIds()` |
+
+#### Security Dashboards Plugin Integration
+
+```mermaid
+graph TB
+    subgraph Dashboard["OpenSearch Dashboards"]
+        RAM[Resource Access Management App]
+        RSP[ResourceSharingPanel Component]
+        API[Dashboard API Routes]
+    end
+    
+    subgraph Security["Security Plugin Backend"]
+        TYPES[/api/resource/types]
+        LIST[/api/resource/list]
+        SHARE[/api/resource/share]
+    end
+    
+    RAM --> RSP
+    RSP --> API
+    API -->|GET| TYPES
+    API -->|GET| LIST
+    API -->|PUT/PATCH| SHARE
+```
+
+##### New Dashboard Application
+
+| Setting | Value |
+|---------|-------|
+| App ID | `resource_access_management` |
+| Route | `/app/resource_access_management` |
+| Feature Flag | `resource_sharing.enabled` |
+
+##### Dashboard API Routes
+
+| Route | Method | Backend API | Description |
+|-------|--------|-------------|-------------|
+| `/api/resource/types` | GET | `/_plugins/_security/api/resource/types` | List registered resource types |
+| `/api/resource/list` | GET | `/_plugins/_security/api/resource/list` | List accessible resources by type |
+| `/api/resource/view` | GET | `/_plugins/_security/api/resource/share` | Get sharing info for specific resource |
+| `/api/resource/share` | PUT | `/_plugins/_security/api/resource/share` | Share a resource |
+| `/api/resource/update_sharing` | PATCH | `/_plugins/_security/api/resource/share` | Update sharing (add/revoke) |
+
+##### UI Components
+
+The `ResourceSharingPanel` component (850+ lines) provides:
+
+- Type selector dropdown for resource types
+- Table view of accessible resources with owner, tenant, and sharing info
+- Share/Update Access modal for managing permissions
+- Support for users, roles, and backend_roles at different access levels
+- Expandable rows showing detailed sharing configuration
+
+### Configuration
+
+#### ML-Commons
+
+No additional configuration required. When the Security plugin's resource sharing feature is enabled, ML-Commons automatically uses the centralized authorization framework.
+
+#### Security Dashboards Plugin
+
+```yaml
+# opensearch_dashboards.yml
+opensearch_security.resource_sharing.enabled: true
+```
+
+### Usage Example
+
+**Sharing a Model Group via Dashboard:**
+
+1. Navigate to `/app/resource_access_management`
+2. Select "Ml Model Group" from the type dropdown
+3. Find your model group in the table
+4. Click "Share" or "Update Access"
+5. Add access levels with users/roles/backend_roles
+6. Click "Share" to save
+
+**Programmatic Access (ML-Commons):**
+
+```java
+// Access is automatically evaluated by Security Filter
+// when DocRequest interface is implemented
+
+MLModelGroupGetRequest request = MLModelGroupGetRequest.builder()
+    .modelGroupId("my-model-group-id")
+    .build();
+
+// Security plugin evaluates access based on:
+// - request.index() -> ML_MODEL_GROUP_INDEX
+// - request.id() -> modelGroupId
+// - request.type() -> ML_MODEL_GROUP_RESOURCE_TYPE
+```
+
+### Migration Notes
+
+- Existing model groups continue to work with legacy `backend_roles` field
+- New sharing via the Resource Access Control framework is additive
+- To migrate existing sharing, use the Security plugin's migration API:
+  ```
+  POST /_plugins/_security/api/resources/migrate
+  ```
+
+## Limitations
+
+- Resource Access Management Dashboard only appears when `resource_sharing.enabled: true`
+- ML-Commons is the first plugin to onboard; other plugins will follow in future releases
+- The `all_shared_principals` field must be maintained for DLS filtering to work correctly
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#3715](https://github.com/opensearch-project/ml-commons/pull/3715) | ml-commons | Onboards ML-Model-Group to centralized resource access control |
+| [#2304](https://github.com/opensearch-project/security-dashboards-plugin/pull/2304) | security-dashboards-plugin | Adds Resource Access Management Dashboard |
+
+## References
+
+- [Issue #3890](https://github.com/opensearch-project/ml-commons/issues/3890): Onboard ML plugin to Centralized Resource AuthZ framework
+- [Issue #2303](https://github.com/opensearch-project/security-dashboards-plugin/issues/2303): Resource Access Management Dashboard feature request
+- [Issue #4500](https://github.com/opensearch-project/security/issues/4500): Resource Permissions and Sharing (main tracking issue)
+- [Blog: Introducing resource sharing](https://opensearch.org/blog/introducing-resource-sharing-a-new-access-control-model-for-opensearch/): Official announcement
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/resource-access-control-framework.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -178,6 +178,7 @@
 ### Multi-Plugin
 
 - [Gradle 9 Compatibility](features/multi-plugin/gradle-9-compatibility.md)
+- [Resource Access Control](features/multi-plugin/resource-access-control.md)
 - [Version Increment](features/multi-plugin/version-increment.md)
 
 ### User Behavior Insights


### PR DESCRIPTION
## Summary

Adds release report and updates feature report for Resource Access Control in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/multi-plugin/resource-access-control.md`
- Feature report updated: `docs/features/security/resource-access-control-framework.md`

### Key Changes in v3.3.0
- ML-Commons model group onboarding to centralized resource access control framework
- Resource Access Management Dashboard UI in OpenSearch Dashboards
- New `ResourceSharingClientAccessor` singleton for ML-Commons
- `DocRequest` interface implementation for model group requests
- Dashboard API routes for resource management
- `all_shared_principals` field in ml_model_group index mapping (schema v4)

### PRs Investigated
- ml-commons #3715: Onboards ML-Model-Group to centralized resource access control
- security-dashboards-plugin #2304: Adds Resource Access Management Dashboard

Closes #1316