### PR TITLE
docs: add repository encryption report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -141,6 +141,7 @@
 - [Remote Store](opensearch/remote-store.md)
 - [Remote Store Metadata API](opensearch/remote-store-metadata-api.md)
 - [Repository Rate Limiters](opensearch/repository-rate-limiters.md)
+- [Repository Encryption](opensearch/repository-encryption.md)
 - [RestHandler.Wrapper](opensearch/resthandler-wrapper.md)
 - [ActionPlugin REST Handler Wrapper](opensearch/actionplugin-rest-handler-wrapper.md)
 - [Remote Store Metrics](opensearch/remote-store-metrics.md)

--- a/docs/features/opensearch/repository-encryption.md
+++ b/docs/features/opensearch/repository-encryption.md
@@ -1,0 +1,162 @@
+# Repository Encryption
+
+## Summary
+
+Repository Encryption enables OpenSearch remote store repositories to support both server-side encryption (SSE) and client-side encryption simultaneously. This feature allows data stored in remote repositories (such as S3) to be encrypted at rest using server-side encryption while maintaining compatibility with existing client-side encryption mechanisms.
+
+The feature introduces a `BlobStoreProvider` abstraction that manages multiple `BlobStore` instances, enabling repositories to serve both encrypted and non-encrypted operations based on index-level configuration.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Repository Management"
+        BSR[BlobStoreRepository]
+        BSP[BlobStoreProvider]
+    end
+    
+    subgraph "BlobStore Instances"
+        CSE[Client-Side Encrypted BlobStore]
+        SSE[Server-Side Encrypted BlobStore]
+    end
+    
+    subgraph "Remote Store Components"
+        RSSDF[RemoteSegmentStoreDirectoryFactory]
+        RFT[RemoteFsTranslog]
+        TTM[TranslogTransferManager]
+        BTS[BlobStoreTransferService]
+    end
+    
+    subgraph "Metadata Resolution"
+        RSCMR[RemoteStoreCustomMetadataResolver]
+        RSU[RemoteStoreUtils]
+        IM[IndexMetadata]
+    end
+    
+    BSR --> BSP
+    BSP --> CSE
+    BSP --> SSE
+    
+    RSSDF -->|blobStore| BSR
+    RFT --> TTM
+    TTM --> BTS
+    BTS -->|blobStore| BSR
+    
+    RSCMR -->|isRemoteStoreRepoServerSideEncryptionEnabled| BSR
+    RSU -->|isServerSideEncryptionEnabledIndex| IM
+    IM -->|sse_enabled_index| BSP
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Index Creation"
+        IC[Create Index Request]
+        MCIS[MetadataCreateIndexService]
+        RSCMR[RemoteStoreCustomMetadataResolver]
+        IMB[IndexMetadata.Builder]
+    end
+    
+    subgraph "SSE Check"
+        CS[Cluster Setting Check]
+        RS[Repository SSE Check]
+        VER[Version Check >= 3.4.0]
+    end
+    
+    subgraph "Metadata Storage"
+        RCD[RemoteStoreCustomData]
+        SSE_KEY[sse_enabled_index = true]
+    end
+    
+    IC --> MCIS
+    MCIS --> RSCMR
+    RSCMR --> CS
+    RSCMR --> RS
+    RSCMR --> VER
+    CS & RS & VER -->|All true| IMB
+    IMB --> RCD
+    RCD --> SSE_KEY
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `BlobStoreProvider` | Manages creation and lifecycle of client-side and server-side encrypted `BlobStore` instances |
+| `BlobStoreRepository.blobStore(boolean serverSideEncryptionEnabled)` | Returns appropriate `BlobStore` based on SSE flag |
+| `RemoteStoreCustomMetadataResolver` | Resolves remote store custom metadata including SSE settings |
+| `RemoteStoreUtils.isServerSideEncryptionEnabledIndex()` | Utility to check if an index has SSE enabled |
+| `S3Repository.isSeverSideEncryptionEnabled()` | S3-specific implementation that returns `true` (S3 always supports SSE) |
+
+### Configuration
+
+| Setting | Description | Default | Scope |
+|---------|-------------|---------|-------|
+| `cluster.remote_store.server_side_encryption` | Enables server-side encryption for remote store repositories | `true` | Cluster (Dynamic) |
+
+### Index Metadata
+
+The SSE status is stored in index custom metadata under the `remote_store` key:
+
+```json
+{
+  "custom": {
+    "remote_store": {
+      "sse_enabled_index": "true"
+    }
+  }
+}
+```
+
+### Usage Example
+
+Server-side encryption is automatically enabled for new indexes when all conditions are met:
+
+```yaml
+# opensearch.yml - No special configuration needed
+# SSE is enabled by default when using S3 repositories
+
+# To disable SSE at cluster level (not recommended):
+cluster.remote_store.server_side_encryption: false
+```
+
+When creating an S3 repository for remote store:
+
+```bash
+PUT _snapshot/my-s3-repo
+{
+  "type": "s3",
+  "settings": {
+    "bucket": "my-bucket",
+    "server_side_encryption": true
+  }
+}
+```
+
+## Limitations
+
+- Server-side encryption support is currently implemented only for S3 repositories
+- Requires all nodes in the cluster to be on v3.4.0 or later for SSE-enabled indexes
+- The `BlobStoreProvider` maintains separate `BlobStore` instances, which may increase memory usage
+- SSE setting is determined at index creation time and cannot be changed afterward
+- Snapshot restore preserves the original SSE setting from the source index
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#19630](https://github.com/opensearch-project/OpenSearch/pull/19630) | Add support for repository with Server side encryption enabled and client side encryption |
+
+## References
+
+- [Issue #19235](https://github.com/opensearch-project/OpenSearch/issues/19235): Original feature request
+- [Remote-backed storage](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/remote-store/index/): Official documentation
+- [S3 Server-side encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html): AWS S3 SSE documentation
+- [Register Snapshot Repository](https://docs.opensearch.org/3.0/api-reference/snapshots/create-repository/): Repository configuration options
+
+## Change History
+
+- **v3.4.0** (2025-10-28): Initial implementation with `BlobStoreProvider` and SSE support for S3 repositories

--- a/docs/releases/v3.4.0/features/opensearch/repository-encryption.md
+++ b/docs/releases/v3.4.0/features/opensearch/repository-encryption.md
@@ -1,0 +1,106 @@
+# Repository Encryption
+
+## Summary
+
+OpenSearch v3.4.0 adds support for S3 repositories with both server-side encryption (SSE) and client-side encryption enabled. This enhancement allows remote store indexes to use server-side encrypted repositories, providing improved data protection for remote-backed storage.
+
+Previously, `BlobStoreRepository` only supported a single `BlobStore` created lazily, and once created, the repository was tied to that `BlobStore`. This change introduces a `BlobStoreProvider` that can create both client-side encrypted and server-side encrypted `BlobStore` instances, enabling repositories to support both encryption modes simultaneously.
+
+## Details
+
+### What's New in v3.4.0
+
+This release introduces the ability to configure remote store repositories with server-side encryption enabled. The key changes include:
+
+1. **BlobStoreProvider**: A new component responsible for creating and managing both client-side and server-side encrypted `BlobStore` instances
+2. **SSE-enabled index metadata**: New index metadata key `sse_enabled_index` to track whether an index uses server-side encryption
+3. **Cluster setting**: New `cluster.remote_store.server_side_encryption` setting to enable/disable SSE at the cluster level
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Repository Layer"
+        BSR[BlobStoreRepository]
+        BSP[BlobStoreProvider]
+        CSE[Client-Side Encrypted BlobStore]
+        SSE[Server-Side Encrypted BlobStore]
+    end
+    
+    subgraph "Remote Store"
+        RS[RemoteSegmentStoreDirectoryFactory]
+        RT[RemoteFsTranslog]
+        TTM[TranslogTransferManager]
+    end
+    
+    subgraph "Index Metadata"
+        IM[IndexMetadata]
+        RC[RemoteStoreCustomMetadata]
+    end
+    
+    BSR --> BSP
+    BSP --> CSE
+    BSP --> SSE
+    RS --> BSR
+    RT --> TTM
+    TTM --> BSR
+    IM --> RC
+    RC -->|sse_enabled_index| BSP
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `BlobStoreProvider` | Manages creation of client-side and server-side encrypted `BlobStore` instances |
+| `RemoteStoreCustomMetadataResolver.isRemoteStoreRepoServerSideEncryptionEnabled()` | Checks if SSE is enabled for remote store repositories |
+| `RemoteStoreUtils.isServerSideEncryptionEnabledIndex()` | Utility to check if an index has SSE enabled |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.remote_store.server_side_encryption` | Enables server-side encryption for remote store repositories | `true` |
+
+#### Index Metadata Changes
+
+A new custom metadata key `sse_enabled_index` is added under `remote_store` custom data to track whether an index was created with server-side encryption enabled.
+
+### Usage Example
+
+Server-side encryption is automatically enabled when:
+1. The cluster setting `cluster.remote_store.server_side_encryption` is `true`
+2. The repository supports server-side encryption (e.g., S3 with SSE enabled)
+3. The minimum node version is v3.4.0 or later
+
+For S3 repositories, the `S3Repository.isSeverSideEncryptionEnabled()` method always returns `true` since S3 is always server-side encrypted.
+
+### Migration Notes
+
+- Existing indexes created before v3.4.0 will not have the `sse_enabled_index` metadata
+- When restoring from snapshots, the SSE setting is preserved from the original index metadata
+- The feature requires all nodes in the cluster to be on v3.4.0 or later
+
+## Limitations
+
+- Server-side encryption support is currently implemented only for S3 repositories
+- The `BlobStoreProvider` creates separate `BlobStore` instances for SSE and non-SSE operations, which may increase resource usage
+- Mixed-version clusters (with nodes below v3.4.0) cannot use this feature
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19630](https://github.com/opensearch-project/OpenSearch/pull/19630) | Add support for repository with Server side encryption enabled and client side encryption |
+
+## References
+
+- [Issue #19235](https://github.com/opensearch-project/OpenSearch/issues/19235): Feature request for server-side encrypted repository support
+- [Remote-backed storage documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/remote-store/index/): Official docs on remote store
+- [S3 Server-side encryption](https://docs.aws.amazon.com/AmazonS3/latest/dev/serv-side-encryption.html): AWS documentation on S3 SSE
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/repository-encryption.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -27,6 +27,7 @@
 - [Transport Actions API](features/opensearch/transport-actions-api.md) - Internal API for retrieving metadata about requested indices from transport actions
 - [XContent Filtering](features/opensearch/xcontent-filtering.md) - Case-insensitive filtering support for XContentMapValues.filter
 - [Plugin Dependencies](features/opensearch/plugin-dependencies.md) - Range semver support for dependencies in plugin-descriptor.properties
+- [Repository Encryption](features/opensearch/repository-encryption.md) - Server-side encryption support for S3 remote store repositories
 - [ActionPlugin Enhancements](features/opensearch/actionplugin-enhancements.md) - Pass REST header registry to getRestHandlerWrapper for efficient header access
 - [WildcardFieldMapper](features/opensearch/wildcardfieldmapper.md) - Change doc_values default to true for nested query support
 


### PR DESCRIPTION
## Summary

Add documentation for the Repository Encryption feature introduced in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch/repository-encryption.md`
- Feature report: `docs/features/opensearch/repository-encryption.md`

### Key Changes in v3.4.0
- New `BlobStoreProvider` component for managing client-side and server-side encrypted BlobStore instances
- New cluster setting `cluster.remote_store.server_side_encryption` (default: true)
- New index metadata key `sse_enabled_index` to track SSE status
- S3 repository now reports SSE as always enabled

### Resources Used
- PR: [#19630](https://github.com/opensearch-project/OpenSearch/pull/19630)
- Issue: [#19235](https://github.com/opensearch-project/OpenSearch/issues/19235)
- Docs: https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/remote-store/index/