### PR TITLE
docs: add dashboards-navigation report for v3.4.0

### DIFF
--- a/docs/features/opensearch-dashboards/navigation.md
+++ b/docs/features/opensearch-dashboards/navigation.md
@@ -123,6 +123,7 @@ The navigation automatically adapts to screen size:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#10678](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10678) | Fix disabled prop propagation for EuiSideNavItem |
 | v2.18.0 | [#8332](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8332) | Flatten left nav in Analytics(all) use case |
 | v2.18.0 | [#8286](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8286) | Remember state when expand/collapse left nav |
 | v2.18.0 | [#8489](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8489) | Update border style when new left nav expanded |
@@ -135,4 +136,5 @@ The navigation automatically adapts to screen size:
 
 ## Change History
 
+- **v3.4.0** (2025-10-08): Fixed disabled prop propagation for navigation links - `isDisabled` state now correctly passed to `EuiSideNavItem` components
 - **v2.18.0** (2024-10-22): Flattened navigation in Analytics(all) use case, persistent expand/collapse state, small screen compatibility, border style updates, sample data menu restored

--- a/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-navigation.md
+++ b/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-navigation.md
@@ -1,0 +1,80 @@
+# Dashboards Navigation
+
+## Summary
+
+This bugfix ensures that the `disabled` prop is correctly passed to `EuiSideNavItem` components for navigation links. Previously, navigation items that were registered with a disabled status (`AppNavLinkStatus.disabled`) were not visually or functionally disabled in the side navigation, causing inconsistent behavior. This fix respects the `AppNavLinkStatus` field from application registration.
+
+## Details
+
+### What's New in v3.4.0
+
+The fix adds proper propagation of the `isDisabled` property from the navigation link item to the `EuiSideNavItem` component's `disabled` prop.
+
+### Technical Changes
+
+#### Code Change
+
+The fix is a single-line addition in `collapsible_nav_groups.tsx`:
+
+```typescript
+// src/core/public/chrome/ui/header/collapsible_nav_groups.tsx
+return {
+  id: `${link.id}-${link.title}`,
+  name: <EuiText>{link.title}</EuiText>,
+  onClick: euiListItem.onClick,
+  href: euiListItem.href,
+  emphasize: euiListItem.isActive,
+  className: `nav-link-item ${className || ''}`,
+  buttonClassName: 'nav-link-item-btn',
+  'data-test-subj': euiListItem['data-test-subj'],
+  'aria-label': link.title,
+  disabled: euiListItem.isDisabled,  // NEW: Pass disabled state
+};
+```
+
+#### Affected Components
+
+| Component | Change |
+|-----------|--------|
+| `collapsible_nav_groups.tsx` | Added `disabled` prop mapping |
+
+### Usage Example
+
+When registering an application with a disabled navigation link:
+
+```typescript
+// Plugin registration with disabled nav link
+core.application.register({
+  id: 'myPlugin',
+  title: 'My Plugin',
+  navLinkStatus: AppNavLinkStatus.disabled,
+  mount: async (params) => {
+    // ...
+  }
+});
+```
+
+The navigation item will now correctly appear disabled in the side navigation, preventing user interaction and displaying appropriate visual styling.
+
+### Migration Notes
+
+No migration required. This is a bugfix that automatically takes effect for any applications using `AppNavLinkStatus.disabled`.
+
+## Limitations
+
+- Only affects the collapsible navigation groups component
+- Visual styling of disabled items depends on the EUI theme
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10678](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10678) | Ensure the disabled prop gets passed to the EuiSideNavItem for navlinks |
+
+## References
+
+- [OpenSearch Dashboards Quickstart Guide](https://docs.opensearch.org/3.0/dashboards/quickstart/): Navigation documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/navigation.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -1,0 +1,7 @@
+# OpenSearch v3.4.0 Release
+
+## Bug Fixes
+
+### OpenSearch Dashboards
+
+- [Dashboards Navigation](features/opensearch-dashboards/dashboards-navigation.md) - Fix disabled prop propagation for navigation links


### PR DESCRIPTION
## Summary

Adds release report for the Dashboards Navigation bugfix in v3.4.0.

### Changes
- **Release report**: `docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-navigation.md`
- **Feature report update**: `docs/features/opensearch-dashboards/navigation.md`

### Bug Fix Details
This fix ensures the `disabled` prop is correctly passed to `EuiSideNavItem` components for navigation links. Previously, navigation items registered with `AppNavLinkStatus.disabled` were not visually or functionally disabled in the side navigation.

### Related
- Closes #1743
- PR: opensearch-project/OpenSearch-Dashboards#10678