### PR TITLE
docs: add Maximal Marginal Relevance (MMR) report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -474,6 +474,7 @@
 - [k-NN Engine Enhancements](k-nn/k-nn-engine-enhancements.md)
 - [k-NN Performance & Engine](k-nn/k-nn-performance-engine.md)
 - [Late Interaction](k-nn/late-interaction.md)
+- [Maximal Marginal Relevance (MMR)](k-nn/maximal-marginal-relevance-mmr.md)
 - [Vector Search (k-NN)](k-nn/vector-search-k-nn.md)
 - [k-NN Explain API](k-nn/explain-api.md)
 - [k-NN Iterative Graph Build](k-nn/k-nn-iterative-graph-build.md)

--- a/docs/features/k-nn/maximal-marginal-relevance-mmr.md
+++ b/docs/features/k-nn/maximal-marginal-relevance-mmr.md
@@ -1,0 +1,240 @@
+# Maximal Marginal Relevance (MMR)
+
+## Summary
+
+Maximal Marginal Relevance (MMR) is a reranking algorithm that balances relevance and diversity in search results. In vector search, embeddings often cluster similar results together, causing top-k results to look nearly identical. MMR addresses this by iteratively selecting results that are both relevant to the query and different from previously selected results, controlled by a `diversity` parameter (0 = prioritize relevance, 1 = prioritize diversity).
+
+OpenSearch provides native MMR support for k-NN and neural queries, eliminating the need for external custom pipelines and reducing latency.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "MMR Search Pipeline"
+        A[Search Request] --> B{Has MMR Extension?}
+        B -->|Yes| C[MMROverSampleProcessor]
+        B -->|No| D[Standard Search]
+        
+        C --> E[Extract MMR Parameters]
+        E --> F[Resolve Vector Field Info]
+        F --> G[Transform Query for Oversampling]
+        G --> H[Execute Search]
+        
+        H --> I[MMRRerankProcessor]
+        I --> J[Extract Vectors from Hits]
+        J --> K[Apply MMR Algorithm]
+        K --> L[Return Diverse Results]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Request Processing"
+        A1[MMRSearchExtBuilder] --> A2[Parse diversity, candidates]
+        A2 --> A3[Validate parameters]
+        A3 --> A4[Store in MMRRerankContext]
+    end
+    
+    subgraph "Query Transformation"
+        B1[MMRQueryTransformer] --> B2{Query Type}
+        B2 -->|knn| B3[MMRKnnQueryTransformer]
+        B2 -->|neural| B4[MMRNeuralQueryTransformer]
+        B3 --> B5[Set k = candidates]
+        B4 --> B5
+        B5 --> B6[Resolve space type & data type]
+    end
+    
+    subgraph "Response Reranking"
+        C1[Get candidate hits] --> C2[Extract vectors from _source]
+        C2 --> C3[Compute similarity matrix]
+        C3 --> C4[Iterative MMR selection]
+        C4 --> C5[Return top-k diverse results]
+    end
+    
+    A4 --> B1
+    B6 --> C1
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `MMRSearchExtBuilder` | Parses MMR parameters from the `ext.mmr` section of search requests |
+| `MMROverSampleProcessor` | System-generated request processor that modifies queries to fetch more candidates |
+| `MMRRerankProcessor` | System-generated response processor that applies MMR algorithm to rerank results |
+| `MMRQueryTransformer` | Extensible interface for query-specific transformation logic |
+| `MMRKnnQueryTransformer` | Handles k-NN query transformation for MMR |
+| `MMRNeuralQueryTransformer` | Handles neural query transformation for MMR (neural-search plugin) |
+| `MMRRerankContext` | Context object carrying MMR configuration between processors |
+| `MMRTransformContext` | Context for query transformers with index metadata |
+| `MMRVectorFieldInfo` | DTO for resolved vector field metadata (space type, data type, path) |
+| `MMRUtil` | Utility class for vector extraction, field resolution, and similarity computation |
+
+### Configuration
+
+#### Cluster Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.search.enabled_system_generated_factories` | List of enabled system-generated processor factories | `[]` |
+
+Required factories for MMR:
+- `mmr_over_sample_factory`
+- `mmr_rerank_factory`
+
+#### MMR Query Extension Parameters
+
+| Parameter | Type | Description | Default | Required |
+|-----------|------|-------------|---------|----------|
+| `diversity` | float | Trade-off between relevance (0) and diversity (1) | `0.5` | No |
+| `candidates` | integer | Number of candidates to oversample | `3 × query_size` | No |
+| `vector_field_path` | string | Path to vector field for reranking | Auto-resolved | For cross-cluster |
+| `vector_field_data_type` | string | Vector data type (`float`, `byte`) | Auto-resolved | For cross-cluster |
+| `vector_field_space_type` | string | Distance metric (`l2`, `cosinesimil`, `innerproduct`) | Auto-resolved | For cross-cluster |
+
+### Usage Examples
+
+#### Enable MMR Processors
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.search.enabled_system_generated_factories": [
+      "mmr_over_sample_factory",
+      "mmr_rerank_factory"
+    ]
+  }
+}
+```
+
+#### Basic k-NN Query with MMR
+
+```json
+GET /my-index/_search
+{
+  "size": 10,
+  "query": {
+    "knn": {
+      "my_vector_field": {
+        "vector": [1.0, 2.0, 3.0],
+        "k": 10
+      }
+    }
+  },
+  "ext": {
+    "mmr": {
+      "diversity": 0.5,
+      "candidates": 30
+    }
+  }
+}
+```
+
+#### Neural Query with MMR
+
+```json
+GET /my-nlp-index/_search
+{
+  "size": 3,
+  "_source": { "exclude": ["product_description_semantic_info"] },
+  "query": {
+    "neural": {
+      "product_description": {
+        "query_text": "Red apple"
+      }
+    }
+  },
+  "ext": {
+    "mmr": {
+      "candidates": 10,
+      "diversity": 0.4
+    }
+  }
+}
+```
+
+#### Cross-Cluster Search with MMR
+
+```json
+POST /my-index/_search
+{
+  "query": {
+    "neural": {
+      "my_vector_field": {
+        "query_text": "query text",
+        "model_id": "<your model id>"
+      }
+    }
+  },
+  "ext": {
+    "mmr": {
+      "diversity": 0.5,
+      "candidates": 10,
+      "vector_field_path": "my_vector_field",
+      "vector_field_data_type": "float",
+      "vector_field_space_type": "l2"
+    }
+  }
+}
+```
+
+### MMR Algorithm
+
+The MMR algorithm iteratively selects documents that maximize:
+
+```
+MMR(d_i) = λ × Sim(d_i, query) - (1 - λ) × max_{d_j ∈ selected} Sim(d_i, d_j)
+```
+
+Where:
+- `λ` is the relevance/diversity trade-off (controlled by `diversity` parameter where `diversity = 1 - λ`)
+- `Sim(d_i, query)` is the similarity score from the original search
+- `Sim(d_i, d_j)` is the similarity between candidate and already-selected documents
+
+### Performance Characteristics
+
+MMR adds latency that grows with:
+- Number of MMR candidates
+- Query size (k)
+- Vector dimensionality
+
+Benchmark guidance:
+- For k=10 with 30 candidates: ~34% latency increase for k-NN, ~7% for neural
+- For k=10 with 100 candidates: ~96% latency increase for k-NN, ~17% for neural
+
+Choose candidates based on your diversity requirements and latency budget.
+
+## Limitations
+
+- Supports only k-NN queries and neural queries using `knn_vector` fields
+- Does not support `bool`, `hybrid`, or other compound query types
+- Semantic fields with chunking enabled are not supported (multiple vectors per document)
+- Cross-cluster search requires explicit vector field configuration
+- Nested fields containing vectors are not supported
+- Remote cluster vector field info cannot be auto-resolved
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [k-NN #2868](https://github.com/opensearch-project/k-NN/pull/2868) | Support native Maximal Marginal Relevance |
+| v3.3.0 | [neural-search #1567](https://github.com/opensearch-project/neural-search/pull/1567) | Support native MMR for neural query |
+
+## References
+
+- [Issue k-NN #2804](https://github.com/opensearch-project/k-NN/issues/2804): Original feature request
+- [Issue neural-search #1481](https://github.com/opensearch-project/neural-search/issues/1481): Neural-search feature request
+- [Blog: Improving vector search diversity through native MMR](https://opensearch.org/blog/improving-vector-search-diversity-through-native-mmr/)
+- [Documentation: System-generated search processors](https://docs.opensearch.org/latest/search-plugins/search-pipelines/system-generated-search-processors/)
+- [Documentation: Semantic field type](https://docs.opensearch.org/latest/field-types/supported-field-types/semantic/)
+- [Documentation: Cross-cluster search](https://docs.opensearch.org/latest/search-plugins/cross-cluster-search/)
+- [LangChain MMR Retriever](https://docs.langchain.com/docs/modules/data_connection/retrievers/vectorstores#maximal-marginal-relevance)
+
+## Change History
+
+- **v3.3.0** (2025-09-26): Initial implementation with native MMR support for k-NN and neural queries

--- a/docs/releases/v3.3.0/features/k-nn/maximal-marginal-relevance-mmr.md
+++ b/docs/releases/v3.3.0/features/k-nn/maximal-marginal-relevance-mmr.md
@@ -1,0 +1,174 @@
+# Maximal Marginal Relevance (MMR)
+
+## Summary
+
+OpenSearch 3.3 introduces native Maximal Marginal Relevance (MMR) support for k-NN and neural queries. MMR is a reranking algorithm that balances relevance and diversity in search results, helping users see a range of results rather than multiple near-duplicates. This feature eliminates the need for external custom pipelines and reduces latency by implementing MMR directly within OpenSearch.
+
+## Details
+
+### What's New in v3.3.0
+
+- Native MMR support for k-NN queries using `knn_vector` fields
+- Native MMR support for neural queries with semantic fields
+- System-generated search pipeline processors for automatic oversampling and reranking
+- Extensible query transformer architecture for plugin integration
+- Cross-cluster search support with explicit vector field configuration
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Search Request Flow"
+        A[Search Request with MMR Extension] --> B[MMRSearchExtBuilder]
+        B --> C[MMROverSampleProcessor]
+        C --> D[MMRQueryTransformer]
+        D --> E[Modified Search Request]
+    end
+    
+    subgraph "Search Response Flow"
+        F[Search Response] --> G[MMRRerankProcessor]
+        G --> H[MMR Algorithm]
+        H --> I[Reranked Results]
+    end
+    
+    E --> F
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `MMRSearchExtBuilder` | Search extension builder for parsing MMR parameters from query |
+| `MMROverSampleProcessor` | System-generated request processor that modifies query to oversample candidates |
+| `MMRRerankProcessor` | System-generated response processor that reranks results using MMR algorithm |
+| `MMRQueryTransformer` | Interface for transforming queries for MMR (extensible by plugins) |
+| `MMRKnnQueryTransformer` | Transformer implementation for k-NN queries |
+| `MMRNeuralQueryTransformer` | Transformer implementation for neural queries (in neural-search plugin) |
+| `MMRRerankContext` | Context object passed between processors containing MMR configuration |
+| `MMRVectorFieldInfo` | DTO for vector field metadata resolution |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.search.enabled_system_generated_factories` | Cluster setting to enable MMR processors | `[]` |
+
+MMR query extension parameters:
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `diversity` | Trade-off between relevance (0) and diversity (1) | `0.5` |
+| `candidates` | Number of candidates to oversample for MMR | `3 × query_size` |
+| `vector_field_path` | Path to vector field (required for cross-cluster search) | Auto-resolved |
+| `vector_field_data_type` | Vector data type (`float`, `byte`) | Auto-resolved |
+| `vector_field_space_type` | Distance metric (`l2`, `cosinesimil`, etc.) | Auto-resolved |
+
+### Usage Example
+
+#### Enable MMR Processors
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.search.enabled_system_generated_factories": [
+      "mmr_over_sample_factory",
+      "mmr_rerank_factory"
+    ]
+  }
+}
+```
+
+#### k-NN Query with MMR
+
+```json
+GET /my-index/_search
+{
+  "size": 10,
+  "query": {
+    "knn": {
+      "my_vector_field": {
+        "vector": [1.0, 2.0, 3.0],
+        "k": 10
+      }
+    }
+  },
+  "ext": {
+    "mmr": {
+      "diversity": 0.5,
+      "candidates": 30
+    }
+  }
+}
+```
+
+#### Neural Query with MMR
+
+```json
+GET /my-nlp-index/_search
+{
+  "size": 3,
+  "query": {
+    "neural": {
+      "product_description": {
+        "query_text": "Red apple"
+      }
+    }
+  },
+  "ext": {
+    "mmr": {
+      "candidates": 10,
+      "diversity": 0.4
+    }
+  }
+}
+```
+
+### Performance Benchmarks
+
+Benchmark results on OpenSearch 3.3 with 3 × r6g.2xlarge data nodes:
+
+**Vector Search (cohere-1m dataset):**
+
+| k | Query Size | MMR Candidates | k-NN p50 (ms) | k-NN + MMR p50 (ms) | Δ (%) |
+|---|------------|----------------|---------------|---------------------|-------|
+| 10 | 10 | 30 | 8.09 | 10.83 | +33.9% |
+| 10 | 10 | 50 | 8.09 | 11.76 | +45.4% |
+| 10 | 10 | 100 | 8.09 | 15.81 | +95.5% |
+
+**Neural Search (Quora dataset):**
+
+| k | Query Size | MMR Candidates | Neural p50 (ms) | Neural + MMR p50 (ms) | Δ (%) |
+|---|------------|----------------|-----------------|----------------------|-------|
+| 10 | 10 | 30 | 112.03 | 119.57 | +6.7% |
+| 10 | 10 | 50 | 112.03 | 122.56 | +9.4% |
+| 10 | 10 | 100 | 112.03 | 130.52 | +16.5% |
+
+## Limitations
+
+- MMR currently supports only k-NN queries and neural queries using `knn_vector` fields
+- Does not support `bool` or `hybrid` queries (planned for future releases)
+- Semantic fields with chunking enabled (multiple vectors per document) are not supported
+- Cross-cluster search requires explicit vector field configuration
+- Nested fields containing vectors are not supported
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [k-NN #2868](https://github.com/opensearch-project/k-NN/pull/2868) | Support native Maximal Marginal Relevance |
+| [neural-search #1567](https://github.com/opensearch-project/neural-search/pull/1567) | Support native MMR for neural query |
+
+## References
+
+- [Issue k-NN #2804](https://github.com/opensearch-project/k-NN/issues/2804): Feature request for native MMR support
+- [Issue neural-search #1481](https://github.com/opensearch-project/neural-search/issues/1481): Feature request for MMR in neural-search
+- [Blog: Improving vector search diversity through native MMR](https://opensearch.org/blog/improving-vector-search-diversity-through-native-mmr/)
+- [Documentation: System-generated search processors](https://docs.opensearch.org/latest/search-plugins/search-pipelines/system-generated-search-processors/)
+- [Documentation: Semantic field type](https://docs.opensearch.org/latest/field-types/supported-field-types/semantic/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/k-nn/maximal-marginal-relevance-mmr.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -130,6 +130,7 @@
 - [k-NN Bug Fixes](features/k-nn/k-nn-bug-fixes.md)
 - [k-NN Engine Enhancements](features/k-nn/k-nn-engine-enhancements.md)
 - [Late Interaction](features/k-nn/late-interaction.md)
+- [Maximal Marginal Relevance (MMR)](features/k-nn/maximal-marginal-relevance-mmr.md)
 
 ### Geospatial
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Maximal Marginal Relevance (MMR) feature introduced in OpenSearch v3.3.0.

## Reports Created

- Release report: `docs/releases/v3.3.0/features/k-nn/maximal-marginal-relevance-mmr.md`
- Feature report: `docs/features/k-nn/maximal-marginal-relevance-mmr.md`

## Key Changes in v3.3.0

- Native MMR support for k-NN queries using `knn_vector` fields
- Native MMR support for neural queries with semantic fields
- System-generated search pipeline processors (`mmr_over_sample_factory`, `mmr_rerank_factory`)
- Extensible query transformer architecture for plugin integration
- Cross-cluster search support with explicit vector field configuration

## Resources Used

- PR: [k-NN #2868](https://github.com/opensearch-project/k-NN/pull/2868)
- PR: [neural-search #1567](https://github.com/opensearch-project/neural-search/pull/1567)
- Issue: [k-NN #2804](https://github.com/opensearch-project/k-NN/issues/2804)
- Issue: [neural-search #1481](https://github.com/opensearch-project/neural-search/issues/1481)
- Blog: https://opensearch.org/blog/improving-vector-search-diversity-through-native-mmr/

Closes #1311