### PR TITLE
docs: add SQL CI/Tests report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -361,6 +361,7 @@
 - [SQL/PPL Bug Fixes](sql/sql-ppl-bug-fixes.md)
 - [SQL/PPL Engine](sql/sql-ppl-engine.md)
 - [SQL/PPL Breaking Changes](sql/sql-ppl-breaking-changes.md)
+- [SQL CI/Tests](sql/sql-ci-tests.md)
 
 ## asynchronous-search
 

--- a/docs/features/sql/sql-ci-tests.md
+++ b/docs/features/sql/sql-ci-tests.md
@@ -1,0 +1,139 @@
+# SQL CI/Tests
+
+## Summary
+
+The SQL plugin CI/CD infrastructure provides automated testing, build validation, and release workflows for the OpenSearch SQL and PPL query engines. It includes unit tests, integration tests, backward compatibility tests, and continuous deployment pipelines that ensure code quality and compatibility across OpenSearch versions.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "CI/CD Pipeline"
+        A[Pull Request] --> B[GitHub Actions]
+        B --> C[Unit Tests]
+        B --> D[Integration Tests]
+        B --> E[BWC Tests]
+        B --> F[Doc Tests]
+    end
+    
+    subgraph "Test Types"
+        C --> G[JUnit Tests]
+        C --> H[yamlRestTest]
+        D --> I[SQL IT]
+        D --> J[PPL IT]
+        E --> K[Rolling Upgrade]
+        E --> L[Full Restart]
+    end
+    
+    subgraph "Build System"
+        M[Gradle] --> N[Build Cache]
+        M --> O[Maven Publishing]
+        M --> P[Plugin Assembly]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Code Change] --> B[PR Created]
+    B --> C{CI Checks}
+    C -->|Pass| D[Review]
+    C -->|Fail| E[Fix Required]
+    D --> F[Merge]
+    F --> G[Snapshot Build]
+    G --> H[Maven Repository]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Unit Tests | Fast tests for individual components |
+| Integration Tests | End-to-end tests with OpenSearch cluster |
+| BWC Rolling Upgrade | Tests upgrade from previous version one node at a time |
+| BWC Full Restart | Tests upgrade with full cluster restart |
+| yamlRestTest | YAML-based REST API tests |
+| Doc Tests | Documentation validation tests |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ppl.query.timeout` | PPL query execution timeout | 300s |
+| Build Cache | Gradle build cache for dependencies | Enabled |
+| JDK Version | Java Development Kit version | 25 |
+| Gradle Version | Build tool version | 9.2.0 |
+
+### GitHub Actions Workflows
+
+| Workflow | Trigger | Purpose |
+|----------|---------|---------|
+| `sql-test-and-build-workflow.yml` | PR, Push | Main CI workflow |
+| `bwc-rolling-upgrade.yml` | PR, Push | Rolling upgrade BWC tests |
+| `bwc-full-restart.yml` | PR, Push | Full restart BWC tests |
+| `publish-snapshot.yml` | Push to main | Publish snapshots to Maven |
+| `delete_backport_branch.yml` | PR merge | Clean up backport branches |
+
+### Usage Example
+
+```yaml
+# Running tests locally
+./gradlew test                    # Unit tests
+./gradlew integTest               # Integration tests
+./gradlew yamlRestTest            # YAML REST tests
+./gradlew bwcTestSuite            # BWC tests
+
+# With specific options
+./gradlew integTest -PignorePrometheus=true
+./gradlew docTest -PignorePrometheus=true
+```
+
+### Build Configuration
+
+```groovy
+// Gradle plugins (v3.4.0)
+plugins {
+    id 'me.champeau.jmh' version '0.7.3'
+    id 'com.diffplug.spotless' version '8.1.0'
+    id 'info.solidsoft.pitest' version '1.19.0-rc.2'
+}
+
+// Google Java Format
+googleJavaFormat {
+    version = '1.32.0'
+}
+```
+
+## Limitations
+
+- BWC tests require significant disk space (~10GB per workflow)
+- Query timeout only applies to Calcite-based queries
+- Some tests may be flaky due to timing dependencies
+- Build cache may need manual clearing for dependency resolution issues
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#4824](https://github.com/opensearch-project/sql/pull/4824) | Bump Gradle to 9.2.0 and JDK to 25 |
+| v3.4.0 | [#4857](https://github.com/opensearch-project/sql/pull/4857) | Support timeouts for Calcite queries |
+| v3.4.0 | [#4838](https://github.com/opensearch-project/sql/pull/4838) | Execute yamlRestTest in integration job |
+| v3.4.0 | [#4716](https://github.com/opensearch-project/sql/pull/4716) | Split BWC tests to prevent disk exhaustion |
+| v3.4.0 | [#4646](https://github.com/opensearch-project/sql/pull/4646) | Add build cache for jitpack dependencies |
+| v3.4.0 | [#4598](https://github.com/opensearch-project/sql/pull/4598) | Onboard async query core to maven snapshots |
+| v3.4.0 | [#4588](https://github.com/opensearch-project/sql/pull/4588) | Onboard maven snapshots publishing to S3 |
+| v3.4.0 | [#4484](https://github.com/opensearch-project/sql/pull/4484) | Publish internal modules for downstream reuse |
+
+## References
+
+- [Issue #4722](https://github.com/opensearch-project/sql/issues/4722): Gradle upgrade tracking
+- [Issue #4842](https://github.com/opensearch-project/sql/issues/4842): Query timeout issue
+- [opensearch-build #5789](https://github.com/opensearch-project/opensearch-build/pull/5789): S3 publishing support
+- [opensearch-build #5360](https://github.com/opensearch-project/opensearch-build/issues/5360): Maven snapshots onboarding
+
+## Change History
+
+- **v3.4.0** (2026-01-11): Major CI/CD improvements including Gradle 9.2.0, JDK 25, BWC test splitting, query timeouts, and maven snapshots publishing

--- a/docs/releases/v3.4.0/features/sql/sql-ci-tests.md
+++ b/docs/releases/v3.4.0/features/sql/sql-ci-tests.md
@@ -1,0 +1,133 @@
+# SQL CI/Tests
+
+## Summary
+
+OpenSearch SQL plugin v3.4.0 includes significant improvements to CI/CD infrastructure, test stability, and build tooling. These changes address flaky tests, disk space issues in backward compatibility tests, and modernize the build system with Gradle 9.2.0 and JDK 25 support.
+
+## Details
+
+### What's New in v3.4.0
+
+This release focuses on CI/CD reliability and developer experience improvements:
+
+- **Build System Modernization**: Upgraded to Gradle 9.2.0 and JDK 25
+- **BWC Test Improvements**: Split backward compatibility tests to prevent disk space exhaustion
+- **Test Stability Fixes**: Addressed multiple flaky integration tests
+- **Maven Snapshots**: Onboarded internal modules for downstream reuse
+- **Query Timeout Support**: Added configurable timeouts for Calcite queries
+
+### Technical Changes
+
+#### CI/CD Infrastructure
+
+```mermaid
+graph TB
+    subgraph "GitHub Actions Workflows"
+        A[PR Trigger] --> B[Unit Tests]
+        A --> C[Integration Tests]
+        A --> D[BWC Rolling Upgrade]
+        A --> E[BWC Full Restart]
+    end
+    
+    subgraph "Build Improvements"
+        F[Gradle 9.2.0] --> G[JDK 25]
+        F --> H[Build Cache]
+        H --> I[Reduced CI Failures]
+    end
+    
+    B --> J[yamlRestTest]
+    C --> K[Integration Job]
+```
+
+#### Key Changes
+
+| Category | Change | PR |
+|----------|--------|-----|
+| Build System | Gradle 9.2.0 + JDK 25 | [#4824](https://github.com/opensearch-project/sql/pull/4824) |
+| BWC Tests | Split into rolling-upgrade and full-restart | [#4716](https://github.com/opensearch-project/sql/pull/4716) |
+| CI Stability | Build cache for jitpack dependencies | [#4646](https://github.com/opensearch-project/sql/pull/4646) |
+| Test Organization | yamlRestTest moved to integration job | [#4838](https://github.com/opensearch-project/sql/pull/4838) |
+| Query Timeouts | Configurable PPL query timeout | [#4857](https://github.com/opensearch-project/sql/pull/4857) |
+| Maven Publishing | Internal modules for downstream reuse | [#4484](https://github.com/opensearch-project/sql/pull/4484) |
+
+#### Gradle Plugin Updates
+
+| Plugin | Old Version | New Version |
+|--------|-------------|-------------|
+| me.champeau.jmh | 0.6.8 | 0.7.3 |
+| com.diffplug.spotless | 7.2.1 | 8.1.0 |
+| googleJavaFormat | 1.17.0 | 1.32.0 |
+| info.solidsoft.pitest | 1.9.0 | 1.19.0-rc.2 |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ppl.query.timeout` | PPL query execution timeout | 300s |
+
+### Usage Example
+
+```yaml
+# Configure PPL query timeout
+PUT _cluster/settings
+{
+  "persistent": {
+    "plugins.ppl.query.timeout": "600s"
+  }
+}
+```
+
+### Migration Notes
+
+- **Gradle Upgrade**: Projects depending on SQL plugin should ensure compatibility with Gradle 9.2.0
+- **JDK 25**: CI now uses JDK 25; local development should use compatible JDK version
+- **BWC Tests**: If running BWC tests locally, note they are now split into separate workflows
+
+## Limitations
+
+- Query timeout only applies to Calcite-based queries
+- Build cache may need manual clearing if dependency issues occur
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4890](https://github.com/opensearch-project/sql/pull/4890) | Add config for CodeRabbit review |
+| [#4857](https://github.com/opensearch-project/sql/pull/4857) | Support timeouts for Calcite queries |
+| [#4846](https://github.com/opensearch-project/sql/pull/4846) | Fix flaky CalcitePPLTcphIT |
+| [#4838](https://github.com/opensearch-project/sql/pull/4838) | Execute yamlRestTest in integration job |
+| [#4824](https://github.com/opensearch-project/sql/pull/4824) | Bump Gradle to 9.2.0 and JDK to 25 |
+| [#4809](https://github.com/opensearch-project/sql/pull/4809) | Fix UT failure and Linkchecker failure |
+| [#4779](https://github.com/opensearch-project/sql/pull/4779) | Update workflows from macos-13 to 14 |
+| [#4773](https://github.com/opensearch-project/sql/pull/4773) | Enforce PR label 'bugFix' instead of 'bug' |
+| [#4748](https://github.com/opensearch-project/sql/pull/4748) | Fix test failures due to version in mapping |
+| [#4731](https://github.com/opensearch-project/sql/pull/4731) | Add allowed_warnings in yaml restful tests |
+| [#4716](https://github.com/opensearch-project/sql/pull/4716) | Split bwc-tests to rolling-upgrade and full-restart |
+| [#4695](https://github.com/opensearch-project/sql/pull/4695) | Adding IT suite for PPL-based dashboards |
+| [#4668](https://github.com/opensearch-project/sql/pull/4668) | Update big5 ppl queries and check plans |
+| [#4646](https://github.com/opensearch-project/sql/pull/4646) | Mitigate CI failure from 500 Internal Server Error |
+| [#4623](https://github.com/opensearch-project/sql/pull/4623) | Refactor JsonExtractAllFunctionIT and MapConcatFunctionIT |
+| [#4598](https://github.com/opensearch-project/sql/pull/4598) | Onboarding async query core to maven snapshots |
+| [#4588](https://github.com/opensearch-project/sql/pull/4588) | Onboarding new maven snapshots publishing to s3 |
+| [#4556](https://github.com/opensearch-project/sql/pull/4556) | Fix JsonExtractAllFunctionIT failure |
+| [#4537](https://github.com/opensearch-project/sql/pull/4537) | Check server status before starting Prometheus |
+| [#4485](https://github.com/opensearch-project/sql/pull/4485) | Update stalled action |
+| [#4484](https://github.com/opensearch-project/sql/pull/4484) | Publish internal modules for downstream reuse |
+| [#4462](https://github.com/opensearch-project/sql/pull/4462) | Switch to Guice#createInjector and add concurrent ITs |
+| [#4452](https://github.com/opensearch-project/sql/pull/4452) | Increment version to 3.4.0-SNAPSHOT |
+| [#4442](https://github.com/opensearch-project/sql/pull/4442) | Add ignorePrometheus flag for integTest and docTest |
+| [#4393](https://github.com/opensearch-project/sql/pull/4393) | Refactor name resolution in Calcite PPL |
+| [#4345](https://github.com/opensearch-project/sql/pull/4345) | Implement one-batch lookahead for index enumerators |
+| [#4301](https://github.com/opensearch-project/sql/pull/4301) | Revert grammar files and developer guide |
+| [#4401](https://github.com/opensearch-project/sql/pull/4401) | Revert partial changes |
+| [#4025](https://github.com/opensearch-project/sql/pull/4025) | Update delete_backport_branch workflow |
+| [#4861](https://github.com/opensearch-project/sql/pull/4861) | Fix clickbench query 43 |
+
+## References
+
+- [Issue #4722](https://github.com/opensearch-project/sql/issues/4722): Gradle upgrade tracking
+- [Issue #4842](https://github.com/opensearch-project/sql/issues/4842): Query timeout issue
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/sql/sql-ci-tests.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -96,6 +96,7 @@
 
 ### SQL
 
+- [SQL CI/Tests](features/sql/sql-ci-tests.md) - CI/CD improvements including Gradle 9.2.0, JDK 25, BWC test splitting, query timeouts, and maven snapshots publishing
 - [SQL Documentation](features/sql/sql-documentation.md) - PPL command documentation standardization, typo fixes, enhanced examples, and function documentation improvements
 
 ### Multi-Repository


### PR DESCRIPTION
## Summary

This PR adds documentation for SQL CI/Tests improvements in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/sql/sql-ci-tests.md`
- Feature report: `docs/features/sql/sql-ci-tests.md`

### Key Changes in v3.4.0
- Build system modernization: Gradle 9.2.0 + JDK 25
- BWC test splitting to prevent disk space exhaustion
- Build cache for jitpack dependencies
- Query timeout support for Calcite queries
- Maven snapshots publishing for internal modules
- Multiple flaky test fixes

### PRs Investigated
30 PRs related to CI/CD, testing, and build infrastructure improvements.

Closes #1664