### PR TITLE
docs: add java-agent report for v3.4.0

### DIFF
--- a/docs/features/opensearch/java-agent-accesscontroller.md
+++ b/docs/features/opensearch/java-agent-accesscontroller.md
@@ -146,16 +146,19 @@ CityResponse response = AccessController.doPrivileged(() ->
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#19683](https://github.com/opensearch-project/OpenSearch/pull/19683) | Allow JRT protocol URLs in protection domain extraction |
 | v3.2.0 | [#18346](https://github.com/opensearch-project/OpenSearch/pull/18346) | Create equivalents of JSM's AccessController in the java agent |
 
 ## References
 
 - [Issue #18339](https://github.com/opensearch-project/OpenSearch/issues/18339): Feature request for AccessController replacement
 - [Issue #1687](https://github.com/opensearch-project/OpenSearch/issues/1687): Original JSM replacement discussion
+- [Issue #4209](https://github.com/opensearch-project/ml-commons/issues/4209): Bug report - Failed to get tools from external MCP server
 - [JEP 411](https://openjdk.org/jeps/411): Deprecate the Security Manager for Removal
 - [JEP 486](https://openjdk.org/jeps/486): Permanently Disable the Security Manager
 - [Blog: Finding a replacement for JSM in OpenSearch 3.0](https://opensearch.org/blog/finding-a-replacement-for-jsm-in-opensearch-3-0/): Detailed explanation of JSM replacement strategy
 
 ## Change History
 
+- **v3.4.0** (2026-01-11): Fix JRT protocol URL filtering in protection domain extraction to allow MCP server connections
 - **v3.2.0** (2026-01-11): Initial implementation with `doPrivileged` and `doPrivilegedChecked` methods

--- a/docs/releases/v3.4.0/features/opensearch/java-agent.md
+++ b/docs/releases/v3.4.0/features/opensearch/java-agent.md
@@ -1,0 +1,93 @@
+# Java Agent JRT Protocol Fix
+
+## Summary
+
+This release fixes a bug in OpenSearch's Java agent where connections to external MCP (Model Context Protocol) servers failed with a `SecurityException`. The issue occurred because the Java agent's protection domain extraction incorrectly included JDK internal classes loaded via the `jrt:` protocol, which have no permissions granted.
+
+## Details
+
+### What's New in v3.4.0
+
+The `StackCallerProtectionDomainChainExtractor` now filters out protection domains with `jrt:` protocol URLs. This prevents false security denials when JDK internal classes (like `java.net.http.HttpClient`) appear in the call stack during network operations.
+
+### Technical Changes
+
+#### Root Cause
+
+When OpenSearch's Java agent intercepts network operations, it walks the call stack to identify which code is requesting the operation. Each stack frame's class has a `ProtectionDomain` that determines its permissions.
+
+JDK internal classes (loaded from `jrt:/java.net.http`) have protection domains with no granted permissions. When these classes appeared in the call stack (e.g., when using `HttpClient` for MCP connections), the agent incorrectly denied access because the JDK classes had no socket permissions.
+
+#### The Fix
+
+A single-line filter was added to exclude protection domains with `jrt:` protocol URLs:
+
+```java
+.filter(pd -> !"jrt".equals(pd.getCodeSource().getLocation().getProtocol()))
+```
+
+This ensures JDK internal classes are treated similarly to classes with null code sources (which were already filtered out).
+
+#### Code Change
+
+```java
+// StackCallerProtectionDomainChainExtractor.java
+public Collection<ProtectionDomain> apply(Stream<StackFrame> frames) {
+    return frames.takeWhile(
+        frame -> !(ACCESS_CONTROLLER_CLASSES.contains(frame.getClassName()) 
+                   && DO_PRIVILEGED_METHODS.contains(frame.getMethodName()))
+    )
+        .map(StackFrame::getDeclaringClass)
+        .map(Class::getProtectionDomain)
+        .filter(pd -> pd.getCodeSource() != null) // Filter out JDK classes
+        .filter(pd -> !"jrt".equals(pd.getCodeSource().getLocation().getProtocol())) // NEW: Filter jrt: URLs
+        .collect(Collectors.toSet());
+}
+```
+
+### Error Before Fix
+
+```
+java.lang.SecurityException: Denied access to: my-mcp-endpoint:443, 
+domain ProtectionDomain (jrt:/java.net.http <no signer certificates>)
+ jdk.internal.loader.ClassLoaders$PlatformClassLoader@d8948cd
+ <no principals>
+ java.security.Permissions@4633b6d ()
+```
+
+### Usage Example
+
+After this fix, MCP connector operations work correctly:
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "My MCP Server",
+  "description": "External MCP server connector",
+  "version": "1",
+  "protocol": "mcp",
+  "parameters": {
+    "endpoint": "https://my-mcp-endpoint:443/sse"
+  }
+}
+```
+
+## Limitations
+
+- This fix specifically addresses the `jrt:` protocol filtering; other protocol-related issues may require separate fixes
+- The Java agent security model still requires proper `plugin-security.policy` configuration for plugin code
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19683](https://github.com/opensearch-project/OpenSearch/pull/19683) | Allow JRT protocol URLs in protection domain extraction |
+
+## References
+
+- [Issue #4209](https://github.com/opensearch-project/ml-commons/issues/4209): Bug report - Failed to get tools from external MCP server
+- [Blog: Finding a replacement for JSM in OpenSearch 3.0](https://opensearch.org/blog/finding-a-replacement-for-jsm-in-opensearch-3-0/): Background on Java agent security model
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/java-agent-accesscontroller.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -30,6 +30,7 @@
 
 ### OpenSearch
 
+- [Java Agent](features/opensearch/java-agent.md) - Fix JRT protocol URL filtering to allow MCP server connections
 - [Bulk Request Bugfixes](features/opensearch/bulk-request-bugfixes.md) - Fix indices property initialization during BulkRequest deserialization
 - [Cluster State & Allocation Bugfixes](features/opensearch/cluster-state-allocation-bugfixes.md) - Fix concurrent modification in allocation filters and version compatibility in remote state
 - [Data Stream & Index Template Bugfixes](features/opensearch/data-stream-index-template-bugfixes.md) - Fix deletion of unused index templates matching data streams with lower priority


### PR DESCRIPTION
## Summary\n\nAdds documentation for the Java Agent JRT protocol fix in OpenSearch v3.4.0.\n\n### Reports Created\n- Release report: `docs/releases/v3.4.0/features/opensearch/java-agent.md`\n- Feature report: `docs/features/opensearch/java-agent-accesscontroller.md` (updated)\n\n### Key Changes in v3.4.0\n- Fix JRT protocol URL filtering in `StackCallerProtectionDomainChainExtractor`\n- Resolves issue where MCP server connections failed with SecurityException\n\n### Related\n- Closes #1710\n- OpenSearch PR: opensearch-project/OpenSearch#19683\n- Bug report: opensearch-project/ml-commons#4209"