### PR TITLE
docs: add Search Relevance CI/Tests report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -321,6 +321,7 @@
 ## search-relevance
 
 - [Search Relevance Workbench](search-relevance/search-relevance-workbench.md)
+- [Search Relevance CI/Tests](search-relevance/ci-tests.md)
 
 ## dashboards-flow-framework
 

--- a/docs/features/search-relevance/ci-tests.md
+++ b/docs/features/search-relevance/ci-tests.md
@@ -1,0 +1,98 @@
+# Search Relevance CI/Tests
+
+## Summary
+The Search Relevance plugin includes a comprehensive CI/CD infrastructure and test framework that supports unit testing, integration testing, and debugging capabilities. This documentation covers the testing infrastructure, debugging tools, and best practices for developers working with the Search Relevance Workbench.
+
+## Details
+
+### Architecture
+```mermaid
+graph TB
+    subgraph "Test Infrastructure"
+        UT[Unit Tests]
+        IT[Integration Tests]
+        JDWP[JDWP Debugger]
+    end
+    
+    subgraph "Gradle Tasks"
+        TEST[test task]
+        INTEG[integTest task]
+    end
+    
+    subgraph "Debug Ports"
+        P8000[Port 8000 - Test JVM]
+        P5005[Port 5005 - Cluster]
+    end
+    
+    TEST --> UT
+    INTEG --> IT
+    JDWP --> P8000
+    JDWP --> P5005
+    TEST -.->|debug mode| JDWP
+    INTEG -.->|debug mode| JDWP
+```
+
+### Components
+| Component | Description |
+|-----------|-------------|
+| Unit Tests | Fast-running tests for individual components |
+| Integration Tests | End-to-end tests with OpenSearch cluster |
+| JDWP Debugger | Java Debug Wire Protocol support for debugging |
+| UBI Mappings | Manual mappings for User Behavior Insights integration |
+
+### Configuration
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `test.debug` | Enable JDWP debugging for tests | disabled |
+| Debug Port (test) | Port for test JVM debugging | 8000 |
+| Debug Port (cluster) | Port for cluster debugging | 5005 |
+
+### Usage Example
+
+#### Running Unit Tests
+```bash
+# Run all unit tests
+./gradlew test
+
+# Run with debugging enabled
+./gradlew test -Dtest.debug=1
+```
+
+#### Running Integration Tests
+```bash
+# Run all integration tests
+./gradlew :integTest
+
+# Run with debugging enabled
+./gradlew :integTest -Dtest.debug=1
+```
+
+#### Debugging Workflow
+1. Start tests with `-Dtest.debug=1` flag
+2. Wait for "Listening for transport dt_socket at address: 8000"
+3. Attach IDE debugger to `localhost:8000`
+4. Set breakpoints and debug
+
+## Limitations
+- Debug mode runs tests sequentially (`maxParallelForks = 1`)
+- Only one debug agent can be loaded per JVM
+- Integration tests require OpenSearch cluster to be running
+
+## Related PRs
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#311](https://github.com/opensearch-project/search-relevance/pull/311) | Fixed CalculateJudgmentsIT dependency on UBI plugin |
+| v3.4.0 | [#300](https://github.com/opensearch-project/search-relevance/pull/300) | Added JDWP debug support for test Gradle task |
+| v3.4.0 | [#296](https://github.com/opensearch-project/search-relevance/pull/296) | Fixed duplicate JDWP configuration in integTest |
+| v3.4.0 | [#307](https://github.com/opensearch-project/search-relevance/pull/307) | Removed deprecated AccessController.doPrivileged() |
+| v3.4.0 | [#288](https://github.com/opensearch-project/search-relevance/pull/288) | Small cleanups to test classes |
+
+## References
+- [Issue #302](https://github.com/opensearch-project/search-relevance/issues/302): CalculateJudgmentsIT UBI dependency issue
+- [Issue #299](https://github.com/opensearch-project/search-relevance/issues/299): JDWP debug support request
+- [Issue #295](https://github.com/opensearch-project/search-relevance/issues/295): Duplicate JDWP configuration bug
+- [Issue #306](https://github.com/opensearch-project/search-relevance/issues/306): AccessController deprecation warnings
+- [Search Relevance Repository](https://github.com/opensearch-project/search-relevance)
+
+## Change History
+- **v3.4.0** (2026-01-11): Fixed UBI test dependencies, added JDWP debug support, removed deprecated AccessController usage, test code cleanups

--- a/docs/releases/v3.4.0/features/search-relevance/ci-tests.md
+++ b/docs/releases/v3.4.0/features/search-relevance/ci-tests.md
@@ -1,0 +1,63 @@
+# Search Relevance CI/Tests
+
+## Summary
+This release includes several improvements to the Search Relevance plugin's CI/CD infrastructure and test framework. The changes fix test dependencies, improve debugging capabilities, remove deprecated API usage, and clean up test code.
+
+## Details
+
+### What's New in v3.4.0
+
+#### Test Dependency Fixes
+- Fixed `CalculateJudgmentsIT.java` integration test dependency on UBI plugin by adding manual UBI mappings
+- Tests no longer require the UBI plugin to be installed for proper execution
+
+#### Debugging Improvements
+- Added JDWP debug support to the `test` Gradle task, enabling developers to debug unit tests with `-Dtest.debug=1`
+- Fixed duplicate JDWP configuration in `integTest` task that caused JVM TI agent load failures
+- Consistent debug port usage: `8000` for test JVM, `5005` for cluster
+
+#### Code Modernization
+- Removed deprecated `AccessController.doPrivileged()` usage from `JsonUtils`
+- OpenSearch does not run under a SecurityManager, making privileged blocks unnecessary
+- Eliminates deprecation warnings for newer Java versions
+
+#### Test Code Cleanup
+- Applied IntelliJ-recommended fixes to test classes
+- Improved code quality and maintainability
+
+### Technical Changes
+
+#### New Configuration
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `test.debug` | Enable JDWP debugging for unit tests | disabled |
+
+#### Usage Example
+```bash
+# Debug unit tests
+./gradlew test -Dtest.debug=1
+
+# Debug integration tests
+./gradlew :integTest -Dtest.debug=1
+```
+
+## Limitations
+- Debug mode runs tests with `maxParallelForks = 1` for proper debugger attachment
+
+## Related PRs
+| PR | Description |
+|----|-------------|
+| [#311](https://github.com/opensearch-project/search-relevance/pull/311) | Fixed CalculateJudgmentsIT dependency on UBI plugin |
+| [#300](https://github.com/opensearch-project/search-relevance/pull/300) | Added JDWP debug support for test Gradle task |
+| [#296](https://github.com/opensearch-project/search-relevance/pull/296) | Fixed duplicate JDWP configuration in integTest |
+| [#307](https://github.com/opensearch-project/search-relevance/pull/307) | Removed deprecated AccessController.doPrivileged() |
+| [#288](https://github.com/opensearch-project/search-relevance/pull/288) | Small cleanups to test classes |
+
+## References
+- [Issue #302](https://github.com/opensearch-project/search-relevance/issues/302): CalculateJudgmentsIT UBI dependency issue
+- [Issue #299](https://github.com/opensearch-project/search-relevance/issues/299): JDWP debug support request
+- [Issue #295](https://github.com/opensearch-project/search-relevance/issues/295): Duplicate JDWP configuration bug
+- [Issue #306](https://github.com/opensearch-project/search-relevance/issues/306): AccessController deprecation warnings
+
+## Related Feature Report
+- [Full feature documentation](../../../../features/search-relevance/ci-tests.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -83,3 +83,7 @@
 ### User Behavior Insights
 
 - [User Behavior Insights Build](features/user-behavior-insights/user-behavior-insights-build.md) - Migrate Maven snapshot publishing from Sonatype to S3-backed repository
+
+### Search Relevance
+
+- [Search Relevance CI/Tests](features/search-relevance/ci-tests.md) - Test dependency fixes, JDWP debugging support, deprecated API removal, and test code cleanups


### PR DESCRIPTION
## Summary

This PR adds documentation for Search Relevance CI/Tests improvements in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/search-relevance/ci-tests.md`
- Feature report: `docs/features/search-relevance/ci-tests.md`

### Key Changes in v3.4.0
- Fixed `CalculateJudgmentsIT.java` integration test dependency on UBI plugin (#311)
- Added JDWP debug support for unit test Gradle task (#300)
- Fixed duplicate JDWP configuration in integTest Gradle task (#296)
- Removed deprecated `AccessController.doPrivileged()` usage (#307)
- Small cleanups to test classes (#288)

### Related Issue
Closes #1672