### PR TITLE
docs: add observability-integrations report for v3.4.0

### DIFF
--- a/docs/features/observability/observability-integrations.md
+++ b/docs/features/observability/observability-integrations.md
@@ -113,6 +113,7 @@ curl -O https://github.com/opensearch-project/opensearch-catalog/releases/downlo
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#2530](https://github.com/opensearch-project/dashboards-observability/pull/2530) | Clean up interface for integrations static serving |
 | v3.0.0 | [#2387](https://github.com/opensearch-project/dashboards-observability/pull/2387) | Improve error handling when setting up and reading a new integration |
 | v3.0.0 | [#2376](https://github.com/opensearch-project/dashboards-observability/pull/2376) | Improve the test results for Integrations internals |
 
@@ -124,4 +125,5 @@ curl -O https://github.com/opensearch-project/opensearch-catalog/releases/downlo
 
 ## Change History
 
+- **v3.4.0** (2026-01-14): Improved static file serving with image type validation and SVG sanitization
 - **v3.0.0** (2025-05-06): Improved error handling and test result quality for integration configuration parsing

--- a/docs/releases/v3.4.0/features/dashboards-observability/observability-integrations.md
+++ b/docs/releases/v3.4.0/features/dashboards-observability/observability-integrations.md
@@ -1,0 +1,98 @@
+# Observability Integrations
+
+## Summary
+
+This enhancement improves the static file serving interface for integrations by adding proper image type validation and SVG sanitization. Previously, the integrations router could serve non-image files, causing rendering issues when displayed in `<img>` tags. This change introduces a clean error response for unsupported file types and sanitizes SVG content to prevent XSS attacks.
+
+## Details
+
+### What's New in v3.4.0
+
+- Added `serveStaticImage()` function to handle static file serving with proper content type validation
+- Implemented SVG sanitization using `isomorphic-dompurify` to prevent XSS vulnerabilities
+- Added explicit support for common image formats: GIF, JPEG, PNG, TIFF, WebP, AVIF
+- Returns HTTP 400 error for unsupported image types instead of serving potentially malicious content
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `serveStaticImage()` | New function that validates image types and sanitizes SVG content before serving |
+| `RequestError` interface | TypeScript interface for consistent error handling |
+
+#### Security Improvements
+
+The change addresses a security concern where arbitrary files could be served through the static endpoint:
+
+```typescript
+export const serveStaticImage = (
+  path: string,
+  content: Buffer,
+  response: OpenSearchDashboardsResponseFactory
+): OpenSearchDashboardsResponse => {
+  const mtype = mime.getType(path);
+  switch (mime.getType(path)) {
+    case 'image/gif':
+    case 'image/jpeg':
+    case 'image/png':
+    case 'image/tiff':
+    case 'image/webp':
+    case 'image/avif':
+      return response.ok({
+        headers: { 'Content-Type': mtype },
+        body: content,
+      });
+    case 'image/svg+xml':
+      return response.ok({
+        headers: { 'Content-Type': mtype },
+        body: DOMPurify.sanitize(content.toString('utf8')),
+      });
+    default:
+      return response.custom({
+        body: `not a supported image type: ${mtype}`,
+        statusCode: 400,
+      });
+  }
+};
+```
+
+#### New Dependencies
+
+| Dependency | Version | Purpose |
+|------------|---------|---------|
+| `isomorphic-dompurify` | ^2.33.0 | Server-side SVG sanitization |
+
+### Usage Example
+
+The static file endpoint now properly validates and serves integration assets:
+
+```
+GET /api/integrations/repository/{id}/static/{path}
+```
+
+- For supported image types (GIF, JPEG, PNG, etc.): Returns the image with correct Content-Type
+- For SVG files: Returns sanitized SVG content (scripts and malicious elements removed)
+- For unsupported types: Returns HTTP 400 with error message
+
+## Limitations
+
+- Only image file types are supported for static serving
+- SVG sanitization may remove legitimate interactive elements
+- BMP and other less common image formats are not supported
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2530](https://github.com/opensearch-project/dashboards-observability/pull/2530) | Clean up interface for integrations static serving |
+
+## References
+
+- [Integrations in OpenSearch Dashboards](https://docs.opensearch.org/3.0/dashboards/integrations/index/): Official documentation
+- [DOMPurify](https://github.com/cure53/DOMPurify): XSS sanitization library
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/observability/observability-integrations.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -109,6 +109,7 @@
 ### Dashboards Observability
 
 - [Observability CI/Tests](features/dashboards-observability/observability-ci-tests.md) - CI workflow updates for 3.4.0, snapshot repository migration, test snapshot updates
+- [Observability Integrations](features/dashboards-observability/observability-integrations.md) - Static file serving cleanup with image type validation and SVG sanitization
 
 ### Dashboards Reporting
 


### PR DESCRIPTION
## Summary

Add release report for Observability Integrations enhancement in v3.4.0.

### Changes
- **Release report**: `docs/releases/v3.4.0/features/dashboards-observability/observability-integrations.md`
- **Feature report update**: Added v3.4.0 entry to `docs/features/observability/observability-integrations.md`
- **Release index update**: Added link to new report

### Key Changes in v3.4.0
- Added `serveStaticImage()` function for proper image type validation
- Implemented SVG sanitization using `isomorphic-dompurify` to prevent XSS
- Added explicit support for common image formats (GIF, JPEG, PNG, TIFF, WebP, AVIF)
- Returns HTTP 400 error for unsupported image types

### Related PR
- opensearch-project/dashboards-observability#2530