### PR TITLE
docs: add Lucene Integration report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -92,6 +92,7 @@
 - [Index Refresh](opensearch/index-refresh.md)
 - [Java Runtime & JPMS](opensearch/java-runtime-and-jpms.md)
 - [Lucene 10 Upgrade](opensearch/lucene-10-upgrade.md)
+- [Lucene Integration](opensearch/lucene-integration.md)
 - [Lucene Similarity](opensearch/lucene-similarity.md)
 - [Lucene Upgrade](opensearch/lucene-upgrade.md)
 - [Merge & Segment Settings](opensearch/merge-segment-settings.md)

--- a/docs/features/opensearch/lucene-integration.md
+++ b/docs/features/opensearch/lucene-integration.md
@@ -1,0 +1,111 @@
+# Lucene Integration
+
+## Summary
+
+OpenSearch integrates with Apache Lucene for core search functionality. This feature tracks improvements to how OpenSearch leverages Lucene's APIs, reducing custom wrapper code and improving maintainability by adopting Lucene's public interfaces as they become available.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph OpenSearch
+        QP[Query Phase]
+        TDC[TopDocsCollectorContext]
+        CM[CollectorManager]
+    end
+    
+    subgraph Lucene
+        MC[MultiCollector]
+        GC[getCollectors]
+        LC[LeafCollector]
+    end
+    
+    QP --> TDC
+    TDC --> CM
+    CM --> MC
+    MC --> GC
+    MC --> LC
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `MultiCollector` | Lucene class that wraps multiple collectors into a single collector |
+| `CollectorManager` | Interface for creating and reducing collectors in concurrent search |
+| `TopDocsCollectorContext` | OpenSearch class managing top docs collection during query phase |
+
+### Key Integration Points
+
+#### MultiCollector Usage
+
+OpenSearch uses Lucene's `MultiCollector` to combine multiple collectors (e.g., `TopDocsCollector` and `MaxScoreCollector`) during search operations. This is particularly important for:
+
+- Concurrent segment search where multiple collectors run in parallel
+- Field collapsing with score tracking
+- Custom collector implementations
+
+#### CollectorManager Pattern
+
+The `CollectorManager` interface enables concurrent search by:
+
+1. Creating independent collector instances per segment via `newCollector()`
+2. Reducing results from all collectors via `reduce()`
+
+```java
+class SearchCollectorManager implements CollectorManager<Collector, TopDocs> {
+    @Override
+    public Collector newCollector() throws IOException {
+        return MultiCollector.wrap(
+            new TopScoreDocCollector(numHits),
+            new MaxScoreCollector()
+        );
+    }
+    
+    @Override
+    public TopDocs reduce(Collection<Collector> collectors) throws IOException {
+        List<TopDocs> topDocs = new ArrayList<>();
+        float maxScore = Float.NaN;
+        
+        for (Collector collector : collectors) {
+            if (collector instanceof MultiCollector m) {
+                for (Collector sub : m.getCollectors()) {
+                    if (sub instanceof TopScoreDocCollector tdc) {
+                        topDocs.add(tdc.topDocs());
+                    } else if (sub instanceof MaxScoreCollector msc) {
+                        maxScore = Math.max(maxScore, msc.getMaxScore());
+                    }
+                }
+            }
+        }
+        return TopDocs.merge(numHits, topDocs.toArray(new TopDocs[0]));
+    }
+}
+```
+
+### Configuration
+
+No user-facing configuration. This is an internal implementation detail.
+
+## Limitations
+
+- Lucene API changes may require OpenSearch updates
+- Custom collectors must be compatible with `MultiCollector` wrapping
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#19595](https://github.com/opensearch-project/OpenSearch/pull/19595) | Remove MultiCollectorWrapper and use MultiCollector in Lucene instead |
+
+## References
+
+- [LUCENE-10244](https://github.com/apache/lucene/issues/11280): Lucene issue for public `getCollectors()` method
+- [Lucene PR #455](https://github.com/apache/lucene/pull/455): Made `MultiCollector.getCollectors()` public in Lucene 9.1
+- [OpenSearch PR #1500](https://github.com/opensearch-project/OpenSearch/pull/1500): Original concurrent segment search implementation
+
+## Change History
+
+- **v3.4.0** (2026-01-11): Removed `MultiCollectorWrapper`, now using Lucene's native `MultiCollector.getCollectors()` API

--- a/docs/releases/v3.4.0/features/opensearch/lucene-integration.md
+++ b/docs/releases/v3.4.0/features/opensearch/lucene-integration.md
@@ -1,0 +1,96 @@
+# Lucene Integration
+
+## Summary
+
+This release removes the custom `MultiCollectorWrapper` class from OpenSearch and replaces it with the native `MultiCollector.getCollectors()` method from Apache Lucene. This change reduces code duplication and improves maintainability by leveraging Lucene's public API that was made available in Lucene 9.1.
+
+## Details
+
+### What's New in v3.4.0
+
+OpenSearch previously maintained a custom `MultiCollectorWrapper` class to access individual collectors wrapped by Lucene's `MultiCollector`. This was necessary because `MultiCollector.getCollectors()` was package-private in earlier Lucene versions.
+
+With Lucene 9.1+, the `getCollectors()` method became public (via [LUCENE-10244](https://github.com/apache/lucene/pull/455)), allowing OpenSearch to remove its wrapper class and use Lucene's native implementation directly.
+
+### Technical Changes
+
+#### Removed Components
+
+| Component | Description |
+|-----------|-------------|
+| `MultiCollectorWrapper` | Custom wrapper class that provided access to underlying collectors |
+
+#### Code Changes
+
+The `TopDocsCollectorContext` class was updated to:
+
+1. Replace `MultiCollectorWrapper.wrap()` calls with `MultiCollector.wrap()`
+2. Replace `instanceof MultiCollectorWrapper` checks with `instanceof MultiCollector`
+3. Use `MultiCollector.getCollectors()` directly instead of the wrapper's method
+4. Adopt Java pattern matching for `instanceof` (e.g., `instanceof MultiCollector m`)
+
+```java
+// Before (v3.3.x and earlier)
+return MultiCollectorWrapper.wrap(manager.newCollector(), maxScoreCollector);
+// ...
+if (collector instanceof MultiCollectorWrapper) {
+    subs.addAll(((MultiCollectorWrapper) collector).getCollectors());
+}
+
+// After (v3.4.0)
+return MultiCollector.wrap(manager.newCollector(), maxScoreCollector);
+// ...
+if (collector instanceof MultiCollector m) {
+    subs.addAll(List.of(m.getCollectors()));
+}
+```
+
+### Usage Example
+
+The change is internal and does not affect user-facing APIs. The `CollectorManager` pattern continues to work as before:
+
+```java
+// CollectorManager implementation using MultiCollector
+class CustomCollectorManager implements CollectorManager<Collector, Result> {
+    @Override
+    public Collector newCollector() throws IOException {
+        return MultiCollector.wrap(new TopDocsCollector(), new MaxScoreCollector());
+    }
+    
+    @Override
+    public Result reduce(Collection<Collector> collectors) throws IOException {
+        for (Collector collector : collectors) {
+            if (collector instanceof MultiCollector m) {
+                // Access individual collectors via Lucene's public API
+                for (Collector sub : m.getCollectors()) {
+                    // Process each sub-collector
+                }
+            }
+        }
+        return result;
+    }
+}
+```
+
+### Migration Notes
+
+This is an internal refactoring with no user-facing changes. No migration is required.
+
+## Limitations
+
+None. This is a code cleanup change that improves maintainability.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19595](https://github.com/opensearch-project/OpenSearch/pull/19595) | Remove MultiCollectorWrapper and use MultiCollector in Lucene instead |
+
+## References
+
+- [LUCENE-10244](https://github.com/apache/lucene/issues/11280): Original Lucene issue requesting public `getCollectors()` method
+- [Lucene PR #455](https://github.com/apache/lucene/pull/455): Lucene PR that made `MultiCollector.getCollectors()` public
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/lucene-integration.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -7,6 +7,7 @@
 - [Build Tool Upgrades](features/opensearch/build-tool-upgrades.md) - Gradle 9.1 and bundled JDK 25 updates
 - [Dependency Updates (OpenSearch Core)](features/opensearch/dependency-updates-opensearch-core.md) - 32 dependency updates including Netty 4.2.4 for HTTP/3 readiness
 - [JDK 25 Support](features/opensearch/jdk-25-support.md) - Painless scripting compatibility fix for JDK 25 ClassValue behavioral change
+- [Lucene Integration](features/opensearch/lucene-integration.md) - Remove MultiCollectorWrapper and use Lucene's native MultiCollector API
 - [Lucene Upgrade](features/opensearch/lucene-upgrade.md) - Bump Apache Lucene from 10.3.1 to 10.3.2 with MaxScoreBulkScorer bug fix
 - [Node Stats Bugfixes](features/opensearch/node-stats-bugfixes.md) - Fix negative CPU usage values in node stats on certain Linux distributions
 - [S3 Repository](features/opensearch/s3-repository.md) - Add LEGACY_MD5_CHECKSUM_CALCULATION to opensearch.yml settings for S3-compatible storage


### PR DESCRIPTION
## Summary

Add documentation for the Lucene Integration feature in OpenSearch v3.4.0.

### Changes

This PR removes the custom `MultiCollectorWrapper` class from OpenSearch and replaces it with the native `MultiCollector.getCollectors()` method from Apache Lucene. This change reduces code duplication and improves maintainability.

### Reports Created

- Release report: `docs/releases/v3.4.0/features/opensearch/lucene-integration.md`
- Feature report: `docs/features/opensearch/lucene-integration.md`

### Related

- OpenSearch PR: [#19595](https://github.com/opensearch-project/OpenSearch/pull/19595)
- Lucene PR: [#455](https://github.com/apache/lucene/pull/455)
- Closes #1698