### PR TITLE
docs: add Scheduled Experiments report for v3.4.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -323,6 +323,7 @@
 
 ## search-relevance
 
+- [Scheduled Experiments](search-relevance/scheduled-experiments.md)
 - [Search Relevance Workbench](search-relevance/search-relevance-workbench.md)
 - [Search Relevance CI/Tests](search-relevance/ci-tests.md)
 - [Security Integration Test Control](search-relevance/security-integ-test-control.md)

--- a/docs/features/search-relevance/scheduled-experiments.md
+++ b/docs/features/search-relevance/scheduled-experiments.md
@@ -1,0 +1,225 @@
+# Scheduled Experiments
+
+## Summary
+
+Scheduled Experiments is a feature in the OpenSearch Search Relevance plugin that enables automated, recurring execution of search relevance experiments. Users can schedule pointwise evaluation and hybrid optimizer experiments to run at specified intervals using cron expressions, allowing continuous monitoring of search quality over time. Results are stored historically, enabling trend analysis and performance tracking through dedicated dashboards.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "User Interface"
+        Dashboard[OpenSearch Dashboards]
+        ExperimentList[Experiment Listing]
+        ExperimentDetail[Experiment Detail View]
+        ScheduleModal[Schedule Modal]
+        ScheduledRunsDashboard[Scheduled Runs Dashboard]
+    end
+    
+    subgraph "Dashboards Plugin"
+        ExperimentService[Experiment Service]
+        ScheduleAPI[Schedule API Client]
+        ScheduleDetails[Schedule Details Component]
+    end
+    
+    subgraph "Backend Plugin"
+        ScheduleEndpoints[Schedule REST Endpoints]
+        ScheduledJobRunner[Scheduled Job Runner]
+        ExperimentRunner[Experiment Execution Engine]
+    end
+    
+    subgraph "OpenSearch Core"
+        JobScheduler[Job Scheduler Plugin]
+        ScheduledJobsIndex[.scheduled-jobs]
+        HistoryIndex[scheduled-experiment-history]
+        ExperimentsIndex[search-relevance-experiments]
+        ResultsIndex[search-relevance-evaluation-result]
+    end
+    
+    Dashboard --> ExperimentList
+    ExperimentList --> ScheduleModal
+    ExperimentList --> ExperimentDetail
+    ExperimentDetail --> ScheduleDetails
+    ExperimentList --> ScheduledRunsDashboard
+    
+    ScheduleModal --> ExperimentService
+    ExperimentService --> ScheduleAPI
+    ScheduleAPI --> ScheduleEndpoints
+    
+    ScheduleEndpoints --> JobScheduler
+    JobScheduler --> ScheduledJobsIndex
+    JobScheduler --> ScheduledJobRunner
+    ScheduledJobRunner --> ExperimentRunner
+    ExperimentRunner --> HistoryIndex
+    ExperimentRunner --> ResultsIndex
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph "Schedule Creation"
+        A[User] --> B[Enter Cron Expression]
+        B --> C[Create Schedule API]
+        C --> D[Job Scheduler]
+        D --> E[.scheduled-jobs Index]
+    end
+    
+    subgraph "Scheduled Execution"
+        F[Cron Trigger] --> G[Job Runner]
+        G --> H[Execute Experiment]
+        H --> I[Store Results]
+        I --> J[History Index]
+    end
+    
+    subgraph "Visualization"
+        K[Scheduled Runs Dashboard]
+        J --> K
+        K --> L[Trend Analysis]
+    end
+```
+
+### Components
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| `ScheduleModal` | dashboards-search-relevance | Modal dialog for entering cron expressions to schedule experiments |
+| `DeleteScheduleModal` | dashboards-search-relevance | Modal for viewing schedule details and deleting schedules |
+| `ScheduleDetails` | dashboards-search-relevance | Component displaying schedule information (cron, start time, last run) |
+| `ExperimentService` | dashboards-search-relevance | Service class with methods for scheduled experiment CRUD operations |
+| `ScheduledJobRunner` | search-relevance | Backend component that executes experiments on schedule |
+| `Pointwise Daily Scheduled Runs Dashboard` | dashboards-search-relevance | Pre-built dashboard for visualizing scheduled experiment results over time |
+
+### API Reference
+
+#### Create Scheduled Experiment
+
+```
+POST /_plugins/_search_relevance/experiments/schedule
+```
+
+Request body:
+```json
+{
+  "experimentId": "string",
+  "cronExpression": "string"
+}
+```
+
+Response:
+```json
+{
+  "id": "string",
+  "enabled": true,
+  "schedule": {
+    "cron": {
+      "expression": "0 1 * * *",
+      "timezone": "America/Los_Angeles"
+    }
+  },
+  "enabledTime": 1234567890000,
+  "lastUpdateTime": 1234567890000
+}
+```
+
+#### List Scheduled Experiments
+
+```
+GET /_plugins/_search_relevance/experiments/schedule
+```
+
+#### Get Scheduled Experiment
+
+```
+GET /_plugins/_search_relevance/experiments/schedule/{id}
+```
+
+#### Delete Scheduled Experiment
+
+```
+DELETE /_plugins/_search_relevance/experiments/schedule/{id}
+```
+
+### Configuration
+
+| Setting | Description | Default | Required |
+|---------|-------------|---------|----------|
+| `experimentId` | ID of the experiment to schedule | - | Yes |
+| `cronExpression` | Unix cron expression (5 fields) | - | Yes |
+| `timezone` | Timezone for schedule evaluation | System default | No |
+
+### Cron Expression Examples
+
+| Expression | Description |
+|------------|-------------|
+| `0 1 * * *` | Daily at 1:00 AM |
+| `0 */6 * * *` | Every 6 hours |
+| `0 0 * * 0` | Weekly on Sunday at midnight |
+| `0 0 1 * *` | Monthly on the 1st at midnight |
+| `*/30 * * * *` | Every 30 minutes |
+
+### Usage Example
+
+#### Scheduling an Experiment via UI
+
+1. Navigate to the Experiments listing page
+2. Find a completed pointwise or hybrid optimizer experiment
+3. Click the clock icon (unscheduled) to open the Schedule Modal
+4. Enter a valid cron expression (e.g., `0 1 * * *` for daily at 1 AM)
+5. Click "Schedule Experiment to Run"
+
+#### Viewing Scheduled Results
+
+1. For scheduled pointwise experiments, click the dashboard icon
+2. The "Pointwise Daily Scheduled Runs" dashboard shows:
+   - Metrics over time (NDCG, MAP, Precision) as line charts
+   - Tabular view of daily results with all metrics
+
+#### Deleting a Schedule
+
+1. Click the clock icon (blue, indicating scheduled) on a scheduled experiment
+2. View the current cron expression and schedule details
+3. Click "Delete" to remove the schedule (experiment remains intact)
+
+### Supported Experiment Types
+
+| Type | Scheduling Support |
+|------|-------------------|
+| `POINTWISE_EVALUATION` | ✅ Supported |
+| `HYBRID_OPTIMIZER` | ✅ Supported |
+| `PAIRWISE_COMPARISON` | ❌ Not supported |
+
+## Limitations
+
+- Only experiments in `COMPLETED` status can be scheduled
+- Cron expressions must use single spaces between the five fields
+- Workload management integration is not yet available
+- Alerting integration for failed scheduled runs is planned for future releases
+- Resource monitoring for scheduled jobs is not yet implemented
+- Cannot modify an existing schedule; must delete and recreate
+
+## Related PRs
+
+| Version | PR | Repository | Description |
+|---------|-----|------------|-------------|
+| v3.4.0 | [#220](https://github.com/opensearch-project/search-relevance/pull/220) | search-relevance | Backend APIs and scheduled job runner |
+| v3.4.0 | [#636](https://github.com/opensearch-project/dashboards-search-relevance/pull/636) | dashboards-search-relevance | UI components for scheduling |
+| v3.4.0 | [#324](https://github.com/opensearch-project/search-relevance/pull/324) | search-relevance | Data integrity for experiment deletion |
+| v3.4.0 | [#685](https://github.com/opensearch-project/dashboards-search-relevance/pull/685) | dashboards-search-relevance | GUID search for Search Configuration |
+| v3.4.0 | [#686](https://github.com/opensearch-project/dashboards-search-relevance/pull/686) | dashboards-search-relevance | Type/status filtering |
+| v3.4.0 | [#670](https://github.com/opensearch-project/dashboards-search-relevance/pull/670) | dashboards-search-relevance | Experiment detail page title |
+
+## References
+
+- [Issue #213](https://github.com/opensearch-project/search-relevance/issues/213): Original feature request for scheduled experiments
+- [Issue #226](https://github.com/opensearch-project/search-relevance/issues/226): Scheduling requirements
+- [Issue #238](https://github.com/opensearch-project/search-relevance/issues/238): Data integrity requirements
+- [Job Scheduler Plugin](https://docs.opensearch.org/3.0/monitoring-your-cluster/job-scheduler/index/): OpenSearch Job Scheduler documentation
+- [Cron Expression Reference](https://docs.opensearch.org/3.0/observing-your-data/alerting/cron/): Cron expression format guide
+- [Search Relevance Overview](https://docs.opensearch.org/3.0/search-plugins/search-relevance/index/): Search Relevance plugin documentation
+
+## Change History
+
+- **v3.4.0** (2025-12): Initial implementation with scheduling APIs, UI components, and dedicated dashboard

--- a/docs/releases/v3.4.0/features/search-relevance/scheduled-experiments.md
+++ b/docs/releases/v3.4.0/features/search-relevance/scheduled-experiments.md
@@ -1,0 +1,139 @@
+# Scheduled Experiments
+
+## Summary
+
+Scheduled Experiments enables users to run search relevance experiments on a recurring basis using cron expressions. This feature allows continuous monitoring of search quality over time by automatically executing pointwise evaluation and hybrid optimizer experiments at specified intervals, storing historical results for trend analysis.
+
+## Details
+
+### What's New in v3.4.0
+
+- New scheduling APIs for creating, retrieving, and deleting scheduled experiment jobs
+- UI components for scheduling and descheduling experiments in OpenSearch Dashboards
+- New "Pointwise Daily Scheduled Runs" dashboard for visualizing experiment results over time
+- Historical experiment results stored with timestamps for trend analysis
+- Data integrity support ensuring scheduled jobs are cleaned up when experiments are deleted
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        UI[Search Relevance UI]
+        ScheduleModal[Schedule Modal]
+        DeleteScheduleModal[Delete Schedule Modal]
+        ScheduleDetails[Schedule Details Component]
+    end
+    
+    subgraph "Backend Plugin"
+        API[Scheduled Experiments API]
+        JobRunner[Scheduled Job Runner]
+    end
+    
+    subgraph "OpenSearch"
+        JobScheduler[Job Scheduler Plugin]
+        ScheduledJobsIndex[.scheduled-jobs Index]
+        HistoryIndex[scheduled-experiment-history Index]
+        ExperimentsIndex[Experiments Index]
+    end
+    
+    UI --> ScheduleModal
+    UI --> DeleteScheduleModal
+    UI --> ScheduleDetails
+    ScheduleModal --> API
+    DeleteScheduleModal --> API
+    API --> JobScheduler
+    JobScheduler --> ScheduledJobsIndex
+    JobRunner --> HistoryIndex
+    JobRunner --> ExperimentsIndex
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ScheduleModal` | UI modal for creating scheduled experiments with cron expression input |
+| `DeleteScheduleModal` | UI modal for viewing and deleting existing schedules |
+| `ScheduleDetails` | Component displaying schedule information on experiment detail pages |
+| `ExperimentSchedule` | TypeScript type for scheduled experiment data |
+| `ScheduledJob` | TypeScript type for job scheduler metadata |
+
+#### New API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/_plugins/_search_relevance/experiments/schedule` | POST | Create a scheduled experiment |
+| `/_plugins/_search_relevance/experiments/schedule` | GET | List all scheduled experiments |
+| `/_plugins/_search_relevance/experiments/schedule/{id}` | GET | Get a specific scheduled experiment |
+| `/_plugins/_search_relevance/experiments/schedule/{id}` | DELETE | Delete a scheduled experiment |
+
+#### New Indices
+
+| Index | Description |
+|-------|-------------|
+| `.scheduled-jobs` | Stores currently running experiment schedules |
+| `search-relevance-scheduled-experiment-history` | Stores historical experiment results with timestamps |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cronExpression` | Cron expression defining the schedule (e.g., `0 1 * * *` for daily at 1 AM) | Required |
+| `timezone` | Timezone for cron expression evaluation | System default |
+
+### Usage Example
+
+#### Creating a Scheduled Experiment via API
+
+```json
+POST /_plugins/_search_relevance/experiments/schedule
+{
+  "experimentId": "abc123-def456",
+  "cronExpression": "0 1 * * *"
+}
+```
+
+#### Cron Expression Format
+
+The cron expression follows standard Unix cron format:
+- `0 1 * * *` - Run daily at 1:00 AM
+- `0 */6 * * *` - Run every 6 hours
+- `0 0 * * 0` - Run weekly on Sunday at midnight
+
+### Migration Notes
+
+- Existing experiments can be scheduled without modification
+- Only `POINTWISE_EVALUATION` and `HYBRID_OPTIMIZER` experiment types support scheduling
+- Experiments must be in `COMPLETED` status before scheduling
+
+## Limitations
+
+- Scheduling is only available for pointwise evaluation and hybrid optimizer experiments
+- Cron expressions must use single spaces between parts
+- Workload management and alerting integration are planned for future releases
+- Resource monitoring for scheduled jobs is not yet available
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#220](https://github.com/opensearch-project/search-relevance/pull/220) | search-relevance | Backend APIs and components for scheduled experiments |
+| [#636](https://github.com/opensearch-project/dashboards-search-relevance/pull/636) | dashboards-search-relevance | UI for scheduling and descheduling experiments |
+| [#324](https://github.com/opensearch-project/search-relevance/pull/324) | search-relevance | Data integrity support for deleting experiments |
+| [#685](https://github.com/opensearch-project/dashboards-search-relevance/pull/685) | dashboards-search-relevance | GUID search support for Search Configuration |
+| [#686](https://github.com/opensearch-project/dashboards-search-relevance/pull/686) | dashboards-search-relevance | Client-side filtering by type/status |
+| [#670](https://github.com/opensearch-project/dashboards-search-relevance/pull/670) | dashboards-search-relevance | Experiment detail page title fix |
+
+## References
+
+- [Issue #213](https://github.com/opensearch-project/search-relevance/issues/213): Original feature request
+- [Issue #226](https://github.com/opensearch-project/search-relevance/issues/226): Related scheduling requirements
+- [Issue #238](https://github.com/opensearch-project/search-relevance/issues/238): Data integrity for experiment deletion
+- [Job Scheduler Documentation](https://docs.opensearch.org/3.0/monitoring-your-cluster/job-scheduler/index/): OpenSearch Job Scheduler plugin
+- [Cron Expression Reference](https://docs.opensearch.org/3.0/observing-your-data/alerting/cron/): Cron expression format
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/search-relevance/scheduled-experiments.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -128,6 +128,7 @@
 
 ### Search Relevance
 
+- [Scheduled Experiments](features/search-relevance/scheduled-experiments.md) - Cron-based scheduling for recurring experiment execution with historical results tracking
 - [Query Sets & Judgment Lists](features/dashboards-search-relevance/query-sets-judgment-lists.md) - GUID filtering support for Query Sets with strongly typed QuerySetItem interface
 - [Search Relevance CI/Tests](features/search-relevance/ci-tests.md) - Test dependency fixes, JDWP debugging support, deprecated API removal, and test code cleanups
 - [Search Relevance Bugfixes](features/search-relevance/search-relevance-bugfixes.md) - Fix query serialization for plugins (e.g., Learning to Rank) that extend OpenSearch's DSL


### PR DESCRIPTION
## Summary

Adds documentation for the Scheduled Experiments feature in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/search-relevance/scheduled-experiments.md`
- Feature report: `docs/features/search-relevance/scheduled-experiments.md`

### Key Changes in v3.4.0
- New scheduling APIs for creating, retrieving, and deleting scheduled experiment jobs
- UI components for scheduling and descheduling experiments in OpenSearch Dashboards
- New "Pointwise Daily Scheduled Runs" dashboard for visualizing experiment results over time
- Historical experiment results stored with timestamps for trend analysis
- Data integrity support ensuring scheduled jobs are cleaned up when experiments are deleted

### Related PRs
| PR | Repository | Description |
|----|------------|-------------|
| #220 | search-relevance | Backend APIs and components for scheduled experiments |
| #636 | dashboards-search-relevance | UI for scheduling and descheduling experiments |
| #324 | search-relevance | Data integrity support for deleting experiments |
| #685 | dashboards-search-relevance | GUID search support for Search Configuration |
| #686 | dashboards-search-relevance | Client-side filtering by type/status |
| #670 | dashboards-search-relevance | Experiment detail page title fix |

Closes #1615