### PR TITLE
docs: add Flow Framework bugfixes report for v3.4.0

### DIFF
--- a/docs/features/flow-framework/flow-framework.md
+++ b/docs/features/flow-framework/flow-framework.md
@@ -190,6 +190,7 @@ POST /_plugins/_flow_framework/workflow/<id>/_deprovision
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#1270](https://github.com/opensearch-project/flow-framework/pull/1270) | Fix incorrect field map output dimensions in semantic search with local model template |
 | v3.3.0 | [#1217](https://github.com/opensearch-project/flow-framework/pull/1217) | Pre-create ML Commons indices for Tenant Aware tests |
 | v3.2.0 | [#1185](https://github.com/opensearch-project/flow-framework/pull/1185) | Fix ApiSpecFetcher Memory Issues and Exception Handling |
 | v3.2.0 | [#1190](https://github.com/opensearch-project/flow-framework/pull/1190) | Better handling of Workflow Steps with Bad Request status |
@@ -224,6 +225,8 @@ POST /_plugins/_flow_framework/workflow/<id>/_deprovision
 - [Workflow Template Security](https://docs.opensearch.org/3.0/automating-configurations/workflow-security/)
 - [Register Agent API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/agent-apis/register-agent/)
 - [Flow Agents](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/agents/flow/)
+- [Hugging Face paraphrase-MiniLM-L3-v2](https://huggingface.co/sentence-transformers/paraphrase-MiniLM-L3-v2): Model documentation for semantic search with local model template
+- [Issue #1254](https://github.com/opensearch-project/flow-framework/issues/1254): Incorrect field map output dimensions in semantic search with local model template
 - [Issue #1216](https://github.com/opensearch-project/flow-framework/issues/1216): Tenant Aware Integ Tests failing because indices aren't being created
 - [Issue #1180](https://github.com/opensearch-project/flow-framework/issues/1180): Migrate workflow custom model registration to 3.1
 - [Issue #1189](https://github.com/opensearch-project/flow-framework/issues/1189): Error message for CreateIndexStep when index exists is unhelpful
@@ -239,6 +242,7 @@ POST /_plugins/_flow_framework/workflow/<id>/_deprovision
 
 ## Change History
 
+- **v3.4.0** (2025-11-12): Fixed incorrect output dimension default (768→384) in `semantic-search-with-local-model-defaults.json` template to match the actual output dimension of the `paraphrase-MiniLM-L3-v2` model
 - **v3.3.0** (2025-10-07): Fixed tenant-aware integration test failures by pre-creating ML Commons indices; Added `createMLCommonsIndices()` helper method to test infrastructure
 - **v3.2.0** (2025-08-06): Bug fixes for ApiSpecFetcher memory issues and exception handling; Improved error messages for workflow steps with Bad Request status; Updated RegisterLocalCustomModelStep for OpenSearch 3.1+ API compatibility with model_config nesting and space_type support; Fixed encryption key race condition during concurrent template creation; Fixed connector name substitution in default use case templates
 - **v3.1.0** (2025-07-15): Bug fixes for RegisterAgentStep LLM field processing, exception type in WorkflowState error messages, and LLM spec parameter passing; Conditional DynamoDB client dependency inclusion via environment variable; New data summary with log pattern agent template for query assist

--- a/docs/releases/v3.4.0/features/flow-framework/flow-framework-bugfixes.md
+++ b/docs/releases/v3.4.0/features/flow-framework/flow-framework-bugfixes.md
@@ -1,0 +1,86 @@
+# Flow Framework Bugfixes
+
+## Summary
+
+This release fixes an incorrect default value for the output dimension in the semantic search with local model workflow template. The `paraphrase-MiniLM-L3-v2` model outputs 384-dimensional vectors, but the template incorrectly specified 768 dimensions, causing vector dimension mismatch errors during document ingestion.
+
+## Details
+
+### What's New in v3.4.0
+
+Fixed the `text_embedding.field_map.output.dimension` default value in the `semantic-search-with-local-model-defaults.json` template from 768 to 384 to match the actual output dimension of the `paraphrase-MiniLM-L3-v2` model.
+
+### Technical Changes
+
+#### Bug Description
+
+When using the `semantic_search_with_local_model` workflow template, users encountered the following error when uploading documents to the vector index:
+
+```json
+{
+  "caused_by": {
+    "type": "illegal_argument_exception",
+    "reason": "Vector dimension mismatch. Expected: 768, Given: 384"
+  }
+}
+```
+
+The root cause was that the default configuration file specified an incorrect output dimension (768) that did not match the actual output dimension (384) of the `huggingface/sentence-transformers/paraphrase-MiniLM-L3-v2` model.
+
+#### Configuration Change
+
+| Setting | Before | After |
+|---------|--------|-------|
+| `text_embedding.field_map.output.dimension` | `768` | `384` |
+
+#### Affected File
+
+- `src/main/resources/defaults/semantic-search-with-local-model-defaults.json`
+
+### Usage Example
+
+The semantic search with local model workflow can now be used without overriding the dimension parameter:
+
+```bash
+# Create and provision the workflow (now works correctly)
+POST /_plugins/_flow_framework/workflow?use_case=semantic_search_with_local_model&provision=true
+
+# Ingest documents (no longer causes dimension mismatch error)
+PUT /my-nlp-index/_doc/1
+{
+  "passage_text": "Hello world",
+  "id": "s1"
+}
+```
+
+### Migration Notes
+
+Users who previously worked around this issue by manually overriding the dimension parameter can now remove that override:
+
+```json
+// No longer needed
+{
+  "text_embedding.field_map.output.dimension": "384"
+}
+```
+
+## Limitations
+
+- This fix only affects the `semantic_search_with_local_model` workflow template
+- Existing workflows created with the incorrect dimension will need to be recreated
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1270](https://github.com/opensearch-project/flow-framework/pull/1270) | Fix incorrect field map output dimensions in default values |
+
+## References
+
+- [Issue #1254](https://github.com/opensearch-project/flow-framework/issues/1254): Bug report for incorrect output dimensions
+- [Hugging Face Model](https://huggingface.co/sentence-transformers/paraphrase-MiniLM-L3-v2): Model documentation confirming 384-dimensional output
+- [Workflow Templates Documentation](https://docs.opensearch.org/3.0/automating-configurations/workflow-templates/): Official documentation for workflow templates
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/flow-framework/flow-framework.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -159,3 +159,7 @@
 ### Index Management
 
 - [Index Management Bugfixes](features/index-management/index-management-bugfixes.md) - Fix ISM policy rebinding, SM deletion snapshot pattern parsing, ExplainSMPolicy serialization, rollup test race conditions
+
+### Flow Framework
+
+- [Flow Framework Bugfixes](features/flow-framework/flow-framework-bugfixes.md) - Fix incorrect output dimension default (768→384) in semantic search with local model template


### PR DESCRIPTION
## Summary

This PR adds documentation for the Flow Framework bugfix in v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/flow-framework/flow-framework-bugfixes.md`
- Feature report: `docs/features/flow-framework/flow-framework.md` (updated)

### Key Changes in v3.4.0
- Fixed incorrect output dimension default (768→384) in `semantic-search-with-local-model-defaults.json` template
- The `paraphrase-MiniLM-L3-v2` model outputs 384-dimensional vectors, but the template incorrectly specified 768 dimensions

### Resources Used
- PR: [#1270](https://github.com/opensearch-project/flow-framework/pull/1270)
- Issue: [#1254](https://github.com/opensearch-project/flow-framework/issues/1254)
- Docs: [Workflow Templates](https://docs.opensearch.org/3.0/automating-configurations/workflow-templates/)

Closes #1643