### PR TITLE
docs: add normalizer enhancements report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -106,6 +106,7 @@
 - [Node Stats](opensearch/node-stats.md)
 - [Nodes Info API](opensearch/nodes-info-api.md)
 - [Node Roles Configuration](opensearch/node-roles-configuration.md)
+- [Normalizer Enhancements](opensearch/normalizer-enhancements.md)
 - [Numeric Terms Aggregation Optimization](opensearch/numeric-terms-aggregation-optimization.md)
 - [Offline Nodes (Background Tasks)](opensearch/offline-nodes.md)
 - [OOM Prevention](opensearch/oom-prevention.md)

--- a/docs/features/opensearch/normalizer-enhancements.md
+++ b/docs/features/opensearch/normalizer-enhancements.md
@@ -1,0 +1,145 @@
+# Normalizer Enhancements
+
+## Summary
+
+OpenSearch normalizers provide a way to apply character-level transformations to keyword fields, producing a single normalized token. This feature tracks enhancements to the normalizer functionality, including support for additional token filters that can be used within normalizers.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Text Analysis Pipeline"
+        Input[Input Text] --> Normalizer
+        subgraph Normalizer["Normalizer"]
+            CF[Character Filters] --> TF[Token Filters]
+        end
+        Normalizer --> Output[Single Normalized Token]
+    end
+    
+    subgraph "Supported Token Filters"
+        TF --> Truncate[truncate]
+        TF --> Lowercase[lowercase]
+        TF --> Uppercase[uppercase]
+        TF --> ASCIIFolding[asciifolding]
+        TF --> Others[...]
+    end
+```
+
+### How Normalizers Work
+
+Unlike analyzers that can produce multiple tokens, normalizers:
+- Output exactly one token
+- Do not use a tokenizer
+- Only accept filters that implement `NormalizingTokenFilterFactory` or `NormalizingCharFilterFactory`
+- Perform character-level operations only
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `NormalizingTokenFilterFactory` | Interface that token filters must implement to be usable in normalizers |
+| `NormalizingCharFilterFactory` | Interface for character filters compatible with normalizers |
+| `TruncateTokenFilterFactory` | Token filter that truncates tokens to a specified length |
+
+### Supported Filters
+
+#### Token Filters (common-analysis module)
+
+| Filter | Description |
+|--------|-------------|
+| `arabic_normalization` | Arabic text normalization |
+| `asciifolding` | Converts non-ASCII characters to ASCII equivalents |
+| `bengali_normalization` | Bengali text normalization |
+| `cjk_width` | Normalizes CJK width differences |
+| `decimal_digit` | Converts decimal digits |
+| `elision` | Removes elisions |
+| `german_normalization` | German text normalization |
+| `hindi_normalization` | Hindi text normalization |
+| `indic_normalization` | Indic text normalization |
+| `lowercase` | Converts to lowercase |
+| `persian_normalization` | Persian text normalization |
+| `scandinavian_folding` | Scandinavian character folding |
+| `scandinavian_normalization` | Scandinavian text normalization |
+| `serbian_normalization` | Serbian text normalization |
+| `sorani_normalization` | Sorani text normalization |
+| `trim` | Removes leading/trailing whitespace |
+| `truncate` | Truncates tokens to specified length (added in v3.4.0) |
+| `uppercase` | Converts to uppercase |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `type` | Must be `custom` for custom normalizers | Required |
+| `char_filter` | Array of character filters to apply | `[]` |
+| `filter` | Array of token filters to apply | `[]` |
+
+### Usage Example
+
+```json
+PUT /my_index
+{
+  "settings": {
+    "analysis": {
+      "filter": {
+        "truncate_filter": {
+          "type": "truncate",
+          "length": 20
+        }
+      },
+      "normalizer": {
+        "my_normalizer": {
+          "type": "custom",
+          "char_filter": [],
+          "filter": ["lowercase", "asciifolding", "truncate_filter"]
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "code": {
+        "type": "keyword",
+        "normalizer": "my_normalizer"
+      }
+    }
+  }
+}
+```
+
+Test the normalizer:
+
+```json
+GET /my_index/_analyze
+{
+  "normalizer": "my_normalizer",
+  "text": "Naïve APPROACH with LONG TEXT"
+}
+```
+
+Result: `naive approach with l` (lowercased, ASCII-folded, truncated to 20 chars)
+
+## Limitations
+
+- Normalizers can only use filters that implement the normalizing interfaces
+- Cannot perform operations that change token count (e.g., synonyms, stemming)
+- The truncate filter requires a positive `length` parameter
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#19779](https://github.com/opensearch-project/OpenSearch/pull/19779) | Add truncate filter support in normalizers |
+
+## References
+
+- [Issue #19778](https://github.com/opensearch-project/OpenSearch/issues/19778): Feature request for truncate filter in normalizers
+- [Normalizers Documentation](https://docs.opensearch.org/3.0/analyzers/normalizers/)
+- [Truncate Token Filter Documentation](https://docs.opensearch.org/3.0/analyzers/token-filters/truncate/)
+- [Normalizer Mapping Parameter](https://docs.opensearch.org/3.0/field-types/mapping-parameters/normalizer/)
+
+## Change History
+
+- **v3.4.0** (2025-11-17): Added `truncate` token filter support in normalizers

--- a/docs/releases/v3.4.0/features/opensearch/normalizer-enhancements.md
+++ b/docs/releases/v3.4.0/features/opensearch/normalizer-enhancements.md
@@ -1,0 +1,110 @@
+# Normalizer Enhancements
+
+## Summary
+
+OpenSearch v3.4.0 adds support for using the `truncate` token filter within normalizers. This enhancement allows users to truncate keyword field values to a specified length during normalization, providing an alternative to the `ignore_above` mapping parameter when you want to keep truncated data rather than discard it entirely.
+
+## Details
+
+### What's New in v3.4.0
+
+The `truncate` token filter can now be used in custom normalizers. Previously, the truncate filter was only available for use in analyzers. This change enables keyword fields to have their values shortened to a maximum character length during the normalization process.
+
+### Technical Changes
+
+#### Implementation
+
+The change involves marking `TruncateTokenFilterFactory` as a `NormalizingTokenFilterFactory`:
+
+```java
+public class TruncateTokenFilterFactory extends AbstractTokenFilterFactory 
+    implements NormalizingTokenFilterFactory {
+    // ...
+}
+```
+
+This simple interface implementation allows the truncate filter to be recognized as compatible with normalizers.
+
+#### How Normalizers Work
+
+A normalizer functions similarly to an analyzer but outputs only a single token. It does not contain a tokenizer and can only include specific types of character and token filters that perform character-level operations. The truncate filter qualifies because it operates on individual characters without changing the token structure.
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `length` | Maximum number of characters for the token | Required (no default) |
+
+### Usage Example
+
+Create an index with a custom normalizer using the truncate filter:
+
+```json
+PUT /my_index
+{
+  "settings": {
+    "analysis": {
+      "filter": {
+        "my_truncate": {
+          "type": "truncate",
+          "length": 10
+        }
+      },
+      "normalizer": {
+        "my_normalizer": {
+          "type": "custom",
+          "filter": ["lowercase", "my_truncate"]
+        }
+      }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "product_code": {
+        "type": "keyword",
+        "normalizer": "my_normalizer"
+      }
+    }
+  }
+}
+```
+
+Index a document with a long value:
+
+```json
+POST /my_index/_doc/1
+{
+  "product_code": "ABCDEFGHIJKLMNOP"
+}
+```
+
+The stored and indexed value will be truncated to `abcdefghij` (10 characters, lowercased).
+
+### Use Cases
+
+- **Data preservation**: Keep truncated keyword values instead of ignoring documents that exceed `ignore_above`
+- **Consistent field lengths**: Ensure all keyword values conform to a maximum length
+- **Combined normalization**: Apply truncation along with other normalizing filters like `lowercase` or `asciifolding`
+
+## Limitations
+
+- The `length` parameter is required and must be a positive integer
+- Truncation happens at the character level, which may split multi-byte characters in certain edge cases
+- Cannot be combined with non-normalizing token filters in a normalizer
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19779](https://github.com/opensearch-project/OpenSearch/pull/19779) | Make truncate filter a normalizer token filter |
+
+## References
+
+- [Issue #19778](https://github.com/opensearch-project/OpenSearch/issues/19778): Feature request for truncate filter in normalizers
+- [Truncate Token Filter Documentation](https://docs.opensearch.org/3.0/analyzers/token-filters/truncate/)
+- [Normalizers Documentation](https://docs.opensearch.org/3.0/analyzers/normalizers/)
+- [Documentation PR #11429](https://github.com/opensearch-project/documentation-website/pull/11429): Public documentation update
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/normalizer-enhancements.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -14,6 +14,7 @@
 - [Lucene Upgrade](features/opensearch/lucene-upgrade.md) - Bump Apache Lucene from 10.3.1 to 10.3.2 with MaxScoreBulkScorer bug fix
 - [Maven Snapshots Publishing](features/opensearch/maven-snapshots-publishing.md) - Migrate snapshot publishing from Sonatype to S3-backed repository at ci.opensearch.org
 - [Node Stats Bugfixes](features/opensearch/node-stats-bugfixes.md) - Fix negative CPU usage values in node stats on certain Linux distributions
+- [Normalizer Enhancements](features/opensearch/normalizer-enhancements.md) - Allow truncate token filter in normalizers for keyword field truncation
 - [S3 Repository](features/opensearch/s3-repository.md) - Add LEGACY_MD5_CHECKSUM_CALCULATION to opensearch.yml settings for S3-compatible storage
 - [Scroll Query Optimization](features/opensearch/scroll-query-optimization.md) - Cache StoredFieldsReader per segment for improved scroll query performance
 - [Search API Tracker](features/opensearch/search-api-tracker.md) - Track search response status codes at coordinator node for observability


### PR DESCRIPTION
## Summary

This PR adds documentation for the Normalizer Enhancements feature in OpenSearch v3.4.0.

### What's New

OpenSearch v3.4.0 adds support for using the `truncate` token filter within normalizers. This allows users to truncate keyword field values to a specified length during normalization, providing an alternative to `ignore_above` when you want to keep truncated data rather than discard it.

### Reports Created

- Release report: `docs/releases/v3.4.0/features/opensearch/normalizer-enhancements.md`
- Feature report: `docs/features/opensearch/normalizer-enhancements.md`

### Key Changes in v3.4.0

- `TruncateTokenFilterFactory` now implements `NormalizingTokenFilterFactory`
- The `truncate` filter can be used in custom normalizers
- Enables keyword field value truncation during normalization

### Related

- Closes #1690
- PR: [opensearch-project/OpenSearch#19779](https://github.com/opensearch-project/OpenSearch/pull/19779)
- Issue: [opensearch-project/OpenSearch#19778](https://github.com/opensearch-project/OpenSearch/issues/19778)