### PR TITLE
docs: add dashboards-logs-view report for v3.4.0

### DIFF
--- a/docs/features/opensearch-dashboards/explore-traces.md
+++ b/docs/features/opensearch-dashboards/explore-traces.md
@@ -97,7 +97,8 @@ flowchart TB
 | Tree View | Hierarchical span table with parent-child relationships |
 | Timeline Waterfall | Inline waterfall bars showing span timing relative to trace |
 | Timeline Ruler | Ruler with millisecond measurements for visual comparison |
-| Logs Tab | Correlated logs view with redirect to Discover |
+| Logs Tab | Correlated logs view with accordion-based dataset grouping and expandable rows |
+| DatasetLogsTable | Table component with expandable rows and code block message display |
 | Span Flyout | Detailed span information panel |
 | Correlation Saved Object | Stores trace-to-log correlation configuration |
 | Tab Registry | Flavor-based tab registration system |
@@ -109,6 +110,7 @@ flowchart TB
 | Setting | Description | Default |
 |---------|-------------|---------|
 | `explore:defaultTraceColumns` | Default columns for Explore traces tab | Experimental |
+| `LOGS_DATA` | Maximum number of logs displayed per dataset in Logs tab | 10 |
 | Correlation Type | `APM-Correlation` for trace-log relationships | N/A |
 | Log Service Name Field | Field mapping for service name in logs | `service.name` |
 | Log Span ID Field | Field mapping for span ID in logs | `span_id` |
@@ -218,6 +220,8 @@ POST .kibana/_doc/correlations:trace-logs-1
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#10703](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10703) | Redesigned logs tab with accordion and expandable rows |
+| v3.4.0 | [#10716](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10716) | Added support for multiple log datasets with accordion display |
 | v3.4.0 | [#10745](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10745) | Add span status filters to trace details |
 | v3.4.0 | [#10630](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10630) | Fix trace details page header to always show root span |
 | v3.4.0 | [#10651](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10651) | Traces code block scrollbar to scroll on edge |
@@ -239,5 +243,5 @@ POST .kibana/_doc/correlations:trace-logs-1
 
 ## Change History
 
-- **v3.4.0** (2026-03-18): Added span status filters (Error, OK, Unset), improved page header to show root span service/operation, copyable trace ID badge, scrollbar fixes, removed duplicate service.name column
+- **v3.4.0** (2026-03-18): Redesigned Logs tab with expandable rows and code block message display, accordion-based dataset grouping, support for multiple log datasets, added span status filters (Error, OK, Unset), improved page header to show root span service/operation, copyable trace ID badge, scrollbar fixes, removed duplicate service.name column
 - **v3.3.0** (2026-03-18): Initial implementation with trace charts, log correlation, timeline waterfall visualization, external datasource support, configurable default columns, and OTEL schema support

--- a/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-logs-view.md
+++ b/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-logs-view.md
@@ -1,0 +1,108 @@
+# Dashboards Logs View
+
+## Summary
+
+This release enhances the Logs tab in Trace Details with a redesigned UI featuring expandable log rows, accordion-based dataset grouping, and support for multiple log datasets. Users can now view logs from multiple correlated datasets simultaneously, with each dataset displayed in a collapsible accordion showing the 10 most recent results.
+
+## Details
+
+### What's New in v3.4.0
+
+- Redesigned logs table component with expandable rows for detailed message viewing
+- Accordion-based UI for organizing logs by dataset
+- Support for multiple log datasets instead of just one
+- Code block display for log messages with copy functionality
+- Configurable display limit of 10 logs per dataset
+- Improved "View in Discover Logs" button placement within each dataset accordion
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Trace Details"
+        LOGTAB[Logs Tab]
+    end
+    
+    subgraph "New Components"
+        DSTABLE[DatasetLogsTable]
+        ACCORDION[Dataset Accordion]
+    end
+    
+    subgraph "Data Layer"
+        CORR[CorrelationService]
+        MULTI[Multiple Dataset Support]
+    end
+    
+    LOGTAB --> ACCORDION
+    ACCORDION --> DSTABLE
+    CORR --> MULTI
+    MULTI --> LOGTAB
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `DatasetLogsTable` | New table component with expandable rows and code block message display |
+| Dataset Accordion | Collapsible accordion for each log dataset with title and result count |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `LOGS_DATA` | Maximum number of logs displayed per dataset | 10 |
+
+#### API Changes
+
+The `CorrelationService.checkCorrelationsAndFetchLogs` method now returns an additional `datasetLogs` property:
+
+```typescript
+// Before
+Promise<{ logDatasets: Dataset[]; logs: LogHit[] }>
+
+// After
+Promise<{ 
+  logDatasets: Dataset[]; 
+  logs: LogHit[]; 
+  datasetLogs: Record<string, LogHit[]> 
+}>
+```
+
+### Usage Example
+
+```
+1. Navigate to Trace Details page
+2. Click on the "Logs" tab
+3. View logs organized by dataset in collapsible accordions
+4. Click the expand icon (arrow) on any log row to see full message
+5. Expanded messages display in a code block with copy functionality
+6. Click "View in Discover Logs" to open full log view for a specific dataset
+```
+
+### Migration Notes
+
+No migration required. The new UI is automatically available when viewing trace logs.
+
+## Limitations
+
+- Maximum of 10 logs displayed per dataset
+- Log correlation requires pre-configured correlation saved objects
+- Empty datasets show "No logs found for this dataset" message
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10703](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10703) | Redesigned logs tab with accordion and expandable rows |
+| [#10716](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10716) | Added support for multiple log datasets with accordion display |
+
+## References
+
+- [PR #10703](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10703): Initial redesign implementation
+- [PR #10716](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10716): Multiple dataset support
+
+## Related Feature Report
+
+- [Explore Traces](../../../../features/opensearch-dashboards/explore-traces.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -10,6 +10,7 @@
 - [Dashboards Query Action Service](features/opensearch-dashboards/dashboards-query-action-service.md) - Flyout registration support for query panel actions
 - [Dashboards Workspace](features/opensearch-dashboards/dashboards-workspace.md) - Remove restriction requiring data source for workspace creation
 - [Dashboards Traces](features/opensearch-dashboards/dashboards-traces.md) - Span status filters and trace details UX improvements
+- [Dashboards Logs View](features/opensearch-dashboards/dashboards-logs-view.md) - Redesigned logs tab with expandable rows and multiple dataset support
 
 ## Bug Fixes
 


### PR DESCRIPTION
## Summary

Add documentation for the Dashboards Logs View feature in v3.4.0.

### Changes
- Created release report: `docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-logs-view.md`
- Updated feature report: `docs/features/opensearch-dashboards/explore-traces.md`
- Updated release index

### Key Features
- Redesigned logs table with expandable rows
- Accordion-based UI for organizing logs by dataset
- Support for multiple log datasets
- Code block display for log messages with copy functionality
- Display limit of 10 logs per dataset

### Related PRs
- opensearch-project/OpenSearch-Dashboards#10703
- opensearch-project/OpenSearch-Dashboards#10716

Closes #1733