### PR TITLE
docs: add PPL Eval Functions report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -349,6 +349,7 @@
 - [PPL Aggregate Functions](sql/ppl-aggregate-functions.md)
 - [PPL Aggregation Pushdown](sql/ppl-aggregation-pushdown.md)
 - [PPL Documentation](sql/ppl-documentation.md)
+- [PPL Eval Functions](sql/ppl-eval-functions.md)
 - [PPL Patterns Command](sql/ppl-patterns-command.md)
 - [PPL Query Enhancements](sql/ppl-query-enhancements.md)
 - [PPL Query Optimization](sql/ppl-query-optimization.md)

--- a/docs/features/sql/ppl-eval-functions.md
+++ b/docs/features/sql/ppl-eval-functions.md
@@ -1,0 +1,208 @@
+# PPL Eval Functions
+
+## Summary
+
+PPL (Piped Processing Language) eval functions provide data transformation capabilities within OpenSearch queries. These functions enable users to manipulate multivalue arrays, convert data types, and perform string operations directly in PPL queries. The eval functions are particularly useful for log analysis, data processing pipelines, and complex field transformations.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "PPL Query Engine"
+        Parser[PPL Parser]
+        Analyzer[Query Analyzer]
+        Calcite[Calcite Engine]
+    end
+    
+    subgraph "Eval Functions"
+        MV[Multivalue Functions]
+        Conv[Conversion Functions]
+        Str[String Functions]
+    end
+    
+    subgraph "Multivalue Functions"
+        mvappend[mvappend]
+        mvindex[mvindex]
+        mvdedup[mvdedup]
+    end
+    
+    subgraph "Conversion Functions"
+        tostring[tostring]
+    end
+    
+    subgraph "String Functions"
+        regexp_replace[regexp_replace]
+        regexp_match[regexp_match]
+    end
+    
+    Parser --> Analyzer
+    Analyzer --> Calcite
+    Calcite --> MV
+    Calcite --> Conv
+    Calcite --> Str
+    MV --> mvappend
+    MV --> mvindex
+    MV --> mvdedup
+    Conv --> tostring
+    Str --> regexp_replace
+    Str --> regexp_match
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `mvappend` | Combines multiple values/arrays into a single array |
+| `mvindex` | Extracts elements from arrays by index or range |
+| `mvdedup` | Removes duplicate values from arrays (order-preserving) |
+| `tostring` | Converts values to strings with optional formatting |
+| `regexp_replace` | Replaces text matching regex patterns (alias for `replace`) |
+| `regexp_match` | Matches text against regex patterns |
+
+### Function Reference
+
+#### mvappend(value1, value2, ...)
+
+Combines all arguments into a single array.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| value1, value2, ... | any | Values, arrays, or null to combine |
+
+**Returns**: Array containing all input values flattened
+
+```ppl
+source=index | eval combined = mvappend(array('a', 'b'), 'c', array('d'))
+# Result: ['a', 'b', 'c', 'd']
+```
+
+#### mvindex(array, index) / mvindex(array, start, end)
+
+Returns element(s) from an array by index or range.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| array | array | Input array |
+| index | integer | Single index (0-based, negative supported) |
+| start | integer | Start index for range (inclusive) |
+| end | integer | End index for range (inclusive) |
+
+**Indexing Rules**:
+- 0-based indexing (first element at index 0)
+- Negative indexing (-1 = last, -2 = second-to-last)
+- Range is inclusive on both ends
+
+```ppl
+# Single element
+source=people | eval result = mvindex(array('a','b','c','d','e'), 1)
+# Result: b
+
+# Negative index
+source=people | eval result = mvindex(array('a','b','c','d','e'), -1)
+# Result: e
+
+# Range
+source=people | eval result = mvindex(array(1,2,3,4,5), 1, 3)
+# Result: [2, 3, 4]
+```
+
+#### mvdedup(array)
+
+Removes duplicate values from an array while preserving order.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| array | array | Input array with potential duplicates |
+
+**Returns**: Array with duplicates removed (first occurrence kept)
+
+```ppl
+source=index | eval result = mvdedup(array(1, 2, 2, 3, 1, 4))
+# Result: [1, 2, 3, 4]
+```
+
+#### tostring(value, format)
+
+Converts a value to a string with optional formatting.
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| value | any | Value to convert |
+| format | string | Optional format: "binary", "hex", "commas", "duration" |
+
+**Format Options**:
+
+| Format | Description | Example |
+|--------|-------------|---------|
+| `"binary"` | Binary representation | `tostring(9, "binary")` → `"1001"` |
+| `"hex"` | Hexadecimal representation | `tostring(15, "hex")` → `"0xF"` |
+| `"commas"` | Number with commas (2 decimal places) | `tostring(12345.6789, "commas")` → `"12,345.68"` |
+| `"duration"` | Seconds to HH:MM:SS | `tostring(615, "duration")` → `"00:10:15"` |
+
+**Boolean Conversion**: Returns `"True"` or `"False"`
+
+```ppl
+# Combined example
+... | eval n = tostring(1==1) + " " + tostring(15, "hex") + " " + tostring(12345.6789, "commas")
+# Result: "True 0xF 12,345.68"
+```
+
+#### regexp_replace(string, pattern, replacement)
+
+Replaces text matching a regex pattern. Alias for `replace()`.
+
+```ppl
+source=index | eval result = regexp_replace(field, "pattern", "replacement")
+```
+
+### Usage Examples
+
+#### Log Processing with Multivalue Functions
+
+```ppl
+source=logs 
+| eval tags = mvappend(existing_tags, extracted_tags)
+| eval unique_tags = mvdedup(tags)
+| eval first_tag = mvindex(unique_tags, 0)
+```
+
+#### Data Formatting
+
+```ppl
+source=metrics
+| eval formatted_value = tostring(value, "commas")
+| eval duration_str = tostring(elapsed_seconds, "duration")
+| eval binary_flags = tostring(flags, "binary")
+```
+
+## Limitations
+
+- `mvindex` range is inclusive on both ends (differs from Python-style slicing)
+- `tostring` format argument only applies to numeric values
+- Functions require the Calcite-based PPL engine
+- `mvdedup` preserves first occurrence only; cannot preserve last
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#4438](https://github.com/opensearch-project/sql/pull/4438) | Add `mvappend` function |
+| v3.4.0 | [#4497](https://github.com/opensearch-project/sql/pull/4497) | Support `tostring()` eval function |
+| v3.4.0 | [#4765](https://github.com/opensearch-project/sql/pull/4765) | Add `regexp_replace()` as alias |
+| v3.4.0 | [#4794](https://github.com/opensearch-project/sql/pull/4794) | Support `mvindex` eval function |
+| v3.4.0 | [#4828](https://github.com/opensearch-project/sql/pull/4828) | Support `mvdedup` eval function |
+
+## References
+
+- [Issue #4492](https://github.com/opensearch-project/sql/issues/4492): tostring implementation request
+- [Issue #4433](https://github.com/opensearch-project/sql/issues/4433): mvappend function request
+- [Issue #4764](https://github.com/opensearch-project/sql/issues/4764): regexp_replace alias request
+- [RFC #4287](https://github.com/opensearch-project/sql/issues/4287): tostring function RFC
+- [OpenSearch PPL Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/ppl/index/)
+- [OpenSearch SQL Functions](https://docs.opensearch.org/3.0/search-plugins/sql/functions/)
+
+## Change History
+
+- **v3.4.0** (2026-01-11): Added `mvappend`, `mvindex`, `mvdedup`, `tostring`, and `regexp_replace` functions

--- a/docs/releases/v3.4.0/features/sql/ppl-eval-functions.md
+++ b/docs/releases/v3.4.0/features/sql/ppl-eval-functions.md
@@ -1,0 +1,130 @@
+# PPL Eval Functions
+
+## Summary
+
+OpenSearch v3.4.0 adds several new eval functions to PPL (Piped Processing Language) for working with multivalue arrays and string conversion. These functions enhance data transformation capabilities within PPL queries, enabling users to manipulate arrays, remove duplicates, extract subsets, and convert values to strings with various formatting options.
+
+## Details
+
+### What's New in v3.4.0
+
+This release introduces four new eval functions and one function alias:
+
+| Function | Description |
+|----------|-------------|
+| `mvappend(value1, value2, ...)` | Combines multiple values or arrays into a single array |
+| `mvindex(array, index)` / `mvindex(array, start, end)` | Returns element(s) from an array by index or range |
+| `mvdedup(array)` | Removes duplicate values from an array (order-preserving) |
+| `tostring(value, format)` | Converts values to strings with optional formatting |
+| `regexp_replace()` | Alias for `replace()` function |
+
+### Technical Changes
+
+#### New Multivalue Functions
+
+**mvappend** - Combines all arguments into a single array:
+- Each argument can be a value, an array, or null
+- Useful for merging extracted fields with existing fields (e.g., in `spath` command)
+
+**mvindex** - Returns array elements by index:
+- Supports 0-based indexing (first element at index 0)
+- Supports negative indexing (-1 = last element, -2 = second-to-last)
+- Range access is inclusive (start to end)
+
+**mvdedup** - Removes duplicates from arrays:
+- Order-preserving: keeps first occurrence of each value
+- Empty arrays return empty arrays
+
+#### String Conversion Function
+
+**tostring** - Converts values to strings with formatting:
+- Supports format options: `"binary"`, `"hex"`, `"commas"`, `"duration"`
+- Boolean values return `"True"` or `"False"`
+
+#### Function Alias
+
+**regexp_replace** - Added as alias for `replace()`:
+- Also renamed `regex_match()` to `regexp_match()` (keeping `regex_match()` as synonym)
+
+### Usage Examples
+
+#### mvappend
+```ppl
+source=index | eval combined = mvappend(array('a', 'b'), 'c', array('d'))
+# Returns: ['a', 'b', 'c', 'd']
+```
+
+#### mvindex - Single Element
+```ppl
+source=people | eval array = array('a', 'b', 'c', 'd', 'e'), result = mvindex(array, 1)
+# Returns: b
+
+source=people | eval array = array('a', 'b', 'c', 'd', 'e'), result = mvindex(array, -1)
+# Returns: e
+```
+
+#### mvindex - Range Access
+```ppl
+source=people | eval array = array(1, 2, 3, 4, 5), result = mvindex(array, 1, 3)
+# Returns: [2, 3, 4]
+
+source=people | eval array = array(1, 2, 3, 4, 5), result = mvindex(array, -3, -1)
+# Returns: [3, 4, 5]
+```
+
+#### mvdedup
+```ppl
+source=index | eval result = mvdedup(array(1, 2, 2, 3, 1, 4))
+# Returns: [1, 2, 3, 4]
+```
+
+#### tostring
+```ppl
+# Binary conversion
+... | eval result = tostring(9, "binary")
+# Returns: 1001
+
+# Hex conversion
+... | eval result = tostring(15, "hex")
+# Returns: 0xF
+
+# Commas formatting
+... | eval result = tostring(12345.6789, "commas")
+# Returns: 12,345.68
+
+# Duration formatting (seconds to HH:MM:SS)
+... | eval foo=615 | eval foo2 = tostring(foo, "duration")
+# Returns: 00:10:15
+
+# Boolean conversion
+... | eval n = tostring(1==1)
+# Returns: True
+```
+
+## Limitations
+
+- `mvindex` range access is inclusive on both ends (differs from some programming languages)
+- `tostring` format argument only applies to numeric values
+- These functions are available in the Calcite-based PPL engine
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4438](https://github.com/opensearch-project/sql/pull/4438) | Add `mvappend` function for Calcite PPL |
+| [#4497](https://github.com/opensearch-project/sql/pull/4497) | Support `tostring()` eval function |
+| [#4765](https://github.com/opensearch-project/sql/pull/4765) | Add `regexp_replace()` function as alias of `replace()` |
+| [#4794](https://github.com/opensearch-project/sql/pull/4794) | Support `mvindex` eval function |
+| [#4828](https://github.com/opensearch-project/sql/pull/4828) | Support `mvdedup` eval function |
+
+## References
+
+- [Issue #4492](https://github.com/opensearch-project/sql/issues/4492): tostring implementation request
+- [Issue #4433](https://github.com/opensearch-project/sql/issues/4433): mvappend function request
+- [Issue #4764](https://github.com/opensearch-project/sql/issues/4764): regexp_replace alias request
+- [RFC #4287](https://github.com/opensearch-project/sql/issues/4287): tostring function RFC
+- [OpenSearch PPL Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/ppl/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/sql/ppl-eval-functions.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -134,6 +134,7 @@
 
 ### SQL
 
+- [PPL Eval Functions](features/sql/ppl-eval-functions.md) - New multivalue functions (mvappend, mvindex, mvdedup), tostring conversion function, and regexp_replace alias
 - [PPL Timechart Functions](features/sql/ppl-timechart-functions.md) - Rate-based aggregation functions (per_second, per_minute, per_hour, per_day), millisecond span support, custom timefield option, merged timechart/chart implementation
 - [PPL Query Optimization](features/sql/ppl-query-optimization.md) - 33 enhancements including sort pushdown, aggregation optimization, distinct count approx, case-to-range queries, fillnull command, YAML explain format
 - [SQL/PPL Bugfixes](features/sql/sql-ppl-bugfixes.md) - 48 bug fixes including memory exhaustion fix, race condition fix, rex nested capture groups, filter pushdown improvements, and CVE-2025-48924


### PR DESCRIPTION
## Summary

This PR adds documentation for PPL Eval Functions introduced in OpenSearch v3.4.0.

### New Functions
- **mvappend**: Combines multiple values/arrays into a single array
- **mvindex**: Extracts elements from arrays by index or range
- **mvdedup**: Removes duplicate values from arrays (order-preserving)
- **tostring**: Converts values to strings with optional formatting (binary, hex, commas, duration)
- **regexp_replace**: Alias for `replace()` function

### Reports Created
- Release report: `docs/releases/v3.4.0/features/sql/ppl-eval-functions.md`
- Feature report: `docs/features/sql/ppl-eval-functions.md`

### Related PRs
- opensearch-project/sql#4438 - mvappend
- opensearch-project/sql#4497 - tostring
- opensearch-project/sql#4765 - regexp_replace
- opensearch-project/sql#4794 - mvindex
- opensearch-project/sql#4828 - mvdedup

Closes #1623