### PR TITLE
docs: add Dashboards Chat report for v3.4.0

### DIFF
--- a/docs/features/opensearch-dashboards/ai-chat.md
+++ b/docs/features/opensearch-dashboards/ai-chat.md
@@ -130,6 +130,10 @@ flowchart TB
 | ReAct Agent | `src/agents/langgraph/react_agent.ts` | LangGraph-based reasoning agent |
 | Bedrock Client | `src/agents/langgraph/bedrock_client.ts` | AWS Bedrock API integration |
 | MCP Clients | `src/mcp/` | Local and HTTP MCP server clients |
+| SuggestedActionsService | `src/plugins/chat` | Registry for suggestion providers (v3.4.0) |
+| ChatSuggestions | `src/plugins/chat` | UI for contextual suggestions (v3.4.0) |
+| LogActionRegistry | `src/plugins/explore` | Registry for log entry actions (v3.4.0) |
+| LogActionMenu | `src/plugins/explore` | Dropdown for log actions (v3.4.0) |
 
 ### Configuration
 
@@ -250,12 +254,19 @@ npm run start:ag-ui
 - **Single-threaded**: One conversation at a time per agent instance
 - **MCP Configuration**: Servers must be pre-configured before agent starts
 - **Limited Testing**: Comprehensive test coverage is ongoing
-- **No Persistence**: Conversation history not persisted across sessions
+- **Session-based Persistence**: Conversation history persists within browser session only (v3.4.0+)
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.4.0 | [#10824](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10824) | Register chat as the global search command |
+| v3.4.0 | [#10834](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10834) | Add AI related actions in Explore |
+| v3.4.0 | [#10863](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10863) | Add suggestion system for chat |
+| v3.4.0 | [#10895](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10895) | Persist chatbot state in localStorage |
+| v3.4.0 | [#10916](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10916) | Add session storage persistence for chat history |
+| v3.4.0 | [#10924](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10924) | Add close button for chatbot header |
+| v3.4.0 | [#10934](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10934) | Add getThreadId$ observable in chat service |
 | v3.3.0 | [#10600](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10600) | Add experimental AI Chat and Context Provider plugins |
 | v3.3.0 | [#10612](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10612) | AG-UI compliant LangGraph ReAct agent implementation |
 | v3.3.0 | [#10624](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10624) | Mark context provider and chat as experimental |
@@ -264,6 +275,7 @@ npm run start:ag-ui
 
 - [RFC #10585](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10585): AI Assistant Framework for OpenSearch Dashboards
 - [RFC #10571](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10571): Context Design and Page Tools Architecture
+- [OpenSearch Assistant Documentation](https://docs.opensearch.org/3.4/dashboards/dashboards-assistant/index/)
 - [AG-UI Protocol Documentation](https://docs.ag-ui.com/introduction)
 - [Model Context Protocol](https://modelcontextprotocol.io/)
 - [LangGraph Documentation](https://langchain-ai.github.io/langgraph/)
@@ -271,4 +283,5 @@ npm run start:ag-ui
 
 ## Change History
 
+- **v3.4.0** (2025-11): Global search integration, suggestion system, state persistence, session storage, Explore integration, UI improvements
 - **v3.3.0** (2025-10): Initial implementation with Chat plugin, Context Provider plugin, and osd-agents ReAct agent

--- a/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-chat.md
+++ b/docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-chat.md
@@ -1,0 +1,176 @@
+# Dashboards Chat
+
+## Summary
+
+OpenSearch Dashboards v3.4.0 introduces significant enhancements to the AI Chat feature, focusing on improved integration, state persistence, and extensibility. Key additions include global search integration for initiating chat from the search bar, a suggestion system allowing plugins to provide contextual suggestions, state persistence across page navigation, and session storage for conversation continuity.
+
+## Details
+
+### What's New in v3.4.0
+
+This release enhances the experimental AI Chat feature with:
+
+1. **Global Search Integration**: Users can now initiate AI conversations directly from the global search bar
+2. **Suggestion System**: Extensible framework for plugins to provide contextual suggestions based on conversation history
+3. **State Persistence**: Chatbot window state (open/closed, layout mode, size) persists in localStorage
+4. **Session Storage**: Chat history and thread continuity maintained across page navigation
+5. **Explore Integration**: "Ask AI" action available on log entries in the Explore plugin
+6. **UI Improvements**: Close button added to chatbot header, observable thread ID for plugin integration
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        GlobalSearch[Global Search Bar]
+        ChatPlugin[Chat Plugin]
+        ExplorePlugin[Explore Plugin]
+        
+        subgraph "Chat Service"
+            ChatWindow[Chat Window]
+            SuggestedActions[Suggested Actions Service]
+            StateManager[State Persistence]
+            SessionStorage[Session Storage]
+            ThreadObservable[Thread ID Observable]
+        end
+        
+        subgraph "Log Actions Framework"
+            LogActionRegistry[Log Action Registry]
+            LogActionMenu[Log Action Menu]
+            AskAIAction[Ask AI Action]
+        end
+    end
+    
+    GlobalSearch -->|AI_CHATBOT_COMMAND| ChatPlugin
+    ChatPlugin --> ChatWindow
+    ChatPlugin --> SuggestedActions
+    ChatPlugin --> StateManager
+    ChatPlugin --> SessionStorage
+    ChatPlugin --> ThreadObservable
+    
+    ExplorePlugin --> LogActionRegistry
+    LogActionRegistry --> LogActionMenu
+    LogActionMenu --> AskAIAction
+    AskAIAction --> ChatPlugin
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `SuggestedActionsService` | Registry for suggestion providers with priority-based ordering |
+| `ChatSuggestions` | UI component displaying contextual suggestions as interactive bubbles |
+| `LogActionRegistry` | Centralized registry for log entry actions in Explore |
+| `LogActionMenu` | Dropdown interface showing available actions for log entries |
+| `CurrentChatState` | Interface for session storage persistence |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `localStorage.chatbot.state` | Persisted chatbot window state (open, layout, size) | - |
+| `sessionStorage.chat.state` | Current chat thread ID and messages | - |
+
+#### API Changes
+
+**SuggestedActionsProvider Interface**:
+```typescript
+interface SuggestedActionsProvider {
+  id: string;
+  priority: number;
+  getSuggestions: (context: ChatContext) => Promise<Suggestion[]>;
+  isEnabled?: () => boolean;
+}
+```
+
+**LogActionDefinition Interface**:
+```typescript
+interface LogActionDefinition {
+  id: string;
+  displayName: string;
+  iconType: string;
+  order: number;
+  isCompatible: (context: LogActionContext) => boolean;
+  component: React.ComponentType<LogActionItemProps>;
+}
+```
+
+**ChatService Extensions**:
+```typescript
+// New methods in ChatService
+getThreadId$(): Observable<string | undefined>;
+saveCurrentChatState(): void;
+loadCurrentChatState(): CurrentChatState | null;
+clearCurrentChatState(): void;
+startNewConversation(initialContent?: string): void;
+```
+
+### Usage Example
+
+**Registering a suggestion provider**:
+```typescript
+// In plugin setup()
+chat.suggestedActions.registerProvider({
+  id: 'my-plugin-suggestions',
+  priority: 100,
+  getSuggestions: async (context: ChatContext) => {
+    if (context.messageHistory.some(msg => 
+      msg.content.includes('visualization'))) {
+      return [{
+        actionType: 'customize',
+        message: 'Create a visualization from this data',
+        action: async () => {
+          application.navigateToApp('visualize');
+          return true;
+        }
+      }];
+    }
+    return [];
+  },
+  isEnabled: () => true
+});
+```
+
+**Using global search to start chat**:
+Users can type a question in the global search bar and press Enter. The chat window opens with the query pre-populated, enabling seamless AI interaction.
+
+**Observing thread changes**:
+```typescript
+// Other plugins can observe thread ID changes
+chatService.getThreadId$().subscribe(threadId => {
+  console.log('Chat thread changed:', threadId);
+});
+```
+
+### Migration Notes
+
+No migration required. New features are additive and backward compatible with existing chat functionality.
+
+## Limitations
+
+- Suggestion providers must be registered during plugin setup phase
+- Log actions framework currently only available in Explore plugin
+- Session storage cleared when browser tab is closed
+- Global search integration requires chat plugin to be enabled
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#10824](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10824) | Register chat as the global search command |
+| [#10834](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10834) | Add AI related actions in Explore with log actions framework |
+| [#10863](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10863) | Add suggestion system for chat with provider registry |
+| [#10895](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10895) | Persist chatbot state in localStorage |
+| [#10916](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10916) | Add session storage persistence for chat history |
+| [#10924](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10924) | Add close button for chatbot header |
+| [#10934](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10934) | Add getThreadId$ observable in chat service |
+
+## References
+
+- [OpenSearch Assistant Documentation](https://docs.opensearch.org/3.4/dashboards/dashboards-assistant/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/ai-chat.md)

--- a/docs/releases/v3.4.0/index.md
+++ b/docs/releases/v3.4.0/index.md
@@ -66,6 +66,7 @@
 ### OpenSearch Dashboards
 
 - [Dashboards AI Insights](features/opensearch-dashboards/dashboards-ai-insights.md) - Detection Insights workspace category and log pattern agent support for Discover Summary
+- [Dashboards Chat](features/opensearch-dashboards/dashboards-chat.md) - Global search integration, suggestion system, state persistence, session storage, Explore integration
 - [Dashboards Dev Tools](features/opensearch-dashboards/dashboards-dev-tools.md) - PATCH method support for Dev Tools console
 - [Dashboards Explore](features/opensearch-dashboards/dashboards-explore.md) - Histogram breakdowns, Field Statistics tab, trace flyout, correlations, cancel query, and by-value embeddables
 - [Dashboards Global Search](features/opensearch-dashboards/dashboards-global-search.md) - Assets search and enhanced command system for global search


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dashboards Chat feature enhancements in OpenSearch v3.4.0.

### Reports Created
- Release report: `docs/releases/v3.4.0/features/opensearch-dashboards/dashboards-chat.md`
- Feature report: `docs/features/opensearch-dashboards/ai-chat.md` (updated)

### Key Changes in v3.4.0
- Global search integration for initiating AI conversations from search bar
- Suggestion system with extensible provider registry
- State persistence in localStorage (window state, layout mode)
- Session storage for chat history and thread continuity
- Explore plugin integration with "Ask AI" action on log entries
- UI improvements including close button and observable thread ID

### Related PRs
- #10824: Register chat as the global search command
- #10834: Add AI related actions in Explore
- #10863: Add suggestion system for chat
- #10895: Persist chatbot state in localStorage
- #10916: Add session storage persistence for chat history
- #10924: Add close button for chatbot header
- #10934: Add getThreadId$ observable in chat service

Closes #1736