### PR TITLE
docs: add dashboards-traces report for v3.4.0

### DIFF
--- a/docs/features/opensearch-dashboards/explore-traces.md
+++ b/docs/features/opensearch-dashboards/explore-traces.md
@@ -101,6 +101,8 @@ flowchart TB
 | Span Flyout | Detailed span information panel |
 | Correlation Saved Object | Stores trace-to-log correlation configuration |
 | Tab Registry | Flavor-based tab registration system |
+| Span Status Filter | Popover-based filter for span status (Error, OK, Unset) |
+| Trace ID Badge | Clickable badge displaying trace ID with copy functionality |
 
 ### Configuration
 
@@ -181,6 +183,27 @@ POST .kibana/_doc/correlations:trace-logs-1
 4. Query traces from external cluster
 ```
 
+#### Filtering Spans by Status
+
+```
+1. Navigate to Trace Details page
+2. Click "Filter by status" button in the span hierarchy table toolbar
+3. Select one or more status options:
+   - Error: Shows spans with error status
+   - OK: Shows spans with successful status
+   - Unset: Shows spans with unset/unknown status
+4. Selected filters appear as badges and persist across navigation
+```
+
+#### Copying Trace ID
+
+```
+1. Open Trace Details page
+2. Locate the "Trace ID: {id}" badge in the header
+3. Click the badge to copy the trace ID to clipboard
+4. A tooltip confirms the copy action
+```
+
 ## Limitations
 
 - Service map tab is currently disabled
@@ -188,11 +211,17 @@ POST .kibana/_doc/correlations:trace-logs-1
 - Start time rounding may occur with imprecise data
 - Maximum spans displayed limited by browser performance
 - Log correlation requires manual saved object configuration
+- Span status filter state is stored in session storage and resets on browser close
+- Root span detection falls back to earliest span if no span without parent is found
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#10745](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10745) | Add span status filters to trace details |
+| v3.4.0 | [#10630](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10630) | Fix trace details page header to always show root span |
+| v3.4.0 | [#10651](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10651) | Traces code block scrollbar to scroll on edge |
+| v3.4.0 | [#10698](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10698) | Remove service.name column from traces table |
 | v3.3.0 | [#10386](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10386) | Add Correlations Saved Object Type Registration |
 | v3.3.0 | [#10392](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10392) | Add traces chart (request count, error count, latency) |
 | v3.3.0 | [#10393](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10393) | Trace Details: Log correlation (tabs + redirect) |
@@ -210,4 +239,5 @@ POST .kibana/_doc/correlations:trace-logs-1
 
 ## Change History
 
+- **v3.4.0** (2026-03-18): Added span status filters (Error, OK, Unset), improved page header to show root span service/operation, copyable trace ID badge, scrollbar fixes, removed duplicate service.name column
 - **v3.3.0** (2026-03-18): Initial implementation with trace charts, log correlation, timeline waterfall visualization, external datasource support, configurable default columns, and OTEL schema support

--- a/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-traces.md
+++ b/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-traces.md
@@ -1,0 +1,117 @@
+# Dashboards Traces
+
+## Summary
+
+This release introduces span status filters and multiple UX improvements to the Trace Details page in OpenSearch Dashboards. Users can now filter spans by status (Error, OK, Unset), the page header always displays the root span's service name and operation, and the trace ID is shown as a copyable badge. Additional bug fixes improve scrollbar behavior and remove duplicate columns.
+
+## Details
+
+### What's New in v3.4.0
+
+The Trace Details page receives significant usability enhancements:
+
+1. **Span Status Filters**: New filter component allowing users to filter spans by status (Error, OK, Unset)
+2. **Improved Page Header**: Header now always shows root span information (service name: operation) instead of trace ID
+3. **Copyable Trace ID Badge**: Trace ID displayed as a clickable badge that copies to clipboard
+4. **UI Polish**: Removed duplicate service.name column, fixed scrollbar positioning in code blocks
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Trace Details Page"
+        HEADER[Top Nav Header]
+        TABS[Trace Detail Tabs]
+        PANEL[Span Detail Panel]
+    end
+    
+    subgraph "New Components"
+        BADGE[Trace ID Badge]
+        FILTER[Span Status Filter]
+    end
+    
+    subgraph "Data Layer"
+        SPANS[Span Data]
+        ROOT[Root Span Detection]
+    end
+    
+    HEADER --> BADGE
+    PANEL --> FILTER
+    SPANS --> ROOT
+    ROOT --> HEADER
+    FILTER --> SPANS
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `SpanStatusFilter` | Popover-based filter for span status (Error, OK, Unset) |
+| `TraceIdBadge` | Clickable badge displaying trace ID with copy functionality |
+| `getServiceInfo()` | Helper function to extract service name and operation from root span |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Span Status Filter | Filter spans by status code | All statuses shown |
+
+#### API Changes
+
+New utility functions added:
+
+- `isSpanOk(span)`: Determines if a span has OK status (not error)
+- `isStatusMatch(span, field, value)`: Matches span against status filter criteria
+- `getServiceInfo(selectedSpan, traceId)`: Returns formatted service info string
+
+### Usage Example
+
+#### Filtering Spans by Status
+
+```
+1. Navigate to Trace Details page
+2. Click "Filter by status" button in the span hierarchy table toolbar
+3. Select one or more status options:
+   - Error: Shows spans with error status
+   - OK: Shows spans with successful status
+   - Unset: Shows spans with unset/unknown status
+4. Selected filters appear as badges and persist across navigation
+```
+
+#### Copying Trace ID
+
+```
+1. Open Trace Details page
+2. Locate the "Trace ID: {id}" badge in the header
+3. Click the badge to copy the trace ID to clipboard
+4. A tooltip confirms the copy action
+```
+
+### Migration Notes
+
+No migration required. Changes are backward compatible.
+
+## Limitations
+
+- Span status filter state is stored in session storage and resets on browser close
+- Root span detection falls back to earliest span if no span without parent is found
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10745](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10745) | Add span status filters to trace details. Combine bug fixes. |
+| [#10630](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10630) | Fix trace details page header to always show root span |
+| [#10651](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10651) | Traces code block scrollbar to scroll on edge |
+| [#10698](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10698) | Remove service.name column from traces table |
+
+## References
+
+- [Trace Analytics Documentation](https://docs.opensearch.org/3.0/observing-your-data/trace/ta-dashboards/): Official trace analytics guide
+- [OpenTelemetry Trace Specification](https://opentelemetry.io/docs/concepts/signals/traces/): OTEL trace concepts
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/explore-traces.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -9,6 +9,7 @@
 - [Dashboards Data Connections](features/opensearch-dashboards/dashboards-data-connections.md) - Prometheus saved object support for data connections
 - [Dashboards Query Action Service](features/opensearch-dashboards/dashboards-query-action-service.md) - Flyout registration support for query panel actions
 - [Dashboards Workspace](features/opensearch-dashboards/dashboards-workspace.md) - Remove restriction requiring data source for workspace creation
+- [Dashboards Traces](features/opensearch-dashboards/dashboards-traces.md) - Span status filters and trace details UX improvements
 
 ## Bug Fixes
 


### PR DESCRIPTION
## Summary

Add documentation for Dashboards Traces feature improvements in v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-traces.md`
- Feature report: `docs/features/opensearch-dashboards/explore-traces.md` (updated)

### Key Changes in v3.4.0
- Added span status filters (Error, OK, Unset) to trace details
- Improved page header to always show root span service/operation
- Added copyable trace ID badge
- Fixed scrollbar positioning in code blocks
- Removed duplicate service.name column

### Related PRs
- opensearch-project/OpenSearch-Dashboards#10745
- opensearch-project/OpenSearch-Dashboards#10630
- opensearch-project/OpenSearch-Dashboards#10651
- opensearch-project/OpenSearch-Dashboards#10698

Closes #1734