### PR TITLE
docs: add user-behavior-insights-build report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -579,6 +579,7 @@
 
 ## user-behavior-insights
 
+- [User Behavior Insights Build Infrastructure](user-behavior-insights/user-behavior-insights-build.md)
 - [User Behavior Insights Data Generator](user-behavior-insights/user-behavior-insights-data-generator.md)
 - [User Plugin Fixes](user-behavior-insights/user-plugin-fixes.md)
 

--- a/docs/features/user-behavior-insights/user-behavior-insights-build.md
+++ b/docs/features/user-behavior-insights/user-behavior-insights-build.md
@@ -1,0 +1,113 @@
+# User Behavior Insights Build Infrastructure
+
+## Summary
+
+This document tracks the build infrastructure and CI/CD configuration for the User Behavior Insights (UBI) plugin. UBI is a plugin that captures client-side events and queries for improving search relevance and user experience. The build infrastructure ensures proper dependency management, snapshot publishing, and automated workflows.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph CI["CI/CD Pipeline"]
+        GHA[GitHub Actions]
+        Backport[Backport Workflow]
+        Publish[Maven Publish]
+    end
+    
+    subgraph Build["Build System"]
+        Gradle[Gradle]
+        Deps[Dependencies]
+    end
+    
+    subgraph Artifacts["Artifact Publishing"]
+        S3[AWS S3 Snapshots]
+        Maven[Maven Central]
+    end
+    
+    GHA --> Gradle
+    GHA --> Backport
+    Gradle --> Deps
+    Publish --> S3
+    Publish --> Maven
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    PR[Pull Request] --> CI[CI Checks]
+    CI --> Build[Gradle Build]
+    Build --> Test[Tests]
+    Test --> Publish[Publish Snapshots]
+    Publish --> S3["S3 Repository"]
+    
+    Merge[PR Merge] --> Backport[Backport Workflow]
+    Backport --> BackportPR[Backport PR]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `build.gradle` | Main build configuration with dependency and publishing setup |
+| `maven-publish.yml` | GitHub Actions workflow for publishing Maven snapshots |
+| `backport.yml` | Automated backporting workflow for merged PRs |
+| `delete_backport_branch.yml` | Cleanup workflow for backport branches |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `MAVEN_SNAPSHOTS_S3_REPO` | S3 repository URL for snapshot publishing | `ci.opensearch.org/ci/dbc/snapshots/maven/` |
+| `MAVEN_SNAPSHOTS_S3_ROLE` | IAM role for S3 access | (from secrets) |
+
+### Repository URLs
+
+| Purpose | URL |
+|---------|-----|
+| Snapshot Repository | `https://ci.opensearch.org/ci/dbc/snapshots/maven/` |
+| Gradle Plugins | `https://plugins.gradle.org/m2/` |
+| JitPack | `https://jitpack.io` |
+
+### Usage Example
+
+To use UBI snapshots in your project:
+
+```groovy
+repositories {
+    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    mavenCentral()
+}
+
+dependencies {
+    implementation "org.opensearch.plugin:opensearch-ubi:3.4.0-SNAPSHOT"
+}
+```
+
+## Limitations
+
+- Snapshot publishing requires AWS credentials (handled automatically in CI)
+- Backport workflow requires GitHub App token for cross-branch operations
+- S3 repository does not provide the same browsing interface as Sonatype
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#140](https://github.com/opensearch-project/user-behavior-insights/pull/140) | Onboarding new maven snapshots publishing to s3 |
+| v3.3.0 | [#127](https://github.com/opensearch-project/user-behavior-insights/pull/127) | Increment version to 3.3.0-SNAPSHOT |
+| v3.3.0 | [#128](https://github.com/opensearch-project/user-behavior-insights/pull/128) | Fix dependency errors for integration tests |
+
+## References
+
+- [Issue #5360](https://github.com/opensearch-project/opensearch-build/issues/5360): Migration from sonatype snapshots repo to ci.opensearch.org
+- [User Behavior Insights Repository](https://github.com/opensearch-project/user-behavior-insights): Main UBI repository
+- [UBI Documentation](https://docs.opensearch.org/3.0/search-plugins/ubi/index/): Official OpenSearch UBI documentation
+- [UBI Specification](https://github.com/o19s/ubi): Industry-standard UBI schema
+
+## Change History
+
+- **v3.4.0** (2026-01-11): Migrated Maven snapshot publishing from Sonatype to S3, added backport workflows
+- **v3.3.0** (2026-01-11): Fixed dependency version conflicts for integration tests

--- a/docs/releases/v3.4.0/features/user-behavior-insights/user-behavior-insights-build.md
+++ b/docs/releases/v3.4.0/features/user-behavior-insights/user-behavior-insights-build.md
@@ -1,0 +1,89 @@
+# User Behavior Insights Build
+
+## Summary
+
+This release item updates the User Behavior Insights (UBI) plugin build infrastructure to migrate Maven snapshot publishing from Sonatype to the new OpenSearch S3-based snapshot repository. This is part of a broader OpenSearch project initiative to consolidate snapshot publishing across all plugins.
+
+## Details
+
+### What's New in v3.4.0
+
+The UBI plugin now publishes Maven snapshots to the OpenSearch-managed S3 repository (`ci.opensearch.org`) instead of Sonatype. This migration was necessary because Sonatype implemented new policies removing snapshots older than 30 days.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph Before["Before v3.4.0"]
+        GHA1[GitHub Actions] --> Sonatype[Sonatype Snapshots]
+        Sonatype --> Dev1[Developers]
+    end
+    
+    subgraph After["After v3.4.0"]
+        GHA2[GitHub Actions] --> AWS[AWS S3]
+        AWS --> S3Repo["ci.opensearch.org/ci/dbc/snapshots"]
+        S3Repo --> Dev2[Developers]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `backport.yml` | New GitHub Actions workflow for automated backporting of PRs |
+| `delete_backport_branch.yml` | Workflow to clean up backport branches after merge |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `MAVEN_SNAPSHOTS_S3_REPO` | S3 repository URL for snapshot publishing | `ci.opensearch.org/ci/dbc/snapshots/maven/` |
+| `MAVEN_SNAPSHOTS_S3_ROLE` | IAM role for S3 access | (from secrets) |
+
+#### Build Changes
+
+The `build.gradle` file was updated to:
+1. Replace Sonatype repository URLs with the new S3 snapshot repository
+2. Use AWS credentials (via IAM role assumption) instead of Sonatype username/password
+3. Configure `AwsCredentials` for S3 publishing
+
+### Usage Example
+
+Developers pulling UBI snapshots should update their `build.gradle`:
+
+```groovy
+repositories {
+    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    mavenCentral()
+}
+```
+
+### Migration Notes
+
+- No action required for end users
+- Developers using UBI snapshots should update repository URLs in their build configurations
+- The old Sonatype URLs will no longer receive new snapshots
+
+## Limitations
+
+- Requires AWS credentials for publishing (handled automatically in CI)
+- S3 repository browsing may differ from Sonatype's web interface
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#140](https://github.com/opensearch-project/user-behavior-insights/pull/140) | Onboarding new maven snapshots publishing to s3 (UBI) |
+| [#127](https://github.com/opensearch-project/user-behavior-insights/pull/127) | Increment version to 3.3.0-SNAPSHOT |
+
+## References
+
+- [Issue #5360](https://github.com/opensearch-project/opensearch-build/issues/5360): Migration from sonatype snapshots repo to ci.opensearch.org snapshots repo
+- [UBI Documentation](https://docs.opensearch.org/3.0/search-plugins/ubi/index/): Official OpenSearch UBI documentation
+- [User Behavior Insights Repository](https://github.com/opensearch-project/user-behavior-insights): Main UBI repository
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/user-behavior-insights/user-behavior-insights-build.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -79,3 +79,7 @@
 
 - [Dashboards Console](features/opensearch-dashboards/dashboards-console.md) - Fix for console_polling setting update
 - [Dashboards Navigation](features/opensearch-dashboards/dashboards-navigation.md) - Fix disabled prop propagation for navigation links
+
+### User Behavior Insights
+
+- [User Behavior Insights Build](features/user-behavior-insights/user-behavior-insights-build.md) - Migrate Maven snapshot publishing from Sonatype to S3-backed repository


### PR DESCRIPTION
## Summary

This PR adds documentation for the User Behavior Insights Build infrastructure changes in v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/user-behavior-insights/user-behavior-insights-build.md`
- Feature report: `docs/features/user-behavior-insights/user-behavior-insights-build.md`

### Key Changes in v3.4.0
- Migrated Maven snapshot publishing from Sonatype to S3-backed repository at ci.opensearch.org
- Added backport workflow for automated PR backporting
- Added cleanup workflow for backport branches

### Resources Used
- PR: [#140](https://github.com/opensearch-project/user-behavior-insights/pull/140)
- PR: [#127](https://github.com/opensearch-project/user-behavior-insights/pull/127)
- Issue: [#5360](https://github.com/opensearch-project/opensearch-build/issues/5360)

Closes #1673