### PR TITLE
docs: add concurrent segment search auto mode default report for v3.0.0

### DIFF
--- a/docs/features/opensearch/concurrent-segment-search.md
+++ b/docs/features/opensearch/concurrent-segment-search.md
@@ -120,6 +120,9 @@ PUT _cluster/settings
 | v3.4.0 | [#19584](https://github.com/opensearch-project/OpenSearch/pull/19584) | Omit maxScoreCollector in SimpleTopDocsCollectorContext when concurrent segment search enabled |
 | v3.3.0 | [#19053](https://github.com/opensearch-project/OpenSearch/pull/19053) | Fix assertion error when collapsing search results with concurrent segment search |
 | v3.2.0 | [#18451](https://github.com/opensearch-project/OpenSearch/pull/18451) | Optimize grouping for segment concurrent search |
+| v3.0.0 | [#17978](https://github.com/opensearch-project/OpenSearch/pull/17978) | Enable concurrent_segment_search auto mode by default |
+| v2.17.0 | - | Introduced `auto` mode for aggregation requests |
+| v2.12.0 | - | GA release of concurrent segment search (disabled by default) |
 
 ## References
 
@@ -135,5 +138,6 @@ PUT _cluster/settings
 - **v3.4.0** (2026-01-14): Performance optimization - omit MaxScoreCollector in SimpleTopDocsCollectorContext when sorting by score with concurrent segment search enabled (~10% latency improvement)
 - **v3.3.0** (2025-10-30): Fixed assertion error when using field collapsing with concurrent segment search by removing setShardIndex parameter from CollapseTopFieldDocs.merge()
 - **v3.2.0** (2025-07-31): Optimized segment grouping algorithm using priority queue for better load balancing
-- **v3.0.0**: Concurrent segment search enabled by default in `auto` mode
-- **v2.12.0**: Initial experimental release of concurrent segment search
+- **v3.0.0** (2025-04-24): **Breaking change** - Concurrent segment search enabled by default in `auto` mode. Default slice count formula: `Math.min(vCPU / 2, 4)`. Setting key renamed from `CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY` to `CONCURRENT_SEGMENT_SEARCH_MAX_SLICE_COUNT_KEY`. Aggregation workloads may experience increased CPU utilization.
+- **v2.17.0**: Introduced `auto` mode with pluggable `ConcurrentSearchRequestDecider` for aggregation requests
+- **v2.12.0**: GA release of concurrent segment search (disabled by default)

--- a/docs/releases/v3.0.0/features/opensearch/concurrent-segment-search.md
+++ b/docs/releases/v3.0.0/features/opensearch/concurrent-segment-search.md
@@ -1,0 +1,116 @@
+# Concurrent Segment Search Auto Mode Default
+
+## Summary
+
+OpenSearch 3.0.0 enables concurrent segment search in `auto` mode by default, a significant change from previous versions where it was disabled. This enhancement improves search latency for aggregation workloads by searching Lucene segments in parallel during the query phase, without requiring manual configuration.
+
+## Details
+
+### What's New in v3.0.0
+
+The key changes in this release:
+
+1. **Default mode changed**: `search.concurrent_segment_search.mode` now defaults to `auto` instead of `none`
+2. **Setting key renamed**: `CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY` → `CONCURRENT_SEGMENT_SEARCH_MAX_SLICE_COUNT_KEY`
+3. **Default slice count formula**: `Math.min(vCPU / 2, 4)` - balances performance with resource utilization
+4. **Pluggable decider support**: Plugins like k-NN can enable concurrent search for specific query types
+
+### Technical Changes
+
+#### Mode Behavior
+
+| Mode | Behavior |
+|------|----------|
+| `auto` (new default) | Uses pluggable decider; enables for aggregation requests by default |
+| `all` | Enables concurrent search for all requests |
+| `none` | Disables concurrent search (previous default) |
+
+#### Default Slice Count Calculation
+
+```java
+Math.max(1, Math.min(Runtime.getRuntime().availableProcessors() / 2, 4))
+```
+
+This formula ensures:
+- Minimum of 1 slice
+- Maximum of 4 slices
+- Uses half of available vCPUs
+
+#### Files Modified
+
+| File | Change |
+|------|--------|
+| `IndexSettings.java` | Updated default mode to `auto`, renamed setting key |
+| `DefaultSearchContext.java` | Updated slice count calculation |
+| `SearchService.java` | Integrated new default behavior |
+| `CHANGELOG.md` | Documented breaking change |
+
+### Usage Example
+
+The feature is enabled by default. To disable:
+
+```json
+PUT _cluster/settings
+{
+   "persistent": {
+      "search.concurrent_segment_search.mode": "none"
+   }
+}
+```
+
+To enable for all requests (not just aggregations):
+
+```json
+PUT _cluster/settings
+{
+   "persistent": {
+      "search.concurrent_segment_search.mode": "all"
+   }
+}
+```
+
+Configure slice count:
+
+```json
+PUT _cluster/settings
+{
+   "persistent": {
+      "search.concurrent.max_slice_count": 4
+   }
+}
+```
+
+### Migration Notes
+
+**Important**: After upgrading to OpenSearch 3.0, aggregation workloads may experience increased CPU utilization because concurrent search is now enabled by default in `auto` mode.
+
+Recommendations:
+- Monitor cluster resource usage after upgrade
+- If CPU utilization exceeds 25% with aggregation workloads before upgrade, consider:
+  - Scaling cluster resources
+  - Disabling concurrent search if scaling is not feasible
+- The legacy `search.concurrent_segment_search.enabled` setting is deprecated; migrate to `search.concurrent_segment_search.mode`
+
+## Limitations
+
+- Not supported with `terminate_after` search parameter
+- Parent aggregations on join fields not supported
+- `sampler` and `diversified_sampler` aggregations not supported
+- Terms aggregations may have additional document count error due to slice-level `shard_size` application
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17978](https://github.com/opensearch-project/OpenSearch/pull/17978) | Enable concurrent_segment_search auto mode by default |
+
+## References
+
+- [Issue #17981](https://github.com/opensearch-project/OpenSearch/issues/17981): Feature request for enabling auto mode by default
+- [Documentation](https://docs.opensearch.org/3.0/search-plugins/concurrent-segment-search/): Official concurrent segment search docs
+- [Blog: Exploring concurrent segment search performance](https://opensearch.org/blog/concurrent-search-follow-up/): Performance benchmarks and guidelines
+- [Blog: Introducing concurrent segment search](https://opensearch.org/blog/concurrent_segment_search/): Original feature introduction
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/concurrent-segment-search.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -15,6 +15,7 @@
 
 - [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)
 - [Bulk API Changes](features/opensearch/bulk-api-changes.md)
+- [Concurrent Segment Search Auto Mode Default](features/opensearch/concurrent-segment-search.md)
 - [Deprecated Code Cleanup](features/opensearch/deprecated-code-cleanup.md)
 - [Field Type Fixes](features/opensearch/field-type-fixes.md)
 - [Cluster Permissions](features/opensearch/cluster-permissions.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Concurrent Segment Search feature enhancement in OpenSearch v3.0.0.

### Key Changes in v3.0.0

- **Default mode changed**: `search.concurrent_segment_search.mode` now defaults to `auto` instead of `none`
- **Setting key renamed**: `CONCURRENT_SEGMENT_SEARCH_TARGET_MAX_SLICE_COUNT_KEY` → `CONCURRENT_SEGMENT_SEARCH_MAX_SLICE_COUNT_KEY`
- **Default slice count formula**: `Math.min(vCPU / 2, 4)`
- **Pluggable decider support**: Plugins like k-NN can enable concurrent search for specific query types

### Reports Created

- Release report: `docs/releases/v3.0.0/features/opensearch/concurrent-segment-search.md`
- Feature report updated: `docs/features/opensearch/concurrent-segment-search.md`

### Related

- PR: opensearch-project/OpenSearch#17978
- Issue: opensearch-project/OpenSearch#17981
- Closes #264