### PR TITLE
docs: add shard & segment bugfixes report for v3.4.0

### DIFF
--- a/docs/features/opensearch/segment-warmer.md
+++ b/docs/features/opensearch/segment-warmer.md
@@ -148,6 +148,8 @@ PUT /my-index
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#19436](https://github.com/opensearch-project/OpenSearch/pull/19436) | Exception handling to prevent shard failures during warming |
+| v3.4.0 | [#20105](https://github.com/opensearch-project/OpenSearch/pull/20105) | Fix EngineConfig.toBuilder() to include mergedSegmentTransferTracker |
 | v3.3.0 | [#18929](https://github.com/opensearch-project/OpenSearch/pull/18929) | Add metrics for merged segment warmer operations |
 | v3.2.0 | [#18683](https://github.com/opensearch-project/OpenSearch/pull/18683) | Remote store support for merged segment warming |
 | v3.0.0 | [#18255](https://github.com/opensearch-project/OpenSearch/pull/18255) | Local merged segment warmer implementation |
@@ -163,6 +165,7 @@ PUT /my-index
 
 ## Change History
 
+- **v3.4.0** (2025-12-09): Bugfixes - Added exception handling in `MergedSegmentWarmer.warm()` to prevent primary shard failures during node restarts; Fixed `EngineConfig.toBuilder()` to include `mergedSegmentTransferTracker` preventing `_cat/indices` API failures
 - **v3.3.0** (2025-10-14): Added comprehensive metrics for monitoring segment warmer operations - `MergedSegmentTransferTracker` and `MergedSegmentWarmerStats` expose invocation counts, timing, bytes transferred, and failure counts via stats APIs
 - **v3.2.0** (2025-08-05): Added remote store support - merged segments are uploaded to remote store and replicated to replicas via `RemoteStorePublishMergedSegmentAction`
 - **v3.0.0** (2025-05-06): Initial implementation - introduced `MergedSegmentWarmerFactory` with `LocalMergedSegmentWarmer` and `RemoteStoreMergedSegmentWarmer` infrastructure

--- a/docs/releases/v3.4.0/features/opensearch/shard-segment-bugfixes.md
+++ b/docs/releases/v3.4.0/features/opensearch/shard-segment-bugfixes.md
@@ -1,0 +1,112 @@
+# Shard & Segment Bugfixes
+
+## Summary
+
+OpenSearch v3.4.0 includes three critical bugfixes related to shard and segment operations that improve cluster stability during node restarts, early cluster initialization, and when using custom engine configurations. These fixes prevent primary shard failures during merged segment warming, resolve assertion errors in resource usage collection, and fix `_cat/indices` API failures when using engine configuration builders.
+
+## Details
+
+### What's New in v3.4.0
+
+This release addresses three distinct issues in shard and segment handling:
+
+1. **Merged Segment Warmer Exception Handling** - Prevents primary shard failures caused by exceptions during the merged segment warming process
+2. **ClusterService State Assertion Fix** - Resolves assertion errors when collecting resource usage stats during early cluster initialization
+3. **EngineConfig Builder Fix** - Fixes missing `mergedSegmentTransferTracker` in the `toBuilder()` method causing `_cat/indices` API failures
+
+### Technical Changes
+
+#### 1. Merged Segment Warmer Exception Handling (PR #19436)
+
+**Problem**: During node restarts with merged segment warmer enabled, a race condition could cause primary shard failures. When `InternalEngine` is created but `IndexShard.currentEngineReference` is not yet set, segment merges could trigger the warmer which calls `IndexShard.getEngine()`, throwing `AlreadyClosedException` and causing shard failure.
+
+**Solution**: Wrap the entire warming logic in a try-catch block to gracefully handle exceptions without failing the merge operation.
+
+```java
+// MergedSegmentWarmer.java - Before
+@Override
+public void warm(LeafReader leafReader) throws IOException {
+    if (shouldWarm() == false) {
+        return;
+    }
+    // ... warming logic that could throw exceptions
+}
+
+// After
+@Override
+public void warm(LeafReader leafReader) throws IOException {
+    try {
+        if (shouldWarm() == false) {
+            return;
+        }
+        // ... warming logic
+    } catch (Exception e) {
+        logger.warn("Exception during merged segment warmer, skip warming", e);
+    }
+}
+```
+
+#### 2. ClusterService State Assertion Fix (PR #19775)
+
+**Problem**: `ResourceUsageCollectorService.collectLocalNodeResourceUsageStats()` called `clusterService.state()` to check if the cluster state was initialized. However, `ClusterApplierService.state()` throws an assertion error if the state is null (during early initialization), making the null check ineffective in assertion-enabled environments.
+
+**Solution**: Use `clusterService.isStateInitialised()` instead of checking `clusterService.state() != null`.
+
+```java
+// Before
+if (nodeResourceUsageTracker.isReady() && clusterService.state() != null) {
+    collectNodeResourceUsageStats(...);
+}
+
+// After
+if (nodeResourceUsageTracker.isReady() && clusterService.isStateInitialised()) {
+    collectNodeResourceUsageStats(...);
+}
+```
+
+#### 3. EngineConfig Builder Fix (PR #20105)
+
+**Problem**: The `EngineConfig.toBuilder()` method was missing the `mergedSegmentTransferTracker` field (added in PR #18929). This caused `NullPointerException` when calling `_cat/indices` API on indexes using custom engine configurations (e.g., `opensearch-storage-encryption` plugin).
+
+**Solution**: Add the missing field to the builder method.
+
+```java
+// EngineConfig.java
+public Builder toBuilder() {
+    return new Builder()
+        // ... existing fields
+        .clusterApplierService(this.clusterApplierService)
+        .mergedSegmentTransferTracker(this.mergedSegmentTransferTracker); // Added
+}
+```
+
+### Impact
+
+| Fix | Impact | Affected Scenarios |
+|-----|--------|-------------------|
+| Warmer Exception Handling | Prevents shard failures | Node restarts with segment replication enabled |
+| ClusterService Assertion | Prevents test failures | Early cluster initialization with assertions enabled |
+| EngineConfig Builder | Fixes API errors | `_cat/indices` with custom engine plugins |
+
+## Limitations
+
+- The merged segment warmer exception handling logs warnings but silently skips warming - administrators should monitor logs for repeated warnings
+- These fixes are specific to edge cases and do not change normal operation behavior
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19436](https://github.com/opensearch-project/OpenSearch/pull/19436) | Avoid primary shard failure caused by merged segment warmer exceptions |
+| [#19775](https://github.com/opensearch-project/OpenSearch/pull/19775) | Fixed assertion unsafe use of ClusterService.state() in ResourceUsageCollectorService |
+| [#20105](https://github.com/opensearch-project/OpenSearch/pull/20105) | Fix toBuilder method in EngineConfig to include mergedSegmentTransferTracker |
+
+## References
+
+- [Issue #19435](https://github.com/opensearch-project/OpenSearch/issues/19435): BUG - Avoid primary shard failure caused by merge segment warmer exceptions
+- [PR #18929](https://github.com/opensearch-project/OpenSearch/pull/18929): Original PR that added MergedSegmentTransferTracker to EngineConfig
+- [Remote Segment Warmer Documentation](https://docs.opensearch.org/3.4/tuning-your-cluster/availability-and-recovery/remote-store/remote-segment-warmer/): Official docs
+
+## Related Feature Report
+
+- [Segment Warmer](../../../../features/opensearch/segment-warmer.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -37,6 +37,7 @@
 - [GRPC Transport Bugfixes](features/opensearch/grpc-transport-bugfixes.md) - Fix ClassCastException for large requests, Bulk API fixes, and node bootstrap with streaming transport
 - [Pull-based Ingestion Bugfixes](features/opensearch/pull-based-ingestion-bugfixes.md) - Fix out-of-bounds offset handling and remove persisted pointers for at-least-once guarantees
 - [Reactor Netty Transport](features/opensearch/reactor-netty-transport.md) - Fix HTTP channel tracking and release during node shutdown
+- [Shard & Segment Bugfixes](features/opensearch/shard-segment-bugfixes.md) - Fix merged segment warmer exceptions, ClusterService state assertion, and EngineConfig builder
 - [Snapshot & Restore Bugfixes](features/opensearch/snapshot-restore-bugfixes.md) - Fix NullPointerException when restoring remote snapshot with missing shard size information
 
 ### OpenSearch Dashboards


### PR DESCRIPTION
## Summary

This PR adds documentation for the Shard & Segment Bugfixes in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch/shard-segment-bugfixes.md`
- Feature report updated: `docs/features/opensearch/segment-warmer.md`

### Key Changes in v3.4.0
- **PR #19436**: Added exception handling in `MergedSegmentWarmer.warm()` to prevent primary shard failures during node restarts
- **PR #19775**: Fixed assertion unsafe use of `ClusterService.state()` in `ResourceUsageCollectorService`
- **PR #20105**: Fixed `EngineConfig.toBuilder()` to include `mergedSegmentTransferTracker` preventing `_cat/indices` API failures

### Resources Used
- PR: #19436, #19775, #20105
- Issue: #19435
- Docs: https://docs.opensearch.org/3.4/tuning-your-cluster/availability-and-recovery/remote-store/remote-segment-warmer/

Closes #1708