### PR TITLE
docs: add Webpack & Build Performance report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -251,6 +251,7 @@
 - [TSVB Visualization](opensearch-dashboards/tsvb-visualization.md)
 - [UI Settings](opensearch-dashboards/ui-settings.md)
 - [Vended Dashboard Progress](opensearch-dashboards/vended-dashboard-progress.md)
+- [Webpack & Build Performance](opensearch-dashboards/webpack-and-build-performance.md)
 - [Workspace](opensearch-dashboards/workspace.md)
 
 ## security

--- a/docs/features/opensearch-dashboards/webpack-and-build-performance.md
+++ b/docs/features/opensearch-dashboards/webpack-and-build-performance.md
@@ -1,0 +1,188 @@
+# Webpack & Build Performance
+
+## Summary
+
+OpenSearch Dashboards includes automated performance monitoring tools to track bundle sizes and page load metrics. These CI workflows help developers identify performance regressions early by monitoring webpack bundle size variations and running Lighthouse audits on key pages.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Performance Monitoring"
+        PR[Pull Request] --> CI[CI Pipeline]
+        CI --> BA[Bundle Analyzer]
+        CI --> LH[Lighthouse CI]
+    end
+    
+    subgraph "Bundle Analysis"
+        BA --> Build[Build Plugins]
+        Build --> Limits[limits.yml]
+        Limits --> Compare[Compare Sizes]
+        Compare --> Delta[limits_delta.yml]
+    end
+    
+    subgraph "Page Performance"
+        LH --> OSD[Start Dashboards]
+        OSD --> Pages[Test Pages]
+        Pages --> Metrics[FCP, Speed Index]
+        Metrics --> Baseline[Compare Baseline]
+    end
+    
+    Delta --> Report[PR Comment]
+    Baseline --> Report
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `performance_testing.yml` | GitHub Actions workflow for bundle size monitoring |
+| `lighthouse_testing.yml` | GitHub Actions workflow for Lighthouse performance testing |
+| `.lighthouserc.js` | Lighthouse CI configuration defining URLs and thresholds |
+| `baselines/lighthouse_baseline.json` | Performance baseline values for key pages |
+| `packages/osd-optimizer/limits.yml` | Bundle size limits per plugin |
+| `packages/osd-optimizer/src/limits.ts` | Logic for tracking bundle size variations |
+
+### Configuration
+
+#### Bundle Size Limits
+
+The `limits.yml` file defines maximum bundle sizes for each plugin:
+
+```yaml
+pageLoadAssetSize:
+  advancedSettings: 27596
+  core: 989885
+  dashboard: 694542
+  data: 2701242
+  discover: 778790
+  # ... more plugins
+```
+
+#### Lighthouse Baselines
+
+Performance thresholds are defined in `baselines/lighthouse_baseline.json`:
+
+| Page | First Contentful Paint | Speed Index |
+|------|----------------------|-------------|
+| `/app/home` | 2800ms | 20000ms |
+| `/app/data-explorer/discover` | 2200ms | 30000ms |
+| `/app/dashboards` | 2200ms | 30000ms |
+| `/app/visualize` | 2200ms | 28000ms |
+
+### Usage
+
+#### Running Lighthouse Locally
+
+```bash
+# Install dependencies
+yarn add --dev @lhci/cli puppeteer
+
+# Bootstrap the project
+yarn osd bootstrap
+
+# Run Lighthouse CI
+yarn lhci autorun --verbose
+```
+
+#### Updating Bundle Limits
+
+```bash
+# Build plugins and update limits
+node scripts/build_opensearch_dashboards_platform_plugins --update-limits
+```
+
+#### Validating Bundle Limits
+
+```bash
+# Validate limits without updating
+node scripts/build_opensearch_dashboards_platform_plugins --validate-limits
+```
+
+### Bundle Size Variation Detection
+
+The system tracks bundle size changes with a 5% threshold:
+
+```typescript
+const DELTA_LIMIT = 0.05; // 5%
+
+const updateBundleSizeVariation = (log: ToolingLog, metric: Metric) => {
+  if (metric.limit != null && metric.value > metric.limit) {
+    const delta = (metric.value - metric.limit) / metric.limit;
+    if (delta > DELTA_LIMIT) {
+      // Log warning and write to limits_delta.yml
+    }
+  }
+};
+```
+
+When a plugin exceeds the threshold, a PR comment is generated:
+
+```
+📊 **Bundle Size crossed 5% for below plugins**
+
+pageLoadAssetSizeVariation:
+  pluginName: 12  # 12% increase
+```
+
+### Lighthouse CI Configuration
+
+```javascript
+module.exports = {
+  ci: {
+    collect: {
+      url: [
+        'http://localhost:5601/app/home',
+        'http://localhost:5601/app/dashboards#/view/...',
+        'http://localhost:5601/app/data-explorer/discover',
+        'http://localhost:5601/app/visualize',
+      ],
+      numberOfRuns: 1,
+      settings: {
+        formFactor: 'desktop',
+        viewport: { width: 1280, height: 800 },
+      },
+    },
+    assert: {
+      assertMatrix: [
+        {
+          matchingUrlPattern: '/app/home',
+          assertions: {
+            'first-contentful-paint': ['warn', { maxNumericValue: 2800 }],
+            'speed-index': ['warn', { maxNumericValue: 20000 }],
+          },
+        },
+        // ... more pages
+      ],
+    },
+  },
+};
+```
+
+## Limitations
+
+- Lighthouse CI runs only on PRs targeting `main` branch
+- Bundle analyzer skips documentation, test files, and workflow changes
+- Performance assertions are warnings only (don't fail the build)
+- Lighthouse results may vary based on CI runner performance
+- Sample data must be loaded for dashboard performance tests
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#9320](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9320) | Webpack bundle analyser limit check |
+| v3.0.0 | [#9304](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9304) | Lighthouse Page Performance Metrics CI workflow |
+
+## References
+
+- [PR #9320](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9320): Bundle analyzer implementation
+- [PR #9304](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9304): Lighthouse CI implementation
+- [Lighthouse CI](https://github.com/GoogleChrome/lighthouse-ci): Google's Lighthouse CI tool
+- [Webpack Bundle Analyzer](https://www.npmjs.com/package/webpack-bundle-analyzer): Bundle analysis tool
+
+## Change History
+
+- **v3.0.0** (2025-03-20): Initial implementation with bundle analyzer and Lighthouse CI workflows

--- a/docs/releases/v3.0.0/features/opensearch-dashboards/webpack-and-build-performance.md
+++ b/docs/releases/v3.0.0/features/opensearch-dashboards/webpack-and-build-performance.md
@@ -1,0 +1,144 @@
+# Webpack & Build Performance
+
+## Summary
+
+OpenSearch Dashboards v3.0.0 introduces automated performance monitoring for build artifacts and page load metrics. Two new CI workflows help developers track bundle size variations and page performance regressions, enabling proactive optimization and preventing performance degradation.
+
+## Details
+
+### What's New in v3.0.0
+
+This release adds two complementary performance monitoring capabilities:
+
+1. **Webpack Bundle Analyzer** - Monitors plugin bundle sizes and alerts when changes exceed 5% threshold
+2. **Lighthouse CI** - Measures page load performance metrics (First Contentful Paint, Speed Index) against baselines
+
+### Technical Changes
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph "CI Pipeline"
+        PR[Pull Request] --> BA[Bundle Analyzer]
+        PR --> LH[Lighthouse CI]
+    end
+    
+    subgraph "Bundle Analyzer"
+        BA --> Build[Build Plugins]
+        Build --> Compare[Compare vs limits.yml]
+        Compare --> Delta{Delta > 5%?}
+        Delta -->|Yes| Report[Post PR Comment]
+        Delta -->|No| Pass[Pass Silently]
+    end
+    
+    subgraph "Lighthouse CI"
+        LH --> Start[Start OSD + OpenSearch]
+        Start --> Run[Run Lighthouse]
+        Run --> Assert[Assert vs Baseline]
+        Assert --> Comment[Post Results]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `performance_testing.yml` | GitHub Actions workflow for bundle size monitoring |
+| `lighthouse_testing.yml` | GitHub Actions workflow for Lighthouse CI |
+| `.lighthouserc.js` | Lighthouse CI configuration with page URLs and thresholds |
+| `baselines/lighthouse_baseline.json` | Performance baseline values for key pages |
+| `packages/osd-optimizer/src/limits.ts` | Enhanced to track bundle size variations |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `DELTA_LIMIT` | Bundle size variation threshold | 0.05 (5%) |
+| `first-contentful-paint` | FCP threshold per page | 1800-2800ms |
+| `speed-index` | Speed Index threshold per page | 15000-30000ms |
+
+#### Lighthouse Baseline Configuration
+
+```json
+{
+  "/app/home": {
+    "first-contentful-paint": 2800,
+    "speed-index": 20000
+  },
+  "/app/data-explorer/discover": {
+    "first-contentful-paint": 2200,
+    "speed-index": 30000
+  },
+  "/app/dashboards": {
+    "first-contentful-paint": 2200,
+    "speed-index": 30000
+  },
+  "/app/visualize": {
+    "first-contentful-paint": 2200,
+    "speed-index": 28000
+  }
+}
+```
+
+### Usage Example
+
+#### Running Lighthouse Locally
+
+```bash
+# Install Lighthouse CI
+yarn add --dev @lhci/cli
+
+# Run Lighthouse CI
+yarn lhci autorun
+```
+
+#### Bundle Size Monitoring
+
+The bundle analyzer runs automatically on PRs. When a plugin's bundle size increases by more than 5%, a comment is posted:
+
+```
+📊 **Bundle Size crossed 5% for below plugins**
+
+pageLoadAssetSizeVariation:
+  myPlugin: 12
+```
+
+### How It Works
+
+**Bundle Analyzer Workflow:**
+1. Builds all platform plugins
+2. Runs `--update-limits` to compare against `limits.yml`
+3. Generates `limits_delta.yml` for plugins exceeding 5% threshold
+4. Posts results as PR comment
+
+**Lighthouse Workflow:**
+1. Starts OpenSearch and OpenSearch Dashboards
+2. Loads sample e-commerce data
+3. Runs Lighthouse against configured URLs
+4. Compares metrics against baseline
+5. Posts detailed report with links to hosted Lighthouse reports
+
+## Limitations
+
+- Lighthouse CI runs only on PRs to `main` branch
+- Bundle analyzer ignores documentation, test files, and workflow changes
+- Performance thresholds are warnings only (don't fail CI)
+- Lighthouse results can vary based on CI runner load
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9320](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9320) | Webpack bundle analyser limit check |
+| [#9304](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9304) | Lighthouse Page Performance Metrics CI workflow |
+
+## References
+
+- [PR #9320](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9320): Bundle analyzer implementation
+- [PR #9304](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9304): Lighthouse CI implementation
+- [Lighthouse CI Documentation](https://github.com/GoogleChrome/lighthouse-ci)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/webpack-and-build-performance.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -65,6 +65,7 @@
 - [UI/UX Improvements](features/opensearch-dashboards/ui-ux-improvements.md)
 - [Workspace Improvements](features/opensearch-dashboards/workspace-improvements.md)
 - [Multi-Data Source (MDS)](features/opensearch-dashboards/multi-data-source-mds.md)
+- [Webpack & Build Performance](features/opensearch-dashboards/webpack-and-build-performance.md)
 
 ## reporting
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Webpack & Build Performance feature in OpenSearch Dashboards v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch-dashboards/webpack-and-build-performance.md`
- Feature report: `docs/features/opensearch-dashboards/webpack-and-build-performance.md`

### Key Changes in v3.0.0
- **Webpack Bundle Analyzer** - New CI workflow that monitors plugin bundle sizes and alerts when changes exceed 5% threshold
- **Lighthouse CI** - New CI workflow that measures page load performance metrics (First Contentful Paint, Speed Index) against baselines

### Related PRs
- [#9320](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9320): Webpack bundle analyser limit check
- [#9304](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9304): Lighthouse Page Performance Metrics CI workflow

Closes #273