### PR TITLE
docs: add Stats Builder Pattern Deprecations report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -153,6 +153,7 @@
 - [Skip List](opensearch/skip-list.md)
 - [Snapshot Restore Enhancements](opensearch/snapshot-restore-enhancements.md)
 - [Star Tree Index](opensearch/star-tree-index.md)
+- [Stats Builder Pattern](opensearch/stats-builder-pattern.md)
 - [Store Factory](opensearch/store-factory.md)
 - [Store Subdirectory Module](opensearch/store-subdirectory-module.md)
 - [Streaming Indexing](opensearch/streaming-indexing.md)

--- a/docs/features/opensearch/stats-builder-pattern.md
+++ b/docs/features/opensearch/stats-builder-pattern.md
@@ -1,0 +1,132 @@
+# Stats Builder Pattern
+
+## Summary
+
+OpenSearch Stats API classes use the Builder pattern for object construction, replacing traditional multi-parameter constructors. This design pattern improves API evolvability by allowing new metrics to be added without breaking backward compatibility, and provides a more readable, fluent API for creating stats objects.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Stats API Design"
+        Client[Client Code]
+        Builder[Stats.Builder]
+        Stats[Stats Object]
+        
+        Client -->|"1. Create Builder"| Builder
+        Builder -->|"2. Set fields"| Builder
+        Builder -->|"3. build()"| Stats
+    end
+    
+    subgraph "Internal Flow"
+        Stats -->|"Serialization"| StreamOutput[StreamOutput]
+        StreamInput[StreamInput] -->|"Deserialization"| Stats
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Creation
+        A[Builder] -->|build| B[Stats Object]
+    end
+    subgraph Usage
+        B --> C[Node Stats Response]
+        B --> D[Index Stats Response]
+        B --> E[Cluster Stats Response]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `Stats` | Immutable data class holding metric values |
+| `Stats.Builder` | Fluent builder for constructing Stats objects |
+| `StreamInput/Output` | Serialization for cluster communication |
+
+### Affected Stats Classes
+
+| Category | Classes |
+|----------|---------|
+| Index Stats | `IndexingStats.Stats`, `RefreshStats`, `DocStats`, `StoreStats`, `GetStats`, `FlushStats` |
+| Cache Stats | `QueryCacheStats`, `FieldDataStats`, `CompletionStats`, `RequestCacheStats`, `Cache.CacheStats` |
+| Thread/Transport | `ThreadPoolStats.Stats`, `TransportStats`, `HttpStats` |
+| Remote Store | `RemoteTranslogTransferTracker.Stats`, `RemoteSegmentTransferTracker.Stats` |
+| System Stats | `OsStats`, `ScriptStats`, `AdaptiveSelectionStats` |
+| Shard Stats | `ShardStats`, `WarmerStats`, `IndexingPressureStats`, `IndexPressureStats` |
+| Other | `TranslogStats`, `Condition.Stats`, `DirectoryFileTransferTracker.Stats`, `DeviceStats` |
+
+### Usage Example
+
+```java
+// Create IndexingStats using Builder pattern
+IndexingStats.Stats stats = new IndexingStats.Stats.Builder()
+    .indexCount(1000)
+    .indexTimeInMillis(5000)
+    .indexCurrent(5)
+    .indexFailedCount(2)
+    .deleteCount(100)
+    .deleteTimeInMillis(500)
+    .deleteCurrent(1)
+    .noopUpdateCount(10)
+    .isThrottled(false)
+    .throttleTimeInMillis(0)
+    .docStatusStats(new DocStatusStats())
+    .maxLastIndexRequestTimestamp(System.currentTimeMillis())
+    .build();
+
+// Create ThreadPoolStats using Builder pattern
+ThreadPoolStats.Stats threadStats = new ThreadPoolStats.Stats.Builder()
+    .name("search")
+    .threads(10)
+    .queue(5)
+    .active(3)
+    .rejected(0)
+    .largest(15)
+    .completed(1000)
+    .build();
+```
+
+### Benefits
+
+1. **Backward Compatibility**: New fields can be added with default values without breaking existing code
+2. **Readability**: Named parameters make code self-documenting
+3. **Flexibility**: Optional fields can be omitted, using defaults
+4. **Immutability**: Stats objects remain immutable after construction
+5. **Validation**: Builder can validate field combinations before construction
+
+## Limitations
+
+- Slightly more verbose than constructor calls for simple cases
+- Requires migration from deprecated constructors before next major version
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#19317](https://github.com/opensearch-project/OpenSearch/pull/19317) | ThreadPoolStats.Stats Builder |
+| v3.4.0 | [#19306](https://github.com/opensearch-project/OpenSearch/pull/19306) | IndexingStats.Stats Builder |
+| v3.4.0 | [#19835](https://github.com/opensearch-project/OpenSearch/pull/19835) | RefreshStats Builder |
+| v3.4.0 | [#19863](https://github.com/opensearch-project/OpenSearch/pull/19863) | DocStats and StoreStats Builder |
+| v3.4.0 | [#19862](https://github.com/opensearch-project/OpenSearch/pull/19862) | Condition.Stats and DirectoryFileTransferTracker.Stats Builder |
+| v3.4.0 | [#19837](https://github.com/opensearch-project/OpenSearch/pull/19837) | RemoteTranslogTransferTracker.Stats and RemoteSegmentTransferTracker.Stats Builder |
+| v3.4.0 | [#19935](https://github.com/opensearch-project/OpenSearch/pull/19935) | GetStats, FlushStats and QueryCacheStats Builder |
+| v3.4.0 | [#19936](https://github.com/opensearch-project/OpenSearch/pull/19936) | FieldDataStats and CompletionStats Builder |
+| v3.4.0 | [#19961](https://github.com/opensearch-project/OpenSearch/pull/19961) | TranslogStats and RequestCacheStats Builder |
+| v3.4.0 | [#19991](https://github.com/opensearch-project/OpenSearch/pull/19991) | IndexPressureStats, DeviceStats and TransportStats Builder |
+| v3.4.0 | [#20015](https://github.com/opensearch-project/OpenSearch/pull/20015) | Cache.CacheStats Builder |
+| v3.4.0 | [#20014](https://github.com/opensearch-project/OpenSearch/pull/20014) | HttpStats, ScriptStats, AdaptiveSelectionStats and OsStats Builder |
+| v3.4.0 | [#19966](https://github.com/opensearch-project/OpenSearch/pull/19966) | ShardStats, WarmerStats and IndexingPressureStats Builder |
+
+## References
+
+- [Issue #19225](https://github.com/opensearch-project/OpenSearch/issues/19225): Use Builder pattern instead of constructors for Stats API classes
+- [Issue #18723](https://github.com/opensearch-project/OpenSearch/issues/18723): Related SearchStats refactoring
+
+## Change History
+
+- **v3.4.0** (2026-01-11): Initial implementation - deprecated constructors in 30+ Stats classes in favor of Builder pattern

--- a/docs/releases/v3.4.0/features/opensearch/stats-builder-pattern-deprecations.md
+++ b/docs/releases/v3.4.0/features/opensearch/stats-builder-pattern-deprecations.md
@@ -1,0 +1,136 @@
+# Stats Builder Pattern Deprecations
+
+## Summary
+
+OpenSearch v3.4.0 deprecates existing constructors in over 30 Stats API classes in favor of the Builder pattern. This refactoring improves API evolvability, allowing new metrics to be added without breaking backward compatibility. The existing constructors are marked as deprecated and will be removed in a future major version.
+
+## Details
+
+### What's New in v3.4.0
+
+This release introduces Builder classes for numerous Stats API classes across the codebase. The Builder pattern replaces direct constructor usage, providing a fluent API for creating stats objects.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.4.0"
+        A1[Client Code] -->|"new Stats(arg1, arg2, ...)"| B1[Stats Constructor]
+        B1 --> C1[Stats Object]
+    end
+    subgraph "After v3.4.0"
+        A2[Client Code] -->|"new Stats.Builder()"| B2[Builder]
+        B2 -->|".field1(value)"| B2
+        B2 -->|".field2(value)"| B2
+        B2 -->|".build()"| C2[Stats Object]
+    end
+```
+
+#### Affected Classes
+
+| Category | Classes |
+|----------|---------|
+| Index Stats | `IndexingStats.Stats`, `RefreshStats`, `DocStats`, `StoreStats`, `GetStats`, `FlushStats` |
+| Cache Stats | `QueryCacheStats`, `FieldDataStats`, `CompletionStats`, `RequestCacheStats`, `Cache.CacheStats` |
+| Thread/Transport | `ThreadPoolStats.Stats`, `TransportStats`, `HttpStats` |
+| Remote Store | `RemoteTranslogTransferTracker.Stats`, `RemoteSegmentTransferTracker.Stats` |
+| System Stats | `OsStats`, `ScriptStats`, `AdaptiveSelectionStats` |
+| Shard Stats | `ShardStats`, `WarmerStats`, `IndexingPressureStats`, `IndexPressureStats` |
+| Other | `TranslogStats`, `Condition.Stats`, `DirectoryFileTransferTracker.Stats`, `DeviceStats` |
+
+#### Builder Pattern Implementation
+
+Each affected class now includes a nested `Builder` class:
+
+```java
+public static class Builder {
+    private long indexCount = 0;
+    private long indexTimeInMillis = 0;
+    // ... other fields with defaults
+
+    public Builder indexCount(long count) {
+        this.indexCount = count;
+        return this;
+    }
+
+    public Builder indexTimeInMillis(long time) {
+        this.indexTimeInMillis = time;
+        return this;
+    }
+
+    // ... other setter methods
+
+    public Stats build() {
+        return new Stats(this);
+    }
+}
+```
+
+### Usage Example
+
+```java
+// Deprecated approach (will be removed in future version)
+IndexingStats.Stats stats = new IndexingStats.Stats(
+    indexCount, indexTimeInMillis, indexCurrent, indexFailedCount,
+    deleteCount, deleteTimeInMillis, deleteCurrent, noopUpdateCount,
+    isThrottled, throttleTimeInMillis, docStatusStats, maxLastIndexRequestTimestamp
+);
+
+// New Builder approach (recommended)
+IndexingStats.Stats stats = new IndexingStats.Stats.Builder()
+    .indexCount(indexCount)
+    .indexTimeInMillis(indexTimeInMillis)
+    .indexCurrent(indexCurrent)
+    .indexFailedCount(indexFailedCount)
+    .deleteCount(deleteCount)
+    .deleteTimeInMillis(deleteTimeInMillis)
+    .deleteCurrent(deleteCurrent)
+    .noopUpdateCount(noopUpdateCount)
+    .isThrottled(isThrottled)
+    .throttleTimeInMillis(throttleTimeInMillis)
+    .docStatusStats(docStatusStats)
+    .maxLastIndexRequestTimestamp(maxLastIndexRequestTimestamp)
+    .build();
+```
+
+### Migration Notes
+
+1. **Deprecation Warning**: Existing constructors are marked `@Deprecated` and will emit compiler warnings
+2. **No Functional Change**: The Builder pattern produces identical Stats objects
+3. **Gradual Migration**: Migrate to Builder pattern before the next major version
+4. **Default Values**: Builder fields have sensible defaults, allowing partial initialization
+
+## Limitations
+
+- Existing constructors remain functional but deprecated
+- Plugin developers using Stats constructors should migrate to Builder pattern
+- Serialization/deserialization behavior unchanged
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19317](https://github.com/opensearch-project/OpenSearch/pull/19317) | ThreadPoolStats.Stats Builder |
+| [#19306](https://github.com/opensearch-project/OpenSearch/pull/19306) | IndexingStats.Stats Builder |
+| [#19835](https://github.com/opensearch-project/OpenSearch/pull/19835) | RefreshStats Builder |
+| [#19863](https://github.com/opensearch-project/OpenSearch/pull/19863) | DocStats and StoreStats Builder |
+| [#19862](https://github.com/opensearch-project/OpenSearch/pull/19862) | Condition.Stats and DirectoryFileTransferTracker.Stats Builder |
+| [#19837](https://github.com/opensearch-project/OpenSearch/pull/19837) | RemoteTranslogTransferTracker.Stats and RemoteSegmentTransferTracker.Stats Builder |
+| [#19935](https://github.com/opensearch-project/OpenSearch/pull/19935) | GetStats, FlushStats and QueryCacheStats Builder |
+| [#19936](https://github.com/opensearch-project/OpenSearch/pull/19936) | FieldDataStats and CompletionStats Builder |
+| [#19961](https://github.com/opensearch-project/OpenSearch/pull/19961) | TranslogStats and RequestCacheStats Builder |
+| [#19991](https://github.com/opensearch-project/OpenSearch/pull/19991) | IndexPressureStats, DeviceStats and TransportStats Builder |
+| [#20015](https://github.com/opensearch-project/OpenSearch/pull/20015) | Cache.CacheStats Builder |
+| [#20014](https://github.com/opensearch-project/OpenSearch/pull/20014) | HttpStats, ScriptStats, AdaptiveSelectionStats and OsStats Builder |
+| [#19966](https://github.com/opensearch-project/OpenSearch/pull/19966) | ShardStats, WarmerStats and IndexingPressureStats Builder |
+
+## References
+
+- [Issue #19225](https://github.com/opensearch-project/OpenSearch/issues/19225): Use Builder pattern instead of constructors for Stats API classes
+- [Issue #18723](https://github.com/opensearch-project/OpenSearch/issues/18723): Related SearchStats refactoring
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/stats-builder-pattern.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -5,6 +5,7 @@
 ### OpenSearch
 
 - [Security Kerberos Integration](features/opensearch/security-kerberos-integration.md) - Update Hadoop to 3.4.2 and enable Kerberos integration tests for JDK-24+
+- [Stats Builder Pattern Deprecations](features/opensearch/stats-builder-pattern-deprecations.md) - Deprecated constructors in 30+ Stats classes in favor of Builder pattern
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Stats Builder Pattern Deprecations in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch/stats-builder-pattern-deprecations.md`
- Feature report: `docs/features/opensearch/stats-builder-pattern.md`

### Key Changes in v3.4.0
- Deprecated existing constructors in 30+ Stats API classes
- Added Builder pattern for all affected Stats classes
- Improves API evolvability and backward compatibility

### Affected Classes
- Index Stats: IndexingStats.Stats, RefreshStats, DocStats, StoreStats, GetStats, FlushStats
- Cache Stats: QueryCacheStats, FieldDataStats, CompletionStats, RequestCacheStats, Cache.CacheStats
- Thread/Transport: ThreadPoolStats.Stats, TransportStats, HttpStats
- Remote Store: RemoteTranslogTransferTracker.Stats, RemoteSegmentTransferTracker.Stats
- System Stats: OsStats, ScriptStats, AdaptiveSelectionStats
- Shard Stats: ShardStats, WarmerStats, IndexingPressureStats, IndexPressureStats
- Other: TranslogStats, Condition.Stats, DirectoryFileTransferTracker.Stats, DeviceStats

### Related Issue
Closes #1727