### PR TITLE
docs: add node-stats-bugfixes report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -97,6 +97,7 @@
 - [Netty Arena Settings](opensearch/netty-arena-settings.md)
 - [Network Configuration](opensearch/network-configuration.md)
 - [Node Join/Leave](opensearch/node-join-leave.md)
+- [Node Stats](opensearch/node-stats.md)
 - [Nodes Info API](opensearch/nodes-info-api.md)
 - [Node Roles Configuration](opensearch/node-roles-configuration.md)
 - [Numeric Terms Aggregation Optimization](opensearch/numeric-terms-aggregation-optimization.md)

--- a/docs/features/opensearch/node-stats.md
+++ b/docs/features/opensearch/node-stats.md
@@ -1,0 +1,176 @@
+# Node Stats
+
+## Summary
+
+Node Stats provides comprehensive statistics about OpenSearch cluster nodes through the `/_nodes/stats` API. This feature enables monitoring of node health, resource usage, and performance metrics including CPU, memory, JVM, disk I/O, and various OpenSearch-specific statistics. The API is essential for cluster monitoring, capacity planning, and troubleshooting.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Client"
+        REQ[Stats Request]
+    end
+    
+    subgraph "OpenSearch Node"
+        API[REST API Handler]
+        NSA[NodesStatsAction]
+        
+        subgraph "Stats Collectors"
+            OS[OS Stats]
+            JVM[JVM Stats]
+            PROC[Process Stats]
+            FS[Filesystem Stats]
+            IDX[Index Stats]
+            TP[Thread Pool Stats]
+        end
+        
+        subgraph "System Resources"
+            CGROUP[cgroup Files]
+            PROC_FS[/proc Filesystem]
+            SYS_FS[/sys Filesystem]
+        end
+    end
+    
+    REQ --> API
+    API --> NSA
+    NSA --> OS
+    NSA --> JVM
+    NSA --> PROC
+    NSA --> FS
+    NSA --> IDX
+    NSA --> TP
+    
+    OS --> CGROUP
+    OS --> PROC_FS
+    FS --> SYS_FS
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Client Request] --> B[REST Handler]
+    B --> C[NodesStatsRequest]
+    C --> D[Transport Action]
+    D --> E[Node Stats Collection]
+    E --> F[Aggregate Response]
+    F --> G[JSON Response]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `NodesStatsRequest` | Request object specifying which metrics to collect |
+| `NodesStatsResponse` | Response containing statistics from all requested nodes |
+| `NodeStats` | Statistics for a single node |
+| `OsStats` | Operating system statistics (CPU, memory, swap) |
+| `ProcessStats` | Process-level statistics (file descriptors, CPU time) |
+| `JvmStats` | JVM statistics (heap, GC, threads) |
+| `FsInfo` | Filesystem statistics (disk space, I/O) |
+| `ThreadPoolStats` | Thread pool statistics per pool |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| N/A | Node stats is always available | - |
+
+### API Endpoints
+
+```
+GET /_nodes/stats
+GET /_nodes/<node_id>/stats
+GET /_nodes/stats/<metric>
+GET /_nodes/<node_id>/stats/<metric>
+GET /_nodes/stats/<metric>/<index_metric>
+```
+
+### Available Metrics
+
+| Metric | Description |
+|--------|-------------|
+| `indices` | Index statistics (docs, store, indexing, search, etc.) |
+| `os` | OS statistics (CPU, memory, swap, cgroup) |
+| `process` | Process statistics (file descriptors, CPU) |
+| `jvm` | JVM statistics (heap, GC, threads, buffer pools) |
+| `thread_pool` | Thread pool statistics |
+| `fs` | Filesystem statistics |
+| `transport` | Transport layer statistics |
+| `http` | HTTP layer statistics |
+| `breaker` | Circuit breaker statistics |
+| `script` | Script compilation statistics |
+| `discovery` | Cluster discovery statistics |
+| `ingest` | Ingest pipeline statistics |
+
+### Usage Example
+
+```bash
+# Get all stats for all nodes
+GET /_nodes/stats
+
+# Get specific metrics
+GET /_nodes/stats/os,jvm
+
+# Get stats for specific node
+GET /_nodes/node1/stats
+
+# Example response (partial)
+{
+  "nodes": {
+    "node_id": {
+      "os": {
+        "cpu": {
+          "percent": 12,
+          "load_average": {
+            "1m": 0.5,
+            "5m": 0.4,
+            "15m": 0.3
+          }
+        },
+        "mem": {
+          "total_in_bytes": 17179869184,
+          "free_in_bytes": 8589934592,
+          "used_percent": 50
+        }
+      }
+    }
+  }
+}
+```
+
+### Security Policy (cgroup access)
+
+OpenSearch requires read access to cgroup files for CPU statistics on Linux:
+
+```
+/sys/fs/cgroup/cpu
+/sys/fs/cgroup/cpuacct
+/sys/fs/cgroup/cpu,cpuacct  # Combined controller (added in v3.4.0)
+/sys/fs/cgroup/cpuset
+/sys/fs/cgroup/memory
+```
+
+## Limitations
+
+- CPU statistics may show -1 on systems where cgroup files are not accessible
+- Some metrics are platform-specific (e.g., cgroup stats are Linux-only)
+- High-frequency polling can impact cluster performance
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#20108](https://github.com/opensearch-project/OpenSearch/pull/20108) | Fix negative CPU usage values by adding cgroup permissions |
+
+## References
+
+- [Issue #19120](https://github.com/opensearch-project/OpenSearch/issues/19120): Bug report for negative CPU values
+- [Nodes Stats API Documentation](https://docs.opensearch.org/3.0/api-reference/nodes-apis/nodes-stats/): Official API documentation
+
+## Change History
+
+- **v3.4.0** (2026-01-11): Fixed negative CPU usage values on Linux systems with combined cpu,cpuacct cgroup controller

--- a/docs/releases/v3.4.0/features/opensearch/node-stats-bugfixes.md
+++ b/docs/releases/v3.4.0/features/opensearch/node-stats-bugfixes.md
@@ -1,0 +1,73 @@
+# Node Stats Bugfixes
+
+## Summary
+
+This release fixes a bug where the `_cat/nodes` and `_nodes/stats` APIs reported negative CPU usage values (-1) on certain Linux distributions. The issue occurred because OpenSearch lacked file permissions to read CPU-related cgroup paths on systems using the combined `cpu,cpuacct` cgroup controller.
+
+## Details
+
+### What's New in v3.4.0
+
+The fix adds read permissions for additional cgroup paths in OpenSearch's security policy, enabling proper CPU statistics collection on Linux distributions that use combined cgroup controllers.
+
+### Technical Changes
+
+#### Root Cause
+
+On certain Linux distributions (particularly RHEL 8.x and similar), the cgroup filesystem uses a combined `cpu,cpuacct` controller path instead of separate `cpu` and `cpuacct` paths. OpenSearch's security policy only granted read permissions for the separate paths, causing CPU stat collection to fail silently and return -1.
+
+#### Security Policy Changes
+
+| Path | Permission | Purpose |
+|------|------------|---------|
+| `/sys/fs/cgroup/cpu,cpuacct` | read | Combined CPU accounting cgroup directory |
+| `/sys/fs/cgroup/cpu,cpuacct/-` | read | Files within combined cgroup |
+| `/sys/fs/cgroup/cpuset/-` | read | CPU set files |
+
+#### Affected APIs
+
+- `GET /_cat/nodes` - CPU column showed -1
+- `GET /_nodes/stats` - `os.cpu.percent` returned -1
+- `GET /_cluster/stats` - CPU statistics were incorrect
+
+### Usage Example
+
+After the fix, CPU statistics are correctly reported:
+
+```bash
+# Before fix (on affected systems)
+$ curl "/_cat/nodes?v&h=name,cpu"
+name                              cpu
+opensearch-node-1                 -1
+opensearch-node-2                 -1
+
+# After fix
+$ curl "/_cat/nodes?v&h=name,cpu"
+name                              cpu
+opensearch-node-1                 12
+opensearch-node-2                 8
+```
+
+### Migration Notes
+
+No migration required. The fix is automatically applied when upgrading to v3.4.0.
+
+## Limitations
+
+- This fix specifically addresses Linux systems using cgroups v1 with combined controllers
+- Systems using cgroups v2 may have different path structures
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#20108](https://github.com/opensearch-project/OpenSearch/pull/20108) | Add file permissions for 'cpu,cpuacct' cgroup |
+
+## References
+
+- [Issue #19120](https://github.com/opensearch-project/OpenSearch/issues/19120): Original bug report for negative CPU usage values
+- [Nodes Stats API Documentation](https://docs.opensearch.org/3.0/api-reference/nodes-apis/nodes-stats/): Official API documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/node-stats.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -7,6 +7,7 @@
 - [Build Tool Upgrades](features/opensearch/build-tool-upgrades.md) - Gradle 9.1 and bundled JDK 25 updates
 - [Dependency Updates (OpenSearch Core)](features/opensearch/dependency-updates-opensearch-core.md) - 32 dependency updates including Netty 4.2.4 for HTTP/3 readiness
 - [Lucene Upgrade](features/opensearch/lucene-upgrade.md) - Bump Apache Lucene from 10.3.1 to 10.3.2 with MaxScoreBulkScorer bug fix
+- [Node Stats Bugfixes](features/opensearch/node-stats-bugfixes.md) - Fix negative CPU usage values in node stats on certain Linux distributions
 - [Security Kerberos Integration](features/opensearch/security-kerberos-integration.md) - Update Hadoop to 3.4.2 and enable Kerberos integration tests for JDK-24+
 - [Settings Bugfixes](features/opensearch/settings-bugfixes.md) - Fix duplicate registration of dynamic settings and patch version build issues
 - [Stats Builder Pattern Deprecations](features/opensearch/stats-builder-pattern-deprecations.md) - Deprecated constructors in 30+ Stats classes in favor of Builder pattern


### PR DESCRIPTION
## Summary

This PR adds documentation for the Node Stats Bugfixes release item in v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch/node-stats-bugfixes.md`
- Feature report: `docs/features/opensearch/node-stats.md` (new)

### Key Changes in v3.4.0
- Fixed negative CPU usage values (-1) in `_cat/nodes` and `_nodes/stats` APIs
- Added file permissions for `cpu,cpuacct` combined cgroup controller path
- Affects Linux systems using cgroups v1 with combined controllers (e.g., RHEL 8.x)

### Related
- Resolves GitHub Issue #1722
- Based on OpenSearch PR [#20108](https://github.com/opensearch-project/OpenSearch/pull/20108)
- Fixes [Issue #19120](https://github.com/opensearch-project/OpenSearch/issues/19120)