### PR TITLE
docs: add remote-model-bugfixes report for v3.4.0

### DIFF
--- a/docs/features/opensearch-remote-metadata-sdk/remote-metadata-sdk.md
+++ b/docs/features/opensearch-remote-metadata-sdk/remote-metadata-sdk.md
@@ -127,6 +127,7 @@ The following plugins support multi-tenancy with remote metadata storage:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#291](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/291) | Fix error when updating model status |
 | v3.3.0 | [#234](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/234) | Add SeqNo and PrimaryTerm support to Put and Delete requests |
 | v3.3.0 | [#244](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/244) | Add RefreshPolicy and timeout support to Put, Update, Delete, and Bulk requests |
 | v3.3.0 | [#236](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/236) | Throw exception on empty string for put request ID |
@@ -159,6 +160,7 @@ The following plugins support multi-tenancy with remote metadata storage:
 
 ## Change History
 
+- **v3.4.0** (2026-01-14): Fix error when updating global model status in DynamoDB backend - added `isGlobalResource` check to properly handle tenant ID for global resources (PR #291)
 - **v3.3.0** (2025-09-22): Added SeqNo/PrimaryTerm support for Put and Delete requests, RefreshPolicy and timeout configuration for write operations, empty string ID validation fix, and ThreadContextAccess API compatibility fixes (PRs #234, #244, #236, #250, #254)
 - **v3.0.0** (2025-05-06): Bug fixes for version conflict detection, DynamoDB consistency, error handling, response passthrough, URL encoding, and request validation (PRs #114, #121, #128, #130, #141, #156, #157, #158)
 - **v3.0.0** (2025-05-06): Added developer guide with migration instructions (PR #124)

--- a/docs/releases/v3.4.0/features/opensearch-remote-metadata-sdk/remote-model-bugfixes.md
+++ b/docs/releases/v3.4.0/features/opensearch-remote-metadata-sdk/remote-model-bugfixes.md
@@ -1,0 +1,75 @@
+# Remote Model Bugfixes
+
+## Summary
+
+This release fixes a bug in the OpenSearch Remote Metadata SDK that caused errors when updating global model status in DynamoDB-backed deployments. The fix ensures proper tenant ID handling for global resources during update operations.
+
+## Details
+
+### What's New in v3.4.0
+
+This bugfix addresses an error that occurred when deploying global models with DynamoDB as the remote metadata store. While the error did not impact model predictions, it produced misleading error logs during the first model deployment.
+
+### Technical Changes
+
+#### Bug Description
+
+When updating a global model's status in DynamoDB, the SDK failed with a `NullPointerException`:
+
+```
+[ERROR][o.o.m.m.MLModelManager] Failed to update ML model with ID olly2-t2ppl-model-id.
+Details: java.lang.NullPointerException: Cannot invoke
+"software.amazon.awssdk.services.dynamodb.model.AttributeValue.m()"
+because the return value of "java.util.Map.get(Object)" is null
+```
+
+#### Root Cause
+
+The `updateDataObjectAsync` method in `DDBOpenSearchClient` did not check whether the resource being updated was a global resource. For global resources, the tenant ID must be set to the global tenant ID, but the code was using the request's tenant ID directly without this check.
+
+#### Fix Implementation
+
+The fix introduces a new `isGlobalResource` check before performing updates:
+
+```mermaid
+flowchart TB
+    A[Update Request] --> B{Is Global Resource?}
+    B -->|Yes| C[Use Global Tenant ID]
+    B -->|No| D[Use Request Tenant ID or Default]
+    C --> E[Execute Update]
+    D --> E
+    E --> F[Return Response]
+```
+
+| Component | Change |
+|-----------|--------|
+| `DDBOpenSearchClient.updateDataObjectAsync()` | Added `isGlobalResource` check before update |
+| `DDBOpenSearchClient.updateItem()` | New private method extracted for update logic |
+
+### Usage Example
+
+No changes required for users. The fix is transparent and automatically handles global resource updates correctly.
+
+### Migration Notes
+
+No migration required. This is a transparent bug fix.
+
+## Limitations
+
+- The fix requires the cluster manager to ensure `_seq_no` exists in global resources if they may be updated
+- The `_seq_no` value must come from either the update request or the DDB item source
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#291](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/291) | Fix error when updating model status |
+
+## References
+
+- [PR #291](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/291): Fix error when updating model status
+- [opensearch-remote-metadata-sdk Repository](https://github.com/opensearch-project/opensearch-remote-metadata-sdk): Source repository
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-remote-metadata-sdk/remote-metadata-sdk.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -128,6 +128,10 @@
 ### k-NN
 
 - [k-NN Build](features/k-nn/k-nn-build.md) - SIMD library build support and S3 snapshots migration
+
+### OpenSearch Remote Metadata SDK
+
+- [Remote Model Bugfixes](features/opensearch-remote-metadata-sdk/remote-model-bugfixes.md) - Fix error when updating global model status in DynamoDB backend
 - [k-NN Bugfixes](features/k-nn/k-nn-bugfixes.md) - Memory optimized search fixes, race condition in KNNQueryBuilder, Faiss inner product score calculation, and disk-based vector search BWC
 
 ### CI


### PR DESCRIPTION
## Summary

This PR adds documentation for the Remote Model Bugfixes in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch-remote-metadata-sdk/remote-model-bugfixes.md`
- Feature report updated: `docs/features/opensearch-remote-metadata-sdk/remote-metadata-sdk.md`

### Key Changes in v3.4.0
- Fixed error when updating global model status in DynamoDB backend
- Added `isGlobalResource` check to properly handle tenant ID for global resources

### Related PR
- [opensearch-remote-metadata-sdk#291](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/291): Fix error when updating model status

### Related Issue
- Closes #1648