### PR TITLE
docs: add dependency updates (opensearch core) report for v3.4.0

### DIFF
--- a/docs/features/opensearch/dependency-management.md
+++ b/docs/features/opensearch/dependency-management.md
@@ -54,15 +54,18 @@ graph TB
 | Component | Purpose | Current Version |
 |-----------|---------|-----------------|
 | JDK | Java runtime | 21 LTS |
+| Netty | Networking framework | 4.2.4 |
 | AWS SDK | S3, STS, and other AWS service integrations | 2.30.31 |
 | Reactor Netty | Reactive networking for async operations | 1.2.3 |
 | Apache HttpClient5 | HTTP client for REST operations | 5.4.1 |
-| Azure SDK | Azure Blob Storage integration | 12.30.0 |
-| Nimbus JOSE+JWT | JWT token handling | 10.0.2 |
+| Azure SDK | Azure Blob Storage integration | 12.30.3 |
+| Nimbus JOSE+JWT | JWT token handling | 10.6 |
 | Gson | JSON serialization | 2.13.0 |
 | Jetty | Embedded web server | 9.4.57 |
-| Logback | Logging framework | 1.5.18 |
+| Logback | Logging framework | 1.5.20 |
 | zstd-jni | Zstandard compression | 1.5.6-1 |
+| Google Cloud Storage | GCS repository support | 2.60.0 |
+| Bouncy Castle FIPS | FIPS-compliant cryptography | 2.1.2 |
 
 ### Dependency Categories
 
@@ -126,6 +129,11 @@ Dependencies are automatically resolved during build:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#19178](https://github.com/opensearch-project/OpenSearch/pull/19178) | Netty 4.2.4 upgrade |
+| v3.4.0 | [#20084](https://github.com/opensearch-project/OpenSearch/pull/20084) | Nimbus JOSE+JWT 10.6 |
+| v3.4.0 | [#19615](https://github.com/opensearch-project/OpenSearch/pull/19615) | Azure Storage 12.30.3 |
+| v3.4.0 | [#20023](https://github.com/opensearch-project/OpenSearch/pull/20023) | Google Cloud Storage 2.60.0 |
+| v3.4.0 | [#19818](https://github.com/opensearch-project/OpenSearch/pull/19818) | Bouncy Castle FIPS 2.1.2 |
 | v3.0.0 | [#17515](https://github.com/opensearch-project/OpenSearch/pull/17515) | Switch to JDK 21 LTS |
 | v3.0.0 | [#17396](https://github.com/opensearch-project/OpenSearch/pull/17396) | AWS SDK 2.30.31 |
 | v3.0.0 | [#17322](https://github.com/opensearch-project/OpenSearch/pull/17322) | Reactor Netty 1.2.3 |
@@ -135,9 +143,11 @@ Dependencies are automatically resolved during build:
 
 ## References
 
+- [Issue #14804](https://github.com/opensearch-project/OpenSearch/issues/14804): Netty 4.2 upgrade request
 - [Issue #15927](https://github.com/opensearch-project/OpenSearch/issues/15927): ExtendedSocketOption support
 - [OpenSearch Dependency Policy](https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md)
 
 ## Change History
 
+- **v3.4.0** (2026-01-14): Netty 4.2.4 upgrade (HTTP/3 readiness), 32 dependency updates including cloud SDKs and security libraries
 - **v3.0.0** (2025-05-06): JDK 21 LTS default, AWS SDK 2.30.x, Reactor Netty 1.2.x, 30 dependency updates

--- a/docs/releases/v3.4.0/features/opensearch/dependency-updates-opensearch-core.md
+++ b/docs/releases/v3.4.0/features/opensearch/dependency-updates-opensearch-core.md
@@ -1,0 +1,118 @@
+# Dependency Updates (OpenSearch Core)
+
+## Summary
+
+OpenSearch v3.4.0 includes 32 dependency updates for the core engine, covering networking frameworks, cloud SDKs, security libraries, CI/CD tooling, and build dependencies. The most significant update is the Netty 4.2 upgrade, which enables future HTTP/3 support.
+
+## Details
+
+### What's New in v3.4.0
+
+This release focuses on keeping dependencies current with security patches, performance improvements, and compatibility updates.
+
+### Technical Changes
+
+#### Major Framework Updates
+
+| Dependency | Previous | New | Impact |
+|------------|----------|-----|--------|
+| Netty | 4.1.x | 4.2.4 | HTTP/3 readiness, Project Reactor integration |
+| JAXB Implementation | 2.2.3-1 | 4.0.6 | Jakarta EE compatibility |
+| Google HTTP Client Gson | 1.47.1 | 2.0.0 | Major version upgrade |
+
+#### Cloud SDK Updates
+
+| Dependency | New Version | Purpose |
+|------------|-------------|---------|
+| Azure Core HTTP Netty | 1.16.1 | Azure networking |
+| Azure Storage Common | 12.30.3 | Azure Blob Storage |
+| Microsoft MSAL4J | 1.23.1 | Azure authentication |
+| Google Cloud Storage | 2.60.0 | GCS repository |
+| Google API Common | 2.55.1 | GCP base APIs |
+| Google GAX HTTP JSON | 2.72.1 | GCP HTTP transport |
+| Proto Google IAM v1 | 1.57.0 | GCP IAM |
+
+#### Security Library Updates
+
+| Dependency | New Version | Purpose |
+|------------|-------------|---------|
+| Nimbus JOSE+JWT | 10.6 | JWT token handling |
+| Bouncy Castle FIPS | 2.1.2 | FIPS-compliant cryptography |
+
+#### Build & CI Updates
+
+| Dependency | Previous | New | Type |
+|------------|----------|-----|------|
+| peter-evans/create-or-update-comment | 4 | 5 | GitHub Action |
+| peter-evans/create-issue-from-file | 5 | 6 | GitHub Action |
+| stefanzweifel/git-auto-commit-action | 6 | 7 | GitHub Action |
+| github/codeql-action | 3 | 4 | GitHub Action |
+| gradle/actions | 4 | 5 | GitHub Action |
+| tj-actions/changed-files | 46.0.5 | 47.0.0 | GitHub Action |
+| actions/github-script | 7 | 8 | GitHub Action |
+| actions/upload-artifact | 4 | 5 | GitHub Action |
+
+#### Library Updates
+
+| Dependency | New Version | Purpose |
+|------------|-------------|---------|
+| Apache ZooKeeper | 3.9.4 | Distributed coordination |
+| Apache Avro | 1.12.1 | Data serialization |
+| Apache Commons Text | 1.14.0 | String utilities |
+| Apache Commons CLI | 1.11.0 | CLI parsing |
+| Apache Commons Net | 3.12.0 | Network utilities |
+| Commons Logging | 1.3.5 | Logging abstraction |
+| OkHttp | 5.3.0 | HTTP client |
+| Okio | 3.16.3 | I/O library |
+| Logback | 1.5.20 | Logging (HDFS fixture) |
+| SpotBugs Annotations | 4.9.8 | Static analysis |
+| XZ | 1.11 | Compression |
+
+### Netty 4.2 Upgrade Details
+
+The Netty upgrade (PR #19178) is the most significant change:
+
+- Enables Project Reactor integration for reactive streams
+- Prepares infrastructure for HTTP/3 support
+- Closes long-standing issue [#14804](https://github.com/opensearch-project/OpenSearch/issues/14804)
+
+### Migration Notes
+
+- No breaking changes for users
+- Plugin developers using Netty directly should verify compatibility with 4.2.x APIs
+- JAXB upgrade may affect plugins using XML binding (Jakarta namespace migration)
+
+## Limitations
+
+- Netty 4.2 is a prerequisite for HTTP/3 but does not enable it in this release
+- Some transitive dependencies may have version conflicts requiring resolution
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19178](https://github.com/opensearch-project/OpenSearch/pull/19178) | Netty 4.2.4 upgrade |
+| [#19472](https://github.com/opensearch-project/OpenSearch/pull/19472) | JAXB 4.0.6 upgrade |
+| [#19253](https://github.com/opensearch-project/OpenSearch/pull/19253) | Google HTTP Client Gson 2.0.0 |
+| [#19533](https://github.com/opensearch-project/OpenSearch/pull/19533) | Azure Core HTTP Netty 1.16.1 |
+| [#19615](https://github.com/opensearch-project/OpenSearch/pull/19615) | Azure Storage Common 12.30.3 |
+| [#19688](https://github.com/opensearch-project/OpenSearch/pull/19688) | MSAL4J 1.23.1 |
+| [#20023](https://github.com/opensearch-project/OpenSearch/pull/20023) | Google Cloud Storage 2.60.0 |
+| [#20084](https://github.com/opensearch-project/OpenSearch/pull/20084) | Nimbus JOSE+JWT 10.6 |
+| [#19818](https://github.com/opensearch-project/OpenSearch/pull/19818) | Bouncy Castle FIPS 2.1.2 |
+| [#19535](https://github.com/opensearch-project/OpenSearch/pull/19535) | ZooKeeper 3.9.4 |
+| [#19692](https://github.com/opensearch-project/OpenSearch/pull/19692) | Avro 1.12.1 |
+| [#19614](https://github.com/opensearch-project/OpenSearch/pull/19614) | OkHttp 5.3.0 |
+| [#19763](https://github.com/opensearch-project/OpenSearch/pull/19763) | Logback 1.5.20 |
+| [#19536](https://github.com/opensearch-project/OpenSearch/pull/19536) | peter-evans/create-or-update-comment v5 |
+| [#19785](https://github.com/opensearch-project/OpenSearch/pull/19785) | github/codeql-action v4 |
+| [#19781](https://github.com/opensearch-project/OpenSearch/pull/19781) | gradle/actions v5 |
+
+## References
+
+- [Issue #14804](https://github.com/opensearch-project/OpenSearch/issues/14804): Netty 4.2 upgrade request
+- [Netty 4.2 Release Notes](https://netty.io/news/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/dependency-management.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -4,6 +4,7 @@
 
 ### OpenSearch
 
+- [Dependency Updates (OpenSearch Core)](features/opensearch/dependency-updates-opensearch-core.md) - 32 dependency updates including Netty 4.2.4 for HTTP/3 readiness
 - [Security Kerberos Integration](features/opensearch/security-kerberos-integration.md) - Update Hadoop to 3.4.2 and enable Kerberos integration tests for JDK-24+
 - [Stats Builder Pattern Deprecations](features/opensearch/stats-builder-pattern-deprecations.md) - Deprecated constructors in 30+ Stats classes in favor of Builder pattern
 


### PR DESCRIPTION
## Summary

Adds release report for OpenSearch v3.4.0 dependency updates (32 PRs).

### Key Changes
- **Netty 4.2.4**: Major framework upgrade enabling HTTP/3 readiness
- **Cloud SDK updates**: Azure, Google Cloud, and related libraries
- **Security updates**: Nimbus JOSE+JWT 10.6, Bouncy Castle FIPS 2.1.2
- **CI/CD updates**: 8 GitHub Actions version bumps

### Reports
- Release report: `docs/releases/v3.4.0/features/opensearch/dependency-updates-opensearch-core.md`
- Feature report updated: `docs/features/opensearch/dependency-management.md`

Closes #1726