### PR TITLE
docs: add DocValues optimization report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -75,6 +75,7 @@
 - [Dependency Management](opensearch/dependency-management.md)
 - [Derived Fields](opensearch/derived-fields.md)
 - [Derived Source](opensearch/derived-source.md)
+- [DocValues Optimization](opensearch/docvalues-optimization.md)
 - [Docker Compose v2 Support](opensearch/docker-compose-v2-support.md)
 - [Docker Image Base](opensearch/docker-image-base.md)
 - [Dynamic Threadpool Resize](opensearch/dynamic-threadpool-resize.md)

--- a/docs/features/opensearch/docvalues-optimization.md
+++ b/docs/features/opensearch/docvalues-optimization.md
@@ -1,0 +1,191 @@
+# DocValues Singleton Optimization
+
+## Summary
+
+DocValues singleton optimization is a performance enhancement for OpenSearch aggregations that provides a specialized fast path for single-valued fields. By using Lucene's `DocValues.unwrapSingleton()` method, aggregators can bypass unnecessary iteration logic and access values directly, reducing method call overhead and improving aggregation performance by 3-10%.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Aggregation Request"
+        Query[Search Query]
+        Agg[Aggregation Definition]
+    end
+    
+    subgraph "DocValues Access Layer"
+        DVS[SortedNumericDocValues]
+        Detect{unwrapSingleton}
+        Single[NumericDocValues]
+        Multi[Multi-value Iterator]
+    end
+    
+    subgraph "Optimized Aggregators"
+        DateHist[DateHistogramAggregator]
+        GlobalOrd[GlobalOrdinalValuesSource]
+    end
+    
+    Query --> DVS
+    Agg --> DVS
+    DVS --> Detect
+    Detect -->|"Single-valued"| Single
+    Detect -->|"Multi-valued"| Multi
+    Single --> DateHist
+    Single --> GlobalOrd
+    Multi --> DateHist
+    Multi --> GlobalOrd
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Standard Path (Multi-valued)"
+        M1[advanceExact] --> M2[docValueCount]
+        M2 --> M3[Loop: i < count]
+        M3 --> M4[nextValue]
+        M4 --> M5[Process]
+        M5 --> M3
+    end
+    
+    subgraph "Optimized Path (Single-valued)"
+        S1[unwrapSingleton] --> S2{singleton != null?}
+        S2 -->|Yes| S3[advanceExact]
+        S3 --> S4[longValue/ordValue]
+        S4 --> S5[Process - Direct]
+        S2 -->|No| M1
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `DocValues.unwrapSingleton()` | Lucene utility to detect and unwrap single-valued DocValues |
+| `NumericDocValues` | Direct access interface for single numeric values |
+| `SortedDocValues` | Direct access interface for single ordinal values |
+| `DateHistogramAggregator` | Date histogram with singleton optimization |
+| `GlobalOrdinalValuesSource` | Composite aggregation source with singleton optimization |
+
+### Configuration
+
+No configuration required. The optimization is automatically applied when:
+
+| Condition | Description |
+|-----------|-------------|
+| Single-valued field | Field contains at most one value per document |
+| DocValues enabled | Field has `doc_values: true` (default for most field types) |
+
+### How It Works
+
+#### Before Optimization
+
+```java
+SortedNumericDocValues values = valuesSource.longValues(ctx);
+return new LeafBucketCollectorBase(sub, values) {
+    @Override
+    public void collect(int doc, long owningBucketOrd) throws IOException {
+        if (values.advanceExact(doc)) {
+            int valuesCount = values.docValueCount();  // Always 1 for single values
+            for (int i = 0; i < valuesCount; ++i) {    // Unnecessary loop
+                long value = values.nextValue();
+                // ... processing
+            }
+        }
+    }
+};
+```
+
+#### After Optimization
+
+```java
+final SortedNumericDocValues values = valuesSource.longValues(ctx);
+final NumericDocValues singleton = DocValues.unwrapSingleton(values);
+
+if (singleton != null) {
+    // Optimized path for single-valued fields
+    return new LeafBucketCollectorBase(sub, values) {
+        @Override
+        public void collect(int doc, long owningBucketOrd) throws IOException {
+            if (singleton.advanceExact(doc)) {
+                long value = singleton.longValue();  // Direct access
+                collectValue(sub, doc, owningBucketOrd, value);
+            }
+        }
+    };
+}
+
+// Original path for multi-valued fields
+return new LeafBucketCollectorBase(sub, values) {
+    // ... iteration logic preserved
+};
+```
+
+### Performance Benefits
+
+| Optimization | Benefit |
+|--------------|---------|
+| Eliminated loop | No iteration overhead for single values |
+| Reduced method calls | `advanceExact → longValue` instead of `advanceExact → docValueCount → nextValue` |
+| Better memory access | Direct value access without iteration state |
+| Preserved compatibility | Multi-valued fields use original path |
+
+### Usage Example
+
+```json
+// Date histogram on single-valued timestamp field
+GET /logs/_search
+{
+  "size": 0,
+  "aggs": {
+    "events_over_time": {
+      "date_histogram": {
+        "field": "@timestamp",
+        "calendar_interval": "hour"
+      }
+    }
+  }
+}
+
+// Composite aggregation on single-valued keyword field
+GET /sales/_search
+{
+  "size": 0,
+  "aggs": {
+    "sales_by_region": {
+      "composite": {
+        "size": 100,
+        "sources": [
+          { "region": { "terms": { "field": "region.keyword" } } }
+        ]
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Only benefits single-valued fields; multi-valued fields use the standard path
+- Requires DocValues to be enabled on the field
+- Performance improvement varies based on query complexity and data characteristics
+- Currently implemented for DateHistogramAggregator and GlobalOrdinalValuesSource
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17643](https://github.com/opensearch-project/OpenSearch/pull/17643) | Unwrap singleton DocValues in date histogram aggregation |
+| v3.0.0 | [#17740](https://github.com/opensearch-project/OpenSearch/pull/17740) | Unwrap singleton DocValues in global ordinal value source of composite aggregation |
+
+## References
+
+- [Date Histogram Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/date-histogram/)
+- [Bucket Aggregations Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/index/)
+- [Lucene DocValues](https://lucene.apache.org/core/9_0_0/core/org/apache/lucene/index/DocValues.html)
+
+## Change History
+
+- **v3.0.0** (2025-04): Initial implementation for DateHistogramAggregator and GlobalOrdinalValuesSource

--- a/docs/releases/v3.0.0/features/opensearch/docvalues-optimization.md
+++ b/docs/releases/v3.0.0/features/opensearch/docvalues-optimization.md
@@ -1,0 +1,153 @@
+# DocValues Optimization
+
+## Summary
+
+OpenSearch v3.0.0 introduces singleton DocValues unwrapping optimization for date histogram and composite aggregations. This optimization provides a specialized fast path for single-valued fields by using `DocValues.unwrapSingleton()` to bypass unnecessary iteration logic, resulting in ~3-10% performance improvement in aggregation service time.
+
+## Details
+
+### What's New in v3.0.0
+
+Two key aggregators now detect single-valued fields and use direct value access instead of iterative processing:
+
+1. **DateHistogramAggregator**: Optimized for single-valued date fields
+2. **GlobalOrdinalValuesSource**: Optimized for single-valued keyword fields in composite aggregations
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before Optimization"
+        A1[SortedNumericDocValues] --> B1[advanceExact]
+        B1 --> C1[docValueCount]
+        C1 --> D1[Loop: nextValue]
+        D1 --> E1[Process Value]
+    end
+    
+    subgraph "After Optimization"
+        A2[SortedNumericDocValues] --> B2{unwrapSingleton}
+        B2 -->|"Single-valued"| C2[NumericDocValues]
+        C2 --> D2[advanceExact]
+        D2 --> E2[longValue - Direct]
+        B2 -->|"Multi-valued"| F2[Original Path]
+    end
+```
+
+#### Optimization Pattern
+
+The optimization uses Lucene's `DocValues.unwrapSingleton()` method to detect single-valued fields:
+
+```java
+// Detection
+final NumericDocValues singleton = DocValues.unwrapSingleton(values);
+
+if (singleton != null) {
+    // Fast path: direct value access
+    return new LeafBucketCollectorBase(sub, values) {
+        @Override
+        public void collect(int doc, long owningBucketOrd) throws IOException {
+            if (singleton.advanceExact(doc)) {
+                long value = singleton.longValue();  // Direct access
+                collectValue(sub, doc, owningBucketOrd, value);
+            }
+        }
+    };
+}
+
+// Original path for multi-valued fields
+return new LeafBucketCollectorBase(sub, values) {
+    // ... iteration logic
+};
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `DateHistogramAggregator` | Enhanced with singleton detection for date fields |
+| `GlobalOrdinalValuesSource` | Enhanced with singleton detection for keyword fields |
+
+### Performance Impact
+
+#### Date Histogram Aggregation
+
+| Metric | Before | After | Improvement |
+|--------|--------|-------|-------------|
+| 90th percentile service time (avg) | 851 ms | 824 ms | ~3.2% |
+
+Benchmark: `date_histogram_minute_agg` on big5 workload
+
+#### Composite Aggregation
+
+| Metric | Before | After | Improvement |
+|--------|--------|-------|-------------|
+| 90th percentile service time (avg) | 418 ms | 378 ms | ~9.5% |
+
+Benchmark: `composite_terms-keyword` on big5 workload
+
+### Usage Example
+
+No configuration changes required. The optimization is automatically applied when:
+
+1. The aggregated field is single-valued
+2. The field uses DocValues storage
+
+```json
+// Date histogram - automatically optimized for single-valued date fields
+GET /logs/_search
+{
+  "size": 0,
+  "aggs": {
+    "events_per_minute": {
+      "date_histogram": {
+        "field": "@timestamp",
+        "calendar_interval": "minute"
+      }
+    }
+  }
+}
+
+// Composite aggregation - automatically optimized for single-valued keyword fields
+GET /events/_search
+{
+  "size": 0,
+  "aggs": {
+    "by_category": {
+      "composite": {
+        "size": 100,
+        "sources": [
+          { "category": { "terms": { "field": "category.keyword" } } }
+        ]
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+This is a transparent performance optimization. No migration steps required.
+
+## Limitations
+
+- Only applies to single-valued fields (multi-valued fields use the original path)
+- Requires DocValues to be enabled on the field
+- Performance gains vary based on data distribution and query patterns
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17643](https://github.com/opensearch-project/OpenSearch/pull/17643) | Unwrap singleton DocValues in date histogram aggregation |
+| [#17740](https://github.com/opensearch-project/OpenSearch/pull/17740) | Unwrap singleton DocValues in global ordinal value source of composite aggregation |
+
+## References
+
+- [Date Histogram Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/date-histogram/)
+- [Bucket Aggregations Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/index/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/docvalues-optimization.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -15,6 +15,7 @@
 
 - [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)
 - [Bulk API Changes](features/opensearch/bulk-api-changes.md)
+- [DocValues Optimization](features/opensearch/docvalues-optimization.md)
 - [Concurrent Segment Search Auto Mode Default](features/opensearch/concurrent-segment-search.md)
 - [Deprecated Code Cleanup](features/opensearch/deprecated-code-cleanup.md)
 - [Field Type Fixes](features/opensearch/field-type-fixes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the DocValues singleton optimization feature introduced in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/docvalues-optimization.md`
- Feature report: `docs/features/opensearch/docvalues-optimization.md`

### Key Changes in v3.0.0
- DateHistogramAggregator now uses `DocValues.unwrapSingleton()` for single-valued date fields
- GlobalOrdinalValuesSource now uses `DocValues.unwrapSingleton()` for single-valued keyword fields in composite aggregations
- ~3.2% improvement in date histogram aggregation service time
- ~9.5% improvement in composite aggregation service time

### Related PRs
- [#17643](https://github.com/opensearch-project/OpenSearch/pull/17643): Unwrap singleton DocValues in date histogram aggregation
- [#17740](https://github.com/opensearch-project/OpenSearch/pull/17740): Unwrap singleton DocValues in global ordinal value source of composite aggregation

Closes #261