### PR TITLE
docs: add reactor-netty-transport report for v3.4.0

### DIFF
--- a/docs/features/opensearch/reactor-netty-transport.md
+++ b/docs/features/opensearch/reactor-netty-transport.md
@@ -105,6 +105,7 @@ The Reactor Netty transport enables several advanced features:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#20106](https://github.com/opensearch-project/OpenSearch/pull/20106) | Keep track and release accepted Http Channels during Node shutdown |
 | v3.3.0 | [#19458](https://github.com/opensearch-project/OpenSearch/pull/19458) | Fix SslHandler retrieval for Security plugin compatibility |
 | v3.2.0 | - | Added `SecureHttpTransportParameters` interface |
 | v2.17.0 | - | Initial streaming support |
@@ -118,6 +119,7 @@ The Reactor Netty transport enables several advanced features:
 
 ## Change History
 
+- **v3.4.0** (2026-01-14): Fixed HTTP channel tracking and release during node shutdown, resolving flaky test failures
 - **v3.3.0** (2025-09-29): Fixed SslHandler retrieval logic for Security plugin compatibility, added clientAuth support
 - **v3.2.0** (2025-07-15): Added `SecureHttpTransportParameters` interface for cleaner SSL configuration
 - **v2.17.0** (2024-09-17): Initial streaming support with reactor-netty4 transport

--- a/docs/releases/v3.4.0/features/opensearch/reactor-netty-transport.md
+++ b/docs/releases/v3.4.0/features/opensearch/reactor-netty-transport.md
@@ -1,0 +1,79 @@
+# Reactor Netty Transport
+
+## Summary
+
+This release fixes a resource leak issue in the Reactor Netty 4 Transport plugin where HTTP channels were not being properly tracked and released during node shutdown. The fix ensures that accepted HTTP channels are registered with `RestCancellableNodeClient` and properly cleaned up, resolving flaky test failures in `DetailedErrorsDisabledIT`.
+
+## Details
+
+### What's New in v3.4.0
+
+The Reactor Netty 4 Transport now properly tracks and releases accepted HTTP channels during node shutdown. Previously, after executing Multi Search API requests, the `HttpChannel` could remain registered with `RestCancellableNodeClient` because the underlying channel was not always closed properly.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "HTTP Channel Lifecycle (Fixed)"
+        Request[HTTP Request] --> Transport[ReactorNetty4HttpServerTransport]
+        Transport --> |serverAcceptedChannel| Track[RestCancellableNodeClient<br/>Channel Tracking]
+        Transport --> NonStreaming[NonStreamingRequestConsumer]
+        Transport --> Streaming[StreamingRequestConsumer]
+        NonStreaming --> |serverAcceptedChannel| Track
+        Streaming --> |serverAcceptedChannel| Track
+        Track --> |Node Shutdown| Release[Channel Release]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `serverAcceptedChannel()` override | Public method in `ReactorNetty4HttpServerTransport` to track accepted channels |
+| Channel close listener | Proper close context handling in `close()` methods |
+
+#### Code Changes
+
+The fix involves several key modifications:
+
+1. **ReactorNetty4HttpServerTransport**: Added `serverAcceptedChannel()` override to enable channel tracking by request consumers
+2. **ReactorNetty4NonStreamingRequestConsumer**: Now calls `transport.serverAcceptedChannel(channel)` when processing requests
+3. **ReactorNetty4StreamingRequestConsumer**: Now calls `transport.serverAcceptedChannel(httpChannel)` in constructor
+4. **ReactorNetty4NonStreamingHttpChannel**: Enhanced `close()` method to properly handle close context
+5. **ReactorNetty4StreamingHttpChannel**: Enhanced `close()` method to properly handle close context
+
+### Usage Example
+
+No configuration changes required. The fix is automatically applied when using the Reactor Netty 4 Transport plugin.
+
+```yaml
+# opensearch.yml - Enable reactor-netty4 transport
+http.type: reactor-netty4
+```
+
+### Migration Notes
+
+No migration required. This is a bug fix that improves resource management without changing the API or configuration.
+
+## Limitations
+
+- The Reactor Netty 4 Transport remains an experimental feature
+- Requires explicit plugin installation: `./bin/opensearch-plugin install transport-reactor-netty4`
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#20106](https://github.com/opensearch-project/OpenSearch/pull/20106) | Keep track and release Reactor Netty 4 Transport accepted Http Channels during the Node shutdown |
+
+## References
+
+- [Issue #20034](https://github.com/opensearch-project/OpenSearch/issues/20034): Flaky Test Report for DetailedErrorsDisabledIT
+- [Network Settings Documentation](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/network-settings/): Official configuration guide
+- [Streaming Bulk API](https://docs.opensearch.org/3.0/api-reference/document-apis/bulk-streaming/): Streaming bulk documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/reactor-netty-transport.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -31,6 +31,7 @@
 
 - [Bulk Request Bugfixes](features/opensearch/bulk-request-bugfixes.md) - Fix indices property initialization during BulkRequest deserialization
 - [Data Stream & Index Template Bugfixes](features/opensearch/data-stream-index-template-bugfixes.md) - Fix deletion of unused index templates matching data streams with lower priority
+- [Reactor Netty Transport](features/opensearch/reactor-netty-transport.md) - Fix HTTP channel tracking and release during node shutdown
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Reactor Netty Transport bug fix in OpenSearch v3.4.0.

### Changes

- **Release Report**: `docs/releases/v3.4.0/features/opensearch/reactor-netty-transport.md`
  - Documents the HTTP channel tracking and release fix during node shutdown
  - Explains the technical changes to `ReactorNetty4HttpServerTransport` and related components

- **Feature Report Update**: `docs/features/opensearch/reactor-netty-transport.md`
  - Added v3.4.0 entry to Related PRs table
  - Added v3.4.0 entry to Change History

- **Release Index Update**: `docs/releases/v3.4.0/index.md`
  - Added link to the new release report under Bug Fixes section

### Related Issue

Closes #1719

### Key Changes in v3.4.0

- Fixed HTTP channel tracking and release during node shutdown
- Resolved flaky test failures in `DetailedErrorsDisabledIT`
- Channels are now properly registered with `RestCancellableNodeClient`

### Source PR

- [opensearch-project/OpenSearch#20106](https://github.com/opensearch-project/OpenSearch/pull/20106)