### PR TITLE
docs: add ML Commons Enhancements report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -415,6 +415,7 @@
 - [ML Commons Connector and Model Validation](ml-commons/connector-model-validation.md)
 - [ML Commons Connector Blueprints](ml-commons/ml-commons-blueprints.md)
 - [ML Commons Documentation & Tutorials](ml-commons/ml-commons-documentation-tutorials.md)
+- [ML Commons Enhancements](ml-commons/ml-commons-enhancements.md)
 - [ML Commons Error Handling](ml-commons/ml-commons-error-handling.md)
 - [ML Commons Dependencies](ml-commons/ml-commons-dependencies.md)
 - [Global Resource Support](ml-commons/global-resource-support.md)

--- a/docs/features/ml-commons/ml-commons-enhancements.md
+++ b/docs/features/ml-commons/ml-commons-enhancements.md
@@ -1,0 +1,181 @@
+# ML Commons Enhancements
+
+## Summary
+
+ML Commons provides machine learning capabilities within OpenSearch, including support for local and remote model inference, connectors to external AI services, and batch processing. This document covers enhancements to connector security, resource access control, and batch task scalability.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "ML Commons Plugin"
+        REST[REST API Layer]
+        FILTER[Request Filter]
+        CONN[Connector Manager]
+        MODEL[Model Manager]
+        BATCH[Batch Task Manager]
+        RSC[Resource Sharing Client]
+    end
+    
+    subgraph "Security Plugin"
+        AUTH[Authentication]
+        AUTHZ[Authorization]
+        RS[Resource Sharing]
+    end
+    
+    subgraph "External Services"
+        OPENAI[OpenAI]
+        BEDROCK[Amazon Bedrock]
+        SAGEMAKER[SageMaker]
+    end
+    
+    REST --> FILTER
+    FILTER --> CONN
+    FILTER --> MODEL
+    CONN --> BATCH
+    MODEL --> RSC
+    RSC --> RS
+    CONN --> OPENAI
+    CONN --> BEDROCK
+    CONN --> SAGEMAKER
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| RestMLCreateConnectorAction | REST handler for connector creation with sensitive parameter filtering |
+| RestMLUpdateConnectorAction | REST handler for connector updates with sensitive parameter filtering |
+| RestMLRegisterModelAction | REST handler for model registration with credential filtering |
+| RestMLUpdateModelAction | REST handler for model updates with credential filtering |
+| ResourceSharingClient | Client for resource-level access control using resource types |
+| MLCommonsSettings | Cluster settings including batch task limits |
+
+### Sensitive Parameter Filtering
+
+ML Commons implements `RestRequestFilter` interface to declare sensitive fields that should be filtered from request logging and audit trails.
+
+#### Filtered Fields by API
+
+| API | Filtered Fields |
+|-----|-----------------|
+| Create Connector | `credential`, `*.Authorization` |
+| Update Connector | `credential`, `*.Authorization` |
+| Register Model | `connector.credential`, `*.Authorization` |
+| Update Model | `connector.credential`, `*.Authorization` |
+
+#### Implementation
+
+```java
+public class RestMLCreateConnectorAction extends BaseRestHandler 
+    implements RestRequestFilter {
+    
+    @Override
+    public Set<String> getFilteredFields() {
+        return Set.of("credential", "*.Authorization");
+    }
+}
+```
+
+### Resource Sharing Integration
+
+ML Commons integrates with the security plugin's resource sharing framework for fine-grained access control on model groups.
+
+#### Resource Type vs Index
+
+The resource sharing client now uses resource type identifiers instead of index names, enabling:
+- Multiple resource types per index
+- Consistent resource identification across plugins
+- Future support for hierarchical resource relationships
+
+```java
+// Resource type constant
+public static final String ML_MODEL_GROUP_RESOURCE_TYPE = "ml_model_group";
+
+// Usage in access control
+resourceSharingClient.getAccessibleResourceIds(
+    ML_MODEL_GROUP_RESOURCE_TYPE, 
+    listener
+);
+```
+
+### Configuration
+
+| Setting | Description | Default | Range |
+|---------|-------------|---------|-------|
+| `plugins.ml_commons.max_batch_inference_tasks` | Maximum concurrent batch inference tasks | 100 | [0, 10000] |
+| `plugins.ml_commons.max_batch_ingestion_tasks` | Maximum concurrent batch ingestion tasks | 100 | [0, 10000] |
+
+### Usage Example
+
+#### Connector with Credentials
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "OpenAI GPT-4 Connector",
+  "description": "Connector for OpenAI chat completions",
+  "version": 1,
+  "protocol": "http",
+  "parameters": {
+    "endpoint": "api.openai.com",
+    "model": "gpt-4"
+  },
+  "credential": {
+    "openAI_key": "sk-your-api-key"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://api.openai.com/v1/chat/completions",
+      "headers": {
+        "Authorization": "Bearer ${credential.openAI_key}",
+        "Content-Type": "application/json"
+      },
+      "request_body": "{ \"model\": \"${parameters.model}\", \"messages\": ${parameters.messages} }"
+    }
+  ]
+}
+```
+
+#### Batch Inference Configuration
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "plugins.ml_commons.max_batch_inference_tasks": 1000,
+    "plugins.ml_commons.max_batch_ingestion_tasks": 1000
+  }
+}
+```
+
+## Limitations
+
+- Sensitive parameter filtering applies only to REST request logging, not to stored data
+- Resource type support requires security plugin v3.4.0 or later
+- Batch task limits are per-cluster, not per-node
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#4308](https://github.com/opensearch-project/ml-commons/pull/4308) | Declare credential and *.Authorization as sensitive param |
+| v3.4.0 | [#4333](https://github.com/opensearch-project/ml-commons/pull/4333) | Pass resourceType instead of resourceIndex to resourceSharingClient |
+| v3.4.0 | [#4474](https://github.com/opensearch-project/ml-commons/pull/4474) | Allow higher maximum number of batch inference job tasks |
+
+## References
+
+- [ML Commons Cluster Settings](https://docs.opensearch.org/3.0/ml-commons-plugin/cluster-settings/): Full list of configuration options
+- [Create Connector API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/connector-apis/create-connector/): Connector creation documentation
+- [Connectors Overview](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/connectors/): Remote model connector concepts
+- [Batch Predict API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/model-apis/batch-predict/): Batch inference documentation
+- [Asynchronous Batch Ingestion](https://docs.opensearch.org/3.0/ml-commons-plugin/remote-models/async-batch-ingestion/): Batch ingestion documentation
+- [Security PR #5713](https://github.com/opensearch-project/security/pull/5713): Resource type support in security plugin
+
+## Change History
+
+- **v3.4.0** (2026-01-11): Added sensitive parameter filtering for connector APIs, resource type support for resource sharing client, increased batch task limits (default: 100, max: 10,000)

--- a/docs/releases/v3.4.0/features/ml-commons/ml-commons-enhancements.md
+++ b/docs/releases/v3.4.0/features/ml-commons/ml-commons-enhancements.md
@@ -1,0 +1,135 @@
+# ML Commons Enhancements
+
+## Summary
+
+OpenSearch v3.4.0 introduces several enhancements to ML Commons focused on security, scalability, and multi-resource support. Key improvements include marking sensitive connector parameters for filtering, updating resource sharing client to use resource types instead of indexes, and significantly increasing batch inference/ingestion task limits.
+
+## Details
+
+### What's New in v3.4.0
+
+#### Sensitive Parameter Filtering in Connector APIs
+
+The connector and model registration APIs now implement `RestRequestFilter` to mark sensitive parameters that should be filtered from logs and audit trails. This prevents accidental exposure of credentials and authorization tokens.
+
+**Filtered Fields:**
+- `credential` - API keys and secrets in connector configurations
+- `*.Authorization` - Authorization headers in connector actions
+- `connector.credential` - Nested credentials in model registration
+
+**Affected APIs:**
+- Create Connector (`POST /_plugins/_ml/connectors/_create`)
+- Update Connector (`PUT /_plugins/_ml/connectors/{connector_id}`)
+- Register Model (`POST /_plugins/_ml/models/_register`)
+- Update Model (`PUT /_plugins/_ml/models/{model_id}`)
+
+#### Resource Sharing Client Enhancement
+
+The resource sharing client now accepts resource type instead of resource index name. This change supports the security plugin's ability to handle multiple resource types within the same index (similar to Dashboards saved objects).
+
+**Technical Change:**
+```java
+// Before
+rsc.getAccessibleResourceIds(ML_MODEL_GROUP_INDEX, listener);
+rsc.verifyAccess(modelGroupId, ML_MODEL_GROUP_INDEX, action, listener);
+
+// After  
+rsc.getAccessibleResourceIds(ML_MODEL_GROUP_RESOURCE_TYPE, listener);
+rsc.verifyAccess(modelGroupId, ML_MODEL_GROUP_RESOURCE_TYPE, action, listener);
+```
+
+This enables future support for more granular resource-level access control.
+
+#### Increased Batch Task Limits
+
+Based on customer feedback, the maximum limits for batch inference and batch ingestion tasks have been significantly increased to support larger workloads.
+
+| Setting | Previous Default | New Default | Previous Max | New Max |
+|---------|------------------|-------------|--------------|---------|
+| `plugins.ml_commons.max_batch_inference_tasks` | 10 | 100 | 500 | 10,000 |
+| `plugins.ml_commons.max_batch_ingestion_tasks` | 10 | 100 | 500 | 10,000 |
+
+### Configuration
+
+#### Batch Task Settings
+
+```yaml
+# opensearch.yml
+plugins.ml_commons.max_batch_inference_tasks: 100   # Default: 100, Range: [0, 10000]
+plugins.ml_commons.max_batch_ingestion_tasks: 100   # Default: 100, Range: [0, 10000]
+```
+
+These settings are dynamic and can be updated at runtime:
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "plugins.ml_commons.max_batch_inference_tasks": 500,
+    "plugins.ml_commons.max_batch_ingestion_tasks": 500
+  }
+}
+```
+
+### Usage Example
+
+#### Creating a Connector with Sensitive Credentials
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "OpenAI Connector",
+  "description": "Connector for OpenAI GPT models",
+  "version": 1,
+  "protocol": "http",
+  "parameters": {
+    "endpoint": "api.openai.com",
+    "model": "gpt-4"
+  },
+  "credential": {
+    "openAI_key": "sk-..."
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://api.openai.com/v1/chat/completions",
+      "headers": {
+        "Authorization": "Bearer ${credential.openAI_key}"
+      }
+    }
+  ]
+}
+```
+
+The `credential` and `Authorization` fields are now automatically filtered from request logging.
+
+### Migration Notes
+
+- **No breaking changes** - Existing connectors and models continue to work
+- **Security improvement** - Sensitive parameters are now filtered by default
+- **Capacity planning** - Review batch task limits if running large-scale inference workloads
+
+## Limitations
+
+- Sensitive parameter filtering only applies to REST API request logging; stored credentials remain encrypted in the connector index
+- Resource type changes require corresponding security plugin updates (v3.4.0+)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4308](https://github.com/opensearch-project/ml-commons/pull/4308) | Declare credential and *.Authorization as sensitive param in create connector API |
+| [#4333](https://github.com/opensearch-project/ml-commons/pull/4333) | Pass resourceType instead of resourceIndex to resourceSharingClient |
+| [#4474](https://github.com/opensearch-project/ml-commons/pull/4474) | Allow higher maximum number of batch inference job tasks |
+
+## References
+
+- [ML Commons Cluster Settings](https://docs.opensearch.org/3.0/ml-commons-plugin/cluster-settings/): Configuration options
+- [Create Connector API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/connector-apis/create-connector/): Connector creation documentation
+- [Batch Predict API](https://docs.opensearch.org/3.0/ml-commons-plugin/api/model-apis/batch-predict/): Batch inference documentation
+- [Security PR #5713](https://github.com/opensearch-project/security/pull/5713): Related security plugin changes for resource type support
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/ml-commons/ml-commons-enhancements.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -163,6 +163,7 @@
 
 ### ML Commons
 
+- [ML Commons Enhancements](features/ml-commons/ml-commons-enhancements.md) - Sensitive parameter filtering for connector APIs, resource type support for resource sharing, increased batch task limits (default: 100, max: 10,000)
 - [ML Commons Bugfixes](features/ml-commons/ml-commons-bugfixes.md) - Agent type update validation, QueryPlanningTool model ID parsing, tool config empty values, agentic memory multi-node fixes
 
 ### Skills


### PR DESCRIPTION
## Summary

This PR adds documentation for ML Commons Enhancements in OpenSearch v3.4.0.

### Changes in v3.4.0

1. **Sensitive Parameter Filtering** - Connector and model APIs now implement `RestRequestFilter` to mark `credential` and `*.Authorization` fields as sensitive, preventing accidental exposure in logs and audit trails.

2. **Resource Sharing Client Enhancement** - Updated to use resource type instead of resource index name, enabling support for multiple resource types within the same index.

3. **Increased Batch Task Limits** - Based on customer feedback, batch inference and ingestion task limits increased:
   - Default: 10 → 100
   - Maximum: 500 → 10,000

### Reports Created

- Release report: `docs/releases/v3.4.0/features/ml-commons/ml-commons-enhancements.md`
- Feature report: `docs/features/ml-commons/ml-commons-enhancements.md`

### Related PRs

- [#4308](https://github.com/opensearch-project/ml-commons/pull/4308) - Sensitive parameter filtering
- [#4333](https://github.com/opensearch-project/ml-commons/pull/4333) - Resource type support
- [#4474](https://github.com/opensearch-project/ml-commons/pull/4474) - Batch task limit increase

Closes #1628