### PR TITLE
docs: add ML Inference Processors report for v3.3.0

### DIFF
--- a/docs/features/ml-commons/ml-inference-processor.md
+++ b/docs/features/ml-commons/ml-inference-processor.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-The ML Inference Processor enables seamless integration of machine learning models into OpenSearch ingest and search pipelines. It allows documents to be enriched with ML model predictions during indexing or search operations, supporting use cases like semantic search, text embedding generation, document classification, reranking, and content summarization.
+The ML Inference Processor enables seamless integration of machine learning models into OpenSearch ingest and search pipelines. It allows documents to be enriched with ML model predictions during indexing or search operations, supporting use cases like semantic search, text embedding generation, document classification, reranking, and content summarization. In v3.3.0, the processor adds output transformation support with pooling functions and a processor chain framework for flexible output processing.
 
 ## Details
 
@@ -13,7 +13,8 @@ graph TB
     subgraph "Ingest Pipeline"
         D[Document] --> IP[ML Inference<br/>Ingest Processor]
         IP --> M1[ML Model]
-        M1 --> IP
+        M1 --> OT[Output<br/>Transformations]
+        OT --> IP
         IP --> I[Index]
     end
     
@@ -27,6 +28,13 @@ graph TB
         M3 --> SRSP
         SRSP --> R[Response]
     end
+    
+    subgraph "Agent Tools"
+        T[Tool Output] --> PC[Processor Chain]
+        PC --> P1[Processor 1]
+        P1 --> P2[Processor N]
+        P2 --> TO[Transformed Output]
+    end
 ```
 
 ### Components
@@ -36,6 +44,8 @@ graph TB
 | ML Inference Ingest Processor | Enriches documents during indexing with ML model predictions |
 | ML Inference Search Request Processor | Transforms search queries using ML models (e.g., query embedding) |
 | ML Inference Search Response Processor | Enriches search results with ML model predictions |
+| Output Transformations | Applies pooling functions to multi-vector outputs (v3.3.0+) |
+| Processor Chain | Chainable processors for tool output transformation (v3.3.0+) |
 
 ### Configuration
 
@@ -44,7 +54,7 @@ graph TB
 | `model_id` | ID of the ML model to invoke | Required |
 | `function_name` | Function name (`remote`, `text_embedding`, `sparse_encoding`, etc.) | `remote` |
 | `input_map` | Maps document/query fields to model input parameters | Optional |
-| `output_map` | Maps model output to new document fields | Optional |
+| `output_map` | Maps model output to new document fields (supports transformation suffixes) | Optional |
 | `model_config` | Additional model configuration parameters | Optional |
 | `model_input` | Template for model input format | Auto-generated |
 | `full_response_path` | Use JSON path for output field extraction | `false` (remote), `true` (local) |
@@ -53,6 +63,42 @@ graph TB
 | `override` | Overwrite existing fields with same name | `false` |
 | `max_prediction_tasks` | Maximum concurrent model invocations | `10` |
 | `one_to_one` | Invoke model per document (search response only) | `false` |
+
+### Output Transformations (v3.3.0+)
+
+Output transformations enable automatic pooling of multi-vector outputs from models like Copali.
+
+| Transformation | Suffix | Description |
+|----------------|--------|-------------|
+| Mean Pooling | `.meanPooling()` | Averages vectors across all dimensions |
+| Max Pooling | `.maxPooling()` | Takes maximum value per dimension |
+
+**Example:**
+```json
+{
+  "output_map": [
+    {
+      "embedding.meanPooling()": "embeddings"
+    }
+  ]
+}
+```
+
+### Processor Chain (v3.3.0+)
+
+The processor chain framework enables flexible output processing from ML models and tools.
+
+| Processor | Description |
+|-----------|-------------|
+| `to_string` | Converts input to string format |
+| `regex_replace` | Performs regex-based text replacement |
+| `jsonpath_filter` | Filters JSON using JsonPath expressions |
+| `extract_json` | Extracts JSON objects/arrays from text |
+| `regex_capture` | Captures text using regex groups |
+| `remove_jsonpath` | Removes elements at specified JsonPath |
+| `conditional` | Applies different processors based on conditions |
+| `process_and_set` | Processes input and sets to a field |
+| `set_field` | Sets a field to a specific value |
 
 ### Usage Examples
 
@@ -73,6 +119,31 @@ PUT /_ingest/pipeline/embedding_pipeline
         "output_map": [
           {
             "text_embedding": "embedding"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+#### Ingest Pipeline - Multi-Vector with Mean Pooling (v3.3.0+)
+
+```json
+PUT /_ingest/pipeline/copali_embedding_pipeline
+{
+  "processors": [
+    {
+      "ml_inference": {
+        "model_id": "<copali_model_id>",
+        "input_map": [
+          {
+            "inputText": "text_field"
+          }
+        ],
+        "output_map": [
+          {
+            "embedding.meanPooling()": "embeddings"
           }
         ]
       }
@@ -136,24 +207,61 @@ PUT /_search/pipeline/summarization_pipeline
 }
 ```
 
+#### Agent Tool with Processor Chain (v3.3.0+)
+
+```json
+POST _plugins/_ml/agents/_register
+{
+  "name": "Test Agent",
+  "type": "flow",
+  "tools": [
+    {
+      "type": "ListIndexTool",
+      "parameters": {
+        "output_processors": [
+          {
+            "type": "regex_replace",
+            "pattern": "(?m)^(?!row,health,status).*?,.*?,.*?,\\.plugins[^\\n]*\\n",
+            "replacement": ""
+          },
+          {
+            "type": "regex_replace",
+            "pattern": "(?m)^row,|^\\d+,",
+            "replacement": ""
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
 ## Limitations
 
 - Local models require explicit `function_name` and `model_input` configuration
 - `one_to_one` mode increases latency proportionally to document count
 - Model must be deployed and accessible before pipeline execution
 - Complex nested field mappings require JSON path syntax
+- Output transformations require nested array structure for pooling operations
+- All vectors must have the same dimension for pooling
+- Processor chain is currently available for agent tools, not ingest processors
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
-| v2.14.0 | - | Initial ML Inference Ingest Processor |
-| v2.16.0 | - | ML Inference Search Request/Response Processors |
+| v3.3.0 | [#4111](https://github.com/opensearch-project/ml-commons/pull/4111) | Add passthrough post process function |
+| v3.3.0 | [#4236](https://github.com/opensearch-project/ml-commons/pull/4236) | Add output transformation support with mean pooling |
+| v3.3.0 | [#4093](https://github.com/opensearch-project/ml-commons/pull/4093) | Add processor chain framework |
+| v3.3.0 | [#4260](https://github.com/opensearch-project/ml-commons/pull/4260) | Refactor processor chain with additional processors |
 | v2.17.0 | [#2801](https://github.com/opensearch-project/ml-commons/pull/2801) | Support one_to_one in ML Inference Search Response Processor |
+| v2.16.0 | - | ML Inference Search Request/Response Processors |
+| v2.14.0 | - | Initial ML Inference Ingest Processor |
 
 ## References
 
 - [Issue #2173](https://github.com/opensearch-project/ml-commons/issues/2173): RFC - ML Inference Processors
+- [Issue #4235](https://github.com/opensearch-project/ml-commons/issues/4235): Processor chain feature request
 - [ML Inference Ingest Processor Documentation](https://docs.opensearch.org/latest/ingest-pipelines/processors/ml-inference/)
 - [ML Inference Search Request Processor Documentation](https://docs.opensearch.org/latest/search-plugins/search-pipelines/ml-inference-search-request/)
 - [ML Inference Search Response Processor Documentation](https://docs.opensearch.org/latest/search-plugins/search-pipelines/ml-inference-search-response/)
@@ -161,6 +269,7 @@ PUT /_search/pipeline/summarization_pipeline
 
 ## Change History
 
+- **v3.3.0** (2025-10-01): Added output transformation support (mean/max pooling), passthrough post-process function, and processor chain framework with 9 built-in processors
 - **v2.17.0** (2024-10-15): Added `one_to_one` parameter for per-document inference in search response processor
 - **v2.16.0**: Added ML Inference Search Request and Search Response Processors
 - **v2.14.0**: Initial ML Inference Ingest Processor implementation

--- a/docs/releases/v3.3.0/features/ml-commons/ml-inference-processors.md
+++ b/docs/releases/v3.3.0/features/ml-commons/ml-inference-processors.md
@@ -1,0 +1,183 @@
+# ML Inference Processors
+
+## Summary
+
+OpenSearch v3.3.0 introduces significant enhancements to ML Inference Processors, including output transformation support with mean/max pooling for multi-vector models, passthrough post-process function for Map responses, and a new processor chain framework for flexible output processing from ML models and tools.
+
+## Details
+
+### What's New in v3.3.0
+
+#### 1. Output Transformation Support (PR #4236)
+
+Adds support for output transformations in ML Inference Ingest Processor, enabling automatic pooling of multi-vector outputs from models like Copali.
+
+**New Transformation Functions:**
+- `.meanPooling()` - Averages vectors across all dimensions
+- `.maxPooling()` - Takes maximum value per dimension
+
+**Usage:**
+```json
+PUT /_ingest/pipeline/copali_embedding_pipeline
+{
+  "processors": [
+    {
+      "ml_inference": {
+        "model_id": "<copali_model_id>",
+        "input_map": [
+          {
+            "inputText": "text_field"
+          }
+        ],
+        "output_map": [
+          {
+            "embedding.meanPooling()": "embeddings"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+The transformation is applied automatically when the output field name contains the suffix. The base field name (without suffix) is used for the actual field storage.
+
+#### 2. Passthrough Post-Process Function (PR #4111)
+
+Adds support for handling Map responses from connectors without transformation. When a connector returns a Map response, the passthrough function preserves the structure as-is.
+
+**Changes:**
+- `AbstractConnector.parseResponse()` now handles Map response types
+- `MLInferenceIngestProcessor` supports passthrough for direct Map output
+
+#### 3. Processor Chain Framework (PR #4093, #4260)
+
+Introduces a new processor chain framework for processing outputs from ML models and tools using chainable processors. This enables complex output transformations without requiring Painless scripts.
+
+**Built-in Processors:**
+
+| Processor | Description |
+|-----------|-------------|
+| `to_string` | Converts input to string format |
+| `regex_replace` | Performs regex-based text replacement |
+| `jsonpath_filter` | Filters JSON using JsonPath expressions |
+| `extract_json` | Extracts JSON objects/arrays from text |
+| `regex_capture` | Captures text using regex groups |
+| `remove_jsonpath` | Removes elements at specified JsonPath |
+| `conditional` | Applies different processors based on conditions |
+| `process_and_set` | Processes input and sets to a field |
+| `set_field` | Sets a field to a specific value |
+
+**Architecture:**
+
+```mermaid
+graph TB
+    subgraph "Processor Chain Framework"
+        I[Input] --> PC[ProcessorChain]
+        PC --> P1[Processor 1]
+        P1 --> P2[Processor 2]
+        P2 --> P3[Processor N]
+        P3 --> O[Output]
+    end
+    
+    subgraph "Processor Types"
+        TS[to_string]
+        RR[regex_replace]
+        JF[jsonpath_filter]
+        EJ[extract_json]
+        RC[regex_capture]
+        RJ[remove_jsonpath]
+        CD[conditional]
+        PS[process_and_set]
+        SF[set_field]
+    end
+```
+
+**Example - Agent with Output Processors:**
+```json
+POST _plugins/_ml/agents/_register
+{
+  "name": "Test Agent",
+  "type": "flow",
+  "tools": [
+    {
+      "type": "ListIndexTool",
+      "parameters": {
+        "output_processors": [
+          {
+            "type": "regex_replace",
+            "pattern": "(?m)^(?!row,health,status).*?,.*?,.*?,\\.plugins[^\\n]*\\n",
+            "replacement": ""
+          },
+          {
+            "type": "regex_replace",
+            "pattern": "(?m)^row,|^\\d+,",
+            "replacement": ""
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `OutputTransformations` | Utility class for output transformations (mean/max pooling) |
+| `MLProcessor` | Interface for processor chain processors |
+| `AbstractMLProcessor` | Base class for processor implementations |
+| `MLConditionalProcessor` | Conditional branching processor |
+| `MLExtractJsonProcessor` | JSON extraction processor |
+| `MLJsonPathFilterProcessor` | JsonPath filtering processor |
+| `MLProcessAndSetProcessor` | Process and set field processor |
+| `MLRegexCaptureProcessor` | Regex capture processor |
+| `MLRegexReplaceProcessor` | Regex replacement processor |
+| `MLRemoveJsonPathProcessor` | JsonPath removal processor |
+| `MLSetFieldProcessor` | Field setting processor |
+| `MLToStringProcessor` | String conversion processor |
+| `@Processor` | Annotation for processor class loading |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `output_processors` | Array of processor configurations for tool output | Optional |
+| `type` | Processor type (e.g., `regex_replace`, `jsonpath_filter`) | Required |
+| `pattern` | Regex pattern for regex-based processors | Required for regex processors |
+| `replacement` | Replacement string for regex_replace | Required for regex_replace |
+
+### Migration Notes
+
+- Existing ML Inference Processor configurations continue to work without changes
+- Output transformations are opt-in via field name suffixes
+- Processor chain is configured via `output_processors` parameter in tool definitions
+
+## Limitations
+
+- Output transformations require nested array structure for pooling operations
+- All vectors must have the same dimension for pooling
+- Processor chain is currently available for agent tools, not ingest processors
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4111](https://github.com/opensearch-project/ml-commons/pull/4111) | Add ml-commons passthrough post process function |
+| [#4236](https://github.com/opensearch-project/ml-commons/pull/4236) | Add output transformation support with mean pooling |
+| [#4093](https://github.com/opensearch-project/ml-commons/pull/4093) | Add processor chain and support for model and tool |
+| [#4260](https://github.com/opensearch-project/ml-commons/pull/4260) | Refactor and add more validation to processor chain |
+
+## References
+
+- [Issue #4235](https://github.com/opensearch-project/ml-commons/issues/4235): Processor chain feature request
+- [ML Inference Ingest Processor Documentation](https://docs.opensearch.org/latest/ingest-pipelines/processors/ml-inference/)
+- [ML Inference Search Request Processor Documentation](https://docs.opensearch.org/latest/search-plugins/search-pipelines/ml-inference-search-request/)
+- [ML Inference Search Response Processor Documentation](https://docs.opensearch.org/latest/search-plugins/search-pipelines/ml-inference-search-response/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/ml-inference-processor.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -109,6 +109,7 @@
 - [ML Commons Connector Enhancements](features/ml-commons/ml-commons-connector-enhancements.md)
 - [ML Commons Multi-tenancy](features/ml-commons/ml-commons-multi-tenancy.md)
 - [ML Commons Tools Enhancements](features/ml-commons/ml-commons-tools-enhancements.md)
+- [ML Inference Processors](features/ml-commons/ml-inference-processors.md)
 - [Metrics Framework Bug Fix](features/ml-commons/metrics-framework.md)
 - [Move Common String](features/ml-commons/move-common-string.md)
 - [Streaming APIs](features/ml-commons/streaming-apis.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for ML Inference Processors enhancements in OpenSearch v3.3.0.

### Changes in v3.3.0

1. **Output Transformation Support (PR #4236)**
   - Mean pooling (`.meanPooling()`) and max pooling (`.maxPooling()`) for multi-vector models
   - Enables use cases like Copali embedding models

2. **Passthrough Post-Process Function (PR #4111)**
   - Support for Map response handling in connectors
   - Preserves response structure without transformation

3. **Processor Chain Framework (PR #4093, #4260)**
   - 9 built-in processors: `to_string`, `regex_replace`, `jsonpath_filter`, `extract_json`, `regex_capture`, `remove_jsonpath`, `conditional`, `process_and_set`, `set_field`
   - Enables complex output transformations without Painless scripts
   - Available for agent tools

### Files Changed
- `docs/releases/v3.3.0/features/ml-commons/ml-inference-processors.md` (new)
- `docs/features/ml-commons/ml-inference-processor.md` (updated)
- `docs/releases/v3.3.0/index.md` (updated)

### Related Issue
Closes #1315