### PR TITLE
docs: add thread-pool report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -180,6 +180,7 @@
 - [Task Management](opensearch/task-management.md)
 - [Test Fixes](opensearch/test-fixes.md)
 - [Thread Context Permissions](opensearch/thread-context-permissions.md)
+- [Thread Pool](opensearch/thread-pool.md)
 - [Tiered Caching](opensearch/tiered-caching.md)
 - [Translog](opensearch/translog.md)
 - [Transport Nodes Action Optimization](opensearch/transport-nodes-action-optimization.md)

--- a/docs/features/opensearch/thread-pool.md
+++ b/docs/features/opensearch/thread-pool.md
@@ -1,0 +1,174 @@
+# Thread Pool
+
+## Summary
+
+OpenSearch's Thread Pool system manages concurrent task execution across the cluster. It provides different pool types optimized for various workloads, from fixed-size pools for predictable resource usage to scaling pools that adapt to demand. Starting with v3.4.0, OpenSearch also supports ForkJoinPool for work-stealing parallelism, enabling efficient recursive task processing for components like vector search engines.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph ThreadPool["ThreadPool System"]
+        TP[ThreadPool Manager]
+        
+        subgraph PoolTypes["Pool Types"]
+            DIRECT[Direct Executor]
+            FIXED[Fixed Pool]
+            SCALING[Scaling Pool]
+            RESIZABLE[Resizable Pool]
+            FORKJOIN[ForkJoinPool]
+        end
+        
+        subgraph Builders["Executor Builders"]
+            FB[FixedExecutorBuilder]
+            SB[ScalingExecutorBuilder]
+            RB[ResizableExecutorBuilder]
+            FJB[ForkJoinPoolExecutorBuilder]
+        end
+    end
+    
+    subgraph Plugins["Plugin Registration"]
+        P1[Core Pools]
+        P2[Plugin Pools]
+    end
+    
+    TP --> PoolTypes
+    FB --> FIXED
+    SB --> SCALING
+    RB --> RESIZABLE
+    FJB --> FORKJOIN
+    
+    P1 --> TP
+    P2 --> TP
+```
+
+### Thread Pool Types
+
+| Type | Description | Use Case |
+|------|-------------|----------|
+| `DIRECT` | Executes on calling thread | Lightweight synchronous tasks |
+| `FIXED` | Fixed number of threads | Predictable workloads (search, write) |
+| `SCALING` | Scales between min/max | Variable workloads (generic, management) |
+| `RESIZABLE` | Dynamically adjustable | Auto-tuning workloads |
+| `FORK_JOIN` | Work-stealing pool | Recursive parallel tasks (v3.4.0+) |
+
+### Built-in Thread Pools
+
+OpenSearch includes several pre-configured thread pools:
+
+| Pool Name | Type | Description |
+|-----------|------|-------------|
+| `generic` | SCALING | General-purpose operations |
+| `search` | FIXED | Search query execution |
+| `write` | FIXED | Index/update/delete operations |
+| `management` | SCALING | Cluster management tasks |
+| `flush` | SCALING | Flush operations |
+| `force_merge` | FIXED | Force merge operations |
+| `snapshot` | SCALING | Snapshot operations |
+
+### ForkJoinPool Configuration (v3.4.0+)
+
+Plugins can register ForkJoinPool executors with these settings:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `thread_pool.{name}.parallelism` | Worker thread count (>= 1) | Required |
+| `thread_pool.{name}.async_mode` | FIFO scheduling mode | `false` |
+| `thread_pool.{name}.thread_factory` | Custom thread factory class | `""` |
+| `thread_pool.{name}.enable_exception_handling` | Log uncaught exceptions | `true` |
+
+### Usage Example
+
+#### Registering a ForkJoinPool (Plugin)
+
+```java
+public class MyPlugin extends Plugin {
+    @Override
+    public List<ExecutorBuilder<?>> getExecutorBuilders(final Settings settings) {
+        // Register a ForkJoinPool with 8 worker threads
+        return List.of(new ForkJoinPoolExecutorBuilder("my_pool", 8));
+    }
+}
+```
+
+#### Using the Pool
+
+```java
+// Get the executor from ThreadPool
+ForkJoinPool pool = (ForkJoinPool) threadPool.executor("my_pool");
+
+// Submit parallel tasks
+pool.submit(() -> {
+    // Work-stealing parallel execution
+    processInParallel(data);
+});
+
+// Use RecursiveTask for divide-and-conquer
+RecursiveTask<Integer> task = new RecursiveTask<>() {
+    @Override
+    protected Integer compute() {
+        // Fork subtasks and join results
+        return leftTask.fork().join() + rightTask.compute();
+    }
+};
+int result = pool.invoke(task);
+```
+
+### Monitoring Thread Pools
+
+#### CAT API
+
+```bash
+GET _cat/thread_pool?v&h=name,type,active,queue,rejected,parallelism
+```
+
+#### Nodes Stats API
+
+```bash
+GET _nodes/stats/thread_pool
+```
+
+Response includes pool-specific metrics:
+
+```json
+{
+  "thread_pool": {
+    "search": {
+      "threads": 13,
+      "queue": 0,
+      "active": 0,
+      "rejected": 0,
+      "largest": 13,
+      "completed": 1000
+    },
+    "jvector": {
+      "parallelism": 8
+    }
+  }
+}
+```
+
+## Limitations
+
+- ForkJoinPool executors cannot be dynamically resized after node startup
+- Queue size and keep-alive settings do not apply to ForkJoinPool types
+- ForkJoinPool stats show simplified metrics (parallelism only) as the pool manages internal state differently
+- Custom thread factories must implement `ForkJoinWorkerThreadFactory`
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#19008](https://github.com/opensearch-project/OpenSearch/pull/19008) | Add support for a ForkJoinPool type |
+
+## References
+
+- [Issue #18674](https://github.com/opensearch-project/OpenSearch/issues/18674): Feature request for ForkJoinPool support
+- [CAT Thread Pool API](https://docs.opensearch.org/latest/api-reference/cat/cat-thread-pool/): Official documentation
+- [Nodes Stats API](https://docs.opensearch.org/latest/api-reference/nodes-apis/nodes-stats/): Thread pool statistics
+
+## Change History
+
+- **v3.4.0** (2025-10-17): Added ForkJoinPool thread pool type support for work-stealing parallelism

--- a/docs/releases/v3.4.0/features/opensearch/thread-pool.md
+++ b/docs/releases/v3.4.0/features/opensearch/thread-pool.md
@@ -1,0 +1,103 @@
+# Thread Pool - ForkJoinPool Support
+
+## Summary
+
+OpenSearch v3.4.0 introduces support for a new `ForkJoinPool` thread pool type, enabling plugins to register and manage ForkJoinPool-based executors within the OpenSearch cluster lifecycle. This enhancement is particularly beneficial for components like jVector that leverage ForkJoinPool for parallel processing during index building operations.
+
+## Details
+
+### What's New in v3.4.0
+
+This release adds a new `FORK_JOIN` thread pool type to the existing thread pool infrastructure, allowing plugins to create work-stealing thread pools optimized for recursive, divide-and-conquer style parallel computations.
+
+### Technical Changes
+
+#### New Thread Pool Type
+
+A new `ThreadPoolType.FORK_JOIN` enum value has been added to the existing thread pool types:
+
+| Type | Description |
+|------|-------------|
+| `DIRECT` | Executes tasks directly on the calling thread |
+| `FIXED` | Fixed-size thread pool |
+| `RESIZABLE` | Dynamically resizable thread pool |
+| `SCALING` | Scales between min and max threads |
+| `FORK_JOIN` | **New** - Work-stealing ForkJoinPool for parallel tasks |
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ForkJoinPoolExecutorBuilder` | Builder class for creating ForkJoinPool executors |
+| `ForkJoinPoolExecutorSettings` | Settings container for ForkJoinPool configuration |
+
+#### New Configuration
+
+Plugins can register ForkJoinPool executors with the following settings:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `thread_pool.{name}.parallelism` | Number of worker threads (must be >= 1) | Required |
+| `thread_pool.{name}.async_mode` | Enable FIFO scheduling for forked tasks | `false` |
+| `thread_pool.{name}.thread_factory` | Custom ForkJoinWorkerThreadFactory class name | `""` (default factory) |
+| `thread_pool.{name}.enable_exception_handling` | Enable uncaught exception logging | `true` |
+
+#### API Changes
+
+The CAT thread pool API (`_cat/thread_pool`) now includes a `parallelism` column for ForkJoinPool types:
+
+```
+GET _cat/thread_pool?v&h=name,type,parallelism
+```
+
+Thread pool stats now include a `parallelism` field in the response for ForkJoinPool executors.
+
+### Usage Example
+
+Plugins can register a ForkJoinPool executor using the `ExecutorBuilder` mechanism:
+
+```java
+public class MyPlugin extends Plugin {
+    @Override
+    public List<ExecutorBuilder<?>> getExecutorBuilders(final Settings settings) {
+        return List.of(new ForkJoinPoolExecutorBuilder("jvector", 8));
+    }
+}
+```
+
+The executor can then be used within the plugin:
+
+```java
+ForkJoinPool pool = (ForkJoinPool) threadPool.executor("jvector");
+pool.submit(() -> {
+    // Parallel task execution
+});
+```
+
+### Migration Notes
+
+- This is a new feature with no breaking changes
+- Existing thread pool configurations remain unchanged
+- ForkJoinPool executors do not support dynamic setting updates (unlike FIXED/SCALING pools)
+- The `parallelism` setting is mandatory and must be >= 1
+
+## Limitations
+
+- ForkJoinPool executors cannot be dynamically resized after creation
+- Queue size and keep-alive settings are not applicable to ForkJoinPool types
+- Stats for ForkJoinPool show fixed values (active=0, queue=0, etc.) as ForkJoinPool manages its own internal state differently
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#19008](https://github.com/opensearch-project/OpenSearch/pull/19008) | Add support for a ForkJoinPool type |
+
+## References
+
+- [Issue #18674](https://github.com/opensearch-project/OpenSearch/issues/18674): Feature request for ForkJoinPool support
+- [opensearch-jvector PR #116](https://github.com/opensearch-project/opensearch-jvector/pull/116): Related jVector integration
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/thread-pool.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -26,6 +26,7 @@
 - [Settings Bugfixes](features/opensearch/settings-bugfixes.md) - Fix duplicate registration of dynamic settings and patch version build issues
 - [Stats Builder Pattern Deprecations](features/opensearch/stats-builder-pattern-deprecations.md) - Deprecated constructors in 30+ Stats classes in favor of Builder pattern
 - [Terms Query Optimization](features/opensearch/terms-query-optimization.md) - Pack terms once for keyword fields with index and docValues enabled
+- [Thread Pool](features/opensearch/thread-pool.md) - ForkJoinPool thread pool type support for work-stealing parallelism
 - [Transport Actions API](features/opensearch/transport-actions-api.md) - Internal API for retrieving metadata about requested indices from transport actions
 - [XContent Filtering](features/opensearch/xcontent-filtering.md) - Case-insensitive filtering support for XContentMapValues.filter
 - [Plugin Dependencies](features/opensearch/plugin-dependencies.md) - Range semver support for dependencies in plugin-descriptor.properties


### PR DESCRIPTION
## Summary

Add documentation for the Thread Pool ForkJoinPool support feature introduced in OpenSearch v3.4.0.

### Changes
- **Release report**: `docs/releases/v3.4.0/features/opensearch/thread-pool.md`
- **Feature report**: `docs/features/opensearch/thread-pool.md` (new)
- Updated release index and features index

### Key Feature Details
- New `FORK_JOIN` thread pool type for work-stealing parallelism
- `ForkJoinPoolExecutorBuilder` for plugin registration
- Configurable parallelism, async mode, and exception handling
- Useful for components like jVector that leverage ForkJoinPool for faster index building

### Related
- PR: opensearch-project/OpenSearch#19008
- Issue: opensearch-project/OpenSearch#18674
- Investigation Issue: #1681