### PR TITLE
docs: add plugin-system report for v3.0.0

### DIFF
--- a/docs/features/opensearch/plugin-dependencies.md
+++ b/docs/features/opensearch/plugin-dependencies.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-OpenSearch plugins declare their compatibility with OpenSearch versions through the `plugin-descriptor.properties` file. The plugin dependencies feature allows plugins to specify version compatibility using semantic versioning (semver) notation, including range expressions. This enables plugins to declare compatibility with multiple OpenSearch versions without requiring separate builds for each version.
+OpenSearch plugins declare their compatibility with OpenSearch versions through the `plugin-descriptor.properties` file. The plugin dependencies feature allows plugins to specify version compatibility using semantic versioning (semver) notation, including range expressions. This enables plugins to declare compatibility with multiple OpenSearch versions without requiring separate builds for each version. Additionally, plugins can declare optional dependencies on other plugins, with relaxed jarHell validation for optional extended plugins.
 
 ## Details
 
@@ -80,8 +80,10 @@ Plugins specify version compatibility in `plugin-descriptor.properties`:
 |----------|-------------|---------|
 | `opensearch.version` | Single version or semver expression | `2.3.0`, `~2.3.0`, `^2.3.0` |
 | `dependencies` | JSON object with opensearch version | `{ opensearch: "[2.0.0, 3.0.0)" }` |
+| `extended.plugins` | Comma-separated list of plugins this plugin extends | `opensearch-job-scheduler` |
+| `optional.plugins` | Comma-separated list of optional extended plugins | `opensearch-security` |
 
-Note: Only one of `opensearch.version` or `dependencies` can be specified.
+Note: Only one of `opensearch.version` or `dependencies` can be specified. Plugins listed in `optional.plugins` must also be in `extended.plugins`.
 
 ### Supported Version Notations
 
@@ -129,18 +131,36 @@ java.version=21
 classname=org.example.MyPlugin
 ```
 
+#### Using optional extended plugins (v3.0.0+)
+
+```properties
+name=my-plugin
+description=Plugin with optional security integration
+version=3.0.0
+opensearch.version=3.0.0
+java.version=21
+classname=org.example.MyPlugin
+extended.plugins=opensearch-security
+optional.plugins=opensearch-security
+```
+
+When `opensearch-security` is listed in both `extended.plugins` and `optional.plugins`, the jarHell check is skipped for that dependency, allowing installation even if both plugins share common JAR files.
+
 ## Limitations
 
 - Only one dependency (`opensearch`) is allowed in the `dependencies` field
 - Only one range can be specified per plugin
 - Cannot use both `opensearch.version` and `dependencies` properties simultaneously
 - Range expressions must follow the exact pattern: `[( ]version, version[) ]`
+- Optional extended plugins must still be listed in `extended.plugins`
+- Some features may not function when optional dependencies are not installed (a warning is logged)
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
 | v3.4.0 | [#19939](https://github.com/opensearch-project/OpenSearch/pull/19939) | Add RangeSemver for `dependencies` in `plugin-descriptor.properties` |
+| v3.0.0 | [#17893](https://github.com/opensearch-project/OpenSearch/pull/17893) | Relaxes jarHell check for optionally extended plugins |
 | v2.16.0 | [#18557](https://github.com/opensearch-project/OpenSearch/pull/18557) | Added support for range version support in semver |
 | v2.13.0 | - | Initial SemverRange implementation with tilde and caret operators |
 
@@ -148,11 +168,13 @@ classname=org.example.MyPlugin
 
 - [Issue #1707](https://github.com/opensearch-project/OpenSearch/issues/1707): Cannot install old patch version of plugins on newer OpenSearch builds
 - [Issue #18554](https://github.com/opensearch-project/OpenSearch/issues/18554): Add range support in SemVer
+- [Issue #4500](https://github.com/opensearch-project/security/issues/4500): Resource Permissions and Sharing - motivation for optional plugin dependencies
 - [Documentation: Installing plugins](https://docs.opensearch.org/3.0/install-and-configure/plugins/): Official plugin installation guide
 - [OpenSearch Versioning Blog](https://opensearch.org/blog/what-is-semver/): OpenSearch Versioning, or What is SemVer anyway?
 
 ## Change History
 
 - **v3.4.0** (2025-11): Extended range semver support to `dependencies` field in plugin-descriptor.properties
+- **v3.0.0** (2025-05): Relaxed jarHell check for optionally extended plugins, enabling plugins to declare optional dependencies without jar conflicts
 - **v2.16.0** (2025-07): Added explicit range notation support (`[2.0.0, 3.0.0)`) for `opensearch.version`
 - **v2.13.0** (2024-02): Initial SemverRange implementation with tilde (`~`) and caret (`^`) operators

--- a/docs/releases/v3.0.0/features/opensearch/plugin-system.md
+++ b/docs/releases/v3.0.0/features/opensearch/plugin-system.md
@@ -1,0 +1,106 @@
+# Plugin System
+
+## Summary
+
+OpenSearch v3.0.0 relaxes the jarHell check for optionally extended plugins, enabling plugins to declare optional dependencies on other plugins without encountering jar conflicts. This change unblocks the Resource Sharing & Access Control framework where plugins need to optionally extend `opensearch-security` for resource-level access control.
+
+## Details
+
+### What's New in v3.0.0
+
+The jarHell check in `PluginsService.checkBundleJarHell()` now skips validation for plugins marked as optional dependencies. Previously, even optional extended plugins were checked for jar conflicts, causing installation failures when plugins shared common transitive dependencies.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Plugin Installation"
+        PI[Plugin Install Command]
+        PS[PluginsService]
+        JH[JarHell Check]
+    end
+    
+    subgraph "Extended Plugins"
+        EP[Extended Plugin List]
+        OPT{Is Optional?}
+        REQ[Required Plugin]
+        SKIP[Skip JarHell]
+    end
+    
+    PI --> PS
+    PS --> JH
+    JH --> EP
+    EP --> OPT
+    OPT -->|Yes| SKIP
+    OPT -->|No| REQ
+    REQ --> |Check URLs| JH
+```
+
+#### Code Change
+
+The change modifies `PluginsService.checkBundleJarHell()`:
+
+```java
+// Before v3.0.0
+if (pluginUrls == null && bundle.plugin.isExtendedPluginOptional(extendedPlugin)) {
+    continue;
+}
+
+// After v3.0.0
+if (bundle.plugin.isExtendedPluginOptional(extendedPlugin)) {
+    continue;
+}
+```
+
+This removes the `pluginUrls == null` condition, allowing the jarHell check to be skipped for all optional extended plugins regardless of whether they are installed.
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `PluginInfo.isExtendedPluginOptional()` | Method to check if an extended plugin is marked as optional |
+
+### Usage Example
+
+Plugins can declare optional dependencies in `plugin-descriptor.properties`:
+
+```properties
+name=my-plugin
+description=Plugin with optional security integration
+version=3.0.0
+opensearch.version=3.0.0
+java.version=21
+classname=org.example.MyPlugin
+extended.plugins=opensearch-security
+optional.plugins=opensearch-security
+```
+
+When `opensearch-security` is listed in both `extended.plugins` and `optional.plugins`, the jarHell check is skipped for that dependency, allowing installation even if both plugins share common JAR files.
+
+### Migration Notes
+
+No migration required. This is a backward-compatible change that relaxes validation rules.
+
+## Limitations
+
+- The jarHell check is only skipped for plugins explicitly marked as optional
+- Plugins must still ensure runtime compatibility when optional dependencies are not installed
+- Some features may not function without the optional dependencies being installed (a warning is logged)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17893](https://github.com/opensearch-project/OpenSearch/pull/17893) | Relaxes jarHell check for optionally extended plugins |
+
+## References
+
+- [Issue #4500](https://github.com/opensearch-project/security/issues/4500): Resource Permissions and Sharing - the feature that required this change
+- [PR #5240](https://github.com/opensearch-project/security/pull/5240): Security plugin changes for resource access control
+- [Documentation: Installing plugins](https://docs.opensearch.org/3.0/install-and-configure/plugins/): Official plugin installation guide
+
+## Related Feature Report
+
+- [Plugin Dependencies](../../../features/opensearch/plugin-dependencies.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -41,6 +41,7 @@
 - [Node Roles & Configuration](features/opensearch/node-roles-and-configuration.md)
 - [Node Roles Configuration (Environment Variables)](features/opensearch/node-roles-configuration.md)
 - [Nodes Info API Changes](features/opensearch/nodes-info-api-changes.md)
+- [Plugin System](features/opensearch/plugin-system.md)
 - [Refresh Task Scheduling](features/opensearch/refresh-task-scheduling.md)
 - [Search Backpressure](features/opensearch/search-backpressure.md)
 - [Segment Warmer](features/opensearch/segment-warmer.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Plugin System enhancement in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/plugin-system.md`
- Feature report updated: `docs/features/opensearch/plugin-dependencies.md`

### Key Changes in v3.0.0
- Relaxed jarHell check for optionally extended plugins
- Enables plugins to declare optional dependencies without jar conflicts
- Unblocks the Resource Sharing & Access Control framework

### Resources Used
- PR: [#17893](https://github.com/opensearch-project/OpenSearch/pull/17893)
- Issue: [#4500](https://github.com/opensearch-project/security/issues/4500)