### PR TITLE
docs: add Query Sets & Judgment Lists report for v3.4.0

### DIFF
--- a/docs/features/dashboards-search-relevance/search-comparison.md
+++ b/docs/features/dashboards-search-relevance/search-comparison.md
@@ -143,6 +143,7 @@ Query 2 - Boosted field:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#687](https://github.com/opensearch-project/dashboards-search-relevance/pull/687) | Added support for filtering Query Sets by GUID |
 | v3.3.0 | [#632](https://github.com/opensearch-project/dashboards-search-relevance/pull/632) | Improve color coding for search result comparison |
 | v3.3.0 | [#637](https://github.com/opensearch-project/dashboards-search-relevance/pull/637) | Allow more than 10 results in pairwise comparison view |
 | v3.3.0 | [#645](https://github.com/opensearch-project/dashboards-search-relevance/pull/645) | Show first 10,000 experiment results |
@@ -160,6 +161,7 @@ Query 2 - Boosted field:
 
 ## Change History
 
+- **v3.4.0** (2026-03-11): Added support for filtering Query Sets by GUID, introduced strongly typed `QuerySetItem` interface
 - **v3.3.0** (2026-01-14): Improved color coding for visual comparison, fixed pairwise comparison to show more than 10 results, added support for large experiment results up to 10,000
 - **v3.1.0** (2025-06-11): Fixed schema validation in POST Query Sets endpoint - added missing `querySetSize` parameter
 - **v2.17.0** (2024-09-17): Added Compare Queries card to Search use case overview page via Content Management integration

--- a/docs/releases/v3.4.0/features/dashboards-search-relevance/query-sets-judgment-lists.md
+++ b/docs/releases/v3.4.0/features/dashboards-search-relevance/query-sets-judgment-lists.md
@@ -1,0 +1,83 @@
+# Query Sets & Judgment Lists
+
+## Summary
+
+This enhancement adds support for filtering Query Sets by their GUID (Globally Unique Identifier) in the Search Relevance Workbench. Previously, filtering only matched against the Query Set name, making it difficult to look up Query Sets using their unique identifier even though the backend returned this field. This improvement enables users to quickly locate specific Query Sets by searching for any part of their GUID.
+
+## Details
+
+### What's New in v3.4.0
+
+- **GUID Filtering**: Query Sets can now be filtered by their `id` field (GUID) in addition to the `name` field
+- **Strongly Typed Interface**: Introduced a new `QuerySetItem` TypeScript interface for better type safety
+- **Aligned Structure**: The `QuerySetItem` interface now aligns with the existing `SearchConfigurationItem` structure for consistency
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `QuerySetItem` | New TypeScript interface defining the structure of Query Set items with `id`, `name`, `sampling`, `description`, `timestamp`, and `numQueries` fields |
+
+#### Code Changes
+
+The filtering logic in `useQuerySetList` hook was updated to include GUID matching:
+
+**Before:**
+```typescript
+const filteredList = search
+  ? list.filter((item) => item.name.toLowerCase().includes(search.toLowerCase()))
+  : list;
+```
+
+**After:**
+```typescript
+const filteredList: QuerySetItem[] = search
+  ? list.filter((qs: QuerySetItem) => {
+      const s = search.toLowerCase();
+      return qs.name.toLowerCase().includes(s) || qs.id.toLowerCase().includes(s);
+    })
+  : list;
+```
+
+### Usage Example
+
+Users can now search for Query Sets using either the name or GUID:
+
+```
+# Search by name
+"My Query Set"
+
+# Search by GUID (partial match supported)
+"guid-12345"
+
+# Search by partial GUID
+"98765"
+```
+
+### Migration Notes
+
+No migration required. This is a backward-compatible enhancement that extends existing filtering functionality.
+
+## Limitations
+
+- GUID is not displayed in the Query Sets table UI, but can be used for filtering
+- Filtering is case-insensitive and supports partial matches
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#687](https://github.com/opensearch-project/dashboards-search-relevance/pull/687) | Added support for filtering Query Sets by GUID and aligned QuerySetItem typing |
+
+## References
+
+- [Issue #679](https://github.com/opensearch-project/dashboards-search-relevance/issues/679): Feature request for GUID filtering
+- [Issue #663](https://github.com/opensearch-project/dashboards-search-relevance/issues/663): Parent issue for Query Set improvements
+- [Documentation](https://docs.opensearch.org/latest/search-plugins/search-relevance/index/): Search Relevance overview
+- [Blog: Measuring and improving search quality metrics](https://opensearch.org/blog/measuring-and-improving-search-quality-metrics/): Detailed guide on using Query Sets and Judgment Lists
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-search-relevance/search-comparison.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -121,6 +121,7 @@
 
 ### Search Relevance
 
+- [Query Sets & Judgment Lists](features/dashboards-search-relevance/query-sets-judgment-lists.md) - GUID filtering support for Query Sets with strongly typed QuerySetItem interface
 - [Search Relevance CI/Tests](features/search-relevance/ci-tests.md) - Test dependency fixes, JDWP debugging support, deprecated API removal, and test code cleanups
 - [Search Relevance Bugfixes](features/search-relevance/search-relevance-bugfixes.md) - Fix query serialization for plugins (e.g., Learning to Rank) that extend OpenSearch's DSL
 - [Hybrid Optimizer Bugfixes](features/search-relevance/hybrid-optimizer-bugfixes.md) - Fix floating-point precision in weight generation and error handling for deleted judgments


### PR DESCRIPTION
## Summary

This PR adds documentation for the Query Sets & Judgment Lists enhancement in OpenSearch v3.4.0.

### Changes

**Release Report** (`docs/releases/v3.4.0/features/dashboards-search-relevance/query-sets-judgment-lists.md`):
- Documents the new GUID filtering capability for Query Sets
- Explains the new `QuerySetItem` TypeScript interface
- Includes code examples showing the filtering logic change

**Feature Report Update** (`docs/features/dashboards-search-relevance/search-comparison.md`):
- Added v3.4.0 entry to Related PRs table
- Added v3.4.0 entry to Change History

**Release Index Update** (`docs/releases/v3.4.0/index.md`):
- Added link to the new release report under Search Relevance section

### Key Changes in v3.4.0

- Query Sets can now be filtered by GUID in addition to name
- New strongly typed `QuerySetItem` interface for better type safety
- Case-insensitive partial matching supported for both name and GUID

### Resources Used

- PR: [#687](https://github.com/opensearch-project/dashboards-search-relevance/pull/687)
- Issue: [#679](https://github.com/opensearch-project/dashboards-search-relevance/issues/679)
- Docs: https://docs.opensearch.org/latest/search-plugins/search-relevance/index/
- Blog: https://opensearch.org/blog/measuring-and-improving-search-quality-metrics/