### PR TITLE
docs: add Global Resource Support report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -379,6 +379,7 @@
 - [ML Commons Documentation & Tutorials](ml-commons/ml-commons-documentation-tutorials.md)
 - [ML Commons Error Handling](ml-commons/ml-commons-error-handling.md)
 - [ML Commons Dependencies](ml-commons/ml-commons-dependencies.md)
+- [Global Resource Support](ml-commons/global-resource-support.md)
 - [ML Commons MCP (Model Context Protocol)](ml-commons/ml-commons-mcp.md)
 - [ML Commons Memory Metadata](ml-commons/ml-commons-memory-metadata.md)
 - [ML Commons Model & Inference](ml-commons/ml-commons-model-inference.md)

--- a/docs/features/ml-commons/global-resource-support.md
+++ b/docs/features/ml-commons/global-resource-support.md
@@ -1,0 +1,157 @@
+# Global Resource Support
+
+## Summary
+
+Global resource support enables ML Commons resources (connectors, models, and agents) to be shared across all tenants in a multi-tenant OpenSearch environment. This feature allows administrators to create centrally-managed resources that any tenant can access while maintaining proper security through dedicated credential management.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Multi-tenant ML Commons"
+        subgraph "Global Resources"
+            GC[Global Connectors]
+            GM[Global Models]
+            GA[Global Agents]
+        end
+        
+        subgraph "Tenant A Resources"
+            TA1[Tenant A Connectors]
+            TA2[Tenant A Models]
+        end
+        
+        subgraph "Tenant B Resources"
+            TB1[Tenant B Connectors]
+            TB2[Tenant B Models]
+        end
+        
+        GC --> |Shared Access| TA2
+        GC --> |Shared Access| TB2
+        GM --> |Shared Access| TA2
+        GM --> |Shared Access| TB2
+    end
+    
+    subgraph "Credential Management"
+        GlobalTenant[Global Tenant ID]
+        Encryptor[Encryptor]
+        GlobalTenant --> Encryptor
+    end
+    
+    GC --> Encryptor
+    GM --> Encryptor
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Deploy Model Request] --> B[MLModelManager]
+    B --> C[Get Model from Index]
+    C --> D[SdkClient.isGlobalResource]
+    D --> E{Is Global?}
+    E -->|Yes| F[Use Global Tenant ID]
+    E -->|No| G[Use Request Tenant ID]
+    F --> H[Decrypt Credentials]
+    G --> H
+    H --> I[Initialize Connector]
+    I --> J[Deploy Model]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SdkClient.isGlobalResource()` | Checks if a resource is designated as global in remote metadata storage |
+| `RemoteModel.initModelAsync()` | Async model initialization with global resource support |
+| `MLModelManager` | Updated to pass SDK client and settings to model initialization |
+| `GetConfigTransportAction` | Migrated to use SdkClient for config retrieval |
+| `REMOTE_METADATA_GLOBAL_TENANT_ID` | Cluster setting for global tenant ID |
+| `REMOTE_METADATA_GLOBAL_RESOURCE_CACHE_TTL` | Cluster setting for cache TTL |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ml-commons.global_tenant_id` | Tenant ID used for decrypting global resource credentials | - |
+| `plugins.ml-commons.global_resource_cache_ttl` | TTL for caching global resource lookup results | - |
+
+### How It Works
+
+1. **Resource Creation**: Administrators create connectors, models, or agents and mark them as global resources in the remote metadata store (DynamoDB)
+
+2. **Resource Access**: When any tenant deploys a model that uses a global connector:
+   - The system queries `SdkClient.isGlobalResource()` to check the resource type
+   - If global, credentials are decrypted using the configured `global_tenant_id`
+   - If tenant-specific, credentials are decrypted using the requesting tenant's ID
+
+3. **Credential Security**: Global resources use a dedicated global tenant ID for credential encryption/decryption, ensuring:
+   - Consistent access across all tenants
+   - Centralized credential management
+   - Proper isolation from tenant-specific credentials
+
+### Usage Example
+
+Configure global resource settings in `opensearch.yml`:
+
+```yaml
+# Enable multi-tenancy
+plugins.ml_commons.multi_tenancy_enabled: true
+
+# Configure remote metadata storage
+plugins.ml-commons.remote_metadata_type: AWSDynamoDB
+plugins.ml-commons.remote_metadata_endpoint: https://dynamodb.us-east-1.amazonaws.com
+plugins.ml-commons.remote_metadata_region: us-east-1
+
+# Configure global resource support
+plugins.ml-commons.global_tenant_id: "_global_tenant"
+plugins.ml-commons.global_resource_cache_ttl: "300s"
+```
+
+Create a global connector (via admin operations):
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "Shared Bedrock Connector",
+  "description": "Global connector for all tenants",
+  "version": 1,
+  "protocol": "aws_sigv4",
+  "credential": {
+    "access_key": "...",
+    "secret_key": "..."
+  },
+  "parameters": {
+    "region": "us-east-1",
+    "service_name": "bedrock"
+  },
+  "actions": [...]
+}
+```
+
+Any tenant can then create models using this global connector.
+
+## Limitations
+
+- Requires remote metadata SDK with DynamoDB backend
+- Global tenant ID and cache TTL settings are immutable after node startup
+- Global resources must be managed by administrators with appropriate permissions
+- The `isGlobalResource()` check adds latency to model deployment (mitigated by caching)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#4003](https://github.com/opensearch-project/ml-commons/pull/4003) | Add global resource support |
+
+## References
+
+- [PR #4003](https://github.com/opensearch-project/ml-commons/pull/4003): Main implementation
+- [Remote Metadata SDK](https://github.com/opensearch-project/opensearch-remote-metadata-sdk): SDK for remote metadata storage
+- [Multi-tenancy Documentation](https://docs.opensearch.org/3.0/security/multi-tenancy/multi-tenancy-config/): OpenSearch multi-tenancy configuration
+- [ML Commons Cluster Settings](https://docs.opensearch.org/3.0/ml-commons-plugin/cluster-settings/): ML Commons configuration reference
+
+## Change History
+
+- **v3.3.0** (2025-09-24): Initial implementation with support for global connectors, models, and agents; async model initialization; DynamoDB integration via remote metadata SDK

--- a/docs/releases/v3.3.0/features/ml-commons/global-resource-support.md
+++ b/docs/releases/v3.3.0/features/ml-commons/global-resource-support.md
@@ -1,0 +1,119 @@
+# Global Resource Support
+
+## Summary
+
+Global resource support enables ML Commons resources (connectors, models, and agents) to be shared across all tenants in a multi-tenant environment. This feature allows administrators to create resources that any tenant can access, while maintaining proper credential decryption using a designated global tenant ID.
+
+## Details
+
+### What's New in v3.3.0
+
+This release introduces the ability to designate ML resources as "global" resources that can be accessed by any tenant. When a resource is marked as global, credential decryption uses the configured global tenant ID instead of the requesting tenant's ID, enabling shared access to external services.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Multi-tenant ML Commons"
+        Request[Model Deploy Request] --> Check{Is Global Resource?}
+        Check -->|Yes| GlobalDecrypt[Decrypt with Global Tenant ID]
+        Check -->|No| TenantDecrypt[Decrypt with Request Tenant ID]
+        GlobalDecrypt --> Init[Initialize Model]
+        TenantDecrypt --> Init
+        Init --> Deploy[Deploy Model]
+    end
+    
+    subgraph "Remote Metadata SDK"
+        SdkClient[SdkClient]
+        DDB[(DynamoDB)]
+        SdkClient --> DDB
+    end
+    
+    Check --> SdkClient
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `isGlobalResource()` | SdkClient method to check if a resource is global |
+| `initModelAsync()` | Async model initialization supporting global resource checks |
+| `REMOTE_METADATA_GLOBAL_TENANT_ID` | Setting for global tenant ID configuration |
+| `REMOTE_METADATA_GLOBAL_RESOURCE_CACHE_TTL` | Setting for global resource cache TTL |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ml-commons.global_tenant_id` | Tenant ID used for global resource credential decryption | - |
+| `plugins.ml-commons.global_resource_cache_ttl` | Cache TTL for global resource lookups | - |
+
+#### API Changes
+
+The `Predictable` interface now includes an async initialization method:
+
+```java
+// New async initialization method
+default CompletionStage<Boolean> initModelAsync(
+    MLModel model, 
+    Map<String, Object> params, 
+    Encryptor encryptor
+) {
+    throw new IllegalStateException("Method is not implemented");
+}
+```
+
+The `RemoteModel` class uses the SDK client to determine if a resource is global before decrypting credentials:
+
+```java
+sdkClient.isGlobalResource(MLIndex.MODEL.getIndexName(), model.getModelId())
+    .thenCompose(isGlobalResource -> {
+        String decryptTenantId = Boolean.TRUE.equals(isGlobalResource)
+            ? REMOTE_METADATA_GLOBAL_TENANT_ID.get(settings)
+            : model.getTenantId();
+        // Decrypt with appropriate tenant ID
+    });
+```
+
+### Usage Example
+
+Configure global tenant ID in `opensearch.yml`:
+
+```yaml
+plugins.ml-commons.global_tenant_id: "_global_tenant"
+plugins.ml-commons.global_resource_cache_ttl: "300s"
+```
+
+When deploying a model that references a global connector, the system automatically:
+1. Checks if the connector is a global resource via `SdkClient.isGlobalResource()`
+2. Uses the global tenant ID for credential decryption if global
+3. Uses the requesting tenant's ID otherwise
+
+### Migration Notes
+
+- Existing multi-tenant deployments should configure `global_tenant_id` before creating global resources
+- The `GetConfigTransportAction` now uses `SdkClient` for config retrieval, supporting remote metadata storage
+
+## Limitations
+
+- Global resources require the remote metadata SDK with DynamoDB support
+- The `global_tenant_id` setting must be configured at node startup (NodeScope, Final)
+- Cache TTL configuration is also immutable after startup
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4003](https://github.com/opensearch-project/ml-commons/pull/4003) | Add global resource support |
+
+## References
+
+- [PR #4003](https://github.com/opensearch-project/ml-commons/pull/4003): Main implementation
+- [Remote Metadata SDK](https://github.com/opensearch-project/opensearch-remote-metadata-sdk): SDK for remote metadata storage
+- [Multi-tenancy Documentation](https://docs.opensearch.org/3.0/security/multi-tenancy/multi-tenancy-config/): OpenSearch multi-tenancy configuration
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/global-resource-support.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -102,6 +102,7 @@
 
 ### ML Commons
 
+- [Global Resource Support](features/ml-commons/global-resource-support.md)
 - [Index Insight](features/ml-commons/index-insight.md)
 - [MCP Connector - Streamable HTTP Support](features/ml-commons/mcp-connector.md)
 - [ML Commons Agent Enhancements](features/ml-commons/ml-commons-agent-enhancements.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Global Resource Support feature in ML Commons v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/ml-commons/global-resource-support.md`
- Feature report: `docs/features/ml-commons/global-resource-support.md`

### Key Changes in v3.3.0
- Global resource support for connectors, models, and agents in multi-tenant environments
- New configuration settings: `global_tenant_id` and `global_resource_cache_ttl`
- Async model initialization with `initModelAsync()` method
- Integration with Remote Metadata SDK for global resource detection

### Resources Used
- PR: [#4003](https://github.com/opensearch-project/ml-commons/pull/4003)

Closes #1314