### PR TITLE
docs: add Reporting Bugfixes report for v3.4.0

### DIFF
--- a/docs/features/dashboards-reporting/dashboards-reporting.md
+++ b/docs/features/dashboards-reporting/dashboards-reporting.md
@@ -116,6 +116,8 @@ opensearch-reporting-cli \
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#650](https://github.com/opensearch-project/dashboards-reporting/pull/650) | Bump jspdf to fix CVE-2025-57810 |
+| v3.4.0 | [#649](https://github.com/opensearch-project/dashboards-reporting/pull/649) | Undefined and null check for date time values |
 | v3.0.0 | [#524](https://github.com/opensearch-project/dashboards-reporting/pull/524) | Support for date range in report generation |
 | v3.0.0 | [#554](https://github.com/opensearch-project/dashboards-reporting/pull/554) | Updated optional parameters for timeFrom and timeTo |
 | v3.0.0 | [#570](https://github.com/opensearch-project/dashboards-reporting/pull/570) | Reporting Popover UI fix |
@@ -123,6 +125,7 @@ opensearch-reporting-cli \
 
 ## References
 
+- [Issue #308](https://github.com/opensearch-project/dashboards-reporting/issues/308): Undefined date throws error while creating CSV
 - [Issue #414](https://github.com/opensearch-project/dashboards-reporting/issues/414): Absolute date interval interpreted as relative to "now"
 - [Issue #401](https://github.com/opensearch-project/dashboards-reporting/issues/401): Reporting UI issue
 - [Documentation](https://docs.opensearch.org/3.0/reporting/): Reporting overview
@@ -131,5 +134,6 @@ opensearch-reporting-cli \
 
 ## Change History
 
+- **v3.4.0** (2026-01-14): Security fix for CVE-2025-57810 (jspdf bump), fixed null/undefined datetime handling in CSV reports
 - **v3.0.0** (2025-05-20): Fixed date range handling in report generation, made time parameters optional, fixed popover UI positioning
 - **v2.18.0** (2024-11-12): Fixed missing EUI component imports in report_settings component

--- a/docs/releases/v3.4.0/features/dashboards-reporting/reporting-bugfixes.md
+++ b/docs/releases/v3.4.0/features/dashboards-reporting/reporting-bugfixes.md
@@ -1,0 +1,89 @@
+# Reporting Bugfixes
+
+## Summary
+
+OpenSearch Dashboards Reporting v3.4.0 includes two important bugfixes: a security vulnerability fix for the jspdf library (CVE-2025-57810) and a fix for handling null/undefined datetime values when generating CSV reports from Discover.
+
+## Details
+
+### What's New in v3.4.0
+
+This release addresses two bugs in the dashboards-reporting plugin:
+
+1. **CVE-2025-57810 Security Fix**: Bumped jspdf dependency from v3.0.1 to v3.0.2 to address a security vulnerability
+2. **DateTime Null Check Fix**: Added proper handling for null and undefined datetime field values when generating reports
+
+### Technical Changes
+
+#### Security Dependency Update
+
+The jspdf library was updated to fix CVE-2025-57810:
+
+| Dependency | Previous Version | New Version |
+|------------|------------------|-------------|
+| jspdf | 3.0.1 | 3.0.2 |
+
+The update also brought in new transitive dependencies:
+- `fast-png` ^6.2.0
+- `pako` ^2.1.0
+- `iobuffer` ^5.3.2
+
+#### DateTime Null Check Implementation
+
+The fix modifies `dataReportHelpers.ts` to properly handle cases where datetime fields may be null or undefined:
+
+```typescript
+// Before (would throw error on null/undefined)
+const fieldDateValue = fields[dateField];
+
+// After (safe access with optional chaining)
+const fieldDateValue = fields?.[dateField];
+```
+
+Key changes in the datetime processing logic:
+- Added optional chaining (`?.`) for accessing field values
+- Added null checks before processing date arrays
+- Added conditional checks before string type comparisons
+
+### Usage Example
+
+The fix ensures CSV reports can be generated even when datetime fields contain null values:
+
+```json
+// Document with null datetime field - now handled correctly
+{
+  "_source": {
+    "time": "2025-10-16T09:30:00Z",
+    "attributes": {
+      "time": null,
+      "logtime": "2025-10-16T09:30:00.123Z"
+    },
+    "timefield": null
+  }
+}
+```
+
+### Migration Notes
+
+No migration required. The fixes are backward compatible and automatically applied when upgrading to v3.4.0.
+
+## Limitations
+
+- The datetime null check fix only applies to CSV report generation from Discover
+- PDF report generation uses the updated jspdf library but behavior remains unchanged
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#650](https://github.com/opensearch-project/dashboards-reporting/pull/650) | Bump jspdf to fix CVE-2025-57810 |
+| [#649](https://github.com/opensearch-project/dashboards-reporting/pull/649) | Undefined and null check for date time values |
+
+## References
+
+- [Issue #308](https://github.com/opensearch-project/dashboards-reporting/issues/308): Original bug report for undefined date error
+- [CVE-2025-57810](https://nvd.nist.gov/vuln/detail/CVE-2025-57810): Security vulnerability in jspdf
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-reporting/dashboards-reporting.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -98,6 +98,10 @@
 
 - [Observability CI/Tests](features/dashboards-observability/observability-ci-tests.md) - CI workflow updates for 3.4.0, snapshot repository migration, test snapshot updates
 
+### Dashboards Reporting
+
+- [Reporting Bugfixes](features/dashboards-reporting/reporting-bugfixes.md) - Security fix for CVE-2025-57810 (jspdf bump) and null/undefined datetime handling in CSV reports
+
 ### User Behavior Insights
 
 - [User Behavior Insights Build](features/user-behavior-insights/user-behavior-insights-build.md) - Migrate Maven snapshot publishing from Sonatype to S3-backed repository


### PR DESCRIPTION
## Summary

This PR adds documentation for the Reporting Bugfixes in OpenSearch Dashboards v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/dashboards-reporting/reporting-bugfixes.md`
- Feature report updated: `docs/features/dashboards-reporting/dashboards-reporting.md`

### Key Changes in v3.4.0
- **CVE-2025-57810 Security Fix**: Bumped jspdf dependency from v3.0.1 to v3.0.2
- **DateTime Null Check Fix**: Added proper handling for null/undefined datetime field values when generating CSV reports from Discover

### PRs Investigated
- [#650](https://github.com/opensearch-project/dashboards-reporting/pull/650): Bump jspdf to fix CVE-2025-57810
- [#649](https://github.com/opensearch-project/dashboards-reporting/pull/649): Undefined and null check for date time values

### Related Issue
Closes #1642