### PR TITLE
docs: add k-NN build report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -505,6 +505,7 @@
 - [Disk-Based Vector Search](k-nn/disk-based-vector-search.md)
 - [k-NN AVX512 SIMD Support](k-nn/k-nn-avx512-support.md)
 - [k-NN Bug Fixes](k-nn/k-nn-bug-fixes.md)
+- [k-NN Build Infrastructure](k-nn/k-nn-build.md)
 - [k-NN Byte Vector Support](k-nn/k-nn-byte-vector-support.md)
 - [k-NN Engine Enhancements](k-nn/k-nn-engine-enhancements.md)
 - [k-NN Performance & Engine](k-nn/k-nn-performance-engine.md)

--- a/docs/features/k-nn/k-nn-build.md
+++ b/docs/features/k-nn/k-nn-build.md
@@ -1,0 +1,137 @@
+# k-NN Build Infrastructure
+
+## Summary
+
+The k-NN plugin build infrastructure manages the compilation and packaging of native libraries (FAISS, NMSLIB, SIMD) for vector search operations. It includes support for multiple CPU instruction sets (AVX2, AVX512, AVX512_SPR) and integrates with the OpenSearch CI/CD pipeline for snapshot publishing.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Build Process"
+        GR[Gradle Build] --> JNI[JNI Library Build]
+        JNI --> BASE[Base Libraries]
+        JNI --> AVX2[AVX2 Libraries]
+        JNI --> AVX512[AVX512 Libraries]
+        JNI --> SPR[AVX512_SPR Libraries]
+    end
+    
+    subgraph "Native Libraries"
+        BASE --> FAISS_BASE[opensearchknn_faiss]
+        BASE --> SIMD_BASE[opensearchknn_simd]
+        BASE --> NMSLIB[opensearchknn_nmslib]
+        AVX2 --> FAISS_AVX2[opensearchknn_faiss_avx2]
+        AVX2 --> SIMD_AVX2[opensearchknn_simd_avx2]
+        AVX512 --> FAISS_512[opensearchknn_faiss_avx512]
+        AVX512 --> SIMD_512[opensearchknn_simd_avx512]
+        SPR --> FAISS_SPR[opensearchknn_faiss_avx512_spr]
+        SPR --> SIMD_SPR[opensearchknn_simd_avx512_spr]
+    end
+    
+    subgraph "Publishing"
+        GR --> PUB[Maven Publish]
+        PUB --> S3[S3 Snapshots Repository]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `scripts/build.sh` | Main build script for compiling native libraries |
+| `build.gradle` | Gradle configuration for plugin build and publishing |
+| `build-tools/repositories.gradle` | Maven repository configuration |
+| `plugin-security.policy` | Security permissions for native library loading |
+
+### Native Libraries
+
+| Library | Description | AVX Variants |
+|---------|-------------|--------------|
+| `opensearchknn_faiss` | FAISS vector search library | Base, AVX2, AVX512, AVX512_SPR |
+| `opensearchknn_simd` | SIMD-optimized operations | Base, AVX2, AVX512, AVX512_SPR |
+| `opensearchknn_nmslib` | NMSLIB vector search library | Base only |
+| `opensearchknn_common` | Common utilities | Base only |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `knn_libs` | Libraries to build | `opensearchknn_faiss,opensearchknn_simd` |
+| `avx2.enabled` | Enable AVX2 build | `false` |
+| `avx512.enabled` | Enable AVX512 build | `false` |
+| `avx512_spr.enabled` | Enable AVX512 Sapphire Rapids build | `false` |
+| `nproc.count` | Number of parallel build processes | `1` |
+
+### Build Commands
+
+```bash
+# Build base libraries (no AVX optimization)
+./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss,opensearchknn_simd \
+    -Davx512.enabled=false -Davx512_spr.enabled=false -Davx2.enabled=false
+
+# Build with AVX2 optimization
+./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss,opensearchknn_simd \
+    -Davx2.enabled=true -Davx512.enabled=false -Davx512_spr.enabled=false
+
+# Build with AVX512 optimization
+./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss,opensearchknn_simd \
+    -Davx512.enabled=true -Davx512_spr.enabled=false
+
+# Build with AVX512 Sapphire Rapids optimization
+./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss,opensearchknn_simd \
+    -Davx512_spr.enabled=true
+```
+
+### Maven Repository Configuration
+
+The k-NN plugin uses the OpenSearch S3 repository for snapshot publishing:
+
+```groovy
+repositories {
+    mavenLocal()
+    maven { url "https://ci.opensearch.org/ci/dbc/snapshots/maven/" }
+    mavenCentral()
+    maven { url "https://plugins.gradle.org/m2/" }
+}
+```
+
+### Security Permissions
+
+The plugin requires runtime permissions to load native libraries:
+
+```
+permission java.lang.RuntimePermission "loadLibrary.opensearchknn_nmslib";
+permission java.lang.RuntimePermission "loadLibrary.opensearchknn_faiss";
+permission java.lang.RuntimePermission "loadLibrary.opensearchknn_common";
+permission java.lang.RuntimePermission "loadLibrary.opensearchknn_simd";
+permission java.lang.RuntimePermission "loadLibrary.opensearchknn_simd_avx2";
+permission java.lang.RuntimePermission "loadLibrary.opensearchknn_simd_avx512";
+permission java.lang.RuntimePermission "loadLibrary.opensearchknn_simd_avx512_spr";
+permission java.lang.RuntimePermission "loadLibrary.opensearchknn_faiss_avx2";
+permission java.lang.RuntimePermission "loadLibrary.opensearchknn_faiss_avx512";
+permission java.lang.RuntimePermission "loadLibrary.opensearchknn_faiss_avx512_spr";
+```
+
+## Limitations
+
+- SIMD and AVX optimizations are only available on x64 architectures
+- AVX512 Sapphire Rapids requires compatible Intel processors
+- NMSLIB does not have AVX-optimized variants
+- S3 snapshot publishing requires AWS credentials (handled by CI/CD)
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#3025](https://github.com/opensearch-project/k-NN/pull/3025) | Include opensearchknn_simd in build configurations |
+| v3.4.0 | [#2943](https://github.com/opensearch-project/k-NN/pull/2943) | Onboard to S3 snapshots |
+
+## References
+
+- [Issue #5360](https://github.com/opensearch-project/opensearch-build/issues/5360): Migration from Sonatype snapshots repo to ci.opensearch.org snapshots repo
+
+## Change History
+
+- **v3.4.0** (2026-01-11): Added SIMD library to build configurations; migrated to S3 snapshots repository

--- a/docs/releases/v3.4.0/features/k-nn/k-nn-build.md
+++ b/docs/releases/v3.4.0/features/k-nn/k-nn-build.md
@@ -1,0 +1,98 @@
+# k-NN Build
+
+## Summary
+
+This release includes two build infrastructure improvements for the k-NN plugin: adding SIMD library support to build configurations and migrating snapshot publishing from Sonatype to the OpenSearch S3 repository.
+
+## Details
+
+### What's New in v3.4.0
+
+#### SIMD Library Build Support
+
+The `opensearchknn_simd` library is now included in build configurations for all AVX variants. This ensures that SIMD-optimized vector operations are properly built and packaged with the k-NN plugin.
+
+#### S3 Snapshots Migration
+
+The k-NN plugin has migrated from Sonatype snapshot repositories to the OpenSearch CI S3 repository for publishing and consuming Maven snapshots. This change was part of a broader OpenSearch project initiative to consolidate snapshot management.
+
+### Technical Changes
+
+#### Build Script Updates
+
+The build script (`scripts/build.sh`) now includes `opensearchknn_simd` alongside `opensearchknn_faiss` in all build configurations:
+
+```bash
+# Base build (no AVX)
+./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss,opensearchknn_simd -Davx512.enabled=false -Davx512_spr.enabled=false -Davx2.enabled=false
+
+# AVX2 build
+./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss,opensearchknn_simd -Davx2.enabled=true -Davx512.enabled=false -Davx512_spr.enabled=false
+
+# AVX512 build
+./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss,opensearchknn_simd -Davx512.enabled=true -Davx512_spr.enabled=false
+
+# AVX512_SPR build
+./gradlew :buildJniLib -Pknn_libs=opensearchknn_faiss,opensearchknn_simd -Davx512_spr.enabled=true
+```
+
+#### Security Permissions
+
+New security permissions were added to `plugin-security.policy` for loading SIMD libraries:
+
+| Permission | Description |
+|------------|-------------|
+| `loadLibrary.opensearchknn_simd` | Base SIMD library |
+| `loadLibrary.opensearchknn_simd_avx2` | AVX2-optimized SIMD library |
+| `loadLibrary.opensearchknn_simd_avx512` | AVX512-optimized SIMD library |
+| `loadLibrary.opensearchknn_simd_avx512_spr` | AVX512 Sapphire Rapids SIMD library |
+
+#### Repository Configuration Changes
+
+| Setting | Old Value | New Value |
+|---------|-----------|-----------|
+| Snapshot Repository URL | `https://central.sonatype.com/repository/maven-snapshots/` | `https://ci.opensearch.org/ci/dbc/snapshots/maven/` |
+| Authentication | Sonatype username/password | AWS credentials (IAM role) |
+
+The Gradle build configuration now uses AWS credentials for S3 access:
+
+```groovy
+repositories {
+    maven {
+        name = "Snapshots"
+        url = System.getenv("MAVEN_SNAPSHOTS_S3_REPO")
+        credentials(AwsCredentials) {
+            accessKey = System.getenv("AWS_ACCESS_KEY_ID")
+            secretKey = System.getenv("AWS_SECRET_ACCESS_KEY")
+            sessionToken = System.getenv("AWS_SESSION_TOKEN")
+        }
+    }
+}
+```
+
+### Migration Notes
+
+For developers building the k-NN plugin locally:
+
+1. **SIMD Library**: No action required - the SIMD library is now automatically built with the plugin
+2. **Snapshot Dependencies**: Update any local Gradle configurations to use the new S3 repository URL if pulling snapshot dependencies
+
+## Limitations
+
+- The S3 snapshot repository requires AWS credentials for publishing (handled automatically in CI)
+- SIMD optimizations are only available on x64 architectures
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#3025](https://github.com/opensearch-project/k-NN/pull/3025) | Include opensearchknn_simd in build configurations |
+| [#2943](https://github.com/opensearch-project/k-NN/pull/2943) | Onboard to S3 snapshots |
+
+## References
+
+- [Issue #5360](https://github.com/opensearch-project/opensearch-build/issues/5360): Migration from Sonatype snapshots repo to ci.opensearch.org snapshots repo
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/k-nn/k-nn-build.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -99,6 +99,10 @@
 - [SQL CI/Tests](features/sql/sql-ci-tests.md) - CI/CD improvements including Gradle 9.2.0, JDK 25, BWC test splitting, query timeouts, and maven snapshots publishing
 - [SQL Documentation](features/sql/sql-documentation.md) - PPL command documentation standardization, typo fixes, enhanced examples, and function documentation improvements
 
+### k-NN
+
+- [k-NN Build](features/k-nn/k-nn-build.md) - SIMD library build support and S3 snapshots migration
+
 ### Multi-Repository
 
 - [Dependency Updates](features/multi-repo/dependency-updates.md) - 28 dependency updates across 7 repositories addressing CVE-2025-11226, CVE-2025-58457, CVE-2025-41249


### PR DESCRIPTION
## Summary

This PR adds documentation for k-NN build infrastructure improvements in v3.4.0.

### Changes in v3.4.0

1. **SIMD Library Build Support** (PR #3025)
   - Include `opensearchknn_simd` in build configurations for all AVX variants
   - Add security permissions for SIMD library loading

2. **S3 Snapshots Migration** (PR #2943)
   - Migrate from Sonatype snapshot repositories to OpenSearch CI S3 repository
   - Update Gradle configurations for AWS credentials

### Reports Created

- Release report: `docs/releases/v3.4.0/features/k-nn/k-nn-build.md`
- Feature report: `docs/features/k-nn/k-nn-build.md`

### Related Issue

Closes #1663