### PR TITLE
docs: add dashboards-data-connections report for v3.4.0

### DIFF
--- a/docs/features/opensearch-dashboards/data-connections.md
+++ b/docs/features/opensearch-dashboards/data-connections.md
@@ -14,6 +14,7 @@ graph TB
         UI[Data Connections UI]
         DSM[Data Source Management Plugin]
         API[Data Connections API]
+        SO[Saved Objects Service]
     end
     
     subgraph "Connection Types"
@@ -29,12 +30,15 @@ graph TB
     subgraph "OpenSearch Cluster"
         LOCAL[Local Cluster]
         REMOTE[Remote Clusters]
+        SAVED[Saved Objects Index]
     end
     
     UI --> DSM
     DSM --> API
     API --> OSC
     API --> DQC
+    API --> SO
+    SO --> SAVED
     OSC --> LOCAL
     OSC --> REMOTE
     DQC --> S3
@@ -118,6 +122,7 @@ data_source:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#10968](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10968) | Create saved object for prometheus data-connection |
 | v2.18.0 | [#8255](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8255) | Support data connections and multi-select table in dataset picker |
 | v2.18.0 | [#8460](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8460) | Replace segmented button with tabs |
 | v2.18.0 | [#8492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8492) | Add DataSource type display and Discover redirection |
@@ -132,11 +137,13 @@ data_source:
 
 - [Issue #8256](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8256): Redirection issue for direct query datasource
 - [Issue #8536](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8536): Deprecate non-MDS data connection endpoint
-- [Data Sources Documentation](https://docs.opensearch.org/2.18/dashboards/management/data-sources/): Official documentation
-- [Multi-Data Sources Documentation](https://docs.opensearch.org/2.18/dashboards/management/multi-data-sources/): Configuring multiple data sources
+- [RFC #9535](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9535): Prometheus as first-class datasource proposal
+- [Data Sources Documentation](https://docs.opensearch.org/3.0/dashboards/management/data-sources/): Official documentation
+- [Multi-Data Sources Documentation](https://docs.opensearch.org/3.0/dashboards/management/multi-data-sources/): Configuring multiple data sources
 
 ## Change History
 
+- **v3.4.0** (2025-03-11): Prometheus saved object support - Prometheus connections now stored as `data-connection` saved objects with MDS support, added "No Auth" authentication option
 - **v2.18.0** (2024-10-22): Dataset picker data connections support (multi-select table, pagination, search), UI improvements (tabs navigation, type display), MDS endpoint unification, auto-complete MDS support, fit and finish fixes
 - **v2.17.0** (2024-09-17): Added data-connection saved object type for external connections (CloudWatch, Security Lake)
 - **v2.16.0**: Initial migration of direct query data source to data source management plugin

--- a/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-data-connections.md
+++ b/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-data-connections.md
@@ -1,0 +1,149 @@
+# Dashboards Data Connections
+
+## Summary
+
+OpenSearch Dashboards v3.4.0 introduces saved object support for Prometheus data connections. Prometheus connections are now stored as `data-connection` saved objects, enabling better metadata persistence and integration with Multi-Data Source (MDS) environments. This change allows Prometheus to be managed alongside other data sources in the Dashboards Management interface.
+
+## Details
+
+### What's New in v3.4.0
+
+- Prometheus data connections are now stored as `data-connection` saved objects
+- Added "No Auth" authentication option for Prometheus connections
+- MDS (Multi-Data Source) support for associating Prometheus connections with specific OpenSearch clusters
+- Server-side routes automatically create/delete saved objects alongside backend data connections
+- Prometheus connections are filtered from direct query API responses (now retrieved from saved objects)
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        UI[Data Connections UI]
+        API[Data Connections API]
+        SO[Saved Objects Service]
+    end
+    
+    subgraph "Saved Objects"
+        DC[data-connection]
+        DS[data-source]
+    end
+    
+    subgraph "Backend"
+        SQL[SQL Plugin Backend]
+        PROM_BE[Prometheus Backend]
+    end
+    
+    UI --> API
+    API --> SO
+    SO --> DC
+    DC -.->|references| DS
+    API --> SQL
+    SQL --> PROM_BE
+```
+
+#### Saved Object Structure
+
+Prometheus connections are stored with the following saved object format:
+
+```json
+{
+  "data-connection": {
+    "connectionId": "my_prometheus",
+    "type": "Prometheus"
+  },
+  "references": [
+    {
+      "id": "<mds-datasource-id>",
+      "type": "data-source",
+      "name": "dataSource"
+    }
+  ]
+}
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `DataConnectionType.Prometheus` | New enum value for Prometheus connection type |
+| Prometheus Saved Object Handler | Server-side logic to create/delete saved objects |
+| MDS Prometheus Selector | Frontend component for MDS selection |
+
+#### Authentication Options
+
+| Option | Description |
+|--------|-------------|
+| No Auth | Connect without authentication (new in v3.4.0) |
+| Basic Auth | Username/password authentication |
+| AWS Signature Version 4 | AWS IAM-based authentication |
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Create Connection"
+        CREATE_UI[Create Prometheus Form]
+        CREATE_API[POST /api/directquery/dataconnections]
+        CREATE_BE[Create Backend Connection]
+        CREATE_SO[Create Saved Object]
+    end
+    
+    subgraph "List Connections"
+        LIST_UI[Data Connections List]
+        LIST_SO[Query Saved Objects]
+        FILTER[Filter Prometheus from API]
+    end
+    
+    CREATE_UI --> CREATE_API
+    CREATE_API --> CREATE_BE
+    CREATE_BE --> CREATE_SO
+    
+    LIST_UI --> LIST_SO
+    LIST_SO --> FILTER
+```
+
+### Usage Example
+
+Creating a Prometheus data connection:
+
+1. Navigate to **Management > Dashboards Management > Data sources**
+2. Select **Direct Query Connections** tab
+3. Click **Create data connection**
+4. Select **Prometheus** as the data source type
+5. Configure connection:
+   - **Connection name**: Unique identifier
+   - **Prometheus URI**: Endpoint URL
+   - **Authentication**: No Auth, Basic Auth, or AWS SigV4
+   - **Associated OpenSearch cluster** (MDS mode): Select target cluster
+
+### Migration Notes
+
+- Existing Prometheus connections created before v3.4.0 may need to be recreated to benefit from saved object storage
+- The saved object approach enables better integration with Dashboards features like access control and multi-tenancy
+
+## Limitations
+
+- Prometheus connections require the SQL plugin backend to be configured
+- MDS support for Prometheus may be simplified in future releases (see PR #11154)
+- Saved objects are stored in the local OpenSearch cluster, not in remote MDS clusters
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10968](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10968) | Create saved object for prometheus data-connection |
+| [#11154](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11154) | Remove MDS support for Prometheus (follow-up) |
+
+## References
+
+- [Issue #1741](https://github.com/tkykenmt/opensearch-feature-explorer/issues/1741): Feature tracking issue
+- [RFC #9535](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9535): Prometheus as first-class datasource proposal
+- [Data Sources Documentation](https://docs.opensearch.org/3.0/dashboards/management/data-sources/): Official documentation
+- [Multi-Data Sources Documentation](https://docs.opensearch.org/3.0/dashboards/management/multi-data-sources/): Configuring multiple data sources
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/data-connections.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -1,5 +1,11 @@
 # OpenSearch v3.4.0 Release
 
+## Features
+
+### OpenSearch Dashboards
+
+- [Dashboards Data Connections](features/opensearch-dashboards/dashboards-data-connections.md) - Prometheus saved object support for data connections
+
 ## Bug Fixes
 
 ### OpenSearch Dashboards


### PR DESCRIPTION
## Summary

Add release and feature reports for Dashboards Data Connections in v3.4.0.

## Changes

### Release Report
- `docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-data-connections.md`

### Feature Report Update
- `docs/features/opensearch-dashboards/data-connections.md` - Added v3.4.0 changes

## Key Changes in v3.4.0

- Prometheus data connections now stored as `data-connection` saved objects
- Added "No Auth" authentication option for Prometheus connections
- MDS (Multi-Data Source) support for associating Prometheus connections with specific OpenSearch clusters
- Server-side routes automatically create/delete saved objects alongside backend data connections

## Related

- Closes #1741
- PR: opensearch-project/OpenSearch-Dashboards#10968