### PR TITLE
docs: add concurrent segment search report for v3.4.0

### DIFF
--- a/docs/features/opensearch/concurrent-segment-search.md
+++ b/docs/features/opensearch/concurrent-segment-search.md
@@ -117,6 +117,7 @@ PUT _cluster/settings
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#19584](https://github.com/opensearch-project/OpenSearch/pull/19584) | Omit maxScoreCollector in SimpleTopDocsCollectorContext when concurrent segment search enabled |
 | v3.3.0 | [#19053](https://github.com/opensearch-project/OpenSearch/pull/19053) | Fix assertion error when collapsing search results with concurrent segment search |
 | v3.2.0 | [#18451](https://github.com/opensearch-project/OpenSearch/pull/18451) | Optimize grouping for segment concurrent search |
 
@@ -131,6 +132,7 @@ PUT _cluster/settings
 
 ## Change History
 
+- **v3.4.0** (2026-01-14): Performance optimization - omit MaxScoreCollector in SimpleTopDocsCollectorContext when sorting by score with concurrent segment search enabled (~10% latency improvement)
 - **v3.3.0** (2025-10-30): Fixed assertion error when using field collapsing with concurrent segment search by removing setShardIndex parameter from CollapseTopFieldDocs.merge()
 - **v3.2.0** (2025-07-31): Optimized segment grouping algorithm using priority queue for better load balancing
 - **v3.0.0**: Concurrent segment search enabled by default in `auto` mode

--- a/docs/releases/v3.4.0/features/opensearch/concurrent-segment-search.md
+++ b/docs/releases/v3.4.0/features/opensearch/concurrent-segment-search.md
@@ -1,0 +1,85 @@
+# Concurrent Segment Search Performance Optimization
+
+## Summary
+
+This release improves concurrent segment search performance by omitting the `MaxScoreCollector` in `SimpleTopDocsCollectorContext` when sorting by score. This optimization reduces search latency by approximately 10% for queries that use score-based sorting with concurrent segment search enabled.
+
+## Details
+
+### What's New in v3.4.0
+
+The optimization extends the existing `MaxScoreCollector` omission logic (previously applied to `CollapsingTopDocsCollectorContext` in v3.3.0) to `SimpleTopDocsCollectorContext`. When concurrent segment search is enabled and the primary sort is by score, the `MaxScoreCollector` is now skipped because the maximum score can be derived directly from the top-scoring document.
+
+### Technical Changes
+
+#### Code Changes
+
+The change introduces a `sortByScore` field in `SimpleTopDocsCollectorContext` to track whether the query sorts by score as the primary sort field:
+
+```java
+private final boolean sortByScore;
+
+// In constructor:
+this.sortByScore = sortAndFormats == null || SortField.FIELD_SCORE.equals(sortAndFormats.sort.getSort()[0]);
+```
+
+This field is then used in three locations to conditionally skip the `MaxScoreCollector`:
+
+1. **Collector creation** - When creating the collector manager, skip `MaxScoreCollector` if sorting by score
+2. **newCollector()** - In the concurrent search path, only create `MaxScoreCollector` when `!sortByScore && trackMaxScore`
+3. **newTopDocs()** - Use the same condition for determining total hits handling
+
+#### Performance Impact
+
+Benchmark results show approximately 10% improvement in search latency:
+
+| Metric | Before | After | Improvement |
+|--------|--------|-------|-------------|
+| 50th percentile | 286ms | 257ms | ~10% |
+| 90th percentile | 345ms | 282ms | ~18% |
+| 99th percentile | 421ms | 331ms | ~21% |
+
+### Usage Example
+
+The optimization is automatic when using concurrent segment search with score-based sorting:
+
+```json
+GET my-index/_search
+{
+  "query": {
+    "bool": {
+      "must": [
+        { "match": { "message": "search term" } }
+      ]
+    }
+  },
+  "sort": [
+    { "_score": { "order": "desc" } },
+    { "_doc": { "order": "asc" } }
+  ]
+}
+```
+
+With concurrent segment search enabled (`search.concurrent_segment_search.mode: all`), this query will now skip the redundant `MaxScoreCollector`.
+
+## Limitations
+
+- The optimization only applies when `_score` is the primary sort field
+- Queries with custom sort orders that don't use score as primary sort will not benefit from this optimization
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19584](https://github.com/opensearch-project/OpenSearch/pull/19584) | Omit maxScoreCollector in SimpleTopDocsCollectorContext when concurrent segment search enabled |
+| [#19181](https://github.com/opensearch-project/OpenSearch/pull/19181) | Related: Omit maxScoreCollector for field collapsing when sort by score descending |
+
+## References
+
+- [Concurrent Segment Search Documentation](https://docs.opensearch.org/3.0/search-plugins/concurrent-segment-search/): Official documentation
+- [Introducing concurrent segment search in OpenSearch](https://opensearch.org/blog/concurrent_segment_search/): Introduction blog post
+- [Exploring concurrent segment search performance](https://opensearch.org/blog/concurrent-search-follow-up/): Performance analysis blog
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/concurrent-segment-search.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -5,6 +5,7 @@
 ### OpenSearch
 
 - [Build Tool Upgrades](features/opensearch/build-tool-upgrades.md) - Gradle 9.1 and bundled JDK 25 updates
+- [Concurrent Segment Search](features/opensearch/concurrent-segment-search.md) - Performance optimization by omitting MaxScoreCollector when sorting by score
 - [Dependency Updates (OpenSearch Core)](features/opensearch/dependency-updates-opensearch-core.md) - 32 dependency updates including Netty 4.2.4 for HTTP/3 readiness
 - [JDK 25 Support](features/opensearch/jdk-25-support.md) - Painless scripting compatibility fix for JDK 25 ClassValue behavioral change
 - [Lucene Integration](features/opensearch/lucene-integration.md) - Remove MultiCollectorWrapper and use Lucene's native MultiCollector API


### PR DESCRIPTION
## Summary

Add documentation for the concurrent segment search performance optimization in OpenSearch v3.4.0.

### Changes
- Created release report: `docs/releases/v3.4.0/features/opensearch/concurrent-segment-search.md`
- Updated feature report: `docs/features/opensearch/concurrent-segment-search.md`
- Updated release index: `docs/releases/v3.4.0/index.md`

### Key Changes in v3.4.0
- Omit `MaxScoreCollector` in `SimpleTopDocsCollectorContext` when concurrent segment search is enabled and sorting by score
- ~10% latency improvement for score-sorted queries with concurrent segment search

### Related
- PR: [opensearch-project/OpenSearch#19584](https://github.com/opensearch-project/OpenSearch/pull/19584)
- Issue: #1696