### PR TITLE
docs: add skills log insight report for v3.4.0

### DIFF
--- a/docs/features/skills/skills-tools.md
+++ b/docs/features/skills/skills-tools.md
@@ -151,6 +151,7 @@ The `type` parameter (defaults to `Opensearch`) is passed to the LLM model as `d
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#678](https://github.com/opensearch-project/skills/pull/678) | Increase max_sample_count to 5 for log insight |
 | v3.3.0 | [#625](https://github.com/opensearch-project/skills/pull/625) | Log patterns analysis tool |
 | v3.3.0 | [#634](https://github.com/opensearch-project/skills/pull/634) | Data Distribution Tool |
 | v3.3.0 | [#636](https://github.com/opensearch-project/skills/pull/636) | Add more information in PPL tool when passing to SageMaker |
@@ -181,6 +182,7 @@ The `type` parameter (defaults to `Opensearch`) is passed to the LLM model as `d
 
 ## Change History
 
+- **v3.4.0** (2026-01-11): Increased max_sample_count from 2 to 5 for LogPatternAnalysisTool log insight mode, providing more representative sample logs per pattern
 - **v3.3.0** (2026-01-11): Added LogPatternAnalysisTool for intelligent log pattern detection with sequence analysis and time-based comparison; added DataDistributionTool for statistical distribution analysis with divergence calculation; enhanced PPLTool to include mappings, current_time, and os_version when passing to SageMaker; fixed WebSearchTool using AsyncHttpClient from ml-commons; fixed DataDistributionTool to remove baselinePercentage when no baseline provided
 - **v3.2.0** (2026-01-11): Added index schema merging for PPLTool when using index patterns (merges mappings from all matching indexes); added error message masking in PPLTool to redact SageMaker ARNs and AWS account numbers; standardized parameter handling across all tools using `extractInputParameters` utility
 - **v3.1.0** (2025-05-06): Added data source type parameter (`datasourceType`) to PPLTool for Spark/S3 data source support; fixed PPLTool fields bug to properly expose multi-field mappings (e.g., `a.keyword`) to LLM for aggregation queries; fixed httpclient5 dependency version conflict in build.gradle, applied Spotless code formatting to WebSearchTool

--- a/docs/releases/v3.4.0/features/skills/skills-log-insight.md
+++ b/docs/releases/v3.4.0/features/skills/skills-log-insight.md
@@ -1,0 +1,80 @@
+# Skills Log Insight
+
+## Summary
+
+This enhancement increases the `max_sample_count` parameter from 2 to 5 in the log insight feature of the `LogPatternAnalysisTool`. This change provides more representative sample logs for each detected pattern, improving the quality of log analysis insights.
+
+## Details
+
+### What's New in v3.4.0
+
+The log insight feature in `LogPatternAnalysisTool` now returns up to 5 sample logs per pattern instead of 2. This enhancement provides users with more context when analyzing log patterns, making it easier to understand the nature and variations of each detected pattern.
+
+### Technical Changes
+
+#### Configuration Changes
+
+| Setting | Previous Value | New Value | Description |
+|---------|---------------|-----------|-------------|
+| `max_sample_count` | 2 | 5 | Maximum number of sample logs returned per pattern in log insight mode |
+
+#### Code Change
+
+The change is in the PPL query construction within the `logInsight` method of `LogPatternAnalysisTool`:
+
+```java
+// Before
+"mode=aggregation max_sample_count=2 "
+
+// After
+"mode=aggregation max_sample_count=5 "
+```
+
+### Usage Example
+
+When using the `LogPatternAnalysisTool` in log insight mode (without baseline time range), the tool now returns more sample logs:
+
+```json
+{
+  "logInsights": [
+    {
+      "pattern": "ERROR <*> failed to connect to <*>",
+      "count": 150,
+      "sampleLogs": [
+        "ERROR service-a failed to connect to database-1",
+        "ERROR service-b failed to connect to cache-server",
+        "ERROR service-a failed to connect to api-gateway",
+        "ERROR service-c failed to connect to message-queue",
+        "ERROR service-b failed to connect to database-2"
+      ]
+    }
+  ]
+}
+```
+
+### Impact
+
+- **Better Pattern Understanding**: More sample logs help users understand the variations within each pattern
+- **Improved Debugging**: Additional samples provide more context for troubleshooting
+- **No Performance Impact**: The change only affects the number of samples returned, not the pattern detection algorithm
+
+## Limitations
+
+- The `max_sample_count` is currently hardcoded and not configurable by users
+- Sample logs are selected by the PPL patterns command, not by the tool itself
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#678](https://github.com/opensearch-project/skills/pull/678) | Backport: Increase max_sample_count to 5 for log insight |
+| [#677](https://github.com/opensearch-project/skills/pull/677) | Original: Increase max_sample_count to 5 for log insight |
+
+## References
+
+- [LogPatternAnalysisTool Source](https://github.com/opensearch-project/skills/blob/main/src/main/java/org/opensearch/agent/tools/LogPatternAnalysisTool.java): Implementation
+- [Log Pattern Tool Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/tools/log-pattern-tool/): Official documentation
+
+## Related Feature Report
+
+- [Skills Tools](../../../features/skills/skills-tools.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -157,6 +157,10 @@
 
 - [ML Commons Bugfixes](features/ml-commons/ml-commons-bugfixes.md) - Agent type update validation, QueryPlanningTool model ID parsing, tool config empty values, agentic memory multi-node fixes
 
+### Skills
+
+- [Skills Log Insight](features/skills/skills-log-insight.md) - Increase max_sample_count from 2 to 5 for log insight in LogPatternAnalysisTool
+
 ### OpenSearch Remote Metadata SDK
 
 - [Remote Model Bugfixes](features/opensearch-remote-metadata-sdk/remote-model-bugfixes.md) - Fix error when updating global model status in DynamoDB backend


### PR DESCRIPTION
## Summary

Add release report for Skills Log Insight enhancement in v3.4.0.

### Changes
- Created release report: `docs/releases/v3.4.0/features/skills/skills-log-insight.md`
- Updated feature report: `docs/features/skills/skills-tools.md` (added v3.4.0 entry to Related PRs and Change History)
- Updated release index: `docs/releases/v3.4.0/index.md` (added Skills section)

### Key Changes in v3.4.0
- Increased `max_sample_count` from 2 to 5 in LogPatternAnalysisTool log insight mode
- Provides more representative sample logs per detected pattern

### Related PRs
- opensearch-project/skills#678: Backport - Increase max_sample_count to 5 for log insight
- opensearch-project/skills#677: Original - Increase max_sample_count to 5 for log insight

Closes #1635