### PR TITLE
docs: add ApproximatePointRangeQuery pack method optimization report for v3.4.0

### DIFF
--- a/docs/features/opensearch/approximation-framework.md
+++ b/docs/features/opensearch/approximation-framework.md
@@ -169,6 +169,7 @@ GET logs/_search
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#19553](https://github.com/opensearch-project/OpenSearch/pull/19553) | Use Lucene `pack` method for `half_float` and `unsigned_long` |
 | v3.2.0 | [#18530](https://github.com/opensearch-project/OpenSearch/pull/18530) | Extend Approximation Framework to other numeric types (int, float, double, half_float, unsigned_long) |
 | v3.2.0 | [#18896](https://github.com/opensearch-project/OpenSearch/pull/18896) | Support `search_after` numeric queries with Approximation Framework |
 | v3.2.0 | [#18511](https://github.com/opensearch-project/OpenSearch/pull/18511) | Added approximation support for range queries with `now` in date field |
@@ -188,6 +189,7 @@ GET logs/_search
 
 ## Change History
 
+- **v3.4.0**: Adopted Lucene's native `pack` method for `half_float` and `unsigned_long` types, replacing custom encoding methods; requires Lucene 10.3.0
 - **v3.2.0**: Extended Approximation Framework to all numeric types (int, float, double, half_float, unsigned_long); added `search_after` support for numeric queries; approximation for range queries with `now`; automatic disabling for multiple sort fields
 - **v3.1.0** (2025-06-10): Enhanced BKD traversal with DFS strategy for skewed datasets, smart subtree skipping
 - **v3.0.0**: Initial GA release with basic early termination support

--- a/docs/releases/v3.4.0/features/opensearch/approximate-point-range-query.md
+++ b/docs/releases/v3.4.0/features/opensearch/approximate-point-range-query.md
@@ -1,0 +1,129 @@
+# ApproximatePointRangeQuery Pack Method Optimization
+
+## Summary
+
+This release improves the ApproximatePointRangeQuery implementation by adopting Lucene's native `pack` method for `half_float` and `unsigned_long` field types. Previously, these types used custom encoding methods, but with Lucene 10.3.0 making the `pack` methods public for `BigIntegerPoint` and `HalfFloatPoint`, OpenSearch can now use the standardized Lucene API for all numeric types.
+
+This change simplifies the codebase and ensures consistency with other numeric types (int, long, float, double) that already use the `pack` method.
+
+## Details
+
+### What's New in v3.4.0
+
+The change updates `NumberFieldMapper.java` to use Lucene's `pack` method instead of custom encoding for `half_float` and `unsigned_long` types when constructing `ApproximatePointRangeQuery`.
+
+### Technical Changes
+
+#### Before (v3.2.0)
+```java
+// half_float - used custom encodePoint method
+new ApproximatePointRangeQuery(
+    field,
+    NumberType.HALF_FLOAT.encodePoint(l),
+    NumberType.HALF_FLOAT.encodePoint(u),
+    ...
+)
+
+// unsigned_long - used custom encodePoint method
+new ApproximatePointRangeQuery(
+    field,
+    NumberType.UNSIGNED_LONG.encodePoint(l),
+    NumberType.UNSIGNED_LONG.encodePoint(u),
+    ...
+)
+```
+
+#### After (v3.4.0)
+```java
+// half_float - uses Lucene's HalfFloatPoint.pack
+new ApproximatePointRangeQuery(
+    field,
+    HalfFloatPoint.pack(l).bytes,
+    HalfFloatPoint.pack(u).bytes,
+    ...
+)
+
+// unsigned_long - uses Lucene's BigIntegerPoint.pack
+new ApproximatePointRangeQuery(
+    field,
+    BigIntegerPoint.pack(l).bytes,
+    BigIntegerPoint.pack(u).bytes,
+    ...
+)
+```
+
+#### Code Changes Summary
+
+| Numeric Type | Before | After |
+|--------------|--------|-------|
+| `half_float` | `NumberType.HALF_FLOAT.encodePoint()` | `HalfFloatPoint.pack().bytes` |
+| `unsigned_long` | `NumberType.UNSIGNED_LONG.encodePoint()` | `BigIntegerPoint.pack().bytes` |
+| `float` | `FloatPoint.pack(new float[]{})` | `FloatPoint.pack()` (simplified) |
+| `double` | `DoublePoint.pack(new double[]{})` | `DoublePoint.pack()` (simplified) |
+| `int` | `IntPoint.pack(new int[]{})` | `IntPoint.pack()` (simplified) |
+| `long` | `LongPoint.pack(new long[]{})` | `LongPoint.pack()` (simplified) |
+
+### Dependency
+
+This change depends on Lucene 10.3.0, which includes [apache/lucene#14784](https://github.com/apache/lucene/pull/14784) that made the `pack` methods public for `BigIntegerPoint` and `HalfFloatPoint` in the sandbox module.
+
+### Usage Example
+
+No user-facing changes. Range queries on `half_float` and `unsigned_long` fields continue to work as before:
+
+```json
+// half_float range query
+GET metrics/_search
+{
+  "query": {
+    "range": {
+      "score": {
+        "gte": 0.5,
+        "lte": 1.0
+      }
+    }
+  },
+  "sort": [{ "score": "desc" }],
+  "size": 100
+}
+```
+
+```json
+// unsigned_long range query
+GET counters/_search
+{
+  "query": {
+    "range": {
+      "counter": {
+        "gte": 1000000000000,
+        "lte": 9999999999999
+      }
+    }
+  },
+  "sort": [{ "counter": "asc" }],
+  "size": 50
+}
+```
+
+## Limitations
+
+- Requires Lucene 10.3.0 or later
+- No functional changes to query behavior or performance
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19553](https://github.com/opensearch-project/OpenSearch/pull/19553) | Use Lucene `pack` method for `half_float` and `unsigned_long` |
+| [apache/lucene#14784](https://github.com/apache/lucene/pull/14784) | Make `pack` methods public for `BigIntegerPoint` and `HalfFloatPoint` |
+
+## References
+
+- [Issue #14406](https://github.com/opensearch-project/OpenSearch/issues/14406): Feature request to expand ApproximatePointRangeQuery to other numeric types
+- [Issue #18334](https://github.com/opensearch-project/OpenSearch/issues/18334): Feature request to improve numeric range query performance
+- [PR #18530](https://github.com/opensearch-project/OpenSearch/pull/18530): Extend Approximation Framework to other numeric types (v3.2.0)
+- [Lucene 10.3.0 Changes](https://lucene.apache.org/core/10_3_0/changes/Changes.html#v10.3.0.new_features): Lucene release notes
+
+## Related Feature Report
+
+- [Approximation Framework](../../../features/opensearch/approximation-framework.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -5,6 +5,7 @@
 ### OpenSearch
 
 - [Aggregation Optimizations](features/opensearch/aggregation-optimizations.md) - Hybrid cardinality collector, filter rewrite + skip list, MergingDigest for percentiles, matrix_stats primitive arrays
+- [ApproximatePointRangeQuery Pack Method Optimization](features/opensearch/approximate-point-range-query.md) - Use Lucene's native `pack` method for `half_float` and `unsigned_long` types
 - [Build Tool Upgrades](features/opensearch/build-tool-upgrades.md) - Gradle 9.1 and bundled JDK 25 updates
 - [Concurrent Segment Search](features/opensearch/concurrent-segment-search.md) - Performance optimization by omitting MaxScoreCollector when sorting by score
 - [Context Aware Segments](features/opensearch/context-aware-segments.md) - Collocate related documents into same segments based on grouping criteria for improved query performance


### PR DESCRIPTION
## Summary

This PR adds documentation for the ApproximatePointRangeQuery pack method optimization in OpenSearch v3.4.0.

### Changes

- **Release Report**: `docs/releases/v3.4.0/features/opensearch/approximate-point-range-query.md`
  - Documents the adoption of Lucene's native `pack` method for `half_float` and `unsigned_long` types
  - Explains the code changes from custom encoding to standardized Lucene API
  - References the upstream Lucene PR #14784

- **Feature Report Update**: `docs/features/opensearch/approximation-framework.md`
  - Added v3.4.0 entry to Related PRs table
  - Added v3.4.0 entry to Change History

- **Release Index Update**: `docs/releases/v3.4.0/index.md`
  - Added link to the new release report

### Related

- OpenSearch PR: [#19553](https://github.com/opensearch-project/OpenSearch/pull/19553)
- Lucene PR: [apache/lucene#14784](https://github.com/apache/lucene/pull/14784)
- Investigation Issue: #1682