### PR TITLE
docs: add Dashboards Workspace report for v3.4.0

### DIFF
--- a/docs/features/opensearch-dashboards/workspace.md
+++ b/docs/features/opensearch-dashboards/workspace.md
@@ -167,6 +167,7 @@ opensearch_security.multitenancy.enabled: false
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#10861](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10861) | Remove restriction that workspace cannot be created without datasource |
 | v3.3.0 | [#9781](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9781) | Add batch delete method for workspaces, fix deletion error |
 | v3.0.0 | [#9420](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9420) | Fix saved objects find returning all workspaces |
 | v3.0.0 | [#9346](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9346) | Filter out recent items with errors |
@@ -207,6 +208,7 @@ opensearch_security.multitenancy.enabled: false
 
 ## Change History
 
+- **v3.4.0** (2026-02-18): Removed restriction requiring data source selection during workspace creation; workspaces can now be created without associated data sources
 - **v3.3.0** (2026-01-14): Added batch delete method for workspaces with improved error handling and detailed success/failure notifications
 - **v3.0.0** (2025-05-06): Bug fixes for saved object isolation, recent items error filtering, and stale workspace error handling
 - **v2.18.0** (2024-11-05): Major feature additions including workspace-level UI settings, collaborator management system (WorkspaceCollaboratorTypesService, AddCollaboratorsModal, Collaborators Page), data connection integration, global search bar in left nav, ACL auditor for permission bypass detection; 14 bug fixes for UI/UX improvements

--- a/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-workspace.md
+++ b/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-workspace.md
@@ -1,0 +1,77 @@
+# Dashboards Workspace
+
+## Summary
+
+This release removes the restriction that required at least one data source to be selected when creating a workspace. Users can now create workspaces without associating any data sources, providing more flexibility for workspace setup and configuration.
+
+## Details
+
+### What's New in v3.4.0
+
+The workspace creation flow has been simplified by removing the mandatory data source requirement. Previously, users were blocked from creating a workspace if no data sources were selected when the data source feature was enabled. This restriction has been removed.
+
+### Technical Changes
+
+#### Component Changes
+
+The `WorkspaceCreateActionPanel` component was modified to remove the data source validation logic:
+
+| Component | Change |
+|-----------|--------|
+| `WorkspaceCreateActionPanel` | Removed `dataSourceEnabled` prop and associated validation |
+| `WorkspaceFormSummaryPanel` | Removed `dataSourceEnabled` prop propagation |
+
+#### Before (v3.3.0 and earlier)
+
+```typescript
+// Create button was disabled when data source enabled but none selected
+const createButtonDisabled =
+  (formData.name?.length ?? 0) > MAX_WORKSPACE_NAME_LENGTH ||
+  (formData.description?.length ?? 0) > MAX_WORKSPACE_DESCRIPTION_LENGTH ||
+  (dataSourceEnabled && formData.selectedDataSourceConnections.length === 0);
+```
+
+#### After (v3.4.0)
+
+```typescript
+// Create button only validates name and description length
+const createButtonDisabled =
+  (formData.name?.length ?? 0) > MAX_WORKSPACE_NAME_LENGTH ||
+  (formData.description?.length ?? 0) > MAX_WORKSPACE_DESCRIPTION_LENGTH;
+```
+
+### Usage Example
+
+Users can now create a workspace without selecting any data sources:
+
+1. Navigate to workspace creation page
+2. Enter workspace name and description
+3. Select use case
+4. Skip data source selection (optional)
+5. Click "Create workspace"
+
+The workspace will be created successfully even without any associated data sources. Data sources can be added later through the workspace settings.
+
+### Migration Notes
+
+No migration required. Existing workspaces are unaffected. This change only affects the workspace creation flow.
+
+## Limitations
+
+- Workspaces created without data sources will have limited functionality until data sources are associated
+- Some use cases may still require data sources for full functionality
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10861](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10861) | Remove the restriction that workspace cannot be created without datasource |
+
+## References
+
+- [Workspace Documentation](https://docs.opensearch.org/3.0/dashboards/workspace/workspace/): Official workspace feature documentation
+- [Create a Workspace](https://docs.opensearch.org/3.0/dashboards/workspace/create-workspace/): How to create workspaces
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/workspace.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -7,6 +7,7 @@
 - [Dashboards CSP](features/opensearch-dashboards/dashboards-csp.md) - Dynamic configuration support for CSP report-only mode
 - [Dashboards Data Connections](features/opensearch-dashboards/dashboards-data-connections.md) - Prometheus saved object support for data connections
 - [Dashboards Query Action Service](features/opensearch-dashboards/dashboards-query-action-service.md) - Flyout registration support for query panel actions
+- [Dashboards Workspace](features/opensearch-dashboards/dashboards-workspace.md) - Remove restriction requiring data source for workspace creation
 
 ## Bug Fixes
 


### PR DESCRIPTION
## Summary

Add release and feature reports for Dashboards Workspace v3.4.0.

### Changes in v3.4.0

This release removes the restriction that required at least one data source to be selected when creating a workspace. Users can now create workspaces without associating any data sources.

### Reports Created

- Release report: `docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-workspace.md`
- Feature report: `docs/features/opensearch-dashboards/workspace.md` (updated)

### Related PR

- [opensearch-project/OpenSearch-Dashboards#10861](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10861): Remove the restriction that workspace cannot be created without datasource