### PR TITLE
docs: add Dashboards Explore report for v3.4.0

### DIFF
--- a/docs/features/opensearch-dashboards/explore.md
+++ b/docs/features/opensearch-dashboards/explore.md
@@ -38,6 +38,15 @@ Key benefits include:
 - Numerical field support for color mapping (v3.4.0)
 - Customized column ordering for table visualizations (v3.4.0)
 - Improved gauge and bar gauge threshold logic with negative value support (v3.4.0)
+- Histogram breakdowns for subdividing time-series by categorical fields (v3.4.0)
+- Field Statistics tab for data profiling without writing queries (v3.4.0)
+- Trace flyout panel replacing expandable rows (v3.4.0)
+- Hierarchy timeline table with waterfall bars for trace analysis (v3.4.0)
+- Correlations tab for linking trace and logs datasets (v3.4.0)
+- Cancel query feature with timeout-based UI (v3.4.0)
+- By-value explore embeddables without stored saved objects (v3.4.0)
+- State timeline visualization (v3.4.0)
+- Time zoom interaction for explore visualizations (v3.4.0)
 
 ## Details
 
@@ -217,6 +226,15 @@ flowchart TB
 | `useQueryPanelActionDependencies` | Hook to gather all dependencies for query panel actions (v3.4.0) |
 | `buildTemporalAxisFormatting` | Utility for inferring date formats based on data granularity (v3.3.0) |
 | `TabContentErrorGuard` | Error boundary for tab-specific query failures (v3.3.0) |
+| `BreakdownFieldSelector` | UI for selecting breakdown field in histogram header (v3.4.0) |
+| `FieldStatsContainer` | Data fetching and state management for field statistics (v3.4.0) |
+| `FieldStatsTable` | Sortable table with expandable rows for field statistics (v3.4.0) |
+| `TraceFlyout` | Flyout panel for trace details (v3.4.0) |
+| `SpanHierarchyTable` | Hierarchy view with timeline waterfall bars (v3.4.0) |
+| `SpanListTable` | Flat list view with filtering and sorting (v3.4.0) |
+| `CorrelationsTab` | UI for linking trace and logs datasets (v3.4.0) |
+| `QueryCancelButton` | Cancel button for running queries (v3.4.0) |
+| `StateTimeline` | State timeline visualization with value mapping (v3.4.0) |
 
 ### Configuration
 
@@ -295,8 +313,29 @@ source = opensearch_dashboards_sample_data_ecommerce
 | v3.4.0 | [#10894](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10894) | Add tests for gauge and bar gauge |
 | v3.4.0 | [#10896](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10896) | Add tests for table visualization |
 | v3.4.0 | [#10898](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10898) | Add customized column order toggle for table visualization |
+| v3.4.0 | [#10558](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10558) | Add timefield and currentTime to prompt |
+| v3.4.0 | [#10563](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10563) | Add state timeline visualization |
+| v3.4.0 | [#10606](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10606) | Add time zoom in interaction to explore vis |
+| v3.4.0 | [#10629](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10629) | Improve timeline loading state with spinner |
+| v3.4.0 | [#10655](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10655) | Implement trace flyout |
+| v3.4.0 | [#10657](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10657) | Add span kind column |
+| v3.4.0 | [#10663](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10663) | Discover Histogram Breakdowns |
+| v3.4.0 | [#10676](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10676) | Replace Timeline gantt chart with hierarchy timeline table |
+| v3.4.0 | [#10713](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10713) | Show query panel in traces and metrics without datasets |
+| v3.4.0 | [#10723](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10723) | Field Statistics Tab |
+| v3.4.0 | [#10727](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10727) | Add cancel query feature to discover |
+| v3.4.0 | [#10729](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10729) | Add correlations tab for trace and logs linking |
+| v3.4.0 | [#10764](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10764) | Histogram Breakdowns enable timechart for every dataset |
+| v3.4.0 | [#10799](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10799) | Experimental Explore feature flag |
+| v3.4.0 | [#10842](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10842) | Add resultsActionBar slot to explore plugin |
+| v3.4.0 | [#10927](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10927) | Log action menu support for non-filterable time columns |
+| v3.4.0 | [#10970](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10970) | Support by-value explore embeddables |
+| v3.4.0 | [#10513](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10513) | Split Aggregations Query from Logs Query |
+| v3.4.0 | [#10574](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10574) | Fix field formatter not applied to explore query result |
+| v3.4.0 | [#10582](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10582) | Fix column focus issue |
+| v3.4.0 | [#10597](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10597) | Clear editor after dataset change |
+| v3.4.0 | [#10661](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10661) | Add backticks to explore's data source command |
 | v3.4.0 | [#10599](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10599) | Fix breadcrumb floating issue |
-| v3.4.0 | [#10657](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10657) | Fix tabs length and scroll persistence |
 | v3.3.0 | [#10362](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10362) | Introduce facet filter |
 | v3.3.0 | [#10412](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10412) | Introduce tab content error guard |
 | v3.3.0 | [#10425](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10425) | Infer axis date format |
@@ -400,6 +439,6 @@ source = opensearch_dashboards_sample_data_ecommerce
 
 ## Change History
 
-- **v3.4.0** (2026-01-14): Added bar gauge visualization type, customizable legend names, numerical field support for color mapping, customized column ordering for table visualizations with dashboard persistence, improved gauge and bar gauge threshold logic with negative value support and debounce. Enhanced Query Panel Actions Registry with flyout action support, enabling external plugins to render inline flyout panels from the actions dropdown. Added `queryInEditor` dependency for accessing current editor content (pre-transformed with source clause). Bug fixes: breadcrumb floating issue, tabs length and scroll persistence.
+- **v3.4.0** (2026-01-14): Added histogram breakdowns for subdividing time-series visualizations by categorical fields with PPL timechart integration, Field Statistics tab (experimental) for data profiling with type-specific statistics, trace flyout panel replacing expandable rows, hierarchy timeline table with waterfall bars replacing Gantt chart, correlations tab for linking trace and logs datasets, cancel query feature with timeout-based UI, by-value explore embeddables without stored saved objects, state timeline visualization with value mapping and color groups, time zoom interaction for explore visualizations, span kind column for enhanced trace information, query panel display in traces and metrics without datasets, results action bar slot for plugin extensibility, log action menu support for non-filterable time columns. Added bar gauge visualization type, customizable legend names, numerical field support for color mapping, customized column ordering for table visualizations with dashboard persistence, improved gauge and bar gauge threshold logic with negative value support and debounce. Enhanced Query Panel Actions Registry with flyout action support, enabling external plugins to render inline flyout panels from the actions dropdown. Added `queryInEditor` dependency for accessing current editor content (pre-transformed with source clause). Bug fixes: breadcrumb floating issue, tabs length and scroll persistence, field formatter not applied to explore query result, column focus issue, clear editor after dataset change, split aggregations query from logs query.
 - **v3.3.0** (2026-01-14): Added facet filtering with default observability fields (serviceName, http status code, status.code), explore experience modal for first-time user onboarding with saved object tracking, query panel actions registry for plugin extensibility, mouse hover states for line chart interactivity, intelligent date format inference for axis labels based on data granularity, auto-enable related UI settings when Explore is activated (theme v9, new home page, query enhancements), tab content error guard for isolated error handling, query panel display without datasets, link to detail page in expanded row, Patterns tab flyout with detailed pattern inspection, "search with pattern" functionality for log filtering, events table with pagination, Calcite query engine compatibility, "Show Raw Data" toggle for non-table visualizations, improved Patterns tab error handling with custom error page, metric visualization with sparkline support, histogram visualization (numerical, time-series, categorical), table visualization enhancements (column alignment, Excel-like filters, statistical footers, cell customization), dark/light theme support with new color palettes, hover highlighting for bar/pie charts, Gantt chart improvements (service name display, span selection, error indicators), metric style updates with percentage change option. Bug fixes: ScopedHistory navigation error, Refresh button query execution, active tab preservation on save/load, removed Explore from Patterns tab
 - **v3.2.0** (2026-01-10): Initial implementation with query panel, auto-visualization, multi-flavor support, dashboard embeddable, patterns tab, chart type switcher, Trace Details page with Gantt chart and service map visualization, PPL filter support, improved fields selector with result/schema grouping, query editor performance optimizations, bidirectional URL-Redux synchronization, global header controls, and in-editor PPL documentation

--- a/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-explore.md
+++ b/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-explore.md
@@ -1,0 +1,196 @@
+# Dashboards Explore
+
+## Summary
+
+OpenSearch Dashboards v3.4.0 brings significant enhancements to the Explore plugin, introducing a comprehensive set of new features for data exploration and observability. Key additions include histogram breakdowns for subdividing time-series visualizations by categorical fields, a Field Statistics tab for data profiling, trace analysis improvements with flyout panels and hierarchy timeline tables, correlations support for linking traces and logs, query cancellation, and by-value embeddables for dashboard integration without stored saved objects.
+
+## Details
+
+### What's New in v3.4.0
+
+#### Histogram Breakdowns
+Users can now subdivide histogram visualizations by categorical field values, displaying the top 4 values as stacked bars with color-coded series. This provides deeper insights into how different categorical values contribute to overall time-series patterns.
+
+- New "Breakdown" field selector in histogram header
+- Multi-colored stacked bars with legend panel
+- PPL `timechart` command integration with `limit=4` for top values
+- Error handling with graceful fallback to standard histogram
+
+#### Field Statistics Tab (Experimental)
+A new tab providing comprehensive statistical analysis of fields in indices, enabling quick data profiling without writing complex queries.
+
+| Feature | Description |
+|---------|-------------|
+| Field Statistics Table | Sortable table showing field name, type, document count, and distinct value count |
+| Expandable Row Details | Type-specific statistics (top values, numeric summaries, date ranges, examples) |
+| Lazy Loading | Details fetched only when rows are expanded |
+| Field Filtering | Automatically excludes meta fields, multi-fields, and scripted fields |
+
+#### Trace Analysis Improvements
+- Trace flyout panel replacing expandable rows for trace details
+- Hierarchy timeline table with waterfall bars replacing Gantt chart
+- Span kind column for enhanced trace information
+- Correlations tab for linking trace and logs datasets
+
+#### Query Enhancements
+- Cancel query feature with timeout-based UI (appears after 50ms)
+- Query panel display in traces and metrics even without datasets
+- Results action bar slot for plugin extensibility
+- Log action menu support for non-filterable time columns
+
+#### Embeddable Improvements
+- By-value explore embeddables without stored saved objects
+- Support for PromQL and PPL visualizations via JSON input
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Explore v3.4.0 Enhancements"
+        subgraph "Histogram Breakdowns"
+            BreakdownSelector[Breakdown Field Selector]
+            TimechartQuery[PPL Timechart Query]
+            StackedBars[Stacked Bar Rendering]
+        end
+        
+        subgraph "Field Statistics"
+            FieldStatsTab[Field Stats Tab]
+            StatsTable[Statistics Table]
+            DetailSections[Detail Sections Registry]
+        end
+        
+        subgraph "Trace Analysis"
+            TraceFlyout[Trace Flyout]
+            HierarchyTable[Hierarchy Timeline Table]
+            Correlations[Correlations Tab]
+        end
+        
+        subgraph "Query Features"
+            CancelQuery[Cancel Query Button]
+            QueryPanel[Query Panel]
+            ActionBar[Results Action Bar]
+        end
+        
+        subgraph "Embeddables"
+            ByValueEmb[By-Value Embeddables]
+            EmbeddableFactory[Embeddable Factory]
+        end
+    end
+    
+    BreakdownSelector --> TimechartQuery
+    TimechartQuery --> StackedBars
+    
+    FieldStatsTab --> StatsTable
+    StatsTable --> DetailSections
+    
+    TraceFlyout --> HierarchyTable
+    HierarchyTable --> Correlations
+    
+    CancelQuery --> QueryPanel
+    QueryPanel --> ActionBar
+    
+    ByValueEmb --> EmbeddableFactory
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `BreakdownFieldSelector` | UI for selecting breakdown field in histogram header |
+| `FieldStatsContainer` | Data fetching and state management for field statistics |
+| `FieldStatsTable` | Sortable table with expandable rows |
+| `TraceFlyout` | Flyout panel for trace details |
+| `SpanHierarchyTable` | Hierarchy view with timeline waterfall bars |
+| `SpanListTable` | Flat list view with filtering and sorting |
+| `CorrelationsTab` | UI for linking trace and logs datasets |
+| `QueryCancelButton` | Cancel button for running queries |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `explore.experimental` | Enable experimental features (Histogram Breakdowns, Field Statistics) | `false` |
+
+### Usage Example
+
+```ppl
+# Histogram with breakdown by status field
+source = logs | timechart span=1h limit=4 count() by status
+
+# Standard histogram without breakdown
+source = logs | stats count() by span(@timestamp, 1h)
+```
+
+### By-Value Embeddable Example
+
+```tsx
+const factory = DepsStart.embeddable.getEmbeddableFactory('explore')!;
+
+const pplInput = {
+  id: 'explore-demo-ppl-' + Date.now(),
+  timeRange: { from: 'now-15m', to: 'now' },
+  attributes: {
+    title: 'Demo Visualization',
+    visualization: JSON.stringify({
+      chartType: 'bar',
+      axesMapping: { x: 'referer', y: 'count()' },
+    }),
+    kibanaSavedObjectMeta: {
+      searchSourceJSON: JSON.stringify({
+        query: {
+          language: 'PPL',
+          query: 'source = logs | stats count() by referer',
+        },
+      }),
+    },
+  },
+};
+
+<EmbeddableRenderer factory={factory} input={pplInput} />
+```
+
+## Limitations
+
+- Histogram Breakdowns and Field Statistics are behind experimental feature flag
+- Breakdown selector only visible when `@timestamp` is the DataView's time field
+- Field Statistics supports PPL as the default query language
+- Correlations limited to 1 trace per correlation and max 5 logs datasets per correlation
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10558](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10558) | Add timefield and currentTime to prompt |
+| [#10563](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10563) | Add state timeline visualization |
+| [#10606](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10606) | Add time zoom in interaction to explore vis |
+| [#10629](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10629) | Improve timeline loading state with spinner |
+| [#10655](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10655) | Implement trace flyout |
+| [#10657](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10657) | Add span kind column |
+| [#10663](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10663) | Discover Histogram Breakdowns |
+| [#10676](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10676) | Replace Timeline gantt chart with hierarchy timeline table |
+| [#10713](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10713) | Show query panel in traces and metrics without datasets |
+| [#10723](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10723) | Field Statistics Tab |
+| [#10727](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10727) | Add cancel query feature to discover |
+| [#10729](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10729) | Add correlations tab for trace and logs linking |
+| [#10764](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10764) | Histogram Breakdowns enable timechart for every dataset |
+| [#10799](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10799) | Experimental Explore feature flag |
+| [#10842](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10842) | Add resultsActionBar slot to explore plugin |
+| [#10927](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10927) | Log action menu support for non-filterable time columns |
+| [#10970](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10970) | Support by-value explore embeddables |
+| [#10513](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10513) | Split Aggregations Query from Logs Query |
+| [#10574](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10574) | Fix field formatter not applied to explore query result |
+| [#10582](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10582) | Fix column focus issue |
+| [#10597](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10597) | Clear editor after dataset change |
+| [#10661](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10661) | Add backticks to explore's data source command |
+
+## References
+
+- [RFC #10619](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10619): Histogram Breakdowns RFC
+- [RFC #10614](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10614): Field Statistics RFC
+- [Issue #10386](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10386): Correlations feature request
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/explore.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -4,6 +4,7 @@
 
 ### OpenSearch Dashboards
 
+- [Dashboards Explore](features/opensearch-dashboards/dashboards-explore.md) - Histogram breakdowns, Field Statistics tab, trace flyout, correlations, cancel query, and by-value embeddables
 - [Dashboards Global Search](features/opensearch-dashboards/dashboards-global-search.md) - Assets search and enhanced command system for global search
 - [Dashboards CSP](features/opensearch-dashboards/dashboards-csp.md) - Dynamic configuration support for CSP report-only mode
 - [Dashboards Data Connections](features/opensearch-dashboards/dashboards-data-connections.md) - Prometheus saved object support for data connections


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dashboards Explore feature enhancements in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-explore.md`
- Feature report: `docs/features/opensearch-dashboards/explore.md` (updated)

### Key Changes in v3.4.0

**New Features:**
- Histogram breakdowns for subdividing time-series visualizations by categorical fields
- Field Statistics tab (experimental) for data profiling without writing queries
- Trace flyout panel replacing expandable rows
- Hierarchy timeline table with waterfall bars replacing Gantt chart
- Correlations tab for linking trace and logs datasets
- Cancel query feature with timeout-based UI
- By-value explore embeddables without stored saved objects
- State timeline visualization with value mapping and color groups
- Time zoom interaction for explore visualizations

**Enhancements:**
- Span kind column for enhanced trace information
- Query panel display in traces and metrics without datasets
- Results action bar slot for plugin extensibility
- Log action menu support for non-filterable time columns

**Bug Fixes:**
- Field formatter not applied to explore query result
- Column focus issue
- Clear editor after dataset change
- Split aggregations query from logs query

### PRs Investigated
22 PRs from opensearch-dashboards repository including:
- #10663: Discover Histogram Breakdowns
- #10723: Field Statistics Tab
- #10655: Implement trace flyout
- #10676: Replace Timeline gantt chart with hierarchy timeline table
- #10729: Add correlations tab for trace and logs linking
- #10727: Add cancel query feature to discover
- #10970: Support by-value explore embeddables

Closes #1730