### PR TITLE
docs: add Dashboards Query Action Service report for v3.4.0

### DIFF
--- a/docs/features/opensearch-dashboards/explore.md
+++ b/docs/features/opensearch-dashboards/explore.md
@@ -27,6 +27,8 @@ Key benefits include:
 - Facet filtering for quick data narrowing with default observability fields (v3.3.0)
 - Explore experience modal for first-time user onboarding (v3.3.0)
 - Query panel actions registry for plugin extensibility (v3.3.0)
+- Flyout action support in query panel actions registry (v3.4.0)
+- `queryInEditor` dependency for accessing current editor content (v3.4.0)
 - Mouse hover states for line chart interactivity (v3.3.0)
 - Intelligent date format inference for axis labels (v3.3.0)
 - Auto-enable related UI settings when Explore is activated (v3.3.0)
@@ -203,6 +205,9 @@ flowchart TB
 | `FacetFilter` | UI component for facet-based filtering with default observability fields (v3.3.0) |
 | `ExploreExperienceModal` | Welcome modal for first-time users with saved object tracking (v3.3.0) |
 | `queryPanelActionsRegistry` | Registry service for external plugin actions (v3.3.0) |
+| `FlyoutActionConfig` | Configuration interface for flyout-type actions (v3.4.0) |
+| `FlyoutComponentProps` | Props interface passed to flyout React components (v3.4.0) |
+| `useQueryPanelActionDependencies` | Hook to gather all dependencies for query panel actions (v3.4.0) |
 | `buildTemporalAxisFormatting` | Utility for inferring date formats based on data granularity (v3.3.0) |
 | `TabContentErrorGuard` | Error boundary for tab-specific query failures (v3.3.0) |
 
@@ -275,6 +280,7 @@ source = opensearch_dashboards_sample_data_ecommerce
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#10849](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10849) | Enhance query action service to allow flyout registration |
 | v3.3.0 | [#10362](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10362) | Introduce facet filter |
 | v3.3.0 | [#10412](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10412) | Introduce tab content error guard |
 | v3.3.0 | [#10425](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10425) | Infer axis date format |
@@ -378,5 +384,6 @@ source = opensearch_dashboards_sample_data_ecommerce
 
 ## Change History
 
+- **v3.4.0** (2026-01-14): Enhanced Query Panel Actions Registry with flyout action support, enabling external plugins to render inline flyout panels from the actions dropdown. Added `queryInEditor` dependency for accessing current editor content (pre-transformed with source clause). Added comprehensive Explore plugin components architecture documentation.
 - **v3.3.0** (2026-01-14): Added facet filtering with default observability fields (serviceName, http status code, status.code), explore experience modal for first-time user onboarding with saved object tracking, query panel actions registry for plugin extensibility, mouse hover states for line chart interactivity, intelligent date format inference for axis labels based on data granularity, auto-enable related UI settings when Explore is activated (theme v9, new home page, query enhancements), tab content error guard for isolated error handling, query panel display without datasets, link to detail page in expanded row, Patterns tab flyout with detailed pattern inspection, "search with pattern" functionality for log filtering, events table with pagination, Calcite query engine compatibility, "Show Raw Data" toggle for non-table visualizations, improved Patterns tab error handling with custom error page, metric visualization with sparkline support, histogram visualization (numerical, time-series, categorical), table visualization enhancements (column alignment, Excel-like filters, statistical footers, cell customization), dark/light theme support with new color palettes, hover highlighting for bar/pie charts, Gantt chart improvements (service name display, span selection, error indicators), metric style updates with percentage change option. Bug fixes: ScopedHistory navigation error, Refresh button query execution, active tab preservation on save/load, removed Explore from Patterns tab
 - **v3.2.0** (2026-01-10): Initial implementation with query panel, auto-visualization, multi-flavor support, dashboard embeddable, patterns tab, chart type switcher, Trace Details page with Gantt chart and service map visualization, PPL filter support, improved fields selector with result/schema grouping, query editor performance optimizations, bidirectional URL-Redux synchronization, global header controls, and in-editor PPL documentation

--- a/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-query-action-service.md
+++ b/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-query-action-service.md
@@ -1,0 +1,175 @@
+# Dashboards Query Action Service
+
+## Summary
+
+This release enhances the Query Panel Actions Registry in the Explore plugin to support flyout registration, enabling external plugins to render inline flyout panels directly from the query panel actions dropdown. Additionally, it introduces `queryInEditor` to provide access to the current editor content (pre-transformed with source clause) and comprehensive documentation for the Explore plugin's component architecture.
+
+## Details
+
+### What's New in v3.4.0
+
+The Query Panel Actions Registry now supports two action types:
+- **Button actions**: Execute an onClick callback (existing behavior)
+- **Flyout actions**: Render a React component in an inline flyout panel (new)
+
+External plugins can now register flyout actions that open inline panels for complex workflows like creating monitors, alerts, or other integrations without navigating away from the Explore page.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Query Panel Actions"
+        Registry[QueryPanelActionsRegistry]
+        
+        subgraph "Action Types"
+            ButtonAction[Button Action]
+            FlyoutAction[Flyout Action]
+        end
+        
+        subgraph "Dependencies"
+            Query[query - Last Executed]
+            ResultStatus[resultStatus]
+            QueryInEditor[queryInEditor - Current Editor]
+        end
+        
+        subgraph "Flyout Rendering"
+            FlyoutComponent[React Component]
+            FlyoutProps[FlyoutComponentProps]
+        end
+    end
+    
+    Registry --> ButtonAction
+    Registry --> FlyoutAction
+    
+    ButtonAction --> |onClick| Dependencies
+    FlyoutAction --> |component| FlyoutComponent
+    FlyoutAction --> |onFlyoutOpen| Dependencies
+    
+    FlyoutComponent --> FlyoutProps
+    FlyoutProps --> |closeFlyout| Function
+    FlyoutProps --> |dependencies| Dependencies
+    FlyoutProps --> |services| ExploreServices
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `FlyoutActionConfig` | Configuration interface for flyout-type actions |
+| `FlyoutComponentProps` | Props interface passed to flyout React components |
+| `useQueryPanelActionDependencies` | Hook to gather all dependencies for query panel actions |
+| `explore-plugin-components.md` | Comprehensive architecture documentation |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `actionType` | Discriminator for action type (`'button'` or `'flyout'`) | Required |
+| `component` | React component to render in flyout (flyout actions only) | Required for flyout |
+| `onFlyoutOpen` | Optional callback when flyout opens | `undefined` |
+
+#### API Changes
+
+**QueryPanelActionDependencies** (enhanced):
+```typescript
+interface QueryPanelActionDependencies {
+  query: QueryWithQueryAsString;    // Last executed query (pre-transformed)
+  resultStatus: QueryResultStatus;  // Query execution status
+  queryInEditor: string;            // Current editor content (pre-transformed)
+}
+```
+
+**FlyoutActionConfig** (new):
+```typescript
+interface FlyoutActionConfig {
+  id: string;
+  actionType: 'flyout';
+  order: number;
+  getIsEnabled?(deps: QueryPanelActionDependencies): boolean;
+  getLabel(deps: QueryPanelActionDependencies): string;
+  getIcon?(deps: QueryPanelActionDependencies): IconType;
+  component: React.ComponentType<FlyoutComponentProps>;
+  onFlyoutOpen?(deps: QueryPanelActionDependencies): void;
+}
+```
+
+**FlyoutComponentProps** (new):
+```typescript
+interface FlyoutComponentProps {
+  closeFlyout: () => void;
+  dependencies: QueryPanelActionDependencies;
+  services: ExploreServices;
+}
+```
+
+### Usage Example
+
+```tsx
+// Register a flyout action in your plugin
+export class MyPlugin {
+  public setup(core: CoreSetup, { explore }: MyPluginSetupDependencies) {
+    explore.queryPanelActionsRegistry.register({
+      id: 'create-monitor-flyout',
+      actionType: 'flyout',
+      order: 2,
+      getIsEnabled: (deps) => deps.resultStatus.status === QueryExecutionStatus.READY,
+      getLabel: () => 'Create Monitor',
+      getIcon: () => 'bell',
+      component: CreateMonitorFlyout,
+      onFlyoutOpen: (deps) => {
+        console.log('Opening flyout with query:', deps.queryInEditor);
+      }
+    });
+  }
+}
+
+// Flyout component
+const CreateMonitorFlyout: React.FC<FlyoutComponentProps> = ({
+  closeFlyout,
+  dependencies,
+  services,
+}) => {
+  return (
+    <EuiFlyout onClose={closeFlyout} size="m">
+      <EuiFlyoutHeader hasBorder>
+        <EuiTitle size="m"><h2>Create Monitor</h2></EuiTitle>
+      </EuiFlyoutHeader>
+      <EuiFlyoutBody>
+        <p>Query: {dependencies.queryInEditor}</p>
+        <p>Language: {dependencies.query.language}</p>
+      </EuiFlyoutBody>
+    </EuiFlyout>
+  );
+};
+```
+
+### Migration Notes
+
+- Existing button actions continue to work without changes (backward compatible)
+- Legacy actions without `actionType` are automatically converted to button actions
+- The `queryInEditor` field is now available in dependencies for all action types
+- Both `query.query` and `queryInEditor` are pre-transformed with the `source = <dataset>` clause
+
+## Limitations
+
+- Flyout components must render the complete `EuiFlyout` structure
+- Only one flyout can be open at a time
+- Dependencies are not memoized to ensure fresh editor content is always passed
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10849](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10849) | Enhance query action service to allow flyout registration |
+
+## References
+
+- [PR #10849](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10849): Main implementation
+- [Query Panel Actions Documentation](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/docs/plugins/explore/query-panel-actions.md): Official API documentation
+- [Explore Plugin Components Architecture](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/docs/plugins/explore/explore-plugin-components.md): Comprehensive architecture guide
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/explore.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -6,6 +6,7 @@
 
 - [Dashboards CSP](features/opensearch-dashboards/dashboards-csp.md) - Dynamic configuration support for CSP report-only mode
 - [Dashboards Data Connections](features/opensearch-dashboards/dashboards-data-connections.md) - Prometheus saved object support for data connections
+- [Dashboards Query Action Service](features/opensearch-dashboards/dashboards-query-action-service.md) - Flyout registration support for query panel actions
 
 ## Bug Fixes
 


### PR DESCRIPTION
## Summary

Add documentation for the Dashboards Query Action Service enhancement in v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-query-action-service.md`
- Feature report: Updated `docs/features/opensearch-dashboards/explore.md`

### Key Changes in v3.4.0
- Enhanced Query Panel Actions Registry with flyout action support
- External plugins can now register flyout actions that render inline panels
- Added `queryInEditor` dependency for accessing current editor content (pre-transformed)
- Added comprehensive Explore plugin components architecture documentation

### Source PR
- [opensearch-project/OpenSearch-Dashboards#10849](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10849)

Closes #1739