### PR TITLE
docs: add Security Analytics Bugfixes report for v3.4.0

### DIFF
--- a/docs/features/security-analytics-dashboards-plugin/security-analytics.md
+++ b/docs/features/security-analytics-dashboards-plugin/security-analytics.md
@@ -94,6 +94,7 @@ graph TB
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#1360](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1360) | Correlation table rendering fixed |
 | v3.2.0 | [#1313](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1313) | Remove correlated findings bar chart that uses vega |
 | v3.2.0 | [#1312](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1312) | Update API call to get IOC types |
 
@@ -103,8 +104,10 @@ graph TB
 - [Setting up Security Analytics](https://docs.opensearch.org/3.0/security-analytics/sec-analytics-config/index/)
 - [Threat Intelligence](https://docs.opensearch.org/3.0/security-analytics/threat-intelligence/index/)
 - [Working with the Correlation Graph](https://docs.opensearch.org/3.0/security-analytics/usage/correlation-graph/)
+- [Creating Correlation Rules](https://docs.opensearch.org/3.0/security-analytics/sec-analytics-config/correlation-config/)
 - [Security Analytics Settings](https://docs.opensearch.org/3.0/security-analytics/settings/)
 
 ## Change History
 
+- **v3.4.0** (2026-01): Fixed correlation table rendering bug - table was not being populated due to missing error handling and incorrect filter logic
 - **v3.2.0** (2026-01): Bugfixes for correlations page (removed Vega chart) and IOC types API update

--- a/docs/releases/v3.4.0/features/security-analytics-dashboards-plugin/security-analytics-bugfixes.md
+++ b/docs/releases/v3.4.0/features/security-analytics-dashboards-plugin/security-analytics-bugfixes.md
@@ -1,0 +1,75 @@
+# Security Analytics Bugfixes
+
+## Summary
+
+This release fixes a bug in the Security Analytics Dashboards plugin where the correlation table was not being populated correctly. The fix ensures proper data rendering in the correlations overview page table view.
+
+## Details
+
+### What's New in v3.4.0
+
+This bugfix release addresses an issue where the correlation table in the Security Analytics Dashboards plugin was not displaying data. The table view, which shows correlated findings grouped by correlation rules, was failing to populate due to issues in the data fetching and filtering logic.
+
+### Technical Changes
+
+#### Bug Description
+
+The correlation table on the Correlations overview page was not rendering data. Users could see the table structure but no correlation data was being displayed, making it difficult to analyze security event correlations.
+
+#### Root Cause
+
+Two issues were identified:
+
+1. **Missing error handling**: The correlation data fetching logic lacked proper error handling and null checks, causing silent failures when fetching correlated findings
+2. **Incorrect filter logic**: The log type and severity filters were incorrectly excluding all rows when no filters were selected
+
+#### Fix Implementation
+
+**CorrelationsContainer.tsx changes:**
+- Added try-catch block around correlation data fetching
+- Added null checks for `alertsSeverity` with fallback to empty array
+- Added validation for `correlationRuleObj.queries` and `query.conditions` arrays
+- Added null checks for `condition.name` and `condition.value` before pushing to resources
+
+**CorrelationsTableView.tsx changes:**
+- Fixed filter logic to include all rows when no filters are selected
+- Changed filter behavior: empty filter selection now shows all data instead of hiding all data
+- Added proper handling for rows with empty `logTypes` or `alertSeverity` arrays
+
+### Code Changes
+
+```typescript
+// Before: Filter excluded all when no selection
+const logTypeMatch = row.logTypes?.some((logType) => selectedLogTypes.includes(logType));
+
+// After: Include all when no filters selected
+const logTypeMatch =
+  selectedLogTypes.length === 0 ||
+  !row.logTypes?.length ||
+  row.logTypes.some((logType) => selectedLogTypes.includes(logType));
+```
+
+### Migration Notes
+
+No migration required. The fix is backward compatible and automatically applies when upgrading to v3.4.0.
+
+## Limitations
+
+- The correlation table requires findings data to be present for correlations to be displayed
+- Correlation rules must be properly configured with at least two log sources
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1360](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1360) | Correlation table rendering fixed |
+
+## References
+
+- [Security Analytics Documentation](https://docs.opensearch.org/3.0/security-analytics/)
+- [Creating Correlation Rules](https://docs.opensearch.org/3.0/security-analytics/sec-analytics-config/correlation-config/)
+- [Working with the Correlation Graph](https://docs.opensearch.org/3.0/security-analytics/usage/correlation-graph/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security-analytics-dashboards-plugin/security-analytics.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -49,6 +49,10 @@
 
 - [Security Dashboards Bugfixes](features/security-dashboards-plugin/security-dashboards-bugfixes.md) - Filter blank backend roles before creating internal user
 
+### Security Analytics Dashboards Plugin
+
+- [Security Analytics Bugfixes](features/security-analytics-dashboards-plugin/security-analytics-bugfixes.md) - Fix correlation table rendering bug in correlations overview page
+
 ### OpenSearch Dashboards
 
 - [Dashboards Dev Tools](features/opensearch-dashboards/dashboards-dev-tools.md) - PATCH method support for Dev Tools console


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security Analytics Bugfixes release item in v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/security-analytics-dashboards-plugin/security-analytics-bugfixes.md`
- Feature report updated: `docs/features/security-analytics-dashboards-plugin/security-analytics.md`

### Key Changes in v3.4.0
- Fixed correlation table rendering bug where the table was not being populated
- Added proper error handling for correlation data fetching
- Fixed filter logic to show all data when no filters are selected

### Resources Used
- PR: [#1360](https://github.com/opensearch-project/security-analytics-dashboards-plugin/pull/1360)
- Docs: [Creating Correlation Rules](https://docs.opensearch.org/3.0/security-analytics/sec-analytics-config/correlation-config/)

Related Issue: #1653