### PR TITLE
docs: add dashboards-visualizations report for v3.4.0

### DIFF
--- a/docs/features/opensearch-dashboards/explore.md
+++ b/docs/features/opensearch-dashboards/explore.md
@@ -33,6 +33,11 @@ Key benefits include:
 - Intelligent date format inference for axis labels (v3.3.0)
 - Auto-enable related UI settings when Explore is activated (v3.3.0)
 - Tab content error guard for isolated error handling (v3.3.0)
+- Bar gauge visualization type (v3.4.0)
+- Customizable legend names (v3.4.0)
+- Numerical field support for color mapping (v3.4.0)
+- Customized column ordering for table visualizations (v3.4.0)
+- Improved gauge and bar gauge threshold logic with negative value support (v3.4.0)
 
 ## Details
 
@@ -83,6 +88,8 @@ graph TB
                 Heatmap[Heatmap]
                 Area[Area]
                 SingleMetric[Single Metric]
+                Gauge[Gauge]
+                BarGauge[Bar Gauge]
             end
         end
         
@@ -281,6 +288,15 @@ source = opensearch_dashboards_sample_data_ecommerce
 | Version | PR | Description |
 |---------|-----|-------------|
 | v3.4.0 | [#10849](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10849) | Enhance query action service to allow flyout registration |
+| v3.4.0 | [#10604](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10604) | Allow customizing legend name |
+| v3.4.0 | [#10697](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10697) | Add bar gauge visualization |
+| v3.4.0 | [#10808](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10808) | Support numerical field as color field |
+| v3.4.0 | [#10868](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10868) | Refactor threshold logic of gauge and bar gauge |
+| v3.4.0 | [#10894](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10894) | Add tests for gauge and bar gauge |
+| v3.4.0 | [#10896](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10896) | Add tests for table visualization |
+| v3.4.0 | [#10898](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10898) | Add customized column order toggle for table visualization |
+| v3.4.0 | [#10599](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10599) | Fix breadcrumb floating issue |
+| v3.4.0 | [#10657](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10657) | Fix tabs length and scroll persistence |
 | v3.3.0 | [#10362](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10362) | Introduce facet filter |
 | v3.3.0 | [#10412](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10412) | Introduce tab content error guard |
 | v3.3.0 | [#10425](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10425) | Infer axis date format |
@@ -384,6 +400,6 @@ source = opensearch_dashboards_sample_data_ecommerce
 
 ## Change History
 
-- **v3.4.0** (2026-01-14): Enhanced Query Panel Actions Registry with flyout action support, enabling external plugins to render inline flyout panels from the actions dropdown. Added `queryInEditor` dependency for accessing current editor content (pre-transformed with source clause). Added comprehensive Explore plugin components architecture documentation.
+- **v3.4.0** (2026-01-14): Added bar gauge visualization type, customizable legend names, numerical field support for color mapping, customized column ordering for table visualizations with dashboard persistence, improved gauge and bar gauge threshold logic with negative value support and debounce. Enhanced Query Panel Actions Registry with flyout action support, enabling external plugins to render inline flyout panels from the actions dropdown. Added `queryInEditor` dependency for accessing current editor content (pre-transformed with source clause). Bug fixes: breadcrumb floating issue, tabs length and scroll persistence.
 - **v3.3.0** (2026-01-14): Added facet filtering with default observability fields (serviceName, http status code, status.code), explore experience modal for first-time user onboarding with saved object tracking, query panel actions registry for plugin extensibility, mouse hover states for line chart interactivity, intelligent date format inference for axis labels based on data granularity, auto-enable related UI settings when Explore is activated (theme v9, new home page, query enhancements), tab content error guard for isolated error handling, query panel display without datasets, link to detail page in expanded row, Patterns tab flyout with detailed pattern inspection, "search with pattern" functionality for log filtering, events table with pagination, Calcite query engine compatibility, "Show Raw Data" toggle for non-table visualizations, improved Patterns tab error handling with custom error page, metric visualization with sparkline support, histogram visualization (numerical, time-series, categorical), table visualization enhancements (column alignment, Excel-like filters, statistical footers, cell customization), dark/light theme support with new color palettes, hover highlighting for bar/pie charts, Gantt chart improvements (service name display, span selection, error indicators), metric style updates with percentage change option. Bug fixes: ScopedHistory navigation error, Refresh button query execution, active tab preservation on save/load, removed Explore from Patterns tab
 - **v3.2.0** (2026-01-10): Initial implementation with query panel, auto-visualization, multi-flavor support, dashboard embeddable, patterns tab, chart type switcher, Trace Details page with Gantt chart and service map visualization, PPL filter support, improved fields selector with result/schema grouping, query editor performance optimizations, bidirectional URL-Redux synchronization, global header controls, and in-editor PPL documentation

--- a/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-visualizations.md
+++ b/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-visualizations.md
@@ -1,0 +1,106 @@
+# Dashboards Visualizations
+
+## Summary
+
+OpenSearch Dashboards v3.4.0 introduces significant enhancements to the Explore plugin's visualization capabilities, including a new bar gauge visualization type, customizable legend names, numerical field support for color mapping, customized column ordering for table visualizations, and improved threshold logic for gauge visualizations. These improvements provide users with more flexible and powerful data visualization options.
+
+## Details
+
+### What's New in v3.4.0
+
+#### New Bar Gauge Visualization
+A new bar gauge visualization type has been added to the Explore plugin, providing an alternative way to display metric values with threshold-based coloring. Bar gauges display values as horizontal bars with configurable thresholds.
+
+#### Customizable Legend Names
+Users can now customize legend names in visualizations, allowing for more descriptive and user-friendly chart legends. This works for both single and multiple legend scenarios.
+
+#### Numerical Field as Color Field
+The color field in visualizations now supports numerical fields in addition to categorical fields, enabling gradient-based color mapping for continuous data values.
+
+#### Table Visualization Column Ordering
+Table visualizations now support customized column ordering with proper persistence in dashboards. Users can:
+- Enable "Customized column order" toggle in settings
+- Drag columns to reorder using the columns selector or header actions
+- Hide columns while maintaining order
+- Save column configurations to dashboards
+
+#### Improved Gauge Threshold Logic
+The threshold logic for gauge and bar gauge visualizations has been refactored:
+- Text color now always reflects threshold color
+- MinBase serves as a cutoff line with last threshold color applied to values below
+- Negative values are now supported for min/max controls
+- Debounce added when adding/updating/deleting thresholds
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| Bar Gauge | New visualization type displaying metrics as horizontal bars |
+| Legend Name Editor | UI for customizing legend display names |
+| Numerical Color Field | Support for numerical fields in color mapping |
+| Column Order Toggle | Toggle for enabling customized column ordering |
+| Column Drag Handler | Drag-and-drop column reordering functionality |
+
+#### Configuration Changes
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `customizedColumnOrder` | Enable customized column ordering for tables | `false` |
+| `legendName` | Custom legend name for visualizations | Field name |
+
+### Usage Example
+
+```yaml
+# Enable customized column order in table visualization
+1. Create a table visualization in Explore
+2. Open Settings panel
+3. Enable "Customized column order" toggle
+4. Drag columns to desired order
+5. Save to dashboard
+
+# Customize legend name
+1. Create a chart visualization
+2. Click on legend settings
+3. Enter custom legend name
+4. Apply changes
+
+# Use numerical field for color
+1. Create a visualization with color field
+2. Select a numerical field for color
+3. Configure color gradient range
+```
+
+### Migration Notes
+
+No migration required. New features are additive and backward compatible.
+
+## Limitations
+
+- Column order customization is only available when the toggle is enabled
+- In dashboard mode, column selector and density options are hidden
+- Numerical color fields require appropriate data ranges for effective visualization
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10604](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10604) | Allow customizing legend name |
+| [#10697](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10697) | Add bar gauge visualization |
+| [#10808](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10808) | Support numerical field as color field |
+| [#10868](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10868) | Refactor threshold logic of gauge and bar gauge |
+| [#10894](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10894) | Add tests for gauge and bar gauge |
+| [#10896](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10896) | Add tests for table visualization |
+| [#10898](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10898) | Add customized column order toggle for table visualization |
+| [#10599](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10599) | Fix breadcrumb floating issue |
+| [#10657](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10657) | Fix tabs length and scroll persistence |
+
+## References
+
+- [OpenSearch Dashboards Repository](https://github.com/opensearch-project/OpenSearch-Dashboards)
+- [Building data visualizations](https://docs.opensearch.org/3.4/dashboards/visualize/viz-index/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/explore.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -8,6 +8,7 @@
 - [Dashboards CSP](features/opensearch-dashboards/dashboards-csp.md) - Dynamic configuration support for CSP report-only mode
 - [Dashboards Data Connections](features/opensearch-dashboards/dashboards-data-connections.md) - Prometheus saved object support for data connections
 - [Dashboards Query Action Service](features/opensearch-dashboards/dashboards-query-action-service.md) - Flyout registration support for query panel actions
+- [Dashboards Visualizations](features/opensearch-dashboards/dashboards-visualizations.md) - Bar gauge, customizable legends, numerical color fields, and table column ordering
 - [Dashboards Workspace](features/opensearch-dashboards/dashboards-workspace.md) - Remove restriction requiring data source for workspace creation
 - [Dashboards Traces](features/opensearch-dashboards/dashboards-traces.md) - Span status filters and trace details UX improvements
 - [Dashboards Logs View](features/opensearch-dashboards/dashboards-logs-view.md) - Redesigned logs tab with expandable rows and multiple dataset support


### PR DESCRIPTION
## Summary

This PR adds documentation for Dashboards Visualizations enhancements in v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-visualizations.md`
- Feature report: `docs/features/opensearch-dashboards/explore.md` (updated)

### Key Changes in v3.4.0
- New bar gauge visualization type
- Customizable legend names for visualizations
- Numerical field support for color mapping
- Customized column ordering for table visualizations with dashboard persistence
- Improved gauge and bar gauge threshold logic with negative value support

### Related PRs
- #10604: Allow customizing legend name
- #10697: Add bar gauge visualization
- #10808: Support numerical field as color field
- #10868: Refactor threshold logic of gauge and bar gauge
- #10894: Add tests for gauge and bar gauge
- #10896: Add tests for table visualization
- #10898: Add customized column order toggle for table visualization
- #10599: Fix breadcrumb floating issue
- #10657: Fix tabs length and scroll persistence

Closes #1732