### PR TITLE
docs: add notifications-ux report for v3.4.0

### DIFF
--- a/docs/features/dashboards-notifications/dashboards-notifications.md
+++ b/docs/features/dashboards-notifications/dashboards-notifications.md
@@ -89,6 +89,7 @@ The plugin uses the following URL parameters for state management:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#393](https://github.com/opensearch-project/dashboards-notifications/pull/393) | Fix channel name edit refetching on every keystroke |
 | v2.18.0 | [#256](https://github.com/opensearch-project/dashboards-notifications/pull/256) | Fit & Finish - semantic headers, text sizes, context menus |
 | v2.18.0 | [#263](https://github.com/opensearch-project/dashboards-notifications/pull/263) | Fit & Finish UX Fixes - spacing, full-width content |
 | v2.18.0 | [#270](https://github.com/opensearch-project/dashboards-notifications/pull/270) | Fit & Finish UX Fixes Pt 2 - filter separation, default pill |
@@ -110,6 +111,7 @@ The plugin uses the following URL parameters for state management:
 
 ## Change History
 
+- **v3.4.0** (2026-01-14): Fixed channel name edit UX regression - prevented unnecessary API refetching on every keystroke when editing channel names
 - **v2.18.0** (2024-11-05): Fit & Finish UX improvements - standardized semantic headers (H1/H2/H3), consistent text sizes, smaller context menus, 16px content-to-header spacing, full-width content sections, separated table filters, added default pill to encryption method dropdown. Also fixed default data source selection and typo in recipient groups UI.
 - **v2.17.0** (2024-09-17): Changed navigation parent item name to "Notification channels", added description for left navigation, fixed link checker CI, added dataSourceId persistence for new navigation
 - **v2.15.0**: Bug fixes for MDS support in getServerFeatures API

--- a/docs/releases/v3.4.0/features/dashboards-notifications/notifications-ux.md
+++ b/docs/releases/v3.4.0/features/dashboards-notifications/notifications-ux.md
@@ -1,0 +1,77 @@
+# Notifications UX
+
+## Summary
+
+This release fixes a UX regression in the OpenSearch Dashboards Notifications plugin where editing a channel name would trigger unnecessary API calls on every keystroke, causing the edit page to refresh and lose user input.
+
+## Details
+
+### What's New in v3.4.0
+
+A bug introduced in PR #257 caused the channel edit page to refetch the channel configuration on every keystroke when updating the channel name field. This resulted in:
+
+- Excessive API calls to the backend
+- The edit page refreshing with current values, overwriting user input
+- Poor user experience when trying to rename channels
+
+### Technical Changes
+
+#### Root Cause
+
+The issue was in `CreateChannel.tsx` where the `useEffect` hook had `name` in its dependency array. Since the name field is bound to component state, every keystroke triggered the effect, which called `getChannel()` to fetch the current configuration from the backend.
+
+#### Fix Implementation
+
+The fix separates the initial data loading from the breadcrumb updates:
+
+```typescript
+// Initial load: fetch channel data and set up page
+useEffect(() => {
+  window.scrollTo(0, 0);
+  if (props.edit) {
+    getChannel();
+  }
+}, []);
+
+// Update breadcrumbs when name changes
+useEffect(() => {
+  // ... breadcrumb logic
+  setBreadcrumbs(breadcrumbs);
+}, [name, props.edit]);
+```
+
+Key changes:
+- Initial data fetch now runs only once on component mount (empty dependency array)
+- Breadcrumb updates still respond to name changes but no longer trigger data refetch
+- Removed `getUseUpdatedUx()` from dependencies as it's not needed for this effect
+
+### Usage Example
+
+After this fix, users can edit channel names normally:
+
+1. Navigate to Notifications → Channels
+2. Click on a channel to view details
+3. Click Actions → Edit
+4. Update the channel name field - input is preserved as expected
+5. Click Save to persist changes
+
+## Limitations
+
+- This fix is specific to the channel name field editing flow
+- Other fields in the edit form were not affected by this bug
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#393](https://github.com/opensearch-project/dashboards-notifications/pull/393) | Avoid refetching channel config on every keystroke for name update |
+| [#257](https://github.com/opensearch-project/dashboards-notifications/pull/257) | Edit page changes as per new page header (introduced the regression) |
+
+## References
+
+- [OpenSearch Notifications Documentation](https://docs.opensearch.org/latest/observing-your-data/notifications/index/)
+- [dashboards-notifications Repository](https://github.com/opensearch-project/dashboards-notifications)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-notifications/dashboards-notifications.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -115,6 +115,10 @@
 
 - [Reporting Bugfixes](features/dashboards-reporting/reporting-bugfixes.md) - Security fix for CVE-2025-57810 (jspdf bump) and null/undefined datetime handling in CSV reports
 
+### Dashboards Notifications
+
+- [Notifications UX](features/dashboards-notifications/notifications-ux.md) - Fix channel name edit refetching on every keystroke
+
 ### User Behavior Insights
 
 - [User Behavior Insights Build](features/user-behavior-insights/user-behavior-insights-build.md) - Migrate Maven snapshot publishing from Sonatype to S3-backed repository


### PR DESCRIPTION
## Summary

Add release report for Notifications UX fix in v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/dashboards-notifications/notifications-ux.md`
- Feature report: `docs/features/dashboards-notifications/dashboards-notifications.md` (updated)

### Key Changes in v3.4.0
- Fixed channel name edit UX regression where editing triggered unnecessary API refetching on every keystroke
- The fix separates initial data loading from breadcrumb updates in the React component

### Resources Used
- PR: [#393](https://github.com/opensearch-project/dashboards-notifications/pull/393)
- Related PR: [#257](https://github.com/opensearch-project/dashboards-notifications/pull/257) (introduced the regression)