### PR TITLE
docs: add bulk-request-bugfixes report for v3.4.0

### DIFF
--- a/docs/features/opensearch/bulk-api.md
+++ b/docs/features/opensearch/bulk-api.md
@@ -126,6 +126,7 @@ POST _bulk
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#20132](https://github.com/opensearch-project/OpenSearch/pull/20132) | Fix `indices` property initialization during deserialization |
 | v3.0.0 | [#17801](https://github.com/opensearch-project/OpenSearch/pull/17801) | Remove deprecated `batch_size` parameter |
 | v2.9.0 | [#8039](https://github.com/opensearch-project/OpenSearch/pull/8039) | Enforce 512 byte document ID limit |
 | v2.14.0 | [#12457](https://github.com/opensearch-project/OpenSearch/pull/12457) | Add batch processing for ingest processors |
@@ -138,6 +139,7 @@ POST _bulk
 
 ## Change History
 
+- **v3.4.0** (2026-01-14): Fixed `indices` property not being initialized during deserialization
 - **v3.0.0** (2025-05-13): Removed deprecated `batch_size` parameter; batch processing is now automatic
 - **v2.14.0** (2024-04-30): Added `batch_size` parameter for ingest pipeline batch processing (deprecated)
 - **v2.9.0** (2023-07-18): Enforced 512 byte document ID limit in bulk updates

--- a/docs/releases/v3.4.0/features/opensearch/bulk-request-bugfixes.md
+++ b/docs/releases/v3.4.0/features/opensearch/bulk-request-bugfixes.md
@@ -1,0 +1,103 @@
+# Bulk Request Bugfixes
+
+## Summary
+
+This release fixes a bug in `BulkRequest` where the `indices` property was not properly initialized during deserialization from a `TransportRequest` stream. The fix ensures that the `getIndices()` method returns the correct set of index names after a bulk request is serialized and deserialized, which is critical for proper request routing when ingest pipelines are involved.
+
+## Details
+
+### What's New in v3.4.0
+
+Fixed the handling of the `indices` property in `BulkRequest` during deserialization. Previously, the `indices` Set was empty after deserialization because it was neither serialized nor reconstructed from the request items.
+
+### Technical Changes
+
+#### The Problem
+
+The `BulkRequest` class maintains an `indices` property that provides a shortcut to retrieve all index names referenced in bulk items. This Set is populated when documents are added via `add()` methods. However:
+
+1. The `indices` property was not serialized in `writeTo()`
+2. The deserialization constructor did not reconstruct the `indices` Set from the request items
+3. After serialization/deserialization, `getIndices()` returned an empty Set
+
+#### When This Occurs
+
+This bug manifests in specific scenarios involving ingest pipelines:
+
+```mermaid
+flowchart TB
+    A[Client sends BulkRequest] --> B{Node has ingest role?}
+    B -->|Yes| C[Process locally]
+    B -->|No| D[Serialize & forward to ingest node]
+    D --> E[Deserialize BulkRequest]
+    E --> F[indices Set is EMPTY - BUG]
+    F --> G[Potential routing issues]
+```
+
+The issue occurs when:
+1. A bulk request is sent to a node without the "ingest" role
+2. The request is serialized and forwarded to an ingest node
+3. After deserialization, the `indices` property is empty
+
+#### The Fix
+
+A single line was added to the `BulkRequest` deserialization constructor to reconstruct the `indices` Set:
+
+```java
+public BulkRequest(StreamInput in) throws IOException {
+    super(in);
+    waitForActiveShards = ActiveShardCount.readFrom(in);
+    requests.addAll(in.readList(i -> DocWriteRequest.readDocumentRequest(null, i)));
+    refreshPolicy = RefreshPolicy.readFrom(in);
+    timeout = in.readTimeValue();
+    if (in.getVersion().onOrAfter(Version.V_2_14_0) && in.getVersion().before(Version.V_3_0_0)) {
+        in.readInt(); // formerly batch_size
+    }
+    // NEW: Reconstruct indices Set from deserialized requests
+    requests.stream().map(DocWriteRequest::index).forEach(indices::add);
+}
+```
+
+### Usage Example
+
+After this fix, the following behavior is guaranteed:
+
+```java
+// Create bulk request
+BulkRequest bulkRequest = new BulkRequest()
+    .add(new IndexRequest("index1").id("1").source(Map.of("field", "value")))
+    .add(new IndexRequest("index2").id("2").source(Map.of("field", "value")));
+
+// Serialize
+BytesStreamOutput out = new BytesStreamOutput();
+bulkRequest.writeTo(out);
+
+// Deserialize
+BulkRequest deserializedRequest = new BulkRequest(out.bytes().streamInput());
+
+// Now correctly returns {"index1", "index2"}
+Set<String> indices = deserializedRequest.getIndices();
+```
+
+### Migration Notes
+
+No migration required. This is a transparent bug fix that ensures correct behavior.
+
+## Limitations
+
+- This fix only affects the deserialization path; the `indices` property is still not explicitly serialized (it's reconstructed from the request items)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#20132](https://github.com/opensearch-project/OpenSearch/pull/20132) | Fixed handling of property index in BulkRequest during deserialization |
+
+## References
+
+- [TransportBulkAction.java](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/bulk/TransportBulkAction.java): Code showing when serialization occurs
+- [Bulk API Documentation](https://docs.opensearch.org/3.0/api-reference/document-apis/bulk/): Official documentation
+
+## Related Feature Report
+
+- [Full Bulk API documentation](../../../features/opensearch/bulk-api.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -27,6 +27,10 @@
 
 ## Bug Fixes
 
+### OpenSearch
+
+- [Bulk Request Bugfixes](features/opensearch/bulk-request-bugfixes.md) - Fix indices property initialization during BulkRequest deserialization
+
 ### OpenSearch Dashboards
 
 - [Dashboards Console](features/opensearch-dashboards/dashboards-console.md) - Fix for console_polling setting update


### PR DESCRIPTION
## Summary

This PR adds documentation for the Bulk Request bugfix in OpenSearch v3.4.0.

### Changes

- Created release report: `docs/releases/v3.4.0/features/opensearch/bulk-request-bugfixes.md`
- Updated feature report: `docs/features/opensearch/bulk-api.md` (added v3.4.0 to change history and related PRs)
- Updated release index: `docs/releases/v3.4.0/index.md`

### Bug Fixed

PR [#20132](https://github.com/opensearch-project/OpenSearch/pull/20132) fixes a bug where the `indices` property in `BulkRequest` was not properly initialized during deserialization. This caused `getIndices()` to return an empty Set after a bulk request was serialized and forwarded to another node (e.g., when routing to an ingest node).

### Related Issue

Closes #1721