### PR TITLE
docs: add ActionPlugin Enhancements report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -135,6 +135,7 @@
 - [Remote Store Metadata API](opensearch/remote-store-metadata-api.md)
 - [Repository Rate Limiters](opensearch/repository-rate-limiters.md)
 - [RestHandler.Wrapper](opensearch/resthandler-wrapper.md)
+- [ActionPlugin REST Handler Wrapper](opensearch/actionplugin-rest-handler-wrapper.md)
 - [Remote Store Metrics](opensearch/remote-store-metrics.md)
 - [S3 Repository](opensearch/s3-repository.md)
 - [Scaled Float Field](opensearch/scaled-float-field.md)

--- a/docs/features/opensearch/actionplugin-rest-handler-wrapper.md
+++ b/docs/features/opensearch/actionplugin-rest-handler-wrapper.md
@@ -1,0 +1,131 @@
+# ActionPlugin REST Handler Wrapper
+
+## Summary
+
+The `ActionPlugin.getRestHandlerWrapper` extension point allows plugins to wrap REST handlers with custom functionality such as authentication, authorization, logging, or request modification. In v3.4.0, this API was enhanced to pass the registry of allowlisted REST headers, enabling plugins to efficiently access and preserve headers that should be propagated through the transport layer.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "REST Request Flow"
+        REQ[HTTP Request] --> RC[RestController]
+        RC --> RHW[REST Handler Wrapper]
+        RHW --> RH[REST Handler]
+        RH --> TA[Transport Action]
+    end
+    
+    subgraph "Header Flow"
+        REQ -->|headers| TC[ThreadContext]
+        TC -->|filtered by| RHW
+        RHW -->|preserves allowlisted| TA
+    end
+    
+    subgraph "Plugin Registration"
+        AP[ActionPlugin] -->|getRestHeaders| AM[ActionModule]
+        AP -->|getRestHandlerWrapper| AM
+        AM -->|passes headers to| RHW
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Startup"
+        P[Plugins] -->|register headers| AM[ActionModule]
+        AM -->|collect| HS[Headers Set]
+    end
+    
+    subgraph "Request Processing"
+        HS -->|passed to| GRW[getRestHandlerWrapper]
+        GRW -->|creates| W[Wrapper]
+        W -->|filters| TC[ThreadContext]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ActionPlugin` | Plugin interface for registering actions and REST handlers |
+| `ActionModule` | Core module that manages action and REST handler registration |
+| `RestHeaderDefinition` | Definition of a REST header including name and multi-value support |
+| `ThreadContext` | Thread-local storage for request context including headers |
+| `RestHandler.Wrapper` | Decorator pattern for wrapping REST handlers |
+
+### Configuration
+
+This feature is API-based and does not require configuration. Plugins implement the interface methods to participate.
+
+### API Methods
+
+| Method | Description |
+|--------|-------------|
+| `getRestHeaders()` | Returns headers to copy from REST requests to ThreadContext |
+| `getRestHandlerWrapper(ThreadContext, Set<RestHeaderDefinition>)` | Returns a function to wrap REST handlers (v3.4.0+) |
+| `getRestHandlerWrapper(ThreadContext)` | Deprecated single-parameter version |
+
+### Usage Example
+
+```java
+public class MySecurityPlugin extends Plugin implements ActionPlugin {
+    
+    @Override
+    public Collection<RestHeaderDefinition> getRestHeaders() {
+        return List.of(
+            new RestHeaderDefinition("X-Custom-Auth", false),
+            new RestHeaderDefinition("X-Trace-Id", false)
+        );
+    }
+    
+    @Override
+    public UnaryOperator<RestHandler> getRestHandlerWrapper(
+            ThreadContext threadContext, 
+            Set<RestHeaderDefinition> headersToCopy) {
+        return originalHandler -> new RestHandler() {
+            @Override
+            public void handleRequest(RestRequest request, RestChannel channel, 
+                                       NodeClient client) throws Exception {
+                // Efficiently access only allowlisted headers
+                for (RestHeaderDefinition header : headersToCopy) {
+                    String value = threadContext.getHeader(header.getName());
+                    if (value != null) {
+                        // Validate or process header
+                    }
+                }
+                originalHandler.handleRequest(request, channel, client);
+            }
+            
+            @Override
+            public List<Route> routes() {
+                return originalHandler.routes();
+            }
+        };
+    }
+}
+```
+
+## Limitations
+
+- Only one plugin per cluster can implement `getRestHandlerWrapper`
+- If multiple plugins attempt to register wrappers, an error is thrown
+- The wrapper applies to all REST handlers, not selectively
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#19875](https://github.com/opensearch-project/OpenSearch/pull/19875) | Pass registry of headers to getRestHandlerWrapper |
+
+## References
+
+- [Issue #4799](https://github.com/opensearch-project/security/issues/4799): Original bug report about dropped headers
+- [ActionPlugin.java](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/plugins/ActionPlugin.java): Source code
+- [ActionModule.java](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/ActionModule.java): Implementation
+
+## Change History
+
+- **v3.4.0** (2026-01-14): Added `Set<RestHeaderDefinition>` parameter to `getRestHandlerWrapper` method, deprecated single-parameter version

--- a/docs/releases/v3.4.0/features/opensearch/actionplugin-enhancements.md
+++ b/docs/releases/v3.4.0/features/opensearch/actionplugin-enhancements.md
@@ -1,0 +1,106 @@
+# ActionPlugin Enhancements
+
+## Summary
+
+This release enhances the `ActionPlugin.getRestHandlerWrapper` method by passing the registry of REST headers to the wrapper function. This enables plugins (particularly the Security plugin) to efficiently access allowlisted headers when wrapping REST handlers, fixing a bug where custom headers registered via `ActionPlugin.getRestHeaders` were being dropped by the Security plugin.
+
+## Details
+
+### What's New in v3.4.0
+
+The `ActionPlugin.getRestHandlerWrapper` method signature has been updated to include a `Set<RestHeaderDefinition>` parameter containing all headers registered by plugins via `getRestHeaders()`. This allows REST handler wrappers to know which headers are explicitly allowlisted for propagation through the transport layer.
+
+### Technical Changes
+
+#### API Changes
+
+The `ActionPlugin` interface now has an updated method signature:
+
+```java
+// Before (deprecated)
+default UnaryOperator<RestHandler> getRestHandlerWrapper(ThreadContext threadContext) {
+    return null;
+}
+
+// After (new signature)
+default UnaryOperator<RestHandler> getRestHandlerWrapper(
+    ThreadContext threadContext, 
+    Set<RestHeaderDefinition> headersToCopy) {
+    return this.getRestHandlerWrapper(threadContext);
+}
+```
+
+#### Changed Files
+
+| File | Change |
+|------|--------|
+| `ActionPlugin.java` | Added new method signature with `headersToCopy` parameter |
+| `ActionModule.java` | Updated to pass headers set to `getRestHandlerWrapper` |
+| `ShiroIdentityPlugin.java` | Updated to implement new method signature |
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Plugin Registration"
+        P1[Plugin 1] -->|getRestHeaders| AM[ActionModule]
+        P2[Plugin 2] -->|getRestHeaders| AM
+        P3[Security Plugin] -->|getRestHeaders| AM
+    end
+    
+    subgraph "Header Registry"
+        AM -->|collects| HR[Headers Set]
+    end
+    
+    subgraph "REST Handler Wrapping"
+        AM -->|passes headers| RHW[getRestHandlerWrapper]
+        RHW -->|wraps with| SRF[SecurityRestFilter]
+        SRF -->|preserves| AH[Allowlisted Headers]
+    end
+```
+
+### Usage Example
+
+```java
+@Override
+public UnaryOperator<RestHandler> getRestHandlerWrapper(
+        ThreadContext threadContext, 
+        Set<RestHeaderDefinition> headersToCopy) {
+    return originalHandler -> (request, channel, client) -> {
+        // Can now iterate through headersToCopy to preserve allowlisted headers
+        for (RestHeaderDefinition header : headersToCopy) {
+            String value = threadContext.getHeader(header.getName());
+            if (value != null) {
+                // Process or preserve the header
+            }
+        }
+        originalHandler.handleRequest(request, channel, client);
+    };
+}
+```
+
+### Migration Notes
+
+- The old single-parameter method is deprecated but still functional
+- Plugins implementing `getRestHandlerWrapper` should migrate to the new two-parameter signature
+- The new signature provides access to the complete set of allowlisted headers
+
+## Limitations
+
+- Only one plugin may implement `getRestHandlerWrapper` per cluster
+- The old method signature is deprecated and will be removed in a future release
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19875](https://github.com/opensearch-project/OpenSearch/pull/19875) | Pass registry of headers from ActionPlugin.getRestHeaders to ActionPlugin.getRestHandlerWrapper |
+
+## References
+
+- [Issue #4799](https://github.com/opensearch-project/security/issues/4799): SecurityRestFilter drops headers from ThreadContext
+- [Security PR #5396](https://github.com/opensearch-project/security/pull/5396): Related fix in Security plugin
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/actionplugin-rest-handler-wrapper.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -14,6 +14,7 @@
 - [Stats Builder Pattern Deprecations](features/opensearch/stats-builder-pattern-deprecations.md) - Deprecated constructors in 30+ Stats classes in favor of Builder pattern
 - [XContent Filtering](features/opensearch/xcontent-filtering.md) - Case-insensitive filtering support for XContentMapValues.filter
 - [Plugin Dependencies](features/opensearch/plugin-dependencies.md) - Range semver support for dependencies in plugin-descriptor.properties
+- [ActionPlugin Enhancements](features/opensearch/actionplugin-enhancements.md) - Pass REST header registry to getRestHandlerWrapper for efficient header access
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the ActionPlugin Enhancements feature in OpenSearch v3.4.0.

### Changes

- **Release Report**: `docs/releases/v3.4.0/features/opensearch/actionplugin-enhancements.md`
- **Feature Report**: `docs/features/opensearch/actionplugin-rest-handler-wrapper.md`
- Updated release index and features index

### Key Changes in v3.4.0

The `ActionPlugin.getRestHandlerWrapper` method signature was enhanced to include a `Set<RestHeaderDefinition>` parameter containing all headers registered by plugins via `getRestHeaders()`. This enables plugins (particularly the Security plugin) to efficiently access allowlisted headers when wrapping REST handlers.

### Related

- PR: [opensearch-project/OpenSearch#19875](https://github.com/opensearch-project/OpenSearch/pull/19875)
- Issue: [opensearch-project/security#4799](https://github.com/opensearch-project/security/issues/4799)