### PR TITLE
docs: add aggregation optimizations report for v3.4.0

### DIFF
--- a/docs/features/opensearch/aggregation-optimizations.md
+++ b/docs/features/opensearch/aggregation-optimizations.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-OpenSearch provides various performance optimizations for aggregation operations. These optimizations reduce query latency and memory consumption by using smarter algorithms for bucket selection, precomputation techniques, and object reuse patterns. The optimizations target three key aggregation types: rare terms, string terms, and date histogram aggregations.
+OpenSearch provides various performance optimizations for aggregation operations. These optimizations reduce query latency and memory consumption by using smarter algorithms for bucket selection, precomputation techniques, object reuse patterns, and adaptive collector strategies. The optimizations target multiple aggregation types including rare terms, string terms, date histogram, cardinality, percentiles, and matrix_stats aggregations.
 
 ## Details
 
@@ -19,12 +19,17 @@ graph TB
         PreComp[Precomputation Check]
         Strategy[Strategy Selection]
         Rounding[Rounding Optimization]
+        Hybrid[Hybrid Collector]
+        SkipList[Skip List]
     end
     
     subgraph "Aggregation Types"
         RareTerms[Rare Terms Aggregator]
         StringTerms[String Terms Aggregator]
         DateHist[Date Histogram Aggregator]
+        Cardinality[Cardinality Aggregator]
+        Percentiles[Percentiles Aggregator]
+        MatrixStats[Matrix Stats Aggregator]
     end
     
     Query --> PreComp
@@ -33,10 +38,15 @@ graph TB
     PreComp --> RareTerms
     Strategy --> StringTerms
     Rounding --> DateHist
+    Hybrid --> Cardinality
+    SkipList --> DateHist
     
     RareTerms --> |"Term Frequency"| Result[Aggregation Result]
     StringTerms --> |"Bucket Selection"| Result
-    DateHist --> |"Object Reuse"| Result
+    DateHist --> |"Object Reuse + Skip List"| Result
+    Cardinality --> |"Adaptive Collection"| Result
+    Percentiles --> |"MergingDigest"| Result
+    MatrixStats --> |"Primitive Arrays"| Result
 ```
 
 ### Data Flow
@@ -57,9 +67,17 @@ flowchart TB
         ST2 -->|"buckets > 5×size"| ST5[QuickSelect]
     end
     
-    subgraph "Date Histogram Optimization"
-        DH1[Rounding Request] --> DH2[Reuse Rounding Object]
-        DH2 --> DH3[Compute Bucket Key]
+    subgraph "Hybrid Cardinality"
+        HC1[Start with Ordinals] --> HC2{Memory OK?}
+        HC2 -->|Yes| HC3[Continue Ordinals]
+        HC2 -->|No| HC4[Switch to Direct]
+        HC4 --> HC5[Reuse Computed Data]
+    end
+    
+    subgraph "Sub-aggregation Skip List"
+        SL1[Filter Rewrite] --> SL2[Multi-range Traversal]
+        SL2 --> SL3[Skip List for Sub-agg]
+        SL3 --> SL4[Up to 10x Improvement]
     end
 ```
 
@@ -73,12 +91,17 @@ flowchart TB
 | `Rounding` | Date rounding utilities with object reuse optimization |
 | `TimeUnitPreparedRounding` | Prepared rounding implementations for time units |
 | `TimeIntervalPreparedRounding` | Prepared rounding implementations for time intervals |
+| `HybridCardinalityCollector` | Collector that switches between Ordinals and Direct based on memory |
+| `MergingDigest` | Faster t-digest implementation for percentiles |
+| `RunningStats` | Matrix stats with primitive array optimization |
 
 ### Configuration
 
 | Setting | Description | Default |
 |---------|-------------|---------|
 | `search.bucket_selection_strategy_factor` | Threshold factor for quickselect vs priority queue | 5 |
+| `search.aggregations.cardinality.hybrid_collector.enabled` | Enable hybrid cardinality collector | `true` |
+| `search.aggregations.cardinality.hybrid_collector.memory_threshold` | Memory threshold for switching collectors | Dynamic |
 
 ### Optimization Strategies
 
@@ -102,6 +125,39 @@ Three strategies are available based on the ratio of requested size to total buc
 | `select_all` | Direct copy | O(n) | buckets ≤ size |
 | `priority_queue` | Heap-based selection | O(n log k) | buckets ≤ 5×size |
 | `quick_select` | Partition-based selection | O(n) average | buckets > 5×size |
+
+#### Hybrid Cardinality Collector
+
+The hybrid collector addresses the trade-off between speed and memory:
+
+- **OrdinalsCollector**: Faster but uses more memory (byte arrays sized by cardinality)
+- **DirectCollector**: Slower but more memory-efficient
+
+The hybrid approach starts with OrdinalsCollector and switches to DirectCollector if memory usage exceeds the threshold, reusing already computed aggregation data.
+
+#### Filter Rewrite + Skip List for Sub-aggregations
+
+Combines two optimization techniques for sub-aggregations:
+
+1. **Filter Rewrite**: Uses multi-range traversal for top-level aggregation
+2. **Skip List**: Optimizes sub-aggregation collection when data is sorted
+
+This delivers up to 10x performance improvement for queries like `range-auto-date-histo-metrics` in the big5 benchmark.
+
+#### Percentiles MergingDigest
+
+Replaces `AVLTreeDigest` with `MergingDigest` from the t-digest library:
+
+- Faster execution (up to 97% improvement for low-cardinality fields)
+- Uses less than half the memory
+- Same accuracy guarantees
+
+#### Matrix Stats Primitive Arrays
+
+Replaces `Map<String, Double>` with `double[]` in the hot loop:
+
+- Eliminates boxing/unboxing overhead
+- 80% performance improvement on nyc_taxis benchmark
 
 #### Date Histogram Object Reuse
 
@@ -148,7 +204,7 @@ GET /events/_search
   }
 }
 
-// Date histogram with sub-aggregation
+// Date histogram with sub-aggregation (benefits from skip list)
 GET /metrics/_search
 {
   "size": 0,
@@ -166,6 +222,46 @@ GET /metrics/_search
     }
   }
 }
+
+// Cardinality with hybrid collector (automatic)
+GET /logs/_search
+{
+  "size": 0,
+  "aggs": {
+    "unique_users": {
+      "cardinality": {
+        "field": "user_id.keyword"
+      }
+    }
+  }
+}
+
+// Percentiles with MergingDigest (automatic)
+GET /response_times/_search
+{
+  "size": 0,
+  "aggs": {
+    "latency_percentiles": {
+      "percentiles": {
+        "field": "latency",
+        "percents": [50, 95, 99]
+      }
+    }
+  }
+}
+
+// Matrix stats with primitive arrays (automatic)
+GET /taxi/_search
+{
+  "size": 0,
+  "aggs": {
+    "matrix_stats_result": {
+      "matrix_stats": {
+        "fields": ["trip_distance", "tip_amount"]
+      }
+    }
+  }
+}
 ```
 
 ## Limitations
@@ -174,24 +270,40 @@ GET /metrics/_search
 - String terms quickselect does not apply to significant terms aggregations
 - Date histogram optimization benefits are most visible with sub-aggregations
 - Precomputation does not work with documents containing `_doc_count` field
+- Hybrid cardinality collector memory threshold is dynamically calculated
+- Filter rewrite + skip list requires data sorted on the aggregation field for maximum benefit
+- Auto date histogram skip list currently only works when auto_date_histogram is root or within range filter rewrite context
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#19524](https://github.com/opensearch-project/OpenSearch/pull/19524) | Hybrid Cardinality collector for high cardinality queries |
+| v3.4.0 | [#19573](https://github.com/opensearch-project/OpenSearch/pull/19573) | Filter rewrite + skip list for sub-aggregation optimization |
+| v3.4.0 | [#19648](https://github.com/opensearch-project/OpenSearch/pull/19648) | MergingDigest implementation for percentiles aggregation |
+| v3.4.0 | [#19989](https://github.com/opensearch-project/OpenSearch/pull/19989) | Primitive arrays for matrix_stats aggregation |
+| v3.4.0 | [#20057](https://github.com/opensearch-project/OpenSearch/pull/20057) | Skip list optimization for auto_date_histogram |
 | v3.3.0 | [#18978](https://github.com/opensearch-project/OpenSearch/pull/18978) | Rare terms aggregation precomputation |
 | v3.3.0 | [#18732](https://github.com/opensearch-project/OpenSearch/pull/18732) | String terms aggregation optimization |
 | v3.3.0 | [#19088](https://github.com/opensearch-project/OpenSearch/pull/19088) | Date histogram rounding optimization |
 
 ## References
 
+- [Issue #19260](https://github.com/opensearch-project/OpenSearch/issues/19260): Auto Select Ordinals cardinality collector for high cardinality queries
+- [Issue #18122](https://github.com/opensearch-project/OpenSearch/issues/18122): Speed up percentile aggregation by switching implementation
+- [Issue #19741](https://github.com/opensearch-project/OpenSearch/issues/19741): Remove maps from hot loop in matrix_stats agg for performance
+- [Issue #19827](https://github.com/opensearch-project/OpenSearch/issues/19827): Add skip_list logic to auto date histogram
+- [Issue #17447](https://github.com/opensearch-project/OpenSearch/pull/17447): Support sub agg in filter rewrite optimization
 - [Issue #13122](https://github.com/opensearch-project/OpenSearch/issues/13122): Rare Terms Aggregation Performance Optimization
 - [Issue #18704](https://github.com/opensearch-project/OpenSearch/issues/18704): Optimize String terms agg
 - [Issue #10954](https://github.com/opensearch-project/OpenSearch/issues/10954): Use Collector.setWeight to improve aggregation performance
+- [Cardinality Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/metric/cardinality/)
+- [Percentile Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/metric/percentile/)
 - [Rare Terms Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/rare-terms/)
 - [Terms Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/terms/)
 - [Date Histogram Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/date-histogram/)
 
 ## Change History
 
+- **v3.4.0** (2026-01): Added hybrid cardinality collector, filter rewrite + skip list for sub-aggregations, MergingDigest for percentiles, primitive arrays for matrix_stats, skip list for auto_date_histogram
 - **v3.3.0** (2026-01): Added precomputation for rare terms, quickselect for string terms, object reuse for date histogram

--- a/docs/releases/v3.4.0/features/opensearch/aggregation-optimizations.md
+++ b/docs/releases/v3.4.0/features/opensearch/aggregation-optimizations.md
@@ -1,0 +1,150 @@
+# Aggregation Optimizations
+
+## Summary
+
+OpenSearch v3.4.0 introduces significant performance improvements for multiple aggregation types. These optimizations deliver up to 10x performance gains for sub-aggregations with filter rewrite and skip list, 80% speedup for matrix_stats aggregation, and substantial latency improvements for percentiles and cardinality aggregations.
+
+## Details
+
+### What's New in v3.4.0
+
+This release adds five major aggregation optimizations:
+
+1. **Hybrid Cardinality Collector** - Dynamically switches between OrdinalsCollector and DirectCollector based on memory usage
+2. **Filter Rewrite + Skip List for Sub-aggregations** - Combines multi-range traversal with skip list optimization for up to 10x improvement
+3. **Percentiles MergingDigest Implementation** - Switches from AVLTreeDigest to faster MergingDigest algorithm
+4. **Matrix Stats Primitive Arrays** - Replaces Map<String, Double> with primitive arrays to eliminate boxing overhead
+5. **Auto Date Histogram Skip List** - Extends skip list optimization to auto_date_histogram aggregation
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Cardinality Aggregation"
+        CA[Cardinality Request] --> HC[Hybrid Collector]
+        HC --> OC[Ordinals Collector]
+        HC --> DC[Direct Collector]
+        OC -->|Memory Threshold| DC
+    end
+    
+    subgraph "Sub-aggregation Optimization"
+        SA[Range/Date Histogram] --> FR[Filter Rewrite]
+        FR --> SL[Skip List]
+        SL --> SubAgg[Sub-aggregation]
+    end
+    
+    subgraph "Percentiles"
+        PA[Percentiles Request] --> MD[MergingDigest]
+        MD --> Result[Percentile Values]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `HybridCardinalityCollector` | Collector that starts with OrdinalsCollector and switches to DirectCollector when memory threshold is exceeded |
+| `MergingDigest` | Faster t-digest implementation replacing AVLTreeDigest for percentiles |
+| `RunningStats` (optimized) | Uses primitive double[]/long[] arrays instead of Map<String, Double/Long> |
+| `AutoDateHistogramSkipList` | Skip list support for auto_date_histogram with dynamic rounding |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `search.aggregations.cardinality.hybrid_collector.enabled` | Enable hybrid cardinality collector | `true` |
+| `search.aggregations.cardinality.hybrid_collector.memory_threshold` | Memory threshold for switching collectors | Dynamic |
+
+### Usage Example
+
+```json
+// Hybrid cardinality collector is automatically used
+GET /logs/_search
+{
+  "size": 0,
+  "aggs": {
+    "unique_users": {
+      "cardinality": {
+        "field": "user_id.keyword"
+      }
+    }
+  }
+}
+
+// Sub-aggregation with filter rewrite + skip list (automatic)
+GET /metrics/_search
+{
+  "size": 0,
+  "aggs": {
+    "by_hour": {
+      "date_histogram": {
+        "field": "@timestamp",
+        "fixed_interval": "1h"
+      },
+      "aggs": {
+        "avg_value": { "avg": { "field": "value" } }
+      }
+    }
+  }
+}
+
+// Percentiles with MergingDigest (automatic)
+GET /response_times/_search
+{
+  "size": 0,
+  "aggs": {
+    "latency_percentiles": {
+      "percentiles": {
+        "field": "latency",
+        "percents": [50, 95, 99]
+      }
+    }
+  }
+}
+```
+
+### Performance Improvements
+
+| Optimization | Benchmark | Improvement |
+|--------------|-----------|-------------|
+| Filter Rewrite + Skip List | big5 workload | Up to 10x faster |
+| Percentiles (MergingDigest) | http_logs @timestamp | 13s → 6.3s (52% faster) |
+| Percentiles (MergingDigest) | http_logs status (low cardinality) | 197s → 6.2s (97% faster) |
+| Matrix Stats | nyc_taxis | 15.6s → 3.1s (80% faster) |
+
+### Migration Notes
+
+All optimizations are enabled by default and require no configuration changes. The improvements are transparent to existing queries.
+
+## Limitations
+
+- Hybrid cardinality collector memory threshold is dynamically calculated based on available heap
+- Filter rewrite + skip list optimization requires data sorted on the aggregation field for maximum benefit
+- Auto date histogram skip list currently only works when auto_date_histogram is root or within range filter rewrite context
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19524](https://github.com/opensearch-project/OpenSearch/pull/19524) | Add Hybrid Cardinality collector to prioritize Ordinals Collector |
+| [#19573](https://github.com/opensearch-project/OpenSearch/pull/19573) | Combining filter rewrite and skip list to optimize sub aggregation |
+| [#19648](https://github.com/opensearch-project/OpenSearch/pull/19648) | Change implementation for percentiles aggregation for latency improvement |
+| [#19989](https://github.com/opensearch-project/OpenSearch/pull/19989) | Improve performance of matrix_stats aggregation |
+| [#20057](https://github.com/opensearch-project/OpenSearch/pull/20057) | Add skiplist optimization to auto_date_histogram aggregation |
+
+## References
+
+- [Issue #19260](https://github.com/opensearch-project/OpenSearch/issues/19260): Auto Select Ordinals cardinality collector for high cardinality queries
+- [Issue #18122](https://github.com/opensearch-project/OpenSearch/issues/18122): Speed up percentile aggregation by switching implementation
+- [Issue #19741](https://github.com/opensearch-project/OpenSearch/issues/19741): Remove maps from hot loop in matrix_stats agg for performance
+- [Issue #19827](https://github.com/opensearch-project/OpenSearch/issues/19827): Add skip_list logic to auto date histogram
+- [Issue #17447](https://github.com/opensearch-project/OpenSearch/pull/17447): Support sub agg in filter rewrite optimization
+- [Cardinality Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/metric/cardinality/)
+- [Percentile Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/metric/percentile/)
+- [Date Histogram Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/date-histogram/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/aggregation-optimizations.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -4,6 +4,7 @@
 
 ### OpenSearch
 
+- [Aggregation Optimizations](features/opensearch/aggregation-optimizations.md) - Hybrid cardinality collector, filter rewrite + skip list, MergingDigest for percentiles, matrix_stats primitive arrays
 - [Build Tool Upgrades](features/opensearch/build-tool-upgrades.md) - Gradle 9.1 and bundled JDK 25 updates
 - [Concurrent Segment Search](features/opensearch/concurrent-segment-search.md) - Performance optimization by omitting MaxScoreCollector when sorting by score
 - [Dependency Updates (OpenSearch Core)](features/opensearch/dependency-updates-opensearch-core.md) - 32 dependency updates including Netty 4.2.4 for HTTP/3 readiness


### PR DESCRIPTION
## Summary

This PR adds documentation for the Aggregation Optimizations feature in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch/aggregation-optimizations.md`
- Feature report: `docs/features/opensearch/aggregation-optimizations.md` (updated)

### Key Changes in v3.4.0

1. **Hybrid Cardinality Collector** - Dynamically switches between OrdinalsCollector and DirectCollector based on memory usage
2. **Filter Rewrite + Skip List for Sub-aggregations** - Up to 10x performance improvement
3. **Percentiles MergingDigest Implementation** - Up to 97% faster for low-cardinality fields
4. **Matrix Stats Primitive Arrays** - 80% performance improvement
5. **Auto Date Histogram Skip List** - Extended skip list optimization

### Related PRs
- [#19524](https://github.com/opensearch-project/OpenSearch/pull/19524): Hybrid Cardinality collector
- [#19573](https://github.com/opensearch-project/OpenSearch/pull/19573): Filter rewrite + skip list
- [#19648](https://github.com/opensearch-project/OpenSearch/pull/19648): MergingDigest for percentiles
- [#19989](https://github.com/opensearch-project/OpenSearch/pull/19989): Matrix stats optimization
- [#20057](https://github.com/opensearch-project/OpenSearch/pull/20057): Auto date histogram skip list

Closes #1693