### PR TITLE
docs: add security-dashboards-bugfixes report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -290,6 +290,7 @@
 
 ## security-dashboards-plugin
 
+- [Security Dashboards Bugfixes](security-dashboards-plugin/security-dashboards-bugfixes.md)
 - [Security Dashboards Role Management](security-dashboards-plugin/security-dashboards-role-management.md)
 
 ## security-analytics-dashboards-plugin

--- a/docs/features/security-dashboards-plugin/security-dashboards-bugfixes.md
+++ b/docs/features/security-dashboards-plugin/security-dashboards-bugfixes.md
@@ -1,0 +1,80 @@
+# Security Dashboards Bugfixes
+
+## Summary
+
+This document tracks bug fixes in the Security Dashboards Plugin, which provides the UI for managing OpenSearch security features including internal users, roles, role mappings, and access control.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Security Dashboards Plugin"
+        UI[Security UI]
+        UserEdit[Internal User Edit Panel]
+        RoleEdit[Role Edit Panel]
+        Validation[Input Validation]
+    end
+    
+    subgraph "Security Plugin Backend"
+        API[Security REST API]
+        UserDB[Internal User Database]
+    end
+    
+    UI --> UserEdit
+    UI --> RoleEdit
+    UserEdit --> Validation
+    RoleEdit --> Validation
+    Validation --> API
+    API --> UserDB
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Internal User Edit | Panel for creating and editing internal users with credentials, backend roles, and attributes |
+| Backend Role Panel | UI component for managing backend roles assigned to users |
+| Input Validation | Client-side validation for user input before API submission |
+
+### Bug Fixes
+
+#### Filter Blank Backend Roles (v3.4.0)
+
+When creating or editing internal users, blank backend role entries are now filtered out before submission. This prevents empty strings from being stored in user configurations.
+
+**Before fix:**
+- Empty backend role fields would be saved as empty strings
+- Could cause unexpected behavior in role-based access control
+
+**After fix:**
+- Backend roles are filtered using `role.trim() !== ''`
+- Only non-empty roles are submitted to the API
+
+```typescript
+const updateObject: InternalUserUpdate = {
+  backend_roles: backendRoles.filter((role) => role.trim() !== ''),
+  attributes: unbuildAttributeState(validAttributes),
+};
+```
+
+## Limitations
+
+- Client-side validation only; server-side validation should also be implemented for complete protection
+- Does not retroactively clean up existing users with blank backend roles
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#2330](https://github.com/opensearch-project/security-dashboards-plugin/pull/2330) | Filter blank backend role before creating internal user |
+
+## References
+
+- [Defining users and roles](https://docs.opensearch.org/3.0/security/access-control/users-roles/): OpenSearch Security documentation
+- [Security Dashboards Plugin](https://github.com/opensearch-project/security-dashboards-plugin): GitHub repository
+
+## Change History
+
+- **v3.4.0** (2026-01): Filter blank backend roles before creating internal user

--- a/docs/releases/v3.4.0/features/security-dashboards-plugin/security-dashboards-bugfixes.md
+++ b/docs/releases/v3.4.0/features/security-dashboards-plugin/security-dashboards-bugfixes.md
@@ -1,0 +1,57 @@
+# Security Dashboards Bugfixes
+
+## Summary
+
+This release fixes a bug in the Security Dashboards Plugin where blank backend roles could be inadvertently saved when creating or editing internal users. The fix filters out empty or whitespace-only backend role entries before submitting the user creation/update request.
+
+## Details
+
+### What's New in v3.4.0
+
+A bug fix that prevents blank backend roles from being saved to internal users in the Security Dashboards Plugin.
+
+### Technical Changes
+
+#### Bug Fix: Filter Blank Backend Roles
+
+When creating or editing an internal user through the Security Dashboards UI, users can add multiple backend roles. Previously, if a user left a backend role field empty or containing only whitespace, this blank value would be saved to the user's configuration.
+
+The fix adds a filter to remove blank backend roles before the user update request is submitted:
+
+```typescript
+const updateObject: InternalUserUpdate = {
+  backend_roles: backendRoles.filter((role) => role.trim() !== ''),
+  attributes: unbuildAttributeState(validAttributes),
+};
+```
+
+#### Changed Files
+
+| File | Change |
+|------|--------|
+| `public/apps/configuration/panels/internal-user-edit/internal-user-edit.tsx` | Filter blank backend roles before creating/updating user |
+
+### Impact
+
+- Prevents invalid empty backend roles from being stored in user configurations
+- Improves data quality for internal user management
+- Consistent with existing validation for user attributes (which already filters empty keys)
+
+## Limitations
+
+- This fix only applies to the Dashboards UI; direct REST API calls to the security plugin can still create users with blank backend roles if not validated server-side
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2330](https://github.com/opensearch-project/security-dashboards-plugin/pull/2330) | Filter blank backend role before creating internal user |
+
+## References
+
+- [PR #2330](https://github.com/opensearch-project/security-dashboards-plugin/pull/2330): Main implementation
+- [Defining users and roles](https://docs.opensearch.org/3.0/security/access-control/users-roles/): OpenSearch Security documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security-dashboards-plugin/security-dashboards-bugfixes.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -45,6 +45,10 @@
 - [Security Features](features/security/security-features.md) - Webhook Basic Auth, REST header propagation, system indices deprecation, static/custom config overlap, search relevance permissions
 - [GitHub Actions Updates](features/security/github-actions-updates.md) - Update GitHub Actions dependencies to support Node.js 24 runtime
 
+### Security Dashboards Plugin
+
+- [Security Dashboards Bugfixes](features/security-dashboards-plugin/security-dashboards-bugfixes.md) - Filter blank backend roles before creating internal user
+
 ### OpenSearch Dashboards
 
 - [Dashboards Dev Tools](features/opensearch-dashboards/dashboards-dev-tools.md) - PATCH method support for Dev Tools console


### PR DESCRIPTION
## Summary

Add documentation for Security Dashboards Bugfixes in v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/security-dashboards-plugin/security-dashboards-bugfixes.md`
- Feature report: `docs/features/security-dashboards-plugin/security-dashboards-bugfixes.md`

### Key Changes in v3.4.0
- Filter blank backend roles before creating internal user (PR #2330)

### Resources Used
- PR: opensearch-project/security-dashboards-plugin#2330
- Docs: https://docs.opensearch.org/3.0/security/access-control/users-roles/

Closes #1654