### PR TITLE
docs: add S3/Direct Query Connections report for v3.0.0

### DIFF
--- a/docs/features/opensearch-dashboards/data-connections.md
+++ b/docs/features/opensearch-dashboards/data-connections.md
@@ -87,6 +87,7 @@ flowchart TB
 |---------|-------------|---------|
 | `data_source.enabled` | Enable Multi-Data Source feature | `false` |
 | `data_source.hideLocalCluster` | Hide local cluster from data source selection | `false` |
+| `data_source.clientPool.size` | Client pool size for data source connections | `10` |
 | `query:enhancements:enabled` | Enable query enhancements for redirection | `true` |
 
 ### API Endpoints
@@ -95,6 +96,7 @@ flowchart TB
 |----------|-------------|
 | `/api/directquery/dataconnections/dataSourceMDSId={id}` | MDS-aware data connections endpoint |
 | `/api/directquery/dataconnections` | Legacy non-MDS endpoint (deprecated when MDS enabled) |
+| `DELETE /api/enhancements/jobs?id={dataSourceId}&queryId={queryId}` | Cancel async query jobs |
 
 ### Usage Example
 
@@ -117,11 +119,15 @@ data_source:
 - When `query:enhancements:enabled` is disabled, redirection from data connections to Discover is disabled
 - Direct query connections require the Observability plugin for full functionality
 - The "Query data" card redirects to Discover without pre-selecting the datasource
+- If more than 10 data sources are loaded on a single page, server crashes may occur due to deprecated `parseUrl` function in elasticsearch legacy library
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.0.0 | [#9355](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9355) | Deletes S3 Jobs in Backend when Original Query is Canceled |
+| v3.0.0 | [#9430](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9430) | Add mappings for tinyint, smallint, and bigint in S3 dataset type |
+| v3.0.0 | [#9575](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9575) | Fix potential memory leak in getDirectQueryConnections |
 | v3.4.0 | [#10968](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10968) | Create saved object for prometheus data-connection |
 | v2.18.0 | [#8255](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8255) | Support data connections and multi-select table in dataset picker |
 | v2.18.0 | [#8460](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8460) | Replace segmented button with tabs |
@@ -137,12 +143,15 @@ data_source:
 
 - [Issue #8256](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8256): Redirection issue for direct query datasource
 - [Issue #8536](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/8536): Deprecate non-MDS data connection endpoint
+- [Issue #9459](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9459): Node.js v20 Plugin Verification Meta Issue
 - [RFC #9535](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9535): Prometheus as first-class datasource proposal
 - [Data Sources Documentation](https://docs.opensearch.org/3.0/dashboards/management/data-sources/): Official documentation
 - [Multi-Data Sources Documentation](https://docs.opensearch.org/3.0/dashboards/management/multi-data-sources/): Configuring multiple data sources
+- [Connecting Amazon S3 to OpenSearch](https://docs.opensearch.org/3.0/dashboards/management/S3-data-source/): S3 data source documentation
 
 ## Change History
 
+- **v3.0.0** (2025-05-13): S3 query cancellation, extended numeric type mappings (tinyint, smallint, bigint), memory leak fix for Node.js 20 compatibility, increased client pool size to 10
 - **v3.4.0** (2025-03-11): Prometheus saved object support - Prometheus connections now stored as `data-connection` saved objects with MDS support, added "No Auth" authentication option
 - **v2.18.0** (2024-10-22): Dataset picker data connections support (multi-select table, pagination, search), UI improvements (tabs navigation, type display), MDS endpoint unification, auto-complete MDS support, fit and finish fixes
 - **v2.17.0** (2024-09-17): Added data-connection saved object type for external connections (CloudWatch, Security Lake)

--- a/docs/releases/v3.0.0/features/opensearch-dashboards/s3-direct-query-connections.md
+++ b/docs/releases/v3.0.0/features/opensearch-dashboards/s3-direct-query-connections.md
@@ -1,0 +1,117 @@
+# S3 / Direct Query Connections
+
+## Summary
+
+OpenSearch Dashboards v3.0.0 includes several improvements to S3 and Direct Query Connections, focusing on query cancellation, data type mappings, and memory leak prevention. These changes improve the reliability and stability of querying external S3 data sources through OpenSearch Dashboards.
+
+## Details
+
+### What's New in v3.0.0
+
+1. **Backend Job Cancellation**: When users abort S3 queries in Discover, the backend jobs are now properly canceled/deleted via the SQL plugin API
+2. **Extended Numeric Type Mappings**: Added support for `tinyint`, `smallint`, and `bigint` data types in S3 datasets
+3. **Memory Leak Fix**: Fixed potential memory leak in `getDirectQueryConnections` with Node.js 20 compatibility
+
+### Technical Changes
+
+#### Query Cancellation Flow
+
+```mermaid
+flowchart TB
+    subgraph "User Action"
+        ABORT[User Aborts Query]
+    end
+    
+    subgraph "Frontend"
+        SIGNAL[AbortSignal Triggered]
+        CATCH[Catch AbortError]
+        DELETE[Send DELETE Request]
+    end
+    
+    subgraph "Backend"
+        ROUTE[DELETE /api/enhancements/jobs]
+        CLIENT[Data Source Client]
+        SQL[SQL Plugin API]
+    end
+    
+    subgraph "OpenSearch"
+        JOB[Async Query Job]
+    end
+    
+    ABORT --> SIGNAL
+    SIGNAL --> CATCH
+    CATCH --> DELETE
+    DELETE --> ROUTE
+    ROUTE --> CLIENT
+    CLIENT --> SQL
+    SQL --> JOB
+    JOB -->|Job Deleted| SQL
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `DELETE /api/enhancements/jobs` | New API endpoint for canceling async query jobs |
+| `enhancements.deleteJob` | Backend client method to delete jobs via SQL plugin |
+| S3 Field Type Mappings | Extended numeric type support for S3 datasets |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `data_source.clientPool.size` | Client pool size for data source connections | `10` (was `5`) |
+| Request timeout for `ppl.getDataConnections` | Timeout for direct query connection requests | `5000ms` |
+
+#### API Changes
+
+New DELETE endpoint for job cancellation:
+
+```
+DELETE /api/enhancements/jobs?id={dataSourceId}&queryId={queryId}
+```
+
+### Usage Example
+
+When a user starts an S3 query and then clicks the query button again or navigates away, the previous query is automatically canceled:
+
+```typescript
+// Frontend automatically cancels previous query
+// When AbortError is caught, DELETE request is sent
+await http.fetch({
+  method: 'DELETE',
+  path: '/api/enhancements/jobs',
+  query: {
+    id: dataSource.id,
+    queryId: previousQueryId,
+  },
+});
+```
+
+### Migration Notes
+
+- The default client pool size has increased from 5 to 10, which may affect memory usage in environments with many concurrent data source connections
+- The 5-second timeout on `ppl.getDataConnections` prevents hanging requests but may cause timeouts in slow network environments
+
+## Limitations
+
+- If more than 10 data sources are loaded on a single page, server crashes may still occur due to a deprecated `parseUrl` function in the elasticsearch legacy library (tracked in Issue #2220)
+- Query cancellation requires the SQL plugin to be installed and configured
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9355](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9355) | Deletes S3 Jobs in Backend when Original Query is Canceled |
+| [#9430](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9430) | Add mappings for tinyint, smallint, and bigint in S3 dataset type |
+| [#9575](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9575) | Fix potential memory leak in getDirectQueryConnections |
+
+## References
+
+- [Issue #9459](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9459): Node.js v20 Plugin Verification Meta Issue
+- [Issue #2220](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2220): Elasticsearch legacy client deprecation
+- [Connecting Amazon S3 to OpenSearch](https://docs.opensearch.org/3.0/dashboards/management/S3-data-source/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/data-connections.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -61,6 +61,7 @@
 - [Discover Summary / AI Assistant Integration](features/opensearch-dashboards/discover-summary-ai-assistant-integration.md)
 - [Monaco Editor Upgrade](features/opensearch-dashboards/monaco-editor-upgrade.md)
 - [PPL Query Support](features/opensearch-dashboards/ppl-query-support.md)
+- [S3 / Direct Query Connections](features/opensearch-dashboards/s3-direct-query-connections.md)
 - [UI/UX Improvements](features/opensearch-dashboards/ui-ux-improvements.md)
 - [Workspace Improvements](features/opensearch-dashboards/workspace-improvements.md)
 - [Multi-Data Source (MDS)](features/opensearch-dashboards/multi-data-source-mds.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the S3 / Direct Query Connections improvements in OpenSearch Dashboards v3.0.0.

### Changes in v3.0.0

1. **Backend Job Cancellation** (PR #9355): When users abort S3 queries in Discover, the backend jobs are now properly canceled/deleted via the SQL plugin API
2. **Extended Numeric Type Mappings** (PR #9430): Added support for `tinyint`, `smallint`, and `bigint` data types in S3 datasets
3. **Memory Leak Fix** (PR #9575): Fixed potential memory leak in `getDirectQueryConnections` with Node.js 20 compatibility

### Reports Created

- Release report: `docs/releases/v3.0.0/features/opensearch-dashboards/s3-direct-query-connections.md`
- Feature report updated: `docs/features/opensearch-dashboards/data-connections.md`

### Related Issue

Closes #274