### PR TITLE
docs: add PPL Query Support report for v3.0.0

### DIFF
--- a/docs/features/opensearch-dashboards/query-enhancements.md
+++ b/docs/features/opensearch-dashboards/query-enhancements.md
@@ -117,6 +117,11 @@ source = logs-* | where status >= 400 | head 100
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.0.0 | [#9120](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9120) | Fix PPL grammar parsing issues in auto-suggest |
+| v3.0.0 | [#9379](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9379) | Make PPL time column respect timezone and date format |
+| v3.0.0 | [#9436](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9436) | Make PPL handle milliseconds in date fields |
+| v3.0.0 | [#9586](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9586) | Correctly show error message in DQL and PPL query editor |
+| v3.0.0 | [#9603](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9603) | Skip appending time range when not querying with source |
 | v2.18.0 | [#8245](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8245) | Expose method to register search strategy routes |
 | v2.18.0 | [#8252](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8252) | Fix running recent query button |
 | v2.18.0 | [#8299](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8299) | Expose datasets and data_frames directories for imports |
@@ -130,9 +135,11 @@ source = logs-* | where status >= 400 | head 100
 
 ## References
 
-- [Dashboards Query Language (DQL)](https://docs.opensearch.org/2.18/dashboards/dql/): Official DQL documentation
-- [Query Workbench](https://docs.opensearch.org/2.18/dashboards/query-workbench/): SQL/PPL query interface documentation
+- [Dashboards Query Language (DQL)](https://docs.opensearch.org/3.0/dashboards/dql/): Official DQL documentation
+- [PPL Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/ppl/index/): Official PPL language reference
+- [Query Workbench](https://docs.opensearch.org/3.0/dashboards/query-workbench/): SQL/PPL query interface documentation
 
 ## Change History
 
+- **v3.0.0** (2025-03-11): PPL query bugfixes - grammar parsing in auto-suggest, timezone handling for time columns, millisecond precision in date fields, error message display in query editors, time range handling for non-search queries
 - **v2.18.0** (2024-11-05): Bug fixes for async polling, error handling, language compatibility, saved query persistence; Added extensibility for custom search strategies via `defineSearchStrategyRoute`; Added keyboard shortcut (Cmd/Ctrl+Enter) for query execution; Exposed datasets and data_frames modules for external plugin imports

--- a/docs/releases/v3.0.0/features/opensearch-dashboards/ppl-query-support.md
+++ b/docs/releases/v3.0.0/features/opensearch-dashboards/ppl-query-support.md
@@ -1,0 +1,140 @@
+# PPL Query Support
+
+## Summary
+
+This release includes several bugfixes for PPL (Piped Processing Language) query support in OpenSearch Dashboards. The fixes address grammar parsing issues in auto-suggest, timezone handling for time columns, millisecond precision in date fields, error message display in query editors, and time range handling for non-search queries.
+
+## Details
+
+### What's New in v3.0.0
+
+Five bugfixes improve the PPL query experience in Discover and query editors:
+
+1. **Grammar Parsing Fix** - Auto-suggest now correctly handles PPL grammar changes
+2. **Timezone Handling** - Time columns respect user's timezone and date format settings
+3. **Millisecond Precision** - Date fields now include milliseconds (`YYYY-MM-DDTHH:mm:ss.SSSZ`)
+4. **Error Message Display** - Error messages correctly display in both DQL and PPL query editors
+5. **Time Range Handling** - Time range is only appended when using the `source` command
+
+### Technical Changes
+
+#### Date Formatting Architecture
+
+```mermaid
+graph TB
+    subgraph "Query Execution"
+        QE[Query Editor] --> SI[Search Interceptor]
+        SI --> PPL[PPL Search Strategy]
+    end
+    subgraph "Result Processing"
+        PPL --> DF[Data Frame Response]
+        DF --> CR[convertResult]
+        CR --> FMT[Field Formatter]
+    end
+    subgraph "Display"
+        FMT --> DT[Discover Table]
+        DT --> TZ[Timezone Conversion]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `formatter` option in `ISearchOptions` | Allows language-specific field formatting during result conversion |
+| `processField` / `processNestedField` | Handles date formatting for flat and nested object fields |
+| `isPPLSearchQuery` | Utility to detect if a PPL query uses the `source` command |
+| `safeJSONParse` | Safely parses JSON error messages without throwing |
+| `displayErrorMessage` | Extracts error details from various error response formats |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `UI_SETTINGS.DATE_FORMAT` | Date format setting key | - |
+| `UI_SETTINGS.DATE_FORMAT_TIMEZONE` | Timezone setting key | - |
+
+#### API Changes
+
+The `convertResult` function signature changed to accept an options object:
+
+```typescript
+// Before
+convertResult(response: IDataFrameResponse): SearchResponse<any>
+
+// After
+convertResult({
+  response,
+  fields,
+  options,
+}: {
+  response: IDataFrameResponse;
+  fields?: SearchSourceFields;
+  options?: ISearchOptions;
+}): SearchResponse<any>
+```
+
+The `ISearchOptions` interface now includes a `formatter` property:
+
+```typescript
+interface ISearchOptions {
+  withLongNumeralsSupport?: boolean;
+  formatter?: (value: any, type: OSD_FIELD_TYPES) => any;
+}
+```
+
+### Usage Example
+
+PPL date fields are automatically formatted with the correct timezone:
+
+```typescript
+// PPL language config registers a formatter
+fields: {
+  formatter: (value: string, type: OSD_FIELD_TYPES) => {
+    switch (type) {
+      case OSD_FIELD_TYPES.DATE:
+        return moment.utc(value).format('YYYY-MM-DDTHH:mm:ss.SSSZ');
+      default:
+        return value;
+    }
+  },
+}
+```
+
+Time range is only appended for queries using the `source` command:
+
+```ppl
+# Time range appended
+source = logs-* | where status >= 400
+
+# Time range NOT appended (non-search queries)
+describe logs-*
+```
+
+### Migration Notes
+
+No migration required. These are bugfixes that improve existing PPL query functionality.
+
+## Limitations
+
+- PPL date formatting relies on UTC conversion; complex timezone scenarios may require additional handling
+- Error message parsing handles multiple formats but may not cover all edge cases
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9120](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9120) | Fix PPL grammar parsing issues in auto-suggest |
+| [#9379](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9379) | Make PPL time column respect timezone and date format |
+| [#9436](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9436) | Make PPL handle milliseconds in date fields |
+| [#9586](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9586) | Correctly show error message in DQL and PPL query editor |
+| [#9603](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9603) | Skip appending time range when not querying with source |
+
+## References
+
+- [PPL Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/ppl/index/): Official PPL language reference
+- [SQL and PPL](https://docs.opensearch.org/3.0/search-plugins/sql/index/): SQL/PPL plugin overview
+
+## Related Feature Report
+
+- [Query Enhancements](../../../../features/opensearch-dashboards/query-enhancements.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -57,6 +57,7 @@
 - [Dashboards Frontend Cleanup](features/opensearch-dashboards/dashboards-frontend-cleanup.md)
 - [Dashboards UI/UX Fixes](features/opensearch-dashboards/dashboards-ui-ux-fixes.md)
 - [Monaco Editor Upgrade](features/opensearch-dashboards/monaco-editor-upgrade.md)
+- [PPL Query Support](features/opensearch-dashboards/ppl-query-support.md)
 - [UI/UX Improvements](features/opensearch-dashboards/ui-ux-improvements.md)
 - [Workspace Improvements](features/opensearch-dashboards/workspace-improvements.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for PPL Query Support bugfixes in OpenSearch Dashboards v3.0.0.

## Reports Created

- **Release report**: `docs/releases/v3.0.0/features/opensearch-dashboards/ppl-query-support.md`
- **Feature report**: Updated `docs/features/opensearch-dashboards/query-enhancements.md`

## Key Changes in v3.0.0

Five bugfixes improve PPL query experience:

1. **Grammar Parsing Fix** (#9120) - Auto-suggest correctly handles PPL grammar changes
2. **Timezone Handling** (#9379) - Time columns respect user's timezone and date format settings
3. **Millisecond Precision** (#9436) - Date fields include milliseconds (`YYYY-MM-DDTHH:mm:ss.SSSZ`)
4. **Error Message Display** (#9586) - Error messages correctly display in DQL and PPL query editors
5. **Time Range Handling** (#9603) - Time range only appended when using `source` command

## Related Issue

Closes #279