### PR TITLE
docs: add PPL Query Optimization report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -351,6 +351,7 @@
 - [PPL Documentation](sql/ppl-documentation.md)
 - [PPL Patterns Command](sql/ppl-patterns-command.md)
 - [PPL Query Enhancements](sql/ppl-query-enhancements.md)
+- [PPL Query Optimization](sql/ppl-query-optimization.md)
 - [PPL Rename Command](sql/ppl-rename-command.md)
 - [PPL Rex and Regex Commands](sql/ppl-rex-and-regex-commands.md)
 - [PPL Spath Command](sql/ppl-spath-command.md)

--- a/docs/features/sql/ppl-query-optimization.md
+++ b/docs/features/sql/ppl-query-optimization.md
@@ -1,0 +1,322 @@
+# PPL Query Optimization
+
+## Summary
+
+PPL Query Optimization is a comprehensive set of performance enhancements for the Piped Processing Language (PPL) in OpenSearch. These optimizations leverage the Apache Calcite query engine to translate PPL operations directly into efficient OpenSearch DSL queries, bypassing expensive coordination-node processing. Key optimizations include aggregation pushdown, sort pushdown, expression standardization, and intelligent query rewriting—delivering up to 100x performance improvements for analytics workloads.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "PPL Query Processing"
+        Q[PPL Query] --> Parser[PPL Parser]
+        Parser --> AST[Abstract Syntax Tree]
+        AST --> Calcite[Calcite Optimizer]
+    end
+    
+    subgraph "Optimization Rules"
+        Calcite --> AggOpt[Aggregation Optimizer]
+        Calcite --> SortOpt[Sort Optimizer]
+        Calcite --> ExprOpt[Expression Optimizer]
+        Calcite --> LimitOpt[Limit Optimizer]
+        
+        AggOpt --> SingleGB[Single Group-By]
+        AggOpt --> RangeAgg[Range Aggregation]
+        AggOpt --> CardAgg[Cardinality Aggregation]
+        AggOpt --> TopHits[Top Hits]
+        
+        SortOpt --> SortPush[Sort Pushdown]
+        SortOpt --> SortAfterLimit[Sort After Limit]
+        SortOpt --> SortMetrics[Sort on Metrics]
+        
+        ExprOpt --> RexStd[RexNode Standardization]
+        ExprOpt --> ScriptOpt[Script Optimization]
+    end
+    
+    subgraph "DSL Generation"
+        SingleGB --> DSL[OpenSearch DSL]
+        RangeAgg --> DSL
+        CardAgg --> DSL
+        TopHits --> DSL
+        SortPush --> DSL
+        SortAfterLimit --> DSL
+        SortMetrics --> DSL
+        RexStd --> DSL
+        ScriptOpt --> DSL
+    end
+    
+    subgraph "Execution"
+        DSL --> ES[OpenSearch Engine]
+        ES --> Results[Query Results]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Without Optimization"
+        Q1[PPL Query] --> F1[Fetch All Documents]
+        F1 --> C1[Coordination Node]
+        C1 --> P1[Process in Memory]
+        P1 --> R1[Results]
+    end
+    
+    subgraph "With Optimization"
+        Q2[PPL Query] --> O2[Calcite Optimizer]
+        O2 --> T2[Translate to DSL]
+        T2 --> E2[Execute on Data Nodes]
+        E2 --> R2[Optimized Results]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SingleGroupByOptimizer` | Converts single group-by to terms aggregation instead of composite |
+| `RangeAggregationBuilder` | Translates CASE expressions to range aggregations |
+| `CardinalityAggregationBuilder` | Pushes distinct count approx to cardinality aggregation |
+| `TopHitsAggregationBuilder` | Builds top_hits for earliest/latest functions |
+| `AutoDateHistogramBuilder` | Builds auto_date_histogram for time-based binning |
+| `SortPushdownRule` | Pushes sort operations to OpenSearch scan |
+| `LimitPushdownRule` | Pushes LIMIT into aggregation bucket sizes |
+| `RexNodeStandardizer` | Standardizes expressions for script pushdown |
+| `ScriptSizeOptimizer` | Minimizes script size with necessary fields only |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.calcite.enabled` | Enable Calcite engine for advanced optimizations | `false` |
+| `plugins.query.buckets` | Composite aggregation bucket size | 10000 |
+| `plugins.ppl.subsearch.maxout` | Maximum rows from subsearch | 10000 |
+| `plugins.ppl.join.subsearch_maxout` | Maximum rows for join subsearch | 50000 |
+| `plugins.ppl.syntax.legacy.preferred` | Use legacy PPL behavior | `true` |
+
+### Optimization Categories
+
+#### 1. Aggregation Pushdown
+
+**Single Group-By Optimization**: Replaces composite aggregations with faster terms aggregations.
+
+```ppl
+source=accounts | stats avg(balance) by state
+```
+
+**Before (Composite):**
+```json
+{
+  "aggregations": {
+    "composite_buckets": {
+      "composite": {
+        "size": 1000,
+        "sources": [{"state": {"terms": {"field": "state"}}}]
+      }
+    }
+  }
+}
+```
+
+**After (Terms):**
+```json
+{
+  "aggregations": {
+    "state": {
+      "terms": {"field": "state", "size": 1000},
+      "aggregations": {"avg(balance)": {"avg": {"field": "balance"}}}
+    }
+  }
+}
+```
+
+#### 2. Case-to-Range Aggregation
+
+Converts CASE expressions in aggregations to efficient range queries.
+
+```ppl
+source=bank | eval age_range = case(age < 30, 'young', age < 50, 'middle' else 'senior') 
+| stats avg(balance) by age_range
+```
+
+Generated DSL:
+```json
+{
+  "aggregations": {
+    "age_range": {
+      "range": {
+        "field": "age",
+        "ranges": [
+          {"key": "young", "to": 30},
+          {"key": "middle", "from": 30, "to": 50},
+          {"key": "senior", "from": 50}
+        ],
+        "keyed": true
+      },
+      "aggregations": {
+        "avg(balance)": {"avg": {"field": "balance"}}
+      }
+    }
+  }
+}
+```
+
+#### 3. Distinct Count Approximation
+
+Pushes `DISTINCT_COUNT_APPROX` to OpenSearch cardinality aggregation using HyperLogLog++.
+
+```ppl
+source=logs | stats distinct_count_approx(user_id) as unique_users
+```
+
+#### 4. Sort Pushdown
+
+**Sort by Complex Expressions:**
+```ppl
+source=accounts | sort abs(balance - 1000) | head 10
+```
+
+**Sort After Limit:**
+```ppl
+source=accounts | head 100 | sort balance
+# Transformed to: sort balance | head 100
+```
+
+**Sort on Aggregation Metrics:**
+```ppl
+source=sales | stats sum(amount) by product | sort -sum(amount) | head 10
+```
+
+Converts composite aggregation to terms/multi-terms with order parameter.
+
+#### 5. Filtered Aggregation
+
+```ppl
+source=logs | stats count(eval(status="200")) as success_count
+```
+
+Generated DSL:
+```json
+{
+  "aggregations": {
+    "success_count": {
+      "filter": {"term": {"status": "200"}},
+      "aggregations": {
+        "success_count": {"value_count": {"field": "_index"}}
+      }
+    }
+  }
+}
+```
+
+#### 6. Auto Date Histogram
+
+```ppl
+source=logs | stats count() by bins(@timestamp, 20)
+```
+
+Generated DSL:
+```json
+{
+  "aggregations": {
+    "date": {
+      "auto_date_histogram": {
+        "field": "@timestamp",
+        "buckets": 20
+      }
+    }
+  }
+}
+```
+
+### Internal Functions
+
+| Function | Description | Version |
+|----------|-------------|---------|
+| `MAP_REMOVE(map, key)` | Remove key from map | v3.4.0 |
+| `MAP_APPEND(map, key, value)` | Append value to map | v3.4.0 |
+| `MAP_CONCAT(map1, map2)` | Concatenate maps | v3.4.0 |
+| `JSON_EXTRACT_ALL(json)` | Extract all values from JSON | v3.4.0 |
+
+### Command Enhancements
+
+#### fillnull Command (v3.4.0)
+
+New option-style syntax alongside existing `with/using` syntax:
+
+```ppl
+# New syntax
+source=accounts | fillnull value=0 balance age
+source=accounts | fillnull value='N/A' name
+
+# Existing syntax (still supported)
+source=accounts | fillnull with 0 in balance, age
+source=accounts | fillnull using balance=0, age=0
+```
+
+#### Explain API YAML Format (v3.4.0)
+
+```ppl
+explain format=yaml source=accounts | where age > 30
+```
+
+Output:
+```yaml
+calcite:
+  logical: |
+    LogicalSystemLimit(fetch=[10000], type=[QUERY_SIZE_LIMIT])
+      LogicalFilter(condition=[>($5, 30)])
+        CalciteLogicalIndexScan(table=[[OpenSearch, accounts]])
+  physical: |
+    CalciteEnumerableIndexScan(table=[[OpenSearch, accounts]], 
+      PushDownContext=[[FILTER->>($5, 30), LIMIT->10000]])
+```
+
+## Limitations
+
+- Requires `plugins.calcite.enabled=true` for advanced optimizations
+- Case-to-range pushdown only works with:
+  - String literal results
+  - Numeric fields
+  - Closed-open intervals [a, b)
+- Range aggregations ignore null values (differs from CASE function)
+- Single group-by optimization only applies with exactly one group-by expression
+- Sort pushdown for complex expressions requires Calcite engine
+- Some functions are not pushdown-compatible and execute post-aggregation
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#4750](https://github.com/opensearch-project/sql/pull/4750) | Pushdown sort by complex expressions |
+| v3.4.0 | [#4657](https://github.com/opensearch-project/sql/pull/4657) | Support push down sort after limit |
+| v3.4.0 | [#4603](https://github.com/opensearch-project/sql/pull/4603) | Pushdown sort aggregate metrics |
+| v3.4.0 | [#4614](https://github.com/opensearch-project/sql/pull/4614) | Pushdown distinct count approx |
+| v3.4.0 | [#4400](https://github.com/opensearch-project/sql/pull/4400) | Pushdown case function as range queries |
+| v3.4.0 | [#4421](https://github.com/opensearch-project/sql/pull/4421) | PPL fillnull command enhancement |
+| v3.4.0 | [#4446](https://github.com/opensearch-project/sql/pull/4446) | Support format=yaml in Explain API |
+| v3.4.0 | [#4501](https://github.com/opensearch-project/sql/pull/4501) | Configurable subsearch/join limits |
+| v3.4.0 | [#4544](https://github.com/opensearch-project/sql/pull/4544) | Make composite bucket size configurable |
+| v3.3.0 | [#3550](https://github.com/opensearch-project/sql/pull/3550) | Single group-by optimization |
+| v3.3.0 | [#4166](https://github.com/opensearch-project/sql/pull/4166) | Pushdown earliest/latest functions |
+| v3.3.0 | [#4213](https://github.com/opensearch-project/sql/pull/4213) | Filtered aggregation pushdown |
+| v3.3.0 | [#4228](https://github.com/opensearch-project/sql/pull/4228) | Limit pushdown into bucket size |
+| v3.3.0 | [#4329](https://github.com/opensearch-project/sql/pull/4329) | Auto date histogram pushdown |
+
+## References
+
+- [Issue #4201](https://github.com/opensearch-project/sql/issues/4201): Pushdown case function in aggregations
+- [Issue #4282](https://github.com/opensearch-project/sql/issues/4282): Pushdown sort aggregate metrics
+- [Issue #3912](https://github.com/opensearch-project/sql/issues/3912): Pushdown sort by complex expressions
+- [Issue #3528](https://github.com/opensearch-project/sql/issues/3528): Span query slower than date histogram
+- [PPL Commands Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/ppl/functions/)
+- [OpenSearch Aggregations](https://docs.opensearch.org/3.0/aggregations/)
+- [SQL and PPL API](https://docs.opensearch.org/3.0/search-plugins/sql/sql-ppl-api/)
+- [OpenSearch PPL Blog: Lookup, Join, and Subsearch](https://opensearch.org/blog/enhanced-log-analysis-with-opensearch-ppl-introducing-lookup-join-and-subsearch/)
+
+## Change History
+
+- **v3.4.0** (2026-01-11): Added sort pushdown for complex expressions, sort after limit, sort on aggregation metrics, distinct count approx pushdown, case-to-range aggregation, fillnull command enhancement, YAML explain format, configurable subsearch/join limits, composite bucket size configuration, and internal map/JSON functions
+- **v3.3.0** (2025-10-01): Added single group-by optimization, filtered aggregation pushdown, limit pushdown, SUM literal optimization, earliest/latest pushdown, and auto_date_histogram support

--- a/docs/releases/v3.4.0/features/sql/ppl-query-optimization.md
+++ b/docs/releases/v3.4.0/features/sql/ppl-query-optimization.md
@@ -1,0 +1,192 @@
+# PPL Query Optimization
+
+## Summary
+
+OpenSearch v3.4.0 delivers 33 enhancements to PPL (Piped Processing Language) query optimization, focusing on aggregation pushdown, sort optimization, and new internal functions. These improvements leverage the Apache Calcite query engine to translate PPL operations into efficient OpenSearch DSL queries, significantly improving query performance for analytics workloads.
+
+## Details
+
+### What's New in v3.4.0
+
+#### Sort Pushdown Enhancements
+
+Multiple PRs improve sort operation pushdown to OpenSearch:
+
+- **Sort by complex expressions** (#4750): Pushes sort operations with complex expressions directly to scan operations
+- **Sort after limit** (#4657): Transforms `limit + sort` to `sort + limit` when safe, enabling pushdown for join/subsearch scenarios
+- **Sort on aggregation measures** (#4603, #4759, #4867): Converts composite aggregations to terms/histogram/multi-terms aggregations when sorting by metrics
+
+#### Aggregation Optimizations
+
+- **Distinct count approx pushdown** (#4614): Pushes `DISTINCT_COUNT_APPROX` to OpenSearch cardinality aggregation using HyperLogLog++
+- **Case function as range queries** (#4400): Converts CASE expressions in aggregations to efficient range aggregations
+- **Merge group fields** (#4703): Optimizes aggregations with dependent group fields
+- **Remove unnecessary aggregations** (#4867, #4877): Eliminates redundant count aggregations and filters for DateHistogram
+
+#### New Internal Functions
+
+| Function | PR | Description |
+|----------|-----|-------------|
+| `MAP_REMOVE` | #4511 | Remove keys from map structures |
+| `MAP_APPEND` | #4515 | Append values to map structures |
+| `MAP_CONCAT` | #4477 | Concatenate multiple maps |
+| `JSON_EXTRACT_ALL` | #4489 | Extract all values from JSON |
+
+#### Command Enhancements
+
+- **fillnull command** (#4421): New option-style syntax `fillnull value=0 field1 field2`
+- **Explain API YAML format** (#4446): Human-readable YAML output for query plans
+- **Subsearch/join limits** (#4501, #4534): Configurable `plugins.ppl.subsearch.maxout` and `plugins.ppl.join.subsearch_maxout`
+- **Composite bucket size** (#4544): Configurable via `plugins.query.buckets`
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "PPL Query"
+        Q[PPL Query] --> Parser
+        Parser --> AST[Abstract Syntax Tree]
+    end
+    
+    subgraph "Calcite Optimizer"
+        AST --> RelNode[RelNode Tree]
+        RelNode --> Rules[Optimization Rules]
+        Rules --> SortPush[Sort Pushdown]
+        Rules --> AggPush[Aggregation Pushdown]
+        Rules --> ExprStd[Expression Standardization]
+    end
+    
+    subgraph "DSL Generation"
+        SortPush --> DSL[OpenSearch DSL]
+        AggPush --> DSL
+        ExprStd --> DSL
+    end
+    
+    subgraph "Execution"
+        DSL --> ES[OpenSearch Engine]
+    end
+```
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.query.buckets` | Composite aggregation bucket size | 10000 |
+| `plugins.ppl.subsearch.maxout` | Maximum rows from subsearch | 10000 |
+| `plugins.ppl.join.subsearch_maxout` | Maximum rows for join subsearch | 50000 |
+
+### Usage Examples
+
+#### Sort Pushdown with Complex Expressions
+```ppl
+source=accounts | sort abs(balance - 1000) | head 10
+```
+
+#### Distinct Count Approximation
+```ppl
+source=logs | stats distinct_count_approx(user_id) as unique_users by host
+```
+
+#### Case Function as Range Aggregation
+```ppl
+source=bank | eval age_range = case(age < 30, 'young', age < 50, 'middle' else 'senior') 
+| stats avg(balance) by age_range
+```
+
+Generated DSL uses range aggregation:
+```json
+{
+  "aggregations": {
+    "age_range": {
+      "range": {
+        "field": "age",
+        "ranges": [
+          {"key": "young", "to": 30},
+          {"key": "middle", "from": 30, "to": 50},
+          {"key": "senior", "from": 50}
+        ]
+      }
+    }
+  }
+}
+```
+
+#### New fillnull Syntax
+```ppl
+source=accounts | fillnull value=0 balance age
+source=accounts | fillnull value='N/A' name
+```
+
+#### YAML Explain Output
+```ppl
+explain format=yaml source=accounts | where age > 30
+```
+
+### Migration Notes
+
+- Enable Calcite engine with `plugins.calcite.enabled=true` for advanced optimizations
+- Review subsearch/join queries if they exceed new configurable limits
+- YAML explain format is experimental and may change
+
+## Limitations
+
+- Sort pushdown for complex expressions requires Calcite engine
+- Case-to-range pushdown only works with string literal results and numeric fields
+- Range aggregations ignore null values (different from CASE function behavior)
+- Some optimizations require specific query patterns to trigger
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4703](https://github.com/opensearch-project/sql/pull/4703) | Merge group fields for aggregate with dependent group fields |
+| [#4795](https://github.com/opensearch-project/sql/pull/4795) | RexNode expression standardization for script push down |
+| [#4750](https://github.com/opensearch-project/sql/pull/4750) | Pushdown sort by complex expressions to scan |
+| [#4881](https://github.com/opensearch-project/sql/pull/4881) | Refactor alias type field with project alias |
+| [#4867](https://github.com/opensearch-project/sql/pull/4867) | Remove count aggregation for sort on aggregate measure |
+| [#4877](https://github.com/opensearch-project/sql/pull/4877) | Remove unnecessary filter for DateHistogram |
+| [#4759](https://github.com/opensearch-project/sql/pull/4759) | Support push down sort on aggregation measure for multiple buckets |
+| [#4657](https://github.com/opensearch-project/sql/pull/4657) | Support push down sort after limit |
+| [#4554](https://github.com/opensearch-project/sql/pull/4554) | Enhance dynamic source clause for metadata filter |
+| [#4690](https://github.com/opensearch-project/sql/pull/4690) | Bin command error message enhancement |
+| [#4732](https://github.com/opensearch-project/sql/pull/4732) | Update clickbench queries with bucket_nullable=false |
+| [#4603](https://github.com/opensearch-project/sql/pull/4603) | Pushdown sort aggregate metrics |
+| [#4586](https://github.com/opensearch-project/sql/pull/4586) | Allow renaming group-by fields to existing field names |
+| [#4599](https://github.com/opensearch-project/sql/pull/4599) | Support automatic type conversion for REX/SPATH/PARSE |
+| [#4400](https://github.com/opensearch-project/sql/pull/4400) | Pushdown case function in aggregations as range queries |
+| [#4613](https://github.com/opensearch-project/sql/pull/4613) | Update GEOIP function to support IP types |
+| [#4614](https://github.com/opensearch-project/sql/pull/4614) | Pushdown distinct count approx |
+| [#4615](https://github.com/opensearch-project/sql/pull/4615) | Optimize pushdown script size with necessary fields |
+| [#4138](https://github.com/opensearch-project/sql/pull/4138) | Support referring to implicit @timestamp field in span |
+| [#4544](https://github.com/opensearch-project/sql/pull/4544) | Make composite bucket size configurable |
+| [#4511](https://github.com/opensearch-project/sql/pull/4511) | Add internal MAP_REMOVE function |
+| [#4515](https://github.com/opensearch-project/sql/pull/4515) | Add MAP_APPEND internal function |
+| [#4569](https://github.com/opensearch-project/sql/pull/4569) | Use _doc + _shard_doc as sort tiebreaker |
+| [#4434](https://github.com/opensearch-project/sql/pull/4434) | Error handling for illegal character in java regex |
+| [#4489](https://github.com/opensearch-project/sql/pull/4489) | Add JSON_EXTRACT_ALL internal function |
+| [#4534](https://github.com/opensearch-project/sql/pull/4534) | Set 0 and negative value of subsearch.maxout as unlimited |
+| [#4501](https://github.com/opensearch-project/sql/pull/4501) | Add configurable system limitations for subsearch and join |
+| [#4477](https://github.com/opensearch-project/sql/pull/4477) | Add MAP_CONCAT internal function |
+| [#4456](https://github.com/opensearch-project/sql/pull/4456) | Support regex for replace eval function |
+| [#4479](https://github.com/opensearch-project/sql/pull/4479) | Add data anonymizer for spath command |
+| [#4440](https://github.com/opensearch-project/sql/pull/4440) | Support eval returns decimal division result |
+| [#4421](https://github.com/opensearch-project/sql/pull/4421) | PPL fillnull command enhancement |
+| [#4446](https://github.com/opensearch-project/sql/pull/4446) | Support format=yaml in Explain API |
+
+## References
+
+- [Issue #4201](https://github.com/opensearch-project/sql/issues/4201): Pushdown case function in aggregations
+- [Issue #4282](https://github.com/opensearch-project/sql/issues/4282): Pushdown sort aggregate metrics
+- [Issue #4533](https://github.com/opensearch-project/sql/issues/4533): Pushdown distinct count approx
+- [Issue #4570](https://github.com/opensearch-project/sql/issues/4570): Support push down sort after limit
+- [Issue #3912](https://github.com/opensearch-project/sql/issues/3912): Pushdown sort by complex expressions
+- [Issue #4517](https://github.com/opensearch-project/sql/issues/4517): Make composite bucket size configurable
+- [Issue #3731](https://github.com/opensearch-project/sql/issues/3731): Configurable limitations for subsearch/join
+- [PPL Commands Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/ppl/functions/)
+- [OpenSearch PPL Blog: Lookup, Join, and Subsearch](https://opensearch.org/blog/enhanced-log-analysis-with-opensearch-ppl-introducing-lookup-join-and-subsearch/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/sql/ppl-query-optimization.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -126,6 +126,7 @@
 
 ### SQL
 
+- [PPL Query Optimization](features/sql/ppl-query-optimization.md) - 33 enhancements including sort pushdown, aggregation optimization, distinct count approx, case-to-range queries, fillnull command, YAML explain format
 - [SQL/PPL Bugfixes](features/sql/sql-ppl-bugfixes.md) - 48 bug fixes including memory exhaustion fix, race condition fix, rex nested capture groups, filter pushdown improvements, and CVE-2025-48924
 - [SQL CI/Tests](features/sql/sql-ci-tests.md) - CI/CD improvements including Gradle 9.2.0, JDK 25, BWC test splitting, query timeouts, and maven snapshots publishing
 - [SQL Documentation](features/sql/sql-documentation.md) - PPL command documentation standardization, typo fixes, enhanced examples, and function documentation improvements


### PR DESCRIPTION
## Summary

This PR adds documentation for PPL Query Optimization enhancements in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/sql/ppl-query-optimization.md`
- Feature report: `docs/features/sql/ppl-query-optimization.md`

### Key Changes in v3.4.0

**Sort Pushdown Enhancements:**
- Sort by complex expressions (#4750)
- Sort after limit transformation (#4657)
- Sort on aggregation measures (#4603, #4759, #4867)

**Aggregation Optimizations:**
- Distinct count approx pushdown to cardinality (#4614)
- Case function as range queries (#4400)
- Merge group fields optimization (#4703)
- Remove unnecessary aggregations (#4867, #4877)

**New Internal Functions:**
- MAP_REMOVE, MAP_APPEND, MAP_CONCAT, JSON_EXTRACT_ALL

**Command Enhancements:**
- fillnull command option-style syntax (#4421)
- Explain API YAML format (#4446)
- Configurable subsearch/join limits (#4501, #4534)
- Configurable composite bucket size (#4544)

### Related Issue
Closes #1637