### PR TITLE
docs: add observability-ci-tests report for v3.4.0

### DIFF
--- a/docs/features/dashboards-observability/ci-tests.md
+++ b/docs/features/dashboards-observability/ci-tests.md
@@ -1,0 +1,116 @@
+# Dashboards Observability CI/Tests
+
+## Summary
+
+The dashboards-observability plugin maintains a comprehensive CI/CD pipeline for testing and building the plugin. This includes unit tests, integration tests, end-to-end functional tests, and binary installation verification workflows.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "CI Workflows"
+        A[Pull Request / Push] --> B[Test & Build Workflow]
+        A --> C[Integration Tests]
+        A --> D[FTR E2E Tests]
+        A --> E[Binary Install Verification]
+    end
+    
+    subgraph "Dependencies"
+        F[OpenSearch Snapshots]
+        G[Job Scheduler Plugin]
+        H[Observability Plugin]
+        I[SQL Plugin]
+    end
+    
+    subgraph "Test Types"
+        J[Unit Tests]
+        K[Cypress E2E Tests]
+        L[Integration Tests]
+    end
+    
+    B --> J
+    C --> F
+    C --> G
+    C --> H
+    C --> I
+    C --> L
+    D --> F
+    D --> G
+    D --> H
+    D --> I
+    D --> K
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `dashboards-observability-test-and-build-workflow.yml` | Main test and build workflow for unit tests |
+| `integration-tests-workflow.yml` | Integration tests with OpenSearch backend |
+| `ftr-e2e-dashboards-observability-test.yml` | Functional Test Runner (FTR) end-to-end tests using Cypress |
+| `verify-binary-install.yml` | Verifies plugin installation via binary distribution |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `OPENSEARCH_VERSION` | Target OpenSearch version | `3.4.0` |
+| `OPENSEARCH_PLUGIN_VERSION` | Plugin version for snapshots | `3.4.0.0-SNAPSHOT` |
+| `OPENSEARCH_DASHBOARDS_VERSION` | Dashboards branch to test against | `main` |
+
+### Plugin Dependencies
+
+The integration and E2E tests require these OpenSearch plugins:
+
+| Plugin | Purpose |
+|--------|---------|
+| opensearch-job-scheduler | Job scheduling functionality |
+| opensearch-observability | Backend observability features |
+| opensearch-sql-plugin | SQL query support |
+
+### Snapshot Repository
+
+Plugin snapshots are fetched from the OpenSearch CI repository:
+
+```
+https://ci.opensearch.org/ci/dbc/snapshots/maven/org/opensearch/plugin/{plugin}/{version}/
+```
+
+Version resolution uses maven-metadata.xml to get the latest snapshot build.
+
+### Usage Example
+
+```yaml
+# Example: Fetching latest plugin snapshot
+- name: Get latest snapshot version
+  run: |
+    METADATA_URL="https://ci.opensearch.org/ci/dbc/snapshots/maven/org/opensearch/plugin/opensearch-observability/3.4.0.0-SNAPSHOT/maven-metadata.xml"
+    SNAPSHOT_VERSION=$(curl -s $METADATA_URL | grep '<value>' | head -1 | sed 's/.*<value>\(.*\)<\/value>.*/\1/')
+    echo "version=$SNAPSHOT_VERSION"
+```
+
+## Limitations
+
+- CI workflows are specific to GitHub Actions
+- Integration tests require Java 21 (Corretto distribution)
+- E2E tests have a 1200-second timeout for Dashboards startup
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#2501](https://github.com/opensearch-project/dashboards-observability/pull/2501) | Fix typo in checkout step name |
+| v3.4.0 | [#2526](https://github.com/opensearch-project/dashboards-observability/pull/2526) | Update snapshots and unit tests |
+| v3.4.0 | [#2528](https://github.com/opensearch-project/dashboards-observability/pull/2528) | Update CI workflows for Integ tests |
+
+## References
+
+- [dashboards-observability repository](https://github.com/opensearch-project/dashboards-observability)
+- [OpenSearch CI Snapshots](https://ci.opensearch.org/ci/dbc/snapshots/maven/)
+- [GitHub Actions Documentation](https://docs.github.com/en/actions)
+
+## Change History
+
+- **v3.4.0** (2026-01-11): Migrated to OpenSearch CI snapshot repository, updated to 3.4.0, added dynamic snapshot version resolution, improved error handling

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -456,6 +456,7 @@
 
 ## dashboards-observability
 
+- [CI/Tests](dashboards-observability/ci-tests.md)
 - [Getting Started Workflows](dashboards-observability/getting-started-workflows.md)
 - [Observability Multi-Data Source Support](dashboards-observability/observability-multi-data-source-support.md)
 - [Observability Notebooks](dashboards-observability/observability-notebooks.md)

--- a/docs/releases/v3.4.0/features/dashboards-observability/observability-ci-tests.md
+++ b/docs/releases/v3.4.0/features/dashboards-observability/observability-ci-tests.md
@@ -1,0 +1,100 @@
+# Observability CI/Tests
+
+## Summary
+
+This release includes maintenance updates to the dashboards-observability CI/CD workflows, including a typo fix, updated test snapshots, and modernized integration test configurations. These changes ensure CI pipelines work correctly with OpenSearch 3.4.0 and use the new OpenSearch CI snapshot repository.
+
+## Details
+
+### What's New in v3.4.0
+
+Three maintenance PRs improve the CI/CD infrastructure:
+
+1. **Typo Fix**: Corrected "Functioanl" to "Functional" in workflow step name
+2. **Snapshot Updates**: Updated unit test snapshots to include new `globalSearch` mock methods (`getAllSearchCommands$`, `registerSearchCommand`)
+3. **CI Workflow Modernization**: Updated integration test workflows to use OpenSearch 3.4.0 and the new CI snapshot repository
+
+### Technical Changes
+
+#### CI Workflow Updates
+
+| Workflow File | Change |
+|---------------|--------|
+| `ftr-e2e-dashboards-observability-test.yml` | Version bump to 3.4.0, new snapshot URL pattern |
+| `integration-tests-workflow.yml` | Version bump to 3.4.0, new snapshot URL pattern |
+| `dashboards-observability-test-and-build-workflow.yml` | Plugin version bump to 3.4.0.0 |
+| `verify-binary-install.yml` | OpenSearch version bump to 3.4.0 |
+
+#### Maven Repository Migration
+
+The CI workflows now fetch plugin snapshots from the new OpenSearch CI repository instead of Sonatype:
+
+| Before | After |
+|--------|-------|
+| `aws.oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.opensearch.plugin&a={plugin}&v={version}-SNAPSHOT&p=zip` | `ci.opensearch.org/ci/dbc/snapshots/maven/org/opensearch/plugin/{plugin}/{version}/{plugin}-{snapshot-version}.zip` |
+
+#### Dynamic Snapshot Version Resolution
+
+New workflow steps dynamically resolve the latest snapshot version from maven-metadata.xml:
+
+```yaml
+- name: Get latest Job Scheduler snapshot version
+  id: job-scheduler-snapshot
+  run: |
+    METADATA_URL="https://ci.opensearch.org/ci/dbc/snapshots/maven/org/opensearch/plugin/opensearch-job-scheduler/${{ env.OPENSEARCH_PLUGIN_VERSION }}/maven-metadata.xml"
+    SNAPSHOT_VERSION=$(curl -s $METADATA_URL | grep '<value>' | head -1 | sed 's/.*<value>\(.*\)<\/value>.*/\1/')
+    echo "version=$SNAPSHOT_VERSION" >> $GITHUB_OUTPUT
+```
+
+#### Improved Error Handling
+
+Added debugging output when OpenSearch Dashboards fails to start:
+
+```yaml
+else
+  echo "Timeout of 1200 seconds reached. OpenSearch Dashboards did not start successfully."
+  echo "Last 100 lines of dashboard.log for debugging:"
+  tail -100 dashboard.log
+  exit 1
+fi
+```
+
+#### Test Snapshot Updates
+
+Updated component test snapshots to include new `globalSearch` mock interface methods:
+
+- `getAllSearchCommands$`: Observable for search commands
+- `registerSearchCommand`: Method to register search commands
+
+Affected snapshot files:
+- `log_config.test.tsx.snap`
+- `service_config.test.tsx.snap`
+- `trace_config.test.tsx.snap`
+- `custom_panel_view.test.tsx.snap`
+- `panel_grid.test.tsx.snap`
+- `metrics_grid.test.tsx.snap`
+- `dashboard.test.tsx.snap`
+- `services.test.tsx.snap`
+- `traces.test.tsx.snap`
+
+## Limitations
+
+- These are maintenance changes with no user-facing impact
+- CI workflows are specific to the dashboards-observability repository
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2501](https://github.com/opensearch-project/dashboards-observability/pull/2501) | Fix typo in checkout step name |
+| [#2526](https://github.com/opensearch-project/dashboards-observability/pull/2526) | Update snapshots and unit tests |
+| [#2528](https://github.com/opensearch-project/dashboards-observability/pull/2528) | Update CI workflows for Integ tests |
+
+## References
+
+- [dashboards-observability repository](https://github.com/opensearch-project/dashboards-observability)
+- [OpenSearch CI Snapshots](https://ci.opensearch.org/ci/dbc/snapshots/maven/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-observability/ci-tests.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -81,6 +81,10 @@
 - [Dashboards Console](features/opensearch-dashboards/dashboards-console.md) - Fix for console_polling setting update
 - [Dashboards Navigation](features/opensearch-dashboards/dashboards-navigation.md) - Fix disabled prop propagation for navigation links
 
+### Dashboards Observability
+
+- [Observability CI/Tests](features/dashboards-observability/observability-ci-tests.md) - CI workflow updates for 3.4.0, snapshot repository migration, test snapshot updates
+
 ### User Behavior Insights
 
 - [User Behavior Insights Build](features/user-behavior-insights/user-behavior-insights-build.md) - Migrate Maven snapshot publishing from Sonatype to S3-backed repository


### PR DESCRIPTION
## Summary

Add documentation for Observability CI/Tests bugfix in v3.4.0.

### Changes

This PR documents maintenance updates to the dashboards-observability CI/CD workflows:

1. **Typo Fix** (PR #2501): Corrected "Functioanl" to "Functional" in workflow step name
2. **Snapshot Updates** (PR #2526): Updated unit test snapshots to include new `globalSearch` mock methods
3. **CI Workflow Modernization** (PR #2528): Updated integration test workflows to use OpenSearch 3.4.0 and the new CI snapshot repository

### Files Added/Modified

- `docs/releases/v3.4.0/features/dashboards-observability/observability-ci-tests.md` - Release report
- `docs/features/dashboards-observability/ci-tests.md` - Feature report
- `docs/releases/v3.4.0/index.md` - Updated release index
- `docs/features/index.md` - Updated features index

### Related Issue

Closes #1670