### PR TITLE
docs: add Bulk API Enhancements report for v3.4.0

### DIFF
--- a/docs/features/opensearch/bulk-api.md
+++ b/docs/features/opensearch/bulk-api.md
@@ -67,6 +67,7 @@ flowchart TB
 | `pipeline` | Ingest pipeline to use | - |
 | `require_alias` | Require target to be an alias | `false` |
 | `wait_for_active_shards` | Number of active shards required | `1` |
+| `error_trace` | Include stack traces in error responses (v3.4.0+) | `false` |
 
 ### Supported Operations
 
@@ -126,6 +127,7 @@ POST _bulk
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#19985](https://github.com/opensearch-project/OpenSearch/pull/19985) | Implement error_trace parameter for bulk requests |
 | v3.4.0 | [#20132](https://github.com/opensearch-project/OpenSearch/pull/20132) | Fix `indices` property initialization during deserialization |
 | v3.0.0 | [#17801](https://github.com/opensearch-project/OpenSearch/pull/17801) | Remove deprecated `batch_size` parameter |
 | v2.9.0 | [#8039](https://github.com/opensearch-project/OpenSearch/pull/8039) | Enforce 512 byte document ID limit |
@@ -133,12 +135,15 @@ POST _bulk
 
 ## References
 
+- [Issue #19945](https://github.com/opensearch-project/OpenSearch/issues/19945): Bug report - Bulk API ignores error_trace query parameter
 - [Issue #14283](https://github.com/opensearch-project/OpenSearch/issues/14283): Make batch ingestion automatic
 - [Issue #6595](https://github.com/opensearch-project/OpenSearch/issues/6595): Bug report for _id size limit bypass
 - [Bulk API Documentation](https://docs.opensearch.org/3.0/api-reference/document-apis/bulk/): Official documentation
+- [Common REST Parameters](https://docs.opensearch.org/3.0/api-reference/common-parameters/): Documentation for error_trace parameter
 
 ## Change History
 
+- **v3.4.0** (2026-01-14): Added proper `error_trace` parameter support for stack traces in bulk error responses
 - **v3.4.0** (2026-01-14): Fixed `indices` property not being initialized during deserialization
 - **v3.0.0** (2025-05-13): Removed deprecated `batch_size` parameter; batch processing is now automatic
 - **v2.14.0** (2024-04-30): Added `batch_size` parameter for ingest pipeline batch processing (deprecated)

--- a/docs/releases/v3.4.0/features/opensearch/bulk-api-enhancements.md
+++ b/docs/releases/v3.4.0/features/opensearch/bulk-api-enhancements.md
@@ -1,0 +1,122 @@
+# Bulk API Enhancements
+
+## Summary
+
+This release adds proper support for the `error_trace` query parameter in Bulk HTTP APIs (`_bulk`, `_msearch`, `_mget`, `_mtermvectors`). Previously, the `error_trace` parameter was ignored for bulk operations when individual items failed, even though it worked correctly when the entire request failed. Now, detailed stack traces are consistently included in error responses when `error_trace=true` is specified.
+
+## Details
+
+### What's New in v3.4.0
+
+The `error_trace` parameter now works consistently across all REST APIs, including bulk operations. When `error_trace=true` is set and `http.detailed_errors.enabled=true`, failed items in bulk responses will include the `stack_trace` field with detailed exception information.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "REST Request Processing"
+        A[REST Request] --> B[RestController]
+        B --> C{error_trace param?}
+        C -->|true| D[Set detailedErrorStackTraceEnabled]
+        C -->|false| E[Skip stack traces]
+        D --> F[RestChannel]
+        E --> F
+    end
+    
+    subgraph "Response Serialization"
+        F --> G[RestToXContentListener]
+        G --> H{detailedErrorStackTraceEnabled?}
+        H -->|true| I[Include stack_trace in errors]
+        H -->|false| J[Omit stack_trace]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `RestChannel.detailedErrorStackTraceEnabled()` | New method to check if stack traces should be included |
+| `AbstractRestChannel.detailedErrorStackTraceRequested` | Field to track `error_trace` parameter value |
+
+#### Modified Components
+
+| Component | Change |
+|-----------|--------|
+| `RestToXContentListener` | Added `getRequestParams()` method that injects `REST_EXCEPTION_SKIP_STACK_TRACE=false` when error traces are enabled |
+| `RestStatusToXContentListener` | Updated to use `getRequestParams()` for consistent behavior |
+| `RestController` | Added `detailedErrorStackTraceEnabled()` delegation in wrapper classes |
+| `TraceableRestChannel` | Added `detailedErrorStackTraceEnabled()` delegation |
+
+### Root Cause
+
+The issue occurred because bulk API responses are serialized differently from regular error responses:
+
+1. When a bulk request succeeds (HTTP 200) but contains failed items, the response serialization didn't use the `error_trace` parameter
+2. The `rest.exception.stacktrace.skip` parameter defaulted to `true` (skip stack traces) during item serialization
+3. The fix properly transforms `error_trace=true` to `rest.exception.stacktrace.skip=false` for all response serialization
+
+### Usage Example
+
+```bash
+# Request with error_trace enabled
+POST _bulk?error_trace=true
+{ "update": { "_index": "movies", "_id": "nonexistent" } }
+{ "doc": { "field": "value" } }
+
+# Response now includes stack_trace for failed items
+{
+  "took": 2,
+  "errors": true,
+  "items": [
+    {
+      "update": {
+        "_index": "movies",
+        "_id": "nonexistent",
+        "status": 404,
+        "error": {
+          "type": "document_missing_exception",
+          "reason": "[nonexistent]: document missing",
+          "index": "movies",
+          "shard": "0",
+          "index_uuid": "...",
+          "stack_trace": "[movies/...][[movies][0]] DocumentMissingException[[nonexistent]: document missing]\n\tat org.opensearch.action.update.UpdateHelper..."
+        }
+      }
+    }
+  ]
+}
+```
+
+### Affected APIs
+
+- `_bulk` - Bulk indexing/update/delete operations
+- `_msearch` - Multi-search operations
+- `_mget` - Multi-get operations
+- `_mtermvectors` - Multi-term vectors operations
+
+### Prerequisites
+
+- `http.detailed_errors.enabled` must be `true` (default) for stack traces to be included
+- If `http.detailed_errors.enabled=false`, using `error_trace=true` returns HTTP 400
+
+## Limitations
+
+- Stack traces can significantly increase response size for bulk operations with many failures
+- Stack traces are only included when `http.detailed_errors.enabled=true`
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19985](https://github.com/opensearch-project/OpenSearch/pull/19985) | Implement error_trace parameter for HTTP Bulk requests |
+
+## References
+
+- [Issue #19945](https://github.com/opensearch-project/OpenSearch/issues/19945): Bug report - Bulk API ignores error_trace query parameter
+- [Common REST Parameters](https://docs.opensearch.org/3.0/api-reference/common-parameters/): Documentation for error_trace parameter
+
+## Related Feature Report
+
+- [Full Bulk API documentation](../../../features/opensearch/bulk-api.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -50,6 +50,7 @@
 
 - [Java Agent](features/opensearch/java-agent.md) - Fix JRT protocol URL filtering to allow MCP server connections
 - [Bulk Request Bugfixes](features/opensearch/bulk-request-bugfixes.md) - Fix indices property initialization during BulkRequest deserialization
+- [Bulk API Enhancements](features/opensearch/bulk-api-enhancements.md) - Implement error_trace parameter support for bulk requests
 - [Cluster State & Allocation Bugfixes](features/opensearch/cluster-state-allocation-bugfixes.md) - Fix concurrent modification in allocation filters and version compatibility in remote state
 - [Data Stream & Index Template Bugfixes](features/opensearch/data-stream-index-template-bugfixes.md) - Fix deletion of unused index templates matching data streams with lower priority
 - [GRPC Transport Bugfixes](features/opensearch/grpc-transport-bugfixes.md) - Fix ClassCastException for large requests, Bulk API fixes, and node bootstrap with streaming transport


### PR DESCRIPTION
## Summary

This PR adds documentation for the Bulk API Enhancements feature in OpenSearch v3.4.0.

### Changes
- Added release report: `docs/releases/v3.4.0/features/opensearch/bulk-api-enhancements.md`
- Updated feature report: `docs/features/opensearch/bulk-api.md`
- Updated release index: `docs/releases/v3.4.0/index.md`

### Feature Overview
Implements proper `error_trace` parameter support for Bulk HTTP APIs (`_bulk`, `_msearch`, `_mget`, `_mtermvectors`). Previously, the parameter was ignored for bulk operations when individual items failed. Now, detailed stack traces are consistently included in error responses when `error_trace=true` is specified.

### Related
- PR: [opensearch-project/OpenSearch#19985](https://github.com/opensearch-project/OpenSearch/pull/19985)
- Issue: [opensearch-project/OpenSearch#19945](https://github.com/opensearch-project/OpenSearch/issues/19945)
- Closes #1689