### PR TITLE
docs: add Dashboards Dataset Management report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -200,6 +200,7 @@
 - [Data Source Permissions](opensearch-dashboards/data-source-permissions.md)
 - [Data Source Selector](opensearch-dashboards/data-source-selector.md)
 - [Dataset Explorer](opensearch-dashboards/dataset-explorer.md)
+- [Dataset Management](opensearch-dashboards/dataset-management.md)
 - [Dependency Updates](opensearch-dashboards/dependency-updates.md)
 - [Dev Tools](opensearch-dashboards/dev-tools.md)
 - [Discover](opensearch-dashboards/discover.md)

--- a/docs/features/opensearch-dashboards/dataset-management.md
+++ b/docs/features/opensearch-dashboards/dataset-management.md
@@ -1,0 +1,234 @@
+# Dataset Management
+
+## Summary
+
+Dataset Management is a plugin in OpenSearch Dashboards that provides a comprehensive interface for creating, editing, and managing datasets. It extends the traditional index pattern concept with enhanced metadata support including display names, descriptions, and schema mappings. The plugin enables users to define reusable data configurations with OTel schema support, wildcard patterns, and signal type categorization.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        subgraph "Dataset Management Plugin"
+            DMP[Dataset Management App]
+            DTV2[Dataset Table V2]
+            CFV2[Configurator V2]
+            SM[Schema Mapping Service]
+            EP[Edit Page]
+        end
+        
+        subgraph "Data Plugin"
+            DS[Dataset Service]
+            DV[Data Views Service]
+            DSC[Dataset Selector Component]
+            SC[Schema Config]
+        end
+        
+        subgraph "Explore Plugin"
+            EXP[Explore App]
+            LT[Logs Tab]
+            DSW[Dataset Select Widget]
+        end
+        
+        subgraph "Saved Objects Management"
+            SOM[Saved Objects Table]
+            TC[Terminology Converter]
+        end
+        
+        subgraph "Utils"
+            IPD[Index Pattern to Dataset Converter]
+        end
+    end
+    
+    subgraph "OpenSearch"
+        IDX[Indexes]
+        IP[Index Patterns]
+    end
+    
+    DMP --> DTV2
+    DTV2 --> CFV2
+    CFV2 --> SM
+    CFV2 --> DS
+    SM --> SC
+    EP --> SM
+    DS --> DV
+    DV --> IP
+    DS --> IDX
+    EXP --> LT
+    LT --> DSW
+    DSW --> DSC
+    DSC --> DS
+    SOM --> TC
+    TC --> IPD
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User Opens Dataset Management] --> B[Load Dataset Table V2]
+    B --> C[Fetch Datasets with Metadata]
+    C --> D[Display Table with Columns]
+    D --> E{User Action}
+    E -->|Create| F[Open Configurator V2]
+    E -->|Edit| G[Open Edit Page]
+    E -->|Delete| H[Delete Dataset]
+    F --> I[Select Data Source]
+    I --> J[Configure Index Pattern]
+    J --> K{Wildcard?}
+    K -->|Yes| L[Add Wildcard Prefix]
+    K -->|No| M[Use Exact Pattern]
+    L --> N[Configure Schema Mapping]
+    M --> N
+    N --> O[Set Display Name & Description]
+    O --> P{Save as Dataset?}
+    P -->|Yes| Q[Save to Saved Objects]
+    P -->|No| R[Use Temporarily]
+    G --> S[View Data Scope]
+    S --> T[Edit Schema Mapping]
+    T --> U[Update Display Name/Description]
+    U --> V[Save Changes]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `DatasetManagement` | Main plugin entry point and app registration |
+| `DatasetTableV2` | Enhanced table with display name, signal type, description columns |
+| `ConfiguratorV2` | Dataset creation wizard with save-on-create capability |
+| `SchemaMapping` | Service for mapping data fields to UI attributes |
+| `SaveAsDatasetOption` | Checkbox for saving dataset during creation |
+| `DatasetMetadataFields` | Input fields for name and description |
+| `useDatasetFields` | Hook for field fetching logic |
+| `useDatasetTableData` | Hook for loading datasets and sources |
+| `useDatasetSelector` | Hook for selector modal management |
+| `DatasetTableHeader` | Header with title and create button |
+| `DataScopeCell` | Cell displaying data source with icon |
+| `CorrelationEmptyState` | Empty state for logs datasets |
+| `convertIndexPatternToDataset` | Terminology conversion utility |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `datasetManagement.enabled` | Enable the dataset management plugin | `false` |
+| `datasetManagement.aliasedAsIndexPattern` | Display datasets as "Index Patterns" in UI | `true` |
+
+### Dataset Properties
+
+| Property | Description | Required |
+|----------|-------------|----------|
+| `title` | Index pattern (e.g., `logs-*`) | Yes |
+| `timeFieldName` | Time field for time-based queries | No |
+| `displayName` | Human-readable name | No |
+| `description` | Dataset description | No |
+| `signalType` | Signal type (logs, metrics, traces) | No |
+| `schemaMappings` | Field-to-attribute mappings | No |
+
+### Schema Mapping Format
+
+```json
+{
+  "schemaMappings": {
+    "<schemaName>": {
+      "<attributeName>": "<fieldName>"
+    }
+  }
+}
+```
+
+### Supported Schema Types
+
+| Schema | Description | Attributes |
+|--------|-------------|------------|
+| `otel` | OpenTelemetry | timestamp, traceId, spanId, message, severity |
+
+### Usage Example
+
+#### Creating a Dataset with Full Configuration
+
+```typescript
+// Create dataset with all metadata
+const dataset = {
+  title: 'otel-logs-*',
+  timeFieldName: '@timestamp',
+  displayName: 'OpenTelemetry Logs',
+  description: 'Application logs collected via OpenTelemetry Collector',
+  signalType: 'logs',
+  schemaMappings: {
+    otel: {
+      timestamp: '@timestamp',
+      traceId: 'trace.id',
+      spanId: 'span.id',
+      message: 'body',
+      severity: 'severity_text'
+    }
+  }
+};
+
+await savedObjects.create('index-pattern', dataset);
+```
+
+#### Using Terminology Converter
+
+```typescript
+import { convertIndexPatternToDataset } from '@opensearch-project/opensearch-dashboards/utils';
+
+// Case-preserving conversion
+convertIndexPatternToDataset('Index Pattern');   // → 'Dataset'
+convertIndexPatternToDataset('INDEX PATTERNS');  // → 'DATASETS'
+convertIndexPatternToDataset('index-pattern');   // → 'dataset'
+convertIndexPatternToDataset('indexpattern');    // → 'dataset'
+```
+
+#### Configuration File
+
+```yaml
+# opensearch_dashboards.yml
+
+# Enable dataset management plugin
+datasetManagement.enabled: true
+
+# Use "Dataset" terminology instead of "Index Pattern"
+datasetManagement.aliasedAsIndexPattern: false
+```
+
+## Limitations
+
+- Schema mapping UI currently supports only OTel schema
+- Terminology conversion uses MutationObserver for dynamic portal content
+- Display name and description require plugin to be enabled
+- Wildcard prefix only supported for index datasets (not data streams)
+- Schema mappings are stored per-dataset, not globally
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#10623](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10623) | Wildcard prefix support for index datasets |
+| v3.4.0 | [#10690](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10690) | Save dataset from configurator |
+| v3.4.0 | [#10703](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10703) | Logs tab with accordion UI |
+| v3.4.0 | [#10704](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10704) | Dataset creation flow update |
+| v3.4.0 | [#10714](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10714) | Schema mapping introduction |
+| v3.4.0 | [#10716](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10716) | Multiple log datasets support |
+| v3.4.0 | [#10737](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10737) | Data scope and schema mapping on edit page |
+| v3.4.0 | [#10776](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10776) | Dataset table with display name/description |
+| v3.4.0 | [#10779](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10779) | Display name/description on edit page |
+| v3.4.0 | [#10781](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10781) | Empty logs component |
+| v3.4.0 | [#10791](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10791) | Index pattern → dataset terminology conversion |
+| v3.4.0 | [#10572](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10572) | Fix dataset filter by signal type |
+| v3.4.0 | [#10692](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10692) | Restrict patterns tab to default datasets |
+| v3.3.0 | [#10554](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10554) | Initial dataset type and management |
+
+## References
+
+- [Index Patterns Documentation](https://docs.opensearch.org/3.0/dashboards/management/index-patterns/)
+- [Dashboards Management](https://docs.opensearch.org/3.0/dashboards/management/management-index/)
+
+## Change History
+
+- **v3.4.0** (2026-01-11): Major enhancements including schema mapping, wildcard prefix support, multiple log datasets, enhanced table with metadata columns, and dynamic terminology conversion
+- **v3.3.0** (2026-01-11): Initial implementation with basic dataset type and management plugin

--- a/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-dataset-management.md
+++ b/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-dataset-management.md
@@ -1,0 +1,172 @@
+# Dashboards Dataset Management
+
+## Summary
+
+OpenSearch Dashboards v3.4.0 introduces significant enhancements to the Dataset Management feature, providing a comprehensive UI for creating, editing, and managing datasets. Key improvements include wildcard prefix support for index datasets, schema mapping for OTel data, multiple log dataset support, and dynamic terminology conversion between "index pattern" and "dataset" based on plugin enablement.
+
+## Details
+
+### What's New in v3.4.0
+
+This release transforms the dataset management experience with:
+
+1. **Enhanced Dataset Creation Flow** - New V2 configurator with save-on-create capability
+2. **Schema Mapping** - Map data fields to UI-required attributes (OTel support)
+3. **Wildcard Prefix Support** - Create index datasets with wildcard patterns
+4. **Multiple Log Datasets** - Display and manage multiple log datasets with accordion UI
+5. **Improved Dataset Table** - New columns for display name, signal type, and description
+6. **Dynamic Terminology** - Automatic "index pattern" → "dataset" text conversion
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Dataset Management Plugin"
+        DMP[Dataset Management]
+        DTV2[Dataset Table V2]
+        CFV2[Configurator V2]
+        SM[Schema Mapping]
+    end
+    
+    subgraph "Data Plugin"
+        DS[Dataset Service]
+        DSC[Dataset Selector]
+        SC[Schema Config]
+    end
+    
+    subgraph "Explore Plugin"
+        EXP[Explore App]
+        LT[Logs Tab]
+        DSW[Dataset Select Widget]
+    end
+    
+    subgraph "Saved Objects Management"
+        SOM[Saved Objects Table]
+        TC[Terminology Converter]
+    end
+    
+    DMP --> DTV2
+    DTV2 --> CFV2
+    CFV2 --> SM
+    CFV2 --> DS
+    SM --> SC
+    EXP --> LT
+    LT --> DSW
+    DSW --> DSC
+    SOM --> TC
+    TC -->|"index pattern → dataset"| SOM
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ConfiguratorV2` | Enhanced dataset configurator with save-on-create |
+| `DatasetTableV2` | Redesigned table with display name, signal type, description columns |
+| `SchemaMapping` | Maps data fields to UI attributes (OTel schema support) |
+| `SaveAsDatasetOption` | Checkbox component for saving dataset during creation |
+| `DatasetMetadataFields` | Input fields for dataset name and description |
+| `useDatasetFields` | Hook for field fetching with infinite loop prevention |
+| `useDatasetTableData` | Hook for loading datasets, sources, and creation options |
+| `useDatasetSelector` | Hook for managing dataset selector modal and creation flow |
+| `DatasetTableHeader` | Header component with title, description, and create button |
+| `DataScopeCell` | Cell component displaying data source + title with icon |
+| `CorrelationEmptyState` | Empty state component for logs datasets list |
+| `convertIndexPatternToDataset` | Utility for terminology conversion with case preservation |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `schemaMappings` | Schema mappings stored with dataset | `{}` |
+| `displayName` | Human-readable dataset name | - |
+| `description` | Dataset description | - |
+
+#### Schema Mapping Format
+
+```json
+{
+  "schemaMappings": {
+    "<schemaName>": {
+      "<attributeName>": "<fieldName>"
+    }
+  }
+}
+```
+
+Schema attributes are defined in `src/plugins/data/public/ui/dataset_selector/configurator/schema_config.ts`.
+
+### Usage Example
+
+#### Creating Dataset with Schema Mapping
+
+```typescript
+// Dataset with OTel schema mapping
+const dataset = {
+  title: 'otel-logs-*',
+  timeFieldName: '@timestamp',
+  displayName: 'OpenTelemetry Logs',
+  description: 'Logs collected via OpenTelemetry',
+  schemaMappings: {
+    otel: {
+      timestamp: '@timestamp',
+      traceId: 'trace.id',
+      spanId: 'span.id',
+      message: 'body'
+    }
+  }
+};
+```
+
+#### Terminology Conversion Utility
+
+```typescript
+import { convertIndexPatternToDataset } from '@opensearch-project/opensearch-dashboards/utils';
+
+// Converts with case preservation
+convertIndexPatternToDataset('Index Pattern');  // → 'Dataset'
+convertIndexPatternToDataset('INDEX PATTERNS'); // → 'DATASETS'
+convertIndexPatternToDataset('index-pattern');  // → 'dataset'
+```
+
+### Migration Notes
+
+- Existing index patterns continue to work without changes
+- Enable `datasetManagement.enabled: true` to use new features
+- Schema mappings are optional and backward compatible
+- Terminology conversion is automatic when dataset plugin is enabled
+
+## Limitations
+
+- Schema mapping UI only supports OTel schema initially
+- Terminology conversion uses MutationObserver for portal content (performance consideration)
+- Display name and description require dataset management plugin enabled
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10623](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10623) | Add wildcard prefix support for creating index dataset |
+| [#10690](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10690) | Allow saving dataset from dataset configurator |
+| [#10703](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10703) | Redesigned logs tab with accordion and expandable rows |
+| [#10704](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10704) | Update dataset management dataset creation flow |
+| [#10714](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10714) | Introduce schema mapping with OTel support |
+| [#10716](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10716) | Support for multiple log datasets |
+| [#10737](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10737) | Add data scope and schema mapping on edit page |
+| [#10776](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10776) | Dataset table with display name and description |
+| [#10779](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10779) | Display dataset display name and description on edit page |
+| [#10781](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10781) | Empty state component for logs datasets |
+| [#10791](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10791) | Dynamic index pattern → dataset terminology conversion |
+| [#10572](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10572) | Fix dataset filter based on signal type |
+| [#10692](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10692) | Restrict patterns tab to default datasets |
+
+## References
+
+- [Index Patterns Documentation](https://docs.opensearch.org/3.0/dashboards/management/index-patterns/)
+- [Dashboards Management](https://docs.opensearch.org/3.0/dashboards/management/management-index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/dataset-management.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -11,7 +11,7 @@
 - [Dashboards Visualizations](features/opensearch-dashboards/dashboards-visualizations.md) - Bar gauge, customizable legends, numerical color fields, and table column ordering
 - [Dashboards Workspace](features/opensearch-dashboards/dashboards-workspace.md) - Remove restriction requiring data source for workspace creation
 - [Dashboards Traces](features/opensearch-dashboards/dashboards-traces.md) - Span status filters and trace details UX improvements
-- [Dashboards Logs View](features/opensearch-dashboards/dashboards-logs-view.md) - Redesigned logs tab with expandable rows and multiple dataset support
+- [Dashboards Dataset Management](features/opensearch-dashboards/dashboards-dataset-management.md) - Schema mapping, wildcard prefix, and enhanced dataset table
 
 ## Bug Fixes
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dashboards Dataset Management feature in OpenSearch v3.4.0.

### Key Changes in v3.4.0

- **Schema Mapping**: Map data fields to UI-required attributes with OTel schema support
- **Wildcard Prefix Support**: Create index datasets with wildcard patterns
- **Multiple Log Datasets**: Display and manage multiple log datasets with accordion UI
- **Enhanced Dataset Table**: New columns for display name, signal type, and description
- **Dynamic Terminology**: Automatic "index pattern" → "dataset" text conversion
- **V2 Configurator**: Enhanced dataset creation flow with save-on-create capability

### Reports Created

- Release report: `docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-dataset-management.md`
- Feature report: `docs/features/opensearch-dashboards/dataset-management.md`

### Related PRs

- #10623, #10690, #10703, #10704, #10714, #10716, #10737, #10776, #10779, #10781, #10791, #10572, #10692

Closes #1731