### PR TITLE
docs: add Terms Query Optimization report for v3.4.0

### DIFF
--- a/docs/features/opensearch/terms-query.md
+++ b/docs/features/opensearch/terms-query.md
@@ -147,16 +147,21 @@ flowchart LR
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#19350](https://github.com/opensearch-project/OpenSearch/pull/19350) | Pack terms once for keyword fields with index and docValues |
+| v3.4.0 | [#17714](https://github.com/opensearch-project/OpenSearch/pull/17714) | Pass in-order terms as sorted to TermInSetQuery |
 | v3.3.0 | [#19587](https://github.com/opensearch-project/OpenSearch/pull/19587) | Fix rewriting terms query with consecutive whole numbers |
 | v2.17.0 | - | Added bitmap filtering support |
 
 ## References
 
 - [Issue #19566](https://github.com/opensearch-project/OpenSearch/issues/19566): Bug report for must_not terms query issue
+- [Forum Discussion](https://forum.opensearch.org/t/avoid-re-sorting-when-initializing-terminsetquery/23865): Performance issue with TermInSetQuery sorting
+- [Lucene PR #14435](https://github.com/apache/lucene/pull/14435): Lucene enhancement for shared packed terms
 - [Terms Query Documentation](https://docs.opensearch.org/3.0/query-dsl/term/terms/): Official documentation
 - [Roaring Bitmap](https://github.com/RoaringBitmap/RoaringBitmap): Bitmap encoding library
 
 ## Change History
 
+- **v3.4.0** (2025-10-09): Optimized terms query creation for keyword fields with both index and doc_values enabled by packing terms only once when values are identical
 - **v3.3.0** (2025-10-09): Fixed incorrect rewriting of terms query with more than 2 consecutive whole numbers in `must_not` clauses
 - **v2.17.0**: Added bitmap filtering support for efficient large-scale term filtering

--- a/docs/releases/v3.4.0/features/opensearch/terms-query-optimization.md
+++ b/docs/releases/v3.4.0/features/opensearch/terms-query-optimization.md
@@ -1,0 +1,108 @@
+# Terms Query Optimization
+
+## Summary
+
+This release optimizes `terms` query creation for `keyword` fields that have both index and doc_values enabled. When the indexed terms and doc_values terms are identical (the common case), OpenSearch now packs the terms only once instead of twice, reducing CPU overhead and memory allocations during query construction.
+
+## Details
+
+### What's New in v3.4.0
+
+The optimization targets the `termsQuery()` method in `KeywordFieldMapper.KeywordFieldType`. Previously, when both index and doc_values were enabled, OpenSearch would always create two separate `BytesRefsCollectionBuilder` instances and pack terms twice—once for the index query and once for the doc_values query. This was inefficient because in most cases, the indexed value and doc_value are identical.
+
+The new implementation:
+1. Lazily initializes the doc_values term builder only when needed
+2. Detects when indexed terms and doc_values terms diverge (via `rewriteForDocValue()`)
+3. Uses `TermInSetQuery.newIndexOrDocValuesQuery()` when terms are identical, packing once
+4. Falls back to separate queries only when terms actually differ
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+flowchart TB
+    subgraph "Before v3.4.0"
+        A1[Terms Query] --> B1[Build Index Terms]
+        A1 --> C1[Build DocValues Terms]
+        B1 --> D1[TermInSetQuery Index]
+        C1 --> E1[TermInSetQuery DocValues]
+        D1 --> F1[IndexOrDocValuesQuery]
+        E1 --> F1
+    end
+    
+    subgraph "After v3.4.0"
+        A2[Terms Query] --> B2[Build Index Terms]
+        B2 --> G2{Terms Diverge?}
+        G2 --> |No| H2[newIndexOrDocValuesQuery<br/>Pack Once]
+        G2 --> |Yes| I2[Build DocValues Terms]
+        I2 --> J2[IndexOrDocValuesQuery<br/>Separate Queries]
+    end
+```
+
+#### Key Code Changes
+
+| File | Change |
+|------|--------|
+| `KeywordFieldMapper.java` | Lazy initialization of `dVByteRefs`, divergence detection, use of `newIndexOrDocValuesQuery()` |
+| `BytesRefsCollectionBuilder.java` | Documentation clarification |
+
+#### New API Usage
+
+The optimization leverages Lucene's `TermInSetQuery.newIndexOrDocValuesQuery()` method (introduced in Lucene via [apache/lucene#14435](https://github.com/apache/lucene/pull/14435)) which creates an `IndexOrDocValuesQuery` that shares the packed terms between both the index and doc_values queries.
+
+```java
+// When index and docValues terms are identical
+return TermInSetQuery.newIndexOrDocValuesQuery(
+    MultiTermQuery.CONSTANT_SCORE_BLENDED_REWRITE, 
+    name(), 
+    iBytesRefs.get()
+);
+```
+
+### Usage Example
+
+No API changes are required. The optimization is automatic for all `terms` queries on `keyword` fields with both index and doc_values enabled:
+
+```json
+GET my-index/_search
+{
+  "query": {
+    "terms": {
+      "status": ["active", "pending", "completed"]
+    }
+  }
+}
+```
+
+### Performance Impact
+
+This optimization reduces:
+- CPU time spent sorting and packing terms (especially noticeable with large term lists)
+- Memory allocations by avoiding duplicate `BytesRef` collections
+- GC pressure from reduced object creation
+
+The improvement is most significant for queries with many terms, where the sorting overhead in `TermInSetQuery.packTerms()` was previously doubled.
+
+## Limitations
+
+- Only applies to `keyword` fields with both `index: true` and `doc_values: true`
+- Fields using custom `rewriteForDocValue()` implementations that transform values will still use separate queries
+- The optimization is transparent and cannot be disabled
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19350](https://github.com/opensearch-project/OpenSearch/pull/19350) | Pack terms once when `terms` query is created for indexed and docValues keyword field |
+| [#17714](https://github.com/opensearch-project/OpenSearch/pull/17714) | Pass in-order terms as sorted to TermInSetQuery() (prerequisite) |
+
+## References
+
+- [Forum Discussion](https://forum.opensearch.org/t/avoid-re-sorting-when-initializing-terminsetquery/23865): Original performance issue report
+- [Lucene PR #14435](https://github.com/apache/lucene/pull/14435): Lucene enhancement enabling this optimization
+- [Terms Query Documentation](https://docs.opensearch.org/3.0/query-dsl/term/terms/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/terms-query.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -17,6 +17,7 @@
 - [Security Kerberos Integration](features/opensearch/security-kerberos-integration.md) - Update Hadoop to 3.4.2 and enable Kerberos integration tests for JDK-24+
 - [Settings Bugfixes](features/opensearch/settings-bugfixes.md) - Fix duplicate registration of dynamic settings and patch version build issues
 - [Stats Builder Pattern Deprecations](features/opensearch/stats-builder-pattern-deprecations.md) - Deprecated constructors in 30+ Stats classes in favor of Builder pattern
+- [Terms Query Optimization](features/opensearch/terms-query-optimization.md) - Pack terms once for keyword fields with index and docValues enabled
 - [XContent Filtering](features/opensearch/xcontent-filtering.md) - Case-insensitive filtering support for XContentMapValues.filter
 - [Plugin Dependencies](features/opensearch/plugin-dependencies.md) - Range semver support for dependencies in plugin-descriptor.properties
 - [ActionPlugin Enhancements](features/opensearch/actionplugin-enhancements.md) - Pass REST header registry to getRestHandlerWrapper for efficient header access


### PR DESCRIPTION
## Summary

This PR adds documentation for the Terms Query Optimization feature in OpenSearch v3.4.0.

### Changes

**Release Report** (`docs/releases/v3.4.0/features/opensearch/terms-query-optimization.md`):
- Documents the optimization that packs terms only once for keyword fields with both index and doc_values enabled
- Explains the technical implementation using `TermInSetQuery.newIndexOrDocValuesQuery()`
- Includes architecture diagrams showing before/after query construction flow

**Feature Report Update** (`docs/features/opensearch/terms-query.md`):
- Added v3.4.0 entry to Related PRs table
- Added references to forum discussion and Lucene PR
- Updated Change History with v3.4.0 optimization

**Release Index Update** (`docs/releases/v3.4.0/index.md`):
- Added link to the new release report

### Key Points

- Optimization reduces CPU time and memory allocations by avoiding duplicate term packing
- Most significant for queries with many terms where sorting overhead was previously doubled
- Transparent optimization - no API changes required

### Related

- PR: opensearch-project/OpenSearch#19350
- Prerequisite PR: opensearch-project/OpenSearch#17714
- Forum Discussion: https://forum.opensearch.org/t/avoid-re-sorting-when-initializing-terminsetquery/23865