### PR TITLE
docs: add GitHub Actions Updates report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -281,6 +281,7 @@
 - [Security FIPS Compliance](security/security-fips-compliance.md)
 - [Security AccessController Migration](security/security-accesscontroller-migration.md)
 - [SPIFFE X.509 SVID Support](security/spiffe-x.509-svid-support.md)
+- [GitHub Actions Updates](security/github-actions-updates.md)
 
 ## security-dashboards
 

--- a/docs/features/security/github-actions-updates.md
+++ b/docs/features/security/github-actions-updates.md
@@ -1,0 +1,126 @@
+# GitHub Actions Updates
+
+## Summary
+
+The OpenSearch Security repositories maintain their CI/CD pipelines using GitHub Actions. Regular updates to action dependencies ensure workflows benefit from the latest features, security patches, and runtime improvements. These updates are typically automated via Dependabot.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "GitHub Actions Workflow"
+        A[Workflow Trigger] --> B[Checkout Code]
+        B --> C[Setup Environment]
+        C --> D[Build & Test]
+        D --> E[Upload Artifacts]
+        E --> F[Auto-commit Changes]
+    end
+    
+    subgraph "Key Actions"
+        B --> B1[actions/checkout]
+        C --> C1[actions/setup-java]
+        C --> C2[derek-ho/start-opensearch]
+        C --> C3[derek-ho/setup-opensearch-dashboards]
+        D --> D1[github/codeql-action]
+        D --> D2[Wandalen/wretry.action]
+        E --> E1[actions/upload-artifact]
+        E --> E2[actions/download-artifact]
+        F --> F1[stefanzweifel/git-auto-commit-action]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `actions/checkout` | Checks out repository code for workflow access |
+| `actions/setup-java` | Sets up Java JDK environment for builds |
+| `actions/upload-artifact` | Uploads build artifacts for sharing between jobs |
+| `actions/download-artifact` | Downloads artifacts from previous workflow runs |
+| `github/codeql-action` | Performs CodeQL security analysis |
+| `stefanzweifel/git-auto-commit-action` | Auto-commits changes made during workflow |
+| `derek-ho/start-opensearch` | Starts OpenSearch instance for integration tests |
+| `derek-ho/setup-opensearch-dashboards` | Sets up OpenSearch Dashboards for plugin testing |
+| `Wandalen/wretry.action` | Retries flaky workflow steps |
+
+### Configuration
+
+GitHub Actions are configured in `.github/workflows/` directory. Example workflow using these actions:
+
+```yaml
+name: CI
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-java@v5
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+      - name: Build
+        run: ./gradlew build
+      - uses: actions/upload-artifact@v5
+        with:
+          name: build-artifacts
+          path: build/
+```
+
+### Usage Example
+
+```yaml
+# Integration test with OpenSearch
+- uses: derek-ho/start-opensearch@v8
+  with:
+    opensearch-version: '3.4.0'
+    security-enabled: true
+
+# Retry flaky tests
+- uses: Wandalen/wretry.action@v3.8.0
+  with:
+    command: ./gradlew integTest
+    attempt_limit: 3
+```
+
+## Limitations
+
+- GitHub Actions runner version requirements may vary by action version
+- Node.js runtime version changes may affect custom JavaScript actions
+- Some actions require specific permissions in workflow files
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [security#5810](https://github.com/opensearch-project/security/pull/5810) | Bump actions/checkout from 5 to 6 |
+| v3.4.0 | [security#5740](https://github.com/opensearch-project/security/pull/5740) | Bump actions/upload-artifact from 4 to 5 |
+| v3.4.0 | [security#5739](https://github.com/opensearch-project/security/pull/5739) | Bump actions/download-artifact from 5 to 6 |
+| v3.4.0 | [security#5704](https://github.com/opensearch-project/security/pull/5704) | Bump stefanzweifel/git-auto-commit-action from 6 to 7 |
+| v3.4.0 | [security#5702](https://github.com/opensearch-project/security/pull/5702) | Bump github/codeql-action from 3 to 4 |
+| v3.4.0 | [security#5630](https://github.com/opensearch-project/security/pull/5630) | Bump derek-ho/start-opensearch from 7 to 8 |
+| v3.4.0 | [security-dashboards-plugin#2339](https://github.com/opensearch-project/security-dashboards-plugin/pull/2339) | Bump actions/checkout from 5 to 6 |
+| v3.4.0 | [security-dashboards-plugin#2329](https://github.com/opensearch-project/security-dashboards-plugin/pull/2329) | Bump stefanzweifel/git-auto-commit-action from 6 to 7 |
+| v3.4.0 | [security-dashboards-plugin#2323](https://github.com/opensearch-project/security-dashboards-plugin/pull/2323) | Bump actions/setup-java from 4 to 5 |
+| v3.4.0 | [security-dashboards-plugin#2322](https://github.com/opensearch-project/security-dashboards-plugin/pull/2322) | Bump Wandalen/wretry.action from 3.3.0 to 3.8.0 |
+| v3.4.0 | [security-dashboards-plugin#2321](https://github.com/opensearch-project/security-dashboards-plugin/pull/2321) | Bump derek-ho/setup-opensearch-dashboards from 1 to 3 |
+
+## References
+
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)
+- [actions/checkout](https://github.com/actions/checkout)
+- [actions/setup-java](https://github.com/actions/setup-java)
+- [actions/upload-artifact](https://github.com/actions/upload-artifact)
+- [actions/download-artifact](https://github.com/actions/download-artifact)
+- [github/codeql-action](https://github.com/github/codeql-action)
+- [stefanzweifel/git-auto-commit-action](https://github.com/stefanzweifel/git-auto-commit-action)
+- [derek-ho/start-opensearch](https://github.com/derek-ho/start-opensearch)
+- [derek-ho/setup-opensearch-dashboards](https://github.com/derek-ho/setup-opensearch-dashboards)
+- [Wandalen/wretry.action](https://github.com/Wandalen/wretry.action)
+
+## Change History
+
+- **v3.4.0**: Updated multiple GitHub Actions to support Node.js 24 runtime

--- a/docs/releases/v3.4.0/features/security/github-actions-updates.md
+++ b/docs/releases/v3.4.0/features/security/github-actions-updates.md
@@ -1,0 +1,83 @@
+# GitHub Actions Updates
+
+## Summary
+
+This release includes updates to GitHub Actions dependencies across the security and security-dashboards-plugin repositories. These updates ensure CI/CD workflows use the latest action versions with Node.js 24 support, improved security, and enhanced functionality.
+
+## Details
+
+### What's New in v3.4.0
+
+The security repositories updated their GitHub Actions dependencies to newer major versions, primarily to support Node.js 24 runtime and benefit from security improvements.
+
+### Technical Changes
+
+#### Updated Actions in security Repository
+
+| Action | Previous Version | New Version | Key Changes |
+|--------|------------------|-------------|-------------|
+| `actions/checkout` | 5 | 6 | Node.js 24 support, credentials stored in separate file |
+| `actions/upload-artifact` | 4 | 5 | Node.js 24 support |
+| `actions/download-artifact` | 5 | 6 | Node.js 24 support |
+| `github/codeql-action` | 3 | 4 | Node.js 24 support, improved telemetry |
+| `stefanzweifel/git-auto-commit-action` | 6 | 7 | Node.js 24 support, restored skip_fetch/skip_checkout/create_branch options, tag message support |
+| `derek-ho/start-opensearch` | 7 | 8 | Added resource-sharing feature option for cypress tests |
+
+#### Updated Actions in security-dashboards-plugin Repository
+
+| Action | Previous Version | New Version | Key Changes |
+|--------|------------------|-------------|-------------|
+| `actions/checkout` | 5 | 6 | Node.js 24 support, credentials stored in separate file |
+| `actions/setup-java` | 4 | 5 | Node.js 24 support, improved error handling |
+| `stefanzweifel/git-auto-commit-action` | 6 | 7 | Node.js 24 support, restored options |
+| `derek-ho/setup-opensearch-dashboards` | 1 | 3 | Retry on download step, custom plugin suffix support |
+| `Wandalen/wretry.action` | 3.3.0 | 3.8.0 | Added pre_retry_command option, complex expressions support |
+
+### Migration Notes
+
+These are automated dependency updates managed by Dependabot. No manual migration is required for users of OpenSearch Security.
+
+For workflow maintainers:
+- Ensure GitHub Actions runners are updated to v2.327.1 or newer for Node.js 24 support
+- `actions/checkout@v6` stores credentials in `$RUNNER_TEMP` instead of local git config
+
+## Limitations
+
+- Node.js 24 runtime requires Actions Runner v2.327.1 or newer
+- Some actions may have breaking changes in their major version updates
+
+## Related PRs
+
+### security Repository
+
+| PR | Description |
+|----|-------------|
+| [#5810](https://github.com/opensearch-project/security/pull/5810) | Bump actions/checkout from 5 to 6 |
+| [#5740](https://github.com/opensearch-project/security/pull/5740) | Bump actions/upload-artifact from 4 to 5 |
+| [#5739](https://github.com/opensearch-project/security/pull/5739) | Bump actions/download-artifact from 5 to 6 |
+| [#5704](https://github.com/opensearch-project/security/pull/5704) | Bump stefanzweifel/git-auto-commit-action from 6 to 7 |
+| [#5702](https://github.com/opensearch-project/security/pull/5702) | Bump github/codeql-action from 3 to 4 |
+| [#5630](https://github.com/opensearch-project/security/pull/5630) | Bump derek-ho/start-opensearch from 7 to 8 |
+
+### security-dashboards-plugin Repository
+
+| PR | Description |
+|----|-------------|
+| [#2339](https://github.com/opensearch-project/security-dashboards-plugin/pull/2339) | Bump actions/checkout from 5 to 6 |
+| [#2329](https://github.com/opensearch-project/security-dashboards-plugin/pull/2329) | Bump stefanzweifel/git-auto-commit-action from 6 to 7 |
+| [#2323](https://github.com/opensearch-project/security-dashboards-plugin/pull/2323) | Bump actions/setup-java from 4 to 5 |
+| [#2322](https://github.com/opensearch-project/security-dashboards-plugin/pull/2322) | Bump Wandalen/wretry.action from 3.3.0 to 3.8.0 |
+| [#2321](https://github.com/opensearch-project/security-dashboards-plugin/pull/2321) | Bump derek-ho/setup-opensearch-dashboards from 1 to 3 |
+
+## References
+
+- [actions/checkout v6 Release](https://github.com/actions/checkout/releases/tag/v6.0.0)
+- [actions/upload-artifact v5 Release](https://github.com/actions/upload-artifact/releases/tag/v5.0.0)
+- [actions/download-artifact v6 Release](https://github.com/actions/download-artifact/releases/tag/v6.0.0)
+- [actions/setup-java v5 Release](https://github.com/actions/setup-java/releases/tag/v5.0.0)
+- [github/codeql-action v4](https://github.com/github/codeql-action)
+- [stefanzweifel/git-auto-commit-action v7 Release](https://github.com/stefanzweifel/git-auto-commit-action/releases/tag/v7.0.0)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/security/github-actions-updates.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -43,6 +43,7 @@
 
 - [Security AccessController Migration](features/security/security-accesscontroller-migration.md) - Migrate from deprecated java.security.AccessController to org.opensearch.secure_sm.AccessController
 - [Security Features](features/security/security-features.md) - Webhook Basic Auth, REST header propagation, system indices deprecation, static/custom config overlap, search relevance permissions
+- [GitHub Actions Updates](features/security/github-actions-updates.md) - Update GitHub Actions dependencies to support Node.js 24 runtime
 
 ### OpenSearch Dashboards
 


### PR DESCRIPTION
## Summary

Add documentation for GitHub Actions dependency updates in the security and security-dashboards-plugin repositories for OpenSearch v3.4.0.

## Changes

- Release report: `docs/releases/v3.4.0/features/security/github-actions-updates.md`
- Feature report: `docs/features/security/github-actions-updates.md`
- Updated release index and features index

## Key Updates in v3.4.0

### security Repository
- actions/checkout: 5 → 6
- actions/upload-artifact: 4 → 5
- actions/download-artifact: 5 → 6
- github/codeql-action: 3 → 4
- stefanzweifel/git-auto-commit-action: 6 → 7
- derek-ho/start-opensearch: 7 → 8

### security-dashboards-plugin Repository
- actions/checkout: 5 → 6
- actions/setup-java: 4 → 5
- stefanzweifel/git-auto-commit-action: 6 → 7
- derek-ho/setup-opensearch-dashboards: 1 → 3
- Wandalen/wretry.action: 3.3.0 → 3.8.0

## Related Issue

Closes #1671