### PR TITLE
docs: add Track Total Hits report for v3.0.0

### DIFF
--- a/docs/features/opensearch/approximation-framework.md
+++ b/docs/features/opensearch/approximation-framework.md
@@ -175,6 +175,7 @@ GET logs/_search
 | v3.2.0 | [#18511](https://github.com/opensearch-project/OpenSearch/pull/18511) | Added approximation support for range queries with `now` in date field |
 | v3.2.0 | [#18763](https://github.com/opensearch-project/OpenSearch/pull/18763) | Disable approximation framework when dealing with multiple sorts |
 | v3.1.0 | [#18439](https://github.com/opensearch-project/OpenSearch/pull/18439) | BKD traversal optimization for skewed datasets |
+| v3.0.0 | [#18017](https://github.com/opensearch-project/OpenSearch/pull/18017) | Skip approximation when `track_total_hits` is set to `true` |
 | v3.0.0 | - | Initial GA release of Approximation Framework |
 
 ## References
@@ -192,4 +193,4 @@ GET logs/_search
 - **v3.4.0**: Adopted Lucene's native `pack` method for `half_float` and `unsigned_long` types, replacing custom encoding methods; requires Lucene 10.3.0
 - **v3.2.0**: Extended Approximation Framework to all numeric types (int, float, double, half_float, unsigned_long); added `search_after` support for numeric queries; approximation for range queries with `now`; automatic disabling for multiple sort fields
 - **v3.1.0** (2025-06-10): Enhanced BKD traversal with DFS strategy for skewed datasets, smart subtree skipping
-- **v3.0.0**: Initial GA release with basic early termination support
+- **v3.0.0**: Initial GA release with basic early termination support; added logic to skip approximation when `track_total_hits: true` is set

--- a/docs/releases/v3.0.0/features/opensearch/track-total-hits.md
+++ b/docs/releases/v3.0.0/features/opensearch/track-total-hits.md
@@ -1,0 +1,109 @@
+# Track Total Hits
+
+## Summary
+
+This release item adds logic to skip the Approximation Framework's early termination optimization when `track_total_hits` is set to `true`. When users explicitly request accurate total hit counts, the system now correctly falls back to standard query execution to ensure all matching documents are counted.
+
+## Details
+
+### What's New in v3.0.0
+
+The Approximation Framework was enhanced to detect when `track_total_hits: true` is specified and automatically disable approximation in those cases. This ensures users receive accurate total hit counts when explicitly requested.
+
+### Technical Changes
+
+#### Behavior Change
+
+When `track_total_hits` is set to `true`, the search context's `trackTotalHitsUpTo()` returns `SearchContext.TRACK_TOTAL_HITS_ACCURATE` (equivalent to `Integer.MAX_VALUE`). The approximation queries now check for this condition and skip early termination.
+
+| `track_total_hits` Value | Behavior | Approximation |
+|--------------------------|----------|---------------|
+| `true` | Count all matching documents | Disabled |
+| `false` | Count up to 10,000 documents | Enabled |
+| Not specified | Count up to 10 documents (default) | Enabled |
+| Integer (e.g., `1000`) | Count up to specified number | Enabled |
+
+#### Modified Components
+
+| Component | Change |
+|-----------|--------|
+| `ApproximatePointRangeQuery` | Added check for `TRACK_TOTAL_HITS_ACCURATE` in `canApproximate()` |
+| `ApproximateMatchAllQuery` | Added check for `TRACK_TOTAL_HITS_ACCURATE` in `canApproximate()` |
+
+### Usage Example
+
+```json
+// Approximation DISABLED - accurate total count required
+GET logs/_search
+{
+  "track_total_hits": true,
+  "query": {
+    "range": {
+      "@timestamp": {
+        "gte": "2023-01-01T00:00:00",
+        "lt": "2023-01-03T00:00:00"
+      }
+    }
+  }
+}
+
+// Response includes accurate total
+{
+  "hits": {
+    "total": {
+      "value": 1523847,
+      "relation": "eq"
+    }
+  }
+}
+```
+
+```json
+// Approximation ENABLED - default behavior
+GET logs/_search
+{
+  "query": {
+    "range": {
+      "@timestamp": {
+        "gte": "2023-01-01T00:00:00",
+        "lt": "2023-01-03T00:00:00"
+      }
+    }
+  }
+}
+
+// Response may have approximate total
+{
+  "hits": {
+    "total": {
+      "value": 10000,
+      "relation": "gte"
+    }
+  }
+}
+```
+
+### Migration Notes
+
+No migration required. This change ensures correct behavior when `track_total_hits: true` is specified. Users who rely on accurate total hit counts should continue using `track_total_hits: true` as before.
+
+## Limitations
+
+- When `track_total_hits: true` is set, queries will not benefit from the Approximation Framework's performance optimizations
+- For large result sets, queries with `track_total_hits: true` may have higher latency
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#18017](https://github.com/opensearch-project/OpenSearch/pull/18017) | Skip approximation when `track_total_hits` is set to `true` |
+
+## References
+
+- [Issue #14406](https://github.com/opensearch-project/OpenSearch/issues/14406): Expand ApproximatePointRangeQuery to other numeric types
+- [Search API Documentation](https://docs.opensearch.org/3.0/api-reference/search-apis/search/): `track_total_hits` parameter reference
+- [OpenSearch Approximation Framework Blog](https://opensearch.org/blog/opensearch-approximation-framework/): Framework overview
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/approximation-framework.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -47,6 +47,7 @@
 - [Stream Input/Output](features/opensearch/stream-inputoutput.md)
 - [Thread Context Permissions](features/opensearch/thread-context-permissions.md)
 - [Tiered Caching](features/opensearch/tiered-caching.md)
+- [Track Total Hits](features/opensearch/track-total-hits.md)
 - [Wildcard Field](features/opensearch/wildcard-field.md)
 
 ## opensearch-dashboards


### PR DESCRIPTION
## Summary

This PR adds documentation for the Track Total Hits feature in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/track-total-hits.md`
- Feature report: Updated `docs/features/opensearch/approximation-framework.md`

### Key Changes in v3.0.0
- Added logic to skip approximation when `track_total_hits` is set to `true`
- Ensures accurate total hit counts when explicitly requested by users
- Modified `ApproximatePointRangeQuery` and `ApproximateMatchAllQuery` to check for `TRACK_TOTAL_HITS_ACCURATE`

### Resources Used
- PR: #18017
- Issue: #14406
- Docs: https://docs.opensearch.org/3.0/api-reference/search-apis/search/
- Blog: https://opensearch.org/blog/opensearch-approximation-framework/

Closes #265