### PR TITLE
docs: add merged segment warmer report for v3.4.0

### DIFF
--- a/docs/features/opensearch/segment-warmer.md
+++ b/docs/features/opensearch/segment-warmer.md
@@ -66,6 +66,9 @@ flowchart TB
 |-----------|-------------|
 | `MergedSegmentWarmerFactory` | Factory that creates appropriate `IndexReaderWarmer` implementations based on index replication settings |
 | `MergedSegmentWarmer` | Unified implementation handling both local and remote segment warming |
+| `ClusterMergeSchedulerConfig` | Manages cluster-level merge scheduler settings with three-level hierarchy (v3.4.0+) |
+| `MergedSegmentTransferTracker` | Tracks transfer metrics for warming operations (v3.3.0+) |
+| `MergedSegmentWarmerStats` | Exposes warmer statistics via stats APIs (v3.3.0+) |
 | `RemoteStorePublishMergedSegmentAction` | Replication action for uploading merged segments to remote store and publishing checkpoints |
 | `RemoteStoreMergedSegmentCheckpoint` | Checkpoint containing local-to-remote filename mappings for merged segments |
 | `PublishMergedSegmentAction` | Replication action for local segment replication pre-copy |
@@ -73,11 +76,30 @@ flowchart TB
 
 ### Configuration
 
+#### Warmer Settings (v3.4.0+)
+
 | Setting | Description | Default |
 |---------|-------------|---------|
-| `opensearch.experimental.feature.merged_segment_warmer.enabled` | Feature flag to enable merged segment warmer | `false` |
+| `indices.replication.merges.warmer.enabled` | Enable/disable merged segment warmer (cluster setting) | `false` |
+| `indices.replication.merges.warmer.min_segment_size_threshold` | Minimum segment size to trigger warming | `500mb` |
+| `indices.replication.merges.warmer.max_bytes_per_sec` | Rate limit for segment transfer | - |
+| `indices.replication.merges.warmer.timeout` | Timeout for warming operations | - |
 | `index.replication.type` | Must be set to `SEGMENT` for segment warmer to activate | `DOCUMENT` |
-| `max_remote_low_priority_download_bytes_per_sec` | Rate limit for low-priority downloads (merged segments) | `0` (unlimited) |
+
+#### Cluster Merge Scheduler Settings (v3.4.0+)
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.index.merge.scheduler.max_thread_count` | Cluster default for merge threads | `Math.max(1, cores/2)` |
+| `cluster.index.merge.scheduler.max_merge_count` | Cluster default for concurrent merges | `max_thread_count + 5` |
+| `cluster.index.merge.scheduler.auto_throttle` | Cluster default for auto-throttle | `true` |
+
+#### Legacy Settings (v3.0.0-v3.3.0)
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `opensearch.experimental.feature.merged_segment_warmer.enabled` | Experimental feature flag (removed in v3.4.0) | `false` |
+| `max_remote_low_priority_download_bytes_per_sec` | Rate limit for low-priority downloads | `0` (unlimited) |
 
 ### Metrics (v3.3.0+)
 
@@ -102,10 +124,16 @@ Access metrics via:
 
 ### Usage Example
 
-Enable the feature flag in `opensearch.yml`:
+Enable the feature via cluster setting (v3.4.0+):
 
-```yaml
-opensearch.experimental.feature.merged_segment_warmer.enabled: true
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "indices.replication.merges.warmer.enabled": true,
+    "indices.replication.merges.warmer.min_segment_size_threshold": "256mb"
+  }
+}
 ```
 
 Create an index with segment replication:
@@ -121,6 +149,17 @@ PUT /my-index
   }
 }
 ```
+
+<details>
+<summary>Legacy: Enable via feature flag (v3.0.0-v3.3.0)</summary>
+
+Add to `opensearch.yml`:
+
+```yaml
+opensearch.experimental.feature.merged_segment_warmer.enabled: true
+```
+
+</details>
 
 ### How Pre-copy Works
 
@@ -139,7 +178,9 @@ PUT /my-index
 ## Limitations
 
 - Requires segment replication (`replication.type: SEGMENT`)
-- Experimental feature requiring explicit feature flag enablement
+- Feature disabled by default - must be explicitly enabled via cluster setting
+- Only segments larger than threshold are warmed (default 500MB in v3.4.0+)
+- Warming only occurs when all cluster nodes are v3.4.0+ (version check added in v3.4.0)
 - Increases network utilization during merge operations
 - Not applicable to document replication indexes
 - Failures during warming are logged but do not block merge operations
@@ -148,9 +189,11 @@ PUT /my-index
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#19715](https://github.com/opensearch-project/OpenSearch/pull/19715) | Remove experimental feature flag - GA graduation |
+| v3.4.0 | [#19629](https://github.com/opensearch-project/OpenSearch/pull/19629) | Add configurable resiliency features and cluster merge scheduler settings |
+| v3.4.0 | [#18929](https://github.com/opensearch-project/OpenSearch/pull/18929) | Add metrics for merged segment warmer operations |
 | v3.4.0 | [#19436](https://github.com/opensearch-project/OpenSearch/pull/19436) | Exception handling to prevent shard failures during warming |
 | v3.4.0 | [#20105](https://github.com/opensearch-project/OpenSearch/pull/20105) | Fix EngineConfig.toBuilder() to include mergedSegmentTransferTracker |
-| v3.3.0 | [#18929](https://github.com/opensearch-project/OpenSearch/pull/18929) | Add metrics for merged segment warmer operations |
 | v3.2.0 | [#18683](https://github.com/opensearch-project/OpenSearch/pull/18683) | Remote store support for merged segment warming |
 | v3.0.0 | [#18255](https://github.com/opensearch-project/OpenSearch/pull/18255) | Local merged segment warmer implementation |
 | v3.0.0 | [#17881](https://github.com/opensearch-project/OpenSearch/pull/17881) | Initial implementation - MergedSegmentWarmerFactory infrastructure |
@@ -165,7 +208,7 @@ PUT /my-index
 
 ## Change History
 
-- **v3.4.0** (2025-12-09): Bugfixes - Added exception handling in `MergedSegmentWarmer.warm()` to prevent primary shard failures during node restarts; Fixed `EngineConfig.toBuilder()` to include `mergedSegmentTransferTracker` preventing `_cat/indices` API failures
+- **v3.4.0** (2025-12-09): GA graduation - Removed experimental feature flag; feature now controlled by dynamic cluster setting `indices.replication.merges.warmer.enabled`; Added segment size threshold filtering (`min_segment_size_threshold`, default 500MB); Added cluster-level merge scheduler settings (`ClusterMergeSchedulerConfig`); Added min node version check (V_3_4_0); Bugfixes for exception handling and EngineConfig builder
 - **v3.3.0** (2025-10-14): Added comprehensive metrics for monitoring segment warmer operations - `MergedSegmentTransferTracker` and `MergedSegmentWarmerStats` expose invocation counts, timing, bytes transferred, and failure counts via stats APIs
 - **v3.2.0** (2025-08-05): Added remote store support - merged segments are uploaded to remote store and replicated to replicas via `RemoteStorePublishMergedSegmentAction`
 - **v3.0.0** (2025-05-06): Initial implementation - introduced `MergedSegmentWarmerFactory` with `LocalMergedSegmentWarmer` and `RemoteStoreMergedSegmentWarmer` infrastructure

--- a/docs/releases/v3.4.0/features/opensearch/merged-segment-warmer.md
+++ b/docs/releases/v3.4.0/features/opensearch/merged-segment-warmer.md
@@ -1,0 +1,120 @@
+# Merged Segment Warmer
+
+## Summary
+
+The Merged Segment Warmer feature graduates from experimental to GA in v3.4.0. The experimental feature flag has been removed, and the feature is now controlled entirely by dynamic cluster settings. This release also adds configurable resiliency features including segment size thresholds and cluster-level merge scheduler defaults.
+
+## Details
+
+### What's New in v3.4.0
+
+1. **GA Graduation**: Removed `FeatureFlag.MERGED_SEGMENT_WARMER_EXPERIMENTAL_FLAG` - feature is now production-ready
+2. **Dynamic Control**: Feature controlled by `indices.replication.merges.warmer.enabled` cluster setting (default: `false`)
+3. **Segment Size Threshold**: Only warm segments larger than configurable threshold (default: 500MB)
+4. **Cluster-level Merge Scheduler Settings**: New cluster defaults for merge thread count and merge count
+5. **Min Version Check**: Warming only occurs when all nodes are v3.4.0+
+
+### Technical Changes
+
+#### Settings Hierarchy
+
+```mermaid
+graph TB
+    subgraph "Settings Priority"
+        IL[Index Level Settings]
+        CL[Cluster Level Settings]
+        AD[Absolute Defaults]
+    end
+    
+    IL -->|overrides| CL
+    CL -->|overrides| AD
+    
+    subgraph "Example: max_thread_count"
+        I1["index.merge.scheduler.max_thread_count"]
+        C1["cluster.index.merge.scheduler.max_thread_count"]
+        A1["Math.max(1, cores/2)"]
+    end
+```
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `indices.replication.merges.warmer.enabled` | Enable/disable merged segment warmer | `false` |
+| `indices.replication.merges.warmer.min_segment_size_threshold` | Minimum segment size to trigger warming | `500mb` |
+| `indices.replication.merges.warmer.max_bytes_per_sec` | Rate limit for segment transfer | - |
+| `indices.replication.merges.warmer.timeout` | Timeout for warming operations | - |
+| `cluster.index.merge.scheduler.max_thread_count` | Cluster default for merge threads | `Math.max(1, cores/2)` |
+| `cluster.index.merge.scheduler.max_merge_count` | Cluster default for concurrent merges | `max_thread_count + 5` |
+| `cluster.index.merge.scheduler.auto_throttle` | Cluster default for auto-throttle | `true` |
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ClusterMergeSchedulerConfig` | Manages cluster-level merge scheduler settings with three-level hierarchy |
+| `MergedSegmentTransferTracker` | Tracks transfer metrics for warming operations |
+| `MergedSegmentWarmerStats` | Exposes warmer statistics via stats APIs |
+
+#### Behavioral Changes
+
+- `AsyncPublishReferencedSegmentsTask` only runs when warmer is enabled
+- `shouldWarm()` checks minimum node version (V_3_4_0) before warming
+- Setting names standardized with `indices.replication.merges.warmer.*` prefix
+
+### Usage Example
+
+Enable the feature at cluster level:
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "indices.replication.merges.warmer.enabled": true,
+    "indices.replication.merges.warmer.min_segment_size_threshold": "256mb"
+  }
+}
+```
+
+Configure cluster-level merge scheduler defaults:
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.index.merge.scheduler.max_thread_count": 4,
+    "cluster.index.merge.scheduler.max_merge_count": 9
+  }
+}
+```
+
+### Migration Notes
+
+If upgrading from v3.3.0 or earlier with the experimental feature flag:
+
+1. Remove `opensearch.experimental.feature.merged_segment_warmer.enabled` from `opensearch.yml`
+2. Enable via cluster setting: `indices.replication.merges.warmer.enabled: true`
+3. Feature will only activate after all nodes are upgraded to v3.4.0+
+
+## Limitations
+
+- Warming only occurs when all cluster nodes are v3.4.0+
+- Feature disabled by default - must be explicitly enabled
+- Only segments larger than threshold are warmed (default 500MB)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18929](https://github.com/opensearch-project/OpenSearch/pull/18929) | Add metrics for merged segment warmer flow |
+| [#19629](https://github.com/opensearch-project/OpenSearch/pull/19629) | Add configurable resiliency features |
+| [#19715](https://github.com/opensearch-project/OpenSearch/pull/19715) | Remove experimental feature flag |
+
+## References
+
+- [Issue #17528](https://github.com/opensearch-project/OpenSearch/issues/17528): RFC - Introduce Pre-copy Merged Segment
+- [Segment Replication Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/segment-replication/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/segment-warmer.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -18,6 +18,7 @@
 - [Lucene Integration](features/opensearch/lucene-integration.md) - Remove MultiCollectorWrapper and use Lucene's native MultiCollector API
 - [Lucene Upgrade](features/opensearch/lucene-upgrade.md) - Bump Apache Lucene from 10.3.1 to 10.3.2 with MaxScoreBulkScorer bug fix
 - [Maven Snapshots Publishing](features/opensearch/maven-snapshots-publishing.md) - Migrate snapshot publishing from Sonatype to S3-backed repository at ci.opensearch.org
+- [Merged Segment Warmer](features/opensearch/merged-segment-warmer.md) - GA graduation with configurable resiliency features and cluster-level merge scheduler settings
 - [Node Stats Bugfixes](features/opensearch/node-stats-bugfixes.md) - Fix negative CPU usage values in node stats on certain Linux distributions
 - [Normalizer Enhancements](features/opensearch/normalizer-enhancements.md) - Allow truncate token filter in normalizers for keyword field truncation
 - [S3 Repository](features/opensearch/s3-repository.md) - Add LEGACY_MD5_CHECKSUM_CALCULATION to opensearch.yml settings for S3-compatible storage


### PR DESCRIPTION
## Summary

Add release report and update feature report for Merged Segment Warmer in v3.4.0.

## Key Changes in v3.4.0

- **GA Graduation**: Removed experimental feature flag - feature now production-ready
- **Dynamic Control**: Feature controlled by `indices.replication.merges.warmer.enabled` cluster setting
- **Segment Size Threshold**: Only warm segments larger than configurable threshold (default 500MB)
- **Cluster Merge Scheduler Settings**: New cluster-level defaults for merge thread count and merge count
- **Min Version Check**: Warming only occurs when all nodes are v3.4.0+

## Reports

- Release report: `docs/releases/v3.4.0/features/opensearch/merged-segment-warmer.md`
- Feature report: `docs/features/opensearch/segment-warmer.md` (updated)

## Related PRs

- opensearch-project/OpenSearch#18929 - Add metrics
- opensearch-project/OpenSearch#19629 - Add configurable resiliency features
- opensearch-project/OpenSearch#19715 - Remove experimental feature flag

Closes #1678