### PR TITLE
docs: add maven-snapshots-publishing report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -95,6 +95,8 @@
 - [Lucene Integration](opensearch/lucene-integration.md)
 - [Lucene Similarity](opensearch/lucene-similarity.md)
 - [Lucene Upgrade](opensearch/lucene-upgrade.md)
+- [Mapping Transformer](opensearch/mapping-transformer.md)
+- [Maven Snapshots Publishing](opensearch/maven-snapshots-publishing.md)
 - [Merge & Segment Settings](opensearch/merge-segment-settings.md)
 - [Multi-Search API](opensearch/multi-search-api.md)
 - [Nested Aggregations](opensearch/nested-aggregations.md)

--- a/docs/features/opensearch/maven-snapshots-publishing.md
+++ b/docs/features/opensearch/maven-snapshots-publishing.md
@@ -1,0 +1,135 @@
+# Maven Snapshots Publishing
+
+## Summary
+
+OpenSearch publishes Maven snapshot artifacts to enable developers to test pre-release versions of the project. Starting with v3.4.0, snapshots are published to a self-hosted S3 repository at `ci.opensearch.org` instead of Sonatype, providing better control over artifact retention and availability.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "CI/CD Pipeline"
+        Push[Push to main/release branch] --> GHA[GitHub Actions]
+        GHA --> Build[Gradle Build]
+        Build --> Publish[Publish Snapshots]
+    end
+    
+    subgraph "Authentication"
+        GHA --> OIDC[GitHub OIDC]
+        OIDC --> IAM[AWS IAM Role]
+        IAM --> Publish
+    end
+    
+    subgraph "Storage"
+        Publish --> S3[S3 Bucket]
+        S3 --> CDN[ci.opensearch.org]
+    end
+    
+    subgraph "Consumers"
+        CDN --> Dev[Developers]
+        CDN --> CI[Plugin CI]
+        CDN --> Tests[Integration Tests]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Code Push] --> B[GitHub Actions Trigger]
+    B --> C[Load 1Password Secrets]
+    C --> D[Assume AWS IAM Role]
+    D --> E[Gradle publishNebulaPublicationToSnapshotsRepository]
+    E --> F[Upload to S3]
+    F --> G[Available at ci.opensearch.org]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `publish-maven-snapshots.yml` | GitHub Actions workflow for automated publishing |
+| `build.gradle` | Gradle configuration with S3 repository and AWS credentials |
+| `gradle/run.gradle` | Local development configuration for snapshot consumption |
+| 1Password Secrets | Secure storage for S3 repository URL and IAM role ARN |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `MAVEN_SNAPSHOTS_S3_REPO` | S3 repository URL for publishing | `https://ci.opensearch.org/ci/dbc/snapshots/maven/` |
+| `MAVEN_SNAPSHOTS_S3_ROLE` | IAM role ARN for publishing | Stored in 1Password |
+| `AWS_ACCESS_KEY_ID` | AWS access key (from role assumption) | Dynamic |
+| `AWS_SECRET_ACCESS_KEY` | AWS secret key (from role assumption) | Dynamic |
+| `AWS_SESSION_TOKEN` | AWS session token (from role assumption) | Dynamic |
+
+### Usage Example
+
+#### Consuming Snapshots (Gradle)
+
+```groovy
+repositories {
+    maven {
+        name = 'OpenSearch Snapshots'
+        url = 'https://ci.opensearch.org/ci/dbc/snapshots/maven/'
+    }
+}
+
+dependencies {
+    implementation "org.opensearch:opensearch:3.4.0-SNAPSHOT"
+    implementation "org.opensearch.plugin:opensearch-job-scheduler:3.4.0.0-SNAPSHOT"
+}
+```
+
+#### Consuming Snapshots (Maven)
+
+```xml
+<repositories>
+    <repository>
+        <id>opensearch-snapshots</id>
+        <url>https://ci.opensearch.org/ci/dbc/snapshots/maven/</url>
+        <snapshots>
+            <enabled>true</enabled>
+        </snapshots>
+    </repository>
+</repositories>
+
+<dependencies>
+    <dependency>
+        <groupId>org.opensearch</groupId>
+        <artifactId>opensearch</artifactId>
+        <version>3.4.0-SNAPSHOT</version>
+    </dependency>
+</dependencies>
+```
+
+#### Consuming Snapshots (Maven CLI)
+
+```bash
+mvn org.apache.maven.plugins:maven-dependency-plugin:2.1:get \
+  -DrepoUrl=https://ci.opensearch.org/ci/dbc/snapshots/maven/ \
+  -Dartifact=org.opensearch.plugin:opensearch-job-scheduler:3.4.0.0-SNAPSHOT:zip
+```
+
+## Limitations
+
+- Publishing requires AWS IAM role assumption (internal CI only)
+- No web-based browsing interface for the S3 repository
+- Requires GitHub OIDC integration for secure authentication
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#19619](https://github.com/opensearch-project/OpenSearch/pull/19619) | Onboarding new maven snapshots publishing to S3 (OpenSearch Core) |
+
+## References
+
+- [Issue #5360](https://github.com/opensearch-project/opensearch-build/issues/5360): Migration from Sonatype snapshots repo to ci.opensearch.org
+- [Blog: OpenSearch plugin zips now in Maven repo](https://opensearch.org/blog/opensearch-plugin-zips-now-in-maven-repo/): Background on Maven publishing infrastructure
+
+## Change History
+
+- **v3.4.0** (2025-10-15): Migrated snapshot publishing from Sonatype to S3-backed repository at ci.opensearch.org due to Sonatype's 30-day retention policy

--- a/docs/releases/v3.4.0/features/opensearch/maven-snapshots-publishing.md
+++ b/docs/releases/v3.4.0/features/opensearch/maven-snapshots-publishing.md
@@ -1,0 +1,107 @@
+# Maven Snapshots Publishing
+
+## Summary
+
+OpenSearch v3.4.0 migrates Maven snapshot publishing from Sonatype to a self-hosted S3 repository at `ci.opensearch.org`. This change was driven by Sonatype's new policy of removing snapshots older than 30 days, which impacted the project's ability to maintain stable development dependencies.
+
+## Details
+
+### What's New in v3.4.0
+
+The snapshot publishing infrastructure has been migrated from Sonatype's Maven repository to an AWS S3-backed repository hosted at `https://ci.opensearch.org/ci/dbc/snapshots/maven/`.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.4.0"
+        GHA1[GitHub Actions] -->|Username/Password| Sonatype[Sonatype Maven Repo]
+        Sonatype -->|30-day retention| Dev1[Developers]
+    end
+    
+    subgraph "v3.4.0+"
+        GHA2[GitHub Actions] -->|IAM Role via OIDC| S3[S3 Snapshots Repo]
+        S3 -->|No retention limit| Dev2[Developers]
+    end
+```
+
+#### New Configuration
+
+| Setting | Description | Value |
+|---------|-------------|-------|
+| `MAVEN_SNAPSHOTS_S3_REPO` | S3 repository URL | `https://ci.opensearch.org/ci/dbc/snapshots/maven/` |
+| `MAVEN_SNAPSHOTS_S3_ROLE` | IAM role for publishing | Stored in 1Password |
+
+#### Workflow Changes
+
+The GitHub Actions workflow now uses AWS IAM role assumption via OIDC instead of username/password authentication:
+
+```yaml
+- name: Configure AWS credentials
+  uses: aws-actions/configure-aws-credentials@v5
+  with:
+    role-to-assume: ${{ env.MAVEN_SNAPSHOTS_S3_ROLE }}
+    aws-region: us-east-1
+```
+
+The Gradle build configuration uses AWS credentials for S3 publishing:
+
+```groovy
+maven {
+  name = 'Snapshots'
+  url = System.getenv("MAVEN_SNAPSHOTS_S3_REPO")
+  credentials(AwsCredentials) {
+    accessKey = System.getenv("AWS_ACCESS_KEY_ID")
+    secretKey = System.getenv("AWS_SECRET_ACCESS_KEY")
+    sessionToken = System.getenv("AWS_SESSION_TOKEN")
+  }
+}
+```
+
+### Usage Example
+
+Consuming snapshots from the new repository:
+
+```groovy
+// build.gradle
+repositories {
+    maven {
+        name = 'OpenSearch Snapshots'
+        url = 'https://ci.opensearch.org/ci/dbc/snapshots/maven/'
+    }
+}
+
+dependencies {
+    implementation "org.opensearch:opensearch:3.4.0-SNAPSHOT"
+}
+```
+
+### Migration Notes
+
+For developers consuming OpenSearch snapshots:
+
+1. Update repository URL from `https://central.sonatype.com/repository/maven-snapshots/` to `https://ci.opensearch.org/ci/dbc/snapshots/maven/`
+2. No authentication required for consuming snapshots (read-only public access)
+3. Existing snapshot versions have been migrated to the new location
+
+## Limitations
+
+- Publishing requires AWS IAM role assumption (internal CI only)
+- The S3 repository does not support browsing via web interface like Sonatype
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19619](https://github.com/opensearch-project/OpenSearch/pull/19619) | Onboarding new maven snapshots publishing to S3 (OpenSearch Core) |
+
+## References
+
+- [Issue #5360](https://github.com/opensearch-project/opensearch-build/issues/5360): Migration from Sonatype snapshots repo to ci.opensearch.org
+- [Blog: OpenSearch plugin zips now in Maven repo](https://opensearch.org/blog/opensearch-plugin-zips-now-in-maven-repo/): Background on Maven publishing
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/maven-snapshots-publishing.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -9,6 +9,7 @@
 - [JDK 25 Support](features/opensearch/jdk-25-support.md) - Painless scripting compatibility fix for JDK 25 ClassValue behavioral change
 - [Lucene Integration](features/opensearch/lucene-integration.md) - Remove MultiCollectorWrapper and use Lucene's native MultiCollector API
 - [Lucene Upgrade](features/opensearch/lucene-upgrade.md) - Bump Apache Lucene from 10.3.1 to 10.3.2 with MaxScoreBulkScorer bug fix
+- [Maven Snapshots Publishing](features/opensearch/maven-snapshots-publishing.md) - Migrate snapshot publishing from Sonatype to S3-backed repository at ci.opensearch.org
 - [Node Stats Bugfixes](features/opensearch/node-stats-bugfixes.md) - Fix negative CPU usage values in node stats on certain Linux distributions
 - [S3 Repository](features/opensearch/s3-repository.md) - Add LEGACY_MD5_CHECKSUM_CALCULATION to opensearch.yml settings for S3-compatible storage
 - [Security Kerberos Integration](features/opensearch/security-kerberos-integration.md) - Update Hadoop to 3.4.2 and enable Kerberos integration tests for JDK-24+


### PR DESCRIPTION
## Summary

Add documentation for Maven Snapshots Publishing feature in OpenSearch v3.4.0.

### Changes
- Release report: `docs/releases/v3.4.0/features/opensearch/maven-snapshots-publishing.md`
- Feature report: `docs/features/opensearch/maven-snapshots-publishing.md`
- Updated release index and features index

### Key Points
- Migration from Sonatype to S3-backed repository at ci.opensearch.org
- Driven by Sonatype's 30-day retention policy
- Uses AWS IAM role assumption via OIDC for secure publishing
- No authentication required for consuming snapshots

### Related
- PR: opensearch-project/OpenSearch#19619
- Issue: opensearch-project/opensearch-build#5360
- Tracking Issue: #1697