### PR TITLE
docs: add PPL Commands (Calcite) report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -357,6 +357,7 @@
 - [PPL Rex and Regex Commands](sql/ppl-rex-and-regex-commands.md)
 - [PPL Spath Command](sql/ppl-spath-command.md)
 - [PPL Timechart Command](sql/ppl-timechart-command.md)
+- [PPL Commands (Calcite)](sql/ppl-commands-calcite.md)
 - [Security Lake Data Source](sql/security-lake-data-source.md)
 - [SQL Error Handling](sql/sql-error-handling.md)
 - [SQL Pagination](sql/sql-pagination.md)

--- a/docs/features/sql/ppl-commands-calcite.md
+++ b/docs/features/sql/ppl-commands-calcite.md
@@ -1,0 +1,201 @@
+# PPL Commands (Calcite)
+
+## Summary
+
+PPL Commands (Calcite) provides advanced data transformation and analysis capabilities through the Piped Processing Language (PPL) using the Apache Calcite query engine. These commands enable users to perform complex aggregations, streaming statistics, multi-source searches, text replacements, and pipeline operations directly within OpenSearch queries.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "PPL Query Engine"
+        Query[PPL Query] --> Lexer[Lexer/Parser]
+        Lexer --> AST[AST Builder]
+        AST --> Analyzer[Semantic Analyzer]
+        Analyzer --> Planner[Calcite Planner]
+        Planner --> Optimizer[Query Optimizer]
+        Optimizer --> Executor[Query Executor]
+    end
+    
+    subgraph "Command Categories"
+        Agg[Aggregation Commands]
+        Stream[Streaming Commands]
+        Transform[Transformation Commands]
+        Search[Search Commands]
+    end
+    
+    subgraph "Optimization Rules"
+        Pushdown[Aggregation Pushdown]
+        Filter[Filter Optimization]
+        Join[Join Optimization]
+    end
+    
+    Executor --> ES[OpenSearch Engine]
+    Agg --> Planner
+    Stream --> Planner
+    Transform --> Planner
+    Search --> Planner
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    Input[Input Data] --> Parse[Parse PPL]
+    Parse --> Plan[Generate Plan]
+    Plan --> Optimize[Apply Optimizations]
+    Optimize --> Execute[Execute Query]
+    Execute --> Result[Result Set]
+    
+    subgraph "Pushdown Path"
+        Optimize --> PushCheck{Pushdown Eligible?}
+        PushCheck -->|Yes| DSL[Generate DSL]
+        DSL --> ES[OpenSearch Aggregation]
+        ES --> Parse2[Parse Response]
+        Parse2 --> Result
+        PushCheck -->|No| Calcite[Calcite Execution]
+        Calcite --> Result
+    end
+```
+
+### Commands
+
+| Command | Category | Description |
+|---------|----------|-------------|
+| `chart` | Aggregation | Returns aggregation results in visualization-ready format |
+| `streamstats` | Streaming | Computes running statistics over streaming data |
+| `multisearch` | Search | Combines results from multiple search subsearches |
+| `replace` | Transformation | Replaces text patterns in specified fields |
+| `appendpipe` | Pipeline | Appends subpipeline results to search results |
+| `top` | Aggregation | Returns top N values with optional null handling |
+| `rare` | Aggregation | Returns least common values with optional null handling |
+| `dedup` | Deduplication | Removes duplicate documents with pushdown optimization |
+| `eventstats` | Streaming | Computes statistics and appends to events |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ppl.syntax.legacy.preferred` | Controls default behavior for null handling | `true` |
+| `bucket_nullable` | Include null buckets in group-by aggregations | Depends on legacy setting |
+| `usenull` | Output null values in top/rare results | Depends on legacy setting |
+
+### Command Syntax
+
+#### chart
+```
+chart [limit=<int>] [useother=<bool>] [otherstr=<string>] [usenull=<bool>] [nullstr=<string>]
+      <agg-function> [OVER <row-split>] [BY <column-split>]
+```
+
+#### streamstats
+```
+streamstats [current=<bool>] [window=<int>] [global=<bool>]
+            [reset_before="(<eval-expression>)"] [reset_after="(<eval-expression>)"]
+            [bucket_nullable=<bool>]
+            <stats-agg-term> [BY <field-list>]
+```
+
+#### multisearch
+```
+multisearch [search <subsearch>] [search <subsearch>] ...
+```
+
+#### replace
+```
+replace '<pattern>' WITH '<replacement>' IN <field-list>
+```
+
+#### appendpipe
+```
+appendpipe [<subpipeline>]
+```
+
+### Usage Examples
+
+#### Visualization with chart
+```sql
+-- Status distribution by host
+source=logs | chart count OVER status BY host
+
+-- Top 5 categories with "Other" bucket
+source=sales | chart limit=5 useother=true sum(amount) BY category
+```
+
+#### Running Statistics with streamstats
+```sql
+-- Moving average over 10 events
+source=metrics | streamstats window=10 avg(cpu_usage) as moving_avg
+
+-- Cumulative sum with reset on error
+source=events | streamstats reset_before="(level='error')" sum(count) as cumulative
+```
+
+#### Multi-source Analysis with multisearch
+```sql
+-- Compare success vs failure rates
+source=logs | multisearch
+  [search source=logs | where status='success' | eval result='success']
+  [search source=logs | where status!='success' | eval result='failure']
+| stats count by result
+```
+
+#### Text Transformation with replace
+```sql
+-- Normalize error messages
+source=logs | replace 'ERROR' WITH 'error' IN message, level
+
+-- Wildcard replacement
+source=data | replace 'temp*' WITH 'temporary' IN description
+```
+
+#### Pipeline Augmentation with appendpipe
+```sql
+-- Add summary row to results
+source=sales | appendpipe [stats sum(amount) as total | eval category='TOTAL']
+```
+
+## Limitations
+
+- `chart` command does not support dynamic pivoting; pivoting must be done in the front-end
+- `chart` currently supports only single aggregation function
+- `streamstats` with `global=true + window + group` uses correlated joins which may impact performance
+- `dedup` pushdown does not support script expressions
+- `replace` pattern matching is case-sensitive
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#4579](https://github.com/opensearch-project/sql/pull/4579) | Support `chart` command in PPL |
+| v3.4.0 | [#4297](https://github.com/opensearch-project/sql/pull/4297) | Support `streamstats` command with Calcite |
+| v3.4.0 | [#4332](https://github.com/opensearch-project/sql/pull/4332) | Support `multisearch` command in Calcite |
+| v3.4.0 | [#4451](https://github.com/opensearch-project/sql/pull/4451) | Support `replace` command in Calcite |
+| v3.4.0 | [#4602](https://github.com/opensearch-project/sql/pull/4602) | Support `appendpipe` command in PPL |
+| v3.4.0 | [#4831](https://github.com/opensearch-project/sql/pull/4831) | Add `bucket_nullable` for `streamstats` |
+| v3.4.0 | [#4817](https://github.com/opensearch-project/sql/pull/4817) | Add `bucket_nullable` for `eventstats` |
+| v3.4.0 | [#4843](https://github.com/opensearch-project/sql/pull/4843) | Remove redundant push-down-filters |
+| v3.4.0 | [#4844](https://github.com/opensearch-project/sql/pull/4844) | Convert `dedup` pushdown to composite + top_hits |
+| v3.4.0 | [#4698](https://github.com/opensearch-project/sql/pull/4698) | Support wildcard for replace command |
+| v3.4.0 | [#4696](https://github.com/opensearch-project/sql/pull/4696) | Support `usenull` option in `top` and `rare` |
+| v3.4.0 | [#4707](https://github.com/opensearch-project/sql/pull/4707) | Pushdown `top`/`rare` to nested aggregation |
+
+## References
+
+- [Issue #399](https://github.com/opensearch-project/sql/issues/399): chart command feature request
+- [Issue #4207](https://github.com/opensearch-project/sql/issues/4207): streamstats command feature request
+- [Issue #4348](https://github.com/opensearch-project/sql/issues/4348): multisearch command feature request
+- [Issue #3975](https://github.com/opensearch-project/sql/issues/3975): replace command feature request
+- [Issue #4684](https://github.com/opensearch-project/sql/issues/4684): usenull option for top/rare
+- [Issue #4671](https://github.com/opensearch-project/sql/issues/4671): top/rare pushdown optimization
+- [Issue #4797](https://github.com/opensearch-project/sql/issues/4797): dedup pushdown optimization
+- [Issue #4801](https://github.com/opensearch-project/sql/issues/4801): bucket_nullable for eventstats
+- [Issue #4802](https://github.com/opensearch-project/sql/issues/4802): bucket_nullable for streamstats
+- [PPL Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/ppl/index/): Official PPL documentation
+- [PPL Commands Reference](https://docs.opensearch.org/3.0/search-plugins/sql/ppl/functions/): PPL commands reference
+
+## Change History
+
+- **v3.4.0** (2026-01-11): Added `chart`, `streamstats`, `multisearch`, `replace`, `appendpipe` commands; added `bucket_nullable` for eventstats/streamstats; added `usenull` for top/rare; pushdown optimizations for top/rare/dedup

--- a/docs/releases/v3.4.0/features/sql/ppl-commands-calcite.md
+++ b/docs/releases/v3.4.0/features/sql/ppl-commands-calcite.md
@@ -1,0 +1,164 @@
+# PPL Commands (Calcite)
+
+## Summary
+
+OpenSearch v3.4.0 introduces five new PPL commands and seven enhancements to existing commands, all implemented using the Calcite query engine. The new commands (`chart`, `streamstats`, `multisearch`, `replace`, `appendpipe`) expand PPL's data transformation capabilities, while enhancements to `top`, `rare`, `dedup`, `eventstats`, and `streamstats` improve null handling and query performance through aggregation pushdown.
+
+## Details
+
+### What's New in v3.4.0
+
+This release adds significant PPL command functionality through the Calcite-based query engine:
+
+**New Commands:**
+- `chart`: Aggregation command for visualization-ready output
+- `streamstats`: Running statistics over streaming data with window support
+- `multisearch`: Combine results from multiple search subsearches
+- `replace`: Text pattern replacement in specified fields
+- `appendpipe`: Append subpipeline results to search results
+
+**Enhancements:**
+- `bucket_nullable` argument for `eventstats` and `streamstats`
+- `usenull` option for `top` and `rare` commands
+- Wildcard support for `replace` command
+- Pushdown optimization for `top`, `rare`, and `dedup` commands
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "PPL Query Processing"
+        PPL[PPL Query] --> Parser[PPL Parser]
+        Parser --> AST[Abstract Syntax Tree]
+        AST --> Calcite[Calcite Planner]
+        Calcite --> Rules[Optimization Rules]
+        Rules --> Plan[Execution Plan]
+    end
+    
+    subgraph "New Commands"
+        Chart[chart]
+        Stream[streamstats]
+        Multi[multisearch]
+        Replace[replace]
+        Append[appendpipe]
+    end
+    
+    subgraph "Pushdown Optimizations"
+        TopRare[top/rare → nested terms agg]
+        Dedup[dedup → composite + top_hits]
+        Filter[bucket-non-null filter removal]
+    end
+    
+    Plan --> ES[OpenSearch]
+```
+
+#### New Commands
+
+| Command | Description | Key Features |
+|---------|-------------|--------------|
+| `chart` | Aggregation for visualization | `limit`, `useother`, `usenull`, span support |
+| `streamstats` | Running statistics | `window`, `global`, `reset_before/after`, `bucket_nullable` |
+| `multisearch` | Combine multiple searches | UNION ALL + ORDER BY architecture |
+| `replace` | Text replacement | Literal and wildcard pattern support |
+| `appendpipe` | Append subpipeline results | Subpipeline runs at command position |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `bucket_nullable` | Include null buckets in group-by | Depends on `plugins.ppl.syntax.legacy.preferred` |
+| `usenull` | Output null values in top/rare | Depends on `plugins.ppl.syntax.legacy.preferred` |
+
+### Usage Examples
+
+#### chart Command
+```sql
+-- Aggregate by status and host for visualization
+source=logs | chart count OVER status BY host
+
+-- With limit and useother
+source=logs | chart limit=5 useother=true count BY category
+```
+
+#### streamstats Command
+```sql
+-- Running sum with window
+source=data | streamstats window=5 sum(value) BY group
+
+-- With reset condition
+source=data | streamstats reset_before="(status='error')" count() as error_count
+```
+
+#### multisearch Command
+```sql
+-- Combine age group analysis
+source=accounts | multisearch
+  [search source=accounts | where age < 30 | eval age_group = "young"]
+  [search source=accounts | where age >= 30 | eval age_group = "adult"]
+| stats count by age_group
+```
+
+#### replace Command
+```sql
+-- Replace in single field
+source=logs | replace 'error' WITH 'ERROR' IN message
+
+-- Wildcard replacement
+source=logs | replace 'err*' WITH 'ERROR' IN message, level
+```
+
+#### appendpipe Command
+```sql
+-- Append summary statistics
+source=data | appendpipe [stats avg(value) as avg_value]
+```
+
+### Migration Notes
+
+- The `usenull` default behavior depends on `plugins.ppl.syntax.legacy.preferred` setting
+- When `legacy.preferred=true`: `usenull` defaults to `true`
+- When `legacy.preferred=false`: `usenull` defaults to `false`
+
+## Limitations
+
+- `chart` command does not support dynamic pivoting (front-end pivoting required)
+- `chart` currently supports single aggregation function only
+- `dedup` pushdown does not support script expressions
+- `streamstats` with `global=true + window + group` uses correlated joins which may impact performance on large datasets
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#4579](https://github.com/opensearch-project/sql/pull/4579) | Support `chart` command in PPL |
+| [#4297](https://github.com/opensearch-project/sql/pull/4297) | Support `streamstats` command with Calcite |
+| [#4332](https://github.com/opensearch-project/sql/pull/4332) | Support `multisearch` command in Calcite |
+| [#4451](https://github.com/opensearch-project/sql/pull/4451) | Support `replace` command in Calcite |
+| [#4602](https://github.com/opensearch-project/sql/pull/4602) | Support `appendpipe` command in PPL |
+| [#4831](https://github.com/opensearch-project/sql/pull/4831) | Add `bucket_nullable` argument for `streamstats` |
+| [#4817](https://github.com/opensearch-project/sql/pull/4817) | Add `bucket_nullable` argument for `eventstats` |
+| [#4843](https://github.com/opensearch-project/sql/pull/4843) | Remove redundant push-down-filters for bucket-non-null agg |
+| [#4844](https://github.com/opensearch-project/sql/pull/4844) | Convert `dedup` pushdown to composite + top_hits |
+| [#4698](https://github.com/opensearch-project/sql/pull/4698) | Support wildcard for replace command |
+| [#4696](https://github.com/opensearch-project/sql/pull/4696) | Support `usenull` option in PPL `top` and `rare` commands |
+| [#4707](https://github.com/opensearch-project/sql/pull/4707) | Pushdown `top`/`rare` commands to nested aggregation |
+
+## References
+
+- [Issue #399](https://github.com/opensearch-project/sql/issues/399): chart command feature request
+- [Issue #4207](https://github.com/opensearch-project/sql/issues/4207): streamstats command feature request
+- [Issue #4348](https://github.com/opensearch-project/sql/issues/4348): multisearch command feature request
+- [Issue #3975](https://github.com/opensearch-project/sql/issues/3975): replace command feature request
+- [Issue #4684](https://github.com/opensearch-project/sql/issues/4684): usenull option for top/rare
+- [Issue #4671](https://github.com/opensearch-project/sql/issues/4671): top/rare pushdown optimization
+- [Issue #4797](https://github.com/opensearch-project/sql/issues/4797): dedup pushdown optimization
+- [Issue #4801](https://github.com/opensearch-project/sql/issues/4801): bucket_nullable for eventstats
+- [Issue #4802](https://github.com/opensearch-project/sql/issues/4802): bucket_nullable for streamstats
+- [Issue #4811](https://github.com/opensearch-project/sql/issues/4811): redundant filter optimization
+- [PPL Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/ppl/index/): Official PPL documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/sql/ppl-commands-calcite.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -140,6 +140,7 @@
 - [SQL/PPL Bugfixes](features/sql/sql-ppl-bugfixes.md) - 48 bug fixes including memory exhaustion fix, race condition fix, rex nested capture groups, filter pushdown improvements, and CVE-2025-48924
 - [SQL CI/Tests](features/sql/sql-ci-tests.md) - CI/CD improvements including Gradle 9.2.0, JDK 25, BWC test splitting, query timeouts, and maven snapshots publishing
 - [SQL Documentation](features/sql/sql-documentation.md) - PPL command documentation standardization, typo fixes, enhanced examples, and function documentation improvements
+- [PPL Commands (Calcite)](features/sql/ppl-commands-calcite.md) - New PPL commands (chart, streamstats, multisearch, replace, appendpipe) and enhancements (bucket_nullable, usenull, pushdown optimizations)
 
 ### Query Insights
 


### PR DESCRIPTION
## Summary

This PR adds documentation for PPL Commands (Calcite) feature in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/sql/ppl-commands-calcite.md`
- Feature report: `docs/features/sql/ppl-commands-calcite.md`

### Key Changes in v3.4.0

**New Commands:**
- `chart`: Aggregation command for visualization-ready output
- `streamstats`: Running statistics over streaming data with window support
- `multisearch`: Combine results from multiple search subsearches
- `replace`: Text pattern replacement in specified fields
- `appendpipe`: Append subpipeline results to search results

**Enhancements:**
- `bucket_nullable` argument for `eventstats` and `streamstats`
- `usenull` option for `top` and `rare` commands
- Wildcard support for `replace` command
- Pushdown optimization for `top`, `rare`, and `dedup` commands

### Related PRs
- #4579: Support `chart` command in PPL
- #4297: Support `streamstats` command with Calcite
- #4332: Support `multisearch` command in Calcite
- #4451: Support `replace` command in Calcite
- #4602: Support `appendpipe` command in PPL
- #4831: Add `bucket_nullable` argument for `streamstats`
- #4817: Add `bucket_nullable` argument for `eventstats`
- #4843: Remove redundant push-down-filters for bucket-non-null agg
- #4844: Convert `dedup` pushdown to composite + top_hits
- #4698: Support wildcard for replace command
- #4696: Support `usenull` option in PPL `top` and `rare` commands
- #4707: Pushdown `top`/`rare` commands to nested aggregation

Closes #1622