### PR TITLE
docs: add Snapshot & Restore Bugfixes report for v3.4.0

### DIFF
--- a/docs/features/opensearch/snapshot-restore-enhancements.md
+++ b/docs/features/opensearch/snapshot-restore-enhancements.md
@@ -118,11 +118,13 @@ POST /_snapshot/{repository}/{snapshot}/_restore
 - Clone optimization only benefits document replication clusters
 - Repository data fetch still required for remote store enabled clusters during clone
 - When repository is updated during snapshot creation, the snapshot operation will fail and must be retried
+- File cache validation may be less accurate when shard size information is unavailable (logs warning)
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#19684](https://github.com/opensearch-project/OpenSearch/pull/19684) | Fix NPE in validateSearchableSnapshotRestorable when shard size is unavailable |
 | v3.1.0 | [#17532](https://github.com/opensearch-project/OpenSearch/pull/17532) | Fix infinite loop when simultaneously creating snapshot and updating repository |
 | v3.1.0 | [#18218](https://github.com/opensearch-project/OpenSearch/pull/18218) | Avoid NPE on SnapshotInfo if 'shallow' boolean not present |
 | v2.18.0 | [#16292](https://github.com/opensearch-project/OpenSearch/pull/16292) | Add support for renaming aliases during snapshot restore |
@@ -130,6 +132,7 @@ POST /_snapshot/{repository}/{snapshot}/_restore
 
 ## References
 
+- [Issue #19349](https://github.com/opensearch-project/OpenSearch/issues/19349): Bug report for NullPointerException when restoring remote snapshots with missing shard size
 - [Issue #17531](https://github.com/opensearch-project/OpenSearch/issues/17531): Bug report for infinite loop during concurrent snapshot/repository update
 - [Issue #18187](https://github.com/opensearch-project/OpenSearch/issues/18187): Bug report for NPE when restoring legacy searchable snapshots
 - [Issue #15632](https://github.com/opensearch-project/OpenSearch/issues/15632): Original feature request for alias renaming
@@ -139,5 +142,6 @@ POST /_snapshot/{repository}/{snapshot}/_restore
 
 ## Change History
 
+- **v3.4.0** (2026-01-11): Fixed NPE when restoring remote snapshots with missing shard size information in ClusterInfo cache
 - **v3.1.0** (2026-01-10): Fixed infinite loop when updating repository during snapshot creation; fixed NPE when restoring legacy searchable snapshots
 - **v2.18.0** (2024-11-05): Added alias renaming support during snapshot restore; optimized clone operations for doc-rep clusters

--- a/docs/releases/v3.4.0/features/opensearch/snapshot-restore-bugfixes.md
+++ b/docs/releases/v3.4.0/features/opensearch/snapshot-restore-bugfixes.md
@@ -1,0 +1,120 @@
+# Snapshot & Restore Bugfixes
+
+## Summary
+
+This release fixes a NullPointerException that occurred when restoring remote snapshots (searchable snapshots) when shard size information was unavailable in the ClusterInfo cache. The bug manifested during rapid successive restore operations where the cluster hadn't yet collected size information for recently restored shards.
+
+## Details
+
+### What's New in v3.4.0
+
+Fixed a critical bug in the `validateSearchableSnapshotRestorable` method within `RestoreService` that caused restore operations to fail with a NullPointerException when restoring multiple remote snapshots in quick succession.
+
+### Technical Changes
+
+#### Root Cause
+
+The `validateSearchableSnapshotRestorable` method calculates the total size of existing remote snapshot shards to validate against file cache capacity. The original implementation used a Java Stream with `mapToLong(Long::longValue)` which threw NPE when `ClusterInfo.getShardSize()` returned null:
+
+```java
+// Before (buggy code)
+long totalRestoredRemoteIndexesSize = shardsIterator.getShardRoutings()
+    .stream()
+    .map(clusterInfo::getShardSize)
+    .mapToLong(Long::longValue)  // NPE when getShardSize returns null
+    .sum();
+```
+
+#### The Fix
+
+The fix replaces the stream-based approach with an explicit loop that handles null values gracefully:
+
+```java
+// After (fixed code)
+long totalRestoredRemoteIndicesSize = 0;
+int missingSizeCount = 0;
+List<ShardRouting> routings = shardsIterator.getShardRoutings();
+
+for (ShardRouting shardRouting : routings) {
+    Long shardSize = clusterInfo.getShardSize(shardRouting);
+    if (shardSize != null) {
+        totalRestoredRemoteIndicesSize += shardSize;
+    } else {
+        missingSizeCount++;
+    }
+}
+
+if (missingSizeCount > 0) {
+    logger.warn(
+        "Size information unavailable for {} out of {} remote snapshot shards. "
+            + "File cache validation will use available data only.",
+        missingSizeCount,
+        routings.size()
+    );
+}
+```
+
+#### Behavior Change
+
+| Aspect | Before | After |
+|--------|--------|-------|
+| Null shard size | Throws NPE | Skips and logs warning |
+| File cache validation | Fails on missing data | Uses available data only |
+| Logging | None | Warns about missing size info |
+
+### When This Bug Occurs
+
+The bug occurs when:
+1. Restoring indexes from snapshots using `storage_type: remote_snapshot` (searchable snapshots)
+2. Performing multiple restore operations in rapid succession
+3. The `ClusterInfo` cache hasn't been updated with shard size information for recently restored shards
+4. The `cluster.info.update.interval` setting delays size information collection
+
+### Usage Example
+
+The following restore operations could trigger the bug before this fix:
+
+```json
+// First restore
+POST /_snapshot/my-repo/snapshot-1/_restore
+{
+  "indices": "index-1",
+  "storage_type": "remote_snapshot",
+  "rename_pattern": "(.+)",
+  "rename_replacement": "remote-$1"
+}
+
+// Second restore immediately after (could fail with NPE)
+POST /_snapshot/my-repo/snapshot-2/_restore
+{
+  "indices": "index-2",
+  "storage_type": "remote_snapshot",
+  "rename_pattern": "(.+)",
+  "rename_replacement": "remote-$1"
+}
+```
+
+### Migration Notes
+
+No migration required. This is a bugfix that improves reliability of searchable snapshot restore operations.
+
+## Limitations
+
+- File cache validation may be less accurate when shard size information is unavailable
+- The warning log indicates validation is proceeding with incomplete data
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19684](https://github.com/opensearch-project/OpenSearch/pull/19684) | Fix NPE in validateSearchableSnapshotRestorable when shard size is unavailable |
+
+## References
+
+- [Issue #19349](https://github.com/opensearch-project/OpenSearch/issues/19349): Bug report for NullPointerException when creating remote index from snapshot
+- [Searchable Snapshots Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot/): Official documentation
+- [Restore Snapshot API](https://docs.opensearch.org/3.0/api-reference/snapshots/restore-snapshot/): API reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/snapshot-restore-enhancements.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -33,6 +33,7 @@
 - [Data Stream & Index Template Bugfixes](features/opensearch/data-stream-index-template-bugfixes.md) - Fix deletion of unused index templates matching data streams with lower priority
 - [GRPC Transport Bugfixes](features/opensearch/grpc-transport-bugfixes.md) - Fix ClassCastException for large requests, Bulk API fixes, and node bootstrap with streaming transport
 - [Reactor Netty Transport](features/opensearch/reactor-netty-transport.md) - Fix HTTP channel tracking and release during node shutdown
+- [Snapshot & Restore Bugfixes](features/opensearch/snapshot-restore-bugfixes.md) - Fix NullPointerException when restoring remote snapshot with missing shard size information
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Snapshot & Restore Bugfixes in OpenSearch v3.4.0.

### Changes
- Created release report: `docs/releases/v3.4.0/features/opensearch/snapshot-restore-bugfixes.md`
- Updated feature report: `docs/features/opensearch/snapshot-restore-enhancements.md`
- Updated release index: `docs/releases/v3.4.0/index.md`

### Key Fix
Fixed a NullPointerException in `validateSearchableSnapshotRestorable` method that occurred when restoring remote snapshots (searchable snapshots) when shard size information was unavailable in the ClusterInfo cache.

### Related
- Closes #1713
- PR: opensearch-project/OpenSearch#19684
- Issue: opensearch-project/OpenSearch#19349