### PR TITLE
docs: add semantic highlighting batch inference report for v3.3.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -14,6 +14,7 @@
 - [Neural Sparse Search](neural-search/neural-sparse-search.md)
 - [SEISMIC Sparse ANN](neural-search/seismic-sparse-ann.md)
 - [Semantic Field](neural-search/semantic-field.md)
+- [Semantic Highlighting](neural-search/semantic-highlighting.md)
 - [Text Chunking](neural-search/text-chunking.md)
 
 ## opensearch

--- a/docs/features/neural-search/semantic-highlighting.md
+++ b/docs/features/neural-search/semantic-highlighting.md
@@ -1,0 +1,225 @@
+# Semantic Highlighting
+
+## Summary
+
+Semantic highlighting is an AI-powered feature that intelligently identifies and emphasizes the most semantically relevant sentences or passages within search results based on the query's meaning. Unlike traditional highlighters that rely on exact keyword matches, semantic highlighting uses ML models to understand context and relevance, allowing users to pinpoint pertinent information even when exact search terms aren't present in the highlighted passage.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Search Request"
+        A[Search Query]
+        B[Highlight Configuration]
+    end
+    
+    subgraph "Highlight Processing"
+        C{Highlight Type}
+        D[Traditional Highlighter<br/>Keyword Matching]
+        E[Semantic Highlighter]
+    end
+    
+    subgraph "Semantic Highlighting Modes"
+        F{batch_inference?}
+        G[Single Inference<br/>SemanticHighlighter]
+        H[Batch Inference<br/>SemanticHighlightingProcessor]
+    end
+    
+    subgraph "ML Inference"
+        I[Local Model<br/>1 call per doc]
+        J[Remote Model<br/>1 call per batch]
+    end
+    
+    subgraph "Output"
+        K[Highlighted Text<br/>with em tags]
+    end
+    
+    A --> C
+    B --> C
+    C -->|type: unified/plain| D
+    C -->|type: semantic| E
+    E --> F
+    F -->|false| G
+    F -->|true| H
+    G --> I
+    H --> J
+    I --> K
+    J --> K
+    D --> K
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Search Request] --> B[Extract Query Text]
+    B --> C[Extract Field Text from Hits]
+    C --> D{Batch Mode?}
+    D -->|No| E[Single ML Inference per Doc]
+    D -->|Yes| F[Collect All Documents]
+    F --> G[Batch ML Inference]
+    E --> H[Parse Highlight Positions]
+    G --> H
+    H --> I[Apply Tags to Text]
+    I --> J[Return Highlighted Response]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SemanticHighlighter` | Main highlighter implementation registered with OpenSearch |
+| `SemanticHighlighterEngine` | Engine for single-document inference operations |
+| `SemanticHighlightingProcessor` | Search response processor for batch inference |
+| `SemanticHighlightingFactory` | System-generated factory for auto-creating processors |
+| `QueryTextExtractorRegistry` | Registry for extracting query text from various query types |
+| `HighlightConfig` | Configuration holder for highlighting options |
+| `HighlightResultApplier` | Applies position-based highlights to text |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `model_id` | ID of the semantic highlighting model (required) | - |
+| `batch_inference` | Enable batch processing for remote models | `false` |
+| `max_inference_batch_size` | Maximum documents per batch | `100` |
+| `pre_tag` | Opening tag for highlights | `<em>` |
+| `post_tag` | Closing tag for highlights | `</em>` |
+
+### Cluster Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `search.pipeline.enabled_system_generated_factories` | Enable system processors (include `semantic-highlighter` for batch mode) | `[]` |
+
+### Usage Example
+
+#### Deploy Models
+
+```bash
+# Register and deploy text embedding model
+POST /_plugins/_ml/models/_register?deploy=true
+{
+  "name": "huggingface/sentence-transformers/all-MiniLM-L6-v2",
+  "version": "1.0.2",
+  "model_format": "TORCH_SCRIPT"
+}
+
+# Register and deploy semantic highlighting model
+POST /_plugins/_ml/models/_register?deploy=true
+{
+  "name": "amazon/sentence-highlighting/opensearch-semantic-highlighter-v1",
+  "version": "1.0.0",
+  "model_format": "TORCH_SCRIPT",
+  "function_name": "QUESTION_ANSWERING"
+}
+```
+
+#### Single Inference Mode (Default)
+
+```json
+POST /my-index/_search
+{
+  "query": {
+    "neural": {
+      "embedding": {
+        "query_text": "treatments for diseases",
+        "model_id": "<embedding-model-id>",
+        "k": 10
+      }
+    }
+  },
+  "highlight": {
+    "fields": {
+      "text": { "type": "semantic" }
+    },
+    "options": {
+      "model_id": "<highlighting-model-id>"
+    }
+  }
+}
+```
+
+#### Batch Inference Mode (v3.3.0+)
+
+```json
+// Enable system processor first
+PUT /_cluster/settings
+{
+  "persistent": {
+    "search.pipeline.enabled_system_generated_factories": ["semantic-highlighter"]
+  }
+}
+
+// Search with batch inference
+POST /my-index/_search
+{
+  "query": {
+    "neural": {
+      "embedding": {
+        "query_text": "treatments for diseases",
+        "model_id": "<embedding-model-id>",
+        "k": 50
+      }
+    }
+  },
+  "highlight": {
+    "fields": {
+      "text": { "type": "semantic" }
+    },
+    "options": {
+      "model_id": "<highlighting-model-id>",
+      "batch_inference": true
+    }
+  }
+}
+```
+
+### Response Format
+
+```json
+{
+  "hits": {
+    "hits": [
+      {
+        "_source": { "text": "..." },
+        "highlight": {
+          "text": [
+            "Document text with <em>semantically relevant passage</em> highlighted."
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+## Limitations
+
+- Requires a deployed semantic highlighting model (local or remote)
+- Batch inference only supported for remote models (REMOTE function type)
+- Long documents exceeding model token limits may require chunked processing
+- Model inference adds latency compared to keyword-based highlighting
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.0 | [neural-search#1520](https://github.com/opensearch-project/neural-search/pull/1520) | Add batch inference support for semantic highlighting |
+| v3.0.0 | - | Initial semantic highlighting implementation |
+
+## References
+
+- [Issue #1516](https://github.com/opensearch-project/neural-search/issues/1516): Batch Inference Support for Semantic Highlighting
+- [Documentation](https://docs.opensearch.org/3.0/tutorials/vector-search/semantic-highlighting-tutorial/): Semantic highlighting tutorial
+- [Documentation](https://docs.opensearch.org/3.0/search-plugins/searching-data/highlight/): Highlight query matches
+- [Blog](https://opensearch.org/blog/introducing-semantic-highlighting-in-opensearch/): Introducing semantic highlighting in OpenSearch
+- [Blog](https://opensearch.org/blog/batch-processing-semantic-highlighting-in-opensearch-3-3/): Batch Processing Semantic Highlighting in OpenSearch 3.3
+- [Pretrained Models](https://docs.opensearch.org/3.0/ml-commons-plugin/pretrained-models/): Semantic sentence highlighting models
+
+## Change History
+
+- **v3.3.0** (2025-10-28): Added batch inference support for remote models with 100-1,300% performance improvements
+- **v3.0.0**: Initial implementation with single inference mode

--- a/docs/releases/v3.3.0/features/neural-search/semantic-highlighting.md
+++ b/docs/releases/v3.3.0/features/neural-search/semantic-highlighting.md
@@ -1,0 +1,157 @@
+# Semantic Highlighting Batch Inference
+
+## Summary
+
+OpenSearch 3.3.0 introduces batch processing for semantic highlighting with remote models, reducing ML inference calls from N (one per document) to 1 per search query. This enhancement delivers 100–1,300% performance improvements depending on document length and result set size, while maintaining full backward compatibility with existing queries.
+
+## Details
+
+### What's New in v3.3.0
+
+Semantic highlighting was introduced in OpenSearch 3.0 to identify and emphasize semantically relevant passages in search results using ML models. In v3.3.0, batch inference support enables processing multiple documents in a single ML call for remote models (e.g., Amazon SageMaker endpoints).
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Search Request"
+        A[Search Query with Semantic Highlighting]
+    end
+    
+    subgraph "Mode Selection"
+        B{batch_inference?}
+        C[Single Inference Mode]
+        D{System Processor Enabled?}
+        E[Batch Inference Mode]
+        F[Error: Enable System Processor]
+    end
+    
+    subgraph "Processing"
+        G[SemanticHighlighter<br/>1 ML call per document]
+        H[SemanticHighlightingProcessor<br/>1 ML call per batch]
+    end
+    
+    subgraph "Output"
+        I[Highlighted Results]
+    end
+    
+    A --> B
+    B -->|false/undefined| C
+    B -->|true| D
+    C --> G
+    D -->|Yes| E
+    D -->|No| F
+    E --> H
+    G --> I
+    H --> I
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `SemanticHighlightingProcessor` | System-generated search response processor for batch inference |
+| `SemanticHighlightingFactory` | Factory that auto-detects semantic highlighting in requests |
+| `HighlightConfig` | Immutable configuration for semantic highlighting options |
+| `HighlightContextBuilder` | Builds execution context from validated configuration |
+| `HighlightResultApplier` | Applies batch highlighting results to search hits |
+| `BatchExecutor` | Handles multi-batch execution for large result sets |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `batch_inference` | Enable batch processing for remote models | `false` |
+| `max_inference_batch_size` | Maximum documents per batch | `100` |
+| `search.pipeline.enabled_system_generated_factories` | Cluster setting to enable system processors | `[]` |
+
+### Usage Example
+
+#### Step 1: Enable System-Generated Pipelines
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "search.pipeline.enabled_system_generated_factories": ["semantic-highlighter"]
+  }
+}
+```
+
+#### Step 2: Search with Batch Inference
+
+```json
+POST /neural-search-index/_search
+{
+  "size": 10,
+  "query": {
+    "neural": {
+      "embedding": {
+        "query_text": "treatments for neurodegenerative diseases",
+        "model_id": "<text-embedding-model-id>",
+        "k": 10
+      }
+    }
+  },
+  "highlight": {
+    "fields": {
+      "text": {
+        "type": "semantic"
+      }
+    },
+    "options": {
+      "model_id": "<semantic-highlighting-model-id>",
+      "batch_inference": true
+    }
+  }
+}
+```
+
+### Performance Benchmarks
+
+Testing on MultiSpanQA dataset with Amazon SageMaker GPU endpoint (ml.g5.xlarge):
+
+| k | Clients | Doc Length | P50 Without Batch (ms) | P50 With Batch (ms) | Improvement |
+|---|---------|------------|------------------------|---------------------|-------------|
+| 10 | 1 | Long | 209 | 123 | 70% |
+| 10 | 8 | Short | 610 | 101 | 504% |
+| 50 | 1 | Short | 760 | 82 | 827% |
+| 50 | 8 | Short | 3,162 | 219 | **1,344%** |
+
+Key findings:
+- Short documents benefit more (up to 1,344% improvement) as they fit within model token limits
+- Larger result sets (k=50) show more dramatic improvements
+- Throughput increases up to 490% with batch processing
+
+### Migration Notes
+
+Existing queries continue to work without changes. To enable batch processing:
+
+1. Deploy a remote semantic highlighting model (e.g., on Amazon SageMaker)
+2. Enable the system processor via cluster settings
+3. Add `batch_inference: true` to highlight options
+
+## Limitations
+
+- Batch inference only supported for **remote models** (REMOTE function type)
+- Local models continue to use single inference mode
+- Long documents exceeding model token limits (512 tokens) may require chunked processing
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [neural-search#1520](https://github.com/opensearch-project/neural-search/pull/1520) | Add semantic highlighting response processor with batch inference support |
+
+## References
+
+- [Issue #1516](https://github.com/opensearch-project/neural-search/issues/1516): Batch Inference Support for Semantic Highlighting
+- [Documentation](https://docs.opensearch.org/3.0/tutorials/vector-search/semantic-highlighting-tutorial/): Semantic highlighting tutorial
+- [Blog](https://opensearch.org/blog/batch-processing-semantic-highlighting-in-opensearch-3-3/): Batch Processing Semantic Highlighting in OpenSearch 3.3
+- [SageMaker Blueprint](https://github.com/opensearch-project/ml-commons/blob/main/docs/remote_inference_blueprints/standard_blueprints/sagemaker_semantic_highlighter_standard_blueprint.md): Amazon SageMaker semantic highlighter blueprint
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/neural-search/semantic-highlighting.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -124,6 +124,7 @@
 - [Neural Search Dependencies](features/neural-search/neural-search-dependencies.md)
 - [SEISMIC Sparse ANN](features/neural-search/seismic-sparse-ann.md)
 - [Semantic Field MultiFields Fix](features/neural-search/semantic-field-multifields-fix.md)
+- [Semantic Highlighting Batch Inference](features/neural-search/semantic-highlighting.md)
 
 ### k-NN
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Semantic Highlighting Batch Inference feature introduced in OpenSearch v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/neural-search/semantic-highlighting.md`
- Feature report: `docs/features/neural-search/semantic-highlighting.md`

### Key Changes in v3.3.0
- Batch processing for remote semantic highlighting models reduces ML inference calls from N to 1 per search query
- Performance improvements of 100-1,300% depending on document length and result set size
- New `SemanticHighlightingProcessor` for system-generated search pipelines
- Backward compatible - existing queries work without changes

### Resources Used
- PR: [neural-search#1520](https://github.com/opensearch-project/neural-search/pull/1520)
- Issue: [neural-search#1516](https://github.com/opensearch-project/neural-search/issues/1516)
- Docs: https://docs.opensearch.org/3.0/tutorials/vector-search/semantic-highlighting-tutorial/
- Blog: https://opensearch.org/blog/batch-processing-semantic-highlighting-in-opensearch-3-3/

Closes #1308