### PR TITLE
docs: add Learning to Rank Enhancements report for v3.4.0

### DIFF
--- a/docs/features/learning/learning-to-rank.md
+++ b/docs/features/learning/learning-to-rank.md
@@ -150,6 +150,8 @@ POST my_index/_search
 | v3.4.0 | [#269](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/269) | Fix ML index warning in YAML test parsing |
 | v3.4.0 | [#271](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/271) | Use implicit wait_for instead of explicit refresh |
 | v3.4.0 | [#266](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/266) | Fix rescore-only feature SLTR logging |
+| v3.4.0 | [#256](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/256) | Allow warnings about directly accessing the .plugins-ml-config index |
+| v3.4.0 | [#259](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/259) | Test isolation improvements - narrow index cleanup scope |
 | v3.3.0 | [#226](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/226) | Fix bad inclusion of log4j in plugin JAR |
 | v3.3.0 | [#219](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/219) | Update System.env syntax for Gradle 9 compatibility |
 | v3.3.0 | [#228](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/228) | Add code coverage report generation |
@@ -174,7 +176,7 @@ POST my_index/_search
 
 ## Change History
 
-- **v3.4.0** (2026-02-18): Bug fixes - legacy version ID computation update for OpenSearch compatibility, integration test stability improvements (ML index warning fix, implicit refresh), rescore-only SLTR logging fix
+- **v3.4.0** (2026-02-18): Bug fixes - legacy version ID computation update for OpenSearch compatibility, integration test stability improvements (ML index warning fix, implicit refresh), rescore-only SLTR logging fix; Test infrastructure enhancements - narrowed index cleanup scope to LTR indexes only, improved test isolation for parallel execution
 - **v3.3.0** (2026-01-14): Build infrastructure fixes - log4j exclusion from JAR, Gradle 9 compatibility, hybrid float comparison for tests, code coverage reporting, spotless plugin upgrade
 - **v3.2.0** (2025-09-16): Added XGBoost missing values support for correct NaN handling; Build infrastructure upgrade (Gradle 8.14, JDK 24 support); fixed flaky test with ULP tolerance adjustment
 - **v3.0.0** (2025-05-13): Added XGBoost raw JSON parser for proper `save_model` format support; fixed ApproximateScoreQuery test

--- a/docs/releases/v3.4.0/features/learning/learning-to-rank-enhancements.md
+++ b/docs/releases/v3.4.0/features/learning/learning-to-rank-enhancements.md
@@ -1,0 +1,137 @@
+# Learning to Rank Enhancements
+
+## Summary
+
+This release includes test infrastructure improvements for the Learning to Rank (LTR) plugin that eliminate system index access warnings during integration tests. The changes improve test isolation and enable parallel test execution by narrowing the scope of index cleanup operations.
+
+## Details
+
+### What's New in v3.4.0
+
+Two enhancements improve test infrastructure:
+
+1. **System Index Warning Allowances** (PR #256) - Temporary fix to allow warnings about `.plugins-ml-config` index access during tests
+2. **Test Isolation Improvements** (PR #259) - Root cause fix that narrows index cleanup scope to LTR-specific indexes only
+
+### Technical Changes
+
+#### System Index Warning Allowances (PR #256)
+
+Integration tests were failing due to unexpected warnings about accessing system indexes like `.plugins-ml-config`. This PR added temporary `allowed_warnings` sections to REST API spec tests:
+
+```yaml
+- do:
+    allowed_warnings:
+      - "this request accesses system indices: [.plugins-ml-config], but in a future major version, direct access to system indices will be prevented by default"
+    ltr.create_store: {}
+```
+
+This was a stopgap measure while the root cause was investigated.
+
+#### Test Isolation Improvements (PR #259)
+
+The root cause of system index warnings was identified and fixed:
+
+**Problem 1**: `LtrQueryClientYamlTestSuiteIT` was wiping ALL indexes after tests, including system indexes created by other plugins:
+
+```java
+// Before: Deleted all non-security indexes
+for (Map<String, Object> index : parserList) {
+    String indexName = (String) index.get("index");
+    if (indexName != null && !".opendistro_security".equals(indexName)) {
+        adminClient().performRequest(new Request("DELETE", "/" + indexName));
+    }
+}
+```
+
+**Solution**: Narrow cleanup to only LTR-specific indexes:
+
+```java
+// After: Delete only LTR indexes
+@After
+protected void wipeLtrIndices() throws IOException {
+    Request delete = new Request("DELETE", "/.ltrstore*");
+    delete.addParameter("ignore_unavailable", "true");
+    delete.addParameter("allow_no_indices", "true");
+    delete.addParameter("expand_wildcards", "all");
+    adminClient().performRequest(delete);
+}
+```
+
+**Problem 2**: YAML tests created `test_index` without cleanup, forcing the broad index deletion.
+
+**Solution**: Added `teardown` sections to clean up test indexes and made index creation lenient:
+
+```yaml
+teardown:
+    - do:
+          indices.delete:
+              index: test_index
+              ignore_unavailable: true
+              expand_wildcards: all
+
+---
+"Test case":
+  - do:
+      indices.create:
+        index: test
+        ignore: [400]  # Allow already exists
+```
+
+**Problem 3**: Deprecated security settings constants were used.
+
+**Solution**: Updated to use string literals for security settings:
+
+```java
+// Before
+.put(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_PASSWORD, "changeit")
+.put(OPENSEARCH_SECURITY_SSL_HTTP_KEYSTORE_KEYPASSWORD, "changeit")
+
+// After
+.put("plugins.security.ssl.http.keystore_password", "changeit")
+.put("plugins.security.ssl.http.keystore_keypassword", "changeit")
+```
+
+### Benefits
+
+| Improvement | Description |
+|-------------|-------------|
+| Test Isolation | Tests no longer interfere with other plugins' system indexes |
+| Parallel Execution | Enables running LTR tests alongside other integration tests |
+| Cleaner Output | Removes `allowed_warnings` noise from test specifications |
+| Maintainability | Proper teardown sections make test intent clearer |
+
+### Files Changed
+
+| File | Changes |
+|------|---------|
+| `LtrQueryClientYamlTestSuiteIT.java` | Narrowed index cleanup, updated security settings |
+| `10_manage.yml` | Added teardown, removed allowed_warnings |
+| `20_features.yml` | Removed allowed_warnings |
+| `30_featuresets.yml` | Removed allowed_warnings |
+| `40_models.yml` | Removed allowed_warnings |
+| `50_add_features_to_set.yml` | Removed allowed_warnings |
+| `60_create_model_from_set.yml` | Removed allowed_warnings |
+| `70_validation.yml` | Added teardown, removed allowed_warnings |
+| `80_search_w_partial_models.yml` | Added teardown, removed allowed_warnings |
+
+## Limitations
+
+- The `ignore: [400]` parameter for index creation may mask legitimate errors in some edge cases
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#256](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/256) | Allow warnings about directly accessing the .plugins-ml-config index |
+| [#259](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/259) | Feature/ltr system origin avoid warnings |
+
+## References
+
+- [Issue #245](https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/245): Integration test failures for v2.19.4
+- [Issue #249](https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/249): Integration test failures for v3.3.2
+- [Learning to Rank Documentation](https://docs.opensearch.org/3.0/search-plugins/ltr/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/learning/learning-to-rank.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -158,6 +158,7 @@
 ### Learning to Rank
 
 - [Learning to Rank Bugfixes](features/learning/learning-to-rank-bugfixes.md) - Legacy version ID fix, integration test stability, rescore-only SLTR logging fix
+- [Learning to Rank Enhancements](features/learning/learning-to-rank-enhancements.md) - Test infrastructure improvements, narrowed index cleanup scope for better test isolation
 
 ### ML Commons
 


### PR DESCRIPTION
## Summary

This PR adds documentation for Learning to Rank test infrastructure enhancements in v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/learning/learning-to-rank-enhancements.md`
- Feature report: Updated `docs/features/learning/learning-to-rank.md`

### Key Changes in v3.4.0
- **PR #256**: Temporary fix to allow `.plugins-ml-config` system index warnings during tests
- **PR #259**: Root cause fix - narrowed index cleanup scope to LTR-specific indexes only, improving test isolation and enabling parallel test execution

### Investigation Source
- GitHub Issue: #1630