### PR TITLE
docs: add Pipeline ID Limits report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -119,6 +119,7 @@
 - [Parent-Child Query](opensearch/parent-child-query.md)
 - [Percentiles Aggregation](opensearch/percentiles-aggregation.md)
 - [Phone Number Analyzer](opensearch/phone-analyzer.md)
+- [Pipeline ID Limits](opensearch/pipeline-id-limits.md)
 - [Platform Support](opensearch/platform-support.md)
 - [Plugin Dependencies](opensearch/plugin-dependencies.md)
 - [Plugin Installation](opensearch/plugin-installation.md)

--- a/docs/features/opensearch/pipeline-id-limits.md
+++ b/docs/features/opensearch/pipeline-id-limits.md
@@ -1,0 +1,121 @@
+# Pipeline ID Limits
+
+## Summary
+
+OpenSearch enforces a maximum length limit on pipeline identifiers for both ingest pipelines and search pipelines. This validation ensures pipeline IDs remain manageable and prevents potential issues with cluster state storage and management.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Pipeline Creation Request"
+        A[PUT _ingest/pipeline/id] --> B[IngestService]
+        C[PUT _search/pipeline/id] --> D[SearchPipelineService]
+    end
+    
+    subgraph "Validation Layer"
+        B --> E[validatePipeline]
+        D --> F[validatePipeline]
+        E --> G{ID Length <= 512 bytes?}
+        F --> G
+    end
+    
+    subgraph "Result"
+        G -->|Yes| H[Create Pipeline]
+        G -->|No| I[IllegalArgumentException]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| IngestService | Handles ingest pipeline CRUD operations with ID validation |
+| SearchPipelineService | Handles search pipeline CRUD operations with ID validation |
+| UnicodeUtil | Lucene utility for accurate UTF-8 byte length calculation |
+
+### Configuration
+
+| Setting | Description | Default | Since |
+|---------|-------------|---------|-------|
+| MAX_PIPELINE_ID_BYTES | Maximum allowed UTF-8 bytes for pipeline ID | 512 | v3.0.0 |
+
+### Usage Example
+
+#### Creating an Ingest Pipeline
+
+```json
+PUT _ingest/pipeline/my-data-pipeline
+{
+  "description": "Pipeline for processing incoming data",
+  "processors": [
+    {
+      "set": {
+        "field": "ingested_at",
+        "value": "{{_ingest.timestamp}}"
+      }
+    }
+  ]
+}
+```
+
+#### Creating a Search Pipeline
+
+```json
+PUT _search/pipeline/my-search-pipeline
+{
+  "request_processors": [
+    {
+      "filter_query": {
+        "query": {
+          "term": {
+            "status": "active"
+          }
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Error Response for Invalid ID
+
+```json
+{
+  "error": {
+    "root_cause": [
+      {
+        "type": "illegal_argument_exception",
+        "reason": "Pipeline id [very-long-id...] exceeds maximum length of 512 UTF-8 bytes (actual: 513 bytes)"
+      }
+    ],
+    "type": "illegal_argument_exception",
+    "reason": "Pipeline id [very-long-id...] exceeds maximum length of 512 UTF-8 bytes (actual: 513 bytes)"
+  },
+  "status": 400
+}
+```
+
+## Limitations
+
+- The 512-byte limit is hardcoded and not configurable via cluster settings
+- Multi-byte UTF-8 characters (e.g., CJK characters, emojis) consume more of the byte limit than ASCII characters
+- Existing pipelines with non-compliant IDs created before v3.0.0 will continue to function but cannot be updated
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17786](https://github.com/opensearch-project/OpenSearch/pull/17786) | Introduce 512 byte limit to search and ingest pipeline IDs |
+
+## References
+
+- [Issue #17766](https://github.com/opensearch-project/OpenSearch/issues/17766): Original feature request
+- [Ingest Pipeline Documentation](https://docs.opensearch.org/latest/ingest-pipelines/create-ingest/): Official ingest pipeline docs
+- [Search Pipeline Documentation](https://docs.opensearch.org/latest/search-plugins/search-pipelines/creating-search-pipeline/): Official search pipeline docs
+
+## Change History
+
+- **v3.0.0** (2025-05-13): Initial implementation - 512 byte limit for ingest and search pipeline IDs

--- a/docs/releases/v3.0.0/features/opensearch/pipeline-id-limits.md
+++ b/docs/releases/v3.0.0/features/opensearch/pipeline-id-limits.md
@@ -1,0 +1,122 @@
+# Pipeline ID Limits
+
+## Summary
+
+OpenSearch v3.0.0 introduces a 512-byte limit for both ingest pipeline and search pipeline IDs. This validation prevents excessively long pipeline identifiers that could cause issues with cluster state management and storage.
+
+## Details
+
+### What's New in v3.0.0
+
+Prior to this change, there was no validation on pipeline ID length, allowing users to create pipelines with arbitrarily long identifiers. This could lead to:
+- Excessive cluster state size
+- Potential storage and memory issues
+- Difficulty in managing and referencing pipelines
+
+The new validation enforces a maximum of 512 UTF-8 bytes for pipeline IDs in both:
+- **Ingest pipelines** (used for document transformation during indexing)
+- **Search pipelines** (used for query/response transformation during search)
+
+### Technical Changes
+
+#### Validation Logic
+
+The validation uses Lucene's `UnicodeUtil.calcUTF16toUTF8Length()` to accurately calculate the UTF-8 byte length of pipeline IDs, ensuring proper handling of multi-byte characters.
+
+```java
+private static final int MAX_PIPELINE_ID_BYTES = 512;
+
+int pipelineIdLength = UnicodeUtil.calcUTF16toUTF8Length(
+    request.getId(), 0, request.getId().length()
+);
+
+if (pipelineIdLength > MAX_PIPELINE_ID_BYTES) {
+    throw new IllegalArgumentException(
+        String.format(
+            Locale.ROOT,
+            "Pipeline id [%s] exceeds maximum length of %d UTF-8 bytes (actual: %d bytes)",
+            request.getId(),
+            MAX_PIPELINE_ID_BYTES,
+            pipelineIdLength
+        )
+    );
+}
+```
+
+#### Modified Components
+
+| Component | File | Description |
+|-----------|------|-------------|
+| IngestService | `server/src/main/java/org/opensearch/ingest/IngestService.java` | Validates ingest pipeline ID length |
+| SearchPipelineService | `server/src/main/java/org/opensearch/search/pipeline/SearchPipelineService.java` | Validates search pipeline ID length |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| MAX_PIPELINE_ID_BYTES | Maximum allowed UTF-8 bytes for pipeline ID | 512 |
+
+### Usage Example
+
+```json
+// Valid pipeline ID (within 512 bytes)
+PUT _ingest/pipeline/my-ingest-pipeline
+{
+  "description": "A sample ingest pipeline",
+  "processors": [
+    {
+      "set": {
+        "field": "processed",
+        "value": true
+      }
+    }
+  ]
+}
+
+// Response: HTTP/1.1 200 OK
+// {"acknowledged":true}
+```
+
+```json
+// Invalid pipeline ID (exceeds 512 bytes)
+PUT _ingest/pipeline/very-long-pipeline-id-that-exceeds-512-bytes...
+
+// Response: HTTP/1.1 400 Bad Request
+// {
+//   "error": {
+//     "type": "illegal_argument_exception",
+//     "reason": "Pipeline id [...] exceeds maximum length of 512 UTF-8 bytes (actual: 513 bytes)"
+//   }
+// }
+```
+
+### Migration Notes
+
+If you have existing pipelines with IDs longer than 512 bytes:
+1. Create new pipelines with shorter IDs
+2. Update any index settings or templates referencing the old pipeline IDs
+3. Delete the old pipelines
+
+Note: Existing pipelines with long IDs will continue to work, but you cannot update them without first renaming to a compliant ID.
+
+## Limitations
+
+- The limit is fixed at 512 bytes and is not configurable
+- The validation is based on UTF-8 byte length, not character count (multi-byte characters consume more of the limit)
+- Existing pipelines with non-compliant IDs are not automatically migrated
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17786](https://github.com/opensearch-project/OpenSearch/pull/17786) | Introduce 512 byte limit to search and ingest pipeline IDs |
+
+## References
+
+- [Issue #17766](https://github.com/opensearch-project/OpenSearch/issues/17766): Original bug report for weak validation
+- [Ingest Pipeline Documentation](https://docs.opensearch.org/3.0/ingest-pipelines/create-ingest/): Official docs for creating ingest pipelines
+- [Search Pipeline Documentation](https://docs.opensearch.org/3.0/search-plugins/search-pipelines/creating-search-pipeline/): Official docs for creating search pipelines
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/pipeline-id-limits.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -41,6 +41,7 @@
 - [Node Roles & Configuration](features/opensearch/node-roles-and-configuration.md)
 - [Node Roles Configuration (Environment Variables)](features/opensearch/node-roles-configuration.md)
 - [Nodes Info API Changes](features/opensearch/nodes-info-api-changes.md)
+- [Pipeline ID Limits](features/opensearch/pipeline-id-limits.md)
 - [Plugin System](features/opensearch/plugin-system.md)
 - [Refresh Task Scheduling](features/opensearch/refresh-task-scheduling.md)
 - [Search Backpressure](features/opensearch/search-backpressure.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Pipeline ID Limits feature introduced in OpenSearch v3.0.0.

### Changes
- **Release report**: `docs/releases/v3.0.0/features/opensearch/pipeline-id-limits.md`
- **Feature report**: `docs/features/opensearch/pipeline-id-limits.md`
- Updated release index and features index

### Feature Overview
OpenSearch v3.0.0 introduces a 512-byte limit for both ingest pipeline and search pipeline IDs. This validation prevents excessively long pipeline identifiers that could cause issues with cluster state management and storage.

### Related
- Resolves investigation for Issue #262
- Based on [PR #17786](https://github.com/opensearch-project/OpenSearch/pull/17786)