### PR TITLE
docs: add Dashboards CVE Fixes report for v3.0.0

### DIFF
--- a/docs/features/opensearch-dashboards/security-cve-fixes.md
+++ b/docs/features/opensearch-dashboards/security-cve-fixes.md
@@ -20,6 +20,10 @@ graph TB
             MM[micromatch<br/>Glob Matching]
             DNS[dns-sync<br/>DNS Resolution]
             TARFS[tar-fs<br/>Archive Extraction]
+            PRISM[prismjs<br/>Syntax Highlighting]
+            BABEL[@babel/runtime<br/>JS Runtime]
+            NANOID[nanoid<br/>ID Generation]
+            POSTCSS[postcss<br/>CSS Processing]
         end
     end
     OSD --> AXIOS
@@ -29,6 +33,10 @@ graph TB
     OSD --> MM
     OSD --> DNS
     OSD --> TARFS
+    OSD --> PRISM
+    OSD --> BABEL
+    OSD --> NANOID
+    OSD --> POSTCSS
 ```
 
 ### Components
@@ -42,12 +50,25 @@ graph TB
 | micromatch | Glob pattern matching | ReDoS vulnerabilities |
 | dns-sync | Synchronous DNS resolution | Command injection |
 | tar-fs | Filesystem bindings for tar archives | Path traversal |
+| prismjs | Syntax highlighting for code | ReDoS vulnerabilities |
+| @babel/runtime | JavaScript runtime helpers | Code execution |
+| nanoid | Unique ID generation | Predictable IDs |
+| postcss | CSS processing tool | ReDoS vulnerabilities |
+| cypress/request | HTTP request library (testing) | SSRF vulnerabilities |
 
 ### CVE Summary
 
 | CVE | Package | Description | Severity |
 |-----|---------|-------------|----------|
 | CVE-2025-48387 | tar-fs | Path traversal during tar extraction | High |
+| CVE-2025-27152 | axios | Server-Side Request Forgery | High |
+| CVE-2025-27789 | @babel/runtime | Code execution vulnerability | Medium |
+| CVE-2024-53382 | prismjs | Regular Expression DoS | Medium |
+| CVE-2024-12905 | tar-fs | Path traversal vulnerability | High |
+| CVE-2024-55565 | nanoid | Predictable ID generation | Low |
+| CVE-2023-28155 | cypress/request | Server-Side Request Forgery | High |
+| CVE-2023-44270 | postcss | Regular Expression DoS | Medium |
+| GHSA-vjh7-7g9h-fjfh | elliptic | Signature verification issues | Medium |
 | CVE-2017-16100 | dns-sync | Command injection via DNS lookup | Critical |
 | CVE-2024-39338 | axios | Server-Side Request Forgery | High |
 | CVE-2024-45296 | path-to-regexp | Regular Expression DoS | High |
@@ -78,6 +99,12 @@ The OpenSearch Dashboards team follows a proactive security update process:
 | Version | PR | Description |
 |---------|-----|-------------|
 | v3.2.0 | [#10225](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10225) | [CVE-2025-48387] tar-fs 2.1.2 → 2.1.3, 3.0.8 → 3.1.0 |
+| v3.0.0 | [#9681](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9681) | [CVE-2025-27789] Bump @babel/runtime, @babel/helpers, @babel/runtime-corejs3 |
+| v3.0.0 | [#9649](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9649) | [CVE-2025-27789][CVE-2024-12905] Bump @babel/runtime to 7.26.10 and tar-fs to 2.1.2 |
+| v3.0.0 | [#9634](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9634) | [CVE-2024-53382] Add prismjs 1.30.0 to resolutions |
+| v3.0.0 | [#9546](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9546) | [GHSA-vjh7-7g9h-fjfh] Bump elliptic to 6.6.1 |
+| v3.0.0 | [#9507](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9507) | [CVE-2025-27152] Bump axios to 1.8.2 |
+| v3.0.0 | [#9503](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9503) | [CVE-2023-28155][CVE-2023-44270][CVE-2024-55565] Bump nanoid, cypress/request, postcss |
 | v2.18.0 | [#7811](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7811) | [CVE-2017-16100] dns-sync patched version |
 | v2.18.0 | [#8026](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8026) | micromatch 4.0.7 → 4.0.8 |
 | v2.18.0 | [#8197](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8197) | [CVE-2024-45296] path-to-regexp updates |
@@ -88,6 +115,14 @@ The OpenSearch Dashboards team follows a proactive security update process:
 ## References
 
 - [CVE-2025-48387](https://nvd.nist.gov/vuln/detail/CVE-2025-48387): tar-fs path traversal
+- [CVE-2025-27152](https://nvd.nist.gov/vuln/detail/CVE-2025-27152): axios SSRF vulnerability
+- [CVE-2025-27789](https://nvd.nist.gov/vuln/detail/CVE-2025-27789): @babel/runtime vulnerability
+- [CVE-2024-53382](https://github.com/advisories/GHSA-968p-4wvh-cqc8): prismjs ReDoS
+- [CVE-2024-12905](https://nvd.nist.gov/vuln/detail/CVE-2024-12905): tar-fs path traversal
+- [CVE-2024-55565](https://nvd.nist.gov/vuln/detail/CVE-2024-55565): nanoid predictable IDs
+- [CVE-2023-28155](https://nvd.nist.gov/vuln/detail/CVE-2023-28155): request SSRF
+- [CVE-2023-44270](https://nvd.nist.gov/vuln/detail/CVE-2023-44270): postcss ReDoS
+- [GHSA-vjh7-7g9h-fjfh](https://github.com/advisories/GHSA-vjh7-7g9h-fjfh): elliptic signature verification
 - [CVE-2017-16100](https://nvd.nist.gov/vuln/detail/CVE-2017-16100): dns-sync command injection
 - [CVE-2024-39338](https://nvd.nist.gov/vuln/detail/CVE-2024-39338): axios SSRF vulnerability
 - [CVE-2024-45296](https://nvd.nist.gov/vuln/detail/CVE-2024-45296): path-to-regexp ReDoS
@@ -97,4 +132,5 @@ The OpenSearch Dashboards team follows a proactive security update process:
 ## Change History
 
 - **v3.2.0** (2026-01-10): Fixed CVE-2025-48387; bumped tar-fs 2.1.2 → 2.1.3, 3.0.8 → 3.1.0
+- **v3.0.0** (2025-05-13): Fixed CVE-2025-27152, GHSA-vjh7-7g9h-fjfh, CVE-2024-53382, CVE-2025-27789, CVE-2024-12905, CVE-2023-28155, CVE-2023-44270, CVE-2024-55565; bumped axios, elliptic, prismjs, @babel/runtime, tar-fs, nanoid, postcss, cypress/request
 - **v2.18.0** (2024-11-05): Fixed CVE-2017-16100, CVE-2024-39338, CVE-2024-45296, CVE-2024-45801, CVE-2024-48948; bumped micromatch

--- a/docs/releases/v3.0.0/features/opensearch-dashboards/dashboards-cve-fixes.md
+++ b/docs/releases/v3.0.0/features/opensearch-dashboards/dashboards-cve-fixes.md
@@ -1,0 +1,74 @@
+# Dashboards CVE Fixes
+
+## Summary
+
+OpenSearch Dashboards v3.0.0 addresses multiple security vulnerabilities by updating npm dependencies. These updates fix CVEs in axios, elliptic, prismjs, @babel/runtime, tar-fs, nanoid, postcss, and cypress/request packages, improving the overall security posture of the dashboard application.
+
+## Details
+
+### What's New in v3.0.0
+
+This release includes 6 PRs that address 8 CVEs across various npm packages:
+
+| CVE | Package | Fixed Version | Severity | Description |
+|-----|---------|---------------|----------|-------------|
+| CVE-2025-27152 | axios | 1.8.2 | High | SSRF vulnerability |
+| GHSA-vjh7-7g9h-fjfh | elliptic | 6.6.1 | Medium | Signature verification issues |
+| CVE-2024-53382 | prismjs | 1.30.0 | Medium | ReDoS vulnerability |
+| CVE-2025-27789 | @babel/runtime | 7.26.10 | Medium | Code execution vulnerability |
+| CVE-2024-12905 | tar-fs | 2.1.2 | High | Path traversal vulnerability |
+| CVE-2023-28155 | cypress/request | 3.0.0 | High | SSRF vulnerability |
+| CVE-2023-44270 | postcss | 8.4.31 | Medium | ReDoS vulnerability |
+| CVE-2024-55565 | nanoid | 3.3.8 | Low | Predictable ID generation |
+
+### Technical Changes
+
+#### Dependency Updates
+
+| Package | Previous Version | New Version | PR |
+|---------|------------------|-------------|-----|
+| axios | < 1.8.2 | 1.8.2 | #9507 |
+| elliptic | < 6.6.1 | 6.6.1 | #9546 |
+| prismjs | < 1.30.0 | 1.30.0 | #9634 |
+| @babel/runtime | 7.23.2 | 7.26.10 | #9649, #9681 |
+| @babel/helpers | - | Updated | #9681 |
+| @babel/runtime-corejs3 | - | Updated | #9681 |
+| tar-fs | 2.1.1 | 2.1.2 | #9649 |
+| cypress/request | < 3.0.0 | 3.0.0 | #9503 |
+| postcss | < 8.4.31 | 8.4.31 | #9503 |
+| nanoid | < 3.3.8 | 3.3.8 | #9503 |
+
+### Migration Notes
+
+No migration steps required. These are dependency updates that do not change any APIs or user-facing functionality.
+
+## Limitations
+
+- Some CVE fixes are applied via yarn resolutions, which may require periodic review as transitive dependencies evolve
+- Low-severity CVEs may still trigger alerts in security scanners until all transitive dependencies are updated
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9507](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9507) | Resolve CVE-2025-27152 by bumping axios to 1.8.2 |
+| [#9546](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9546) | Fix GHSA-vjh7-7g9h-fjfh by bumping elliptic to 6.6.1 |
+| [#9634](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9634) | Resolve CVE-2024-53382 by bumping prismjs to 1.30.0 |
+| [#9649](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9649) | Bump @babel/runtime to 7.26.10 and tar-fs to 2.1.2 for CVE-2025-27789 and CVE-2024-12905 |
+| [#9503](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9503) | [CVE-2023-28155][CVE-2023-44270][CVE-2024-55565] Resolve CVEs |
+| [#9681](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9681) | [CVE-2025-27789] Bump @babel/runtime, @babel/helpers and @babel/runtime-corejs3 |
+
+## References
+
+- [CVE-2025-27152](https://nvd.nist.gov/vuln/detail/CVE-2025-27152): axios SSRF vulnerability
+- [GHSA-vjh7-7g9h-fjfh](https://github.com/advisories/GHSA-vjh7-7g9h-fjfh): elliptic signature verification
+- [CVE-2024-53382](https://github.com/advisories/GHSA-968p-4wvh-cqc8): prismjs ReDoS
+- [CVE-2025-27789](https://nvd.nist.gov/vuln/detail/CVE-2025-27789): @babel/runtime vulnerability
+- [CVE-2024-12905](https://nvd.nist.gov/vuln/detail/CVE-2024-12905): tar-fs path traversal
+- [CVE-2023-28155](https://nvd.nist.gov/vuln/detail/CVE-2023-28155): request SSRF
+- [CVE-2023-44270](https://nvd.nist.gov/vuln/detail/CVE-2023-44270): postcss ReDoS
+- [CVE-2024-55565](https://nvd.nist.gov/vuln/detail/CVE-2024-55565): nanoid predictable IDs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch-dashboards/security-cve-fixes.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -67,6 +67,7 @@
 - [Workspace Improvements](features/opensearch-dashboards/workspace-improvements.md)
 - [Multi-Data Source (MDS)](features/opensearch-dashboards/multi-data-source-mds.md)
 - [Webpack & Build Performance](features/opensearch-dashboards/webpack-and-build-performance.md)
+- [Dashboards CVE Fixes](features/opensearch-dashboards/dashboards-cve-fixes.md)
 
 ## reporting
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dashboards CVE Fixes in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch-dashboards/dashboards-cve-fixes.md`
- Feature report: `docs/features/opensearch-dashboards/security-cve-fixes.md` (updated)

### CVEs Addressed in v3.0.0
- CVE-2025-27152 (axios)
- GHSA-vjh7-7g9h-fjfh (elliptic)
- CVE-2024-53382 (prismjs)
- CVE-2025-27789 (@babel/runtime)
- CVE-2024-12905 (tar-fs)
- CVE-2023-28155 (cypress/request)
- CVE-2023-44270 (postcss)
- CVE-2024-55565 (nanoid)

### Related PRs
- opensearch-project/OpenSearch-Dashboards#9507
- opensearch-project/OpenSearch-Dashboards#9546
- opensearch-project/OpenSearch-Dashboards#9634
- opensearch-project/OpenSearch-Dashboards#9649
- opensearch-project/OpenSearch-Dashboards#9503
- opensearch-project/OpenSearch-Dashboards#9681

Closes #271