### PR TITLE
docs: add Agentic Memory and ScratchPad report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -367,6 +367,7 @@
 ## ml-commons
 
 - [Agent Framework](ml-commons/ml-commons-agent-framework.md)
+- [Agentic Memory](ml-commons/agentic-memory.md)
 - [Batch Ingestion](ml-commons/batch-ingestion.md)
 - [Index Insight](ml-commons/index-insight.md)
 - [Metrics Framework](ml-commons/metrics-framework.md)

--- a/docs/features/ml-commons/agentic-memory.md
+++ b/docs/features/ml-commons/agentic-memory.md
@@ -1,0 +1,197 @@
+# Agentic Memory
+
+## Summary
+
+Agentic Memory is a comprehensive persistent memory system in OpenSearch ML Commons that enables AI agents to maintain context, extract knowledge, and build understanding across conversations. Built on OpenSearch's search and storage infrastructure, it provides hierarchical memory organization with working memory for immediate context and long-term memory for persistent knowledge. The feature supports multiple memory processing strategies (semantic facts, user preferences, summaries) and includes ScratchPad tools for agent state management during complex tasks.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Memory Container"
+        MC[Memory Container]
+        MC --> |manages| SI[Session Index<br/>Conversation sessions]
+        MC --> |manages| WM[Working Memory Index<br/>Short-term context]
+        MC --> |manages| LTM[Long-Term Memory Index<br/>Extracted facts]
+        MC --> |manages| HI[History Index<br/>Memory audit trail]
+    end
+    
+    subgraph "Memory Processing Pipeline"
+        WM --> |infer=true| MP[Memory Processing Service]
+        MP --> |invoke| LLM[LLM]
+        LLM --> |extract| FACTS[Facts/Preferences]
+        FACTS --> |compare| OLD[Existing Memories]
+        OLD --> |decide| ACTION[ADD/UPDATE/DELETE]
+        ACTION --> LTM
+        ACTION --> HI
+    end
+    
+    subgraph "Embedding Pipeline"
+        LTM --> |ingest| EMB[Embedding Model]
+        EMB --> |vector| KNN[KNN Index]
+    end
+    
+    subgraph "Memory Strategies"
+        MP --> SEM[SEMANTIC<br/>Facts & Knowledge]
+        MP --> UP[USER_PREFERENCE<br/>Choices & Styles]
+        MP --> SUM[SUMMARY<br/>Conversation Summaries]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Agent/User Input] --> B{Memory Type?}
+    B --> |conversation| C[Working Memory]
+    B --> |data| D[Structured Data Storage]
+    
+    C --> E{infer=true?}
+    E --> |yes| F[LLM Processing]
+    E --> |no| G[Store Only]
+    
+    F --> H[Strategy Processing]
+    H --> I[Namespace Matching]
+    I --> J[Fact Extraction]
+    J --> K[Memory Comparison]
+    K --> L[Long-Term Memory Update]
+    L --> M[History Logging]
+    
+    subgraph "Retrieval"
+        N[Query] --> O[Semantic Search]
+        O --> P[Namespace Filter]
+        P --> Q[Relevant Memories]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Memory Container | Logical container holding all memory types for a specific use case |
+| Working Memory | Short-term storage for active conversations and agent state |
+| Long-Term Memory | Persistent storage for extracted facts, preferences, and summaries |
+| Session Index | Tracks conversation sessions and their metadata |
+| History Index | Audit trail of all memory operations (add/update/delete) |
+| Memory Processing Service | Orchestrates LLM-based fact extraction and memory updates |
+| WriteToScratchPadTool | Agent tool for writing intermediate thoughts and results |
+| ReadFromScratchPadTool | Agent tool for reading scratchpad content including persistent notes |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ml_commons.agentic_memory_enabled` | Enable/disable agentic memory feature | `true` |
+| `embedding_model_type` | Type of embedding model (TEXT_EMBEDDING, SPARSE_ENCODING) | - |
+| `embedding_model_id` | ID of the embedding model for semantic search | - |
+| `embedding_dimension` | Dimension of embedding vectors | 1024 |
+| `llm_id` | ID of the LLM for memory processing | - |
+| `disable_history` | Disable history index creation | `false` |
+| `disable_session` | Disable session index creation | `false` |
+| `use_system_index` | Use system index for storage | `true` |
+
+### Memory Strategies
+
+| Strategy | Purpose | Namespace Scope |
+|----------|---------|-----------------|
+| SEMANTIC | Extract facts and knowledge from conversations | Configurable (e.g., user_id) |
+| USER_PREFERENCE | Capture user preferences and communication styles | Configurable (e.g., user_id) |
+| SUMMARY | Create running summaries of conversations | Configurable (e.g., user_id, session_id) |
+
+### Usage Example
+
+**Create Memory Container**
+```json
+POST _plugins/_ml/memory_containers/_create
+{
+  "name": "customer-service-agent",
+  "description": "Memory for customer service interactions",
+  "configuration": {
+    "index_prefix": "cs-agent",
+    "embedding_model_type": "TEXT_EMBEDDING",
+    "embedding_model_id": "{{embed_model}}",
+    "embedding_dimension": 1024,
+    "llm_id": "{{llm}}",
+    "strategies": [
+      {
+        "enabled": true,
+        "type": "SEMANTIC",
+        "namespace": ["user_id"]
+      },
+      {
+        "enabled": true,
+        "type": "USER_PREFERENCE",
+        "namespace": ["user_id"]
+      }
+    ]
+  }
+}
+```
+
+**Add Conversation Memory**
+```json
+POST _plugins/_ml/memory_containers/{container_id}/memories
+{
+  "messages": [
+    {"role": "user", "content": "I prefer email notifications over SMS"},
+    {"role": "assistant", "content": "I've noted your preference for email notifications."}
+  ],
+  "namespace": {
+    "user_id": "user123",
+    "session_id": "session-456"
+  },
+  "tags": {"topic": "preferences"},
+  "infer": true,
+  "memory_type": "conversation"
+}
+```
+
+**Search Long-Term Memory**
+```json
+GET _plugins/_ml/memory_containers/{container_id}/memories/long-term/_search
+{
+  "query": {
+    "bool": {
+      "must": [
+        {"term": {"namespace.user_id": "user123"}},
+        {"match": {"memory": "notification preferences"}}
+      ]
+    }
+  }
+}
+```
+
+## Limitations
+
+- Long-term memory extraction is asynchronous; design for eventual consistency
+- PII is excluded from long-term memory records by default
+- ScratchPad data is session-scoped unless explicitly stored in long-term memory
+- Token limits of LLMs constrain the amount of context that can be processed at once
+- Namespace matching is exact; partial matches are not supported
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#4192](https://github.com/opensearch-project/ml-commons/pull/4192) | Add WriteToScratchPad and ReadFromScratchPad tools |
+| v3.3.0 | [#4218](https://github.com/opensearch-project/ml-commons/pull/4218) | Refactor Agentic Memory |
+| v3.3.0 | [#4246](https://github.com/opensearch-project/ml-commons/pull/4246) | Add create session API |
+| v3.3.0 | [#4201](https://github.com/opensearch-project/ml-commons/pull/4201) | Add updated time to message |
+| v3.3.0 | [#4240](https://github.com/opensearch-project/ml-commons/pull/4240) | Enable agentic memory by default for GA |
+| v3.3.0 | [#4238](https://github.com/opensearch-project/ml-commons/pull/4238) | Add delete_all_memories parameter |
+| v3.3.0 | [#4282](https://github.com/opensearch-project/ml-commons/pull/4282) | Improve semantic fact extraction prompt |
+| v3.3.0 | [#4288](https://github.com/opensearch-project/ml-commons/pull/4288) | Improve user preference extraction prompt |
+
+## References
+
+- [Agentic Memory APIs Documentation](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/agentic_memory/agentic_memory_apis.md)
+- [Agentic Memory Tutorial](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/agentic_memory/agentic_memory_tutorial.md)
+- [Agentic Memory with Strands Agent](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/agentic_memory/agentic_memory_with_strands_agent.md)
+- [OpenSearch as an Agentic Memory Solution Blog](https://opensearch.org/blog/opensearch-as-an-agentic-memory-solution-building-context-aware-agents-using-persistent-memory/)
+- [Memory APIs Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/api/memory-apis/index/)
+
+## Change History
+
+- **v3.3.0** (2025-10): GA release with ScratchPad tools, session API, refactored architecture, improved fact extraction prompts, and feature enabled by default

--- a/docs/releases/v3.3.0/features/ml-commons/agentic-memory-and-scratchpad.md
+++ b/docs/releases/v3.3.0/features/ml-commons/agentic-memory-and-scratchpad.md
@@ -1,0 +1,173 @@
+# Agentic Memory and ScratchPad
+
+## Summary
+
+OpenSearch v3.3.0 introduces Agentic Memory as a GA (Generally Available) feature in ML Commons, providing a comprehensive persistent memory system for AI agents. This release includes major refactoring of the memory architecture, new ScratchPad tools for agent state management, session management APIs, and improved fact extraction prompts. The feature enables AI agents to maintain context across conversations, extract knowledge, and build understanding over time using OpenSearch's search and storage infrastructure.
+
+## Details
+
+### What's New in v3.3.0
+
+This release marks the GA launch of Agentic Memory with several key enhancements:
+
+1. **ScratchPad Tools**: New `WriteToScratchPadTool` and `ReadFromScratchPadTool` for intermediate state management
+2. **Memory Architecture Refactoring**: Complete restructuring of the agentic memory system
+3. **Session Management API**: New API for creating and managing conversation sessions
+4. **Feature Enabled by Default**: Agentic memory is now enabled by default for GA
+5. **Improved Fact Extraction**: Enhanced prompts with XML-based structure and JSON enforcement
+
+### Technical Changes
+
+#### Architecture Overview
+
+```mermaid
+graph TB
+    subgraph "Memory Container"
+        MC[Memory Container API]
+        MC --> SI[Session Index]
+        MC --> WM[Working Memory Index]
+        MC --> LTM[Long-Term Memory Index]
+        MC --> HI[History Index]
+    end
+    
+    subgraph "Memory Processing"
+        WM --> |infer=true| LLM[LLM Processing]
+        LLM --> |Extract Facts| LTM
+        LLM --> |Track Changes| HI
+    end
+    
+    subgraph "Agent Tools"
+        SP[ScratchPad Tools]
+        SP --> |Write| WM
+        SP --> |Read| WM
+    end
+    
+    subgraph "Strategies"
+        LLM --> SEM[SEMANTIC Strategy]
+        LLM --> UP[USER_PREFERENCE Strategy]
+        LLM --> SUM[SUMMARY Strategy]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `WriteToScratchPadTool` | Tool for agents to write intermediate thoughts and results to a persistent scratchpad |
+| `ReadFromScratchPadTool` | Tool for agents to read from their scratchpad, including persistent notes |
+| `CreateSessionAction` | New action for creating conversation sessions with custom or auto-generated IDs |
+| `MemoryProcessingService` | Refactored service for handling memory extraction and processing |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ml_commons.agentic_memory_enabled` | Enable/disable agentic memory feature | `true` (GA) |
+| `delete_all_memories` | Parameter to control memory deletion when deleting container | `false` |
+
+#### API Changes
+
+**Create Session API**
+```json
+POST _plugins/_ml/memory_containers/{container_id}/memories/sessions
+{
+  "session_id": "custom-session-id",  // Optional: auto-generated if not provided
+  "summary": "Session description",
+  "metadata": {
+    "key1": "value1"
+  },
+  "namespace": {
+    "user_id": "bob"
+  }
+}
+```
+
+**ScratchPad Tools Configuration**
+```json
+{
+  "tools": [
+    {
+      "type": "ReadFromScratchPadTool",
+      "name": "ReadFromScratchPadTool",
+      "parameters": {
+        "persistent_notes": "Initial instructions for the agent..."
+      }
+    },
+    {
+      "type": "WriteToScratchPadTool",
+      "name": "WriteToScratchPadTool"
+    }
+  ]
+}
+```
+
+### Usage Example
+
+**Creating a Research Agent with ScratchPad**
+```json
+POST _plugins/_ml/agents/_register
+{
+  "name": "RAG Agent",
+  "type": "conversational",
+  "description": "Research agent with scratchpad",
+  "llm": {
+    "model_id": "{{model_id}}",
+    "parameters": {
+      "max_iteration": 50,
+      "system_prompt": "You are a research assistant with access to a persistent scratchpad..."
+    }
+  },
+  "memory": {
+    "type": "conversation_index"
+  },
+  "tools": [
+    {"type": "SearchIndexTool"},
+    {"type": "ListIndexTool"},
+    {"type": "IndexMappingTool"},
+    {
+      "type": "ReadFromScratchPadTool",
+      "parameters": {
+        "persistent_notes": "Remember to use ListIndexTool first..."
+      }
+    },
+    {"type": "WriteToScratchPadTool"}
+  ]
+}
+```
+
+### Migration Notes
+
+- The agentic memory feature is now enabled by default (`plugins.ml_commons.agentic_memory_enabled: true`)
+- Existing memory implementations should continue to work; the refactoring maintains backward compatibility
+- New `delete_all_memories` parameter provides control over cascade deletion behavior
+
+## Limitations
+
+- ScratchPad is session-scoped; data does not persist across different agent sessions unless explicitly stored in long-term memory
+- Long-term memory extraction is asynchronous; design for eventual consistency
+- PII is excluded from long-term memory records by default
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4192](https://github.com/opensearch-project/ml-commons/pull/4192) | Add WriteToScratchPad and ReadFromScratchPad tools |
+| [#4218](https://github.com/opensearch-project/ml-commons/pull/4218) | Refactor Agentic Memory |
+| [#4246](https://github.com/opensearch-project/ml-commons/pull/4246) | Add create session API; add message id to working memory; fix update api |
+| [#4201](https://github.com/opensearch-project/ml-commons/pull/4201) | Add updated time to message |
+| [#4240](https://github.com/opensearch-project/ml-commons/pull/4240) | Enable agentic memory feature by default for GA |
+| [#4238](https://github.com/opensearch-project/ml-commons/pull/4238) | Add parameter to control delete memories when delete container |
+| [#4282](https://github.com/opensearch-project/ml-commons/pull/4282) | Improve semantic fact extraction prompt and add JSON enforcement |
+| [#4288](https://github.com/opensearch-project/ml-commons/pull/4288) | Improve user preference extraction prompt with XML-based structure |
+
+## References
+
+- [Agentic Memory APIs Documentation](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/agentic_memory/agentic_memory_apis.md)
+- [Agentic Memory Tutorial](https://github.com/opensearch-project/ml-commons/blob/main/docs/tutorials/agentic_memory/agentic_memory_tutorial.md)
+- [OpenSearch as an Agentic Memory Solution Blog](https://opensearch.org/blog/opensearch-as-an-agentic-memory-solution-building-context-aware-agents-using-persistent-memory/)
+- [Issue #4239](https://github.com/opensearch-project/ml-commons/issues/4239): Related feature request
+- [Issue #4193](https://github.com/opensearch-project/ml-commons/issues/4193): Add updated time to message request
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/agentic-memory.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -102,6 +102,7 @@
 
 ### ML Commons
 
+- [Agentic Memory and ScratchPad](features/ml-commons/agentic-memory-and-scratchpad.md)
 - [Global Resource Support](features/ml-commons/global-resource-support.md)
 - [Index Insight](features/ml-commons/index-insight.md)
 - [MCP Connector - Streamable HTTP Support](features/ml-commons/mcp-connector.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Agentic Memory and ScratchPad feature in OpenSearch v3.3.0.

## Changes

### Release Report
- `docs/releases/v3.3.0/features/ml-commons/agentic-memory-and-scratchpad.md`

### Feature Report
- `docs/features/ml-commons/agentic-memory.md`

## Key Features Documented

- **ScratchPad Tools**: WriteToScratchPadTool and ReadFromScratchPadTool for agent state management
- **Memory Architecture Refactoring**: Complete restructuring of the agentic memory system
- **Session Management API**: New API for creating and managing conversation sessions
- **GA Release**: Agentic memory enabled by default
- **Improved Fact Extraction**: Enhanced prompts with XML-based structure and JSON enforcement

## Related PRs

- [#4192](https://github.com/opensearch-project/ml-commons/pull/4192) - Add WriteToScratchPad and ReadFromScratchPad tools
- [#4218](https://github.com/opensearch-project/ml-commons/pull/4218) - Refactor Agentic Memory
- [#4246](https://github.com/opensearch-project/ml-commons/pull/4246) - Add create session API
- [#4201](https://github.com/opensearch-project/ml-commons/pull/4201) - Add updated time to message
- [#4240](https://github.com/opensearch-project/ml-commons/pull/4240) - Enable agentic memory by default for GA
- [#4238](https://github.com/opensearch-project/ml-commons/pull/4238) - Add delete_all_memories parameter
- [#4282](https://github.com/opensearch-project/ml-commons/pull/4282) - Improve semantic fact extraction prompt
- [#4288](https://github.com/opensearch-project/ml-commons/pull/4288) - Improve user preference extraction prompt

Closes #1313