### PR TITLE
docs: add performance-analyzer report for v3.4.0

### DIFF
--- a/docs/features/performance-analyzer/performance-analyzer.md
+++ b/docs/features/performance-analyzer/performance-analyzer.md
@@ -115,6 +115,7 @@ GET localhost:9600/_plugins/_performanceanalyzer/rca?name=HighHeapUsageClusterRC
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#902](https://github.com/opensearch-project/performance-analyzer/pull/902) | Restore java min compatible to 21 and remove 24 |
 | v3.3.0 | [#845](https://github.com/opensearch-project/performance-analyzer/pull/845) | Use Subclass method for Version and Channel type for security plugin compatibility |
 | v3.3.0 | [#846](https://github.com/opensearch-project/performance-analyzer/pull/846) | Increment to 3.3.0.0 and update SHA files |
 | v3.2.0 | [#826](https://github.com/opensearch-project/performance-analyzer/pull/826) | Bump SpotBugs to 6.2.2 and Checkstyle to 10.26.1 |
@@ -130,6 +131,7 @@ GET localhost:9600/_plugins/_performanceanalyzer/rca?name=HighHeapUsageClusterRC
 
 ## Change History
 
+- **v3.4.0** (2026-01-11): Build configuration update - restore Java 21 minimum compatibility, remove Java 24 from CI matrix, simplify build.gradle version selection
 - **v3.3.0** (2026-01-11): Transport channel wrapper improvements - delegate getProfileName(), getChannelType(), getVersion(), and get() to wrapped channel; removed getInnerChannel() method for better security plugin compatibility
 - **v3.2.0** (2025-07-18): Build infrastructure update - SpotBugs 6.2.2, Checkstyle 10.26.1; Removed CVE-2025-27820 workaround
 - **v2.17.0** (2024-09-17): Added RTFCacheConfigMetricsCollector for cache configuration telemetry; Updated PA Commons dependency to 1.6.0

--- a/docs/releases/v3.4.0/features/performance-analyzer/performance-analyzer.md
+++ b/docs/releases/v3.4.0/features/performance-analyzer/performance-analyzer.md
@@ -1,0 +1,72 @@
+# Performance Analyzer
+
+## Summary
+
+This release item restores Java 21 as the minimum compatible version for Performance Analyzer and removes Java 24 from the CI test matrix. This change ensures consistent build behavior and aligns with the broader OpenSearch ecosystem's Java compatibility requirements while maintaining support for JDK 25.
+
+## Details
+
+### What's New in v3.4.0
+
+The Performance Analyzer plugin received a build configuration update that:
+
+1. **Restores Java 21 minimum compatibility**: The `sourceCompatibility` and `targetCompatibility` in `build.gradle` are now explicitly set to `JavaVersion.VERSION_21`, removing the conditional logic that previously selected between Java 21 and Java 25.
+
+2. **Updates GitHub Actions CI matrix**: The CI workflow now tests against Java 21 and Java 25, removing Java 24 from the test matrix.
+
+### Technical Changes
+
+#### Build Configuration Changes
+
+The `build.gradle` file was simplified:
+
+**Before:**
+```groovy
+def javaVersion = JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_25) ?
+        JavaVersion.VERSION_25 : JavaVersion.VERSION_21
+
+java {
+    sourceCompatibility = javaVersion
+    targetCompatibility = javaVersion
+}
+```
+
+**After:**
+```groovy
+java {
+    sourceCompatibility = JavaVersion.VERSION_21
+    targetCompatibility = JavaVersion.VERSION_21
+}
+```
+
+#### CI Workflow Changes
+
+| File | Change |
+|------|--------|
+| `.github/workflows/gradle.yml` | Changed Java matrix from `[24, 25]` to `[21, 25]` |
+| `.github/workflows/maven-publish.yml` | Changed Java version from `25` to `21` |
+
+### Migration Notes
+
+No migration required. This is a build infrastructure change that does not affect runtime behavior or APIs.
+
+## Limitations
+
+- This change only affects the build and CI configuration
+- Runtime Java version requirements remain unchanged (Java 21+)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#902](https://github.com/opensearch-project/performance-analyzer/pull/902) | Restore java min compatible to 21 and remove 24 |
+
+## References
+
+- [Issue #883](https://github.com/opensearch-project/performance-analyzer/issues/883): [Release 3.4.0] Gradle 9.2.0 and GitHub Actions JDK 25 Upgrade
+- [PR #896](https://github.com/opensearch-project/performance-analyzer/pull/896): Upgrade to JDK25 and gradle 9.2.0
+- [Performance Analyzer Documentation](https://docs.opensearch.org/latest/monitoring-your-cluster/pa/index/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/performance-analyzer/performance-analyzer.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -151,6 +151,10 @@
 
 - [SEISMIC Bugfixes](features/neural-search/seismic-bugfixes.md) - Fix IT failures in multi-node environments, query handling without method_parameters, and disk space recovery on index deletion
 
+### Performance Analyzer
+
+- [Performance Analyzer](features/performance-analyzer/performance-analyzer.md) - Restore Java 21 minimum compatibility and remove Java 24 from CI matrix
+
 ### Learning to Rank
 
 - [Learning to Rank Bugfixes](features/learning/learning-to-rank-bugfixes.md) - Legacy version ID fix, integration test stability, rescore-only SLTR logging fix


### PR DESCRIPTION
## Summary

Add release report for Performance Analyzer v3.4.0 enhancement.

## Changes

### Release Report
- Created `docs/releases/v3.4.0/features/performance-analyzer/performance-analyzer.md`
- Documents the Java 21 minimum compatibility restoration and Java 24 removal from CI matrix

### Feature Report Update
- Updated `docs/features/performance-analyzer/performance-analyzer.md`
- Added v3.4.0 entry to Related PRs table
- Added v3.4.0 entry to Change History

### Release Index Update
- Added Performance Analyzer link to `docs/releases/v3.4.0/index.md`

## Related Issue
Closes #1632