### PR TITLE
docs: add WildcardFieldMapper report for v3.4.0

### DIFF
--- a/docs/features/opensearch/wildcard-field.md
+++ b/docs/features/opensearch/wildcard-field.md
@@ -63,7 +63,7 @@ flowchart TB
 
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `doc_values` | Enable doc values for aggregations/sorting | `false` |
+| `doc_values` | Enable doc values for aggregations/sorting | `true` (since v3.4.0, was `false` before) |
 | `ignore_above` | Maximum string length to index | `2147483647` |
 | `normalizer` | Normalizer for preprocessing (e.g., `lowercase`) | none |
 | `null_value` | Value to use for null fields | `null` |
@@ -142,6 +142,7 @@ GET logs/_search
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#19796](https://github.com/opensearch-project/OpenSearch/pull/19796) | Change doc_values default to true |
 | v3.3.0 | [#18568](https://github.com/opensearch-project/OpenSearch/pull/18568) | Fix sorting bug by disabling pruning for doc_values |
 | v3.0.0 | [#17349](https://github.com/opensearch-project/OpenSearch/pull/17349) | Optimize to 3-gram only indexing |
 | v2.18.0 | [#15737](https://github.com/opensearch-project/OpenSearch/pull/15737) | Fix wildcard query containing escaped character |
@@ -151,6 +152,7 @@ GET logs/_search
 ## References
 
 - [Wildcard Field Documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/wildcard/): Official documentation
+- [Issue #18678](https://github.com/opensearch-project/OpenSearch/issues/18678): Bug report for nested query on wildcard field returning no results
 - [Issue #18461](https://github.com/opensearch-project/OpenSearch/issues/18461): Bug report for wildcard sort error with doc_values
 - [Issue #17099](https://github.com/opensearch-project/OpenSearch/issues/17099): 3-gram optimization feature request with benchmarks
 - [Issue #15555](https://github.com/opensearch-project/OpenSearch/issues/15555): Bug report for escaped wildcard character handling
@@ -159,6 +161,7 @@ GET logs/_search
 
 ## Change History
 
+- **v3.4.0** (2025-11-18): Changed `doc_values` default from `false` to `true`, fixing nested query issues
 - **v3.3.0** (2025-09-10): Fixed sorting bug when `doc_values` enabled by disabling Lucene's dynamic pruning optimization
 - **v3.0.0** (2025-05-06): Changed indexing strategy from 1-3 gram to 3-gram only, reducing index size by ~20% and improving write throughput by 5-30%
 - **v2.18.0** (2024-11-05): Fixed escaped wildcard character handling and case-insensitive query behavior

--- a/docs/releases/v3.4.0/features/opensearch/wildcardfieldmapper.md
+++ b/docs/releases/v3.4.0/features/opensearch/wildcardfieldmapper.md
@@ -1,0 +1,143 @@
+# WildcardFieldMapper
+
+## Summary
+
+OpenSearch v3.4.0 changes the default value of `doc_values` in `WildcardFieldMapper` from `false` to `true`. This aligns the wildcard field type with other field mappers and fixes a bug where nested queries on wildcard fields returned no results when `doc_values` was not explicitly enabled.
+
+## Details
+
+### What's New in v3.4.0
+
+The `doc_values` parameter for wildcard fields now defaults to `true` instead of `false`. This change:
+
+1. **Fixes nested query bug**: Wildcard fields inside nested objects now work correctly without explicit configuration
+2. **Aligns with other field types**: Most field mappers default to `doc_values: true`
+3. **Enables aggregations and sorting by default**: Users can now aggregate and sort on wildcard fields without additional configuration
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.4.0"
+        A1[Wildcard Field] --> B1[doc_values: false]
+        B1 --> C1[Nested Query]
+        C1 --> D1[No stored field in sub-doc]
+        D1 --> E1[No Results]
+    end
+    
+    subgraph "After v3.4.0"
+        A2[Wildcard Field] --> B2[doc_values: true]
+        B2 --> C2[Nested Query]
+        C2 --> D2[DocValueFetcher retrieves value]
+        D2 --> E2[Correct Results]
+    end
+```
+
+#### Code Changes
+
+| File | Change |
+|------|--------|
+| `WildcardFieldMapper.java` | Changed `hasDocValues` default from `false` to `true` |
+| `WildcardFieldMapper.java` | Added null check for `searchLookup` in `valueFetcher()` |
+
+#### Root Cause
+
+The wildcard field type retrieves field values from either:
+- **DocValues** (if `doc_values: true`)
+- **Stored field** (if `doc_values: false`)
+
+For nested fields, sub-documents do not build stored indexes. When `doc_values` was `false` by default, nested wildcard queries could not retrieve values from sub-documents, causing queries to return no results.
+
+### Usage Example
+
+Before v3.4.0, nested wildcard queries required explicit `doc_values: true`:
+
+```json
+PUT wildcard_index
+{
+  "mappings": {
+    "properties": {
+      "outer_field": {
+        "type": "nested",
+        "properties": {
+          "wildcard_field": {
+            "type": "wildcard",
+            "doc_values": true  // Required before v3.4.0
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+After v3.4.0, the explicit setting is no longer needed:
+
+```json
+PUT wildcard_index
+{
+  "mappings": {
+    "properties": {
+      "outer_field": {
+        "type": "nested",
+        "properties": {
+          "wildcard_field": {
+            "type": "wildcard"  // doc_values: true by default
+          }
+        }
+      }
+    }
+  }
+}
+
+PUT wildcard_index/_doc/1
+{
+  "outer_field": {
+    "wildcard_field": "abcd"
+  }
+}
+
+POST wildcard_index/_search
+{
+  "query": {
+    "nested": {
+      "path": "outer_field",
+      "query": {
+        "wildcard": {
+          "outer_field.wildcard_field": "*bc*"
+        }
+      }
+    }
+  }
+}
+```
+
+This query now returns the expected document.
+
+### Migration Notes
+
+- **Backward compatible**: The parameter is always serialized, so existing indexes with explicit `doc_values` settings are unaffected
+- **New indexes**: Will have `doc_values: true` by default, which may slightly increase storage but enables more functionality
+- **To disable**: Explicitly set `doc_values: false` if you want the previous behavior
+
+## Limitations
+
+- Indexes created before v3.4.0 without explicit `doc_values: true` will retain `doc_values: false`
+- Slightly increased storage for new indexes due to doc values being enabled by default
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19796](https://github.com/opensearch-project/OpenSearch/pull/19796) | Change the default value of doc_values in WildcardFieldMapper to true |
+
+## References
+
+- [Issue #18678](https://github.com/opensearch-project/OpenSearch/issues/18678): Bug report for nested query on wildcard type field returning no results
+- [Wildcard Field Documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/wildcard/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/wildcard-field.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -15,6 +15,7 @@
 - [XContent Filtering](features/opensearch/xcontent-filtering.md) - Case-insensitive filtering support for XContentMapValues.filter
 - [Plugin Dependencies](features/opensearch/plugin-dependencies.md) - Range semver support for dependencies in plugin-descriptor.properties
 - [ActionPlugin Enhancements](features/opensearch/actionplugin-enhancements.md) - Pass REST header registry to getRestHandlerWrapper for efficient header access
+- [WildcardFieldMapper](features/opensearch/wildcardfieldmapper.md) - Change doc_values default to true for nested query support
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the WildcardFieldMapper `doc_values` default change in OpenSearch v3.4.0.

### Changes

- **Release report**: `docs/releases/v3.4.0/features/opensearch/wildcardfieldmapper.md`
  - Documents the change from `doc_values: false` to `doc_values: true` as default
  - Explains the nested query bug fix
  - Includes architecture diagram and usage examples

- **Feature report update**: `docs/features/opensearch/wildcard-field.md`
  - Updated Configuration table with new default value
  - Added v3.4.0 PR to Related PRs table
  - Added Issue #18678 to References
  - Added v3.4.0 entry to Change History

- **Release index update**: `docs/releases/v3.4.0/index.md`
  - Added link to new release report

### Related Issue

Closes #1702