### PR TITLE
docs: add query-string-monitoring report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -131,6 +131,7 @@
 - [Query Phase Result Consumer](opensearch/query-phase-result-consumer.md)
 - [Query Rewriting](opensearch/query-rewriting.md)
 - [Query String & Regex Queries](opensearch/query-string-regex.md)
+- [Query String Monitoring](opensearch/query-string-monitoring.md)
 - [Randomness](opensearch/randomness.md)
 - [Reactor Netty Transport](opensearch/reactor-netty-transport.md)
 - [Refresh Task Scheduling](opensearch/refresh-task-scheduling.md)

--- a/docs/features/opensearch/query-string-monitoring.md
+++ b/docs/features/opensearch/query-string-monitoring.md
@@ -1,0 +1,131 @@
+# Query String Monitoring
+
+## Summary
+
+Query String Monitoring provides cluster-level settings to control and monitor the length of query strings in `query_string` and `simple_query_string` queries. This feature helps administrators protect clusters from potentially expensive or malicious queries with excessively long query strings, while providing a monitoring mode to assess impact before enforcing strict limits.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph Client
+        Q[Search Request]
+    end
+    
+    subgraph SearchService
+        SS[SearchService]
+        QP[QueryStringQueryParser]
+    end
+    
+    subgraph ClusterSettings
+        ML[max_query_string_length]
+        MM[max_query_string_length_monitor_only]
+    end
+    
+    Q --> SS
+    SS --> QP
+    QP --> ML
+    QP --> MM
+    
+    QP -->|Length OK| E[Execute Query]
+    QP -->|Length Exceeded + Monitor| W[Log Warning] --> E
+    QP -->|Length Exceeded + Enforce| R[Reject Query]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SearchService` | Registers cluster settings and propagates updates to QueryStringQueryParser |
+| `QueryStringQueryParser` | Validates query string length and applies monitoring/enforcement logic |
+| `ClusterSettings` | Stores the max length and monitoring mode configuration |
+
+### Configuration
+
+| Setting | Description | Default | Dynamic |
+|---------|-------------|---------|---------|
+| `search.query.max_query_string_length` | Maximum allowed length for query strings | `Integer.MAX_VALUE` | Yes |
+| `search.query.max_query_string_length_monitor_only` | When `true`, log warnings instead of rejecting queries | `false` | Yes |
+
+### Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant SearchService
+    participant QueryStringQueryParser
+    participant Logger
+    
+    Client->>SearchService: Search Request
+    SearchService->>QueryStringQueryParser: Parse Query
+    QueryStringQueryParser->>QueryStringQueryParser: Check query.length()
+    
+    alt Length <= max_query_string_length
+        QueryStringQueryParser->>SearchService: Parsed Query
+    else Length > max_query_string_length
+        alt monitor_only = true
+            QueryStringQueryParser->>Logger: Log Warning
+            QueryStringQueryParser->>SearchService: Parsed Query
+        else monitor_only = false
+            QueryStringQueryParser->>Client: ParseException
+        end
+    end
+```
+
+### Usage Example
+
+```json
+// Set a query string length limit with monitoring enabled
+PUT _cluster/settings
+{
+  "persistent": {
+    "search.query.max_query_string_length": 10000,
+    "search.query.max_query_string_length_monitor_only": true
+  }
+}
+
+// Example query that would trigger monitoring
+GET my-index/_search
+{
+  "query": {
+    "query_string": {
+      "query": "term1 OR term2 OR term3 OR ... (very long query)"
+    }
+  }
+}
+
+// After assessment, enforce the limit
+PUT _cluster/settings
+{
+  "persistent": {
+    "search.query.max_query_string_length_monitor_only": false
+  }
+}
+```
+
+## Limitations
+
+- Only applies to `query_string` and `simple_query_string` query types
+- Cluster-wide setting only; cannot be configured per-index
+- Warning logs may increase log volume in high-traffic environments
+- Does not limit other query types or overall request size
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#19539](https://github.com/opensearch-project/OpenSearch/pull/19539) | Introduced monitoring mode for query string query max length |
+| v2.19.4 | [#19491](https://github.com/opensearch-project/OpenSearch/pull/19491) | Initial implementation of `search.query.max_query_string_length` setting |
+
+## References
+
+- [PR #19539](https://github.com/opensearch-project/OpenSearch/pull/19539): Monitoring mode implementation
+- [PR #19491](https://github.com/opensearch-project/OpenSearch/pull/19491): Original max length setting
+- [Query String Query Documentation](https://docs.opensearch.org/3.0/query-dsl/full-text/query-string/): Official documentation
+
+## Change History
+
+- **v3.4.0** (2025-12-09): Added `search.query.max_query_string_length_monitor_only` setting for monitoring mode
+- **v2.19.4** (2025-10-01): Initial implementation of `search.query.max_query_string_length` setting

--- a/docs/releases/v3.4.0/features/opensearch/query-string-monitoring.md
+++ b/docs/releases/v3.4.0/features/opensearch/query-string-monitoring.md
@@ -1,0 +1,91 @@
+# Query String Monitoring
+
+## Summary
+
+This release introduces a new cluster setting `search.query.max_query_string_length_monitor_only` that enables monitoring mode for query string length validation. When enabled, queries exceeding the maximum length limit are executed with a warning logged instead of being rejected, allowing administrators to assess the impact of enforcing query string length limits before enabling strict enforcement.
+
+## Details
+
+### What's New in v3.4.0
+
+A new boolean cluster setting `search.query.max_query_string_length_monitor_only` has been added to complement the existing `search.query.max_query_string_length` setting. This provides a non-disruptive way to monitor query string lengths in production environments.
+
+### Technical Changes
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `search.query.max_query_string_length_monitor_only` | When `true`, queries exceeding `max_query_string_length` are executed with a warning instead of being rejected | `false` |
+
+#### Behavior
+
+```mermaid
+flowchart TB
+    A[Query String Query] --> B{Length > max_query_string_length?}
+    B -->|No| C[Execute Query]
+    B -->|Yes| D{monitor_only enabled?}
+    D -->|Yes| E[Log Warning]
+    E --> C
+    D -->|No| F[Reject with ParseException]
+```
+
+When monitoring mode is enabled:
+- Queries exceeding the configured maximum length are still executed
+- A warning is logged with the message: `Query string length exceeds max allowed length {limit} ({setting_key}); actual length: {actual_length}`
+- No error is returned to the client
+
+When monitoring mode is disabled (default):
+- Queries exceeding the maximum length are rejected with a `ParseException`
+
+### Usage Example
+
+Enable monitoring mode to assess impact before enforcing limits:
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "search.query.max_query_string_length": 10000,
+    "search.query.max_query_string_length_monitor_only": true
+  }
+}
+```
+
+After reviewing logs and confirming acceptable query patterns, disable monitoring mode to enforce limits:
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "search.query.max_query_string_length_monitor_only": false
+  }
+}
+```
+
+### Migration Notes
+
+This feature is additive and requires no migration. Existing clusters using `search.query.max_query_string_length` will continue to enforce limits as before. Enable `search.query.max_query_string_length_monitor_only` only when you want to switch to monitoring mode.
+
+## Limitations
+
+- Monitoring mode only applies to `query_string` and `simple_query_string` queries
+- Warning logs may impact log volume in high-traffic environments with many oversized queries
+- The setting is cluster-wide; per-index configuration is not supported
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19539](https://github.com/opensearch-project/OpenSearch/pull/19539) | Introduced monitoring mode for query string query max length |
+| [#19491](https://github.com/opensearch-project/OpenSearch/pull/19491) | Original implementation of `search.query.max_query_string_length` setting |
+
+## References
+
+- [PR #19539](https://github.com/opensearch-project/OpenSearch/pull/19539): Main implementation
+- [PR #19491 Discussion](https://github.com/opensearch-project/OpenSearch/pull/19491#issuecomment-3362082746): Feature request discussion
+- [Query String Query Documentation](https://docs.opensearch.org/3.0/query-dsl/full-text/query-string/): Official query string documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/query-string-monitoring.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -28,6 +28,7 @@
 - [Transport Actions API](features/opensearch/transport-actions-api.md) - Internal API for retrieving metadata about requested indices from transport actions
 - [XContent Filtering](features/opensearch/xcontent-filtering.md) - Case-insensitive filtering support for XContentMapValues.filter
 - [Plugin Dependencies](features/opensearch/plugin-dependencies.md) - Range semver support for dependencies in plugin-descriptor.properties
+- [Query String Monitoring](features/opensearch/query-string-monitoring.md) - Monitoring mode for query string length validation with warning logs instead of rejection
 - [Repository Encryption](features/opensearch/repository-encryption.md) - Server-side encryption support for S3 remote store repositories
 - [ActionPlugin Enhancements](features/opensearch/actionplugin-enhancements.md) - Pass REST header registry to getRestHandlerWrapper for efficient header access
 - [WildcardFieldMapper](features/opensearch/wildcardfieldmapper.md) - Change doc_values default to true for nested query support


### PR DESCRIPTION
## Summary

Add documentation for the Query String Monitoring feature introduced in OpenSearch v3.4.0.

### Changes
- Release report: `docs/releases/v3.4.0/features/opensearch/query-string-monitoring.md`
- Feature report: `docs/features/opensearch/query-string-monitoring.md`
- Updated release index and features index

### Feature Overview
This feature introduces a new cluster setting `search.query.max_query_string_length_monitor_only` that enables monitoring mode for query string length validation. When enabled, queries exceeding the maximum length limit are executed with a warning logged instead of being rejected.

### Related
- PR: [opensearch-project/OpenSearch#19539](https://github.com/opensearch-project/OpenSearch/pull/19539)
- Issue: #1683