### PR TITLE
docs: add Discover Plugin Enhancements report for v3.0.0

### DIFF
--- a/docs/features/opensearch-dashboards/discover.md
+++ b/docs/features/opensearch-dashboards/discover.md
@@ -100,6 +100,7 @@ flowchart TB
 | `discover:sampleSize` | Number of documents to show | 500 |
 | `query:enhancements:enabled` | Enable query enhancements (SQL/PPL support) | Off |
 | `queryEnhancements.queryAssist.summary.enabled` | Enable AI data summary panel | false |
+| `queryEnhancements.queryAssist.summary.branding.label` | Custom title for summary panel | (none) |
 
 ### Usage Example
 
@@ -146,6 +147,18 @@ Requires ML agent configuration:
 | v3.4.0 | [#9693](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9693) | Support log pattern agent in discover summary |
 | v3.2.0 | [#10345](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10345) | Fix empty page when no index patterns exist |
 | v3.2.0 | [#10315](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10315) | Add cypress tests for discover visualization |
+| v3.0.0 | [#9530](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9530) | Add CSV export from Discover page |
+| v3.0.0 | [#9498](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9498) | Move HITs counter and show results count |
+| v3.0.0 | [#9494](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9494) | Update position of query summary and editor |
+| v3.0.0 | [#9481](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9481) | Allow customizing summary panel title |
+| v3.0.0 | [#9469](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9469) | Update formatHit to accept type parameter |
+| v3.0.0 | [#9655](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9655) | Enable experimental __enhance with resultsActionBar |
+| v3.0.0 | [#9316](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9316) | Clean up sync URL subscription in topNav |
+| v3.0.0 | [#9347](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9347) | Fix flattenHit modifying original array |
+| v3.0.0 | [#9523](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9523) | Correctly show selected columns from saved search |
+| v3.0.0 | [#9529](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9529) | Correctly load saved search from snapshot URL |
+| v3.0.0 | [#9541](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9541) | Correctly load saved search query in query editor |
+| v3.0.0 | [#9465](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9465) | Prevent visiting Discover outside workspace |
 | v2.18.0 | [#8186](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8186) | Add data summary panel in discover |
 | v2.18.0 | [#8214](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8214) | Add cache time and refresh button to dataset selector |
 | v2.18.0 | [#8651](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8651) | Update the appearance of Discover |
@@ -164,9 +177,12 @@ Requires ML agent configuration:
 - [Issue #8177](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8177): Feature request for LLM data summary
 - [Issue #7626](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7626): Discover hang bug report
 - [Issue #8612](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8612): Bug report for deleted index pattern issue
+- [Issue #9309](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9309): URL sync subscription leak
+- [Issue #9318](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9318): flattenHit array mutation bug
 
 ## Change History
 
 - **v3.4.0** (2025-11-06): Added log pattern detection for Discover Summary - automatically uses specialized `os_data2summary_with_log_pattern` agent for log indexes
 - **v3.2.0** (2025-08-05): Fixed empty page issue when no index patterns exist, added Cypress tests for discover visualization
+- **v3.0.0** (2025-05-13): Added CSV export functionality, reorganized results display with ResultsActionBar, customizable summary panel title, experimental Data plugin `__enhance` API with resultsActionBar, and 6 bug fixes for saved search handling and workspace integration
 - **v2.18.0** (2024-11-05): Added AI-powered data summary panel, updated visual appearance, cache management in dataset selector, and 14 bug fixes for stability and usability

--- a/docs/releases/v3.0.0/features/opensearch-dashboards/discover-plugin-enhancements.md
+++ b/docs/releases/v3.0.0/features/opensearch-dashboards/discover-plugin-enhancements.md
@@ -1,0 +1,137 @@
+# Discover Plugin Enhancements
+
+## Summary
+
+OpenSearch Dashboards v3.0.0 introduces significant enhancements to the Discover plugin, including CSV export functionality, improved UI layout with relocated results counter, customizable summary panel titles, and extensibility improvements through the Data plugin's `__enhance` API. Additionally, multiple bug fixes improve saved search handling, workspace integration, and URL synchronization.
+
+## Details
+
+### What's New in v3.0.0
+
+#### CSV Export from Discover
+
+Users can now export search results directly from the Discover page to CSV format with two options:
+- **Visible**: Downloads currently displayed rows (up to sample size)
+- **Max Available**: Downloads up to 10,000 documents matching the query (DQL/Lucene only)
+
+```mermaid
+flowchart TB
+    A[User clicks Download] --> B{Select Option}
+    B -->|Visible| C[Export current table rows]
+    B -->|Max Available| D{Has HITS data?}
+    D -->|Yes| E[Query up to 10,000 docs]
+    D -->|No| F[Option disabled]
+    E --> G[Generate CSV]
+    C --> G
+    G --> H[Download file]
+```
+
+#### Results Action Bar
+
+The results display has been reorganized:
+- HITs counter moved closer to the table
+- New `ResultsActionBar` component houses results count and export button
+- Format: `Results (X/Y)` where X = displayed rows, Y = total hits
+- For SQL queries without hits: `Results (X)`
+
+#### Summary Panel Customization
+
+New configuration option allows customizing the AI summary panel title:
+
+```yaml
+# opensearch_dashboards.yml
+queryEnhancements.queryAssist.summary.branding.label: 'AI Assistant'
+```
+
+#### Data Plugin Extensibility
+
+The Data plugin's `__enhance` API is now experimental and includes:
+- `resultsActionBar`: Area for custom buttons in the results action bar
+- Renamed `getSearchBarButton` to `getQueryControlButtons`
+- Documentation for extension usage
+
+### Technical Changes
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ResultsActionBar` | Container for results count and action buttons |
+| `DownloadCSV` | CSV export functionality with visible/max options |
+| `useSyncQueryStateWithUrl` | Hook for proper URL sync cleanup |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `queryEnhancements.queryAssist.summary.branding.label` | Custom title for summary panel | (none) |
+
+#### API Changes
+
+| Change | Description |
+|--------|-------------|
+| `formatHit.formatField()` | Now accepts `type` parameter for text/html output |
+| `__enhance` | Marked as experimental, includes `resultsActionBar` |
+| `getSearchBarButton` | Renamed to `getQueryControlButtons` |
+
+### Bug Fixes
+
+| Issue | Fix |
+|-------|-----|
+| URL sync memory leak | Properly clean up URL subscription when navigating away |
+| Array mutation in flattenHit | Create new array instead of modifying original |
+| Saved search columns not loading | Move column filtering to `DiscoverTable` |
+| Saved search from snapshot URL | Preserve URL state when loading saved search |
+| Query not loading in editor | Compare incoming props with state, not previous props |
+| Workspace access | Prevent access to Discover outside workspace context |
+
+### Usage Example
+
+```typescript
+// CSV Export - triggered from ResultsActionBar
+// Visible option
+downloadCSV(rows, columns, 'visible');
+
+// Max Available option (up to 10,000)
+const maxRows = Math.min(hits, 10000);
+const data = await fetchAllDocuments(query, maxRows);
+downloadCSV(data, columns, 'max-available');
+```
+
+### Migration Notes
+
+- The `getSearchBarButton` method has been renamed to `getQueryControlButtons`
+- The `__enhance` API is now experimental - usage may change in future versions
+- `formatHit.formatField()` now requires explicit `type` parameter for non-HTML output
+
+## Limitations
+
+- CSV export "Max Available" option limited to 10,000 documents
+- CSV export "Max Available" only available for DQL/Lucene queries (not SQL)
+- Summary panel customization requires server restart
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9530](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9530) | Add CSV export from Discover page |
+| [#9498](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9498) | Move HITs counter and show results count |
+| [#9494](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9494) | Update position of query summary and editor |
+| [#9481](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9481) | Allow customizing summary panel title |
+| [#9469](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9469) | Update formatHit to accept type parameter |
+| [#9655](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9655) | Enable experimental __enhance with resultsActionBar |
+| [#9316](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9316) | Clean up sync URL subscription in topNav |
+| [#9347](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9347) | Fix flattenHit modifying original array |
+| [#9523](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9523) | Correctly show selected columns from saved search |
+| [#9529](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9529) | Correctly load saved search from snapshot URL |
+| [#9541](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9541) | Correctly load saved search query in query editor |
+| [#9465](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9465) | Prevent visiting Discover outside workspace |
+
+## References
+
+- [Issue #9309](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9309): URL sync subscription leak
+- [Issue #9318](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9318): flattenHit array mutation bug
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/discover.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -57,6 +57,7 @@
 - [Dashboards Dependencies](features/opensearch-dashboards/dashboards-dependencies.md)
 - [Dashboards Frontend Cleanup](features/opensearch-dashboards/dashboards-frontend-cleanup.md)
 - [Dashboards UI/UX Fixes](features/opensearch-dashboards/dashboards-ui-ux-fixes.md)
+- [Discover Plugin Enhancements](features/opensearch-dashboards/discover-plugin-enhancements.md)
 - [Discover Summary / AI Assistant Integration](features/opensearch-dashboards/discover-summary-ai-assistant-integration.md)
 - [Monaco Editor Upgrade](features/opensearch-dashboards/monaco-editor-upgrade.md)
 - [PPL Query Support](features/opensearch-dashboards/ppl-query-support.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Discover Plugin Enhancements in OpenSearch Dashboards v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch-dashboards/discover-plugin-enhancements.md`
- Feature report: `docs/features/opensearch-dashboards/discover.md` (updated)

### Key Changes in v3.0.0

**New Features:**
- CSV export from Discover page (Visible and Max Available options)
- ResultsActionBar component with relocated HITs counter
- Customizable summary panel title via configuration
- Experimental Data plugin `__enhance` API with resultsActionBar extension point

**Bug Fixes:**
- URL sync subscription cleanup in topNav
- flattenHit no longer modifies original array
- Saved search columns load correctly
- Saved search loads properly from snapshot URL
- Query loads correctly in query editor
- Workspace access restriction for Discover

### PRs Investigated
- #9530, #9498, #9494, #9481, #9469, #9655 (features)
- #9316, #9347, #9523, #9529, #9541, #9465 (bugfixes)

Closes #276