### PR TITLE
docs: add settings-bugfixes report for v3.4.0

### DIFF
--- a/docs/features/opensearch/settings-management.md
+++ b/docs/features/opensearch/settings-management.md
@@ -133,6 +133,7 @@ PUT /_cluster/settings
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#20140](https://github.com/opensearch-project/OpenSearch/pull/20140) | Fix duplicate registration of FieldDataCache dynamic setting |
 | v3.2.0 | [#18885](https://github.com/opensearch-project/OpenSearch/pull/18885) | Ignore archived settings on update |
 | v2.10.0 | [#9019](https://github.com/opensearch-project/OpenSearch/pull/9019) | Add support to clear archived index settings |
 
@@ -140,10 +141,11 @@ PUT /_cluster/settings
 
 - [Issue #8714](https://github.com/opensearch-project/OpenSearch/issues/8714): Unable to change any cluster setting with archived settings
 - [Issue #18515](https://github.com/opensearch-project/OpenSearch/issues/18515): Cannot update cluster settings after upgrading to 3.0.0
-- [Cluster Settings API](https://docs.opensearch.org/3.2/api-reference/cluster-api/cluster-settings/): Official API documentation
-- [Configuring OpenSearch](https://docs.opensearch.org/3.2/install-and-configure/configuring-opensearch/): Configuration guide
+- [Cluster Settings API](https://docs.opensearch.org/3.0/api-reference/cluster-api/cluster-settings/): Official API documentation
+- [Configuring OpenSearch](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/): Configuration guide
 
 ## Change History
 
+- **v3.4.0** (2026-01): Fixed duplicate registration of dynamic settings (FieldDataCache, QueryCache) that caused memory issues on cluster manager nodes
 - **v3.2.0** (2026-01): Fixed issue where archived settings blocked all settings updates
 - **v2.10.0** (2023-08): Added support to clear archived index settings on closed indices

--- a/docs/releases/v3.4.0/features/opensearch/settings-bugfixes.md
+++ b/docs/releases/v3.4.0/features/opensearch/settings-bugfixes.md
@@ -1,0 +1,98 @@
+# Settings Bugfixes
+
+## Summary
+
+OpenSearch v3.4.0 includes two important bugfixes related to settings management: fixing duplicate registration of dynamic settings that caused memory issues on cluster manager nodes, and resolving build system issues when updating to patch versions other than 0.
+
+## Details
+
+### What's New in v3.4.0
+
+#### Fix Duplicate Registration of FieldDataCache Dynamic Setting
+
+A critical bug was discovered where the `indices.fielddata.cache.size` and `indices.queries.cache.skip_cache_factor` settings were being registered multiple times during index creation/update operations. This caused the `settingUpdaters` list to grow unbounded, eventually leading to memory issues on active cluster manager nodes.
+
+**Root Cause**: During index metadata verification, temporary `IndicesFieldDataCache` and `IndicesQueryCache` objects were created, which registered their dynamic settings with the cluster settings. These temporary objects were later closed, but the settings remained registered, causing duplicates with each index operation.
+
+**Fix**: The fix removes the creation of temporary cache objects during metadata verification, as they are not needed for validation purposes.
+
+#### Fix Patch Version Update Issue
+
+A bug in the build system prevented version bumps to patch versions other than 0 (e.g., 3.3.1). Running `./gradlew localDistro` would fail with:
+
+```
+Expected exactly 2 majors in parsed versions but found: [2, 3, 6, 7]
+```
+
+**Root Cause**: The `BwcVersions` class was parsing both the current version file and a legacy ES version file. When the patch version was non-zero, a code path was triggered that incorrectly included legacy ES major versions (6, 7) in the version list.
+
+**Fix**: Removed references to the legacy ES version file, which is no longer relevant as ES versions are more than 2 major versions in the past.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before Fix (PR #20140)"
+        A1[Index Create/Update] --> B1[verifyIndexMetadata]
+        B1 --> C1[Create temp IndicesFieldDataCache]
+        B1 --> D1[Create temp IndicesQueryCache]
+        C1 --> E1[Register settings - DUPLICATE]
+        D1 --> E1
+        E1 --> F1[settingUpdaters list grows]
+        F1 --> G1[Memory issues on CM node]
+    end
+    
+    subgraph "After Fix (PR #20140)"
+        A2[Index Create/Update] --> B2[verifyIndexMetadata]
+        B2 --> H2[Skip temp cache creation]
+        H2 --> I2[No duplicate registration]
+    end
+```
+
+#### Code Changes
+
+| Component | Change | PR |
+|-----------|--------|-----|
+| `IndicesService.verifyIndexMetadata()` | Removed creation of temporary `IndicesFieldDataCache` and `IndicesQueryCache` | #20140 |
+| `AbstractScopedSettings` | Added `getSettingUpdaters()` method for debugging/testing | #20140 |
+| `GlobalBuildInfoPlugin` | Removed legacy ES version file parsing | #19377 |
+
+#### New Test Coverage
+
+| Test | Description |
+|------|-------------|
+| `ClusterSettingsIT.testWithMultipleIndexCreationAndVerifySettingRegisteredOnce` | Verifies settings are registered exactly once across multiple index operations |
+
+### Usage Example
+
+To verify settings are not duplicated, you can check the cluster settings:
+
+```bash
+GET /_cluster/settings?include_defaults=true&flat_settings=true
+```
+
+### Migration Notes
+
+No migration required. These are internal bugfixes that take effect automatically after upgrading to v3.4.0.
+
+## Limitations
+
+- The fix for duplicate settings registration only prevents future duplicates; existing clusters with bloated `settingUpdaters` lists will need a cluster manager restart to clear the duplicates.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#20140](https://github.com/opensearch-project/OpenSearch/pull/20140) | Fix duplicate registration of FieldDataCache dynamic setting |
+| [#19377](https://github.com/opensearch-project/OpenSearch/pull/19377) | Fix issue with updating core with a patch number other than 0 |
+
+## References
+
+- [opensearch-build#5720](https://github.com/opensearch-project/opensearch-build/issues/5720): Related build issue for patch version updates
+- [Cluster Settings API](https://docs.opensearch.org/3.0/api-reference/cluster-api/cluster-settings/): Official API documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/settings-management.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -8,6 +8,7 @@
 - [Dependency Updates (OpenSearch Core)](features/opensearch/dependency-updates-opensearch-core.md) - 32 dependency updates including Netty 4.2.4 for HTTP/3 readiness
 - [Lucene Upgrade](features/opensearch/lucene-upgrade.md) - Bump Apache Lucene from 10.3.1 to 10.3.2 with MaxScoreBulkScorer bug fix
 - [Security Kerberos Integration](features/opensearch/security-kerberos-integration.md) - Update Hadoop to 3.4.2 and enable Kerberos integration tests for JDK-24+
+- [Settings Bugfixes](features/opensearch/settings-bugfixes.md) - Fix duplicate registration of dynamic settings and patch version build issues
 - [Stats Builder Pattern Deprecations](features/opensearch/stats-builder-pattern-deprecations.md) - Deprecated constructors in 30+ Stats classes in favor of Builder pattern
 
 ### OpenSearch Dashboards


### PR DESCRIPTION
## Summary

This PR adds documentation for the Settings Bugfixes release item in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch/settings-bugfixes.md`
- Feature report: `docs/features/opensearch/settings-management.md` (updated)

### Key Changes in v3.4.0

1. **Fix duplicate registration of FieldDataCache dynamic setting** (PR #20140)
   - Fixed memory issues on cluster manager nodes caused by duplicate setting registrations
   - Removed unnecessary temporary cache object creation during index metadata verification

2. **Fix patch version update issue** (PR #19377)
   - Fixed build system issue preventing version bumps to patch versions other than 0
   - Removed legacy ES version file references from build configuration

### Resources Used
- PR: #20140, #19377
- Docs: https://docs.opensearch.org/3.0/api-reference/cluster-api/cluster-settings/

Closes #1723