### PR TITLE
docs: add ML Commons bugfixes report for v3.4.0

### DIFF
--- a/docs/features/ml-commons/ml-commons-bugfixes.md
+++ b/docs/features/ml-commons/ml-commons-bugfixes.md
@@ -103,6 +103,13 @@ graph TB
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#4341](https://github.com/opensearch-project/ml-commons/pull/4341) | Fix agent type update - make type immutable |
+| v3.4.0 | [#4458](https://github.com/opensearch-project/ml-commons/pull/4458) | Fix model ID parsing for QueryPlanningTool in agentic search |
+| v3.4.0 | [#4479](https://github.com/opensearch-project/ml-commons/pull/4479) | Handle edge case of empty values in tool configs |
+| v3.4.0 | [#4476](https://github.com/opensearch-project/ml-commons/pull/4476) | Fix several bugs on agentic memory (multi-node, context, NPE) |
+| v3.4.0 | [#4410](https://github.com/opensearch-project/ml-commons/pull/4410) | Fix tool error message escaping in MLChatAgentRunner |
+| v3.4.0 | [#4450](https://github.com/opensearch-project/ml-commons/pull/4450) | Remove sensitive error log on request body |
+| v3.4.0 | [#4472](https://github.com/opensearch-project/ml-commons/pull/4472) | Fix OpenAI RAG integration tests |
 | v3.3.0 | [#4138](https://github.com/opensearch-project/ml-commons/pull/4138) | Agent/Tool Parsing Fixes |
 | v3.3.0 | [#4189](https://github.com/opensearch-project/ml-commons/pull/4189) | Fix NPE when execute flow agent with multi tenancy is off |
 | v3.3.0 | [#4263](https://github.com/opensearch-project/ml-commons/pull/4263) | Exception handling for runtime exceptions during async execution |
@@ -152,6 +159,9 @@ graph TB
 
 ## References
 
+- [Issue #4340](https://github.com/opensearch-project/ml-commons/issues/4340): Update agent API silently fails when changing agent type
+- [Issue #4424](https://github.com/opensearch-project/ml-commons/issues/4424): Updating conversational agents causes agentic search to fail
+- [Issue #4477](https://github.com/opensearch-project/ml-commons/issues/4477): Conversational agent execution fails with remote Claude models for certain tool configs
 - [Issue #4135](https://github.com/opensearch-project/ml-commons/issues/4135): Agent parsing issue
 - [Issue #4136](https://github.com/opensearch-project/ml-commons/issues/4136): Empty LLM content issue
 - [Issue #4137](https://github.com/opensearch-project/ml-commons/issues/4137): Steps with commas issue
@@ -169,6 +179,7 @@ graph TB
 
 ## Change History
 
+- **v3.4.0** (2026-01-14): 7 bug fixes including agent type update validation, QueryPlanningTool model ID parsing, tool config empty values handling, agentic memory multi-node fixes, error message escaping, and sensitive log removal
 - **v3.3.0** (2025-10-15): 29 bug fixes including Agent Framework parsing fixes, Agentic Memory validation and security improvements, multi-tenancy NPE fix, RAG response fix for search templates, metrics correlation fix, and various serialization/parsing fixes
 - **v3.1.0** (2025-07-15): Hidden model trusted connector bypass, enhanced deploy/undeploy logging, HTTP client alignment, core EnumSet API integration, SearchIndexTool MCP compatibility, commons-beanutils CVE fix
 - **v2.18.0** (2024-11-05): Multiple bugfixes for RAG pipelines, ML inference processors, connector time fields, model deployment stability, master key race condition, Bedrock BWC, and agent logging

--- a/docs/releases/v3.4.0/features/ml-commons/ml-commons-bugfixes.md
+++ b/docs/releases/v3.4.0/features/ml-commons/ml-commons-bugfixes.md
@@ -1,0 +1,131 @@
+# ML Commons Bugfixes
+
+## Summary
+
+OpenSearch v3.4.0 includes 7 bug fixes for the ML Commons plugin, focusing on agent framework stability, agentic memory improvements, tool configuration handling, and security-related logging fixes. These fixes improve reliability for conversational agents, agentic search, and remote model integrations.
+
+## Details
+
+### What's New in v3.4.0
+
+This release addresses critical bugs in the agent framework and agentic memory features:
+
+1. **Agent Type Update Validation** - Properly reject attempts to change agent type during updates
+2. **QueryPlanningTool Model ID Parsing** - Fix model ID propagation for agentic search
+3. **Tool Config Empty Values** - Handle empty name/description in tool configurations
+4. **Agentic Memory Multi-node Support** - Fix index creation in multi-node clusters
+5. **Memory Search NPE Fix** - Handle null user during memory container search
+6. **Error Message Escaping** - Properly escape special characters in agent error messages
+7. **Sensitive Log Removal** - Remove request body from error logs during connector invocation
+
+### Technical Changes
+
+#### Agent Framework Fixes
+
+| Fix | Description | Impact |
+|-----|-------------|--------|
+| Agent Type Update | Agent type is now immutable; update attempts return 400 error | Prevents silent failures when changing agent type |
+| Model ID Parsing | QueryPlanningTool uses agent's LLM model_id as fallback | Fixes "Model ID can't be null" errors after agent updates |
+| Error Message Escaping | `StringUtils.processTextDoc()` escapes exception messages | Prevents JSON parsing errors from special characters |
+
+#### Agentic Memory Fixes
+
+| Fix | Description | Impact |
+|-----|-------------|--------|
+| Default Index Settings | Added default settings for memory indices | Fixes index creation exceptions in multi-node clusters |
+| Context Stashing | Fixed context stashing for non-system indices | Proper thread context handling |
+| Null User Handling | Skip backend-role filtering when user is null | Prevents NPE during memory search |
+
+#### Tool Configuration Fixes
+
+| Fix | Description | Impact |
+|-----|-------------|--------|
+| Empty Values Handling | Omit empty name/description/parameters from serialization | Fixes Bedrock Claude validation errors |
+
+#### Security Improvements
+
+| Fix | Description | Impact |
+|-----|-------------|--------|
+| Sensitive Log Removal | Remove request body from connector error logs | Prevents credential exposure in logs |
+
+### Usage Example
+
+Agent type is now immutable - attempting to change it returns an error:
+
+```json
+// Create flow agent
+POST /_plugins/_ml/agents/_register
+{
+  "name": "test",
+  "type": "flow"
+}
+
+// Attempt to update to conversational - now returns 400 error
+PUT /_plugins/_ml/agents/<agent-id>
+{
+  "name": "test",
+  "type": "conversational"
+}
+
+// Response
+{
+  "error": {
+    "type": "illegal_argument_exception",
+    "reason": "Agent type cannot be updated"
+  },
+  "status": 400
+}
+```
+
+QueryPlanningTool now automatically uses the agent's LLM model_id:
+
+```json
+// Agent with QueryPlanningTool - no explicit model_id needed
+POST /_plugins/_ml/agents/_register
+{
+  "name": "agentic-search-agent",
+  "type": "conversational",
+  "tools": [
+    {
+      "type": "QueryPlanningTool"
+    }
+  ],
+  "llm": {
+    "model_id": "my-model-id"
+  }
+}
+```
+
+### Migration Notes
+
+- **Agent Type Changes**: If you need to change an agent's type, delete and recreate the agent
+- **Tool Configs**: Empty `description` or `parameters` fields are now automatically omitted from serialization - no action required
+- **Error Handling**: Applications parsing agent error responses should continue to work as JSON structure is preserved
+
+## Limitations
+
+- Agent type remains immutable once created
+- Empty tool config fields are silently omitted rather than validated at registration time
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4341](https://github.com/opensearch-project/ml-commons/pull/4341) | Fix agent type update - make type immutable |
+| [#4458](https://github.com/opensearch-project/ml-commons/pull/4458) | Fix model ID parsing for QueryPlanningTool in agentic search |
+| [#4479](https://github.com/opensearch-project/ml-commons/pull/4479) | Handle edge case of empty values in tool configs |
+| [#4476](https://github.com/opensearch-project/ml-commons/pull/4476) | Fix several bugs on agentic memory (multi-node, context, NPE) |
+| [#4410](https://github.com/opensearch-project/ml-commons/pull/4410) | Fix tool error message escaping in MLChatAgentRunner |
+| [#4450](https://github.com/opensearch-project/ml-commons/pull/4450) | Remove sensitive error log on request body |
+| [#4472](https://github.com/opensearch-project/ml-commons/pull/4472) | Fix OpenAI RAG integration tests (test-only) |
+
+## References
+
+- [Issue #4340](https://github.com/opensearch-project/ml-commons/issues/4340): Update agent API silently fails when changing agent type
+- [Issue #4424](https://github.com/opensearch-project/ml-commons/issues/4424): Updating conversational agents causes agentic search to fail
+- [Issue #4477](https://github.com/opensearch-project/ml-commons/issues/4477): Conversational agent execution fails with remote Claude models for certain tool configs
+- [ML Commons Agents and Tools Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/ml-commons/ml-commons-bugfixes.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -137,6 +137,10 @@
 
 - [Learning to Rank Bugfixes](features/learning/learning-to-rank-bugfixes.md) - Legacy version ID fix, integration test stability, rescore-only SLTR logging fix
 
+### ML Commons
+
+- [ML Commons Bugfixes](features/ml-commons/ml-commons-bugfixes.md) - Agent type update validation, QueryPlanningTool model ID parsing, tool config empty values, agentic memory multi-node fixes
+
 ### OpenSearch Remote Metadata SDK
 
 - [Remote Model Bugfixes](features/opensearch-remote-metadata-sdk/remote-model-bugfixes.md) - Fix error when updating global model status in DynamoDB backend


### PR DESCRIPTION
## Summary

Add release report for ML Commons bugfixes in v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/ml-commons/ml-commons-bugfixes.md`
- Feature report: `docs/features/ml-commons/ml-commons-bugfixes.md` (updated)

### Key Changes in v3.4.0
- Agent type update validation - make type immutable
- QueryPlanningTool model ID parsing fix for agentic search
- Tool config empty values handling for Bedrock Claude
- Agentic memory multi-node support fixes
- Error message escaping in MLChatAgentRunner
- Sensitive log removal from connector error logs

### PRs Investigated
- #4341: Fix agent type update
- #4458: Fix model ID parsing for QueryPlanningTool
- #4479: Handle edge case of empty values in tool configs
- #4476: Fix several bugs on agentic memory
- #4410: Fix tool error message escaping
- #4450: Remove sensitive error log on request body
- #4472: Fix OpenAI RAG integration tests

Closes #1645