### PR TITLE
docs: add security-configuration report for v3.4.0

### DIFF
--- a/docs/features/security/security-configuration.md
+++ b/docs/features/security/security-configuration.md
@@ -14,6 +14,7 @@ graph TB
         YAML[Security YAML Files]
         Index[.opendistro_security Index]
         Loader[ConfigurationLoader]
+        ReloadThread[ReloadThread]
     end
     
     subgraph "Configuration Types"
@@ -28,8 +29,15 @@ graph TB
         Nodesdn[nodes_dn.yml]
     end
     
+    subgraph "Authentication"
+        CertAuth[Client Certificate Auth]
+        DN[DN Extraction]
+        SAN[SAN Extraction]
+    end
+    
     YAML --> Loader
     Loader --> Index
+    ReloadThread --> Loader
     Config --> YAML
     Roles --> YAML
     RolesMapping --> YAML
@@ -39,6 +47,9 @@ graph TB
     Allowlist --> YAML
     Audit --> YAML
     Nodesdn --> YAML
+    
+    CertAuth --> DN
+    CertAuth --> SAN
 ```
 
 ### Configuration Version Model
@@ -66,6 +77,13 @@ config:
     # configuration options
 ```
 
+### Configuration Reloading
+
+Starting with v3.4.0, security configuration reloading is handled by a dedicated `ReloadThread` that:
+- Prevents MANAGEMENT thread pool exhaustion during high-frequency configuration changes
+- Merges consecutive reload requests to minimize queue buildup
+- Improves overall node stability during configuration updates
+
 ### Authentication Handling
 
 The Security plugin supports various authentication backends including:
@@ -76,6 +94,26 @@ The Security plugin supports various authentication backends including:
 - SAML
 - Kerberos
 - JWT
+- Client Certificate (with DN or SAN extraction)
+
+#### Client Certificate Authentication
+
+Client certificate authentication supports two modes for extracting the username:
+
+1. **Distinguished Name (DN)**: Traditional extraction from certificate subject
+2. **Subject Alternative Name (SAN)**: Extract from X509v3 SAN fields (v3.4.0+)
+
+Supported SAN types: EMAIL, DNS, IP, URI with glob pattern matching.
+
+```yaml
+# SAN-based authentication example
+clientcert_auth_domain:
+  http_enabled: true
+  http_authenticator:
+    type: clientcert
+    config:
+      username_attribute: "san:EMAIL:*@example.com"
+```
 
 #### OIDC Username Handling
 
@@ -86,9 +124,11 @@ OIDC providers may send usernames with special characters. The plugin handles pi
 | Component | Description |
 |-----------|-------------|
 | ConfigurationLoader | Loads and validates security configurations |
+| ReloadThread | Dedicated thread for configuration reloading with request merging (v3.4.0+) |
 | SecurityAdmin | CLI tool for managing security configurations |
 | Installer | Demo configuration installer |
 | ThreadContext | Stores user information during request processing |
+| HTTPClientCertAuthenticator | Handles client certificate authentication with DN/SAN support |
 
 ### Configuration
 
@@ -98,8 +138,30 @@ OIDC providers may send usernames with special characters. The plugin handles pi
 | `plugins.security.allow_default_init_securityindex` | Allow default initialization | `false` | No |
 | `plugins.security.audit.type` | Audit log type | `internal_opensearch` | No |
 | `plugins.security.user_attribute_serialization.enabled` | Enable user attribute serialization | `false` | Yes |
-| `plugins.security.experimental.resource_sharing.enabled` | Enable resource sharing framework | `false` | No |
-| `plugins.security.experimental.resource_sharing.protected_types` | List of resource types to protect | `[]` | No |
+| `plugins.security.experimental.resource_sharing.enabled` | Enable resource sharing framework | `false` | Yes (v3.4.0+) |
+| `plugins.security.experimental.resource_sharing.protected_types` | List of resource types to protect | `[]` | Yes (v3.4.0+) |
+
+### SecurityAdmin CLI
+
+The `securityadmin.sh` tool manages security configurations:
+
+```bash
+# Basic usage
+./securityadmin.sh -cd ../config/ -icl -nhnv \
+  -cacert /path/to/root-ca.pem \
+  -cert /path/to/admin.pem \
+  -key /path/to/admin-key.pem
+
+# With custom timeout (v3.4.0+)
+./securityadmin.sh -cd ../config/ --timeout 60 ...
+```
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `-cd` | Configuration directory | - |
+| `-icl` | Ignore cluster name | - |
+| `-nhnv` | No hostname verification | - |
+| `--timeout` / `-to` | Request timeout in seconds (v3.4.0+) | 30 |
 
 ### Usage Example
 
@@ -128,11 +190,18 @@ config:
 - Configuration changes require either a cluster restart or use of the Security Admin tool
 - Some configuration options are not hot-reloadable
 - OIDC usernames with escaped pipe characters may need special handling in downstream systems
+- SAN extraction requires certificates with properly configured X509v3 extensions
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#5479](https://github.com/opensearch-project/security/pull/5479) | Moved configuration reloading to dedicated thread |
+| v3.4.0 | [#5677](https://github.com/opensearch-project/security/pull/5677) | Makes resource settings dynamic |
+| v3.4.0 | [#5701](https://github.com/opensearch-project/security/pull/5701) | Add support for X509v3 extensions (SAN) for authentication |
+| v3.4.0 | [#5752](https://github.com/opensearch-project/security/pull/5752) | Call AdminDns.isAdmin once per request |
+| v3.4.0 | [#5769](https://github.com/opensearch-project/security/pull/5769) | Headers copy optimization |
+| v3.4.0 | [#5787](https://github.com/opensearch-project/security/pull/5787) | Add --timeout option to securityadmin.sh |
 | v3.3.0 | [#5671](https://github.com/opensearch-project/security/pull/5671) | Adds protected resource types setting |
 | v3.3.0 | [#5673](https://github.com/opensearch-project/security/pull/5673) | Make user attribute serialization dynamic |
 | v3.0.0 | [#5193](https://github.com/opensearch-project/security/pull/5193) | Default to v7 models if _meta not present |
@@ -142,14 +211,19 @@ config:
 
 ## References
 
+- [Issue #5464](https://github.com/opensearch-project/security/issues/5464): ActionPrivileges initialization performance issue
+- [Issue #5643](https://github.com/opensearch-project/security/issues/5643): SAN authentication feature request
+- [Issue #5653](https://github.com/opensearch-project/security/issues/5653): SocketTimeoutException in securityadmin
+- [Issue #4209](https://github.com/opensearch-project/security/issues/4209): X509v3 SAN support request
 - [Issue #5191](https://github.com/opensearch-project/security/issues/5191): Upgrade failure from 2.19 to 3.0.0-alpha1
 - [Issue #2756](https://github.com/opensearch-project/security/issues/2756): Username cannot have '|' in the security plugin
+- [Documentation: Client Certificate Authentication](https://docs.opensearch.org/3.4/security/authentication-backends/client-auth/)
 - [Documentation: Configuration APIs](https://docs.opensearch.org/3.0/api-reference/security/configuration/index/)
 - [Documentation: Upgrade Perform API](https://docs.opensearch.org/3.0/api-reference/security/configuration/upgrade-perform/)
-- [Documentation: Rolling Upgrade](https://docs.opensearch.org/3.0/install-and-configure/upgrade-opensearch/rolling-upgrade/)
 
 ## Change History
 
+- **v3.4.0** (2025-01-11): Dedicated configuration reloading thread, dynamic resource settings, X509v3 SAN authentication, performance optimizations, securityadmin timeout option
 - **v3.3.0** (2025-10-01): Added protected resource types setting, made user attribute serialization dynamic
 - **v3.0.0** (2025-05-06): Default to v7 models, escape pipe characters in usernames, fix demo config version matcher
 - **v2.18.0** (2024-11-05): Auto-convert security config models from v6 to v7

--- a/docs/releases/v3.4.0/features/security/security-configuration.md
+++ b/docs/releases/v3.4.0/features/security/security-configuration.md
@@ -1,0 +1,146 @@
+# Security Configuration
+
+## Summary
+
+OpenSearch v3.4.0 introduces significant improvements to security configuration management, including dedicated configuration reloading threads for improved node stability, dynamic resource sharing settings, X509v3 SAN-based authentication, performance optimizations, and a configurable timeout option for securityadmin.sh.
+
+## Details
+
+### What's New in v3.4.0
+
+#### Configuration Reloading Thread
+Security configuration reloading is now handled by a dedicated thread, preventing MANAGEMENT thread pool exhaustion during high-frequency configuration changes. The new `ReloadThread` class merges consecutive reload requests to minimize queue buildup.
+
+#### Dynamic Resource Settings
+Resource sharing settings can now be updated at runtime via the cluster-settings API without requiring a node restart. Plugins can choose codepaths based on protected resource types.
+
+#### X509v3 SAN Authentication
+Client certificate authentication now supports extracting the Principal from Subject Alternative Name (SAN) fields instead of just the Distinguished Name (DN). Supported SAN types include EMAIL, DNS, IP, and URI with glob pattern matching.
+
+#### Performance Optimizations
+- `AdminDns.isAdmin` is now called once per request instead of repeatedly for every field across all index mappings
+- Header copying optimization prevents creating new maps on every `getHeaders()` call
+
+#### SecurityAdmin Timeout Option
+The `securityadmin.sh` script now accepts `--timeout` (`-to`) parameter for configurable request timeout (default: 30 seconds).
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Configuration Reloading (v3.4.0)"
+        Request[Config Change Request]
+        ReloadThread[ReloadThread]
+        Merger[Request Merger]
+        Loader[ConfigurationLoader]
+    end
+    
+    subgraph "Authentication (v3.4.0)"
+        Cert[Client Certificate]
+        SAN[SAN Extractor]
+        DN[DN Extractor]
+        Auth[HTTPClientCertAuthenticator]
+    end
+    
+    Request --> ReloadThread
+    ReloadThread --> Merger
+    Merger --> Loader
+    
+    Cert --> SAN
+    Cert --> DN
+    SAN --> Auth
+    DN --> Auth
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| ReloadThread | Dedicated thread for security configuration reloading with request merging |
+| SAN Extractor | Extracts Principal from X509v3 SAN fields (EMAIL, DNS, IP, URI) |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `username_attribute` | Certificate attribute for username extraction (`cn` or `san:TYPE:glob`) | `cn` (DN) |
+| `--timeout` / `-to` | SecurityAdmin request timeout in seconds | `30` |
+
+### Usage Example
+
+#### SAN-based Authentication Configuration
+
+```yaml
+# config.yml - Client certificate authentication with SAN
+clientcert_auth_domain:
+  http_enabled: true
+  transport_enabled: true
+  order: 1
+  http_authenticator:
+    type: clientcert
+    config:
+      username_attribute: "san:EMAIL:*@example.com"
+    challenge: false
+  authentication_backend:
+    type: noop
+```
+
+#### SecurityAdmin with Custom Timeout
+
+```bash
+# Use 60-second timeout for large configuration uploads
+./securityadmin.sh -cd ../config/ -icl -nhnv \
+  -cacert /path/to/root-ca.pem \
+  -cert /path/to/admin.pem \
+  -key /path/to/admin-key.pem \
+  --timeout 60
+```
+
+#### Dynamic Resource Settings Update
+
+```bash
+# Update resource sharing settings at runtime
+PUT _cluster/settings
+{
+  "persistent": {
+    "plugins.security.experimental.resource_sharing.enabled": true,
+    "plugins.security.experimental.resource_sharing.protected_types": ["saved_objects"]
+  }
+}
+```
+
+### Migration Notes
+
+- Existing client certificate configurations using DN continue to work unchanged
+- To use SAN-based authentication, update `username_attribute` to `san:TYPE:pattern` format
+- SecurityAdmin scripts using default timeout behavior are unaffected
+
+## Limitations
+
+- SAN extraction requires certificates with properly configured X509v3 extensions
+- Configuration reloading thread improvements are internal and not user-configurable
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5479](https://github.com/opensearch-project/security/pull/5479) | Moved configuration reloading to dedicated thread |
+| [#5677](https://github.com/opensearch-project/security/pull/5677) | Makes resource settings dynamic |
+| [#5701](https://github.com/opensearch-project/security/pull/5701) | Add support for X509v3 extensions (SAN) for authentication |
+| [#5752](https://github.com/opensearch-project/security/pull/5752) | Call AdminDns.isAdmin once per request |
+| [#5769](https://github.com/opensearch-project/security/pull/5769) | Headers copy optimization |
+| [#5787](https://github.com/opensearch-project/security/pull/5787) | Add --timeout option to securityadmin.sh |
+
+## References
+
+- [Issue #5464](https://github.com/opensearch-project/security/issues/5464): ActionPrivileges initialization performance issue
+- [Issue #5643](https://github.com/opensearch-project/security/issues/5643): SAN authentication feature request
+- [Issue #5653](https://github.com/opensearch-project/security/issues/5653): SocketTimeoutException in securityadmin
+- [Issue #4209](https://github.com/opensearch-project/security/issues/4209): X509v3 SAN support request
+- [Documentation: Client Certificate Authentication](https://docs.opensearch.org/3.4/security/authentication-backends/client-auth/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/security/security-configuration.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -44,6 +44,7 @@
 - [Resource Sharing](features/security/resource-sharing.md) - Multi-type index support, ResourceProvider interface, Builder pattern, REST API improvements
 - [Security AccessController Migration](features/security/security-accesscontroller-migration.md) - Migrate from deprecated java.security.AccessController to org.opensearch.secure_sm.AccessController
 - [Security Bugfixes](features/security/security-bugfixes.md) - Multi-tenancy `.kibana` index fix, WildcardMatcher empty string handling, DLS/FLS internal request fix, PrivilegesEvaluator modularization
+- [Security Configuration](features/security/security-configuration.md) - Dedicated config reloading thread, dynamic resource settings, X509v3 SAN authentication, performance optimizations, securityadmin timeout
 - [Security Features](features/security/security-features.md) - Webhook Basic Auth, REST header propagation, system indices deprecation, static/custom config overlap, search relevance permissions
 - [GitHub Actions Updates](features/security/github-actions-updates.md) - Update GitHub Actions dependencies to support Node.js 24 runtime
 


### PR DESCRIPTION
## Summary

Add release and feature reports for Security Configuration enhancements in OpenSearch v3.4.0.

## Changes

### Release Report
- `docs/releases/v3.4.0/features/security/security-configuration.md`

### Feature Report Update
- `docs/features/security/security-configuration.md`

## Key Changes in v3.4.0

Based on investigation of 6 PRs from the security repository:

1. **Configuration Reloading Thread** (PR #5479)
   - Dedicated thread for security configuration reloading
   - Prevents MANAGEMENT thread pool exhaustion
   - Request merging to minimize queue buildup

2. **Dynamic Resource Settings** (PR #5677)
   - Resource sharing settings now dynamically updatable via cluster-settings API
   - No node restart required

3. **X509v3 SAN Authentication** (PR #5701)
   - Extract Principal from SAN fields (EMAIL, DNS, IP, URI)
   - Glob pattern matching support
   - Alternative to DN-based authentication

4. **Performance Optimizations**
   - AdminDns.isAdmin called once per request (PR #5752)
   - Headers copy optimization (PR #5769)

5. **SecurityAdmin Timeout Option** (PR #5787)
   - `--timeout` / `-to` parameter for configurable request timeout
   - Default: 30 seconds

## Related Issue
Closes #1633