### PR TITLE
docs: add FIPS compliance report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -57,6 +57,7 @@
 - [Field Data Cache](opensearch/field-data-cache.md)
 - [Field Mapping](opensearch/field-mapping.md)
 - [File Cache](opensearch/file-cache.md)
+- [FIPS Compliance](opensearch/fips-compliance.md)
 - [Cluster Permissions](opensearch/cluster-permissions.md)
 - [Flat Object Field](opensearch/flat-object-field.md)
 - [Flaky Test Fixes](opensearch/flaky-test-fixes.md)

--- a/docs/features/opensearch/fips-compliance.md
+++ b/docs/features/opensearch/fips-compliance.md
@@ -1,0 +1,153 @@
+# FIPS Compliance
+
+## Summary
+
+OpenSearch supports FIPS 140-3 (Federal Information Processing Standard) compliance, enabling deployment in government and regulated environments that require FIPS-validated cryptographic modules. This is achieved through the use of Bouncy Castle FIPS (BC-FIPS) libraries as the cryptographic provider, replacing standard Bouncy Castle libraries.
+
+FIPS 140-3 is the current U.S. government security standard specifying requirements for cryptographic modules. Organizations in government, healthcare, finance, and other regulated industries often require FIPS-compliant software for handling sensitive data.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Core"
+        OS[OpenSearch Server]
+        SSL[SSL/TLS Layer]
+        KS[Keystore Management]
+        TEST[Test Framework]
+    end
+    
+    subgraph "Cryptographic Providers"
+        BCFIPS[BC-FIPS Provider]
+        BCTLS[bctls-fips]
+        BCUTIL[bcutil-fips]
+        BCPKIX[bcpkix-fips]
+    end
+    
+    subgraph "Keystore Types"
+        BCFKS[BCFKS Format]
+        JKS[JKS Format]
+    end
+    
+    OS --> SSL
+    OS --> KS
+    SSL --> BCFIPS
+    SSL --> BCTLS
+    KS --> BCFKS
+    KS --> JKS
+    TEST --> BCFIPS
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Build Time"
+        GRADLE[Gradle Build]
+        FIPS_FLAG{FIPS Mode?}
+        BCFIPS_DEPS[BC-FIPS Dependencies]
+        STD_DEPS[Standard Dependencies]
+    end
+    
+    subgraph "Runtime"
+        JVM[JVM with FIPS Provider]
+        CRYPTO[Cryptographic Operations]
+        TLS[TLS Connections]
+    end
+    
+    GRADLE --> FIPS_FLAG
+    FIPS_FLAG -->|Yes| BCFIPS_DEPS
+    FIPS_FLAG -->|No| STD_DEPS
+    BCFIPS_DEPS --> JVM
+    JVM --> CRYPTO
+    CRYPTO --> TLS
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `bc-fips` | Core FIPS 140-3 validated cryptographic library |
+| `bctls-fips` | TLS protocol implementation for FIPS mode |
+| `bcutil-fips` | Utility classes for FIPS cryptographic operations |
+| `bcpkix-fips` | PKIX/CMS/EAC/PKCS/OCSP/TSP support for FIPS |
+| `fips.gradle` | Gradle configuration for FIPS build and test |
+| `RestClientFipsAwareTestCase` | Test interface for FIPS-aware SSL handling |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `-Pcrypto.standard=FIPS-140-3` | Gradle parameter to enable FIPS mode | Not set |
+| `testFipsRuntimeOnly` | Gradle configuration for FIPS test dependencies | N/A |
+| Keystore type | BCFKS for FIPS, JKS for standard | JKS |
+
+### Usage Example
+
+Building OpenSearch with FIPS compliance:
+
+```bash
+# Build with FIPS 140-3 compliance
+./gradlew assemble -Pcrypto.standard=FIPS-140-3
+
+# Run tests in FIPS mode
+./gradlew test -Pcrypto.standard=FIPS-140-3
+```
+
+Creating FIPS-compliant keystores:
+
+```bash
+# Convert JKS to BCFKS format
+keytool -importkeystore \
+  -srckeystore keystore.jks \
+  -srcstoretype JKS \
+  -destkeystore keystore.bcfks \
+  -deststoretype BCFKS \
+  -providername BCFIPS \
+  -providerclass org.bouncycastle.jcajce.provider.BouncyCastleFipsProvider \
+  -providerpath bc-fips.jar
+```
+
+FIPS-aware test implementation:
+
+```java
+public class MyFipsTests extends MyTests implements RestClientFipsAwareTestCase {
+    
+    @Override
+    public SSLContext getSslContext(boolean server, String keyStoreType, 
+            SecureRandom secureRandom, String fileExtension) throws Exception {
+        // Implementation using BCFKS keystore and BCFIPS provider
+        KeyStore keyStore = KeyStore.getInstance(keyStoreType);
+        // ... load keystore with .bcfks extension in FIPS mode
+    }
+}
+```
+
+## Limitations
+
+- **Empty Passwords**: Empty keystore passwords are not allowed in FIPS mode
+- **Legacy Keystores**: V1 and V2 keystore formats cannot be loaded in FIPS JVM due to PBE (Password-Based Encryption) unavailability
+- **Algorithm Restrictions**: Some cryptographic algorithms available in standard mode are not FIPS-approved
+- **TLS Protocols**: Only TLSv1.2 and TLSv1.3 are allowed in FIPS mode
+- **Performance**: FIPS-validated implementations may have different performance characteristics
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#18491](https://github.com/opensearch-project/OpenSearch/pull/18491) | Make test-suite runnable under FIPS compliance support |
+| v3.4.0 | [#18921](https://github.com/opensearch-project/OpenSearch/pull/18921) | Add build-tooling to run in FIPS environment |
+
+## References
+
+- [RFC #4254](https://github.com/opensearch-project/security/issues/4254): FIPS-140 Compliance Roadmap for OpenSearch
+- [Issue #17634](https://github.com/opensearch-project/OpenSearch/issues/17634): META - Replace Bouncycastle dependencies with FIPS counterparts
+- [Issue #18324](https://github.com/opensearch-project/OpenSearch/issues/18324): Documentation for FIPS configuration
+- [NIST FIPS 140-3](https://csrc.nist.gov/publications/detail/fips/140/3/final): Security Requirements for Cryptographic Modules
+- [Bouncy Castle FIPS](https://www.bouncycastle.org/fips-java/): BC-FIPS Java Documentation
+
+## Change History
+
+- **v3.4.0** (2026-01): Test suite FIPS 140-3 compliance support with BC-FIPS provider

--- a/docs/releases/v3.4.0/features/opensearch/fips-compliance.md
+++ b/docs/releases/v3.4.0/features/opensearch/fips-compliance.md
@@ -1,0 +1,116 @@
+# FIPS Compliance
+
+## Summary
+
+OpenSearch v3.4.0 adds comprehensive FIPS 140-3 compliance support for the test suite, enabling developers to build and test OpenSearch under FIPS-compliant JVM environments. This change allows the entire test suite to run with FIPS-approved cryptographic algorithms using the Bouncy Castle FIPS (BC-FIPS) provider.
+
+## Details
+
+### What's New in v3.4.0
+
+This release makes the OpenSearch test suite fully runnable under FIPS 140-3 compliance mode by:
+
+1. Adding FIPS-aware test variants that use BCFKS keystores instead of JKS
+2. Introducing `RestClientFipsAwareTestCase` interface for SSL context handling
+3. Creating separate FIPS test classes that extend base tests with FIPS-specific behavior
+4. Adding BC-FIPS dependencies to test runtime configurations
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Test Framework"
+        BT[Base Test Class]
+        FT[FIPS Test Class]
+        FI[RestClientFipsAwareTestCase]
+    end
+    
+    subgraph "Keystore Types"
+        JKS[JKS Keystore]
+        BCFKS[BCFKS Keystore]
+    end
+    
+    subgraph "Crypto Providers"
+        SUN[SunJCE Provider]
+        BCFIPS[BCFIPS Provider]
+    end
+    
+    BT --> JKS
+    BT --> SUN
+    FT --> BT
+    FT --> FI
+    FI --> BCFKS
+    FI --> BCFIPS
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `RestClientFipsAwareTestCase` | Interface providing FIPS-aware SSL context creation |
+| `*FipsTests` classes | FIPS-specific test variants (e.g., `KeyStoreWrapperFipsTests`) |
+| `fips.gradle` | Gradle configuration for FIPS test dependencies |
+| `.bcfks` keystores | BCFKS format keystores for FIPS-compliant testing |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `-Pcrypto.standard=FIPS-140-3` | Gradle parameter to enable FIPS mode | Not set |
+| `testFipsRuntimeOnly` | Gradle configuration for FIPS test dependencies | N/A |
+
+### Usage Example
+
+To run tests in FIPS mode:
+
+```bash
+# Build and test with FIPS compliance
+./gradlew test -Pcrypto.standard=FIPS-140-3
+```
+
+The `RestClientFipsAwareTestCase` interface automatically selects the appropriate keystore type:
+
+```java
+interface RestClientFipsAwareTestCase {
+    default SSLContext getSslContext(boolean server) throws Exception {
+        if (inFipsJvm()) {
+            return getSslContext(server, "BCFKS", 
+                SecureRandom.getInstance("DEFAULT", "BCFIPS"), ".bcfks");
+        }
+        return getSslContext(server, "JKS", new SecureRandom(), ".jks");
+    }
+}
+```
+
+### Migration Notes
+
+For test developers:
+- Extend `*FipsTests` classes for FIPS-specific test behavior
+- Use `assumeFalse("Can't use empty password in a FIPS JVM", inFipsJvm())` to skip tests incompatible with FIPS
+- Provide `.bcfks` keystore files alongside `.jks` files for SSL tests
+
+## Limitations
+
+- Empty keystore passwords are not allowed in FIPS mode
+- Legacy keystore formats (v1, v2) cannot be loaded in FIPS JVM due to PBE unavailability
+- Some tests are skipped in FIPS mode due to algorithm restrictions
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18491](https://github.com/opensearch-project/OpenSearch/pull/18491) | Make test-suite runnable under FIPS compliance support |
+| [#18921](https://github.com/opensearch-project/OpenSearch/pull/18921) | Add build-tooling to run in FIPS environment |
+| [#14912](https://github.com/opensearch-project/OpenSearch/pull/14912) | Original FIPS compliance PR (predecessor) |
+
+## References
+
+- [RFC #4254](https://github.com/opensearch-project/security/issues/4254): FIPS-140 Compliance Roadmap for OpenSearch
+- [Issue #17634](https://github.com/opensearch-project/OpenSearch/issues/17634): META - Replace Bouncycastle dependencies with FIPS counterparts
+- [Issue #18324](https://github.com/opensearch-project/OpenSearch/issues/18324): Documentation for FIPS configuration
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/fips-compliance.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -10,6 +10,7 @@
 - [Context Aware Segments](features/opensearch/context-aware-segments.md) - Collocate related documents into same segments based on grouping criteria for improved query performance
 - [Dependency Updates (OpenSearch Core)](features/opensearch/dependency-updates-opensearch-core.md) - 32 dependency updates including Netty 4.2.4 for HTTP/3 readiness
 - [Engine Refactoring](features/opensearch/engine-refactoring.md) - Move prepareIndex/prepareDelete to Engine class and make NoOpResult constructors public
+- [FIPS Compliance](features/opensearch/fips-compliance.md) - Test suite FIPS 140-3 compliance support with BC-FIPS provider
 - [JDK 25 Support](features/opensearch/jdk-25-support.md) - Painless scripting compatibility fix for JDK 25 ClassValue behavioral change
 - [Lucene Integration](features/opensearch/lucene-integration.md) - Remove MultiCollectorWrapper and use Lucene's native MultiCollector API
 - [Lucene Upgrade](features/opensearch/lucene-upgrade.md) - Bump Apache Lucene from 10.3.1 to 10.3.2 with MaxScoreBulkScorer bug fix


### PR DESCRIPTION
## Summary

Add documentation for FIPS 140-3 compliance support in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch/fips-compliance.md`
- Feature report: `docs/features/opensearch/fips-compliance.md`

### Key Changes in v3.4.0
- Test suite can now run under FIPS-compliant JVM environments
- Added `RestClientFipsAwareTestCase` interface for FIPS-aware SSL context handling
- Created FIPS-specific test variants using BCFKS keystores
- Added BC-FIPS dependencies to test runtime configurations

### Resources Used
- PR: [#18491](https://github.com/opensearch-project/OpenSearch/pull/18491)
- RFC: [#4254](https://github.com/opensearch-project/security/issues/4254)

Closes #1687