### PR TITLE
docs: add alerting user custom attributes report for v3.3.0

### DIFF
--- a/docs/features/alerting/alerting.md
+++ b/docs/features/alerting/alerting.md
@@ -155,6 +155,7 @@ POST _plugins/_alerting/monitors
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.3.0 | [#1917](https://github.com/opensearch-project/alerting/pull/1917) | Adds support for leveraging user custom attributes in Alerting monitors |
 | v3.2.0 | [#1885](https://github.com/opensearch-project/alerting/pull/1885) | Fix MGet bug, randomize fan out distribution |
 | v3.2.0 | [#1818](https://github.com/opensearch-project/alerting/pull/1818) | Refactored consistent responses and fixed unrelated exceptions |
 | v3.2.0 | [#1869](https://github.com/opensearch-project/alerting/pull/1869) | Update the maven snapshot publish endpoint and credential |
@@ -201,7 +202,9 @@ POST _plugins/_alerting/monitors
 - [Per Document Monitors](https://docs.opensearch.org/3.0/observing-your-data/alerting/per-document-monitors/): Per-document monitor documentation
 - [Composite Monitors](https://docs.opensearch.org/3.0/observing-your-data/alerting/composite-monitors/): Composite monitor documentation
 - [Alerting Security](https://docs.opensearch.org/3.0/observing-your-data/alerting/security/): Security configuration for alerting
+- [Document-Level Security](https://docs.opensearch.org/3.0/security/access-control/document-level-security/): Parameter substitution in DLS queries
 - [Notifications Plugin](https://docs.opensearch.org/3.0/observing-your-data/notifications/index/): Notifications integration
+- [Issue #1829](https://github.com/opensearch-project/alerting/issues/1829): Alerting does not work with DLS parameter substitution
 - [Issue #1057](https://github.com/opensearch-project/alerting/issues/1057): Return empty responses if there is no alerting config index created
 - [Issue #1853](https://github.com/opensearch-project/alerting/issues/1853): Timebox doc level monitor to avoid duplicate executions
 - [Issue #1859](https://github.com/opensearch-project/alerting/issues/1859): Change publish findings to accept a list of findings
@@ -210,6 +213,7 @@ POST _plugins/_alerting/monitors
 
 ## Change History
 
+- **v3.3.0** (2025): User custom attributes support for DLS/FLS parameter substitution - monitors now save and pass user custom attributes during execution, enabling DLS queries with `${attr.internal.*}` substitution to work correctly
 - **v3.2.0** (2025): MGet bug fix with proper finding-to-document mapping, randomized fan-out node distribution for better load balancing, consistent API responses when alerting config index doesn't exist, Maven snapshot publishing migration to Sonatype Central
 - **v3.1.0** (2025): Doc-level monitor timeboxing (3-4 min execution limit), batch findings publishing for improved performance, index pattern validation for doc-level monitors, threat intel monitor check fix, alert insight on dashboard overview page, log pattern extraction error handling
 - **v3.0.0** (2025): Bug fixes for bucket selector aggregation, Java Agent migration, and dashboard subfield selection

--- a/docs/releases/v3.3.0/features/alerting/alerting-user-custom-attributes.md
+++ b/docs/releases/v3.3.0/features/alerting/alerting-user-custom-attributes.md
@@ -1,0 +1,129 @@
+# Alerting User Custom Attributes
+
+## Summary
+
+This release adds support for leveraging user custom attributes in Alerting monitors. When a monitor is created or updated, the user's custom attributes are now saved with the monitor and passed to the Security plugin during monitor execution. This enables Document-Level Security (DLS) and Field-Level Security (FLS) queries that rely on parameter substitution with custom attributes to work correctly when monitors execute queries.
+
+## Details
+
+### What's New in v3.3.0
+
+Prior to this change, Alerting monitors failed when users had roles with DLS queries using parameter substitution (e.g., `${attr.internal.team}`). The monitor queries would fail because the custom attributes were not available during execution, resulting in malformed queries.
+
+This enhancement:
+1. Saves user custom attributes when a monitor is created or updated
+2. Passes custom attributes to the Security plugin during monitor execution via `InjectorContextElement`
+3. Enables DLS/FLS queries with parameter substitution to work correctly
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Monitor Creation/Update"
+        User[User with Custom Attributes]
+        Monitor[Monitor]
+        UserObj[User Object]
+    end
+    
+    subgraph "Monitor Execution"
+        Runner[Monitor Runner]
+        Injector[InjectorContextElement]
+        Security[Security Plugin]
+        DLS[DLS Query Evaluation]
+    end
+    
+    User -->|Creates/Updates| Monitor
+    Monitor -->|Stores| UserObj
+    UserObj -->|Contains| CustomAttrs[Custom Attributes Map]
+    
+    Runner -->|Executes with| Injector
+    Injector -->|Passes user info| Security
+    Security -->|Substitutes attributes| DLS
+```
+
+#### Data Model Changes
+
+| Change | Before | After |
+|--------|--------|-------|
+| User custom attributes type | `List<String>` (attribute names only) | `Map<String, String>` (key-value pairs) |
+| Field name | `customAttNames` | `customAttributes` |
+
+#### Modified Components
+
+| Component | Description |
+|-----------|-------------|
+| `TransportIndexMonitorAction` | Now stores `user.customAttributes` instead of `user.customAttNames` |
+| `TransportIndexWorkflowAction` | Updated to use `customAttributes` map |
+| `BucketLevelMonitorRunner` | Passes `monitor.user` to `InjectorContextElement` |
+| `QueryLevelMonitorRunner` | Passes `monitor.user` to `InjectorContextElement` |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.user_attribute_serialization.enabled` | Enables user attribute serialization for alerting | `true` (in integration tests) |
+
+### Usage Example
+
+When a user with custom attributes creates a monitor:
+
+```json
+// User has custom attribute: team=red
+// Role has DLS query with parameter substitution:
+{
+  "term": { "team": "${attr.internal.team}" }
+}
+
+// Monitor query (match all)
+POST _plugins/_alerting/monitors
+{
+  "type": "monitor",
+  "name": "team-data-monitor",
+  "monitor_type": "query_level_monitor",
+  "inputs": [{
+    "search": {
+      "indices": ["team-data-*"],
+      "query": {
+        "query": { "match_all": {} }
+      }
+    }
+  }],
+  "triggers": [...]
+}
+
+// During execution, DLS query becomes:
+{
+  "term": { "team": "red" }
+}
+```
+
+### Migration Notes
+
+- Existing monitors will continue to work
+- Monitors created by users with custom attributes will now properly respect DLS/FLS rules during execution
+- No manual migration required
+
+## Limitations
+
+- Requires `plugins.security.user_attribute_serialization.enabled` to be set to `true` in the Security plugin
+- Custom attributes must be defined for the user in the Security plugin configuration
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1917](https://github.com/opensearch-project/alerting/pull/1917) | Adds support for leveraging user custom attributes in Alerting monitors |
+| [#827](https://github.com/opensearch-project/common-utils/pull/827) | Common-utils changes for custom attributes support |
+| [#5560](https://github.com/opensearch-project/security/pull/5560) | Security plugin changes for user attribute serialization |
+
+## References
+
+- [Issue #1829](https://github.com/opensearch-project/alerting/issues/1829): Bug report - Alerting does not work when user has role with parameter substitution in DLS
+- [Alerting Security Documentation](https://docs.opensearch.org/3.0/observing-your-data/alerting/security/): How monitors access data with user permissions
+- [Document-Level Security](https://docs.opensearch.org/3.0/security/access-control/document-level-security/): Parameter substitution in DLS queries
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/alerting/alerting.md)

--- a/docs/releases/v3.3.0/index.md
+++ b/docs/releases/v3.3.0/index.md
@@ -86,6 +86,10 @@
 - [Anomaly Detection Resource Authorization](features/anomaly-detection/anomaly-detection-resource-authorization.md)
 - [Doc Request Resource Type Support](features/anomaly-detection/doc-request.md)
 
+### Alerting
+
+- [Alerting User Custom Attributes](features/alerting/alerting-user-custom-attributes.md)
+
 ### Security
 
 - [Rule-based Autotagging](features/security/rule-based-autotagging.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Alerting User Custom Attributes feature in v3.3.0.

### Reports Created
- Release report: `docs/releases/v3.3.0/features/alerting/alerting-user-custom-attributes.md`
- Feature report: `docs/features/alerting/alerting.md` (updated)

### Key Changes in v3.3.0
- Monitors now save user custom attributes when created/updated
- Custom attributes are passed to Security plugin during monitor execution
- Enables DLS/FLS queries with parameter substitution (e.g., `${attr.internal.team}`) to work correctly

### Resources Used
- PR: [#1917](https://github.com/opensearch-project/alerting/pull/1917)
- Issue: [#1829](https://github.com/opensearch-project/alerting/issues/1829)
- Docs: [Alerting Security](https://docs.opensearch.org/3.0/observing-your-data/alerting/security/)
- Docs: [Document-Level Security](https://docs.opensearch.org/3.0/security/access-control/document-level-security/)

Closes #1305