### PR TITLE
docs: add dashboard-and-visualization-fixes report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -209,6 +209,7 @@
 - [Content Management](opensearch-dashboards/content-management.md)
 - [Content Security Policy (CSP)](opensearch-dashboards/dashboards-csp.md)
 - [Cross-Cluster Search](opensearch-dashboards/cross-cluster-search.md)
+- [Dashboard & Visualization Fixes](opensearch-dashboards/dashboard-and-visualization-fixes.md)
 - [Dashboards CI/CD & Documentation](opensearch-dashboards/dashboards-ci-cd-documentation.md)
 - [Dashboards CI/Tests](opensearch-dashboards/dashboards-ci-tests.md)
 - [Dashboards Console](opensearch-dashboards/dashboards-console.md)

--- a/docs/features/opensearch-dashboards/dashboard-and-visualization-fixes.md
+++ b/docs/features/opensearch-dashboards/dashboard-and-visualization-fixes.md
@@ -1,0 +1,139 @@
+# Dashboard & Visualization Fixes
+
+## Summary
+
+This feature tracks bug fixes related to adding visualizations to dashboards in OpenSearch Dashboards. The fixes address issues with the "Add to Dashboards after saving" workflow and URL encoding problems that could prevent visualizations from being properly added or loaded.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph Visualization Creation Flow
+        A[User Creates Visualization] --> B[Save Dialog]
+        B --> C{Add to Dashboard?}
+        C -->|Yes| D[Save Visualization]
+        D --> E[Update URL State]
+        E --> F[Preserve Location State]
+        F --> G[Return to Dashboard]
+        G --> H[Add Visualization Panel]
+        C -->|No| I[Save Only]
+    end
+    
+    subgraph URL Handling
+        J[Visualization ID] --> K[encodeURIComponent]
+        K --> L[Add to URL]
+        L --> M[Navigate]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `create_dashboard_app_state.tsx` | Manages dashboard application state and URL synchronization |
+| `use_dashboard_app_state.tsx` | React hook for dashboard state management |
+| `new_vis_modal.tsx` | Modal component for creating new visualizations |
+| `scopedHistory` | Browser history wrapper that maintains location state |
+
+### Data Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant VisModal as Visualization Modal
+    participant Dashboard as Dashboard App
+    participant History as Scoped History
+    participant URL as URL State Storage
+    
+    User->>VisModal: Create & Save Visualization
+    VisModal->>VisModal: Encode searchId
+    VisModal->>Dashboard: Navigate with visualization ID
+    Dashboard->>History: Get current location state
+    Dashboard->>URL: Update URL state
+    URL->>URL: Flush changes
+    Dashboard->>History: Restore location state
+    History->>Dashboard: State preserved
+    Dashboard->>User: Visualization added to dashboard
+```
+
+### Bug Fixes
+
+#### 1. Location State Preservation (v3.0.0)
+
+**Problem:** When creating a visualization from a dashboard with "Add to Dashboards after saving" enabled, the visualization would not be added. This was especially reproducible when `storeInSessionStorage` was enabled.
+
+**Root Cause:** The dashboard application state update at startup would modify the URL, causing the `scopedHistory` location state (containing the new visualization ID) to be lost.
+
+**Solution:** The `updateStateUrl` function now preserves the previous location state after flushing URL changes:
+
+```typescript
+export const updateStateUrl = ({
+  osdUrlStateStorage,
+  state,
+  scopedHistory,
+  replace,
+}: {
+  osdUrlStateStorage: IOsdUrlStateStorage;
+  state: DashboardAppState;
+  scopedHistory: ScopedHistory;
+  replace: boolean;
+}) => {
+  osdUrlStateStorage.set(APP_STATE_STORAGE_KEY, toUrlState(state), { replace });
+  const previousState = scopedHistory.location.state;
+  const changed = osdUrlStateStorage.flush({ replace });
+  if (changed) {
+    scopedHistory.replace({
+      ...scopedHistory.location,
+      state: previousState,
+    });
+  }
+  return changed;
+};
+```
+
+#### 2. Search ID URL Encoding (v3.0.0)
+
+**Problem:** When adding a new visualization, the visualization ID would be decoded after being added to the URL, causing a "not found" error.
+
+**Solution:** Properly encode the `searchId` before adding it to URL parameters:
+
+```typescript
+params = [`type=${encodeURIComponent(visType.name)}`];
+searchId = encodeURIComponent(searchId || '');
+
+if (searchType) {
+  params.push(`${searchType === 'search' ? 'savedSearchId' : 'indexPattern'}=${searchId}`);
+}
+```
+
+### Configuration
+
+No additional configuration is required. These fixes work automatically with existing dashboard settings.
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `state:storeInSessionStorage` | Store URL state in session storage | `false` |
+
+## Limitations
+
+- The location state preservation fix is particularly relevant when `storeInSessionStorage` is enabled
+- These fixes are specific to the visualization creation workflow from within a dashboard
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#9072](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9072) | Preserve location state at dashboard app startup |
+| v3.0.0 | [#8530](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8530) | Encode searchId in URL |
+
+## References
+
+- [Issue #7204](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7204): Original bug report
+- [PR #8164](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8164): Related location state handling PR
+- [Creating dashboards](https://docs.opensearch.org/3.0/dashboards/dashboard/index/): Official documentation
+
+## Change History
+
+- **v3.0.0** (2025-03-11): Fixed "Add to Dashboards after saving" and URL encoding issues

--- a/docs/releases/v3.0.0/features/opensearch-dashboards/dashboard-and-visualization-fixes.md
+++ b/docs/releases/v3.0.0/features/opensearch-dashboards/dashboard-and-visualization-fixes.md
@@ -1,0 +1,101 @@
+# Dashboard & Visualization Fixes
+
+## Summary
+
+This release includes two bug fixes that address issues when adding visualizations to dashboards in OpenSearch Dashboards. The fixes resolve problems with the "Add to Dashboards after saving" feature and URL encoding issues that could cause visualizations to fail to load.
+
+## Details
+
+### What's New in v3.0.0
+
+Two critical bug fixes improve the reliability of adding visualizations to dashboards:
+
+1. **Location State Preservation**: Fixes the "Add to Dashboards after saving" feature when `storeInSessionStorage` is enabled
+2. **Search ID Encoding**: Properly encodes visualization IDs in URLs to prevent decoding issues
+
+### Technical Changes
+
+#### Fix 1: Preserve Location State at Dashboard App Startup (PR #9072)
+
+When creating a new visualization from a dashboard and saving it with "Add to Dashboards after saving" enabled, the visualization would fail to be added. This occurred because the dashboard application state update at startup caused the `scopedHistory` location state to be lost.
+
+```mermaid
+flowchart TB
+    subgraph Before Fix
+        A1[Create Visualization] --> B1[Save with Add to Dashboard]
+        B1 --> C1[Dashboard App State Updates URL]
+        C1 --> D1[Location State Lost]
+        D1 --> E1[Visualization Not Added]
+    end
+    
+    subgraph After Fix
+        A2[Create Visualization] --> B2[Save with Add to Dashboard]
+        B2 --> C2[Dashboard App State Updates URL]
+        C2 --> D2[Location State Preserved]
+        D2 --> E2[Visualization Added Successfully]
+    end
+```
+
+**Changed Files:**
+- `src/plugins/dashboard/public/application/utils/create_dashboard_app_state.tsx`
+- `src/plugins/dashboard/public/application/utils/use/use_dashboard_app_state.tsx`
+- `src/plugins/dashboard/public/application/utils/mocks.ts`
+
+**Key Code Change:**
+The `updateStateUrl` function now preserves the `scopedHistory` location state after flushing URL state changes:
+
+```typescript
+const previousState = scopedHistory.location.state;
+const changed = osdUrlStateStorage.flush({ replace });
+if (changed) {
+  scopedHistory.replace({
+    ...scopedHistory.location,
+    state: previousState,
+  });
+}
+```
+
+#### Fix 2: Encode Search ID in URL (PR #8530)
+
+When adding a new visualization, the visualization ID could be decoded after being added to the URL, causing a "not found" error.
+
+**Changed File:**
+- `src/plugins/visualizations/public/wizard/new_vis_modal.tsx`
+
+**Key Code Change:**
+```typescript
+searchId = encodeURIComponent(searchId || '');
+```
+
+### Usage Example
+
+To reproduce the fixed behavior:
+
+1. Enable `storeInSessionStorage` in OpenSearch Dashboards settings
+2. Navigate to an existing dashboard and click **Edit**
+3. Click **Create New** and select a visualization type
+4. Configure the visualization and click **Save**
+5. Ensure **Add to Dashboards after saving** is enabled
+6. Click **Save and Return**
+7. The visualization is now correctly added to the dashboard
+
+## Limitations
+
+- These fixes are specific to the dashboard visualization workflow
+- The location state preservation fix is particularly relevant when `storeInSessionStorage` is enabled
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9072](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9072) | Preserve location state at dashboard app startup to fix adding a new visualization |
+| [#8530](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8530) | Encode searchId as it tends to be decoded after adds into url |
+
+## References
+
+- [Issue #7204](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7204): Original bug report for "Add to Dashboards after saving" not working
+- [PR #8164](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8164): Original PR that introduced the location state handling
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/dashboard-and-visualization-fixes.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -48,6 +48,7 @@
 ## opensearch-dashboards
 
 - [CI/CD & Build Fixes](features/opensearch-dashboards/ci-cd-build-fixes.md)
+- [Dashboard & Visualization Fixes](features/opensearch-dashboards/dashboard-and-visualization-fixes.md)
 - [Cross-Cluster Search](features/opensearch-dashboards/cross-cluster-search.md)
 - [Data Importer](features/opensearch-dashboards/data-importer.md)
 - [Dashboards CI/CD & Documentation](features/opensearch-dashboards/dashboards-ci-cd-documentation.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for Dashboard & Visualization Fixes in OpenSearch Dashboards v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch-dashboards/dashboard-and-visualization-fixes.md`
- Feature report: `docs/features/opensearch-dashboards/dashboard-and-visualization-fixes.md`

### Key Changes in v3.0.0
- **PR #9072**: Preserve location state at dashboard app startup to fix adding a new visualization
- **PR #8530**: Encode searchId as it tends to be decoded after adds into url

### Bug Fixes
1. Fixed "Add to Dashboards after saving" not working when `storeInSessionStorage` is enabled
2. Fixed URL encoding issues that caused visualizations to fail to load

Closes #280