### PR TITLE
docs: add security-integ-test-control report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -324,6 +324,7 @@
 
 - [Search Relevance Workbench](search-relevance/search-relevance-workbench.md)
 - [Search Relevance CI/Tests](search-relevance/ci-tests.md)
+- [Security Integration Test Control](search-relevance/security-integ-test-control.md)
 
 ## dashboards-flow-framework
 

--- a/docs/features/search-relevance/security-integ-test-control.md
+++ b/docs/features/search-relevance/security-integ-test-control.md
@@ -1,0 +1,98 @@
+# Security Integration Test Control
+
+## Summary
+
+The search-relevance plugin provides a configurable system property to control whether integration tests run with the OpenSearch security plugin enabled. This feature allows developers and CI/CD pipelines to selectively enable security plugin integration during testing, providing flexibility in test execution and reducing unnecessary resource downloads when security testing is not required.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Build Process"
+        GP[Gradle Property<br/>-Dsecurity=true/false]
+        BG[build.gradle]
+        GP --> BG
+    end
+    
+    subgraph "Conditional Resources"
+        BG -->|security=true| DR[Download Security Certs]
+        BG -->|security=false| SK[Skip Download]
+        DR --> TR[Test Resources]
+    end
+    
+    subgraph "Test Execution"
+        TR --> IT[Integration Tests]
+        IT -->|https=true| SEC[Security-Enabled Cluster]
+        IT -->|https=false| STD[Standard Cluster]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `build.gradle` | Contains conditional logic for security resource handling |
+| `test_security.yml` | GitHub Actions workflow for security-enabled testing |
+| `integtest.sh` | Shell script for remote integration testing |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `-Dsecurity` | Enable/disable security plugin integration | Not set (disabled) |
+| `-Dhttps` | Enable HTTPS for test cluster | `false` |
+
+### Security Certificates
+
+When security testing is enabled, the following certificates are downloaded from the security repository:
+
+| Certificate | Purpose |
+|-------------|---------|
+| `esnode.pem` | Node certificate |
+| `esnode-key.pem` | Node private key |
+| `kirk.pem` | Admin certificate |
+| `kirk-key.pem` | Admin private key |
+| `root-ca.pem` | Root CA certificate |
+| `sample.pem` | Sample certificate |
+| `test-kirk.jks` | Java keystore for testing |
+
+### Usage Example
+
+```bash
+# CI workflow with security enabled
+./gradlew integTest -Dhttps=true -Dsecurity=true
+
+# Local development without security
+./gradlew integTest
+
+# Remote integration test with security
+./gradlew integTestRemote -Dsecurity=true \
+  -Dopensearch.version=$VERSION \
+  -Dtests.rest.cluster="localhost:9200" \
+  -Dhttps=true \
+  -Duser=admin \
+  -Dpassword=admin
+```
+
+## Limitations
+
+- Security certificates are fetched from the `main` branch of the security repository
+- The `-Dsecurity` property requires exact string value `"true"` to enable
+- Certificate download requires network access to GitHub
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#287](https://github.com/opensearch-project/search-relevance/pull/287) | Initial implementation |
+
+## References
+
+- [PR #287](https://github.com/opensearch-project/search-relevance/pull/287): Use a system property to control run integ test with security plugin
+- [OpenSearch Security Repository](https://github.com/opensearch-project/security): Source of test certificates
+
+## Change History
+
+- **v3.4.0** (2026-01-11): Initial implementation - Added system property to control security plugin integration in tests

--- a/docs/releases/v3.4.0/features/search-relevance/security-integ-test-control.md
+++ b/docs/releases/v3.4.0/features/search-relevance/security-integ-test-control.md
@@ -1,0 +1,63 @@
+# Security Integration Test Control
+
+## Summary
+
+This release item adds a system property to control whether integration tests run with the security plugin enabled in the search-relevance repository. This allows developers to selectively enable or disable security plugin integration during testing, improving CI/CD flexibility and test execution control.
+
+## Details
+
+### What's New in v3.4.0
+
+The search-relevance plugin now supports a `-Dsecurity=true` system property that controls whether integration tests are executed with the OpenSearch security plugin. Previously, security-related test resources were always downloaded and processed; now this behavior is conditional.
+
+### Technical Changes
+
+#### Build Configuration Changes
+
+The `build.gradle` file was modified to conditionally download security certificates and test resources:
+
+| Change | Description |
+|--------|-------------|
+| System property check | Added `runIntegTestWithSecurityPlugin = System.getProperty("security")` |
+| Conditional resource download | Security certificates (esnode.pem, kirk.pem, etc.) only downloaded when `security=true` |
+| Test resource processing | `processTestResources` only includes security files when enabled |
+
+#### CI Workflow Updates
+
+| File | Change |
+|------|--------|
+| `.github/workflows/test_security.yml` | Added `-Dsecurity=true` flag to gradle command |
+| `scripts/integtest.sh` | Added `-Dsecurity=$SECURITY_ENABLED` to integTestRemote command |
+
+### Usage Example
+
+```bash
+# Run integration tests WITH security plugin
+./gradlew integTest -Dhttps=true -Dsecurity=true
+
+# Run integration tests WITHOUT security plugin (default)
+./gradlew integTest -Dhttps=true
+```
+
+### Migration Notes
+
+No migration required. Existing CI workflows that need security testing should add the `-Dsecurity=true` flag to their gradle commands.
+
+## Limitations
+
+- The system property must be explicitly set to `"true"` (string comparison) to enable security testing
+- Security certificates are downloaded from the security repository's main branch at build time
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#287](https://github.com/opensearch-project/search-relevance/pull/287) | Use a system property to control run integ test with security plugin |
+
+## References
+
+- [PR #287](https://github.com/opensearch-project/search-relevance/pull/287): Main implementation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/search-relevance/security-integ-test-control.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -97,6 +97,7 @@
 ### Search Relevance
 
 - [Search Relevance CI/Tests](features/search-relevance/ci-tests.md) - Test dependency fixes, JDWP debugging support, deprecated API removal, and test code cleanups
+- [Security Integration Test Control](features/search-relevance/security-integ-test-control.md) - System property to control security plugin integration in tests
 
 ### SQL
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the security integration test control feature in the search-relevance plugin for OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/search-relevance/security-integ-test-control.md`
- Feature report: `docs/features/search-relevance/security-integ-test-control.md`

### Key Changes in v3.4.0
- Added `-Dsecurity=true` system property to control security plugin integration in tests
- Conditional download of security certificates based on the system property
- Updated CI workflows and integration test scripts

### Resources Used
- PR: [#287](https://github.com/opensearch-project/search-relevance/pull/287)

Closes #1661