### PR TITLE
docs: add dashboards-csp report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -185,6 +185,7 @@
 - [Chart & Visualization Fixes](opensearch-dashboards/chart-visualization-fixes.md)
 - [Code Quality & Testing](opensearch-dashboards/dashboards-code-quality-testing.md)
 - [Content Management](opensearch-dashboards/content-management.md)
+- [Content Security Policy (CSP)](opensearch-dashboards/dashboards-csp.md)
 - [Cross-Cluster Search](opensearch-dashboards/cross-cluster-search.md)
 - [Dashboards CI/CD & Documentation](opensearch-dashboards/dashboards-ci-cd-documentation.md)
 - [Dashboards Console](opensearch-dashboards/dashboards-console.md)

--- a/docs/features/opensearch-dashboards/dashboards-csp.md
+++ b/docs/features/opensearch-dashboards/dashboards-csp.md
@@ -1,0 +1,141 @@
+# Dashboards Content Security Policy (CSP)
+
+## Summary
+
+Content Security Policy (CSP) is a security standard in OpenSearch Dashboards that helps prevent cross-site scripting (XSS), clickjacking, and other code injection attacks. OpenSearch Dashboards supports both enforced CSP rules and a report-only mode for testing policies without blocking content. The CSP configuration can be managed both statically through YAML configuration and dynamically through the Application Config API.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "CSP Configuration"
+        YAML[opensearch_dashboards.yml] --> StaticCSP[Static CSP Config]
+        AppConfig[Application Config API] --> DynamicCSP[Dynamic CSP Config]
+    end
+    
+    subgraph "CSP Processing"
+        StaticCSP --> CSPService[CSP Service]
+        DynamicCSP --> CSPService
+        CSPService --> Headers[HTTP Headers]
+    end
+    
+    subgraph "HTTP Headers"
+        Headers --> CSPHeader[Content-Security-Policy]
+        Headers --> CSPROHeader[Content-Security-Policy-Report-Only]
+        Headers --> ReportingEndpoints[Reporting-Endpoints]
+    end
+    
+    subgraph "Plugins"
+        cspHandler[csp_handler Plugin] --> CSPService
+        appConfig[application_config Plugin] --> DynamicCSP
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    Request[HTTP Request] --> Handler[Route Handler]
+    Handler --> DynamicCheck{Dynamic Config?}
+    DynamicCheck -->|Yes| DynamicValue[Use Dynamic Value]
+    DynamicCheck -->|No| StaticValue[Use Static Value]
+    DynamicValue --> BuildHeaders[Build CSP Headers]
+    StaticValue --> BuildHeaders
+    BuildHeaders --> Response[HTTP Response]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `csp_handler` Plugin | Registers pre-response handler to manage CSP headers |
+| `application_config` Plugin | Provides read/write APIs for dynamic configuration |
+| `HttpResourcesService` | Applies CSP headers to rendered resources |
+| `CoreRouteHandlerContext` | Provides access to dynamic config from request handlers |
+
+### Configuration
+
+#### Static Configuration (opensearch_dashboards.yml)
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `csp.rules` | Array of CSP directives | Default secure policy |
+| `csp.strict` | Enable strict CSP mode | `true` |
+| `csp.warnLegacyBrowsers` | Warn users on legacy browsers | `true` |
+| `csp_handler.enabled` | Enable CSP handler plugin | `false` |
+| `application_config.enabled` | Enable application config plugin | `false` |
+
+#### Dynamic Configuration
+
+| Setting | Description | API Path |
+|---------|-------------|----------|
+| `frame-ancestors` | Controls which sites can embed Dashboards | `/api/appconfig/csp.rules.frame-ancestors` |
+| `csp-report-only.isEmitting` | Enable/disable CSP-Report-Only header | `/api/appconfig/csp-report-only` |
+
+### Usage Example
+
+#### Enable Dynamic CSP Configuration
+
+```yaml
+# opensearch_dashboards.yml
+application_config.enabled: true
+csp_handler.enabled: true
+```
+
+#### Manage frame-ancestors Dynamically
+
+```bash
+# Enable site embedding
+curl '{osd-endpoint}/api/appconfig/csp.rules.frame-ancestors' \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'osd-xsrf: osd-fetch' \
+  --data-raw '{"newValue":"https://example.com"}'
+
+# Get current frame-ancestors
+curl '{osd-endpoint}/api/appconfig/csp.rules.frame-ancestors'
+
+# Delete frame-ancestors (revert to default)
+curl '{osd-endpoint}/api/appconfig/csp.rules.frame-ancestors' \
+  -X DELETE \
+  -H 'osd-xsrf: osd-fetch'
+```
+
+#### Manage CSP Report-Only Mode
+
+```bash
+# Enable CSP report-only mode
+curl '{osd-endpoint}/api/appconfig/csp-report-only' \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'osd-xsrf: osd-fetch' \
+  --data-raw '{"newValue":{"isEmitting": true}}'
+```
+
+## Limitations
+
+- Dynamic configuration only supports `frame-ancestors` directive and `csp-report-only.isEmitting`
+- Other CSP directives must be configured statically in YAML
+- Requires Security plugin permissions to modify `.opensearch_dashboards_config` index
+- Dynamic configurations override YAML configurations (except for empty CSP rules)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.13.0 | - | Initial CSP dynamic configuration for frame-ancestors |
+| v3.4.0 | [#10877](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10877) | Add dynamic config support to CSP report only |
+
+## References
+
+- [CSP Dynamic Configuration Documentation](https://docs.opensearch.org/3.0/dashboards/csp/csp-dynamic-configuration/)
+- [applicationConfig Plugin README](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/application_config/README.md)
+- [cspHandler Plugin README](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/csp_handler/README.md)
+- [MDN: Content Security Policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP)
+
+## Change History
+
+- **v3.4.0** (2026-01): Added dynamic configuration support for CSP-Report-Only `isEmitting` setting
+- **v2.13.0**: Initial implementation of dynamic CSP configuration for `frame-ancestors` directive

--- a/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-csp.md
+++ b/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-csp.md
@@ -1,0 +1,104 @@
+# Dashboards CSP Dynamic Configuration
+
+## Summary
+
+This release adds dynamic configuration support for the Content-Security-Policy-Report-Only (CSP-RO) header in OpenSearch Dashboards. Administrators can now enable or disable CSP report-only mode at runtime without restarting the server, providing greater flexibility for security monitoring and policy testing.
+
+## Details
+
+### What's New in v3.4.0
+
+The `csp-report-only` configuration can now be dynamically toggled through the `applicationConfig` plugin. This allows administrators to:
+
+- Enable/disable CSP violation reporting without server restarts
+- Test CSP policies in report-only mode before enforcement
+- Dynamically respond to security monitoring needs
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Request Flow"
+        Request[HTTP Request] --> Router[Router Handler]
+        Router --> DynamicConfig[Dynamic Config Service]
+        DynamicConfig --> ConfigStore[Config Store]
+        ConfigStore --> CSPValue[CSP Report-Only Setting]
+        CSPValue --> ResponseHeaders[Response Headers]
+    end
+    
+    subgraph "Configuration Sources"
+        YAML[opensearch_dashboards.yml] --> StaticConfig[Static Config]
+        API[Application Config API] --> DynamicConfig
+    end
+    
+    StaticConfig --> Fallback[Fallback Value]
+    Fallback -.-> CSPValue
+```
+
+#### Modified Components
+
+| Component | Description |
+|-----------|-------------|
+| `HttpResourcesService` | Now fetches CSP-RO setting from dynamic config before falling back to static config |
+| `CoreRouteHandlerContext` | Added `createStoreFromRequest` method to create async local storage context from requests |
+| `ui_render_mixin.js` | Updated to use dynamic config for CSP-RO header emission |
+| `RequestHandlerContext` | Extended interface to include `createStoreFromRequest` function |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `csp-report-only.isEmitting` | Controls whether CSP-Report-Only header is emitted | Falls back to static `csp.report_only` setting |
+
+### Usage Example
+
+Enable CSP report-only mode dynamically via the Application Config API:
+
+```bash
+# Enable CSP report-only
+curl '{osd-endpoint}/api/appconfig/csp-report-only' \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'osd-xsrf: osd-fetch' \
+  --data-raw '{"newValue":{"isEmitting": true}}'
+
+# Disable CSP report-only
+curl '{osd-endpoint}/api/appconfig/csp-report-only' \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -H 'osd-xsrf: osd-fetch' \
+  --data-raw '{"newValue":{"isEmitting": false}}'
+
+# Get current setting
+curl '{osd-endpoint}/api/appconfig/csp-report-only'
+```
+
+### Migration Notes
+
+- No migration required - existing static configuration continues to work as fallback
+- Dynamic configuration takes precedence over YAML configuration when set
+- Requires `application_config.enabled: true` and `csp_handler.enabled: true` in `opensearch_dashboards.yml`
+
+## Limitations
+
+- Only the `isEmitting` property of CSP-Report-Only is dynamically configurable
+- The actual CSP directives and reporting endpoints remain statically configured
+- Requires appropriate permissions to access the `.opensearch_dashboards_config` index when Security plugin is enabled
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10877](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10877) | Add dynamic config support to CSP report only |
+
+## References
+
+- [CSP Dynamic Configuration Documentation](https://docs.opensearch.org/3.0/dashboards/csp/csp-dynamic-configuration/)
+- [applicationConfig Plugin](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/application_config/README.md)
+- [cspHandler Plugin](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/csp_handler/README.md)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/dashboards-csp.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -4,6 +4,7 @@
 
 ### OpenSearch Dashboards
 
+- [Dashboards CSP](features/opensearch-dashboards/dashboards-csp.md) - Dynamic configuration support for CSP report-only mode
 - [Dashboards Data Connections](features/opensearch-dashboards/dashboards-data-connections.md) - Prometheus saved object support for data connections
 
 ## Bug Fixes


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dashboards CSP (Content Security Policy) dynamic configuration feature in v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-csp.md`
- Feature report: `docs/features/opensearch-dashboards/dashboards-csp.md`

### Key Changes in v3.4.0
- Added dynamic configuration support for CSP-Report-Only `isEmitting` setting
- Administrators can now enable/disable CSP report-only mode at runtime without server restart
- Uses the `applicationConfig` plugin for dynamic configuration management

### Related PR
- [OpenSearch-Dashboards#10877](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10877): Add dynamic config support to CSP report only

Closes #1740