### PR TITLE
docs: add Query Assistant report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -244,6 +244,7 @@
 - [Plugin Compatibility](opensearch-dashboards/plugin-compatibility.md)
 - [Query Editor](opensearch-dashboards/query-editor.md)
 - [Query Enhancements](opensearch-dashboards/query-enhancements.md)
+- [Query Assistant](opensearch-dashboards/query-assistant.md)
 - [Sample Data](opensearch-dashboards/sample-data.md)
 - [Saved Query UX](opensearch-dashboards/saved-query-ux.md)
 - [Security CVE Fixes](opensearch-dashboards/security-cve-fixes.md)

--- a/docs/features/opensearch-dashboards/query-assistant.md
+++ b/docs/features/opensearch-dashboards/query-assistant.md
@@ -1,0 +1,144 @@
+# Query Assistant
+
+## Summary
+
+Query Assistant is an AI-powered feature in OpenSearch Dashboards that enables users to generate PPL (Piped Processing Language) queries from natural language questions. It leverages large language models (LLMs) through the OpenSearch Assistant Toolkit to translate user questions into executable queries, making data exploration accessible to users without deep query language expertise.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        UI[Query Assistant UI]
+        SearchBar[Search Bar Component]
+        DatasetSelector[Dataset Selector]
+    end
+    
+    subgraph "Backend Services"
+        API[Assistant API]
+        T2PPL[Text-to-PPL Skill]
+        Summary[Summarization Skill]
+        D2S[Data2Summary Agent]
+    end
+    
+    subgraph "ML Commons"
+        Agent[ML Agent Framework]
+        Connector[LLM Connector]
+        LLM[Large Language Model]
+    end
+    
+    subgraph "OpenSearch"
+        PPL[PPL Engine]
+        Index[Data Index]
+    end
+    
+    UI --> SearchBar
+    SearchBar --> DatasetSelector
+    UI --> API
+    API --> T2PPL
+    API --> Summary
+    API --> D2S
+    T2PPL --> Agent
+    Summary --> Agent
+    D2S --> Agent
+    Agent --> Connector
+    Connector --> LLM
+    T2PPL --> PPL
+    PPL --> Index
+    Index --> UI
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[User Question] --> B[Query Assistant UI]
+    B --> C{Dataset Supported?}
+    C -->|No| D[Show Error Placeholder]
+    C -->|Yes| E[Send to T2PPL Agent]
+    E --> F[LLM Processing]
+    F --> G{Streaming?}
+    G -->|Yes| H[Stream Response]
+    G -->|No| I[Return Full Response]
+    H --> J[Generated PPL]
+    I --> J
+    J --> K[Execute Query]
+    K --> L[Display Results]
+    L --> M[Summarize Results]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Query Assistant UI | Search bar interface for natural language input |
+| Text-to-PPL Skill | Converts natural language to PPL queries using LLM |
+| Summarization Skill | Generates human-readable summaries of query results |
+| Data2Summary Agent | Agent for generating data summaries |
+| Dataset Selector | Allows users to select target index/dataset |
+| Streaming Handler | Processes real-time streaming responses from LLM |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `assistant.chat.enabled` | Enable OpenSearch Assistant | `false` |
+| `assistant.next.enabled` | Enable experimental assistant features | `false` |
+
+### Usage Example
+
+```yaml
+# Enable Query Assistant in opensearch_dashboards.yml
+assistant.chat.enabled: true
+assistant.next.enabled: true
+```
+
+Configure the root agent:
+
+```json
+PUT .plugins-ml-config/_doc/os_chat
+{
+  "type": "os_chat_root_agent",
+  "configuration": {
+    "agent_id": "your_root_agent_id"
+  }
+}
+```
+
+Example natural language queries:
+- "Show me all errors in the last hour"
+- "What are the top 10 source IPs by request count?"
+- "Find failed login attempts from yesterday"
+
+## Limitations
+
+- Requires ML Commons plugin and configured LLM connector
+- Query generation quality depends on the underlying LLM model
+- Only supports datasets/index patterns compatible with PPL
+- Streaming requires backend support for `text/event-stream` content type
+- Data2Summary agent must be configured for assistant entry to appear
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#9647](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9647) | Support streaming when content type is event stream |
+| v3.0.0 | [#9232](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9232) | Display query assistant when dataset is not supported |
+| v3.0.0 | [#9532](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9532) | Append prompt for query assistant in request payload |
+| v3.0.0 | [#9277](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9277) | Hide assistant entry when data2summary agent missing |
+| v3.0.0 | [#9552](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9552) | Remove placeholder of last asked question |
+| v3.0.0 | [#9601](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9601) | Fix PPL refresh on regeneration |
+
+## References
+
+- [OpenSearch Assistant for OpenSearch Dashboards](https://docs.opensearch.org/3.0/dashboards/dashboards-assistant/index/): Official documentation
+- [OpenSearch Assistant Toolkit](https://docs.opensearch.org/3.0/ml-commons-plugin/opensearch-assistant/): ML Commons integration guide
+- [OpenSearch adds a new generative AI assistant toolkit](https://opensearch.org/blog/opensearch-adds-new-generative-ai-assistant-toolkit/): Introduction blog post
+- [Build your own chatbot](https://docs.opensearch.org/3.0/ml-commons-plugin/tutorials/build-chatbot/): Tutorial for configuring the assistant
+
+## Change History
+
+- **v3.0.0** (2025): Added streaming support, unsupported dataset handling, prompt customization, and multiple bug fixes for UI state management
+- **v2.13** (2024): Initial implementation of OpenSearch Assistant toolkit

--- a/docs/releases/v3.0.0/features/opensearch-dashboards/query-assistant.md
+++ b/docs/releases/v3.0.0/features/opensearch-dashboards/query-assistant.md
@@ -1,0 +1,111 @@
+# Query Assistant
+
+## Summary
+
+Query Assistant in OpenSearch Dashboards v3.0.0 receives several enhancements and bug fixes that improve the natural language to PPL query generation experience. Key improvements include streaming response support for real-time feedback, better error handling for unsupported datasets, prompt customization in request payloads, and fixes for UI state management issues.
+
+## Details
+
+### What's New in v3.0.0
+
+This release includes 3 new features and 3 bug fixes for the Query Assistant functionality in OpenSearch Dashboards.
+
+### Technical Changes
+
+#### New Features
+
+| Feature | Description | PR |
+|---------|-------------|-----|
+| Streaming Support | Returns pure fetch response when content-type is `text/event-stream`, enabling real-time streaming responses from LLM | [#9647](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9647) |
+| Unsupported Dataset Handling | Displays error placeholder and disables input when selected dataset is not supported for query generation | [#9232](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9232) |
+| Prompt Customization | Appends custom prompt for query assistant in request payload for enhanced query generation | [#9532](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9532) |
+
+#### Bug Fixes
+
+| Fix | Description | PR |
+|-----|-------------|-----|
+| Assistant Entry Visibility | Hides the assistant entry when data2summary agent is not configured | [#9277](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9277) |
+| Placeholder Cleanup | Removes the placeholder of last asked question after query submission | [#9552](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9552) |
+| PPL Refresh | Fixes issue where query assistant doesn't refresh generated PPL when regenerating | [#9601](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9601) |
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Query Assistant Flow"
+        User[User Input]
+        QA[Query Assistant UI]
+        T2PPL[Text-to-PPL Agent]
+        LLM[LLM Backend]
+        Results[Query Results]
+    end
+    
+    subgraph "v3.0.0 Enhancements"
+        Stream[Streaming Support]
+        Prompt[Custom Prompts]
+        Error[Error Handling]
+    end
+    
+    User --> QA
+    QA --> T2PPL
+    T2PPL --> LLM
+    LLM --> |text/event-stream| Stream
+    Stream --> Results
+    QA --> Prompt
+    QA --> Error
+```
+
+### Usage Example
+
+The streaming support enables real-time response display:
+
+```typescript
+// When content-type is text/event-stream, 
+// the response is returned as a pure fetch response
+// enabling streaming consumption
+const response = await http.fetch('/api/assistant/query', {
+  method: 'POST',
+  body: JSON.stringify({
+    question: 'Show me errors in the last hour',
+    prompt: customPrompt // New in v3.0.0
+  })
+});
+
+// For streaming responses
+if (response.headers.get('content-type')?.includes('text/event-stream')) {
+  // Handle streaming response
+  const reader = response.body.getReader();
+  // Process stream chunks...
+}
+```
+
+### Migration Notes
+
+No migration required. These changes are backward compatible.
+
+## Limitations
+
+- Streaming support requires the backend to return `text/event-stream` content type
+- Query generation is limited to supported dataset types (index patterns)
+- The data2summary agent must be configured for the assistant entry to appear
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9647](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9647) | Support streaming when content type is event stream |
+| [#9232](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9232) | Display query assistant when dataset is not supported |
+| [#9532](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9532) | Append prompt for query assistant in request payload |
+| [#9277](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9277) | Hide the assistant entry when there isn't data2summary agent |
+| [#9552](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9552) | Query-assist removed the placeholder of last ask question |
+| [#9601](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9601) | Query assistant doesn't refresh generated ppl |
+
+## References
+
+- [OpenSearch Assistant for OpenSearch Dashboards](https://docs.opensearch.org/3.0/dashboards/dashboards-assistant/index/): Official documentation
+- [OpenSearch Assistant Toolkit](https://docs.opensearch.org/3.0/ml-commons-plugin/opensearch-assistant/): ML Commons integration
+- [OpenSearch adds a new generative AI assistant toolkit](https://opensearch.org/blog/opensearch-adds-new-generative-ai-assistant-toolkit/): Introduction blog post
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/query-assistant.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -48,6 +48,7 @@
 ## opensearch-dashboards
 
 - [CI/CD & Build Fixes](features/opensearch-dashboards/ci-cd-build-fixes.md)
+- [Query Assistant](features/opensearch-dashboards/query-assistant.md)
 - [Dashboard & Visualization Fixes](features/opensearch-dashboards/dashboard-and-visualization-fixes.md)
 - [Cross-Cluster Search](features/opensearch-dashboards/cross-cluster-search.md)
 - [Data Importer](features/opensearch-dashboards/data-importer.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Query Assistant feature in OpenSearch Dashboards v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch-dashboards/query-assistant.md`
- Feature report: `docs/features/opensearch-dashboards/query-assistant.md`

### Key Changes in v3.0.0

**New Features:**
- Streaming support for real-time LLM responses (`text/event-stream`)
- Unsupported dataset handling with error placeholders
- Custom prompt support in request payloads

**Bug Fixes:**
- Hide assistant entry when data2summary agent is not configured
- Remove placeholder of last asked question after submission
- Fix PPL refresh on regeneration

### Related Issue
Closes #278