### PR TITLE
docs: add cross-cluster-replication-bugfixes report for v3.4.0

### DIFF
--- a/docs/features/cross-cluster-replication/cross-cluster-replication.md
+++ b/docs/features/cross-cluster-replication/cross-cluster-replication.md
@@ -150,6 +150,7 @@ POST _plugins/_replication/follower-index/_stop
 
 | Version | PR | Repository | Description |
 |---------|-----|------------|-------------|
+| v3.4.0 | [#1603](https://github.com/opensearch-project/cross-cluster-replication/pull/1603) | cross-cluster-replication | Fix the requirement of empty request body in pause replication |
 | v3.3.0 | [#1580](https://github.com/opensearch-project/cross-cluster-replication/pull/1580) | cross-cluster-replication | Fix: Replication of large documents breaches the size limit (2GB) of ReleasableBytesStreamOutput |
 | v3.2.0 | [#1564](https://github.com/opensearch-project/cross-cluster-replication/pull/1564) | cross-cluster-replication | Add missing method for RemoteClusterRepository class |
 | v3.0.0 | [#667](https://github.com/opensearch-project/common-utils/pull/667) | common-utils | Adding replication plugin interface |
@@ -161,6 +162,7 @@ POST _plugins/_replication/follower-index/_stop
 ## References
 
 - [Issue #726](https://github.com/opensearch-project/index-management/issues/726): Feature request for managing CCR follower indices
+- [Issue #1468](https://github.com/opensearch-project/cross-cluster-replication/issues/1468): Bug report for required empty request body in pause API
 - [Issue #1557](https://github.com/opensearch-project/cross-cluster-replication/issues/1557): Distribution Build Failed for cross-cluster-replication-3.2.0
 - [Issue #1568](https://github.com/opensearch-project/cross-cluster-replication/issues/1568): Bug report for 2GB limit breach during large document replication
 - [Cross-cluster replication documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/replication-plugin/index/)
@@ -172,6 +174,7 @@ POST _plugins/_replication/follower-index/_stop
 
 ## Change History
 
+- **v3.4.0** (2026-01-14): Made pause replication API request body optional, defaulting to "User initiated" reason
 - **v3.3.0** (2025-11-18): Fixed 2GB limit breach for large document replication with dynamic batch size adjustment and new index-level batch size setting
 - **v3.2.0** (2025-08-06): Build fix - added missing `getLowPriorityRemoteDownloadThrottleTimeInNanos()` method to RemoteClusterRepository
 - **v3.0.0** (2025-05-06): ISM-CCR integration with `stop_replication` action, Gradle 8.10.2 and JDK23 support

--- a/docs/releases/v3.4.0/features/cross-cluster-replication/cross-cluster-replication-bugfixes.md
+++ b/docs/releases/v3.4.0/features/cross-cluster-replication/cross-cluster-replication-bugfixes.md
@@ -1,0 +1,88 @@
+# Cross-Cluster Replication Bugfixes
+
+## Summary
+
+This release fixes a usability issue in the Cross-Cluster Replication (CCR) plugin where the pause replication API required an empty request body `{}` even when no custom pause reason was needed. The fix makes the request body optional, improving API ergonomics.
+
+## Details
+
+### What's New in v3.4.0
+
+The `POST /_plugins/_replication/{index}/_pause` API no longer requires a request body. Previously, calling this endpoint without a body resulted in a `parse_exception` error:
+
+```json
+{
+  "error": {
+    "root_cause": [
+      {
+        "type": "parse_exception",
+        "reason": "request body or source parameter is required"
+      }
+    ],
+    "type": "parse_exception",
+    "reason": "request body or source parameter is required"
+  },
+  "status": 400
+}
+```
+
+### Technical Changes
+
+#### Modified Component
+
+| Component | Description |
+|-----------|-------------|
+| `PauseIndexReplicationHandler` | REST handler for pause replication API |
+
+#### Implementation Details
+
+The `PauseIndexReplicationHandler.prepareRequest()` method was modified to:
+
+1. Check if the request has content (`request.hasContent()`) or a source parameter (`request.hasParam("source")`)
+2. If content/source exists, parse it as before using `contentOrSourceParamParser()`
+3. If no content/source, create a `PauseIndexReplicationRequest` with the default reason: `"User initiated"` (from `ReplicationMetadataManager.CUSTOMER_INITIATED_ACTION`)
+
+### Usage Example
+
+#### Before (v3.3.0 and earlier)
+```bash
+# Required empty body - would fail without it
+POST /_plugins/_replication/follower-index/_pause
+{}
+```
+
+#### After (v3.4.0)
+```bash
+# Body is now optional
+POST /_plugins/_replication/follower-index/_pause
+
+# Custom reason still supported
+POST /_plugins/_replication/follower-index/_pause
+{
+  "reason": "Maintenance window"
+}
+```
+
+### Migration Notes
+
+No migration required. Existing scripts that include an empty body `{}` will continue to work. Scripts can optionally be updated to remove the empty body for cleaner API calls.
+
+## Limitations
+
+- The default pause reason is always `"User initiated"` when no body is provided
+- This change only affects the pause API; other CCR APIs retain their existing body requirements
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1603](https://github.com/opensearch-project/cross-cluster-replication/pull/1603) | Fix the requirement of empty request body in pause replication |
+
+## References
+
+- [Issue #1468](https://github.com/opensearch-project/cross-cluster-replication/issues/1468): Bug report for required empty request body
+- [Cross-cluster replication API documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/replication-plugin/api/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/cross-cluster-replication/cross-cluster-replication.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -176,3 +176,7 @@
 ### Flow Framework
 
 - [Flow Framework Bugfixes](features/flow-framework/flow-framework-bugfixes.md) - Fix incorrect output dimension default (768→384) in semantic search with local model template
+
+### Cross-Cluster Replication
+
+- [Cross-Cluster Replication Bugfixes](features/cross-cluster-replication/cross-cluster-replication-bugfixes.md) - Make pause replication API request body optional


### PR DESCRIPTION
## Summary

This PR adds documentation for the Cross-Cluster Replication bugfix in v3.4.0.

### Changes

**Release Report**: `docs/releases/v3.4.0/features/cross-cluster-replication/cross-cluster-replication-bugfixes.md`
- Documents the fix for pause replication API requiring an empty request body

**Feature Report Update**: `docs/features/cross-cluster-replication/cross-cluster-replication.md`
- Added v3.4.0 PR #1603 to Related PRs table
- Added Issue #1468 to References
- Added v3.4.0 entry to Change History

### Key Changes in v3.4.0

- The `POST /_plugins/_replication/{index}/_pause` API no longer requires a request body
- Default pause reason is "User initiated" when no body is provided
- Existing scripts with empty body `{}` continue to work

### Related

- PR: [opensearch-project/cross-cluster-replication#1603](https://github.com/opensearch-project/cross-cluster-replication/pull/1603)
- Issue: [opensearch-project/cross-cluster-replication#1468](https://github.com/opensearch-project/cross-cluster-replication/issues/1468)

Closes #1640