### PR TITLE
docs: add k-NN memory optimized warmup report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -525,6 +525,7 @@
 - [k-NN Model Metadata](k-nn/k-nn-model-metadata.md)
 - [k-NN Query Rescore](k-nn/k-nn-query-rescore.md)
 - [k-NN Space Type Configuration](k-nn/k-nn-space-type-configuration.md)
+- [k-NN Memory Optimized Warmup](k-nn/k-nn-memory-optimized-warmup.md)
 - [Lucene On Faiss (Memory Optimized Search)](k-nn/lucene-on-faiss.md)
 - [Remote Vector Index Build](k-nn/remote-vector-index-build.md)
 

--- a/docs/features/k-nn/k-nn-memory-optimized-warmup.md
+++ b/docs/features/k-nn/k-nn-memory-optimized-warmup.md
@@ -1,0 +1,161 @@
+# k-NN Memory Optimized Warmup
+
+## Summary
+
+The k-NN Memory Optimized Warmup feature provides an efficient way to pre-load memory-optimized vector indexes into the operating system's page cache, significantly reducing cold start latency for vector search queries. When memory-optimized search is enabled, the warmup API performs a comprehensive loading strategy that touches all index file pages and initializes internal Faiss structures, ensuring that subsequent queries don't incur the overhead of loading data from disk.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "k-NN Plugin"
+        A[KNNIndexShard] --> B[warmup]
+        B --> C[MemoryOptimizedSearchWarmup]
+    end
+    
+    subgraph "Warmup Process"
+        C --> D[getFieldsForMemoryOptimizedSearch]
+        D --> E[loadFullPrecisionVectors]
+        E --> F[warmUpField]
+    end
+    
+    subgraph "Field Warmup"
+        F --> G[Get Engine Files]
+        G --> H[Open IndexInput]
+        H --> I[Read 4KB Pages]
+        I --> J[Trigger Faiss Search]
+    end
+    
+    subgraph "System"
+        I --> K[OS Page Cache]
+        J --> L[Faiss Index Initialized]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[Warmup API] --> B[Index Shard]
+    B --> C[Segment Reader]
+    C --> D[Field Info]
+    D --> E{Memory Optimized?}
+    E -->|Yes| F[Load Vectors]
+    E -->|No| G[Skip]
+    F --> H[Read Index Pages]
+    H --> I[Init Faiss]
+    I --> J[Cached in Memory]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `MemoryOptimizedSearchWarmup` | Main class that orchestrates the warmup process for memory-optimized search fields |
+| `KNNIndexShard` | Shard-level component that invokes the warmup process |
+| `MemoryOptimizedSearchSupportSpec` | Determines if a field supports memory-optimized search |
+
+### How It Works
+
+The warmup process consists of three main phases:
+
+1. **Field Identification**: Scans all fields in the index to identify those configured for memory-optimized search using `MemoryOptimizedSearchSupportSpec.isSupportedFieldType()`.
+
+2. **Vector Pre-loading**: Iterates through all vector values in each eligible field, loading them into memory:
+   ```java
+   FloatVectorValues vectorValues = leafReader.getFloatVectorValues(fieldName);
+   while (iter.nextDoc() != NO_MORE_DOCS) {
+       vectorValues.vectorValue(iter.docID());
+   }
+   ```
+
+3. **Index File Warming**: Reads one byte from every 4KB page of the engine index file to trigger page faults:
+   ```java
+   for (int i = 0; i < input.length(); i += 4096) {
+       input.seek(i);
+       input.readByte();
+   }
+   ```
+
+4. **Faiss Initialization**: Triggers a null search to initialize internal Faiss structures without returning results.
+
+### Configuration
+
+No additional configuration is required. The warmup optimization is automatically applied to indexes with memory-optimized search enabled.
+
+To enable memory-optimized search on an index:
+
+```json
+PUT my-vector-index
+{
+  "settings": {
+    "index": {
+      "knn": true,
+      "knn.memory_optimized_search": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 128,
+        "method": {
+          "name": "hnsw",
+          "engine": "faiss"
+        }
+      }
+    }
+  }
+}
+```
+
+### Usage Example
+
+Invoke the warmup API on your vector index:
+
+```bash
+GET /_plugins/_knn/warmup/my-vector-index
+```
+
+Response:
+```json
+{
+  "_shards": {
+    "total": 6,
+    "successful": 6,
+    "failed": 0
+  }
+}
+```
+
+Monitor warmup progress using the tasks API:
+```bash
+GET /_tasks?actions=*warmup*
+```
+
+## Limitations
+
+- Only applies to indexes using the Faiss engine with memory-optimized search enabled
+- Warmup effectiveness depends on available system memory for the OS page cache
+- Running merge operations during or after warmup may invalidate cached segments
+- The warmup operation is idempotent but may need to be re-run after index changes
+- Does not apply to indexes using the Lucene or nmslib engines
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.4.0 | [#2954](https://github.com/opensearch-project/k-NN/pull/2954) | Memory optimized search warmup |
+
+## References
+
+- [Issue #2939](https://github.com/opensearch-project/k-NN/issues/2939): Original feature request for indirect loading Faiss index in warmup API
+- [k-NN Warmup API Documentation](https://docs.opensearch.org/3.0/vector-search/api/knn/#warmup-operation)
+- [Memory-optimized vectors Documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/knn-memory-optimized/)
+- [Disk-based vector search](https://docs.opensearch.org/3.0/vector-search/optimizing-storage/disk-based-vector-search/)
+
+## Change History
+
+- **v3.4.0** (2026-01-11): Initial implementation of memory-optimized search warmup optimization

--- a/docs/releases/v3.4.0/features/k-nn/k-nn-memory-optimized-warmup.md
+++ b/docs/releases/v3.4.0/features/k-nn/k-nn-memory-optimized-warmup.md
@@ -1,0 +1,110 @@
+# k-NN Memory Optimized Warmup
+
+## Summary
+
+This release introduces an optimized warmup procedure for memory-optimized search in the k-NN plugin. When memory-optimized search is enabled, the warmup API now performs a more effective index loading strategy that reduces cold start latency by pre-loading index files into the operating system's page cache.
+
+## Details
+
+### What's New in v3.4.0
+
+Previously, when memory-optimized search was enabled, the warmup operation only performed a partial index load that determined the starting offset of each logical section within the index. This did not actually load data from the underlying file, meaning users still experienced cold start overhead on their first queries.
+
+The new implementation introduces a comprehensive warmup strategy that:
+
+1. **Touches entire index files** - Reads one byte from each 4KB page to trigger page faults, causing the kernel to load the full page into memory
+2. **Pre-loads full precision vectors** - Iterates through all vector values to ensure they are cached
+3. **Initializes the Faiss index** - Triggers a search operation to initialize internal Faiss structures
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Warmup API Call"
+        A[KNNIndexShard.warmup] --> B[MemoryOptimizedSearchWarmup]
+    end
+    
+    subgraph "New Warmup Process"
+        B --> C[Get Memory Optimized Fields]
+        C --> D[Load Full Precision Vectors]
+        D --> E[Warm Up Each Field]
+        E --> F[Read Index File Pages]
+        F --> G[Initialize Faiss Index]
+    end
+    
+    subgraph "Result"
+        G --> H[Index in Page Cache]
+        H --> I[Reduced Cold Start Latency]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `MemoryOptimizedSearchWarmup` | New class that encapsulates the warmup logic for memory-optimized search fields |
+| `warmUp()` | Main method that orchestrates the warmup process for all eligible fields |
+| `warmUpField()` | Warms up a single field by reading index pages and initializing Faiss |
+| `loadFullPrecisionVectors()` | Pre-loads vector values into memory |
+
+#### Data Flow
+
+```mermaid
+flowchart TB
+    A[Warmup Request] --> B[Acquire Searcher]
+    B --> C[Get LeafReaderContext]
+    C --> D[Identify Memory Optimized Fields]
+    D --> E[Load Float Vector Values]
+    E --> F[Get Engine Files]
+    F --> G[Open IndexInput]
+    G --> H[Read Every 4KB Page]
+    H --> I[Trigger Faiss Search]
+    I --> J[Return Warmed Fields]
+```
+
+### Usage Example
+
+The warmup API usage remains unchanged. Call the warmup endpoint on indexes with memory-optimized search enabled:
+
+```bash
+GET /_plugins/_knn/warmup/my-vector-index
+```
+
+Response:
+```json
+{
+  "_shards": {
+    "total": 6,
+    "successful": 6,
+    "failed": 0
+  }
+}
+```
+
+### Migration Notes
+
+No migration is required. The warmup API automatically uses the new optimized strategy for indexes with memory-optimized search enabled.
+
+## Limitations
+
+- The warmup operation only benefits indexes using the Faiss engine with memory-optimized search enabled
+- Warmup effectiveness depends on available system memory for the page cache
+- Running merge operations during warmup may invalidate the cached segments
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2954](https://github.com/opensearch-project/k-NN/pull/2954) | Memory optimized search warmup |
+
+## References
+
+- [Issue #2939](https://github.com/opensearch-project/k-NN/issues/2939): Indirect loading Faiss index in warmup API when memory optimized search is enabled
+- [k-NN Warmup API Documentation](https://docs.opensearch.org/3.0/vector-search/api/knn/#warmup-operation)
+- [Memory-optimized vectors Documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/knn-memory-optimized/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/k-nn/k-nn-memory-optimized-warmup.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -155,6 +155,7 @@
 
 - [k-NN Build](features/k-nn/k-nn-build.md) - SIMD library build support and S3 snapshots migration
 - [k-NN Enhancements](features/k-nn/k-nn-enhancements.md) - Native SIMD scoring for FP16, VectorSearcherHolder memory optimization, MMR rerank refactoring
+- [k-NN Memory Optimized Warmup](features/k-nn/k-nn-memory-optimized-warmup.md) - Optimized warmup procedure for memory-optimized search with page cache pre-loading
 
 ### Neural Search
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the k-NN Memory Optimized Warmup feature introduced in v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/k-nn/k-nn-memory-optimized-warmup.md`
- Feature report: `docs/features/k-nn/k-nn-memory-optimized-warmup.md`

### Key Changes in v3.4.0
- New `MemoryOptimizedSearchWarmup` class that provides optimized warmup for memory-optimized search
- Warmup now touches all index file pages to pre-load them into the OS page cache
- Pre-loads full precision vectors into memory
- Initializes Faiss index structures to reduce cold start latency

### Resources Used
- PR: [#2954](https://github.com/opensearch-project/k-NN/pull/2954)
- Issue: [#2939](https://github.com/opensearch-project/k-NN/issues/2939)
- Docs: [k-NN API](https://docs.opensearch.org/3.0/vector-search/api/knn/)
- Docs: [Memory-optimized vectors](https://docs.opensearch.org/3.0/field-types/supported-field-types/knn-memory-optimized/)