### PR TITLE
docs: add Security Kerberos Integration report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -58,6 +58,7 @@
 - [Flat Object Field](opensearch/flat-object-field.md)
 - [Flaky Test Fixes](opensearch/flaky-test-fixes.md)
 - [gRPC Transport & Services](opensearch/grpc-transport--services.md)
+- [HDFS Repository Kerberos](opensearch/hdfs-repository-kerberos.md)
 - [Index Settings](opensearch/index-settings.md)
 - [Java 17 Modernization](opensearch/java-17-modernization.md)
 - [List APIs (Paginated)](opensearch/list-apis-paginated.md)

--- a/docs/features/opensearch/hdfs-repository-kerberos.md
+++ b/docs/features/opensearch/hdfs-repository-kerberos.md
@@ -1,0 +1,148 @@
+# HDFS Repository Kerberos Authentication
+
+## Summary
+
+The HDFS Repository plugin enables OpenSearch to use Hadoop Distributed File System (HDFS) as a snapshot repository backend. This feature supports Kerberos authentication for secure HDFS clusters, allowing enterprises to leverage their existing Hadoop infrastructure for OpenSearch backup and restore operations with enterprise-grade security.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph OpenSearch Cluster
+        OS[OpenSearch Node]
+        HDFS_Plugin[repository-hdfs Plugin]
+    end
+    
+    subgraph Kerberos Infrastructure
+        KDC[Key Distribution Center]
+        Keytab[Keytab File]
+        KRB5[krb5.conf]
+    end
+    
+    subgraph Hadoop Cluster
+        NN[NameNode]
+        DN1[DataNode 1]
+        DN2[DataNode 2]
+    end
+    
+    OS --> HDFS_Plugin
+    HDFS_Plugin --> KRB5
+    HDFS_Plugin --> Keytab
+    Keytab --> KDC
+    KDC --> NN
+    HDFS_Plugin --> NN
+    NN --> DN1
+    NN --> DN2
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Authentication
+        A[OpenSearch] -->|1. Read keytab| B[Keytab File]
+        B -->|2. Request TGT| C[KDC]
+        C -->|3. Issue TGT| A
+        A -->|4. Request Service Ticket| C
+        C -->|5. Issue Service Ticket| A
+    end
+    
+    subgraph HDFS Operations
+        A -->|6. Authenticated Request| D[HDFS NameNode]
+        D -->|7. Block Locations| A
+        A -->|8. Read/Write Data| E[HDFS DataNodes]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| repository-hdfs plugin | OpenSearch plugin providing HDFS repository support |
+| hadoop-client-api | Hadoop client API library |
+| hadoop-client-runtime | Hadoop client runtime dependencies |
+| hadoop-hdfs | HDFS client implementation |
+| krb5.conf | Kerberos configuration file |
+| keytab | Kerberos keytab file containing service principal credentials |
+
+### Configuration
+
+#### OpenSearch Node Settings (opensearch.yml)
+
+| Setting | Description | Required |
+|---------|-------------|----------|
+| `plugins.security.kerberos.krb5_filepath` | Path to Kerberos configuration file | Yes |
+| `plugins.security.kerberos.acceptor_keytab_filepath` | Path to keytab file (relative to config directory) | Yes |
+| `plugins.security.kerberos.acceptor_principal` | Kerberos principal for OpenSearch | Yes |
+
+#### Security Backend Configuration (config.yml)
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `krb_debug` | Enable Kerberos debugging output | `false` |
+| `strip_realm_from_principal` | Remove realm from username | `true` |
+| `challenge` | Send WWW-Authenticate header on missing credentials | `true` |
+
+### Usage Example
+
+#### 1. Configure Kerberos in opensearch.yml
+
+```yaml
+plugins.security.kerberos.krb5_filepath: '/etc/krb5.conf'
+plugins.security.kerberos.acceptor_keytab_filepath: 'opensearch_keytab.tab'
+plugins.security.kerberos.acceptor_principal: 'HTTP/opensearch.example.com'
+```
+
+#### 2. Configure Security Backend (config.yml)
+
+```yaml
+kerberos_auth_domain:
+  enabled: true
+  order: 1
+  http_authenticator:
+    type: kerberos
+    challenge: true
+    config:
+      krb_debug: false
+      strip_realm_from_principal: true
+  authentication_backend:
+    type: noop
+```
+
+#### 3. Register HDFS Repository
+
+```json
+PUT _snapshot/hdfs_backup
+{
+  "type": "hdfs",
+  "settings": {
+    "uri": "hdfs://namenode.example.com:8020",
+    "path": "/opensearch/snapshots",
+    "conf.dfs.client.read.shortcircuit": "false"
+  }
+}
+```
+
+## Limitations
+
+- Keytab file must be placed in the `config` directory or a subdirectory (security restriction)
+- Path to keytab in `opensearch.yml` must be relative, not absolute
+- Kerberos/SPNEGO behavior varies by browser and operating system
+- Requires properly configured Kerberos infrastructure (KDC, realm, principals)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#19952](https://github.com/opensearch-project/OpenSearch/pull/19952) | Update Hadoop to 3.4.2 and enable security (Kerberos) integration tests under JDK-24 and above |
+
+## References
+
+- [Kerberos Authentication Documentation](https://docs.opensearch.org/3.0/security/authentication-backends/kerberos/): Official OpenSearch Kerberos configuration guide
+- [Configuring the Security Backend](https://docs.opensearch.org/3.0/security/configuration/configuration/): Security backend configuration reference
+
+## Change History
+
+- **v3.4.0** (2026-01-11): Updated Hadoop to 3.4.2, re-enabled Kerberos integration tests for JDK-24+

--- a/docs/releases/v3.4.0/features/opensearch/security-kerberos-integration.md
+++ b/docs/releases/v3.4.0/features/opensearch/security-kerberos-integration.md
@@ -1,0 +1,91 @@
+# Security Kerberos Integration
+
+## Summary
+
+This release updates Hadoop to version 3.4.2 and re-enables Kerberos security integration tests for JDK-24 and above. The update addresses long-standing compatibility issues with deprecated and removed Java APIs that previously prevented Kerberos authentication tests from running on newer JDK versions.
+
+## Details
+
+### What's New in v3.4.0
+
+The repository-hdfs plugin now supports Kerberos authentication testing on JDK-24+, enabling secure HDFS repository operations with modern Java runtimes.
+
+### Technical Changes
+
+#### Dependency Update
+
+| Component | Previous Version | New Version |
+|-----------|------------------|-------------|
+| Hadoop | 3.3.6 | 3.4.2 |
+| hadoop-client-api | 3.3.6 | 3.4.2 |
+| hadoop-client-runtime | 3.3.6 | 3.4.2 |
+| hadoop-hdfs | 3.3.6 | 3.4.2 |
+
+#### Test Re-enablement
+
+Previously disabled integration tests for JDK-24+ are now enabled:
+
+- `integTestSecure` - Secure HDFS integration tests
+- `integTestSecureHa` - Secure HDFS High Availability integration tests
+
+The following code was removed from `plugins/repository-hdfs/build.gradle`:
+
+```groovy
+// Previously disabled for JDK-24+
+if (BuildParams.runtimeJavaVersion >= JavaVersion.VERSION_24) {
+  disabledIntegTestTaskNames += ['integTestSecure', 'integTestSecureHa']
+  testingConventions.enabled = false
+}
+```
+
+#### Security Policy Update
+
+Added permission for Kerberos configuration file access in `server/src/main/resources/org/opensearch/bootstrap/security.policy`:
+
+```java
+// allow to access krb5.conf
+permission java.io.FilePermission "${{java.security.krb5.conf}}", "read";
+```
+
+#### Third-Party Audit Updates
+
+Updated class exclusions for the new Hadoop version:
+
+| Removed | Added |
+|---------|-------|
+| `LittleEndianByteArray$UnsafeByteArray$3` | `MessageSchema` |
+| | `UnsafeUtil$Android32MemoryAccessor` |
+| | `UnsafeUtil$Android64MemoryAccessor` |
+
+### Usage Example
+
+Kerberos authentication for HDFS repository requires configuration in `opensearch.yml`:
+
+```yaml
+plugins.security.kerberos.krb5_filepath: '/etc/krb5.conf'
+plugins.security.kerberos.acceptor_keytab_filepath: 'opensearch_keytab.tab'
+plugins.security.kerberos.acceptor_principal: 'HTTP/localhost'
+```
+
+### Migration Notes
+
+No migration required. The Hadoop upgrade is backward compatible. Existing HDFS repository configurations will continue to work.
+
+## Limitations
+
+- Kerberos integration tests require a properly configured Kerberos environment
+- The `keytab` file must be placed in the `config` directory or a subdirectory
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19952](https://github.com/opensearch-project/OpenSearch/pull/19952) | Update Hadoop to 3.4.2 and enable security (Kerberos) integration tests under JDK-24 and above |
+
+## References
+
+- [Kerberos Authentication Documentation](https://docs.opensearch.org/3.0/security/authentication-backends/kerberos/): Official OpenSearch Kerberos configuration guide
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/hdfs-repository-kerberos.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -2,6 +2,10 @@
 
 ## Features
 
+### OpenSearch
+
+- [Security Kerberos Integration](features/opensearch/security-kerberos-integration.md) - Update Hadoop to 3.4.2 and enable Kerberos integration tests for JDK-24+
+
 ### OpenSearch Dashboards
 
 - [Dashboards Dev Tools](features/opensearch-dashboards/dashboards-dev-tools.md) - PATCH method support for Dev Tools console


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security Kerberos Integration feature in OpenSearch v3.4.0.

### Changes

- **Release Report**: `docs/releases/v3.4.0/features/opensearch/security-kerberos-integration.md`
  - Documents Hadoop 3.4.2 upgrade
  - Re-enabled Kerberos integration tests for JDK-24+
  - Security policy updates for krb5.conf access

- **Feature Report**: `docs/features/opensearch/hdfs-repository-kerberos.md`
  - Comprehensive documentation of HDFS Repository with Kerberos authentication
  - Architecture and data flow diagrams
  - Configuration examples

### Related Issue

Closes #1728

### Related PR

- [opensearch-project/OpenSearch#19952](https://github.com/opensearch-project/OpenSearch/pull/19952)