### PR TITLE
docs: add Dashboards Dependency Updates report for v3.0.0

### DIFF
--- a/docs/features/opensearch-dashboards/dependency-updates.md
+++ b/docs/features/opensearch-dashboards/dependency-updates.md
@@ -16,15 +16,17 @@ graph TB
             JSON11[json11<br/>JSON Parsing]
             Chokidar[chokidar<br/>File Watching]
             Axios[axios<br/>HTTP Client]
-            Mocha[mocha<br/>Testing]
-            Elliptic[elliptic<br/>Cryptography]
+            Vega[vega<br/>Visualization]
+            DOMPurify[dompurify<br/>HTML Sanitization]
+            MarkdownIt[markdown-it<br/>Markdown Parsing]
         end
     end
     App --> JSON11
     App --> Chokidar
     App --> Axios
-    App --> Mocha
-    App --> Elliptic
+    App --> Vega
+    App --> DOMPurify
+    App --> MarkdownIt
 ```
 
 ### Key Dependencies
@@ -34,8 +36,9 @@ graph TB
 | json11 | JSON parsing with extended features | UTF-8 safety in JSON stringification |
 | chokidar | File system watching for development | Development tooling |
 | axios | HTTP client for API requests | CVE-2024-39338 |
-| mocha | Test framework | SNYK-JS-MOCHA-2863123 |
-| elliptic | Elliptic curve cryptography | CVE-2024-42459, CVE-2024-42460, CVE-2024-42461 |
+| vega | Visualization grammar for charts | CVE-2025-25304 (XSS vulnerability) |
+| dompurify | HTML sanitization | CVE-2025-26791 |
+| markdown-it | Markdown parsing and rendering | Security improvements |
 
 ### Configuration
 
@@ -64,19 +67,26 @@ yarn upgrade json11@^2.0.0
 - Dependency updates may introduce breaking changes requiring code modifications
 - Security patches should be applied promptly but require testing
 - Some dependencies are pinned to specific versions for compatibility
+- Vega updates may require webpack configuration changes
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.0.0 | [#9623](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9623) | Bump vega from 5.23.0 to 5.32.0 |
+| v3.0.0 | [#9447](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9447) | Bump dompurify from 3.1.6 to 3.2.4 |
+| v3.0.0 | [#9412](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9412) | Bump markdown-it from 12.3.2 to 13.0.2 |
 | v2.18.0 | [#8603](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8603) | Upgrade JSON11 from 1.1.2 to 2.0.0 |
 | v2.18.0 | [#8490](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8490) | Bump chokidar from 3.5.3 to 3.6.0 |
 
 ## References
 
+- [Issue #9400](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9400): CVE-2025-25304 in vega-selections
+- [GHSA-mp7w-mhcv-673j](https://github.com/vega/vega/security/advisories/GHSA-mp7w-mhcv-673j): Vega XSS vulnerability advisory
 - [Issue #7367](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7367): JSON.parse bad escaped character bug
 - [OpenSearch Forum](https://forum.opensearch.org/t/json-parse-bad-escaped-character/20211): Community discussion
 
 ## Change History
 
+- **v3.0.0** (2025-05-13): Security updates for vega (5.32.0), dompurify (3.2.4), markdown-it (13.0.2) addressing CVE-2025-25304 and CVE-2025-26791
 - **v2.18.0** (2024-10-22): JSON11 upgrade to 2.0.0 for UTF-8 safety, chokidar bump to 3.6.0

--- a/docs/releases/v3.0.0/features/opensearch-dashboards/dashboards-dependency-updates.md
+++ b/docs/releases/v3.0.0/features/opensearch-dashboards/dashboards-dependency-updates.md
@@ -1,0 +1,95 @@
+# Dashboards Dependency Updates
+
+## Summary
+
+OpenSearch Dashboards v3.0.0 includes critical security updates for three key dependencies: markdown-it, dompurify, and vega. These updates address multiple CVEs and improve the overall security posture of the Dashboards application.
+
+## Details
+
+### What's New in v3.0.0
+
+Three security-focused dependency updates were merged to address known vulnerabilities:
+
+| Dependency | Previous Version | New Version | CVE Addressed |
+|------------|------------------|-------------|---------------|
+| markdown-it | 12.3.2 | 13.0.2 | Security improvements |
+| dompurify | 3.1.6 | 3.2.4 | CVE-2025-26791 |
+| vega | 5.23.0 | 5.32.0 | CVE-2025-25304 (GHSA-mp7w-mhcv-673j) |
+
+### Technical Changes
+
+#### Vega Update (5.23.0 → 5.32.0)
+
+The vega update required significant code changes beyond a simple version bump:
+
+1. **Changed Vega Import Path**: Updated import in `src/plugins/vis_type_vega/public/lib/vega.js` to use standard browser-compatible import:
+   ```javascript
+   import * as vega from 'vega';
+   // Instead of 'vega/build/vega-node' or 'vega/build-es5/vega'
+   ```
+
+2. **Updated Webpack Configuration**: Modified `packages/osd-optimizer/src/worker/webpack.config.ts`:
+   - Removed noParse rules for Vega to allow proper webpack processing
+   - Updated exclude pattern for vega-scenegraph and related packages for Babel processing
+
+3. **Fixed Circular Dependency**: Resolved circular dependency in `src/plugins/vis_type_vega/public/vega_request_handler.ts`:
+   ```javascript
+   const VegaParserModule = await import('./data_model/vega_parser');
+   const vp = new VegaParserModule.VegaParser(...);
+   ```
+
+#### DOMPurify Update (3.1.6 → 3.2.4)
+
+Straightforward version bump addressing CVE-2025-26791 for HTML sanitization security.
+
+#### Markdown-it Update (12.3.2 → 13.0.2)
+
+Version bump for the markdown parsing library used in documentation rendering.
+
+### Security Impact
+
+```mermaid
+graph TB
+    subgraph "CVE Fixes"
+        CVE1[CVE-2025-25304<br/>Vega XSS]
+        CVE2[CVE-2025-26791<br/>DOMPurify]
+    end
+    subgraph "Affected Components"
+        Vega[Vega Visualizations]
+        HTML[HTML Sanitization]
+        MD[Markdown Rendering]
+    end
+    CVE1 --> Vega
+    CVE2 --> HTML
+```
+
+### Migration Notes
+
+These updates are transparent to end users. No configuration changes required.
+
+For plugin developers using Vega:
+- If importing Vega directly, use `import * as vega from 'vega'` instead of build-specific paths
+- Dynamic imports may be needed to avoid circular dependencies
+
+## Limitations
+
+- Vega update required webpack configuration changes that may affect custom builds
+- Some Vega visualizations may need testing to ensure compatibility with the new version
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#9412](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9412) | Bump markdown-it from 12.3.2 to 13.0.2 |
+| [#9447](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9447) | Bump dompurify from 3.1.6 to 3.2.4 |
+| [#9623](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9623) | Bump vega from 5.23.0 to 5.32.0 |
+
+## References
+
+- [Issue #9400](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9400): CVE-2025-25304 in vega-selections
+- [GHSA-mp7w-mhcv-673j](https://github.com/vega/vega/security/advisories/GHSA-mp7w-mhcv-673j): Vega XSS vulnerability advisory
+- [CVE-2025-26791](https://nvd.nist.gov/vuln/detail/CVE-2025-26791): DOMPurify vulnerability
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-dashboards/dependency-updates.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -48,6 +48,7 @@
 ## opensearch-dashboards
 
 - [CI/CD & Build Fixes](features/opensearch-dashboards/ci-cd-build-fixes.md)
+- [Dashboards Dependency Updates](features/opensearch-dashboards/dashboards-dependency-updates.md)
 - [Dashboards Features](features/opensearch-dashboards/dashboards-features.md)
 - [Query Assistant](features/opensearch-dashboards/query-assistant.md)
 - [Dashboard & Visualization Fixes](features/opensearch-dashboards/dashboard-and-visualization-fixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dashboards Dependency Updates in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch-dashboards/dashboards-dependency-updates.md`
- Feature report: `docs/features/opensearch-dashboards/dependency-updates.md` (updated)

### Key Changes in v3.0.0
- **vega**: 5.23.0 → 5.32.0 (CVE-2025-25304 fix)
- **dompurify**: 3.1.6 → 3.2.4 (CVE-2025-26791 fix)
- **markdown-it**: 12.3.2 → 13.0.2 (security improvements)

### PRs Investigated
- [#9412](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9412): Bump markdown-it
- [#9447](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9447): Bump dompurify
- [#9623](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9623): Bump vega

Closes #270