### PR TITLE
docs: add alerting-build report for v3.4.0

### DIFF
--- a/docs/features/alerting/alerting.md
+++ b/docs/features/alerting/alerting.md
@@ -155,6 +155,7 @@ POST _plugins/_alerting/monitors
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#1608](https://github.com/opensearch-project/alerting/pull/1608) | Fix build script to only publish alerting zip |
 | v3.3.0 | [#1917](https://github.com/opensearch-project/alerting/pull/1917) | Adds support for leveraging user custom attributes in Alerting monitors |
 | v3.2.0 | [#1885](https://github.com/opensearch-project/alerting/pull/1885) | Fix MGet bug, randomize fan out distribution |
 | v3.2.0 | [#1818](https://github.com/opensearch-project/alerting/pull/1818) | Refactored consistent responses and fixed unrelated exceptions |
@@ -213,6 +214,7 @@ POST _plugins/_alerting/monitors
 
 ## Change History
 
+- **v3.4.0** (2025): Build script fix to only publish alerting plugin zip, excluding sample remote monitor plugin from release artifacts
 - **v3.3.0** (2025): User custom attributes support for DLS/FLS parameter substitution - monitors now save and pass user custom attributes during execution, enabling DLS queries with `${attr.internal.*}` substitution to work correctly
 - **v3.2.0** (2025): MGet bug fix with proper finding-to-document mapping, randomized fan-out node distribution for better load balancing, consistent API responses when alerting config index doesn't exist, Maven snapshot publishing migration to Sonatype Central
 - **v3.1.0** (2025): Doc-level monitor timeboxing (3-4 min execution limit), batch findings publishing for improved performance, index pattern validation for doc-level monitors, threat intel monitor check fix, alert insight on dashboard overview page, log pattern extraction error handling

--- a/docs/releases/v3.4.0/features/alerting/alerting-build.md
+++ b/docs/releases/v3.4.0/features/alerting/alerting-build.md
@@ -1,0 +1,72 @@
+# Alerting Build
+
+## Summary
+
+This bugfix addresses an issue in the Alerting plugin's build script that was incorrectly publishing both the alerting plugin zip and the sample remote monitor plugin zip to the artifacts folder. The fix ensures only the alerting plugin zip is published during the build process.
+
+## Details
+
+### What's New in v3.4.0
+
+The build script (`scripts/build.sh`) was modified to explicitly copy only the alerting plugin zip file instead of using a wildcard pattern that matched all zip files in the build distributions directory.
+
+### Technical Changes
+
+#### Build Script Fix
+
+The original build script used `find` to locate all zip files in the build distributions, which inadvertently included the `sample-remote-monitor-plugin` zip file alongside the intended `opensearch-alerting` zip.
+
+**Before (problematic):**
+```bash
+zipPath=$(find . -path \*build/distributions/*.zip)
+distributions="$(dirname "${zipPath}")"
+cp ${distributions}/*.zip ./$OUTPUT/plugins
+```
+
+**After (fixed):**
+```bash
+mkdir -p $OUTPUT/plugins
+cp ./alerting/build/distributions/*.zip $OUTPUT/plugins
+```
+
+#### Root Cause
+
+The Alerting repository contains multiple subprojects:
+- `alerting` - The main alerting plugin
+- `alerting-sample-remote-monitor-plugin` - A sample plugin for testing remote monitors
+
+The wildcard `find` command matched zip files from both subprojects, causing the sample plugin to be incorrectly included in the release artifacts.
+
+### Usage Example
+
+Building the alerting plugin now correctly produces only the alerting zip:
+
+```bash
+./scripts/build.sh -v 2.15.0 -s true
+# Output: artifacts/plugins/opensearch-alerting-2.15.0.0-SNAPSHOT.zip
+```
+
+### Migration Notes
+
+No migration required. This is a build infrastructure fix that does not affect runtime behavior.
+
+## Limitations
+
+None specific to this fix.
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1608](https://github.com/opensearch-project/alerting/pull/1608) | Backport to 2.15: Fixing build script to only publish alerting zip |
+| [#1605](https://github.com/opensearch-project/alerting/pull/1605) | Original fix: Fixing build script to only publish alerting zip |
+| [#1604](https://github.com/opensearch-project/alerting/pull/1604) | Related: Fix pluginzippublish issue |
+
+## References
+
+- [Issue #1599](https://github.com/opensearch-project/alerting/issues/1599): Maven failed publishPluginZipPublicationToZipStagingRepository
+- [Alerting Repository](https://github.com/opensearch-project/alerting): OpenSearch Alerting plugin
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/alerting/alerting.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -60,6 +60,10 @@
 
 ## Bug Fixes
 
+### Alerting
+
+- [Alerting Build](features/alerting/alerting-build.md) - Fix build script to only publish alerting plugin zip, excluding sample remote monitor plugin
+
 ### OpenSearch
 
 - [Java Agent](features/opensearch/java-agent.md) - Fix JRT protocol URL filtering to allow MCP server connections


### PR DESCRIPTION
## Summary

This PR adds documentation for the Alerting Build bugfix in v3.4.0.

### Changes
- Created release report: `docs/releases/v3.4.0/features/alerting/alerting-build.md`
- Updated feature report: `docs/features/alerting/alerting.md` (added v3.4.0 to Change History and Related PRs)
- Updated release index: `docs/releases/v3.4.0/index.md`

### Bug Fix Details
The build script was incorrectly publishing both the alerting plugin zip and the sample remote monitor plugin zip. The fix ensures only the alerting plugin zip is published.

### Related PRs
- [alerting#1608](https://github.com/opensearch-project/alerting/pull/1608): Backport fix
- [alerting#1605](https://github.com/opensearch-project/alerting/pull/1605): Original fix
- [alerting#1599](https://github.com/opensearch-project/alerting/issues/1599): Original issue

Closes #1662