### PR TITLE
docs: add security bugfixes report for v3.4.0

### DIFF
--- a/docs/features/security/security-bugfixes.md
+++ b/docs/features/security/security-bugfixes.md
@@ -21,6 +21,9 @@ graph TB
         AUDIT[Compliance Audit Log]
         DLSFLS[DLS/FLS Filter Reader]
         AUTH[Basic Authenticator]
+        WCM[WildcardMatcher]
+        PE[PrivilegesEvaluator]
+        MT[Multi-tenancy]
     end
     
     subgraph "Security Dashboards"
@@ -45,6 +48,9 @@ graph TB
     HASH --> |Field Handling| Core
     CACHE --> |Snapshot Restore| Core
     DLSFLS --> |Field Filtering| Core
+    WCM --> |Pattern Matching| Core
+    PE --> |Authorization| Core
+    MT --> |Index Redirection| Core
 ```
 
 ### Components
@@ -61,6 +67,9 @@ graph TB
 | Compliance Audit Log | Logs diffs for security index write operations | security |
 | DLS/FLS Filter Reader | Handles document and field level security filtering | security |
 | Basic Authenticator | Handles HTTP Basic authentication and logging | security |
+| WildcardMatcher | Pattern matching for index and role names | security |
+| PrivilegesEvaluator | Authorization and privilege evaluation | security |
+| Multi-tenancy | Virtual index redirection for Dashboards tenants | security |
 | Password Reset UI | Manages password reset form in dashboards | security-dashboards-plugin |
 | Permissions Dropdown | Static dropdown for cluster/index permissions | security-dashboards-plugin |
 | Guava Dependencies | Runtime dependencies for security analytics | security-analytics |
@@ -107,6 +116,18 @@ GET /my-index/_search
 
 | Version | PR | Repository | Description |
 |---------|-----|------------|-------------|
+| v3.4.0 | [#5694](https://github.com/opensearch-project/security/pull/5694) | security | Create WildcardMatcher.NONE for empty string input |
+| v3.4.0 | [#5714](https://github.com/opensearch-project/security/pull/5714) | security | Improve array validator to check for blank strings |
+| v3.4.0 | [#5710](https://github.com/opensearch-project/security/pull/5710) | security | Use RestRequestFilter.getFilteredRequest for sensitive params |
+| v3.4.0 | [#5723](https://github.com/opensearch-project/security/pull/5723) | security | Fix deprecated SSL transport settings in demo certificates |
+| v3.4.0 | [#5721](https://github.com/opensearch-project/security/pull/5721) | security | Fix DlsFlsValveImpl condition for internal requests |
+| v3.4.0 | [#5778](https://github.com/opensearch-project/security/pull/5778) | security | Fix `.kibana` index update operations in multi-tenancy |
+| v3.4.0 | [#5750](https://github.com/opensearch-project/security/pull/5750) | security | Replace AccessController and remove Extension restriction |
+| v3.4.0 | [#5749](https://github.com/opensearch-project/security/pull/5749) | security | Add security provider earlier in bootstrap process |
+| v3.4.0 | [#5791](https://github.com/opensearch-project/security/pull/5791) | security | Modularized PrivilegesEvaluator |
+| v3.4.0 | [#5804](https://github.com/opensearch-project/security/pull/5804) | security | Cleaned up use of PrivilegesEvaluatorResponse |
+| v3.4.0 | [#5816](https://github.com/opensearch-project/security/pull/5816) | security | Remove reflective call to getInnerChannel |
+| v3.4.0 | [#5736](https://github.com/opensearch-project/security/pull/5736) | security | Fix build failure in SecurityFilterTests |
 | v3.3.0 | [#5579](https://github.com/opensearch-project/security/pull/5579) | security | Allow plugin system requests when system_indices.enabled is false |
 | v3.3.0 | [#5640](https://github.com/opensearch-project/security/pull/5640) | security | Fix JWT log spam with empty roles_key |
 | v3.3.0 | [#5675](https://github.com/opensearch-project/security/pull/5675) | security | Fix incorrect licenses in Security Principal files |
@@ -133,6 +154,11 @@ GET /my-index/_search
 
 ## References
 
+- [Issue #1951](https://github.com/opensearch-project/observability/issues/1951): `.kibana` index update issue in multi-tenancy
+- [Issue #5697](https://github.com/opensearch-project/security/issues/5697): Deprecated SSL transport settings
+- [Issue #3420](https://github.com/opensearch-project/security/issues/3420): BCFKS keystore loading issue
+- [Issue #5399](https://github.com/opensearch-project/security/issues/5399): Pluggable PrivilegesEvaluator
+- [Issue #840](https://github.com/opensearch-project/performance-analyzer/issues/840): getInnerChannel reflection removal
 - [Issue #5634](https://github.com/opensearch-project/security/issues/5634): JWT log spam bug report
 - [Issue #792](https://github.com/opensearch-project/geospatial/issues/792): Geospatial permissions issue since 3.2.0
 - [Issue #1829](https://github.com/opensearch-project/alerting/issues/1829): Alerting DLS user attribute issue
@@ -148,6 +174,7 @@ GET /my-index/_search
 
 ## Change History
 
+- **v3.4.0** (2026-01-11): Multi-tenancy `.kibana` index update fix, WildcardMatcher empty string handling, array validator blank string checks, audit log sensitive parameter filtering, deprecated SSL settings update, BCFIPS provider bootstrap timing, AccessController migration, PrivilegesEvaluator modularization, PrivilegesEvaluatorResponse cleanup, reflective getInnerChannel removal
 - **v3.3.0** (2026-01-11): System index access fix for disabled protection, JWT log spam fix, user attribute format standardization, Job Scheduler lock management delegation, license corrections, js-yaml security upgrade, SQL UDT serialization fix
 - **v3.1.0** (2025-06-10): Security backend bug fixes including stale cache post snapshot restore, compliance audit log diff computation, DLS/FLS filter reader corrections, authentication header logging improvements, password reset UI fixes, forecasting permissions, and guava dependency fixes
 - **v2.18.0** (2024-10-29): Multiple security bug fixes including system index protection, SAML audit logging, demo config detection, SSL dual mode propagation, stored field handling, and closed index mappings

--- a/docs/releases/v3.4.0/features/security/security-bugfixes.md
+++ b/docs/releases/v3.4.0/features/security/security-bugfixes.md
@@ -1,0 +1,133 @@
+# Security Bugfixes
+
+## Summary
+
+OpenSearch Security plugin v3.4.0 includes 16 bug fixes addressing issues in input validation, DLS/FLS handling, multi-tenancy, SSL configuration, audit logging, code modernization, and internal architecture refactoring. Key fixes include resolving `.kibana` index update operations in multi-tenancy mode, improving WildcardMatcher handling of empty strings, and migrating from deprecated `java.security.AccessController`.
+
+## Details
+
+### What's New in v3.4.0
+
+This release focuses on stability improvements and code modernization:
+
+1. **Multi-tenancy Fix**: Update operations on the virtual `.kibana` index now work correctly with DLS/FLS enabled
+2. **Input Validation**: WildcardMatcher and array validators now properly handle empty/blank strings
+3. **Audit Logging**: Enhanced sensitive parameter filtering using `RestRequestFilter.getFilteredRequest`
+4. **SSL Configuration**: Demo certificates updated to use non-deprecated transport SSL settings
+5. **BCFIPS Support**: Security provider loaded earlier in bootstrap for better BCFKS keystore compatibility
+6. **Code Modernization**: Replaced deprecated `java.security.AccessController` with OpenSearch equivalent
+7. **Architecture Refactoring**: Modularized `PrivilegesEvaluator` for future pluggability
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "PrivilegesEvaluator Refactoring"
+        PC[PrivilegesConfiguration]
+        PE[PrivilegesEvaluator Interface]
+        PEI[PrivilegesEvaluatorImpl]
+        PEN[PrivilegesEvaluator.NotInitialized]
+        RM[RoleMapper Interface]
+        CRM[ConfigurableRoleMapper]
+        IRM[InjectedRoleMapper]
+        TCUI[ThreadContextUserInfo]
+        DMTC[DashboardsMultiTenancyConfiguration]
+    end
+    
+    PC --> PE
+    PE --> PEI
+    PE --> PEN
+    PC --> RM
+    RM --> CRM
+    RM --> IRM
+    PC --> TCUI
+    PC --> DMTC
+```
+
+#### Bug Fix Categories
+
+| Category | PRs | Description |
+|----------|-----|-------------|
+| Input Validation | #5694, #5714 | WildcardMatcher and array validator improvements |
+| DLS/FLS | #5721, #5778 | Fix internal request handling and `.kibana` index updates |
+| Audit Logging | #5710 | Use RestRequestFilter for sensitive parameter redaction |
+| SSL/TLS | #5723 | Update deprecated SSL transport settings in demo config |
+| Bootstrap | #5749 | Load BCFIPS provider earlier for BCFKS keystore support |
+| Code Modernization | #5750 | Replace AccessController, remove Extension restriction |
+| Architecture | #5791, #5804 | Modularize PrivilegesEvaluator, clean up response class |
+| Maintenance | #5816 | Remove reflective call to getInnerChannel |
+| CI/Build | #1994, #5736 | Fix CI checks and build failures |
+
+#### Key Fixes
+
+**WildcardMatcher Empty String Handling (#5694)**
+```java
+// Before: Could create invalid matcher from empty string
+WildcardMatcher.from("");  // Unexpected behavior
+
+// After: Returns WildcardMatcher.NONE for empty strings
+WildcardMatcher.from("");  // Returns NONE matcher
+```
+
+**Multi-tenancy `.kibana` Index Fix (#5778)**
+- Update operations on `.kibana` index failed with "Update is not supported when FLS or DLS or Fieldmasking is active"
+- Root cause: OpenSearch 3's "deny-by-default" model for DLS/FLS
+- Fix: Evaluate `DocumentAllowList` in `DlsFlsValve.invoke()` for multi-tenancy redirected indices
+
+**Audit Log Sensitive Parameter Filtering (#5710)**
+- Wired up `RestRequestFilter.getFilteredRequest` extension point from OpenSearch core
+- Allows plugins to declare API parameters as sensitive for audit log redaction
+- Benefits other plugins that need to filter sensitive values from request payloads
+
+### Migration Notes
+
+**SSL Transport Settings**
+If using demo certificates, update deprecated settings:
+```yaml
+# Deprecated
+plugins.security.ssl.transport.enforce_hostname_verification: false
+
+# New setting
+transport.ssl.enforce_hostname_verification: false
+```
+
+## Limitations
+
+- PrivilegesEvaluator refactoring is preparation for pluggable implementations (not yet available)
+- BCFIPS provider timing change may affect custom bootstrap configurations
+- Some fixes are backported to 2.19 and 3.3 branches
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1994](https://github.com/opensearch-project/security/pull/1994) | Fix CI check with security failing due to empty string in password |
+| [#1006](https://github.com/opensearch-project/security/pull/1006) | CVE fix upgrade jackson-core and Security fix related to host |
+| [#5694](https://github.com/opensearch-project/security/pull/5694) | Create WildcardMatcher.NONE for empty string input |
+| [#5714](https://github.com/opensearch-project/security/pull/5714) | Improve array validator to check for blank strings |
+| [#5710](https://github.com/opensearch-project/security/pull/5710) | Use RestRequestFilter.getFilteredRequest for sensitive params |
+| [#5723](https://github.com/opensearch-project/security/pull/5723) | Fix deprecated SSL transport settings in demo certificates |
+| [#5721](https://github.com/opensearch-project/security/pull/5721) | Fix DlsFlsValveImpl condition for internal requests |
+| [#5778](https://github.com/opensearch-project/security/pull/5778) | Fix `.kibana` index update operations in multi-tenancy |
+| [#1342](https://github.com/opensearch-project/security/pull/1342) | Add null checks to prevent undefined property access |
+| [#1361](https://github.com/opensearch-project/security/pull/1361) | Backport 1360 to 3.3 |
+| [#5736](https://github.com/opensearch-project/security/pull/5736) | Fix build failure in SecurityFilterTests |
+| [#5750](https://github.com/opensearch-project/security/pull/5750) | Replace AccessController and remove Extension restriction |
+| [#5749](https://github.com/opensearch-project/security/pull/5749) | Add security provider earlier in bootstrap process |
+| [#5791](https://github.com/opensearch-project/security/pull/5791) | Modularized PrivilegesEvaluator |
+| [#5804](https://github.com/opensearch-project/security/pull/5804) | Cleaned up use of PrivilegesEvaluatorResponse |
+| [#5816](https://github.com/opensearch-project/security/pull/5816) | Remove reflective call to getInnerChannel |
+
+## References
+
+- [Issue #1951](https://github.com/opensearch-project/observability/issues/1951): `.kibana` index update issue
+- [Issue #5697](https://github.com/opensearch-project/security/issues/5697): Deprecated SSL transport settings
+- [Issue #3420](https://github.com/opensearch-project/security/issues/3420): BCFKS keystore loading issue
+- [Issue #5399](https://github.com/opensearch-project/security/issues/5399): Pluggable PrivilegesEvaluator
+- [Issue #840](https://github.com/opensearch-project/performance-analyzer/issues/840): getInnerChannel reflection removal
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/security-bugfixes.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -42,6 +42,7 @@
 ### Security
 
 - [Security AccessController Migration](features/security/security-accesscontroller-migration.md) - Migrate from deprecated java.security.AccessController to org.opensearch.secure_sm.AccessController
+- [Security Bugfixes](features/security/security-bugfixes.md) - Multi-tenancy `.kibana` index fix, WildcardMatcher empty string handling, DLS/FLS internal request fix, PrivilegesEvaluator modularization
 - [Security Features](features/security/security-features.md) - Webhook Basic Auth, REST header propagation, system indices deprecation, static/custom config overlap, search relevance permissions
 - [GitHub Actions Updates](features/security/github-actions-updates.md) - Update GitHub Actions dependencies to support Node.js 24 runtime
 


### PR DESCRIPTION
## Summary

This PR adds documentation for Security plugin bugfixes in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/security/security-bugfixes.md`
- Feature report updated: `docs/features/security/security-bugfixes.md`

### Key Changes in v3.4.0
- Multi-tenancy `.kibana` index update operations fix (DLS/FLS compatibility)
- WildcardMatcher empty string handling improvement
- Array validator blank string checks
- Audit log sensitive parameter filtering via RestRequestFilter
- Deprecated SSL transport settings update in demo certificates
- BCFIPS provider bootstrap timing fix for BCFKS keystore support
- AccessController migration from deprecated java.security.AccessController
- PrivilegesEvaluator modularization for future pluggability
- PrivilegesEvaluatorResponse cleanup (immutable instances)
- Reflective getInnerChannel call removal

### PRs Investigated
16 PRs from opensearch-project/security repository

Closes #1639