### PR TITLE
docs: add lucene-upgrade report for v3.4.0

### DIFF
--- a/docs/features/opensearch/lucene-upgrade.md
+++ b/docs/features/opensearch/lucene-upgrade.md
@@ -69,6 +69,7 @@ GET /_nodes?filter_path=nodes.*.version
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#20026](https://github.com/opensearch-project/OpenSearch/pull/20026) | Bump Apache Lucene from 10.3.1 to 10.3.2 |
 | v3.3.0 | [#19296](https://github.com/opensearch-project/OpenSearch/pull/19296) | Bump Apache Lucene from 10.2.2 to 10.3.0 |
 | v3.3.0 | [k-NN#2878](https://github.com/opensearch-project/k-NN/pull/2878) | Fix KNN build due to Lucene 10.3 upgrade |
 | v3.3.0 | [custom-codecs#277](https://github.com/opensearch-project/custom-codecs/pull/277) | Update for Lucene 10.3 |
@@ -82,6 +83,7 @@ GET /_nodes?filter_path=nodes.*.version
 
 ## References
 
+- [Lucene 10.3.2 Release](https://github.com/apache/lucene/releases/tag/releases%2Flucene%2F10.3.2): Official Lucene 10.3.2 release
 - [Lucene 10.3.0 Changelog](https://lucene.apache.org/core/10_3_0/changes/Changes.html): Official Lucene 10.3.0 release notes
 - [Lucene 10.2.1 Changelog](https://lucene.apache.org/core/10_2_1/changes/Changes.html): Official Lucene 10.2.1 release notes
 - [Lucene 10.2.0 Changelog](https://lucene.apache.org/core/10_2_0/changes/Changes.html): Official Lucene 10.2.0 release notes
@@ -93,6 +95,7 @@ GET /_nodes?filter_path=nodes.*.version
 
 ## Change History
 
+- **v3.4.0**: Upgrade to Apache Lucene 10.3.2. Bug fix release addressing potential EOF exception in MaxScoreBulkScorer during optimized filter iterations (GITHUB#15380).
 - **v3.3.0**: Upgrade to Apache Lucene 10.3.0. New KNN1030Codec for k-NN plugin, Lucene103 codecs for custom-codecs plugin. API changes include new `AcceptDocs` interface replacing `Bits` in vector search, and `IOContext` hints for optimized file access.
 - **v3.3.0**: Migrate deprecated `Operations#union(Automaton, Automaton)` usages to `Operations#union(Collection<Automaton>)` in AutomatonQueries, XContentMapValues, and SystemIndices classes.
 - **v3.1.0**: Upgrade to Apache Lucene 10.2.1 with SeededKnnVectorQuery, binary quantized vector codecs, TopDocs#rrf, and API changes (DisiPriorityQueue, TopScoreDocCollectorManager). Plugin updates: neural-search hybrid query refactoring, learning-to-rank RankerQuery fix.

--- a/docs/releases/v3.4.0/features/opensearch/lucene-upgrade.md
+++ b/docs/releases/v3.4.0/features/opensearch/lucene-upgrade.md
@@ -1,0 +1,68 @@
+# Lucene Upgrade
+
+## Summary
+
+OpenSearch v3.4.0 upgrades Apache Lucene from 10.3.1 to 10.3.2. This is a bug fix release that addresses a potential EOF issue in the MaxScoreBulkScorer during optimized filter iterations.
+
+## Details
+
+### What's New in v3.4.0
+
+This release bumps Lucene from version 10.3.1 to 10.3.2, incorporating a critical bug fix from the Lucene project.
+
+### Technical Changes
+
+#### Bug Fix: MaxScoreBulkScorer EOF Issue
+
+Lucene 10.3.2 fixes a potential EOF (End of File) exception introduced by optimized filter iterations in `MaxScoreBulkScorer`. The issue occurred when the approximation and match verification could get out of sync, resulting in an `EOFException`.
+
+This fix is tracked in [GITHUB#15380](https://github.com/apache/lucene/issues/15380).
+
+#### Updated Components
+
+| Component | Old Version | New Version |
+|-----------|-------------|-------------|
+| lucene-core | 10.3.1 | 10.3.2 |
+| lucene-analysis-common | 10.3.1 | 10.3.2 |
+| lucene-analysis-icu | 10.3.1 | 10.3.2 |
+| lucene-analysis-kuromoji | 10.3.1 | 10.3.2 |
+| lucene-analysis-nori | 10.3.1 | 10.3.2 |
+| lucene-analysis-phonetic | 10.3.1 | 10.3.2 |
+| lucene-analysis-smartcn | 10.3.1 | 10.3.2 |
+| lucene-analysis-stempel | 10.3.1 | 10.3.2 |
+| lucene-analysis-morfologik | 10.3.1 | 10.3.2 |
+| lucene-backward-codecs | 10.3.1 | 10.3.2 |
+| lucene-grouping | 10.3.1 | 10.3.2 |
+| lucene-highlighter | 10.3.1 | 10.3.2 |
+| lucene-expressions | 10.3.1 | 10.3.2 |
+
+#### Version Mapping Update
+
+The OpenSearch version mapping was updated to associate v3.4.0 with Lucene 10.3.2:
+
+```java
+public static final Version V_3_4_0 = new Version(3040099, org.apache.lucene.util.Version.LUCENE_10_3_2);
+```
+
+### Migration Notes
+
+No migration steps are required. This is a minor version bump with backward-compatible changes.
+
+## Limitations
+
+- This is a bug fix release with no new features from Lucene
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#20026](https://github.com/opensearch-project/OpenSearch/pull/20026) | Bump lucene version from 10.3.1 to 10.3.2 |
+
+## References
+
+- [Lucene 10.3.2 Release](https://github.com/apache/lucene/releases/tag/releases%2Flucene%2F10.3.2): Official Lucene 10.3.2 release
+- [GITHUB#15380](https://github.com/apache/lucene/issues/15380): Fix potential EOF in MaxScoreBulkScorer
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/lucene-upgrade.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -6,6 +6,7 @@
 
 - [Build Tool Upgrades](features/opensearch/build-tool-upgrades.md) - Gradle 9.1 and bundled JDK 25 updates
 - [Dependency Updates (OpenSearch Core)](features/opensearch/dependency-updates-opensearch-core.md) - 32 dependency updates including Netty 4.2.4 for HTTP/3 readiness
+- [Lucene Upgrade](features/opensearch/lucene-upgrade.md) - Bump Apache Lucene from 10.3.1 to 10.3.2 with MaxScoreBulkScorer bug fix
 - [Security Kerberos Integration](features/opensearch/security-kerberos-integration.md) - Update Hadoop to 3.4.2 and enable Kerberos integration tests for JDK-24+
 - [Stats Builder Pattern Deprecations](features/opensearch/stats-builder-pattern-deprecations.md) - Deprecated constructors in 30+ Stats classes in favor of Builder pattern
 


### PR DESCRIPTION
## Summary

Add documentation for Lucene upgrade from 10.3.1 to 10.3.2 in OpenSearch v3.4.0.

### Changes
- Created release report: `docs/releases/v3.4.0/features/opensearch/lucene-upgrade.md`
- Updated feature report: `docs/features/opensearch/lucene-upgrade.md`
- Updated release index: `docs/releases/v3.4.0/index.md`

### Key Points
- Bug fix release addressing potential EOF exception in MaxScoreBulkScorer (GITHUB#15380)
- All Lucene components updated from 10.3.1 to 10.3.2
- No migration required

Closes #1724