### PR TITLE
docs: add xcontent-filtering report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -175,6 +175,7 @@
 - [Warm Storage Tiering](opensearch/warm-storage-tiering.md)
 - [Wildcard Field](opensearch/wildcard-field.md)
 - [Workload Management](opensearch/workload-management.md)
+- [XContent Filtering](opensearch/xcontent-filtering.md)
 - [Hierarchical & ACL-aware Routing](opensearch/hierarchical-acl-aware-routing.md)
 - [Temporal Routing](opensearch/temporal-routing.md)
 - [Terms Lookup Query](opensearch/terms-lookup-query.md)

--- a/docs/features/opensearch/xcontent-filtering.md
+++ b/docs/features/opensearch/xcontent-filtering.md
@@ -1,0 +1,153 @@
+# XContent Filtering
+
+## Summary
+
+XContent Filtering provides utilities for filtering fields from JSON/YAML content maps in OpenSearch. The `XContentMapValues.filter()` method allows including or excluding specific fields from document content, supporting wildcards, nested paths, and case-insensitive matching. This is essential for security features like filtering sensitive data from REST request logs.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "XContent Filtering System"
+        A[Input Map] --> B[XContentMapValues.filter]
+        B --> C{Pattern Type}
+        C -->|Simple Fields| D[Set-Based Filter]
+        C -->|Wildcards/Dots| E[Automaton Filter]
+        D --> F[Filtered Map]
+        E --> F
+    end
+    
+    subgraph "Use Cases"
+        G[RestRequestFilter] --> B
+        H[SourceFieldMapper] --> B
+        I[FetchSourceContext] --> B
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Source Map] --> B{Has Wildcards?}
+    B -->|No| C[HashSet Matching]
+    B -->|Yes| D[Automaton Matching]
+    C --> E{Case Sensitive?}
+    D --> E
+    E -->|Yes| F[Exact Match]
+    E -->|No| G[Lowercase Match]
+    F --> H[Apply Include/Exclude]
+    G --> H
+    H --> I[Filtered Map]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `XContentMapValues` | Core utility class for filtering map content |
+| `RestRequestFilter` | Interface for filtering sensitive REST request content |
+| `SourceFieldMapper` | Uses filtering for `_source` field includes/excludes |
+| `FetchSourceContext` | Applies filtering during search source fetching |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `caseSensitive` | Whether field matching is case-sensitive | `true` (backward compatible) |
+| `includes` | Array of field patterns to include | `null` (include all) |
+| `excludes` | Array of field patterns to exclude | `[]` (exclude none) |
+
+### API Methods
+
+```java
+// Case-sensitive filtering (original API)
+Map<String, Object> filter(Map<String, ?> map, String[] includes, String[] excludes)
+
+// Configurable case sensitivity (v3.4.0+)
+Map<String, Object> filter(Map<String, ?> map, String[] includes, String[] excludes, boolean caseSensitive)
+
+// Reusable filter function
+Function<Map<String, ?>, Map<String, Object>> filter(String[] includes, String[] excludes, boolean caseSensitive)
+```
+
+### Pattern Matching
+
+| Pattern | Example | Matches |
+|---------|---------|---------|
+| Exact field | `password` | `password` only |
+| Nested path | `user.email` | `user.email` field |
+| Wildcard | `*.secret` | Any field ending with `.secret` |
+| Deep wildcard | `credentials.*` | All fields under `credentials` |
+
+### Usage Example
+
+```java
+// Filter sensitive fields from a request body
+Map<String, Object> source = Map.of(
+    "username", "admin",
+    "Password", "secret123",  // Mixed case
+    "apiKey", "key-abc"
+);
+
+// Case-insensitive exclude
+Map<String, Object> filtered = XContentMapValues.filter(
+    source,
+    null,                           // include all
+    new String[]{"password", "apikey"},  // exclude these
+    false                           // case-insensitive
+);
+
+// Result: {"username": "admin"}
+```
+
+### RestRequestFilter Implementation
+
+```java
+public interface RestRequestFilter {
+    /**
+     * Returns fields to filter from request body before logging.
+     * Field names are matched case-insensitively.
+     */
+    Set<String> getFilteredFields();
+    
+    default RestRequest getFilteredRequest(RestRequest request) {
+        Set<String> fields = getFilteredFields();
+        if (request.hasContent() && !fields.isEmpty()) {
+            // Filter with case-insensitive matching
+            Map<String, Object> filtered = XContentMapValues.filter(
+                parseContent(request),
+                null,
+                fields.toArray(new String[0]),
+                false  // case-insensitive
+            );
+            return wrapRequest(request, filtered);
+        }
+        return request;
+    }
+}
+```
+
+## Limitations
+
+- Filtering creates a new map; does not modify the original
+- Wildcard patterns use Lucene automaton matching (may have performance impact for complex patterns)
+- Case-insensitive matching uses `Locale.ROOT` (may not handle all Unicode edge cases)
+- Nested array filtering preserves array structure but filters contained objects
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#19976](https://github.com/opensearch-project/OpenSearch/pull/19976) | Add case sensitivity as an argument to XContentMapValues.filter |
+
+## References
+
+- [XContentMapValues.java](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/common/xcontent/support/XContentMapValues.java): Core implementation
+- [RestRequestFilter.java](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/rest/RestRequestFilter.java): Extension point for sensitive data filtering
+- [ML Commons Connector Documentation](https://docs.opensearch.org/latest/ml-commons-plugin/remote-models/index/#step-2-create-a-connector): Example use case
+
+## Change History
+
+- **v3.4.0** (2025-11-19): Added case-insensitive filtering support via new `caseSensitive` parameter

--- a/docs/releases/v3.4.0/features/opensearch/xcontent-filtering.md
+++ b/docs/releases/v3.4.0/features/opensearch/xcontent-filtering.md
@@ -1,0 +1,122 @@
+# XContent Filtering
+
+## Summary
+
+This release adds case-insensitive filtering support to `XContentMapValues.filter()`, enabling REST request handlers to filter sensitive fields from request bodies regardless of field name casing. This improvement simplifies the implementation of the `RestRequestFilter` extension point, which is used to prevent sensitive data (like passwords and API keys) from being logged.
+
+## Details
+
+### What's New in v3.4.0
+
+The `XContentMapValues.filter()` method now accepts a `caseSensitive` boolean parameter that controls whether field name matching is case-sensitive or case-insensitive.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Request Processing"
+        A[REST Request] --> B[RestRequestFilter]
+        B --> C{Has Sensitive Fields?}
+        C -->|Yes| D[XContentMapValues.filter]
+        C -->|No| E[Pass Through]
+        D --> F{Case Sensitive?}
+        F -->|true| G[Exact Match]
+        F -->|false| H[Case-Insensitive Match]
+        G --> I[Filtered Content]
+        H --> I
+    end
+```
+
+#### API Changes
+
+The `XContentMapValues` class now provides an overloaded `filter()` method:
+
+| Method | Description |
+|--------|-------------|
+| `filter(Map, String[], String[])` | Original method (case-sensitive, backward compatible) |
+| `filter(Map, String[], String[], boolean)` | New method with case sensitivity control |
+| `filter(String[], String[], boolean)` | Returns a reusable filter function |
+
+#### New Method Signature
+
+```java
+public static Map<String, Object> filter(
+    Map<String, ?> map, 
+    String[] includes, 
+    String[] excludes, 
+    boolean caseSensitive
+)
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `map` | The source map to filter |
+| `includes` | Fields to include (null or empty = include all) |
+| `excludes` | Fields to exclude |
+| `caseSensitive` | `true` for exact matching, `false` for case-insensitive |
+
+### Usage Example
+
+```java
+// RestRequestFilter implementation - now case-insensitive
+public interface RestRequestFilter {
+    default RestRequest getFilteredRequest(RestRequest restRequest) {
+        Set<String> fields = getFilteredFields();
+        if (restRequest.hasContent() && !fields.isEmpty()) {
+            Map<String, Object> transformedSource = XContentMapValues.filter(
+                result.v2(),
+                null,                              // includes
+                fields.toArray(Strings.EMPTY_ARRAY), // excludes
+                false                              // case-insensitive
+            );
+            // ... create filtered request
+        }
+    }
+}
+```
+
+**Before v3.4.0** - Required listing all case variations:
+```java
+@Override
+public Set<String> getFilteredFields() {
+    return Set.of("password", "Password", "PASSWORD", 
+                  "apiKey", "ApiKey", "APIKEY", "apikey");
+}
+```
+
+**After v3.4.0** - Single field name works for all cases:
+```java
+@Override
+public Set<String> getFilteredFields() {
+    return Set.of("password", "apikey");
+}
+```
+
+### Migration Notes
+
+- Existing code using `filter(Map, String[], String[])` continues to work unchanged (case-sensitive)
+- To enable case-insensitive filtering, use the new 4-parameter method with `caseSensitive=false`
+- The `RestRequestFilter` interface now uses case-insensitive filtering by default
+
+## Limitations
+
+- Case-insensitive matching uses `Locale.ROOT` for lowercase conversion
+- Wildcard patterns in includes/excludes are also matched case-insensitively when `caseSensitive=false`
+- Performance impact is minimal as the lowercase conversion happens once per filter operation
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19976](https://github.com/opensearch-project/OpenSearch/pull/19976) | Add case sensitivity as an argument to XContentMapValues.filter |
+
+## References
+
+- [RestRequestFilter.java](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/rest/RestRequestFilter.java): Extension point for filtering sensitive request content
+- [ML Commons Connector Documentation](https://docs.opensearch.org/latest/ml-commons-plugin/remote-models/index/#step-2-create-a-connector): Example use case with sensitive credentials
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/xcontent-filtering.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -12,6 +12,7 @@
 - [Security Kerberos Integration](features/opensearch/security-kerberos-integration.md) - Update Hadoop to 3.4.2 and enable Kerberos integration tests for JDK-24+
 - [Settings Bugfixes](features/opensearch/settings-bugfixes.md) - Fix duplicate registration of dynamic settings and patch version build issues
 - [Stats Builder Pattern Deprecations](features/opensearch/stats-builder-pattern-deprecations.md) - Deprecated constructors in 30+ Stats classes in favor of Builder pattern
+- [XContent Filtering](features/opensearch/xcontent-filtering.md) - Case-insensitive filtering support for XContentMapValues.filter
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

Add documentation for XContent Filtering feature in OpenSearch v3.4.0.

### Changes
- Release report: `docs/releases/v3.4.0/features/opensearch/xcontent-filtering.md`
- Feature report: `docs/features/opensearch/xcontent-filtering.md`
- Updated release index and features index

### Feature Overview
This release adds case-insensitive filtering support to `XContentMapValues.filter()`, enabling REST request handlers to filter sensitive fields from request bodies regardless of field name casing. This improvement simplifies the implementation of the `RestRequestFilter` extension point.

### Related
- PR: [opensearch-project/OpenSearch#19976](https://github.com/opensearch-project/OpenSearch/pull/19976)
- Issue: #1705