### PR TITLE
docs: add SEISMIC bugfixes report for v3.4.0

### DIFF
--- a/docs/features/neural-search/seismic-sparse-ann.md
+++ b/docs/features/neural-search/seismic-sparse-ann.md
@@ -276,6 +276,9 @@ Response includes:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#1655](https://github.com/opensearch-project/neural-search/pull/1655) | Fix IT failures in multi-node environments |
+| v3.4.0 | [#1674](https://github.com/opensearch-project/neural-search/pull/1674) | Handle non-specified method_parameters in queries |
+| v3.4.0 | [#1683](https://github.com/opensearch-project/neural-search/pull/1683) | Fix disk space recovery on index deletion |
 | v3.3.0 | [#1502](https://github.com/opensearch-project/neural-search/pull/1502) | Add basic classes for SEISMIC algorithm |
 | v3.3.0 | [#1528](https://github.com/opensearch-project/neural-search/pull/1528) | Clustering algorithms & field mapper |
 | v3.3.0 | [#1536](https://github.com/opensearch-project/neural-search/pull/1536) | Circuit breaker and memory stats |
@@ -306,4 +309,5 @@ Response includes:
 
 ## Change History
 
+- **v3.4.0** (2026-01-11): Bug fixes for IT failures in multi-node environments, query handling without method_parameters, and disk space recovery on index deletion
 - **v3.3.0** (2025-10-23): Initial implementation of SEISMIC sparse ANN algorithm with full indexing, query, caching, and memory management support

--- a/docs/releases/v3.4.0/features/neural-search/seismic-bugfixes.md
+++ b/docs/releases/v3.4.0/features/neural-search/seismic-bugfixes.md
@@ -1,0 +1,117 @@
+# SEISMIC Bugfixes
+
+## Summary
+
+OpenSearch v3.4.0 includes several bug fixes for the SEISMIC (Sparse ANN) feature in the neural-search plugin. These fixes address integration test failures in multi-node environments, query handling when method_parameters is not specified, and disk space recovery issues when deleting sparse ANN indices.
+
+## Details
+
+### What's New in v3.4.0
+
+This release focuses on stability and reliability improvements for the SEISMIC sparse ANN feature introduced in v3.3.0.
+
+### Technical Changes
+
+#### Integration Test Fixes for Multi-Node Environments
+
+The `NeuralSparseCacheOperationIT` tests were failing in environments with dedicated master and data nodes. The tests expected memory usage changes on all nodes after calling warmup and clearcache APIs, but master nodes don't run SEISMIC and therefore don't show memory changes.
+
+**Fix**: Modified tests to count only data nodes when verifying memory usage changes:
+- Added `SparseTestCommon.getDataNodeCount()` helper method
+- Changed assertions from per-node checks to data-node-only checks
+
+#### Sparse ANN Query Method Parameters Handling
+
+When `method_parameters` was not specified in a sparse ANN query, an `unsupported_operation_exception` was thrown. The query worked correctly when `method_parameters` was provided as an empty map `{}`.
+
+**Root Cause**: The `NeuralSparseQueryBuilder` did not initialize a default `SparseAnnQueryBuilder` when method_parameters was omitted.
+
+**Fix**: 
+- Initialize `SparseAnnQueryBuilder` with defaults when SEISMIC is supported but method_parameters is not specified
+- Handle stream deserialization to create default builder when none is present
+
+```java
+// Before: Query without method_parameters failed
+GET my-index/_search
+{
+  "query": {
+    "neural_sparse": {
+      "sparse_embedding": {
+        "query_tokens": { "1012": 1 }
+      }
+    }
+  }
+}
+
+// After: Query works with default parameters
+```
+
+#### Disk Space Recovery Fix
+
+Disk space was not being recovered after deleting a sparse ANN index. The root cause was improper resource closing in `SparseIndexEventListener`.
+
+**Root Cause**: 
+- `SegmentInfos` was not properly closed via `GatedCloseable`
+- Closing `MapperService` could negatively impact `indexAnalyzers`
+
+**Fix**: Changed resource management in `beforeIndexRemoved()`:
+- Use `GatedCloseable<SegmentInfos>` for proper segment info cleanup
+- Remove `MapperService` closing to avoid analyzer side effects
+
+```java
+// Before
+try (MapperService mapperService = shard.mapperService()) {
+    SegmentInfos segmentInfos = shard.getSegmentInfosSnapshot().get();
+    // ...
+}
+
+// After
+try (GatedCloseable<SegmentInfos> snapshot = shard.getSegmentInfosSnapshot()) {
+    MapperService mapperService = shard.mapperService();
+    SegmentInfos segmentInfos = snapshot.get();
+    // ...
+}
+```
+
+### Usage Example
+
+Sparse ANN queries now work without explicitly specifying method_parameters:
+
+```json
+GET my-seismic-index/_search
+{
+  "query": {
+    "neural_sparse": {
+      "sparse_embedding": {
+        "query_tokens": {
+          "1000": 0.1,
+          "2000": 0.2
+        }
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- The fixes are specific to SEISMIC sparse ANN indices (requires `index.sparse: true`)
+- Force merge is still recommended for optimal SEISMIC performance
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1655](https://github.com/opensearch-project/neural-search/pull/1655) | Fix IT failures in multi-node environments with dedicated master/data nodes |
+| [#1674](https://github.com/opensearch-project/neural-search/pull/1674) | Handle non-specified method_parameters in sparse ANN queries |
+| [#1683](https://github.com/opensearch-project/neural-search/pull/1683) | Fix disk space recovery when deleting sparse ANN indices |
+
+## References
+
+- [Issue #1653](https://github.com/opensearch-project/neural-search/issues/1653): IT failures with dedicated master/data nodes
+- [Issue #1673](https://github.com/opensearch-project/neural-search/issues/1673): Query error when method_parameters not specified
+- [SEISMIC Blog](https://opensearch.org/blog/scaling-neural-sparse-search-to-billions-of-vectors-with-approximate-search/): Scaling neural sparse search to billions of vectors
+
+## Related Feature Report
+
+- [SEISMIC Sparse ANN](../../../features/neural-search/seismic-sparse-ann.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -129,6 +129,10 @@
 
 - [k-NN Build](features/k-nn/k-nn-build.md) - SIMD library build support and S3 snapshots migration
 
+### Neural Search
+
+- [SEISMIC Bugfixes](features/neural-search/seismic-bugfixes.md) - Fix IT failures in multi-node environments, query handling without method_parameters, and disk space recovery on index deletion
+
 ### Learning to Rank
 
 - [Learning to Rank Bugfixes](features/learning/learning-to-rank-bugfixes.md) - Legacy version ID fix, integration test stability, rescore-only SLTR logging fix


### PR DESCRIPTION
## Summary

This PR adds documentation for SEISMIC (Sparse ANN) bugfixes in OpenSearch v3.4.0.

## Changes

### Release Report
- Created `docs/releases/v3.4.0/features/neural-search/seismic-bugfixes.md`
- Documents 3 bug fixes:
  - IT failures in multi-node environments with dedicated master/data nodes (#1655)
  - Query handling when method_parameters is not specified (#1674)
  - Disk space recovery when deleting sparse ANN indices (#1683)

### Feature Report Update
- Updated `docs/features/neural-search/seismic-sparse-ann.md`
- Added v3.4.0 bugfix PRs to Related PRs table
- Added v3.4.0 entry to Change History

### Release Index Update
- Added Neural Search section to Bug Fixes in `docs/releases/v3.4.0/index.md`

## Related Issue
Closes #1646