### PR TITLE
docs: add JDK 25 & Gradle 9.2 upgrades report for v3.4.0

### DIFF
--- a/docs/features/multi-plugin/build-infrastructure-gradle-jdk.md
+++ b/docs/features/multi-plugin/build-infrastructure-gradle-jdk.md
@@ -48,7 +48,7 @@ graph TB
 
 | Setting | Description | Current Value |
 |---------|-------------|---------------|
-| Gradle Version | Build tool version | 9.1.0 |
+| Gradle Version | Build tool version | 9.2.0 (plugins), 9.1.0 (core) |
 | JDK (Bundled) | Bundled JDK version | 25.0.1+8 |
 | JDK (Runtime) | Minimum runtime JDK | 21 |
 | JDK Vendor | JDK distribution | Adoptium Temurin |
@@ -101,6 +101,14 @@ jobs:
 |---------|-----|------------|-------------|
 | v3.4.0 | [#19575](https://github.com/opensearch-project/OpenSearch/pull/19575) | OpenSearch | Update to Gradle 9.1 |
 | v3.4.0 | [#19698](https://github.com/opensearch-project/OpenSearch/pull/19698) | OpenSearch | Update bundled JDK to JDK-25 |
+| v3.4.0 | [#2984](https://github.com/opensearch-project/k-NN/pull/2984) | k-NN | Gradle 9.2.0 and GitHub Actions JDK 25 Upgrade |
+| v3.4.0 | [#1995](https://github.com/opensearch-project/alerting/pull/1995) | alerting | JDK upgrade to 25 and gradle upgrade to 9.2 |
+| v3.4.0 | [#4465](https://github.com/opensearch-project/ml-commons/pull/4465) | ml-commons | Update JDK to 25 and Gradle to 9.2 |
+| v3.4.0 | [#1667](https://github.com/opensearch-project/neural-search/pull/1667) | neural-search | Update to Gradle 9.2 and run CI checks with JDK 25 |
+| v3.4.0 | [#1618](https://github.com/opensearch-project/security/pull/1618) | security | JDK upgrade to 25 and gradle upgrade to 9.2 |
+| v3.4.0 | [#1534](https://github.com/opensearch-project/index-management/pull/1534) | index-management | Upgrade gradle to 9.2.0 and github actions JDK 25 |
+| v3.4.0 | [#1101](https://github.com/opensearch-project/notifications/pull/1101) | notifications | Upgrade Gradle to 9.2 and github actions to support java 25 |
+| v3.4.0 | [#1623](https://github.com/opensearch-project/anomaly-detection/pull/1623) | anomaly-detection | Update CI to JDK 25 and gradle to 9.2 |
 | v3.2.0 | [#2792](https://github.com/opensearch-project/k-NN/pull/2792) | k-NN | Bump JDK to 24, Gradle to 8.14 |
 | v3.2.0 | [#2828](https://github.com/opensearch-project/k-NN/pull/2828) | k-NN | Bump Gradle to 8.14.3 |
 | v3.2.0 | [#3983](https://github.com/opensearch-project/ml-commons/pull/3983) | ml-commons | Gradle 8.14, JDK 24 |
@@ -112,6 +120,8 @@ jobs:
 ## References
 
 - [Issue #19314](https://github.com/opensearch-project/OpenSearch/issues/19314): Update bundled JDK to JDK25
+- [Issue #2976](https://github.com/opensearch-project/k-NN/issues/2976): k-NN Gradle/JDK upgrade tracking
+- [Issue #4389](https://github.com/opensearch-project/ml-commons/issues/4389): ml-commons Gradle/JDK upgrade tracking
 - [OpenSearch automated build system](https://opensearch.org/blog/public-jenkins/): Public Jenkins infrastructure
 - [Gradle Documentation](https://docs.gradle.org/): Official Gradle documentation
 - [Adoptium](https://adoptium.net/): Eclipse Temurin JDK distribution
@@ -119,5 +129,6 @@ jobs:
 
 ## Change History
 
-- **v3.4.0** (2026-01): Gradle 9.1, bundled JDK 25.0.1+8, forbiddenapis 3.10, Mockito 5.20.0
+- **v3.4.0** (2026-01): Gradle 9.2 and JDK 25 upgrades across 24 plugin repositories (alerting, anomaly-detection, asynchronous-search, common-utils, cross-cluster-replication, custom-codecs, geospatial, index-management, job-scheduler, k-NN, learning-to-rank, ml-commons, neural-search, notifications, observability, performance-analyzer, query-insights, reporting, search-processor, security, skills, system-templates, user-behavior-insights)
+- **v3.4.0** (2026-01): Gradle 9.1, bundled JDK 25.0.1+8, forbiddenapis 3.10, Mockito 5.20.0 (OpenSearch core)
 - **v3.2.0** (2025): Gradle 8.14/8.14.3, JDK 24 CI support, multi-node testing, Codecov integration, Maven endpoint updates

--- a/docs/releases/v3.4.0/features/multi-plugin/jdk-25-gradle-9.2-upgrades.md
+++ b/docs/releases/v3.4.0/features/multi-plugin/jdk-25-gradle-9.2-upgrades.md
@@ -1,0 +1,122 @@
+# JDK 25 & Gradle 9.2 Upgrades
+
+## Summary
+
+OpenSearch v3.4.0 includes coordinated upgrades to Gradle 9.2 and JDK 25 across 24 plugin repositories. This maintenance effort ensures all plugins remain compatible with the latest build tooling and runtime environment used by OpenSearch core.
+
+## Details
+
+### What's New in v3.4.0
+
+Following OpenSearch core's upgrade to Gradle 9.2 and JDK 25, all plugin repositories have been updated to maintain build compatibility:
+
+- **Gradle 9.2.0/9.2.1**: Updated gradle-wrapper.properties and gradlew scripts
+- **JDK 25**: Updated GitHub Actions CI workflows to test with JDK 25
+- **Kotlin 2.2.0**: Some repositories also upgraded Kotlin plugin version
+
+### Technical Changes
+
+#### Files Modified
+
+| File | Change |
+|------|--------|
+| `gradle/wrapper/gradle-wrapper.properties` | Updated distributionUrl to Gradle 9.2.x |
+| `gradlew` / `gradlew.bat` | Updated wrapper scripts for Gradle 9.2 |
+| `.github/workflows/*.yml` | Updated java matrix from `[21, 24]` to `[21, 25]` |
+| `build.gradle` | Updated sourceCompatibility/targetCompatibility syntax |
+
+#### Gradle Wrapper Changes
+
+```properties
+# Before
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-all.zip
+
+# After
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.0-all.zip
+distributionSha256Sum=16f2b95838c1ddcf7242b1c39e7bbbb43c842f1f1a1a0dc4959b6d4d68abcac3
+```
+
+#### CI Workflow Changes
+
+```yaml
+# Before
+strategy:
+  matrix:
+    java: [21, 24]
+
+# After
+strategy:
+  matrix:
+    java: [21, 25]
+```
+
+#### Build.gradle Changes
+
+```groovy
+// Before (deprecated syntax)
+plugins.withId('java') {
+    sourceCompatibility = targetCompatibility = "21"
+}
+
+// After (Gradle 9.2 compatible)
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+```
+
+### Repositories Updated
+
+| Repository | PRs |
+|------------|-----|
+| alerting | [#1993](https://github.com/opensearch-project/alerting/pull/1993), [#1995](https://github.com/opensearch-project/alerting/pull/1995) |
+| anomaly-detection | [#1623](https://github.com/opensearch-project/anomaly-detection/pull/1623) |
+| asynchronous-search | [#792](https://github.com/opensearch-project/asynchronous-search/pull/792) |
+| common-utils | [#892](https://github.com/opensearch-project/common-utils/pull/892) |
+| cross-cluster-replication | [#1605](https://github.com/opensearch-project/cross-cluster-replication/pull/1605) |
+| custom-codecs | [#294](https://github.com/opensearch-project/custom-codecs/pull/294) |
+| geospatial | [#816](https://github.com/opensearch-project/geospatial/pull/816) |
+| index-management | [#1534](https://github.com/opensearch-project/index-management/pull/1534) |
+| job-scheduler | [#864](https://github.com/opensearch-project/job-scheduler/pull/864) |
+| k-NN | [#2984](https://github.com/opensearch-project/k-NN/pull/2984) |
+| learning-to-rank | [#263](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/263) |
+| ml-commons | [#4465](https://github.com/opensearch-project/ml-commons/pull/4465) |
+| neural-search | [#1667](https://github.com/opensearch-project/neural-search/pull/1667) |
+| notifications | [#1101](https://github.com/opensearch-project/notifications/pull/1101) |
+| observability | [#1959](https://github.com/opensearch-project/observability/pull/1959) |
+| performance-analyzer | [#896](https://github.com/opensearch-project/performance-analyzer/pull/896) |
+| query-insights | [#486](https://github.com/opensearch-project/query-insights/pull/486) |
+| reporting | [#1139](https://github.com/opensearch-project/reporting/pull/1139) |
+| search-processor | [#319](https://github.com/opensearch-project/search-processor/pull/319) |
+| security | [#1618](https://github.com/opensearch-project/security/pull/1618), [#5786](https://github.com/opensearch-project/security/pull/5786) |
+| skills | [#675](https://github.com/opensearch-project/skills/pull/675) |
+| system-templates | [#111](https://github.com/opensearch-project/opensearch-system-templates/pull/111) |
+| user-behavior-insights | [#148](https://github.com/opensearch-project/user-behavior-insights/pull/148) |
+
+## Limitations
+
+- JDK 25 is used for CI testing; production deployments may use different JDK versions
+- Some repositories use Gradle 9.2.0, others use 9.2.1 depending on merge timing
+- Kotlin version upgrades were included in some but not all repositories
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#2984](https://github.com/opensearch-project/k-NN/pull/2984) | k-NN | Gradle 9.2.0 and GitHub Actions JDK 25 Upgrade |
+| [#1995](https://github.com/opensearch-project/alerting/pull/1995) | alerting | JDK upgrade to 25 and gradle upgrade to 9.2 |
+| [#4465](https://github.com/opensearch-project/ml-commons/pull/4465) | ml-commons | Update JDK to 25 and Gradle to 9.2 |
+| [#1667](https://github.com/opensearch-project/neural-search/pull/1667) | neural-search | Update to Gradle 9.2 and run CI checks with JDK 25 |
+| [#1618](https://github.com/opensearch-project/security/pull/1618) | security | JDK upgrade to 25 and gradle upgrade to 9.2 |
+
+## References
+
+- [Issue #2976](https://github.com/opensearch-project/k-NN/issues/2976): k-NN Gradle/JDK upgrade tracking
+- [Issue #1977](https://github.com/opensearch-project/alerting/issues/1977): Alerting Gradle/JDK upgrade tracking
+- [Issue #4389](https://github.com/opensearch-project/ml-commons/issues/4389): ml-commons Gradle/JDK upgrade tracking
+- [Gradle 9.2 Release Notes](https://docs.gradle.org/9.2/release-notes.html): Official Gradle 9.2 release notes
+- [JDK 25 Release](https://openjdk.org/projects/jdk/25/): OpenJDK 25 project page
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/multi-plugin/build-infrastructure-gradle-jdk.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -119,4 +119,5 @@
 ### Multi-Repository
 
 - [Dependency Updates](features/multi-repo/dependency-updates.md) - 28 dependency updates across 7 repositories addressing CVE-2025-11226, CVE-2025-58457, CVE-2025-41249
+- [JDK 25 & Gradle 9.2 Upgrades](features/multi-plugin/jdk-25-gradle-9.2-upgrades.md) - Coordinated Gradle 9.2 and JDK 25 upgrades across 24 plugin repositories
 - [Version Increments](features/multi-repo/version-increments.md) - Version bump to 3.4.0 across index-management, notifications, and dashboards-notifications


### PR DESCRIPTION
## Summary

This PR adds documentation for the coordinated JDK 25 & Gradle 9.2 upgrades across 24 OpenSearch plugin repositories in v3.4.0.

## Changes

### Release Report
- Created `docs/releases/v3.4.0/features/multi-plugin/jdk-25-gradle-9.2-upgrades.md`
- Documents the Gradle 9.2 and JDK 25 CI workflow updates across all plugin repositories

### Feature Report Update
- Updated `docs/features/multi-plugin/build-infrastructure-gradle-jdk.md`
- Added v3.4.0 PRs to Related PRs table
- Updated Configuration table with current Gradle version
- Added v3.4.0 entry to Change History

### Release Index Update
- Added link to new report in `docs/releases/v3.4.0/index.md` under Multi-Repository section

## Related Issue
Closes #1658