### PR TITLE
docs: add Dashboards Agent & Assistant report for v3.4.0

### DIFF
--- a/docs/features/dashboards-flow-framework/ai-search-flows.md
+++ b/docs/features/dashboards-flow-framework/ai-search-flows.md
@@ -162,17 +162,63 @@ workflows:
 | Custom String | Input | Static string value |
 | No Transformation | Output | Preserves model output as-is |
 
+### Agent Configuration (v3.4.0+)
+
+The plugin now includes enhanced agent configuration capabilities:
+
+#### Agent Summary Visualization
+
+A "View agent summary" button displays agent execution steps in a modal, showing:
+- Available tools
+- Tool execution sequence
+- Validation results
+
+#### Memory Integration
+
+Support for conversational search with memory persistence:
+
+| Feature | Description |
+|---------|-------------|
+| Continue conversation | Injects `memory_id` from previous response |
+| Remove conversation | Clears `memory_id` for fresh context |
+| Auto-clear | Memory cleared when switching to flow agents |
+
+#### Simplified Agent Configuration
+
+| Change | Description |
+|--------|-------------|
+| Unified model field | Single "model" field replaces separate LLM configuration |
+| Auto-inferred LLM interface | Automatically detects interface from connector URL |
+| Hidden advanced settings | LLM interface moved under "Advanced settings" |
+
+#### Automatic Response Filters
+
+For flow agents, response filters are auto-configured for supported providers:
+- OpenAI: Auto-configured
+- Bedrock Claude: Auto-configured
+- Unknown/Custom: Manual configuration required
+
 ## Limitations
 
 - Models must have defined interfaces for simplified ML processor forms
 - Datasource version required for simulate API calls
 - Plugin URL unchanged from original "flow-framework" for compatibility
 - Complex nested data may require JSONPath expressions
+- Memory integration only works with conversational agents, not flow agents
+- Automatic LLM interface inference may not work for custom connectors
+- Response filter auto-configuration limited to OpenAI and Bedrock Claude providers
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#626](https://github.com/opensearch-project/dashboards-assistant/pull/626) | Disable dashboards assistant chatbot if investigation feature flag enabled |
+| v3.4.0 | [#801](https://github.com/opensearch-project/dashboards-flow-framework/pull/801) | Add agent summary |
+| v3.4.0 | [#796](https://github.com/opensearch-project/dashboards-flow-framework/pull/796) | Clean up / hide complex fields on agent configuration |
+| v3.4.0 | [#803](https://github.com/opensearch-project/dashboards-flow-framework/pull/803) | Clean up agent summary formatting |
+| v3.4.0 | [#809](https://github.com/opensearch-project/dashboards-flow-framework/pull/809) | Integrate with memory |
+| v3.4.0 | [#817](https://github.com/opensearch-project/dashboards-flow-framework/pull/817) | Automatically add response filters to flow agents when possible |
+| v3.4.0 | [#820](https://github.com/opensearch-project/dashboards-flow-framework/pull/820) | Remove default empty tool field values; fix EuiSelect values in Firefox |
 | v3.1.0 | [#722](https://github.com/opensearch-project/dashboards-flow-framework/pull/722) | Integrate preview panel into inspector panel |
 | v3.1.0 | [#737](https://github.com/opensearch-project/dashboards-flow-framework/pull/737) | Refactor form navigation to left panel |
 | v3.1.0 | [#742](https://github.com/opensearch-project/dashboards-flow-framework/pull/742) | Added Semantic Search using Sparse Encoders template |
@@ -197,5 +243,6 @@ workflows:
 
 ## Change History
 
+- **v3.4.0** (2026-01-14): Added agent summary visualization, memory integration for conversational search, simplified agent configuration with auto-inferred LLM interface, automatic response filters for flow agents, Firefox EuiSelect fixes
 - **v3.1.0** (2025-06-10): Major UI refactor with left panel navigation, integrated preview into inspector panel, added Semantic Search using Sparse Encoders template, configurable thread pool sizes
 - **v3.0.0** (2025-05-13): Renamed to "AI Search Flows", added RAG + hybrid search preset, simplified ML processor forms, improved state persistence, added processor reordering

--- a/docs/releases/v3.4.0/features/dashboards-flow-framework/dashboards-agent-assistant.md
+++ b/docs/releases/v3.4.0/features/dashboards-flow-framework/dashboards-agent-assistant.md
@@ -1,0 +1,124 @@
+# Dashboards Agent & Assistant
+
+## Summary
+
+OpenSearch v3.4.0 introduces significant enhancements to the Dashboards Flow Framework plugin for agent configuration and management. These changes improve the user experience for creating and managing AI agents by adding agent summary visualization, memory integration for conversational search, simplified agent configuration, automatic response filter configuration, and various UI fixes.
+
+## Details
+
+### What's New in v3.4.0
+
+This release focuses on improving the agent configuration experience in OpenSearch Dashboards through the Flow Framework plugin. Key additions include:
+
+1. **Agent Summary Visualization** - View agent execution steps and reasoning
+2. **Memory Integration** - Support for conversational search with memory persistence
+3. **Simplified Agent Configuration** - Cleaner UI with auto-inferred settings
+4. **Automatic Response Filters** - Auto-configuration for supported model providers
+5. **UI/UX Improvements** - Firefox compatibility fixes and cleaner tool configurations
+
+### Technical Changes
+
+#### Agent Summary Feature
+
+A new "View agent summary" button displays agent execution steps in a modal dialog. This helps users understand how the agent processes queries and which tools are used.
+
+```typescript
+// Agent summary is extracted from search response
+// Only appears when agentic_context search response processor is configured
+{
+  "ext": {
+    "agent_steps_summary": "I have these tools available: [ListIndexTool, IndexMappingTool, query_planner_tool]...",
+    "memory_id": "2GMahJkBlF3USoHtuIpW"
+  }
+}
+```
+
+#### Memory Integration for Conversational Search
+
+Users can now inject `memory_id` into queries to maintain conversation context across searches:
+
+- **Continue conversation** button - Injects `memory_id` from previous response
+- **Remove conversation** button - Clears `memory_id` for fresh context
+- Automatic clearing when switching to flow agents (which don't support memory)
+
+#### Simplified Agent Configuration
+
+| Change | Description |
+|--------|-------------|
+| Unified model field | Single "model" field replaces separate LLM configuration |
+| Auto-inferred LLM interface | Automatically detects interface from connector URL and parameters |
+| Hidden advanced settings | LLM interface moved under "Advanced settings" |
+| Removed memory delete button | Memory is required, so delete option removed |
+
+#### Automatic Response Filters
+
+For flow agents, response filters are now automatically configured based on the model provider:
+
+| Provider | Response Filter |
+|----------|-----------------|
+| OpenAI | Auto-configured |
+| Bedrock Claude | Auto-configured |
+| Unknown/Custom | Empty value (manual configuration required) |
+
+### Usage Example
+
+Creating an agent with memory support:
+
+```json
+{
+  "query": {
+    "agentic": {
+      "query_text": "top-rated nike shoes",
+      "memory_id": "2GMahJkBlF3USoHtuIpW"
+    }
+  }
+}
+```
+
+Follow-up query using conversation context:
+
+```json
+{
+  "query": {
+    "agentic": {
+      "query_text": "only black ones",
+      "memory_id": "2GMahJkBlF3USoHtuIpW"
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- Existing agent configurations continue to work without changes
+- Users can now simplify configurations by removing explicit LLM interface settings if using supported models
+- Flow agents automatically get response filters for OpenAI and Bedrock Claude models
+
+## Limitations
+
+- Memory integration only works with conversational agents, not flow agents
+- Automatic LLM interface inference may not work for custom connectors
+- Response filter auto-configuration limited to OpenAI and Bedrock Claude providers
+- Firefox EuiSelect rendering issues require bundled builds (not reproducible in local development)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#626](https://github.com/opensearch-project/dashboards-assistant/pull/626) | Disable dashboards assistant chatbot if investigation feature flag enabled |
+| [#801](https://github.com/opensearch-project/dashboards-flow-framework/pull/801) | Add agent summary |
+| [#796](https://github.com/opensearch-project/dashboards-flow-framework/pull/796) | Clean up / hide complex fields on agent configuration |
+| [#803](https://github.com/opensearch-project/dashboards-flow-framework/pull/803) | Clean up agent summary formatting |
+| [#809](https://github.com/opensearch-project/dashboards-flow-framework/pull/809) | Integrate with memory |
+| [#817](https://github.com/opensearch-project/dashboards-flow-framework/pull/817) | Automatically add response filters to flow agents when possible |
+| [#820](https://github.com/opensearch-project/dashboards-flow-framework/pull/820) | Remove default empty tool field values; fix EuiSelect values in Firefox |
+
+## References
+
+- [OpenSearch Assistant for OpenSearch Dashboards](https://docs.opensearch.org/3.0/dashboards/dashboards-assistant/index/)
+- [Flow Agents Documentation](https://docs.opensearch.org/latest/vector-search/ai-search/agentic-search/flow-agent/)
+- [Agents and Tools](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/dashboards-flow-framework/ai-search-flows.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -106,6 +106,7 @@
 
 ### Dashboards Flow Framework
 
+- [Dashboards Agent & Assistant](features/dashboards-flow-framework/dashboards-agent-assistant.md) - Agent summary visualization, memory integration, simplified configuration, automatic response filters
 - [Dashboards Flow Framework Bugfixes](features/dashboards-flow-framework/dashboards-flow-framework-bugfixes.md) - Gracefully handle workflows with no provisioned resources
 
 ### Dashboards Observability


### PR DESCRIPTION
## Summary

Documents the Dashboards Agent & Assistant feature for OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/dashboards-flow-framework/dashboards-agent-assistant.md`
- Feature report updated: `docs/features/dashboards-flow-framework/ai-search-flows.md`

### Key Changes in v3.4.0
- Agent summary visualization extracted from `ext.agent_steps_summary`
- Memory integration using `memory_id` for conversational context
- Simplified agent configuration with auto-inferred LLM interface
- Automatic response filters for OpenAI and Bedrock Claude providers
- Firefox EuiSelect compatibility fixes

### Related PRs
- dashboards-flow-framework #801, #796, #803, #809, #817, #820
- dashboards-assistant #626

Closes #1614