### PR TITLE
docs: add Context Aware Segments report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -44,6 +44,7 @@
 - [Composite Aggregation](opensearch/composite-aggregation.md)
 - [Composite Directory Factory](opensearch/composite-directory-factory.md)
 - [Concurrent Segment Search](opensearch/concurrent-segment-search.md)
+- [Context Aware Segments](opensearch/context-aware-segments.md)
 - [Crypto KMS Plugin](opensearch/crypto-kms-plugin.md)
 - [Custom Index Name Resolver](opensearch/custom-index-name-resolver.md)
 - [Data Stream & Index Template](opensearch/data-stream-index-template.md)

--- a/docs/features/opensearch/context-aware-segments.md
+++ b/docs/features/opensearch/context-aware-segments.md
@@ -1,0 +1,201 @@
+# Context Aware Segments
+
+## Summary
+
+Context Aware Segments is an indexing optimization feature that collocates related documents into the same segments based on a grouping criteria function. By aligning segment boundaries with anticipated query patterns, documents frequently queried together reside in the same segments, significantly improving query performance for workloads with predictable access patterns.
+
+This feature is particularly beneficial for log analytics scenarios where users often query for anomalies (4xx and 5xx status codes) over success logs (2xx). By segregating anomalies and success logs into distinct segments, queries like "number of faults in the last hour" process only relevant segments, improving performance.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "InternalEngine"
+        CIW[CompositeIndexWriter]
+        VMap[LiveVersionMap]
+    end
+    
+    subgraph "Active IndexWriters"
+        IW1[Group 1 Writer]
+        IW2[Group 2 Writer]
+        IWN[Group N Writer]
+    end
+    
+    subgraph "Mark for Refresh"
+        MR1[Pending Writer 1]
+        MR2[Pending Writer 2]
+    end
+    
+    subgraph "Accumulating Writer"
+        AIW[Parent IndexWriter]
+        DIR[Directory]
+    end
+    
+    Doc[Document] --> CIW
+    CIW -->|Grouping Criteria| IW1
+    CIW -->|Grouping Criteria| IW2
+    CIW -->|Grouping Criteria| IWN
+    
+    IW1 -->|Refresh| MR1
+    IW2 -->|Refresh| MR2
+    
+    MR1 -->|addIndexes| AIW
+    MR2 -->|addIndexes| AIW
+    
+    AIW --> DIR
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph Indexing
+        A[Index Request] --> B{Evaluate Group}
+        B --> C[Get/Create Group Writer]
+        C --> D[Index Document]
+        D --> E[Track in LiveIndexWriterDeletesMap]
+    end
+    
+    subgraph Refresh
+        F[beforeRefresh] --> G[Rotate Writer Map]
+        G --> H[Acquire Write Lock]
+        H --> I[Sync Deletes/Updates]
+        I --> J[addIndexes to Parent]
+        J --> K[Close Child Writers]
+        K --> L[afterRefresh]
+    end
+    
+    subgraph Search
+        M[Search Request] --> N[Open Reader on Parent]
+        N --> O[Execute Query]
+        O --> P[Return Results]
+    end
+    
+    E --> F
+    L --> M
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `CompositeIndexWriter` | Unified interface coordinating write operations with group-specific IndexWriters and managing reads through the accumulating parent IndexWriter |
+| `DisposableIndexWriter` | Group-specific IndexWriter with lifecycle states: Active → Mark for Refresh → Close |
+| `CriteriaBasedIndexWriterLookup` | Per-refresh-cycle lookup containing group-specific writers, update/delete tracking, and locking |
+| `LiveIndexWriterDeletesMap` | Refresh-rotating map structure (similar to LiveVersionMap) tracking updates/deletions |
+| `DocumentIndexWriter` | Interface abstracting IndexWriter operations for both standard and composite writers |
+| `LuceneIndexWriter` | Standard IndexWriter wrapper for non-context-aware indices |
+| `CriteriaBasedMergePolicy` | Merge policy ensuring segments from the same group are merged together |
+| `CriteriaBasedCodec` | Codec attaching bucket attributes to segments for group identification |
+| `CriteriaBasedDocValueFormat` | DocValue format attaching bucket attributes to field info |
+| `BucketedCompositeDirectory` | Directory wrapper filtering out child-level directories |
+| `LookupMapLockAcquisitionException` | Exception thrown when unable to acquire lock on lookup map |
+
+### Configuration
+
+| Setting | Description | Default | Dynamic |
+|---------|-------------|---------|---------|
+| `index.context_aware.enabled` | Enable context aware segments for the index | `false` | No (Final) |
+| `index.context_aware.max_retry_on_lookup_map_acquisition_exception` | Maximum retries when lock acquisition fails | `15` | Yes |
+
+### Feature Flag
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `opensearch.experimental.feature.context_aware.migration.enabled` | Enable context aware segments feature at node level | `false` |
+
+### Disposable IndexWriter States
+
+```mermaid
+stateDiagram-v2
+    [*] --> Active: Create for Group
+    Active --> MarkForRefresh: Refresh Triggered
+    MarkForRefresh --> Closed: Sync Complete
+    Closed --> [*]
+    
+    Active: Handles write requests
+    Active: One per group
+    MarkForRefresh: No new writes
+    MarkForRefresh: Completes ongoing ops
+    Closed: Synced via addIndexes
+    Closed: Resources released
+```
+
+### Locking Mechanism
+
+The feature uses a multi-level locking strategy:
+
+1. **ReentrantReadWriteLock (rwl)**: Existing engine-level lock ensuring IndexWriter isn't closed during indexing
+2. **Per-Map ReentrantReadWriteLock**: Additional lock for each `CriteriaBasedIndexWriterLookup`
+   - Read lock: Acquired during write/update/delete operations
+   - Write lock: Acquired during refresh before rotating the writer map
+3. **KeyedLock**: Per-document lock for version synchronization
+
+### Version Synchronization
+
+Updates and deletes across multiple IndexWriters require special handling:
+
+1. **Updates**: Track in `LiveIndexWriterDeletesMap`; during refresh, soft-delete previous versions in parent writer
+2. **Deletes**: Perform partial soft delete (delete without tombstone) in child writers; full delete in parent writer
+3. **Dummy Tombstone**: Temporary document (id=-2) used for cross-writer soft deletes, hard-deleted before refresh completes
+
+### Usage Example
+
+```yaml
+# opensearch.yml - Enable feature flag
+opensearch.experimental.feature.context_aware.migration.enabled: true
+```
+
+```json
+// Create index with context aware segments
+PUT /logs-index
+{
+  "settings": {
+    "index.context_aware.enabled": true,
+    "index.context_aware.max_retry_on_lookup_map_acquisition_exception": 20
+  },
+  "mappings": {
+    "properties": {
+      "status_code": { "type": "integer" },
+      "message": { "type": "text" },
+      "@timestamp": { "type": "date" }
+    }
+  }
+}
+```
+
+```json
+// Index documents - they will be grouped by criteria
+POST /logs-index/_doc
+{
+  "status_code": 500,
+  "message": "Internal server error",
+  "@timestamp": "2024-01-15T10:30:00Z"
+}
+```
+
+## Limitations
+
+- **Experimental**: Feature is behind a feature flag and not recommended for production
+- **Grouping Field Updates**: Updates to document fields that determine grouping criteria are not supported
+- **Search Idle Disabled**: Automatically disabled for context-aware indices to ensure periodic sync
+- **Blocking Refresh**: Always uses blocking refresh when context aware is enabled
+- **Index Setting Final**: `index.context_aware.enabled` cannot be changed after index creation
+- **Node Restart Required**: Feature flag requires node restart to take effect
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#19098](https://github.com/opensearch-project/OpenSearch/pull/19098) | Add support for context aware segments |
+
+## References
+
+- [Issue #19530](https://github.com/opensearch-project/OpenSearch/issues/19530): LLD for Context Aware Segments
+- [RFC #18576](https://github.com/opensearch-project/OpenSearch/issues/18576): Context Aware Segments RFC
+
+## Change History
+
+- **v3.4.0** (2025-11-07): Initial implementation with CompositeIndexWriter, CriteriaBasedMergePolicy, and experimental feature flag

--- a/docs/releases/v3.4.0/features/opensearch/context-aware-segments.md
+++ b/docs/releases/v3.4.0/features/opensearch/context-aware-segments.md
@@ -1,0 +1,128 @@
+# Context Aware Segments
+
+## Summary
+
+Context Aware Segments is a new indexing optimization feature that collocates related documents into the same segments based on a grouping criteria function. This enables more efficient query execution by ensuring that documents frequently queried together reside in the same segments, significantly improving query performance for workloads with predictable access patterns like log analytics.
+
+## Details
+
+### What's New in v3.4.0
+
+This release introduces the foundational implementation of Context Aware Segments, including:
+
+- **CompositeIndexWriter**: A new wrapper class that manages multiple group-specific IndexWriters
+- **Disposable IndexWriters**: Pool of group-specific IndexWriters modeled after Lucene's DWPTs
+- **CriteriaBasedMergePolicy**: Ensures segments from the same group are merged together
+- **CriteriaBasedCodec**: Attaches bucket attributes to segments for group identification
+- **Feature flag**: `opensearch.experimental.feature.context_aware.migration.enabled`
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph InternalEngine
+        CIW[CompositeIndexWriter]
+    end
+    
+    subgraph "Disposable IndexWriters"
+        IW1[IndexWriter Group 1]
+        IW2[IndexWriter Group 2]
+        IW3[IndexWriter Group N]
+    end
+    
+    subgraph "Accumulating Writer"
+        AIW[Parent IndexWriter]
+    end
+    
+    CIW --> IW1
+    CIW --> IW2
+    CIW --> IW3
+    CIW --> AIW
+    
+    IW1 -->|addIndexes| AIW
+    IW2 -->|addIndexes| AIW
+    IW3 -->|addIndexes| AIW
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `CompositeIndexWriter` | Unified interface for coordinating write operations with group-specific IndexWriters |
+| `DisposableIndexWriter` | Group-specific IndexWriter with three states: Active, Mark for Refresh, Close |
+| `CriteriaBasedIndexWriterLookup` | Lookup map for managing IndexWriters per refresh cycle |
+| `LiveIndexWriterDeletesMap` | Tracks updates/deletions using refresh-rotating map structure |
+| `CriteriaBasedMergePolicy` | Merge policy ensuring same-group segments merge together |
+| `CriteriaBasedCodec` | Codec attaching bucket attributes to segments |
+| `DocumentIndexWriter` | Interface abstracting IndexWriter operations |
+| `LuceneIndexWriter` | Standard IndexWriter wrapper for non-CAS indices |
+| `LookupMapLockAcquisitionException` | Exception for lock acquisition failures |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.context_aware.enabled` | Enable context aware segments for the index | `false` |
+| `index.context_aware.max_retry_on_lookup_map_acquisition_exception` | Max retries on lock acquisition failure | `15` |
+
+#### Feature Flag
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `opensearch.experimental.feature.context_aware.migration.enabled` | Enable context aware segments feature | `false` |
+
+### Usage Example
+
+```yaml
+# Enable feature flag at node startup
+opensearch.experimental.feature.context_aware.migration.enabled: true
+```
+
+```json
+// Create index with context aware segments enabled
+PUT /my-logs-index
+{
+  "settings": {
+    "index.context_aware.enabled": true
+  }
+}
+```
+
+### How It Works
+
+1. **Indexing**: Documents are routed to group-specific IndexWriters based on a grouping criteria function
+2. **Refresh**: Group-specific writers are synced with the parent accumulating IndexWriter via `addIndexes` API
+3. **Version Resolution**: Version map maintained per refresh cycle; lookups check version map then parent IndexWriter
+4. **Updates/Deletes**: Tracked in `LiveIndexWriterDeletesMap`; previous versions soft-deleted during refresh
+5. **Merging**: `CriteriaBasedMergePolicy` ensures segments from the same group merge together
+
+### Migration Notes
+
+- This is an experimental feature behind a feature flag
+- Requires node restart to enable the feature flag
+- Index setting `index.context_aware.enabled` is final (cannot be changed after index creation)
+- Search idle is automatically disabled for context-aware indices
+
+## Limitations
+
+- Experimental feature - not recommended for production use
+- Updates to document fields that determine grouping criteria are not supported
+- Search idle is disabled for context-aware indices to ensure periodic sync between child and parent IndexWriters
+- Blocking refresh is always used when context aware is enabled
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19098](https://github.com/opensearch-project/OpenSearch/pull/19098) | Add support for context aware segments |
+
+## References
+
+- [Issue #19530](https://github.com/opensearch-project/OpenSearch/issues/19530): LLD for Context Aware Segments
+- [RFC #18576](https://github.com/opensearch-project/OpenSearch/issues/18576): Context Aware Segments RFC
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/context-aware-segments.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -7,6 +7,7 @@
 - [Aggregation Optimizations](features/opensearch/aggregation-optimizations.md) - Hybrid cardinality collector, filter rewrite + skip list, MergingDigest for percentiles, matrix_stats primitive arrays
 - [Build Tool Upgrades](features/opensearch/build-tool-upgrades.md) - Gradle 9.1 and bundled JDK 25 updates
 - [Concurrent Segment Search](features/opensearch/concurrent-segment-search.md) - Performance optimization by omitting MaxScoreCollector when sorting by score
+- [Context Aware Segments](features/opensearch/context-aware-segments.md) - Collocate related documents into same segments based on grouping criteria for improved query performance
 - [Dependency Updates (OpenSearch Core)](features/opensearch/dependency-updates-opensearch-core.md) - 32 dependency updates including Netty 4.2.4 for HTTP/3 readiness
 - [Engine Refactoring](features/opensearch/engine-refactoring.md) - Move prepareIndex/prepareDelete to Engine class and make NoOpResult constructors public
 - [JDK 25 Support](features/opensearch/jdk-25-support.md) - Painless scripting compatibility fix for JDK 25 ClassValue behavioral change


### PR DESCRIPTION
## Summary

Add documentation for Context Aware Segments feature introduced in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch/context-aware-segments.md`
- Feature report: `docs/features/opensearch/context-aware-segments.md`

### Key Changes in v3.4.0
- CompositeIndexWriter for managing multiple group-specific IndexWriters
- Disposable IndexWriters modeled after Lucene's DWPTs
- CriteriaBasedMergePolicy ensuring same-group segments merge together
- CriteriaBasedCodec attaching bucket attributes to segments
- Experimental feature flag: `opensearch.experimental.feature.context_aware.migration.enabled`

### Resources Used
- PR: [#19098](https://github.com/opensearch-project/OpenSearch/pull/19098)
- Issue: [#19530](https://github.com/opensearch-project/OpenSearch/issues/19530)

Closes #1688