### PR TITLE
docs: add dashboards-console report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -187,6 +187,7 @@
 - [Content Management](opensearch-dashboards/content-management.md)
 - [Cross-Cluster Search](opensearch-dashboards/cross-cluster-search.md)
 - [Dashboards CI/CD & Documentation](opensearch-dashboards/dashboards-ci-cd-documentation.md)
+- [Dashboards Console](opensearch-dashboards/dashboards-console.md)
 - [Dashboards Cypress Testing](opensearch-dashboards/dashboards-cypress-testing.md)
 - [Dashboards Frontend Cleanup](opensearch-dashboards/dashboards-frontend-cleanup.md)
 - [Dashboards Improvements](opensearch-dashboards/dashboards-improvements.md)

--- a/docs/features/opensearch-dashboards/dashboards-console.md
+++ b/docs/features/opensearch-dashboards/dashboards-console.md
@@ -1,0 +1,97 @@
+# Dashboards Console (Dev Tools)
+
+## Summary
+
+The Dashboards Console is a development environment within OpenSearch Dashboards that allows users to interact with OpenSearch clusters by sending REST API requests. It provides features like autocomplete suggestions, request history, and syntax highlighting to help developers write and test queries efficiently.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        subgraph "Console Plugin"
+            UI[Settings UI]
+            Editor[Query Editor]
+            Settings[Settings Service]
+            Autocomplete[Autocomplete Service]
+        end
+    end
+    
+    subgraph "Storage"
+        LocalStorage[Browser LocalStorage]
+    end
+    
+    subgraph "OpenSearch Cluster"
+        Mappings[Index Mappings]
+        API[REST API]
+    end
+    
+    UI --> Settings
+    Settings --> LocalStorage
+    Settings --> Autocomplete
+    Autocomplete --> Mappings
+    Editor --> API
+    Editor --> Autocomplete
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Settings Service | Manages console settings including autocomplete preferences |
+| Autocomplete Service | Provides query suggestions based on cluster mappings |
+| Query Editor | Monaco-based editor for writing OpenSearch queries |
+| Settings UI | Modal dialog for configuring console behavior |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `console_polling` | Automatically refresh autocomplete suggestions | `true` |
+| `autocomplete.fields` | Enable field name suggestions | `true` |
+| `autocomplete.indices` | Enable index name suggestions | `true` |
+| `autocomplete.templates` | Enable template suggestions | `true` |
+
+### Key Features
+
+1. **Query Editor**: Write and execute REST API requests with syntax highlighting
+2. **Autocomplete**: Get suggestions for indices, fields, and query syntax
+3. **Request History**: Access previously executed queries
+4. **Auto-indent**: Format queries for readability
+5. **cURL Import**: Convert cURL commands to console format
+
+### Usage Example
+
+```
+GET _search
+{
+  "query": {
+    "match": {
+      "title": "OpenSearch"
+    }
+  }
+}
+```
+
+## Limitations
+
+- Autocomplete refresh requires a valid data source connection
+- Large clusters may experience slower autocomplete due to mapping retrieval
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#10595](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10595) | Fix: Allow updating of console_polling through the UI |
+
+## References
+
+- [Issue #10544](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10544): Bug report - Cannot update console_polling value through UI
+- [Dev Tools Documentation](https://docs.opensearch.org/3.0/dashboards/dev-tools/index-dev/): Dev Tools overview
+- [Running Queries Documentation](https://docs.opensearch.org/3.0/dashboards/dev-tools/run-queries/): Running queries in the Dev Tools console
+
+## Change History
+
+- **v3.4.0** (2025-10-03): Fixed bug where `console_polling` setting could not be updated through the UI

--- a/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-console.md
+++ b/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-console.md
@@ -1,0 +1,69 @@
+# Dashboards Console
+
+## Summary
+
+This release fixes a bug where the `console_polling` setting (which controls the "Automatically refresh autocomplete suggestions" option) could not be updated through the Dev Tools console UI. The setting value would not persist when toggled, causing autocomplete refresh to remain disabled even when users enabled it.
+
+## Details
+
+### What's New in v3.4.0
+
+Fixed the inability to update the `console_polling` setting through the UI in the Dev Tools console.
+
+### Technical Changes
+
+#### Bug Description
+
+When users attempted to toggle the "Automatically refresh autocomplete suggestions" setting in the Dev Tools console settings panel, the `console_polling` value in localStorage would not update correctly. This prevented the autocomplete feature from automatically refreshing suggestions based on cluster mappings.
+
+#### Root Cause
+
+The `dataSourceId` parameter was not being passed to the `fetchAutocompleteSettingsIfNeeded` function when saving settings. Without this parameter, the function would fail silently and not trigger the autocomplete refresh mechanism.
+
+#### Code Changes
+
+The fix modifies `src/plugins/console/public/application/containers/settings.tsx`:
+
+1. Added `dataSourceId` parameter to `fetchAutocompleteSettingsIfNeeded` function signature
+2. Added null check for `dataSourceId` before calling `retrieveAutoCompleteInfo`
+3. Updated the `onSaveSettings` callback to pass `dataSourceId` to the function
+
+```typescript
+// Before (broken)
+const onSaveSettings = (newSettings: DevToolsSettings) => {
+  const prevSettings = settings.toJSON();
+  fetchAutocompleteSettingsIfNeeded(http, settings, newSettings, prevSettings);
+  // ...
+};
+
+// After (fixed)
+const onSaveSettings = (newSettings: DevToolsSettings) => {
+  const prevSettings = settings.toJSON();
+  fetchAutocompleteSettingsIfNeeded(http, settings, newSettings, prevSettings, dataSourceId);
+  // ...
+};
+```
+
+### Affected Versions
+
+- Observed in OpenSearch Dashboards 2.19 and 3.1
+- Fixed in v3.4.0
+
+## Limitations
+
+- The fix requires a valid `dataSourceId` to be present for autocomplete refresh to work
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10595](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10595) | Allow updating of console_polling through the UI |
+
+## References
+
+- [Issue #10544](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10544): Bug report - Cannot update console_polling value through UI
+- [Dev Tools Documentation](https://docs.opensearch.org/3.0/dashboards/dev-tools/run-queries/): Running queries in the Dev Tools console
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/dashboards-console.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -4,4 +4,5 @@
 
 ### OpenSearch Dashboards
 
+- [Dashboards Console](features/opensearch-dashboards/dashboards-console.md) - Fix for console_polling setting update
 - [Dashboards Navigation](features/opensearch-dashboards/dashboards-navigation.md) - Fix disabled prop propagation for navigation links


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dashboards Console bug fix in v3.4.0.

### Bug Fixed
- **Issue**: The `console_polling` setting could not be updated through the Dev Tools console UI
- **Root Cause**: The `dataSourceId` parameter was not being passed to the settings update function
- **Fix**: Added `dataSourceId` parameter to `fetchAutocompleteSettingsIfNeeded` function call

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-console.md`
- Feature report: `docs/features/opensearch-dashboards/dashboards-console.md` (new)

### Related
- Closes #1742
- OpenSearch-Dashboards PR: #10595
- OpenSearch-Dashboards Issue: #10544