### PR TITLE
docs: add cluster state & allocation bugfixes report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -36,6 +36,7 @@
 - [Cluster Info & Resource Stats](opensearch/cluster-info-resource-stats.md)
 - [Cluster Manager Metrics](opensearch/cluster-manager-metrics.md)
 - [Cluster State Caching](opensearch/cluster-state-caching.md)
+- [Cluster State & Allocation](opensearch/cluster-state-allocation.md)
 - [Cross-Cluster Settings](opensearch/cross-cluster-settings.md)
 - [Code Cleanup](opensearch/code-cleanup.md)
 - [Code Coverage (Gradle)](opensearch/code-coverage-gradle.md)

--- a/docs/features/opensearch/cluster-state-allocation.md
+++ b/docs/features/opensearch/cluster-state-allocation.md
@@ -1,0 +1,131 @@
+# Cluster State & Allocation
+
+## Summary
+
+Cluster state allocation in OpenSearch manages how shards are distributed across nodes in the cluster. This includes allocation filtering (controlling which nodes can host specific shards) and remote cluster state publication (persisting cluster state to remote storage for durability). These components work together to ensure cluster stability, proper shard placement, and disaster recovery capabilities.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Cluster Manager"
+        CM[Cluster Manager Node]
+        AS[AllocationService]
+        FAD[FilterAllocationDecider]
+        DNF[DiscoveryNodeFilters]
+    end
+    
+    subgraph "Allocation Filtering"
+        RF[Require Filters]
+        IF[Include Filters]
+        EF[Exclude Filters]
+    end
+    
+    subgraph "Remote State"
+        RCS[RemoteClusterStateService]
+        CWBF[ChecksumWritableBlobStoreFormat]
+        RS[Remote Store]
+    end
+    
+    CM --> AS
+    AS --> FAD
+    FAD --> DNF
+    DNF --> RF
+    DNF --> IF
+    DNF --> EF
+    
+    CM --> RCS
+    RCS --> CWBF
+    CWBF --> RS
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `AllocationService` | Orchestrates shard allocation decisions across the cluster |
+| `FilterAllocationDecider` | Decides if a shard can be allocated to a node based on filters |
+| `DiscoveryNodeFilters` | Manages node attribute filters for allocation decisions |
+| `RemoteClusterStateService` | Handles remote cluster state upload and download |
+| `ChecksumWritableBlobStoreFormat` | Serializes/deserializes cluster state entities with version awareness |
+
+### Allocation Filtering
+
+Allocation filters control shard placement using node attributes:
+
+| Filter Type | Setting Prefix | Behavior |
+|-------------|----------------|----------|
+| Require | `cluster.routing.allocation.require.*` | Node must match ALL specified attributes |
+| Include | `cluster.routing.allocation.include.*` | Node must match ANY specified attribute |
+| Exclude | `cluster.routing.allocation.exclude.*` | Node must NOT match ANY specified attribute |
+
+### Remote Cluster State Entities
+
+When remote cluster state publication is enabled, the following entities are serialized to remote storage:
+
+| Entity | Class | Description |
+|--------|-------|-------------|
+| Discovery Nodes | `RemoteDiscoveryNodes` | Node membership information |
+| Cluster Blocks | `RemoteClusterBlocks` | Cluster-level and index-level blocks |
+| Routing Table | `RemoteIndexRoutingTable` | Shard allocation per index |
+| Routing Table Diff | `RemoteRoutingTableDiff` | Incremental routing changes |
+| Consistent Settings | `RemoteHashesOfConsistentSettings` | Hashes for settings consistency |
+| Cluster State Customs | `RemoteClusterStateCustoms` | Custom cluster state extensions |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.remote_store.state.enabled` | Enable remote cluster state | `false` |
+| `cluster.remote_store.publication.enabled` | Enable remote publication | `false` |
+| `cluster.remote_store.state.read_timeout` | Remote state download timeout | `20s` |
+| `cluster.remote_store.state.global_metadata.upload_timeout` | Upload timeout | `20s` |
+
+### Usage Example
+
+```yaml
+# Enable remote cluster state
+cluster.remote_store.state.enabled: true
+cluster.remote_store.publication.enabled: true
+
+# Configure remote state repository
+node.attr.remote_store.state.repository: my-remote-state-repo
+node.attr.remote_store.repository.my-remote-state-repo.type: s3
+node.attr.remote_store.repository.my-remote-state-repo.settings.bucket: my-bucket
+node.attr.remote_store.repository.my-remote-state-repo.settings.region: us-east-1
+```
+
+```json
+// Allocation filter example
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.routing.allocation.exclude._name": "node-to-decommission"
+  }
+}
+```
+
+## Limitations
+
+- Remote cluster state requires all cluster manager nodes to have access to the remote repository
+- Allocation filter updates are eventually consistent across the cluster
+- Mixed-version clusters may experience serialization issues with remote state (fixed in v3.4.0)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#19701](https://github.com/opensearch-project/OpenSearch/pull/19701) | Fix concurrent modification in DiscoveryNodeFilters |
+| v3.4.0 | [#20080](https://github.com/opensearch-project/OpenSearch/pull/20080) | Version-aware serialization for remote state entities |
+
+## References
+
+- [Remote Cluster State Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/remote-store/remote-cluster-state/)
+- [Cluster Settings - Allocation](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/cluster-settings/)
+- [Issue #19843](https://github.com/opensearch-project/OpenSearch/issues/19843): Remote state backward compatibility bug
+
+## Change History
+
+- **v3.4.0** (2026-01-14): Fixed concurrent modification in allocation filters; Added version-aware serialization for remote state entities

--- a/docs/releases/v3.4.0/features/opensearch/cluster-state-allocation-bugfixes.md
+++ b/docs/releases/v3.4.0/features/opensearch/cluster-state-allocation-bugfixes.md
@@ -1,0 +1,94 @@
+# Cluster State & Allocation Bugfixes
+
+## Summary
+
+This release item includes two important bugfixes that improve cluster stability and reliability:
+
+1. **Concurrent Modification Fix in Allocation Filters**: Fixes a potential `ConcurrentModificationException` when updating allocation filters in `DiscoveryNodeFilters`, along with null-pointer safety improvements in `FilterAllocationDecider`.
+
+2. **Remote State Version Compatibility Fix**: Adds version-aware serialization/deserialization for remote cluster state entities, fixing version incompatibility issues during cluster upgrades when using remote publication mode.
+
+## Details
+
+### What's New in v3.4.0
+
+#### Fix 1: Concurrent Modification in DiscoveryNodeFilters
+
+The `DiscoveryNodeFilters.buildOrUpdateFromKeyValue()` method was sharing the internal filters map between the original and updated instances. This could cause `ConcurrentModificationException` when one thread reads filters while another thread updates them.
+
+**Technical Changes:**
+
+- `DiscoveryNodeFilters`: Now creates a defensive copy of the filters map when building from an existing instance
+- `FilterAllocationDecider`: Copies volatile fields to local variables before null-checking to prevent race conditions
+
+```java
+// Before (vulnerable to concurrent modification)
+updated = new DiscoveryNodeFilters(original.opType, original.filters);
+
+// After (thread-safe)
+updated = new DiscoveryNodeFilters(original.opType, new HashMap<>(original.filters));
+```
+
+#### Fix 2: Remote State Version Compatibility
+
+Remote publication entities using bytestream serialization were not setting the OpenSearch version in the bytestream. This caused failures during version upgrades when new nodes tried to deserialize cluster state that didn't include new attributes added in later versions.
+
+**Technical Changes:**
+
+- `ChecksumWritableBlobStoreFormat`: Added `opensearchVersion` field and constructor overload to support version-aware deserialization
+- Remote state entities now pass the manifest's OpenSearch version during deserialization:
+  - `RemoteClusterBlocks`
+  - `RemoteDiscoveryNodes`
+  - `RemoteHashesOfConsistentSettings`
+  - `RemoteClusterStateCustoms`
+  - `RemoteIndexRoutingTable`
+  - `RemoteRoutingTableDiff`
+
+```mermaid
+graph TB
+    subgraph "Before Fix"
+        A1[New Node v3.4.0] -->|Download State| B1[Remote Store]
+        B1 -->|Deserialize| C1[State from v3.3.0]
+        C1 -->|Missing Fields| D1[Deserialization Failure]
+    end
+    
+    subgraph "After Fix"
+        A2[New Node v3.4.0] -->|Download State| B2[Remote Store]
+        B2 -->|Read Manifest Version| C2[v3.3.0]
+        C2 -->|Version-aware Deserialize| D2[Success]
+    end
+```
+
+### Components Changed
+
+| Component | Description |
+|-----------|-------------|
+| `DiscoveryNodeFilters` | Defensive copy of filters map to prevent concurrent modification |
+| `FilterAllocationDecider` | Local variable caching for volatile fields |
+| `ChecksumWritableBlobStoreFormat` | Version-aware serialization/deserialization |
+| `RemoteClusterStateService` | Passes manifest version to remote entity readers |
+| Remote state entities | Accept version parameter for deserialization |
+
+### Migration Notes
+
+These are bugfixes with no migration required. The changes are backward compatible and will automatically take effect after upgrading to v3.4.0.
+
+## Limitations
+
+- The remote state version fix requires all nodes in the cluster to be upgraded to benefit from the improved version handling during mixed-version rolling upgrades.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19701](https://github.com/opensearch-project/OpenSearch/pull/19701) | Fix potential concurrent modification exception in DiscoveryNodeFilters |
+| [#20080](https://github.com/opensearch-project/OpenSearch/pull/20080) | Adding version checks to remote entities using bytestream ser/de |
+
+## References
+
+- [Issue #19843](https://github.com/opensearch-project/OpenSearch/issues/19843): BUG - Modification to ClusterState Object lacks backward compatibility in remote publication mode
+- [Remote Cluster State Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/remote-store/remote-cluster-state/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/cluster-state-allocation.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -31,6 +31,7 @@
 ### OpenSearch
 
 - [Bulk Request Bugfixes](features/opensearch/bulk-request-bugfixes.md) - Fix indices property initialization during BulkRequest deserialization
+- [Cluster State & Allocation Bugfixes](features/opensearch/cluster-state-allocation-bugfixes.md) - Fix concurrent modification in allocation filters and version compatibility in remote state
 - [Data Stream & Index Template Bugfixes](features/opensearch/data-stream-index-template-bugfixes.md) - Fix deletion of unused index templates matching data streams with lower priority
 - [GRPC Transport Bugfixes](features/opensearch/grpc-transport-bugfixes.md) - Fix ClassCastException for large requests, Bulk API fixes, and node bootstrap with streaming transport
 - [Reactor Netty Transport](features/opensearch/reactor-netty-transport.md) - Fix HTTP channel tracking and release during node shutdown


### PR DESCRIPTION
## Summary

This PR adds documentation for the Cluster State & Allocation Bugfixes release item in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch/cluster-state-allocation-bugfixes.md`
- Feature report: `docs/features/opensearch/cluster-state-allocation.md`

### Key Changes in v3.4.0

1. **Concurrent Modification Fix (PR #19701)**
   - Fixed potential `ConcurrentModificationException` in `DiscoveryNodeFilters` when updating allocation filters
   - Added null-pointer safety in `FilterAllocationDecider` by caching volatile fields

2. **Remote State Version Compatibility (PR #20080)**
   - Added version-aware serialization/deserialization for remote cluster state entities
   - Fixes version incompatibility issues during cluster upgrades with remote publication enabled
   - Resolves Issue #19843

### Resources Used
- PR: #19701, #20080
- Issue: #19843
- Docs: https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/remote-store/remote-cluster-state/

Closes #1711