### PR TITLE
docs: add Data Stream & Index Template Bugfixes report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -45,6 +45,7 @@
 - [Concurrent Segment Search](opensearch/concurrent-segment-search.md)
 - [Crypto KMS Plugin](opensearch/crypto-kms-plugin.md)
 - [Custom Index Name Resolver](opensearch/custom-index-name-resolver.md)
+- [Data Stream & Index Template](opensearch/data-stream-index-template.md)
 - [Date Format](opensearch/date-format.md)
 - [Deprecated Code Cleanup](opensearch/deprecated-code-cleanup.md)
 - [DocRequest Refactoring](opensearch/docrequest-refactoring.md)

--- a/docs/features/opensearch/data-stream-index-template.md
+++ b/docs/features/opensearch/data-stream-index-template.md
@@ -1,0 +1,139 @@
+# Data Stream & Index Template
+
+## Summary
+
+Data streams provide a convenient way to manage time-series data in OpenSearch. They automatically handle index rollovers and simplify the management of continuously generated data like logs, events, and metrics. Index templates define the settings, mappings, and aliases that are applied when creating backing indexes for data streams.
+
+When multiple index templates match a data stream's name pattern, OpenSearch uses the template with the highest priority value. This feature documentation covers the interaction between data streams and index templates, including template priority resolution and lifecycle management.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Index Template Resolution"
+        DS[Data Stream Name]
+        T1[Template A<br/>priority: 50]
+        T2[Template B<br/>priority: 51]
+        T3[Template C<br/>priority: 49]
+        
+        DS --> |pattern match| T1
+        DS --> |pattern match| T2
+        DS --> |pattern match| T3
+        
+        T2 --> |highest priority wins| USED[Used Template]
+        T1 --> |unused| UNUSED1[Can be deleted]
+        T3 --> |unused| UNUSED2[Can be deleted]
+    end
+    
+    subgraph "Data Stream"
+        USED --> BI1[Backing Index 1]
+        USED --> BI2[Backing Index 2]
+        USED --> BI3[Backing Index N]
+    end
+```
+
+### Template Priority Resolution
+
+When creating a data stream or its backing indexes, OpenSearch:
+
+1. Finds all composable index templates whose patterns match the data stream name
+2. Selects the template with the highest `priority` value
+3. Applies that template's settings, mappings, and aliases to the backing index
+
+```mermaid
+flowchart LR
+    A[Index/Data Stream Name] --> B{Find Matching Templates}
+    B --> C[Template 1: priority 50]
+    B --> D[Template 2: priority 100]
+    B --> E[Template 3: priority 75]
+    C --> F{Compare Priorities}
+    D --> F
+    E --> F
+    F --> G[Select Highest: Template 2]
+    G --> H[Apply to Index]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `MetadataIndexTemplateService` | Manages index template CRUD operations and template resolution |
+| `ComposableIndexTemplate` | Represents a v2 index template with priority support |
+| `DataStream` | Represents a data stream and its backing indexes |
+| `findV2Template()` | Resolves the highest-priority matching template for an index name |
+| `dataStreamsUsingTemplate()` | Identifies which data streams actively use a specific template |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `priority` | Template priority for conflict resolution | `0` |
+| `index_patterns` | Patterns to match index/data stream names | Required |
+| `data_stream` | Object indicating this is a data stream template | `{}` for data streams |
+
+### Usage Example
+
+```json
+// Create a base template with lower priority
+PUT _index_template/logs-base
+{
+  "index_patterns": ["logs-*"],
+  "data_stream": {},
+  "priority": 100,
+  "template": {
+    "settings": {
+      "number_of_shards": 1,
+      "number_of_replicas": 1
+    }
+  }
+}
+
+// Create a specific template with higher priority
+PUT _index_template/logs-nginx
+{
+  "index_patterns": ["logs-nginx-*"],
+  "data_stream": {},
+  "priority": 200,
+  "template": {
+    "settings": {
+      "number_of_shards": 3,
+      "number_of_replicas": 2
+    }
+  }
+}
+
+// Create data stream - uses logs-nginx template (priority 200)
+PUT _data_stream/logs-nginx-access
+
+// Check which template is used
+GET _data_stream/logs-nginx-access
+
+// Delete unused template (works in v3.4.0+)
+DELETE _index_template/logs-base
+```
+
+## Limitations
+
+- Template priority must be a non-negative integer
+- When priorities are equal, behavior is undefined (avoid this scenario)
+- Legacy (v1) index templates don't support the `priority` field
+- Data stream templates require the `data_stream` object to be present
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#20102](https://github.com/opensearch-project/OpenSearch/pull/20102) | Fix deletion of unused templates matching data streams |
+
+## References
+
+- [Issue #20078](https://github.com/opensearch-project/OpenSearch/issues/20078): Bug report for template deletion failure
+- [Issue #9194](https://github.com/opensearch-project/OpenSearch/issues/9194): Earlier related fix
+- [Data Streams Documentation](https://docs.opensearch.org/3.0/im-plugin/data-streams/): Official documentation
+- [Index Templates Documentation](https://docs.opensearch.org/3.0/im-plugin/index-templates/): Template configuration guide
+
+## Change History
+
+- **v3.4.0** (2025-12-09): Fixed bug preventing deletion of unused index templates that match data stream patterns but have lower priority than the active template

--- a/docs/releases/v3.4.0/features/opensearch/data-stream-index-template-bugfixes.md
+++ b/docs/releases/v3.4.0/features/opensearch/data-stream-index-template-bugfixes.md
@@ -1,0 +1,102 @@
+# Data Stream & Index Template Bugfixes
+
+## Summary
+
+This release fixes a bug where unused index templates matching a data stream pattern could not be deleted when a higher-priority template was actually being used by the data stream. Previously, OpenSearch incorrectly reported that lower-priority templates were "in use" even though they weren't the active template for any data stream.
+
+## Details
+
+### What's New in v3.4.0
+
+Fixed the deletion logic for composable index templates to correctly identify which template is actually being used by a data stream based on priority.
+
+### Technical Changes
+
+#### Problem Description
+
+When multiple index templates match a data stream's name pattern:
+1. OpenSearch uses the template with the **highest priority** for the data stream
+2. Lower-priority templates that also match the pattern are **not used**
+3. Before this fix, attempting to delete unused lower-priority templates failed with:
+   ```
+   unable to remove composable templates [template-name] as they are in use by a data streams [stream-name]
+   ```
+
+#### Root Cause
+
+The `dataStreamsUsingTemplate()` method in `MetadataIndexTemplateService` only checked if a template's index pattern matched a data stream name, without verifying if that template was actually the highest-priority template being used.
+
+#### Fix Implementation
+
+The fix modifies two key methods in `MetadataIndexTemplateService.java`:
+
+1. **`dataStreamsUsingTemplate()`**: Now calls `findV2Template()` to verify the template is actually the highest-priority match before reporting it as "in use"
+
+2. **`findV2Template()`**: Optimized to track the winner during iteration instead of collecting all matches and sorting afterward
+
+```java
+// Before: Only checked pattern match
+dataStreams.stream()
+    .filter(stream -> Regex.simpleMatch(indexPattern, stream))
+    .forEach(matches::add);
+
+// After: Verifies template is actually used
+dataStreams.stream()
+    .filter(stream -> Regex.simpleMatch(indexPattern, stream))
+    .filter(stream -> {
+        final String usingTemplate = findV2Template(state.metadata(), stream, false);
+        return templateName.equals(usingTemplate);
+    })
+    .forEach(matches::add);
+```
+
+### Usage Example
+
+```json
+// Create two templates with different priorities
+PUT _index_template/test
+{
+  "index_patterns": ["test*"],
+  "data_stream": {},
+  "priority": 50
+}
+
+PUT _index_template/test-data-stream
+{
+  "index_patterns": ["test"],
+  "data_stream": {},
+  "priority": 51
+}
+
+// Create data stream (uses test-data-stream due to higher priority)
+PUT _data_stream/test
+
+// Now you can delete the unused lower-priority template
+DELETE _index_template/test
+// Success! (Previously failed with "in use" error)
+```
+
+### Migration Notes
+
+No migration required. This is a bugfix that enables previously blocked operations.
+
+## Limitations
+
+- The fix only applies to composable index templates (v2 templates)
+- Legacy index templates are not affected by this change
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#20102](https://github.com/opensearch-project/OpenSearch/pull/20102) | Fix deletion failure of unused index template matching data stream |
+
+## References
+
+- [Issue #20078](https://github.com/opensearch-project/OpenSearch/issues/20078): Original bug report
+- [Issue #9194](https://github.com/opensearch-project/OpenSearch/issues/9194): Related earlier fix for non-data-stream templates
+- [Data Streams Documentation](https://docs.opensearch.org/3.0/im-plugin/data-streams/): Official docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/data-stream-index-template.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -30,6 +30,7 @@
 ### OpenSearch
 
 - [Bulk Request Bugfixes](features/opensearch/bulk-request-bugfixes.md) - Fix indices property initialization during BulkRequest deserialization
+- [Data Stream & Index Template Bugfixes](features/opensearch/data-stream-index-template-bugfixes.md) - Fix deletion of unused index templates matching data streams with lower priority
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Data Stream & Index Template Bugfixes in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch/data-stream-index-template-bugfixes.md`
- Feature report: `docs/features/opensearch/data-stream-index-template.md`

### Key Changes in v3.4.0
- Fixed bug preventing deletion of unused index templates that match data stream patterns but have lower priority than the active template
- The `dataStreamsUsingTemplate()` method now correctly verifies template priority before reporting it as "in use"
- Optimized `findV2Template()` to track the winner during iteration

### Resources Used
- PR: [#20102](https://github.com/opensearch-project/OpenSearch/pull/20102)
- Issue: [#20078](https://github.com/opensearch-project/OpenSearch/issues/20078)
- Docs: https://docs.opensearch.org/3.0/im-plugin/data-streams/

Closes #1720