### PR TITLE
docs: add Build Tool Upgrades report for v3.4.0

### DIFF
--- a/docs/features/multi-plugin/build-infrastructure-gradle-jdk.md
+++ b/docs/features/multi-plugin/build-infrastructure-gradle-jdk.md
@@ -48,9 +48,10 @@ graph TB
 
 | Setting | Description | Current Value |
 |---------|-------------|---------------|
-| Gradle Version | Build tool version | 8.14.3 |
-| JDK (CI) | CI workflow JDK version | 24 |
+| Gradle Version | Build tool version | 9.1.0 |
+| JDK (Bundled) | Bundled JDK version | 25.0.1+8 |
 | JDK (Runtime) | Minimum runtime JDK | 21 |
+| JDK Vendor | JDK distribution | Adoptium Temurin |
 | Kotlin Version | Kotlin plugin version | 2.2.0 |
 | Codecov | Code coverage reporting | Enabled |
 
@@ -59,7 +60,7 @@ graph TB
 ```groovy
 // build.gradle - Gradle wrapper configuration
 wrapper {
-    gradleVersion = '8.14.3'
+    gradleVersion = '9.1.0'
     distributionType = Wrapper.DistributionType.ALL
 }
 
@@ -71,7 +72,7 @@ jobs:
     steps:
       - uses: actions/setup-java@v4
         with:
-          java-version: '24'
+          java-version: '25'
           distribution: 'temurin'
 ```
 
@@ -89,14 +90,17 @@ jobs:
 
 ## Limitations
 
-- JDK 24 is used for CI builds; production deployments may use different JDK versions
-- Some third-party dependencies may require updates for full JDK 24 compatibility
+- JDK 25 is bundled; production deployments may use different JDK versions
+- Some third-party dependencies may require updates for full JDK 25 compatibility
 - Gradle version upgrades may require plugin compatibility updates
+- Gradle warning mode temporarily set to `all` pending Protobuf plugin update
 
 ## Related PRs
 
 | Version | PR | Repository | Description |
 |---------|-----|------------|-------------|
+| v3.4.0 | [#19575](https://github.com/opensearch-project/OpenSearch/pull/19575) | OpenSearch | Update to Gradle 9.1 |
+| v3.4.0 | [#19698](https://github.com/opensearch-project/OpenSearch/pull/19698) | OpenSearch | Update bundled JDK to JDK-25 |
 | v3.2.0 | [#2792](https://github.com/opensearch-project/k-NN/pull/2792) | k-NN | Bump JDK to 24, Gradle to 8.14 |
 | v3.2.0 | [#2828](https://github.com/opensearch-project/k-NN/pull/2828) | k-NN | Bump Gradle to 8.14.3 |
 | v3.2.0 | [#3983](https://github.com/opensearch-project/ml-commons/pull/3983) | ml-commons | Gradle 8.14, JDK 24 |
@@ -107,10 +111,13 @@ jobs:
 
 ## References
 
+- [Issue #19314](https://github.com/opensearch-project/OpenSearch/issues/19314): Update bundled JDK to JDK25
 - [OpenSearch automated build system](https://opensearch.org/blog/public-jenkins/): Public Jenkins infrastructure
 - [Gradle Documentation](https://docs.gradle.org/): Official Gradle documentation
+- [Adoptium](https://adoptium.net/): Eclipse Temurin JDK distribution
 - [OpenJDK](https://openjdk.org/): OpenJDK project
 
 ## Change History
 
+- **v3.4.0** (2026-01): Gradle 9.1, bundled JDK 25.0.1+8, forbiddenapis 3.10, Mockito 5.20.0
 - **v3.2.0** (2025): Gradle 8.14/8.14.3, JDK 24 CI support, multi-node testing, Codecov integration, Maven endpoint updates

--- a/docs/releases/v3.4.0/features/opensearch/build-tool-upgrades.md
+++ b/docs/releases/v3.4.0/features/opensearch/build-tool-upgrades.md
@@ -1,0 +1,116 @@
+# Build Tool Upgrades
+
+## Summary
+
+OpenSearch v3.4.0 upgrades the build infrastructure with Gradle 9.1 and bundles JDK 25 as the default runtime. These updates bring modern build tooling, improved performance, and access to the latest Java features and optimizations.
+
+## Details
+
+### What's New in v3.4.0
+
+- **Gradle 9.1**: Major upgrade from Gradle 8.x series, bringing improved build performance and new features
+- **JDK 25**: Bundled JDK updated from JDK 24 to JDK 25.0.1+8 (Adoptium Temurin)
+- **Dependency Updates**: Related tooling updates including forbiddenapis 3.10 and Mockito 5.20.0
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Build Infrastructure v3.4.0"
+        GW[Gradle Wrapper 9.1] --> GB[Gradle Build]
+        JDK25[JDK 25.0.1+8] --> GB
+        GB --> UT[Unit Tests]
+        GB --> IT[Integration Tests]
+        GB --> DIST[Distribution Archives]
+    end
+    
+    subgraph "Updated Dependencies"
+        FA[forbiddenapis 3.10]
+        MOCK[Mockito 5.20.0]
+        SPOCK[Spock 2.4-M6-groovy-4.0]
+    end
+    
+    GB --> FA
+    GB --> MOCK
+    GB --> SPOCK
+```
+
+#### Key File Changes
+
+| File | Change |
+|------|--------|
+| `gradle/wrapper/gradle-wrapper.properties` | Updated to Gradle 9.1.0 |
+| `gradle/libs.versions.toml` | JDK version 24.0.2+12 → 25.0.1+8 |
+| `buildSrc/build.gradle` | Spock 2.3-groovy-3.0 → 2.4-M6-groovy-4.0 |
+| `buildSrc/.../ThirdPartyAuditPrecommitPlugin.java` | forbiddenapis 3.8 → 3.10 |
+| `buildSrc/.../DistroTestPlugin.java` | System/Gradle JDK 24.0.2+12 → 25.0.1+8 |
+
+#### New Configuration
+
+| Setting | Description | New Value |
+|---------|-------------|-----------|
+| `bundled_jdk` | Bundled JDK version | 25.0.1+8 |
+| `bundled_jdk_vendor` | JDK vendor | adoptium |
+| Gradle version | Build tool version | 9.1.0 |
+| forbiddenapis | API checking tool | 3.10 |
+| mockito | Mocking framework | 5.20.0 |
+
+### Usage Example
+
+```properties
+# gradle/wrapper/gradle-wrapper.properties
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.1.0-all.zip
+distributionSha256Sum=b84e04fa845fecba48551f425957641074fcc00a88a84d2aae5808743b35fc85
+```
+
+```toml
+# gradle/libs.versions.toml
+bundled_jdk_vendor = "adoptium"
+bundled_jdk = "25.0.1+8"
+mockito = "5.20.0"
+```
+
+### Migration Notes
+
+1. **Gradle 9 Compatibility**: Build scripts using `$System.env.VARIABLE` syntax must be updated to `System.getenv("VARIABLE")` (already addressed in v3.3.0 across plugins)
+2. **Groovy 4.0**: Spock framework updated to use Groovy 4.0, which may affect custom test code
+3. **Warning Mode**: Gradle warning mode temporarily changed from `fail` to `all` pending Protobuf plugin update
+
+### Build Verification
+
+```bash
+# Verify Gradle version
+./gradlew --version
+
+# Run full build with new tooling
+./gradlew assemble
+
+# Run tests with JDK 25
+./gradlew test
+```
+
+## Limitations
+
+- Gradle warning mode set to `all` instead of `fail` due to pending Protobuf Gradle plugin update
+- Some third-party dependencies may require updates for full JDK 25 compatibility
+- HDFS repository plugin requires additional Kerberos file permission for JDK 25
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19575](https://github.com/opensearch-project/OpenSearch/pull/19575) | Update to Gradle 9.1 |
+| [#19698](https://github.com/opensearch-project/OpenSearch/pull/19698) | Update bundled JDK to JDK-25 |
+
+## References
+
+- [Issue #19314](https://github.com/opensearch-project/OpenSearch/issues/19314): Update bundled JDK to JDK25
+- [Gradle 9.1 Release Notes](https://docs.gradle.org/9.1/release-notes.html): Official Gradle documentation
+- [Adoptium JDK 25](https://adoptium.net/): Eclipse Temurin JDK distribution
+- [OpenSearch Releases](https://opensearch.org/releases/): Official release schedule
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/multi-plugin/build-infrastructure-gradle-jdk.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -4,6 +4,7 @@
 
 ### OpenSearch
 
+- [Build Tool Upgrades](features/opensearch/build-tool-upgrades.md) - Gradle 9.1 and bundled JDK 25 updates
 - [Dependency Updates (OpenSearch Core)](features/opensearch/dependency-updates-opensearch-core.md) - 32 dependency updates including Netty 4.2.4 for HTTP/3 readiness
 - [Security Kerberos Integration](features/opensearch/security-kerberos-integration.md) - Update Hadoop to 3.4.2 and enable Kerberos integration tests for JDK-24+
 - [Stats Builder Pattern Deprecations](features/opensearch/stats-builder-pattern-deprecations.md) - Deprecated constructors in 30+ Stats classes in favor of Builder pattern


### PR DESCRIPTION
## Summary

This PR adds documentation for the Build Tool Upgrades feature in OpenSearch v3.4.0.

### Changes

- **Release Report**: `docs/releases/v3.4.0/features/opensearch/build-tool-upgrades.md`
  - Documents Gradle 9.1 upgrade from 8.x series
  - Documents bundled JDK update to JDK 25.0.1+8 (Adoptium Temurin)
  - Includes related dependency updates (forbiddenapis 3.10, Mockito 5.20.0, Spock 2.4-M6)

- **Feature Report Update**: `docs/features/multi-plugin/build-infrastructure-gradle-jdk.md`
  - Updated configuration table with current Gradle 9.1 and JDK 25 values
  - Added v3.4.0 PRs to Related PRs table
  - Updated Change History with v3.4.0 entry

### Related PRs

- [OpenSearch#19575](https://github.com/opensearch-project/OpenSearch/pull/19575): Update to Gradle 9.1
- [OpenSearch#19698](https://github.com/opensearch-project/OpenSearch/pull/19698): Update bundled JDK to JDK-25

### Related Issue

Closes #1725