### PR TITLE
docs: add field-type-fixes report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -57,6 +57,7 @@
 - [Field Data Cache](opensearch/field-data-cache.md)
 - [Field Mapping](opensearch/field-mapping.md)
 - [File Cache](opensearch/file-cache.md)
+- [Filter Field Type](opensearch/filter-field-type.md)
 - [Filter Rewrite Optimization](opensearch/filter-rewrite-optimization.md)
 - [FIPS Compliance](opensearch/fips-compliance.md)
 - [Cluster Permissions](opensearch/cluster-permissions.md)

--- a/docs/features/opensearch/filter-field-type.md
+++ b/docs/features/opensearch/filter-field-type.md
@@ -1,0 +1,134 @@
+# FilterFieldType
+
+## Summary
+
+`FilterFieldType` is a wrapper class that allows developers to wrap an existing `MappedFieldType` while delegating all behavior by default. This enables creating custom field types that extend or modify the behavior of existing types without reimplementing all methods. The pattern is essential for features like `SemanticFieldType` in neural-search that need to wrap delegate field types.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Field Type Hierarchy"
+        MFT[MappedFieldType]
+        FFT[FilterFieldType]
+        SFT[SemanticFieldType]
+        DFT[DateFieldType]
+        GFT[GeoPointFieldType]
+    end
+    
+    subgraph "Wrapper Pattern"
+        Wrapper[FilterFieldType Wrapper]
+        Delegate[Delegate MappedFieldType]
+    end
+    
+    MFT --> FFT
+    FFT --> SFT
+    MFT --> DFT
+    MFT --> GFT
+    
+    Wrapper -->|wraps| Delegate
+    Wrapper -->|unwrap| Delegate
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Type Check Flow"
+        A[Get MappedFieldType] --> B{Is Wrapped?}
+        B -->|Yes| C[Call unwrap]
+        B -->|No| D[Use directly]
+        C --> E[Get delegate type]
+        E --> F[instanceof check]
+        D --> F
+        F --> G[Process field]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `FilterFieldType` | Abstract wrapper class that delegates to an underlying `MappedFieldType` |
+| `MappedFieldType.unwrap()` | Method that returns the underlying type (returns `this` for non-wrapped types) |
+| `SemanticFieldType` | Example implementation in neural-search that wraps delegate types |
+
+### Key Methods
+
+| Method | Description |
+|--------|-------------|
+| `unwrap()` | Returns the underlying `MappedFieldType`, unwrapping any wrapper layers |
+| `delegate()` | Returns the wrapped delegate field type (in `FilterFieldType`) |
+
+### Configuration
+
+No configuration required. The `unwrap()` method is automatically available on all `MappedFieldType` instances.
+
+### Usage Example
+
+**Creating a custom wrapped field type:**
+
+```java
+public class CustomFieldType extends FilterFieldType {
+    
+    public CustomFieldType(MappedFieldType delegate) {
+        super(delegate);
+    }
+    
+    @Override
+    public Query termQuery(Object value, QueryShardContext context) {
+        // Custom behavior before delegating
+        preprocessValue(value);
+        return super.termQuery(value, context);
+    }
+}
+```
+
+**Checking field types correctly:**
+
+```java
+public void processField(MappedFieldType fieldType) {
+    // CORRECT: Always unwrap before instanceof check
+    if (fieldType != null && fieldType.unwrap() instanceof DateFieldMapper.DateFieldType) {
+        DateFieldMapper.DateFieldType dateType = (DateFieldMapper.DateFieldType) fieldType.unwrap();
+        // Process date field
+    }
+    
+    // INCORRECT: This will fail for wrapped types
+    // if (fieldType instanceof DateFieldMapper.DateFieldType) { ... }
+}
+```
+
+**Handling nested wrappers:**
+
+```java
+// unwrap() handles multiple wrapper layers
+MappedFieldType original = wrappedType.unwrap();
+// original is guaranteed to be the innermost non-wrapper type
+```
+
+## Limitations
+
+- Plugin developers must remember to call `unwrap()` before `instanceof` checks
+- Casting after `instanceof` should consider whether wrapper behavior is needed
+- The wrapper pattern adds a small overhead for type resolution
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17627](https://github.com/opensearch-project/OpenSearch/pull/17627) | Add FilterFieldType |
+| v3.0.0 | [#17951](https://github.com/opensearch-project/OpenSearch/pull/17951) | Fix instanceof checks to use unwrap() |
+
+## References
+
+- [Issue #17624](https://github.com/opensearch-project/OpenSearch/issues/17624): FilterFieldType feature request
+- [Issue #17802](https://github.com/opensearch-project/OpenSearch/issues/17802): Unwrap FieldType before instanceof check
+- [Mappings and field types](https://docs.opensearch.org/3.0/field-types/): OpenSearch field types documentation
+- [SemanticFieldType PR](https://github.com/opensearch-project/neural-search/pull/1225): Example usage in neural-search
+
+## Change History
+
+- **v3.0.0** (2025-04-21): Initial implementation of `FilterFieldType` and codebase-wide `instanceof` fixes

--- a/docs/releases/v3.0.0/features/opensearch/field-type-fixes.md
+++ b/docs/releases/v3.0.0/features/opensearch/field-type-fixes.md
@@ -1,0 +1,120 @@
+# Field Type Fixes
+
+## Summary
+
+This release fixes `instanceof` checks throughout the OpenSearch codebase to properly handle the new `FilterFieldType` wrapper pattern. With the introduction of `FilterFieldType` in v3.0.0, field types can now be wrapped by delegate types (e.g., `SemanticFieldType`). All `instanceof` checks must now call `unwrap()` before checking the underlying field type to ensure correct behavior.
+
+## Details
+
+### What's New in v3.0.0
+
+The `FilterFieldType` class was introduced to allow developers to wrap existing field types while delegating behavior by default. This enables features like `SemanticFieldType` in neural-search to wrap delegate field types. However, existing code that used `instanceof` checks on `MappedFieldType` would fail to recognize wrapped types.
+
+This fix updates all `instanceof` checks across the codebase to call `fieldType.unwrap()` before performing type checks.
+
+### Technical Changes
+
+#### Pattern Change
+
+Before:
+```java
+if (fieldType instanceof DateFieldMapper.DateFieldType) {
+    // handle date field
+}
+```
+
+After:
+```java
+if (fieldType.unwrap() instanceof DateFieldMapper.DateFieldType) {
+    // handle date field
+}
+```
+
+#### Affected Components
+
+| Component | Files Modified | Description |
+|-----------|----------------|-------------|
+| Expression Script Engine | 1 | GeoPoint and Date field type checks |
+| Mapper Extras | 1 | RankFeature query builder |
+| Percolator | 1 | Percolator field type check |
+| Star Tree | 3 | Composite field type validation |
+| Analyze Action | 1 | String field type check |
+| Codec | 1 | Completion field type check |
+| Derived Field Resolver | 2 | Derived field type resolution |
+| Mapping Lookup | 1 | Timestamp field check |
+| Query Builders | 8 | Various query type checks |
+| Aggregations | 6 | Composite and filter rewrite sources |
+| Search | 3 | Match query and query string parser |
+| Term Vectors | 1 | String field validation |
+
+#### Key Changes by Area
+
+**Query Builders:**
+- `GeoPolygonQueryBuilder`: GeoPoint field validation
+- `PrefixQueryBuilder`: Constant field type optimization
+- `TermQueryBuilder`: Constant field type optimization
+- `TermsQueryBuilder`: Number field and constant field checks
+- `WildcardQueryBuilder`: Constant field type optimization
+- `DecayFunctionBuilder`: Date, GeoPoint, and Number field handling
+
+**Aggregations:**
+- `BinaryValuesSource`: String field type check
+- `GlobalOrdinalValuesSource`: String field type check
+- `LongValuesSource`: Number and Date field checks
+- `UnsignedLongValuesSource`: Number field check
+- `CompositeAggregatorBridge`: Date field optimization
+- `DateHistogramAggregatorBridge`: Date field optimization
+
+**Mappers:**
+- `MapperService`: Composite field type detection
+- `MappingLookup`: Timestamp field validation
+- `DefaultDerivedFieldResolver`: Derived field type resolution
+- `DerivedFieldType`: Prefilter field validation
+
+### Usage Example
+
+For plugin developers working with field types:
+
+```java
+public void processField(MappedFieldType fieldType) {
+    // Always unwrap before instanceof check
+    MappedFieldType unwrapped = fieldType.unwrap();
+    
+    if (unwrapped instanceof DateFieldMapper.DateFieldType) {
+        DateFieldMapper.DateFieldType dateType = (DateFieldMapper.DateFieldType) unwrapped;
+        // Process date field
+    } else if (unwrapped instanceof GeoPointFieldType) {
+        // Process geo point field
+    }
+}
+```
+
+### Migration Notes
+
+Plugin developers who perform `instanceof` checks on `MappedFieldType` should:
+
+1. Call `unwrap()` before any `instanceof` check
+2. Add null checks where appropriate (some code paths now include `fieldType != null` guards)
+3. Test with wrapped field types like `SemanticFieldType`
+
+## Limitations
+
+- The `unwrap()` method returns `this` for non-wrapped types, so existing code will continue to work
+- Casting after `instanceof` check should use the original `fieldType` if the wrapper behavior is needed
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17951](https://github.com/opensearch-project/OpenSearch/pull/17951) | Add unwrap function to all fieldType instanceof checks |
+| [#17627](https://github.com/opensearch-project/OpenSearch/pull/17627) | Add FilterFieldType (prerequisite) |
+
+## References
+
+- [Issue #17802](https://github.com/opensearch-project/OpenSearch/issues/17802): Unwrap FieldType before instanceof check
+- [Issue #17624](https://github.com/opensearch-project/OpenSearch/issues/17624): FilterFieldType feature request
+- [Mappings and field types](https://docs.opensearch.org/3.0/field-types/): OpenSearch field types documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/filter-field-type.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -16,6 +16,7 @@
 - [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)
 - [Bulk API Changes](features/opensearch/bulk-api-changes.md)
 - [Deprecated Code Cleanup](features/opensearch/deprecated-code-cleanup.md)
+- [Field Type Fixes](features/opensearch/field-type-fixes.md)
 - [Cluster Permissions](features/opensearch/cluster-permissions.md)
 - [gRPC Transport & Services](features/opensearch/grpc-transport--services.md)
 - [Mapping Transformer](features/opensearch/mapping-transformer.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Field Type Fixes release item in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/field-type-fixes.md`
- Feature report: `docs/features/opensearch/filter-field-type.md`

### Key Changes in v3.0.0
- Introduction of `FilterFieldType` wrapper class for field type delegation
- Codebase-wide fix to use `unwrap()` before `instanceof` checks on `MappedFieldType`
- Enables features like `SemanticFieldType` in neural-search to properly wrap delegate types

### Related PRs
- [#17951](https://github.com/opensearch-project/OpenSearch/pull/17951): Add unwrap function to all fieldType instanceof checks
- [#17627](https://github.com/opensearch-project/OpenSearch/pull/17627): Add FilterFieldType

Closes #269