### PR TITLE
docs: add Agentic Search report for v3.4.0

### DIFF
--- a/docs/features/neural-search/agentic-search.md
+++ b/docs/features/neural-search/agentic-search.md
@@ -224,6 +224,10 @@ POST /_plugins/_ml/agents/_register
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [neural-search#1669](https://github.com/opensearch-project/neural-search/pull/1669) | Preserve source parameter for agentic query |
+| v3.4.0 | [dashboards-search-relevance#693](https://github.com/opensearch-project/dashboards-search-relevance/pull/693) | Add support for agent search in pairwise comparison |
+| v3.4.0 | [dashboards-search-relevance#802](https://github.com/opensearch-project/dashboards-search-relevance/pull/802) | Add MCP server support |
+| v3.4.0 | [dashboards-search-relevance#812](https://github.com/opensearch-project/dashboards-search-relevance/pull/812) | Improve Test Flow UX |
 | v3.3.0 | [ml-commons#4203](https://github.com/opensearch-project/ml-commons/pull/4203) | Support Query Planner Tool with Conversational Agent |
 | v3.3.0 | [ml-commons#4262](https://github.com/opensearch-project/ml-commons/pull/4262) | Use same model for Agent and QPT |
 | v3.2.0 | [#1484](https://github.com/opensearch-project/neural-search/pull/1484) | Initial implementation of agentic search query clause and processor |
@@ -231,6 +235,7 @@ POST /_plugins/_ml/agents/_register
 ## References
 
 - [Issue #1479](https://github.com/opensearch-project/neural-search/issues/1479): RFC - Design for Agentic Search
+- [Issue #1664](https://github.com/opensearch-project/neural-search/issues/1664): Agentic Search: Support of `_source.excludes`
 - [Blog: Introducing agentic search in OpenSearch](https://opensearch.org/blog/introducing-agentic-search-in-opensearch-transforming-data-interaction-through-natural-language/): Official announcement
 - [Agentic AI Documentation](https://docs.opensearch.org/3.0/tutorials/gen-ai/agents/index/): Agent tutorials
 - [ML Commons Agents](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/agents/index/): Agent framework documentation
@@ -239,5 +244,6 @@ POST /_plugins/_ml/agents/_register
 
 ## Change History
 
+- **v3.4.0** (2026-01-11): Source parameter preservation (`_source.includes`/`_source.excludes`), Search Relevance Workbench pairwise comparison support, MCP server integration, conversational search UI with memory management, improved test flow UX, version filtering
 - **v3.3.0** (2026-01-11): Conversational agent support, neural search query generation, unified model configuration, automatic index mapping and sample document retrieval
 - **v3.2.0** (2026-01-10): Initial experimental implementation with `agentic` query clause and `agentic_query_translator` processor

--- a/docs/releases/v3.4.0/features/dashboards-search-relevance/agentic-search.md
+++ b/docs/releases/v3.4.0/features/dashboards-search-relevance/agentic-search.md
@@ -1,0 +1,132 @@
+# Agentic Search
+
+## Summary
+
+OpenSearch v3.4.0 enhances the Agentic Search feature with significant improvements to the Search Relevance Workbench (SRW) UI and backend query handling. This release adds support for agentic search in pairwise comparison, MCP server integration, improved UX for test flows and form inputs, version filtering, and preservation of source parameters in agentic queries.
+
+Key improvements:
+- **Pairwise comparison support**: Compare agentic search results side-by-side with other search types
+- **Conversational search UI**: Continue or clear conversations with memory ID management
+- **Source parameter preservation**: Properly handle `_source.includes` and `_source.excludes` in agentic queries
+- **MCP server support**: Connect to external Model Context Protocol servers from the dashboards
+- **Improved UX**: Simplified form inputs, better test flow experience, and version filtering
+
+## Details
+
+### What's New in v3.4.0
+
+#### Agentic Search in Pairwise Comparison
+
+The Search Relevance Workbench now supports agentic search queries in pairwise comparison mode, allowing users to compare agentic search results against keyword, semantic, or other search types.
+
+```mermaid
+graph TB
+    subgraph "Search Relevance Workbench"
+        A[Query Input Panel 1] --> B[Agentic Query]
+        C[Query Input Panel 2] --> D[Keyword/Semantic Query]
+        B --> E[AgentHandler]
+        D --> F[SearchHandler]
+        E --> G[Visual Comparison]
+        F --> G
+    end
+    
+    subgraph "Agent Info Display"
+        G --> H[Agent Steps Summary]
+        G --> I[Memory ID]
+        G --> J[Generated DSL Query]
+    end
+```
+
+#### Technical Changes
+
+##### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `AgentHandler` | Handles agentic query detection and execution |
+| `AgentInfo` | React component displaying agent execution details |
+| `SearchHandler` | Unified search execution handler |
+| `ConversationHandlers` | Memory ID management for conversational search |
+
+##### New UI Features
+
+| Feature | Description |
+|---------|-------------|
+| Loading state | Spinner with "Searching" text during async agent search (up to 30+ seconds) |
+| AgentInfo panel | Displays `memory_id`, `agent_steps_summary`, and generated `dsl_query` |
+| Continue conversation | Auto-populates `memory_id` to continue conversational search |
+| Clear conversation | Removes `memory_id` to start a new conversation |
+| Version filtering | Filter agentic search use cases by OpenSearch version |
+
+##### Backend Enhancement: Source Parameter Preservation
+
+The `AgenticQueryTranslatorProcessor` now preserves `_source` field selection (includes/excludes) when translating agentic queries to DSL:
+
+```java
+// Preserve source field selection
+if (originalSourceBuilder != null && originalSourceBuilder.fetchSource() != null) {
+    newSourceBuilder.fetchSource(originalSourceBuilder.fetchSource());
+}
+```
+
+This fixes an issue where `_source.excludes` (e.g., excluding embedding fields) was not applied to agentic query results.
+
+### Usage Example
+
+#### Agentic Query with Source Filtering
+
+```json
+POST products/_search?search_pipeline=agentic-pipeline
+{
+  "_source": {
+    "excludes": ["description_embedding"]
+  },
+  "query": {
+    "agentic": {
+      "query_text": "Find products with smooth writing feel"
+    }
+  }
+}
+```
+
+#### Conversational Search in SRW
+
+1. Execute an agentic query in the Search Relevance Workbench
+2. View the `memory_id` in the AgentInfo panel
+3. Click "Continue conversation" to add the memory ID to your query
+4. Ask follow-up questions that build on previous context
+5. Click "Clear conversation" to start fresh
+
+### Migration Notes
+
+No migration required. The new features are backward compatible with existing agentic search configurations.
+
+## Limitations
+
+- Agent search is asynchronous and may take 30+ seconds to complete
+- Memory ID management requires a conversational agent type
+- Source parameter preservation only applies to the neural-search plugin's agentic query translator
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#693](https://github.com/opensearch-project/dashboards-search-relevance/pull/693) | dashboards-search-relevance | Add support for agent search in pairwise comparison |
+| [#802](https://github.com/opensearch-project/dashboards-search-relevance/pull/802) | dashboards-search-relevance | Add MCP server support |
+| [#805](https://github.com/opensearch-project/dashboards-search-relevance/pull/805) | dashboards-search-relevance | Improve export / next steps UX |
+| [#807](https://github.com/opensearch-project/dashboards-search-relevance/pull/807) | dashboards-search-relevance | Simplify form inputs |
+| [#808](https://github.com/opensearch-project/dashboards-search-relevance/pull/808) | dashboards-search-relevance | Simplify form inputs II |
+| [#812](https://github.com/opensearch-project/dashboards-search-relevance/pull/812) | dashboards-search-relevance | Improve Test Flow UX |
+| [#813](https://github.com/opensearch-project/dashboards-search-relevance/pull/813) | dashboards-search-relevance | Add version filtering on agentic search use case |
+| [#1669](https://github.com/opensearch-project/neural-search/pull/1669) | neural-search | Preserve source parameter for the query |
+
+## References
+
+- [Issue #1664](https://github.com/opensearch-project/neural-search/issues/1664): Agentic Search: Support of `_source.excludes`
+- [Issue #677](https://github.com/opensearch-project/dashboards-search-relevance/issues/677): Agent search support tracking
+- [Blog: Introducing agentic search in OpenSearch](https://opensearch.org/blog/introducing-agentic-search-in-opensearch-transforming-data-interaction-through-natural-language/): Official announcement
+- [Agentic Search Documentation](https://docs.opensearch.org/latest/vector-search/ai-search/agentic-search/index/): Setup and usage guide
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/neural-search/agentic-search.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -129,6 +129,7 @@
 
 ### Search Relevance
 
+- [Agentic Search](features/dashboards-search-relevance/agentic-search.md) - Pairwise comparison support, MCP server integration, conversational search UI, source parameter preservation
 - [Scheduled Experiments](features/search-relevance/scheduled-experiments.md) - Cron-based scheduling for recurring experiment execution with historical results tracking
 - [Query Sets & Judgment Lists](features/dashboards-search-relevance/query-sets-judgment-lists.md) - GUID filtering support for Query Sets with strongly typed QuerySetItem interface
 - [Search Relevance CI/Tests](features/search-relevance/ci-tests.md) - Test dependency fixes, JDWP debugging support, deprecated API removal, and test code cleanups


### PR DESCRIPTION
## Summary

This PR adds documentation for the Agentic Search feature enhancements in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/dashboards-search-relevance/agentic-search.md`
- Feature report: `docs/features/neural-search/agentic-search.md` (updated)

### Key Changes in v3.4.0

**Dashboards Search Relevance (7 PRs):**
- Pairwise comparison support for agentic search queries
- MCP server integration
- Conversational search UI with memory ID management
- Improved test flow UX
- Simplified form inputs
- Version filtering for agentic search use cases

**Neural Search (1 PR):**
- Source parameter preservation (`_source.includes`/`_source.excludes`) for agentic queries

### Resources Used
- PR: opensearch-project/dashboards-search-relevance#693
- PR: opensearch-project/neural-search#1669
- Issue: opensearch-project/neural-search#1664
- Blog: https://opensearch.org/blog/introducing-agentic-search-in-opensearch-transforming-data-interaction-through-natural-language/

Closes #1613