### PR TITLE
docs: add late-interaction report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -473,6 +473,7 @@
 - [k-NN Byte Vector Support](k-nn/k-nn-byte-vector-support.md)
 - [k-NN Engine Enhancements](k-nn/k-nn-engine-enhancements.md)
 - [k-NN Performance & Engine](k-nn/k-nn-performance-engine.md)
+- [Late Interaction](k-nn/late-interaction.md)
 - [Vector Search (k-NN)](k-nn/vector-search-k-nn.md)
 - [k-NN Explain API](k-nn/explain-api.md)
 - [k-NN Iterative Graph Build](k-nn/k-nn-iterative-graph-build.md)

--- a/docs/features/k-nn/late-interaction.md
+++ b/docs/features/k-nn/late-interaction.md
@@ -1,0 +1,216 @@
+# Late Interaction
+
+## Summary
+
+Late interaction is a vector search technique that enables ColBERT-style token-level matching between queries and documents. Unlike traditional single-vector approaches that compress entire documents into one embedding, late interaction models preserve fine-grained semantic information by representing queries and documents as multiple vectors (one per token or patch). This approach significantly improves search relevance while maintaining computational efficiency.
+
+OpenSearch supports late interaction through the `lateInteractionScore` Painless script function, which implements the MaxSim (Maximum Similarity) scoring mechanism for reranking search results.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Embedding Models Spectrum"
+        BE[Bi-Encoder<br/>Single Vector] --> |No Interaction| Fast[Fast but Less Precise]
+        LI[Late Interaction<br/>Multi-Vector] --> |Token-level Interaction| Balanced[Balanced]
+        CE[Cross-Encoder<br/>Full Interaction] --> |Full Interaction| Precise[Precise but Slow]
+    end
+    
+    subgraph "Late Interaction Flow"
+        Query[Query Text] --> QEnc[Query Encoder]
+        QEnc --> QVecs[Query Vectors<br/>per token]
+        
+        Doc[Document Text] --> DEnc[Document Encoder]
+        DEnc --> DVecs[Document Vectors<br/>per token]
+        
+        QVecs --> MaxSim[MaxSim Scoring]
+        DVecs --> MaxSim
+        MaxSim --> Score[Relevance Score]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Ingestion
+        D[Document] --> Model[Late Interaction Model]
+        Model --> MV[Multi-Vectors]
+        MV --> Index[(OpenSearch Index)]
+    end
+    
+    subgraph Search
+        Q[Query] --> QModel[Query Encoder]
+        QModel --> QV[Query Vectors]
+        QV --> Phase1[Phase 1: k-NN Retrieval]
+        Index --> Phase1
+        Phase1 --> Candidates[Top-K Candidates]
+        Candidates --> Phase2[Phase 2: Late Interaction Rerank]
+        QV --> Phase2
+        Phase2 --> Results[Final Results]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `KNNPainlessScriptUtils` | Utility class providing late interaction scoring functions |
+| `lateInteractionScore` | Painless function calculating MaxSim between multi-vectors |
+| Multi-vector field | Document field storing token-level embeddings as nested arrays |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `space_type` | Similarity metric for vector comparison | `l2` |
+
+#### Supported Space Types
+
+| Space Type | Description | Use Case |
+|------------|-------------|----------|
+| `l2` | Euclidean distance | General purpose |
+| `innerproduct` | Dot product | When vectors are normalized |
+| `cosinesimil` | Cosine similarity | Direction-based similarity |
+
+### Usage Example
+
+#### Index Mapping
+
+```json
+PUT my_index
+{
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "object",
+        "enabled": false
+      },
+      "content": {
+        "type": "text"
+      }
+    }
+  }
+}
+```
+
+#### Index Document with Multi-Vectors
+
+```json
+PUT my_index/_doc/1
+{
+  "content": "OpenSearch is a distributed search engine",
+  "my_vector": [
+    [0.1, 0.2, 0.3, 0.4],
+    [0.5, 0.6, 0.7, 0.8],
+    [0.2, 0.3, 0.4, 0.5]
+  ]
+}
+```
+
+#### Search with Late Interaction Scoring
+
+```json
+GET my_index/_search
+{
+  "query": {
+    "script_score": {
+      "query": { "match_all": {} },
+      "script": {
+        "source": "lateInteractionScore(params.query_vectors, 'my_vector', params._source, params.space_type)",
+        "params": {
+          "query_vectors": [
+            [0.1, 0.2, 0.3, 0.4],
+            [0.5, 0.5, 0.5, 0.5]
+          ],
+          "space_type": "cosinesimil"
+        }
+      }
+    }
+  }
+}
+```
+
+#### Two-Phase Search Pipeline
+
+```json
+GET my_index/_search
+{
+  "query": {
+    "script_score": {
+      "query": {
+        "knn": {
+          "single_vector_field": {
+            "vector": [0.3, 0.4, 0.5, 0.6],
+            "k": 100
+          }
+        }
+      },
+      "script": {
+        "source": "lateInteractionScore(params.query_vectors, 'my_vector', params._source, 'innerproduct')",
+        "params": {
+          "query_vectors": [
+            [0.1, 0.2, 0.3, 0.4],
+            [0.5, 0.5, 0.5, 0.5]
+          ]
+        }
+      }
+    }
+  },
+  "size": 10
+}
+```
+
+### MaxSim Algorithm
+
+The late interaction score is calculated using the MaxSim algorithm:
+
+1. For each query vector `q_i`, compute similarity with all document vectors `d_j`
+2. Take the maximum similarity for each query vector
+3. Sum all maximum similarities
+
+```
+Score(Q, D) = Σ max(sim(q_i, d_j)) for all i, j
+```
+
+This approach ensures that each query token finds its best matching document token, enabling fine-grained semantic matching.
+
+### Supported Models
+
+Late interaction models that can be used with OpenSearch:
+
+| Model | Type | Description |
+|-------|------|-------------|
+| ColBERT | Text | Token-level embeddings for text documents |
+| ColPali | Multimodal | Patch-level embeddings for document images |
+| ColQwen | Multimodal | Vision-language late interaction model |
+
+## Limitations
+
+- Multi-vectors must be stored in `_source` (object field with `enabled: false`)
+- L1 and LINF space types are not supported for late interaction scoring
+- Requires external model inference for generating multi-vector embeddings
+- Storage overhead: 10-100x more vectors compared to single-vector approaches
+- Query latency increases with the number of vectors per document
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [k-NN#2909](https://github.com/opensearch-project/k-NN/pull/2909) | Add lateInteractionFunction |
+
+## References
+
+- [Issue k-NN#2706](https://github.com/opensearch-project/k-NN/issues/2706): RFC for MultiVector Field Type for Late-interaction Score
+- [Issue OpenSearch#18091](https://github.com/opensearch-project/OpenSearch/issues/18091): Feature request for late interaction models support
+- [Documentation: Late Interaction Score](https://docs.opensearch.org/latest/query-dsl/specialized/script-score/#late-interaction-score): Official documentation
+- [Documentation: Reranking by Field (Late Interaction)](https://docs.opensearch.org/latest/search-plugins/search-relevance/rerank-by-field-late-interaction/): Tutorial for late interaction reranking
+- [Blog: Boost search relevance with late interaction models](https://opensearch.org/blog/boost-search-relevance-with-late-interaction-models/): Comprehensive guide to late interaction
+- [ColBERT Paper](https://arxiv.org/abs/2004.12832): Original ColBERT research paper
+- [ColPali Paper](https://arxiv.org/pdf/2407.01449): ColPali for document retrieval
+
+## Change History
+
+- **v3.3.0** (2025-10-14): Initial implementation of `lateInteractionScore` function in k-NN plugin

--- a/docs/releases/v3.3.0/features/k-nn/late-interaction.md
+++ b/docs/releases/v3.3.0/features/k-nn/late-interaction.md
@@ -1,0 +1,119 @@
+# Late Interaction
+
+## Summary
+
+OpenSearch 3.3.0 introduces the `lateInteractionScore` function in the k-NN plugin, enabling ColBERT-style late interaction scoring for enhanced search relevance. This feature allows token-level matching between query and document vectors, providing more precise semantic search results compared to traditional single-vector approaches.
+
+## Details
+
+### What's New in v3.3.0
+
+The `lateInteractionScore` function is a new Painless script function that calculates document relevance using multi-vector representations. It implements the MaxSim (Maximum Similarity) scoring mechanism used by late interaction models like ColBERT and ColPali.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Two-Phase Search Pipeline"
+        Q[Query] --> Phase1[Phase 1: Fast Retrieval]
+        Phase1 --> |Single-vector k-NN| Candidates[Candidate Documents]
+        Candidates --> Phase2[Phase 2: Late Interaction Reranking]
+        Phase2 --> |lateInteractionScore| Results[Final Ranked Results]
+    end
+    
+    subgraph "Late Interaction Scoring"
+        QV[Query Vectors] --> MaxSim[MaxSim Calculation]
+        DV[Document Vectors] --> MaxSim
+        MaxSim --> |Sum of max similarities| Score[Final Score]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `KNNPainlessScriptUtils` | Utility class providing late interaction scoring functions for Painless scripts |
+| `lateInteractionScore` | Function that calculates MaxSim score between query and document multi-vectors |
+
+#### Function Signatures
+
+```java
+// Default space type (L2)
+float lateInteractionScore(List<List<Number>> queryVectors, String docFieldName, Map<String, Object> doc)
+
+// Custom space type
+float lateInteractionScore(List<List<Number>> queryVectors, String docFieldName, Map<String, Object> doc, String spaceType)
+```
+
+#### Supported Space Types
+
+| Space Type | Description |
+|------------|-------------|
+| `l2` | Euclidean distance (default) |
+| `innerproduct` | Inner product / dot product |
+| `cosinesimil` | Cosine similarity |
+
+### Usage Example
+
+```json
+GET my_index/_search
+{
+  "query": {
+    "script_score": {
+      "query": { "match_all": {} },
+      "script": {
+        "source": "lateInteractionScore(params.query_vectors, 'my_vector', params._source, params.space_type)",
+        "params": {
+          "query_vectors": [[1.0, 0.0], [0.0, 1.0]],
+          "space_type": "cosinesimil"
+        }
+      }
+    }
+  }
+}
+```
+
+### How It Works
+
+1. **Multi-vector representation**: Both queries and documents are represented as multiple vectors (one per token/patch)
+2. **MaxSim calculation**: For each query vector, find the maximum similarity with any document vector
+3. **Score aggregation**: Sum all maximum similarities to produce the final document score
+
+```
+Score = Σ max(similarity(q_i, d_j)) for all query vectors q_i
+```
+
+### Migration Notes
+
+To use late interaction scoring:
+
+1. Store document multi-vectors in an `object` field with `enabled: false`
+2. Generate query multi-vectors at search time using a late interaction model (e.g., ColBERT, ColPali)
+3. Use `script_score` query with `lateInteractionScore` function
+
+## Limitations
+
+- Multi-vectors must be stored in document `_source` (not as k-NN vectors)
+- Requires external model for generating multi-vector embeddings
+- L1 and LINF space types are not supported
+- Performance depends on the number of vectors per document
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [k-NN#2909](https://github.com/opensearch-project/k-NN/pull/2909) | Add lateInteractionFunction |
+
+## References
+
+- [Issue k-NN#2706](https://github.com/opensearch-project/k-NN/issues/2706): RFC for MultiVector Field Type for Late-interaction Score
+- [Issue OpenSearch#18091](https://github.com/opensearch-project/OpenSearch/issues/18091): Feature request for late interaction models support
+- [Documentation](https://docs.opensearch.org/latest/query-dsl/specialized/script-score/#late-interaction-score): Official late interaction score documentation
+- [Blog: Boost search relevance with late interaction models](https://opensearch.org/blog/boost-search-relevance-with-late-interaction-models/): Detailed explanation of late interaction models
+- [Blog: Explore OpenSearch 3.3](https://opensearch.org/blog/explore-opensearch-3-3/): Release announcement
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/k-nn/late-interaction.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -129,6 +129,7 @@
 
 - [k-NN Bug Fixes](features/k-nn/k-nn-bug-fixes.md)
 - [k-NN Engine Enhancements](features/k-nn/k-nn-engine-enhancements.md)
+- [Late Interaction](features/k-nn/late-interaction.md)
 
 ### Geospatial
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Late Interaction feature introduced in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/k-nn/late-interaction.md`
- Feature report: `docs/features/k-nn/late-interaction.md`

### Key Changes in v3.3.0
- Added `lateInteractionScore` Painless script function in k-NN plugin
- Enables ColBERT-style token-level matching for enhanced search relevance
- Supports MaxSim scoring mechanism for multi-vector representations
- Supports L2, inner product, and cosine similarity space types

### Resources Used
- PR: [k-NN#2909](https://github.com/opensearch-project/k-NN/pull/2909)
- Issue: [k-NN#2706](https://github.com/opensearch-project/k-NN/issues/2706)
- Issue: [OpenSearch#18091](https://github.com/opensearch-project/OpenSearch/issues/18091)
- Docs: https://docs.opensearch.org/latest/query-dsl/specialized/script-score/#late-interaction-score
- Blog: https://opensearch.org/blog/boost-search-relevance-with-late-interaction-models/