### PR TITLE
docs: add dashboards-global-search report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -208,6 +208,7 @@
 - [Experimental Features](opensearch-dashboards/experimental-features.md)
 - [Explore Plugin](opensearch-dashboards/explore.md)
 - [Explore Traces](opensearch-dashboards/explore-traces.md)
+- [Global Search](opensearch-dashboards/global-search.md)
 - [i18n & Localization](opensearch-dashboards/i18n-localization.md)
 - [Input Control Visualization](opensearch-dashboards/input-control-visualization.md)
 - [Keyboard Shortcuts](opensearch-dashboards/keyboard-shortcuts.md)

--- a/docs/features/opensearch-dashboards/global-search.md
+++ b/docs/features/opensearch-dashboards/global-search.md
@@ -1,0 +1,215 @@
+# Global Search
+
+## Summary
+
+Global Search is a unified search experience in OpenSearch Dashboards that allows users to quickly find and navigate to pages, saved objects (dashboards, visualizations), and execute custom actions directly from a centralized search bar. The feature supports prefix-based filtering, workspace-aware asset search, and extensible command registration for plugin integration.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "User Interface"
+        SearchBar[Global Search Bar]
+        Results[Results Dropdown]
+        Hint[Action Hint]
+    end
+    
+    subgraph "GlobalSearchService"
+        Setup[Setup Contract]
+        Start[Start Contract]
+        Commands$[BehaviorSubject<br/>searchCommands$]
+    end
+    
+    subgraph "Search Commands"
+        Pages[PAGES<br/>Page Navigation]
+        SavedObjects[SAVED_OBJECTS<br/>Assets Search @]
+        Actions[ACTIONS<br/>Enter-key Actions]
+    end
+    
+    subgraph "Data Sources"
+        NavLinks[Navigation Links]
+        SavedObjectsAPI[Saved Objects API]
+        Plugins[Plugin Actions]
+    end
+    
+    SearchBar -->|"Query"| Commands$
+    Commands$ --> Pages
+    Commands$ --> SavedObjects
+    Commands$ --> Actions
+    
+    Pages --> NavLinks
+    SavedObjects --> SavedObjectsAPI
+    Actions --> Plugins
+    
+    Pages --> Results
+    SavedObjects --> Results
+    Actions -->|"Enter"| Plugins
+    Actions --> Hint
+    
+    Setup -->|"registerSearchCommand"| Commands$
+    Start -->|"getAllSearchCommands$"| Commands$
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User Types Query] --> B{Check Prefix}
+    B -->|"@ prefix"| C[Assets Search Only]
+    B -->|"No prefix"| D[Pages Search + Actions]
+    
+    C --> E[Query Saved Objects API]
+    D --> F[Query Navigation Links]
+    D --> G[Prepare Action Commands]
+    
+    E --> H[Filter by Workspace]
+    F --> I[Match Page Titles]
+    
+    H --> J[Format Results]
+    I --> J
+    G --> K[Show Action Hint]
+    
+    J --> L[Display in Dropdown]
+    K --> L
+    
+    L --> M{User Action}
+    M -->|"Click Result"| N[Navigate to Item]
+    M -->|"Press Enter"| O[Execute Actions]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `GlobalSearchService` | Core service managing search command registration and execution |
+| `HeaderSearchBar` | UI component rendering the search input and results dropdown |
+| `searchAssets` | Function to search dashboards and visualizations via saved objects API |
+| `workspaceSearchPages` | Function to search navigation pages within workspace context |
+
+### Search Command Types
+
+| Type | Symbol | Description |
+|------|--------|-------------|
+| `PAGES` | (none) | Search navigation pages and menu items |
+| `SAVED_OBJECTS` | `@` | Search saved objects (dashboards, visualizations) |
+| `ACTIONS` | (none) | Execute custom actions on Enter key |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `inputPlaceholder` | Custom placeholder text for search input | `"Search menu or assets"` |
+| `action` | Callback function executed on Enter key press | `undefined` |
+
+### Public API
+
+**Setup Contract**:
+
+```typescript
+export interface GlobalSearchServiceSetupContract {
+  registerSearchCommand(searchCommand: GlobalSearchCommand): void;
+}
+```
+
+**Start Contract**:
+
+```typescript
+export interface GlobalSearchServiceStartContract {
+  getAllSearchCommands(): GlobalSearchCommand[];
+  getAllSearchCommands$(): Observable<GlobalSearchCommand[]>;
+  registerSearchCommand(searchCommand: GlobalSearchCommand): void;
+  unregisterSearchCommand(id: string): void;
+}
+```
+
+**GlobalSearchCommand Interface**:
+
+```typescript
+export interface GlobalSearchCommand {
+  id: string;
+  type: 'PAGES' | 'SAVED_OBJECTS' | 'ACTIONS';
+  inputPlaceholder?: string;
+  run(
+    value: string,
+    callback?: () => void,
+    options?: GlobalSearchCommandRunOptions
+  ): Promise<ReactNode[]>;
+  action?: (payload: { content: string }) => void;
+}
+
+export interface GlobalSearchCommandRunOptions {
+  abortSignal?: AbortSignal;
+}
+```
+
+### Usage Example
+
+**Registering a Custom Search Command**:
+
+```typescript
+// In plugin setup
+public setup(core: CoreSetup) {
+  core.chrome.globalSearch.registerSearchCommand({
+    id: 'myPluginSearch',
+    type: 'PAGES',
+    inputPlaceholder: 'Search my plugin...',
+    run: async (query, callback, options) => {
+      const results = await searchMyPlugin(query, options?.abortSignal);
+      return results.map(item => (
+        <EuiLink href={item.url} onClick={callback}>
+          {item.title}
+        </EuiLink>
+      ));
+    }
+  });
+}
+```
+
+**Registering an Action Command**:
+
+```typescript
+core.chrome.globalSearch.registerSearchCommand({
+  id: 'aiChatbot',
+  type: 'ACTIONS',
+  run: async () => [],
+  action: ({ content }) => {
+    openChatbot({ initialQuery: content });
+  }
+});
+```
+
+**Subscribing to Command Changes**:
+
+```typescript
+chrome.globalSearch.getAllSearchCommands$().subscribe(commands => {
+  console.log(`Available commands: ${commands.length}`);
+});
+```
+
+## Limitations
+
+- Assets search currently supports only `dashboard` and `visualization` types
+- Action commands receive only the search query text, not page context (filters, time range, etc.)
+- The `@` prefix is required to search assets; default search only queries pages
+- When multiple commands specify `inputPlaceholder`, only the first registered command's placeholder is used
+- Search results are limited to 10 items per command type
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#10789](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10789) | Add assets search command and enhance search commands |
+| v3.3.0 | [#10414](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10414) | Global search URL in workspace |
+| v2.18.0 | [#8538](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8538) | Add global search bar into left nav |
+
+## References
+
+- [Issue #10741](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10741): RFC - Global Search Enhancements for New Home
+
+## Change History
+
+- **v3.4.0** (2025-10-29): Added assets search command (`@` prefix) for searching dashboards and visualizations; enhanced GlobalSearchCommand interface with `action` property for Enter-key triggered actions; migrated to observable-based architecture with `getAllSearchCommands$`; added request cancellation support via `abortSignal`
+- **v3.3.0**: Fixed global search URL handling in workspace context
+- **v2.18.0** (2024-11-05): Initial implementation - added global search bar into left navigation for searching pages across workspaces

--- a/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-global-search.md
+++ b/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-global-search.md
@@ -1,0 +1,172 @@
+# Dashboards Global Search
+
+## Summary
+
+OpenSearch Dashboards v3.4.0 enhances the global search functionality with two key capabilities: **Assets Search** for finding dashboards and visualizations directly from the search bar using the `@` prefix, and **Submit Commands** that execute custom actions when users press Enter. These enhancements improve navigation efficiency and enable extensible interactions like AI chatbot integration.
+
+## Details
+
+### What's New in v3.4.0
+
+This release introduces significant enhancements to the global search bar:
+
+1. **Assets Search Command**: Search for saved objects (dashboards, visualizations) using the `@` prefix
+2. **Enhanced Command Interface**: Extended `GlobalSearchCommand` with `action` property for Enter-key triggered actions
+3. **Observable-based Architecture**: Commands now use RxJS observables for reactive updates
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Global Search Bar"
+        Input[Search Input]
+        Results[Results Dropdown]
+    end
+    
+    subgraph "Search Commands"
+        Pages[Pages Search]
+        Assets[Assets Search @]
+        Actions[Action Commands]
+    end
+    
+    subgraph "Command System"
+        GSS[GlobalSearchService]
+        BehaviorSubject[BehaviorSubject<br/>searchCommands$]
+    end
+    
+    Input -->|"Type query"| GSS
+    GSS --> Pages
+    GSS -->|"@ prefix"| Assets
+    GSS --> Actions
+    Pages --> Results
+    Assets --> Results
+    Actions -->|"Enter key"| Execute[Execute Action]
+    
+    GSS --> BehaviorSubject
+    BehaviorSubject -->|"Observable"| Results
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `searchAssets` | Function to search dashboards and visualizations via saved objects API |
+| `GlobalSearchCommandRunOptions` | Interface with `abortSignal` for cancellable search operations |
+| `ACTIONS` command type | New search command type for Enter-key triggered actions |
+| `AssetType` enum | Defines supported asset types (`Dashboard`, `Visualization`) |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `inputPlaceholder` | Custom placeholder text for search input | `"Search menu or assets"` |
+| `action` | Callback function executed on Enter key press | `undefined` |
+
+#### API Changes
+
+**Extended GlobalSearchCommand Interface**:
+
+```typescript
+export interface GlobalSearchCommand {
+  id: string;
+  type: 'PAGES' | 'SAVED_OBJECTS' | 'ACTIONS';
+  inputPlaceholder?: string;
+  run(
+    value: string,
+    callback?: () => void,
+    options?: GlobalSearchCommandRunOptions
+  ): Promise<ReactNode[]>;
+  action?: (payload: { content: string }) => void;
+}
+```
+
+**New Observable API**:
+
+```typescript
+// Start contract now includes observable
+getAllSearchCommands$: () => Observable<GlobalSearchCommand[]>;
+registerSearchCommand(searchCommand: GlobalSearchCommand): void;
+```
+
+### Usage Example
+
+**Registering an Assets Search Command**:
+
+```typescript
+chrome.globalSearch.registerSearchCommand({
+  id: 'assetsSearch',
+  type: 'SAVED_OBJECTS',
+  run: async (query, callback, options) => {
+    const response = await http.get(
+      '/api/opensearch-dashboards/management/saved_objects/_find',
+      {
+        query: {
+          type: ['dashboard', 'visualization'],
+          search: `*${query}*`,
+          perPage: 10,
+          workspaces: currentWorkspaceId ? [currentWorkspaceId] : [],
+        },
+        signal: options?.abortSignal,
+      }
+    );
+    // Return React elements for display
+    return response.saved_objects.map(asset => (
+      <EuiSimplifiedBreadcrumbs
+        breadcrumbs={[
+          { text: asset.type },
+          { text: asset.meta.title, href: assetUrl, onClick: callback }
+        ]}
+      />
+    ));
+  }
+});
+```
+
+**Registering an Action Command (e.g., AI Chatbot)**:
+
+```typescript
+chrome.globalSearch.registerSearchCommand({
+  id: 'openChatbot',
+  type: 'ACTIONS',
+  run: async () => [],
+  action: ({ content }) => {
+    chatbot.open({ initialMessage: content });
+  }
+});
+```
+
+### Search Behavior
+
+| Search Pattern | Behavior |
+|----------------|----------|
+| `dashboard` | Searches pages only |
+| `@sales` | Searches assets (dashboards, visualizations) containing "sales" |
+| Press Enter | Executes all registered action commands with search query |
+
+### Migration Notes
+
+- The `globalSearchCommands` prop is now `globalSearchCommands$` (Observable)
+- Search command `run` method now accepts an optional `options` parameter with `abortSignal`
+- Previous search requests are automatically cancelled when new searches are triggered
+
+## Limitations
+
+- Assets search currently supports only `dashboard` and `visualization` types
+- Action commands receive only the search query text, not page context
+- The `@` prefix is required to search assets; default search only queries pages
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10789](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10789) | Add assets search command and enhance search commands |
+
+## References
+
+- [Issue #10741](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10741): RFC - Global Search Enhancements for New Home
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/global-search.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -4,6 +4,7 @@
 
 ### OpenSearch Dashboards
 
+- [Dashboards Global Search](features/opensearch-dashboards/dashboards-global-search.md) - Assets search and enhanced command system for global search
 - [Dashboards CSP](features/opensearch-dashboards/dashboards-csp.md) - Dynamic configuration support for CSP report-only mode
 - [Dashboards Data Connections](features/opensearch-dashboards/dashboards-data-connections.md) - Prometheus saved object support for data connections
 - [Dashboards Query Action Service](features/opensearch-dashboards/dashboards-query-action-service.md) - Flyout registration support for query panel actions


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dashboards Global Search enhancements in v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-global-search.md`
- Feature report: `docs/features/opensearch-dashboards/global-search.md` (new)

### Key Changes in v3.4.0
- Added assets search command (`@` prefix) for searching dashboards and visualizations
- Enhanced GlobalSearchCommand interface with `action` property for Enter-key triggered actions
- Migrated to observable-based architecture with `getAllSearchCommands$`
- Added request cancellation support via `abortSignal`

### Resources Used
- PR: [#10789](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10789)
- Issue: [#10741](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10741) (RFC)