### PR TITLE
docs: add hybrid-optimizer-bugfixes report for v3.4.0

### DIFF
--- a/docs/features/search-relevance/search-relevance-workbench.md
+++ b/docs/features/search-relevance/search-relevance-workbench.md
@@ -195,6 +195,8 @@ The plugin includes test data based on Amazon's ESCI (Shopping Queries Dataset):
 | v3.1.0 | [#99](https://github.com/opensearch-project/search-relevance/pull/99) | Change model for Experiment and Evaluation Result entities |
 | v3.1.0 | [#116](https://github.com/opensearch-project/search-relevance/pull/116) | Add text validation and query set file size check |
 | v3.1.0 | [#124](https://github.com/opensearch-project/search-relevance/pull/124) | Fixed missing variants in Hybrid Optimizer |
+| v3.4.0 | [#308](https://github.com/opensearch-project/search-relevance/pull/308) | Fix floating-point precision issues in Hybrid Optimizer weight generation |
+| v3.4.0 | [#292](https://github.com/opensearch-project/search-relevance/pull/292) | Fix hybrid optimizer experiments stuck in PROCESSING after judgment deletion |
 | v3.4.0 | [#260](https://github.com/opensearch-project/search-relevance/pull/260) | Fix query serialization for plugins (e.g., Learning to Rank) that extend OpenSearch's DSL |
 | v3.3.0 | [#230](https://github.com/opensearch-project/search-relevance/pull/230) | Fix ImportJudgmentsProcessor to handle numeric ratings |
 
@@ -218,10 +220,14 @@ The plugin includes test data based on Amazon's ESCI (Shopping Queries Dataset):
 - [Issue #543](https://github.com/opensearch-project/dashboards-search-relevance/issues/543): Backend plugin disabled messaging
 - [Issue #557](https://github.com/opensearch-project/dashboards-search-relevance/issues/557): Pipeline error when no pipelines exist
 - [Issue #584](https://github.com/opensearch-project/dashboards-search-relevance/issues/584): Validation results overflow
+- [Issue #298](https://github.com/opensearch-project/search-relevance/issues/298): Floating-point precision in Hybrid Optimizer weights
+- [Issue #282](https://github.com/opensearch-project/search-relevance/issues/282): Hybrid Optimizer stuck in PROCESSING after judgment deletion
 - [Issue #229](https://github.com/opensearch-project/search-relevance/issues/229): Numeric rating type casting bug
 
 ## Change History
 
+- **v3.4.0** (2026-01-11): Bug fix - Fix floating-point precision issues in Hybrid Optimizer weight generation by switching to step-based iteration and rounding, ensuring clean weight pairs like 0.4/0.6 instead of 0.39999998/0.60000002
+- **v3.4.0** (2026-01-11): Bug fix - Fix hybrid optimizer experiments stuck in PROCESSING after judgment deletion by correcting failure handling to properly transition to ERROR state
 - **v3.4.0** (2026-01-11): Bug fix - Fix query serialization for plugins (e.g., Learning to Rank) that extend OpenSearch's DSL, enabling LTR rescore queries in experiments
 - **v3.3.0** (2026-01-11): Bug fix - ImportJudgmentsProcessor now handles numeric ratings (integers, floats) in addition to strings, and preserves original judgment order
 - **v3.2.0** (2026-01-11): Major enhancements - new default SRW UI, dashboard visualization for experiments, polling mechanism for status updates, date filtering for implicit judgments, task scheduling for experiments

--- a/docs/releases/v3.4.0/features/search-relevance/hybrid-optimizer-bugfixes.md
+++ b/docs/releases/v3.4.0/features/search-relevance/hybrid-optimizer-bugfixes.md
@@ -1,0 +1,89 @@
+# Hybrid Optimizer Bugfixes
+
+## Summary
+
+OpenSearch v3.4.0 includes two bug fixes for the Hybrid Optimizer experiment feature in the Search Relevance Workbench. These fixes address floating-point precision issues in weight generation and improve error handling when experiments reference deleted judgments.
+
+## Details
+
+### What's New in v3.4.0
+
+Two critical bug fixes improve the reliability and accuracy of Hybrid Optimizer experiments:
+
+1. **Floating-point precision fix**: Weight combinations now use clean decimal values (e.g., `0.4/0.6`) instead of imprecise floating-point values (e.g., `0.39999998/0.60000002`)
+2. **Error handling fix**: Experiments now properly transition to ERROR state when referenced judgments are deleted, instead of hanging in PROCESSING state
+
+### Technical Changes
+
+#### Bug Fix 1: Floating-Point Precision in Weight Generation
+
+**Problem**: When generating weight combinations for hybrid search experiments, cumulative floating-point addition caused precision drift. Weights like `0.39999998` or `0.60000002` appeared instead of clean values like `0.4` and `0.6`.
+
+**Solution**: The fix in `ExperimentOptionsForHybridSearch.java` implements:
+- Step-based iteration instead of floating-point accumulation
+- Rounding both weight values to one decimal place
+- Ensuring weight pairs cleanly sum to 1.0
+
+```java
+// Before (caused precision drift)
+queryWeightsForCombination(new float[] { queryWeightForCombination, 1.0f - queryWeightForCombination })
+
+// After (clean decimal values)
+float w1 = Math.round(queryWeightForCombination * 10) / 10.0f;
+float w2 = Math.round((1.0f - w1) * 10) / 10.0f;
+queryWeightsForCombination(new float[] { w1, w2 })
+```
+
+#### Bug Fix 2: Experiment Status Handling for Deleted Judgments
+
+**Problem**: When a judgment was deleted while an experiment was running, the experiment would hang indefinitely in `PROCESSING` state. The internal `hasFailure` flag was toggled prematurely inside the async block, preventing the caller's `handleFailure()` method from triggering.
+
+**Solution**: The fix in `HybridOptimizerExperimentProcessor.java`:
+- Removes the redundant `hasFailure` parameter passed by reference
+- Creates a local `AtomicBoolean hasFailure` within the processor
+- Allows exceptions to propagate correctly to the caller's failure handler
+- Ensures experiments transition to ERROR state when judgment processing fails
+
+```java
+// Before: hasFailure passed by reference caused premature flag toggling
+public void processHybridOptimizerExperiment(..., AtomicBoolean hasFailure, ...) {
+    // Internal check blocked upstream recovery
+}
+
+// After: Local failure tracking with proper exception propagation
+public void processHybridOptimizerExperiment(...) {
+    AtomicBoolean hasFailure = new AtomicBoolean(false);
+    // Exceptions propagate to caller's handleFailure()
+}
+```
+
+### Impact
+
+| Issue | Before Fix | After Fix |
+|-------|------------|-----------|
+| Weight precision | `0.39999998/0.60000002` | `0.4/0.6` |
+| Deleted judgment | Stuck in PROCESSING | Transitions to ERROR |
+| User experience | Confusing weight values | Clean, interpretable results |
+| Error recovery | Manual intervention needed | Automatic error state |
+
+## Limitations
+
+- These fixes are specific to the Hybrid Optimizer experiment type
+- The weight rounding is fixed at one decimal place (0.1 increments)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#308](https://github.com/opensearch-project/search-relevance/pull/308) | Fix floating-point precision issues in hybrid optimizer weight generation |
+| [#292](https://github.com/opensearch-project/search-relevance/pull/292) | Fix hybrid optimizer experiments stuck in PROCESSING after judgment deletion |
+
+## References
+
+- [Issue #298](https://github.com/opensearch-project/search-relevance/issues/298): Query weights not exact multiples of increment step
+- [Issue #282](https://github.com/opensearch-project/search-relevance/issues/282): Hybrid Optimizer Result Stuck in Processing
+- [Optimizing hybrid search in OpenSearch](https://opensearch.org/blog/hybrid-search-optimization/): Blog post on hybrid search optimization
+
+## Related Feature Report
+
+- [Search Relevance Workbench](../../../features/search-relevance/search-relevance-workbench.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -107,6 +107,7 @@
 
 - [Search Relevance CI/Tests](features/search-relevance/ci-tests.md) - Test dependency fixes, JDWP debugging support, deprecated API removal, and test code cleanups
 - [Search Relevance Bugfixes](features/search-relevance/search-relevance-bugfixes.md) - Fix query serialization for plugins (e.g., Learning to Rank) that extend OpenSearch's DSL
+- [Hybrid Optimizer Bugfixes](features/search-relevance/hybrid-optimizer-bugfixes.md) - Fix floating-point precision in weight generation and error handling for deleted judgments
 - [Security Integration Test Control](features/search-relevance/security-integ-test-control.md) - System property to control security plugin integration in tests
 
 ### SQL


### PR DESCRIPTION
## Summary

This PR adds documentation for the Hybrid Optimizer bugfixes in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/search-relevance/hybrid-optimizer-bugfixes.md`
- Feature report: Updated `docs/features/search-relevance/search-relevance-workbench.md`

### Key Changes in v3.4.0
- **PR #308**: Fix floating-point precision issues in Hybrid Optimizer weight generation by switching to step-based iteration and rounding
- **PR #292**: Fix hybrid optimizer experiments stuck in PROCESSING after judgment deletion by correcting failure handling

### Resources Used
- PR: [#308](https://github.com/opensearch-project/search-relevance/pull/308), [#292](https://github.com/opensearch-project/search-relevance/pull/292)
- Issues: [#298](https://github.com/opensearch-project/search-relevance/issues/298), [#282](https://github.com/opensearch-project/search-relevance/issues/282)
- Blog: [Optimizing hybrid search in OpenSearch](https://opensearch.org/blog/hybrid-search-optimization/)