### PR TITLE
docs: add Security AccessController Migration report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -265,6 +265,7 @@
 - [Multi-Tenancy](security/multi-tenancy.md)
 - [Resource Access Control Framework](security/resource-access-control-framework.md)
 - [Security FIPS Compliance](security/security-fips-compliance.md)
+- [Security AccessController Migration](security/security-accesscontroller-migration.md)
 - [SPIFFE X.509 SVID Support](security/spiffe-x.509-svid-support.md)
 
 ## security-dashboards

--- a/docs/features/security/security-accesscontroller-migration.md
+++ b/docs/features/security/security-accesscontroller-migration.md
@@ -1,0 +1,178 @@
+# Security Plugin AccessController Migration
+
+## Summary
+
+The OpenSearch Security plugin has migrated from Java's deprecated `java.security.AccessController` to OpenSearch's custom `org.opensearch.secure_sm.AccessController`. This migration ensures compatibility with Java 21+ and aligns with OpenSearch core's strategy to replace the Java Security Manager (JSM), which is being permanently disabled in JDK 24.
+
+## Details
+
+### Background
+
+Java's Security Manager and `AccessController` have been deprecated since JDK 17 (JEP 411) and are scheduled for permanent removal in JDK 24 (JEP 486). OpenSearch 3.0 introduced a Java agent-based security model as a replacement, with `org.opensearch.secure_sm.AccessController` providing equivalent functionality for privileged operations.
+
+The security plugin extensively uses privileged operations for:
+- Authentication (JWT, SAML, Kerberos, LDAP)
+- Audit logging (Kafka, Webhook sinks)
+- Configuration file access
+- SSL/TLS certificate handling
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Security Plugin"
+        Auth[Authentication Layer]
+        Audit[Audit Layer]
+        Config[Configuration Layer]
+    end
+    subgraph "Authentication Components"
+        JWT[JWT Authenticator]
+        SAML[SAML Authenticator]
+        Kerberos[Kerberos/SPNEGO]
+        LDAP[LDAP Backend]
+    end
+    subgraph "Audit Components"
+        Kafka[Kafka Sink]
+        Webhook[Webhook Sink]
+        Internal[Internal ES Sink]
+    end
+    subgraph "OpenSearch Core"
+        AC[org.opensearch.secure_sm.AccessController]
+        Agent[Java Agent]
+    end
+    Auth --> JWT
+    Auth --> SAML
+    Auth --> Kerberos
+    Auth --> LDAP
+    Audit --> Kafka
+    Audit --> Webhook
+    Audit --> Internal
+    JWT --> AC
+    SAML --> AC
+    Kerberos --> AC
+    LDAP --> AC
+    Kafka --> AC
+    Webhook --> AC
+    Config --> AC
+    AC --> Agent
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Security Plugin Operation] --> B{Requires Privileged Access?}
+    B -->|Yes| C[Call AccessController.doPrivileged]
+    B -->|No| D[Execute Directly]
+    C --> E[Java Agent Intercepts]
+    E --> F[Stack Walk & Permission Check]
+    F --> G{Permitted?}
+    G -->|Yes| H[Execute Operation]
+    G -->|No| I[SecurityException]
+    H --> J[Return Result]
+    D --> J
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `DefaultObjectMapper` | JSON serialization with privileged Jackson operations |
+| `NonValidatingObjectMapper` | Non-validating JSON parsing |
+| `OpenSearchSecurityPlugin` | Main plugin class with file permission checks |
+| `AbstractAuditLog` | Base audit logging with system property access |
+| `AuditLogImpl` | Audit log implementation with shutdown hooks |
+| `KafkaSink` | Kafka producer for audit events |
+| `WebhookSink` | HTTP webhook for audit events |
+| `HTTPJwtAuthenticator` | JWT token parsing and validation |
+| `AbstractHTTPJwtAuthenticator` | Base JWT authentication |
+| `HTTPSpnegoAuthenticator` | Kerberos/SPNEGO authentication |
+| `HTTPSamlAuthenticator` | SAML authentication with metadata resolution |
+| `AuthTokenProcessorHandler` | SAML token processing |
+| `Saml2SettingsProvider` | SAML configuration provider |
+| `SamlHTTPMetadataResolver` | HTTP-based SAML metadata |
+| `SamlFilesystemMetadataResolver` | File-based SAML metadata |
+| `LDAPAuthorizationBackend` | LDAP connection and authorization |
+| `LdapHelper` | LDAP search utilities |
+
+### Configuration
+
+No additional configuration is required. The migration is transparent to users and administrators. Existing `plugin-security.policy` files continue to work without modification.
+
+### Usage Examples
+
+#### Privileged JSON Parsing
+
+```java
+import org.opensearch.secure_sm.AccessController;
+
+public static <T> T readValue(String string, Class<T> clazz) throws IOException {
+    try {
+        return AccessController.doPrivilegedChecked(() -> objectMapper.readValue(string, clazz));
+    } catch (final Exception e) {
+        throw (IOException) e;
+    }
+}
+```
+
+#### Privileged File Operations
+
+```java
+import org.opensearch.secure_sm.AccessController;
+
+final List<Path> filesWithWrongPermissions = AccessController.doPrivileged(() -> {
+    final Path confPath = new Environment(settings, configPath).configDir().toAbsolutePath();
+    if (Files.isDirectory(confPath, LinkOption.NOFOLLOW_LINKS)) {
+        try (Stream<Path> s = Files.walk(confPath)) {
+            return s.distinct().filter(p -> checkFilePermissions(p)).collect(Collectors.toList());
+        } catch (Exception e) {
+            log.error(e.toString());
+            return null;
+        }
+    }
+    return Collections.emptyList();
+});
+```
+
+#### Privileged Network Operations (LDAP)
+
+```java
+import org.opensearch.secure_sm.AccessController;
+
+public static Connection getConnection(final Settings settings, final Path configPath) throws Exception {
+    return AccessController.doPrivilegedChecked(() -> {
+        boolean isJava9OrHigher = PlatformDependent.javaVersion() >= 9;
+        ClassLoader originalClassloader = null;
+        if (isJava9OrHigher) {
+            originalClassloader = Thread.currentThread().getContextClassLoader();
+            Thread.currentThread().setContextClassLoader(new Java9CL());
+        }
+        return getConnection0(settings, configPath, originalClassloader, isJava9OrHigher);
+    });
+}
+```
+
+## Limitations
+
+- This is an internal refactoring with no user-facing changes
+- The migration does not change the security model or permissions
+- Plugin developers extending security plugin classes should update their code to use the new AccessController
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#5750](https://github.com/opensearch-project/security/pull/5750) | Replace AccessController and remove restriction on word Extension |
+| v3.4.0 | [#5815](https://github.com/opensearch-project/security/pull/5815) | Clean up AccessController with Exception disambiguation |
+
+## References
+
+- [Issue #1687](https://github.com/opensearch-project/OpenSearch/issues/1687): RFC - Replace Java Security Manager (JSM)
+- [Issue #17181](https://github.com/opensearch-project/OpenSearch/issues/17181): Permanently turn-off Security Manager starting 3.0
+- [JEP 411](https://openjdk.org/jeps/411): Deprecate the Security Manager for Removal
+- [JEP 486](https://openjdk.org/jeps/486): Permanently Disable the Security Manager
+- [Blog: Finding a replacement for JSM in OpenSearch 3.0](https://opensearch.org/blog/finding-a-replacement-for-jsm-in-opensearch-3-0/)
+
+## Change History
+
+- **v3.4.0** (2026-01-11): Complete migration of security plugin from `java.security.AccessController` to `org.opensearch.secure_sm.AccessController`

--- a/docs/releases/v3.4.0/features/security/security-accesscontroller-migration.md
+++ b/docs/releases/v3.4.0/features/security/security-accesscontroller-migration.md
@@ -1,0 +1,172 @@
+# Security AccessController Migration
+
+## Summary
+
+The OpenSearch Security plugin migrates from the deprecated `java.security.AccessController` to OpenSearch's custom `org.opensearch.secure_sm.AccessController`. This refactoring prepares the security plugin for Java 21+ compatibility and aligns with OpenSearch core's Java Security Manager (JSM) replacement strategy.
+
+## Details
+
+### What's New in v3.4.0
+
+This release completes the migration of AccessController usage across the security plugin's sub-projects and discovery plugins:
+
+1. **Sub-projects with SocketAccess class** - Replaced `java.security.AccessController` with `org.opensearch.secure_sm.AccessController`
+2. **Discovery plugins** - Updated privileged action patterns for network operations
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.4.0"
+        OldAC[java.security.AccessController]
+        OldSM[System.getSecurityManager]
+        OldPerm[SpecialPermission.check]
+    end
+    subgraph "After v3.4.0"
+        NewAC[org.opensearch.secure_sm.AccessController]
+    end
+    subgraph "Security Plugin Components"
+        SAML[SAML Authenticator]
+        JWT[JWT Authenticator]
+        LDAP[LDAP Backend]
+        Kerberos[Kerberos Authenticator]
+        Audit[Audit Log]
+        Webhook[Webhook Sink]
+        Kafka[Kafka Sink]
+    end
+    OldAC -.->|Deprecated| NewAC
+    OldSM -.->|Removed| NewAC
+    OldPerm -.->|Simplified| NewAC
+    NewAC --> SAML
+    NewAC --> JWT
+    NewAC --> LDAP
+    NewAC --> Kerberos
+    NewAC --> Audit
+    NewAC --> Webhook
+    NewAC --> Kafka
+```
+
+#### Code Migration Pattern
+
+The migration follows a consistent pattern across all affected files:
+
+**Before:**
+```java
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.security.PrivilegedActionException;
+import java.security.PrivilegedExceptionAction;
+import org.opensearch.SpecialPermission;
+
+@SuppressWarnings("removal")
+public void someMethod() {
+    final SecurityManager sm = System.getSecurityManager();
+    if (sm != null) {
+        sm.checkPermission(new SpecialPermission());
+    }
+    
+    return AccessController.doPrivileged(new PrivilegedAction<Result>() {
+        @Override
+        public Result run() {
+            return performOperation();
+        }
+    });
+}
+```
+
+**After:**
+```java
+import org.opensearch.secure_sm.AccessController;
+
+public void someMethod() {
+    return AccessController.doPrivileged(() -> performOperation());
+}
+```
+
+#### Affected Components
+
+| Component | File | Changes |
+|-----------|------|---------|
+| DefaultObjectMapper | `DefaultObjectMapper.java` | JSON serialization with privileged access |
+| NonValidatingObjectMapper | `NonValidatingObjectMapper.java` | Non-validating JSON operations |
+| OpenSearchSecurityPlugin | `OpenSearchSecurityPlugin.java` | Plugin initialization, file permission checks |
+| AbstractAuditLog | `AbstractAuditLog.java` | External config logging |
+| AuditLogImpl | `AuditLogImpl.java` | Shutdown hook management |
+| KafkaSink | `KafkaSink.java` | Kafka producer initialization |
+| WebhookSink | `WebhookSink.java` | HTTP webhook operations |
+| HTTPJwtAuthenticator | `HTTPJwtAuthenticator.java` | JWT token parsing |
+| AbstractHTTPJwtAuthenticator | `AbstractHTTPJwtAuthenticator.java` | JWT credential extraction |
+| HTTPSpnegoAuthenticator | `HTTPSpnegoAuthenticator.java` | Kerberos/SPNEGO authentication |
+| HTTPSamlAuthenticator | `HTTPSamlAuthenticator.java` | SAML metadata resolution |
+| AuthTokenProcessorHandler | `AuthTokenProcessorHandler.java` | SAML token processing |
+| Saml2SettingsProvider | `Saml2SettingsProvider.java` | SAML settings building |
+| SamlHTTPMetadataResolver | `SamlHTTPMetadataResolver.java` | SAML HTTP metadata fetching |
+| SamlFilesystemMetadataResolver | `SamlFilesystemMetadataResolver.java` | SAML filesystem metadata |
+| LDAPAuthorizationBackend | `LDAPAuthorizationBackend.java` | LDAP connection management |
+| LdapHelper | `LdapHelper.java` | LDAP search operations |
+
+### API Changes
+
+The new `AccessController` provides cleaner APIs:
+
+| Old API | New API |
+|---------|---------|
+| `AccessController.doPrivileged(PrivilegedAction<T>)` | `AccessController.doPrivileged(Supplier<T>)` |
+| `AccessController.doPrivileged(PrivilegedExceptionAction<T>)` | `AccessController.doPrivilegedChecked(CheckedSupplier<T, E>)` |
+| `PrivilegedAction<Void>` returning `null` | `AccessController.doPrivileged(Runnable)` |
+
+### Usage Example
+
+```java
+// Privileged file operation
+AccessController.doPrivileged(() -> {
+    final Path confPath = new Environment(settings, configPath).configDir().toAbsolutePath();
+    if (Files.isDirectory(confPath, LinkOption.NOFOLLOW_LINKS)) {
+        try (Stream<Path> s = Files.walk(confPath)) {
+            return s.distinct().filter(p -> checkFilePermissions(p)).collect(Collectors.toList());
+        }
+    }
+    return Collections.emptyList();
+});
+
+// Privileged operation with checked exception
+return AccessController.doPrivilegedChecked(() -> {
+    return objectMapper.readValue(string, clazz);
+});
+```
+
+### Migration Notes
+
+For plugin developers extending the security plugin:
+
+1. Replace `java.security.AccessController` imports with `org.opensearch.secure_sm.AccessController`
+2. Remove `@SuppressWarnings("removal")` annotations
+3. Remove `SecurityManager` null checks and `SpecialPermission` checks
+4. Convert `PrivilegedAction<T>` to lambda expressions
+5. Use `doPrivilegedChecked` for operations that throw checked exceptions
+
+## Limitations
+
+- This is a refactoring change with no functional impact
+- Existing `plugin-security.policy` files remain valid
+- The migration is internal to the security plugin
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5750](https://github.com/opensearch-project/security/pull/5750) | Replace AccessController and remove restriction on word Extension |
+| [#5815](https://github.com/opensearch-project/security/pull/5815) | Clean up AccessController with Exception disambiguation |
+
+## References
+
+- [Issue #1687](https://github.com/opensearch-project/OpenSearch/issues/1687): RFC - Replace Java Security Manager
+- [Issue #17181](https://github.com/opensearch-project/OpenSearch/issues/17181): Permanently turn-off Security Manager starting 3.0
+- [JEP 411](https://openjdk.org/jeps/411): Deprecate the Security Manager for Removal
+- [JEP 486](https://openjdk.org/jeps/486): Permanently Disable the Security Manager
+
+## Related Feature Report
+
+- [Java Agent AccessController](../../../../features/opensearch/java-agent-accesscontroller.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -17,6 +17,10 @@
 - [ActionPlugin Enhancements](features/opensearch/actionplugin-enhancements.md) - Pass REST header registry to getRestHandlerWrapper for efficient header access
 - [WildcardFieldMapper](features/opensearch/wildcardfieldmapper.md) - Change doc_values default to true for nested query support
 
+### Security
+
+- [Security AccessController Migration](features/security/security-accesscontroller-migration.md) - Migrate from deprecated java.security.AccessController to org.opensearch.secure_sm.AccessController
+
 ### OpenSearch Dashboards
 
 - [Dashboards Dev Tools](features/opensearch-dashboards/dashboards-dev-tools.md) - PATCH method support for Dev Tools console


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security AccessController Migration feature in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/security/security-accesscontroller-migration.md`
- Feature report: `docs/features/security/security-accesscontroller-migration.md`

### Key Changes in v3.4.0

The OpenSearch Security plugin migrates from the deprecated `java.security.AccessController` to OpenSearch's custom `org.opensearch.secure_sm.AccessController`. This refactoring:

1. Prepares the security plugin for Java 21+ compatibility
2. Aligns with OpenSearch core's Java Security Manager (JSM) replacement strategy
3. Affects authentication components (JWT, SAML, Kerberos, LDAP), audit logging (Kafka, Webhook), and configuration handling

### Related PRs
- [security#5750](https://github.com/opensearch-project/security/pull/5750): Replace AccessController and remove restriction on word Extension
- [security#5815](https://github.com/opensearch-project/security/pull/5815): Clean up AccessController with Exception disambiguation

### Related Issue
Closes #1701