### PR TITLE
docs: add Snapshot Management report for v3.3.0

### DIFF
--- a/docs/features/index-management/snapshot-management.md
+++ b/docs/features/index-management/snapshot-management.md
@@ -1,0 +1,224 @@
+# Snapshot Management
+
+## Summary
+
+Snapshot Management (SM) automates the creation and deletion of OpenSearch snapshots. Part of the Index Management (IM) plugin, SM allows users to define policies that schedule snapshot operations, apply retention conditions, and manage snapshot lifecycle without manual intervention. SM is essential for backup strategies, disaster recovery, and data retention compliance.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Snapshot Management"
+        Policy[SM Policy]
+        Scheduler[Job Scheduler]
+        StateMachine[State Machine]
+    end
+    
+    subgraph "Policy Configuration"
+        Creation[Creation Config]
+        Deletion[Deletion Config]
+        SnapConfig[Snapshot Config]
+        Notification[Notification Config]
+    end
+    
+    subgraph "State Machine Workflows"
+        CreationWF[Creation Workflow]
+        DeletionWF[Deletion Workflow]
+    end
+    
+    subgraph "External Systems"
+        Repository[Snapshot Repository]
+        NotifChannel[Notification Channel]
+    end
+    
+    Policy --> Creation
+    Policy --> Deletion
+    Policy --> SnapConfig
+    Policy --> Notification
+    
+    Scheduler --> StateMachine
+    StateMachine --> CreationWF
+    StateMachine --> DeletionWF
+    
+    CreationWF --> Repository
+    DeletionWF --> Repository
+    Notification --> NotifChannel
+```
+
+### State Machine Flow
+
+```mermaid
+stateDiagram-v2
+    [*] --> CREATION_START
+    CREATION_START --> CREATION_CONDITION_MET: Schedule triggered
+    CREATION_CONDITION_MET --> CREATING: Conditions met
+    CREATING --> CREATION_FINISHED: Snapshot created
+    CREATION_FINISHED --> CREATION_START: Reset for next cycle
+    
+    [*] --> DELETION_START
+    DELETION_START --> DELETION_CONDITION_MET: Schedule triggered
+    DELETION_CONDITION_MET --> DELETING: Conditions met
+    DELETING --> DELETION_FINISHED: Snapshots deleted
+    DELETION_FINISHED --> DELETION_START: Reset for next cycle
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SMPolicy` | Defines snapshot creation/deletion schedules and configurations |
+| `SMMetadata` | Stores policy execution state and metadata |
+| `SMRunner` | Executes SM policies on schedule |
+| `SMStateMachine` | Manages state transitions for creation/deletion workflows |
+| `CreatingState` | Handles snapshot creation operations |
+| `DeletingState` | Handles snapshot deletion operations |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `creation.schedule` | Cron schedule for snapshot creation | Required (if creation enabled) |
+| `creation.time_limit` | Maximum time for snapshot creation | Optional |
+| `deletion.schedule` | Cron schedule for snapshot deletion | Uses creation schedule |
+| `deletion.condition.max_age` | Maximum age of snapshots to retain | Optional |
+| `deletion.condition.max_count` | Maximum number of snapshots to retain | Optional |
+| `deletion.condition.min_count` | Minimum number of snapshots to retain | `1` |
+| `deletion.snapshot_pattern` | Pattern to match external snapshots (v3.3.0+) | `null` |
+| `snapshot_config.repository` | Snapshot repository name | Required |
+| `snapshot_config.indices` | Indices to include in snapshot | `*` |
+| `snapshot_config.include_global_state` | Include cluster state in snapshot | `true` |
+
+### Usage Examples
+
+#### Basic SM Policy
+
+```json
+POST _plugins/_sm/policies/daily-backup
+{
+  "description": "Daily backup policy",
+  "creation": {
+    "schedule": {
+      "cron": {
+        "expression": "0 0 * * *",
+        "timezone": "UTC"
+      }
+    }
+  },
+  "deletion": {
+    "condition": {
+      "max_age": "30d",
+      "min_count": 7
+    }
+  },
+  "snapshot_config": {
+    "repository": "my-repo",
+    "indices": "*"
+  }
+}
+```
+
+#### Deletion-Only Policy (v3.3.0+)
+
+```json
+POST _plugins/_sm/policies/cleanup-external
+{
+  "description": "Cleanup externally created snapshots",
+  "deletion": {
+    "schedule": {
+      "cron": {
+        "expression": "0 2 * * *",
+        "timezone": "UTC"
+      }
+    },
+    "condition": {
+      "max_age": "14d",
+      "min_count": 3
+    },
+    "snapshot_pattern": "external-backup-*"
+  },
+  "snapshot_config": {
+    "repository": "my-repo"
+  }
+}
+```
+
+#### Policy with Notifications
+
+```json
+POST _plugins/_sm/policies/monitored-backup
+{
+  "description": "Backup policy with notifications",
+  "creation": {
+    "schedule": {
+      "cron": {
+        "expression": "0 1 * * *",
+        "timezone": "UTC"
+      }
+    },
+    "time_limit": "1h"
+  },
+  "deletion": {
+    "condition": {
+      "max_age": "7d",
+      "max_count": 21,
+      "min_count": 7
+    }
+  },
+  "snapshot_config": {
+    "repository": "s3-repo",
+    "indices": "logs-*",
+    "include_global_state": false
+  },
+  "notification": {
+    "channel": {
+      "id": "notification-channel-id"
+    },
+    "conditions": {
+      "creation": true,
+      "deletion": true,
+      "failure": true
+    }
+  }
+}
+```
+
+### API Operations
+
+| Operation | Endpoint | Description |
+|-----------|----------|-------------|
+| Create Policy | `POST _plugins/_sm/policies/{name}` | Create a new SM policy |
+| Update Policy | `PUT _plugins/_sm/policies/{name}?if_seq_no=X&if_primary_term=Y` | Update existing policy |
+| Get Policy | `GET _plugins/_sm/policies/{name}` | Retrieve policy details |
+| Get All Policies | `GET _plugins/_sm/policies` | List all SM policies |
+| Delete Policy | `DELETE _plugins/_sm/policies/{name}` | Delete a policy |
+| Explain | `GET _plugins/_sm/policies/{name}/_explain` | Get policy execution status |
+| Start Policy | `POST _plugins/_sm/policies/{name}/_start` | Enable a stopped policy |
+| Stop Policy | `POST _plugins/_sm/policies/{name}/_stop` | Disable a running policy |
+
+## Limitations
+
+- SM does not support concurrent snapshot operations within a single policy
+- Snapshot operations are performed asynchronously with retry logic (max 3 retries)
+- Large repositories require more memory on the cluster manager node
+- Multiple policies with overlapping schedules and indexes may impact performance
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [#1452](https://github.com/opensearch-project/index-management/pull/1452) | Add support for deletion-only policies and snapshot patterns |
+| v3.3.0 | [#1480](https://github.com/opensearch-project/index-management/pull/1480) | Exclude global state from ISM snapshot action |
+
+## References
+
+- [Issue #867](https://github.com/opensearch-project/index-management/issues/867): Feature request for deletion-only SM policies
+- [Issue #1479](https://github.com/opensearch-project/index-management/issues/1479): Bug report for ISM snapshot global state
+- [Snapshot Management Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-management/)
+- [Snapshot Management API](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/snapshots/sm-api/)
+- [OpenSearch Dashboards SM](https://docs.opensearch.org/3.0/dashboards/sm-dashboards/)
+
+## Change History
+
+- **v3.3.0** (2026-01): Added optional creation workflow, snapshot pattern support for deletion, and ISM snapshot global state fix

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -496,6 +496,7 @@
 ## index-management
 
 - [Index Management](index-management/index-management.md)
+- [Snapshot Management](index-management/snapshot-management.md)
 
 ## index-management-dashboards
 

--- a/docs/releases/v3.3.0/features/index-management/snapshot-management.md
+++ b/docs/releases/v3.3.0/features/index-management/snapshot-management.md
@@ -1,0 +1,168 @@
+# Snapshot Management Enhancements
+
+## Summary
+
+OpenSearch v3.3.0 introduces significant enhancements to Snapshot Management (SM), enabling deletion-only policies and snapshot pattern support. These changes allow users to manage externally created snapshots and create cleanup-only workflows without requiring automatic snapshot creation.
+
+## Details
+
+### What's New in v3.3.0
+
+#### 1. Optional Creation Workflow
+
+The `creation` field in SM policies is now optional, enabling deletion-only policies. Previously, SM policies required both creation and deletion configurations. Now users can create policies that only delete snapshots based on retention conditions.
+
+**Key Changes:**
+- Made `creation` field optional in `SMPolicy`
+- Added version compatibility checks (`Version.V_3_3_0`) for backward compatibility
+- Updated JSON parsing and serialization to handle nullable creation workflows
+
+#### 2. Snapshot Pattern Support
+
+A new `snapshot_pattern` field in the deletion configuration allows SM policies to include externally created snapshots in deletion workflows.
+
+**Key Changes:**
+- Added `snapshotPattern` field to `SMPolicy.Deletion`
+- Enhanced deletion states to combine policy-created and pattern-matched snapshots
+- Applied deletion conditions (`max_age`, `min_count`) across all matching snapshots
+
+#### 3. ISM Snapshot Action Fix
+
+The ISM snapshot action now excludes global state by default, preventing potential security issues when restoring snapshots.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "SM Policy (v3.3.0)"
+        Policy[SMPolicy]
+        Creation[Creation Config<br/>Optional]
+        Deletion[Deletion Config]
+        Pattern[snapshot_pattern<br/>New Field]
+    end
+    
+    subgraph "State Machine"
+        CreationWF[Creation Workflow]
+        DeletionWF[Deletion Workflow]
+    end
+    
+    subgraph "Snapshot Sources"
+        PolicySnaps[Policy-Created<br/>Snapshots]
+        ExternalSnaps[External<br/>Snapshots]
+    end
+    
+    Policy --> Creation
+    Policy --> Deletion
+    Deletion --> Pattern
+    
+    Creation -.->|Optional| CreationWF
+    Deletion --> DeletionWF
+    
+    CreationWF --> PolicySnaps
+    Pattern --> ExternalSnaps
+    DeletionWF --> PolicySnaps
+    DeletionWF --> ExternalSnaps
+```
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `deletion.snapshot_pattern` | Glob pattern to match external snapshots for deletion | `null` |
+
+#### API Changes
+
+**Deletion-Only Policy Example:**
+```json
+POST _plugins/_sm/policies/cleanup-policy
+{
+  "description": "Deletion-only SM policy",
+  "deletion": {
+    "schedule": {
+      "cron": {
+        "expression": "0 2 * * *",
+        "timezone": "UTC"
+      }
+    },
+    "condition": {
+      "max_age": "14d",
+      "min_count": 2
+    },
+    "snapshot_pattern": "external-backup-*"
+  },
+  "snapshot_config": {
+    "repository": "my-repo"
+  }
+}
+```
+
+**Policy with Snapshot Pattern:**
+```json
+POST _plugins/_sm/policies/combined-policy
+{
+  "description": "SM policy with snapshot pattern",
+  "creation": {
+    "schedule": {
+      "cron": {
+        "expression": "0 1 * * *",
+        "timezone": "UTC"
+      }
+    }
+  },
+  "deletion": {
+    "schedule": {
+      "cron": {
+        "expression": "0 2 * * *",
+        "timezone": "UTC"
+      }
+    },
+    "condition": {
+      "max_age": "30d",
+      "min_count": 3
+    },
+    "snapshot_pattern": "external-*"
+  },
+  "snapshot_config": {
+    "repository": "my-repo"
+  }
+}
+```
+
+### Use Cases Enabled
+
+1. **Cleanup-only workflows**: Delete old snapshots without automatic creation
+2. **External snapshot management**: Include snapshots created by external tools in retention policies
+3. **Flexible policy configurations**: Support creation-only, deletion-only, or combined workflows
+
+### Migration Notes
+
+- Existing policies with required creation fields continue to work unchanged
+- Version checks ensure proper serialization/deserialization across different versions
+- No breaking changes to existing APIs or data structures
+- No data migration required
+
+## Limitations
+
+- Deletion-only policies require a schedule to be explicitly provided (cannot inherit from creation)
+- Snapshot patterns use simple glob matching, not full regex support
+- Pattern-matched snapshots are combined with policy snapshots for deletion condition evaluation
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1452](https://github.com/opensearch-project/index-management/pull/1452) | Add support in SM Plugin to delete snapshots created manually |
+| [#1480](https://github.com/opensearch-project/index-management/pull/1480) | Do not include global state in snapshot step |
+
+## References
+
+- [Issue #867](https://github.com/opensearch-project/index-management/issues/867): Feature request for deletion-only SM policies
+- [Issue #1479](https://github.com/opensearch-project/index-management/issues/1479): Bug report for ISM snapshot global state
+- [Snapshot Management Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-management/)
+- [Snapshot Management API](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/snapshots/sm-api/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/index-management/snapshot-management.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -139,6 +139,7 @@
 ### Index Management
 
 - [Index Management Enhancements](features/index-management/index-management-enhancements.md)
+- [Snapshot Management](features/index-management/snapshot-management.md)
 
 ### Job Scheduler
 


### PR DESCRIPTION
## Summary

This PR adds documentation for Snapshot Management enhancements in OpenSearch v3.3.0.

### Key Changes in v3.3.0

1. **Optional Creation Workflow**: The `creation` field in SM policies is now optional, enabling deletion-only policies
2. **Snapshot Pattern Support**: New `snapshot_pattern` field allows SM policies to include externally created snapshots in deletion workflows
3. **ISM Snapshot Global State Fix**: ISM snapshot action now excludes global state by default

### Reports Created

- Release report: `docs/releases/v3.3.0/features/index-management/snapshot-management.md`
- Feature report: `docs/features/index-management/snapshot-management.md`

### Related PRs

- [opensearch-project/index-management#1452](https://github.com/opensearch-project/index-management/pull/1452): Add support in SM Plugin to delete snapshots created manually
- [opensearch-project/index-management#1480](https://github.com/opensearch-project/index-management/pull/1480): Do not include global state in snapshot step

### Related Issues

- [opensearch-project/index-management#867](https://github.com/opensearch-project/index-management/issues/867): Feature request for deletion-only SM policies
- [opensearch-project/index-management#1479](https://github.com/opensearch-project/index-management/issues/1479): Bug report for ISM snapshot global state

Closes #1309