### PR TITLE
docs: add JDK 25 Support report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -81,6 +81,7 @@
 - [HTTP API](opensearch/http-api.md)
 - [Jackson & Query Limits](opensearch/jackson--query-limits.md)
 - [Java Agent AccessController](opensearch/java-agent-accesscontroller.md)
+- [JDK 25 Support](opensearch/jdk-25-support.md)
 - [Source Field Matching](opensearch/source-field-matching.md)
 - [Cryptography & Security Libraries](opensearch/cryptography-security-libraries.md)
 - [Gradle Build System](opensearch/gradle-build-system.md)

--- a/docs/features/opensearch/jdk-25-support.md
+++ b/docs/features/opensearch/jdk-25-support.md
@@ -1,0 +1,111 @@
+# JDK 25 Support
+
+## Summary
+
+OpenSearch supports running on JDK 25 through compatibility fixes in the Painless scripting engine. JDK 25 introduced behavioral changes in `ClassValue::remove` that required modifications to exception handling in the dynamic method invocation mechanism.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph "Painless Script Execution"
+        A[Script Invocation] --> B[DefBootstrap]
+        B --> C[PIC - Polymorphic Inline Cache]
+        C --> D[ClassValue.computeValue]
+    end
+    
+    subgraph "Exception Handling"
+        D -->|Exception| E{Exception Type}
+        E -->|Checked| F[WrappedCheckedException]
+        E -->|Unchecked| G[Direct Rethrow]
+        F --> H[PainlessScript]
+        G --> H
+        H --> I[convertToScriptException]
+        I --> J[Unwrap if needed]
+        J --> K[ScriptException]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `DefBootstrap` | Bootstrap class for Painless dynamic method invocation using invokedynamic |
+| `DefBootstrap.PIC` | Polymorphic Inline Cache for caching method handles per receiver type |
+| `DefBootstrap.WrappedCheckedException` | RuntimeException wrapper for checked exceptions during method lookup |
+| `PainlessScript` | Interface for Painless scripts with exception conversion logic |
+
+### JDK 25 Behavioral Change
+
+JDK 25 changed how `ClassValue` handles exceptions in `computeValue`:
+
+| JDK Version | Behavior |
+|-------------|----------|
+| JDK 24 and earlier | Checked exceptions propagate directly from `computeValue` |
+| JDK 25+ | `ClassValue.getFromHashMap` wraps checked exceptions with `java.lang.Error` |
+
+This change is documented in [JDK-8351996](https://bugs.openjdk.org/browse/JDK-8351996).
+
+### Solution
+
+The fix wraps checked exceptions in a custom `RuntimeException` before they can be wrapped by `ClassValue`, then unwraps them when converting to `ScriptException`:
+
+```java
+// In DefBootstrap.PIC.computeValue
+try {
+    return lookup(flavor, name, receiverType).asType(type);
+} catch (Throwable t) {
+    switch (t) {
+        case Exception e -> throw new WrappedCheckedException(e);
+        default -> Def.rethrow(t);
+    }
+}
+
+// In PainlessScript.convertToScriptException
+final Throwable unwrapped = switch (originalThrowable) {
+    case DefBootstrap.WrappedCheckedException w -> w.getCause();
+    default -> originalThrowable;
+};
+```
+
+### Usage Example
+
+Painless scripts work transparently on JDK 25:
+
+```json
+POST /my-index/_update/1
+{
+  "script": {
+    "lang": "painless",
+    "source": "ctx._source.counter += params.count",
+    "params": {
+      "count": 4
+    }
+  }
+}
+```
+
+## Limitations
+
+- This fix specifically addresses the `ClassValue` behavioral change
+- Other JDK 25 compatibility issues may require separate fixes
+- The fix uses Java 21+ pattern matching syntax (`switch` expressions with type patterns)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#19706](https://github.com/opensearch-project/OpenSearch/pull/19706) | Wrap checked exceptions in painless.DefBootstrap to support JDK-25 |
+| v3.4.0 | [#19698](https://github.com/opensearch-project/OpenSearch/pull/19698) | Update bundled JDK to JDK-25 |
+
+## References
+
+- [JDK-8351996](https://bugs.openjdk.org/browse/JDK-8351996): Behavioral updates for ClassValue::remove
+- [Issue #19314](https://github.com/opensearch-project/OpenSearch/issues/19314): JDK 25 support tracking issue
+- [OpenSearch Java Runtime Blog](https://opensearch.org/blog/opensearch-java-runtime/): Using Different Java Runtimes with OpenSearch
+
+## Change History
+
+- **v3.4.0**: Added JDK 25 compatibility through exception wrapping in Painless DefBootstrap

--- a/docs/releases/v3.4.0/features/opensearch/jdk-25-support.md
+++ b/docs/releases/v3.4.0/features/opensearch/jdk-25-support.md
@@ -1,0 +1,111 @@
+# JDK 25 Support
+
+## Summary
+
+OpenSearch v3.4.0 adds compatibility with JDK 25 by addressing a behavioral change in `ClassValue::remove` that was introduced in JDK 25. This fix ensures that the Painless scripting engine continues to work correctly when running on JDK 25.
+
+## Details
+
+### What's New in v3.4.0
+
+JDK 25 introduced a behavioral change in `ClassValue.getFromHashMap` ([JDK-8351996](https://bugs.openjdk.org/browse/JDK-8351996)) that wraps checked exceptions with `java.lang.Error`. This change broke backward compatibility for code that relies on exception handling within `ClassValue.computeValue`.
+
+### Technical Changes
+
+#### Problem
+
+In JDK 25, when `ClassValue.computeValue` throws a checked exception, `ClassValue.getFromHashMap` wraps it with `java.lang.Error` instead of propagating the original exception. This caused issues in the Painless scripting engine's dynamic method invocation mechanism.
+
+#### Solution
+
+The fix introduces a `WrappedCheckedException` wrapper class in `DefBootstrap` to handle checked exceptions properly:
+
+```mermaid
+flowchart TB
+    A[Painless Script Execution] --> B[DefBootstrap.PIC.computeValue]
+    B --> C{Exception thrown?}
+    C -->|Checked Exception| D[Wrap in WrappedCheckedException]
+    C -->|Unchecked/Error| E[Rethrow directly]
+    D --> F[Exception propagates]
+    F --> G[PainlessScript.convertToScriptException]
+    G --> H[Unwrap WrappedCheckedException]
+    H --> I[Create ScriptException with original cause]
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `DefBootstrap.WrappedCheckedException` | RuntimeException wrapper for checked exceptions thrown during dynamic method lookup |
+
+#### Code Changes
+
+The `DefBootstrap.PIC` class now wraps checked exceptions:
+
+```java
+protected MethodHandle computeValue(Class<?> receiverType) {
+    try {
+        return lookup(flavor, name, receiverType).asType(type);
+    } catch (Throwable t) {
+        switch (t) {
+            case Exception e -> throw new WrappedCheckedException(e);
+            default -> Def.rethrow(t);
+        }
+        throw new AssertionError();
+    }
+}
+```
+
+The `PainlessScript.convertToScriptException` method unwraps the exception:
+
+```java
+final Throwable unwrapped = switch (originalThrowable) {
+    case DefBootstrap.WrappedCheckedException w -> w.getCause();
+    default -> originalThrowable;
+};
+```
+
+### Usage Example
+
+No user-facing changes are required. Painless scripts continue to work as expected:
+
+```json
+POST /my-index/_search
+{
+  "script_fields": {
+    "my_field": {
+      "script": {
+        "lang": "painless",
+        "source": "doc['field'].value * 2"
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- No migration required for existing Painless scripts
+- OpenSearch can now run on JDK 25 without Painless scripting issues
+- This is a prerequisite for the bundled JDK upgrade to JDK 25 ([#19698](https://github.com/opensearch-project/OpenSearch/pull/19698))
+
+## Limitations
+
+- This fix specifically addresses the `ClassValue` behavioral change in JDK 25
+- Other JDK 25 compatibility issues may require separate fixes
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19706](https://github.com/opensearch-project/OpenSearch/pull/19706) | Wrap checked exceptions in painless.DefBootstrap to support JDK-25 |
+| [#19698](https://github.com/opensearch-project/OpenSearch/pull/19698) | Update bundled JDK to JDK-25 (depends on this fix) |
+
+## References
+
+- [JDK-8351996](https://bugs.openjdk.org/browse/JDK-8351996): Behavioral updates for ClassValue::remove
+- [Issue #19314](https://github.com/opensearch-project/OpenSearch/issues/19314): JDK 25 support tracking issue
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/jdk-25-support.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -6,6 +6,7 @@
 
 - [Build Tool Upgrades](features/opensearch/build-tool-upgrades.md) - Gradle 9.1 and bundled JDK 25 updates
 - [Dependency Updates (OpenSearch Core)](features/opensearch/dependency-updates-opensearch-core.md) - 32 dependency updates including Netty 4.2.4 for HTTP/3 readiness
+- [JDK 25 Support](features/opensearch/jdk-25-support.md) - Painless scripting compatibility fix for JDK 25 ClassValue behavioral change
 - [Lucene Upgrade](features/opensearch/lucene-upgrade.md) - Bump Apache Lucene from 10.3.1 to 10.3.2 with MaxScoreBulkScorer bug fix
 - [Node Stats Bugfixes](features/opensearch/node-stats-bugfixes.md) - Fix negative CPU usage values in node stats on certain Linux distributions
 - [S3 Repository](features/opensearch/s3-repository.md) - Add LEGACY_MD5_CHECKSUM_CALCULATION to opensearch.yml settings for S3-compatible storage


### PR DESCRIPTION
## Summary

Add documentation for JDK 25 Support feature in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch/jdk-25-support.md`
- Feature report: `docs/features/opensearch/jdk-25-support.md`

### Key Changes in v3.4.0
- Added `WrappedCheckedException` wrapper class in `DefBootstrap` to handle JDK 25's `ClassValue` behavioral change
- Updated `PainlessScript.convertToScriptException` to unwrap the exception
- Prerequisite for bundled JDK 25 upgrade (#19698)

### Resources Used
- PR: opensearch-project/OpenSearch#19706
- Related PR: opensearch-project/OpenSearch#19698 (Update bundled JDK to JDK-25)
- JDK Bug: https://bugs.openjdk.org/browse/JDK-8351996

Closes #1699