### PR TITLE
docs: add Transport Actions API report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -181,6 +181,7 @@
 - [Tiered Caching](opensearch/tiered-caching.md)
 - [Translog](opensearch/translog.md)
 - [Transport Nodes Action Optimization](opensearch/transport-nodes-action-optimization.md)
+- [Transport Actions API](opensearch/transport-actions-api.md)
 - [Unified Highlighter](opensearch/unified-highlighter.md)
 - [Warm Storage Tiering](opensearch/warm-storage-tiering.md)
 - [Wildcard Field](opensearch/wildcard-field.md)

--- a/docs/features/opensearch/transport-actions-api.md
+++ b/docs/features/opensearch/transport-actions-api.md
@@ -1,0 +1,177 @@
+# Transport Actions API
+
+## Summary
+
+The Transport Actions API provides a standardized mechanism for transport actions to communicate precise information about the indices they will operate on. This internal API enables components like `ActionFilter` implementations (particularly the security plugin) to retrieve accurate index metadata without maintaining hard-coded knowledge of how each action interprets index expressions.
+
+The API addresses performance and maintainability issues in index-based access control by allowing transport actions to explicitly report their resolved indices, eliminating the need for external components to guess or duplicate index resolution logic.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Request Processing"
+        Client[Client Request] --> TA[TransportAction]
+        TA --> AF[ActionFilter Chain]
+        AF --> Execute[Action Execution]
+    end
+    
+    subgraph "Index Resolution API"
+        TA -.->|implements| TIRA[TransportIndicesResolvingAction]
+        TIRA -->|resolveIndices| RI[ResolvedIndices]
+        ARM[ActionRequestMetadata] -->|provides| RI
+        AF -->|receives| ARM
+    end
+    
+    subgraph "ResolvedIndices Structure"
+        RI --> Local[ResolvedIndices.Local]
+        RI --> Remote[ResolvedIndices.Remote]
+        Local --> Concrete[Local.Concrete]
+        Local --> SubActions[Sub-Actions Map]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    Request[ActionRequest] --> TIRA[TransportIndicesResolvingAction]
+    TIRA --> Resolve[resolveIndices]
+    Resolve --> RI[ResolvedIndices]
+    RI --> ARM[ActionRequestMetadata]
+    ARM --> AF[ActionFilter.apply]
+    AF --> Auth[Authorization Check]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `TransportIndicesResolvingAction<Request>` | Interface for transport actions to implement explicit index resolution |
+| `ActionRequestMetadata<Request, Response>` | Container passed to `ActionFilter.apply()` providing access to resolved indices |
+| `OptionallyResolvedIndices` | Base class representing potentially unknown resolved indices |
+| `ResolvedIndices` | Immutable class containing resolved local and remote indices |
+| `ResolvedIndices.Local` | Local indices, aliases, and data streams with names |
+| `ResolvedIndices.Local.Concrete` | Concrete indices with `Index` objects from `IndexNameExpressionResolver` |
+| `ResolvedIndices.Remote` | Remote cluster indices as cluster-to-indices map |
+
+### Configuration
+
+This is an internal API with no user-configurable settings. Transport actions opt-in by implementing the `TransportIndicesResolvingAction` interface.
+
+### Usage Example
+
+#### Implementing in a Transport Action
+
+```java
+public class TransportMyAction extends HandledTransportAction<MyRequest, MyResponse>
+    implements TransportIndicesResolvingAction<MyRequest> {
+    
+    private final IndexNameExpressionResolver indexNameExpressionResolver;
+    private final ClusterService clusterService;
+    
+    @Override
+    public ResolvedIndices resolveIndices(MyRequest request) {
+        // Use the same resolution logic as the action execution
+        return ResolvedIndices.of(
+            indexNameExpressionResolver.concreteResolvedIndices(
+                clusterService.state(), 
+                request
+            )
+        );
+    }
+    
+    @Override
+    protected void doExecute(Task task, MyRequest request, ActionListener<MyResponse> listener) {
+        // Action execution uses same resolution
+        Index[] indices = indexNameExpressionResolver.concreteIndices(
+            clusterService.state(), 
+            request
+        );
+        // ...
+    }
+}
+```
+
+#### Consuming in an ActionFilter
+
+```java
+public class MyActionFilter implements ActionFilter {
+    
+    @Override
+    public <Request extends ActionRequest, Response extends ActionResponse> void apply(
+        Task task, 
+        String action, 
+        Request request,
+        ActionRequestMetadata<Request, Response> actionRequestMetadata,
+        ActionListener<Response> listener,
+        ActionFilterChain<Request, Response> chain
+    ) {
+        OptionallyResolvedIndices resolved = actionRequestMetadata.resolvedIndices();
+        
+        if (resolved instanceof ResolvedIndices resolvedIndices) {
+            // Precise index information available
+            Set<String> localIndices = resolvedIndices.local().names();
+            Map<String, OriginalIndices> remoteIndices = resolvedIndices.remote().asClusterToOriginalIndicesMap();
+            
+            // Check sub-actions for composite requests
+            Map<String, ResolvedIndices.Local> subActions = resolvedIndices.local().subActions();
+            
+            // Perform authorization
+            if (!authorize(localIndices)) {
+                listener.onFailure(new SecurityException("Access denied"));
+                return;
+            }
+        } else {
+            // Unknown indices - apply conservative authorization
+            // Assume all indices are potentially accessed
+        }
+        
+        chain.proceed(task, action, request, actionRequestMetadata, listener);
+    }
+}
+```
+
+#### Working with Composite Requests
+
+```java
+// For actions like reindex that touch multiple indices with different roles
+@Override
+public ResolvedIndices resolveIndices(ReindexRequest request) {
+    return transportSearchAction.resolveIndices(request.getSearchRequest())
+        .withLocalSubActions(
+            IndexAction.INSTANCE,
+            ResolvedIndices.Local.of(
+                indexNameExpressionResolver.resolveDateMathExpression(
+                    request.getDestination().index()
+                )
+            )
+        );
+}
+```
+
+## Limitations
+
+- Marked as `@ExperimentalApi` - API may change in future versions
+- Not all transport actions implement the interface; `OptionallyResolvedIndices.unknown()` returned for non-implementing actions
+- Primarily designed for security plugin use case
+- Resolution is performed on each `ActionFilter.apply()` call (not cached) to handle request modifications
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#18523](https://github.com/opensearch-project/OpenSearch/pull/18523) | Initial implementation of explicit index resolution API |
+
+## References
+
+- [Issue #5367](https://github.com/opensearch-project/security/issues/5367): Index pattern resolution improvements (motivation)
+- [PR #5399](https://github.com/opensearch-project/security/pull/5399): Security plugin implementation using this API
+- [TransportIndicesResolvingAction.java](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/action/support/TransportIndicesResolvingAction.java): Interface source
+- [ResolvedIndices.java](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/cluster/metadata/ResolvedIndices.java): Main data class source
+
+## Change History
+
+- **v3.4.0** (2025-10-23): Initial implementation introducing `TransportIndicesResolvingAction`, `ActionRequestMetadata`, `ResolvedIndices`, and `OptionallyResolvedIndices` classes

--- a/docs/releases/v3.4.0/features/opensearch/transport-actions-api.md
+++ b/docs/releases/v3.4.0/features/opensearch/transport-actions-api.md
@@ -1,0 +1,131 @@
+# Transport Actions API
+
+## Summary
+
+OpenSearch v3.4.0 introduces an internal API that allows `ActionFilter` implementations to retrieve precise metadata about the indices a transport action will operate on. This addresses a long-standing architectural issue where the security plugin had to maintain hard-coded knowledge of how each action request interprets index expressions, leading to fragile code and performance overhead.
+
+## Details
+
+### What's New in v3.4.0
+
+This release introduces a new mechanism for transport actions to explicitly communicate their index resolution behavior to other components like `ActionFilter` implementations. Previously, filters had to guess or hard-code how each action interprets index patterns, date math expressions, and remote indices.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.4.0"
+        AF1[ActionFilter] -->|Hard-coded logic| AR1[ActionRequest]
+        AR1 -->|Varying interpretation| TA1[TransportAction]
+    end
+    
+    subgraph "v3.4.0+"
+        AF2[ActionFilter] -->|ActionRequestMetadata| TIRA[TransportIndicesResolvingAction]
+        TIRA -->|resolveIndices| RI[ResolvedIndices]
+        RI -->|Precise index info| AF2
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `TransportIndicesResolvingAction<Request>` | Interface for transport actions to implement index resolution |
+| `ActionRequestMetadata<Request, Response>` | Metadata object passed to `ActionFilter.apply()` with resolved indices |
+| `ResolvedIndices` | Immutable class encapsulating resolved local and remote indices |
+| `OptionallyResolvedIndices` | Base class for cases where indices may be unknown |
+| `ResolvedIndices.Local` | Local indices, aliases, and data streams |
+| `ResolvedIndices.Local.Concrete` | Concrete indices with `Index` objects |
+| `ResolvedIndices.Remote` | Remote cluster indices |
+
+#### API Changes
+
+The `ActionFilter.apply()` method signature has been extended:
+
+```java
+// Before
+void apply(Task task, String action, Request request, 
+           ActionListener<Response> listener, 
+           ActionFilterChain<Request, Response> chain);
+
+// After (v3.4.0+)
+void apply(Task task, String action, Request request,
+           ActionRequestMetadata<Request, Response> actionRequestMetadata,
+           ActionListener<Response> listener, 
+           ActionFilterChain<Request, Response> chain);
+```
+
+Transport actions implementing `TransportIndicesResolvingAction` must provide:
+
+```java
+public interface TransportIndicesResolvingAction<Request extends ActionRequest> {
+    OptionallyResolvedIndices resolveIndices(Request request);
+}
+```
+
+### Usage Example
+
+```java
+// Implementing TransportIndicesResolvingAction in a transport action
+public class TransportSearchAction extends HandledTransportAction<SearchRequest, SearchResponse>
+    implements TransportIndicesResolvingAction<SearchRequest> {
+    
+    @Override
+    public ResolvedIndices resolveIndices(SearchRequest request) {
+        return ResolvedIndices.of(
+            indexNameExpressionResolver.concreteResolvedIndices(clusterState, request)
+        );
+    }
+}
+
+// Using resolved indices in an ActionFilter
+public class SecurityActionFilter implements ActionFilter {
+    @Override
+    public <Request extends ActionRequest, Response extends ActionResponse> void apply(
+        Task task, String action, Request request,
+        ActionRequestMetadata<Request, Response> metadata,
+        ActionListener<Response> listener,
+        ActionFilterChain<Request, Response> chain
+    ) {
+        OptionallyResolvedIndices resolved = metadata.resolvedIndices();
+        
+        if (resolved instanceof ResolvedIndices resolvedIndices) {
+            Set<String> indices = resolvedIndices.local().names();
+            // Perform authorization based on precise index information
+        } else {
+            // Handle unknown case - assume all indices
+        }
+        
+        chain.proceed(task, action, request, metadata, listener);
+    }
+}
+```
+
+### Migration Notes
+
+- **ActionFilter implementations**: Update `apply()` method signature to include `ActionRequestMetadata` parameter
+- **Custom transport actions**: Consider implementing `TransportIndicesResolvingAction` for precise index reporting
+- **Security plugins**: Can now rely on core-provided index resolution instead of maintaining hard-coded logic
+
+## Limitations
+
+- This is an internal API marked with `@ExperimentalApi` - subject to change in future versions
+- Not all transport actions implement `TransportIndicesResolvingAction` yet; `OptionallyResolvedIndices.unknown()` is returned for those
+- The API is primarily designed for the security plugin use case
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18523](https://github.com/opensearch-project/OpenSearch/pull/18523) | Explicit index resolution API - main implementation |
+
+## References
+
+- [Issue #5367](https://github.com/opensearch-project/security/issues/5367): Index pattern resolution improvements (security plugin)
+- [PR #5399](https://github.com/opensearch-project/security/pull/5399): Security plugin draft implementation using this API
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/transport-actions-api.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -24,6 +24,7 @@
 - [Settings Bugfixes](features/opensearch/settings-bugfixes.md) - Fix duplicate registration of dynamic settings and patch version build issues
 - [Stats Builder Pattern Deprecations](features/opensearch/stats-builder-pattern-deprecations.md) - Deprecated constructors in 30+ Stats classes in favor of Builder pattern
 - [Terms Query Optimization](features/opensearch/terms-query-optimization.md) - Pack terms once for keyword fields with index and docValues enabled
+- [Transport Actions API](features/opensearch/transport-actions-api.md) - Internal API for retrieving metadata about requested indices from transport actions
 - [XContent Filtering](features/opensearch/xcontent-filtering.md) - Case-insensitive filtering support for XContentMapValues.filter
 - [Plugin Dependencies](features/opensearch/plugin-dependencies.md) - Range semver support for dependencies in plugin-descriptor.properties
 - [ActionPlugin Enhancements](features/opensearch/actionplugin-enhancements.md) - Pass REST header registry to getRestHandlerWrapper for efficient header access


### PR DESCRIPTION
## Summary

Add documentation for the Transport Actions API feature introduced in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch/transport-actions-api.md`
- Feature report: `docs/features/opensearch/transport-actions-api.md`

### Feature Overview

This PR documents the new internal API that allows `ActionFilter` implementations to retrieve precise metadata about the indices a transport action will operate on. Key components include:

- `TransportIndicesResolvingAction<Request>` interface
- `ActionRequestMetadata<Request, Response>` class
- `ResolvedIndices` and `OptionallyResolvedIndices` classes

### Related
- Closes #1686
- OpenSearch PR: [#18523](https://github.com/opensearch-project/OpenSearch/pull/18523)
- Security Issue: [#5367](https://github.com/opensearch-project/security/issues/5367)