### PR TITLE
docs: add Search Replica & Reader-Writer Separation report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -158,6 +158,7 @@
 - [Search API Enhancements](opensearch/search-api-enhancements.md)
 - [Search API Tracker](opensearch/search-api-tracker.md)
 - [Search Pipeline](opensearch/search-pipeline.md)
+- [Search Replica & Reader-Writer Separation](opensearch/search-replica-reader-writer-separation.md)
 - [Search Request Stats](opensearch/search-request-stats.md)
 - [Search Scoring](opensearch/search-scoring.md)
 - [Search Settings](opensearch/search-settings.md)

--- a/docs/features/opensearch/search-replica-reader-writer-separation.md
+++ b/docs/features/opensearch/search-replica-reader-writer-separation.md
@@ -1,0 +1,160 @@
+# Search Replica & Reader-Writer Separation
+
+## Summary
+
+Search Replica and Reader-Writer Separation is an OpenSearch feature that enables independent scaling of indexing and search workloads within remote-store-enabled clusters. By introducing dedicated search replicas that are separate from write replicas, this feature provides workload isolation, failure resilience, and cost optimization through specialized hardware utilization.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Cluster"
+        subgraph "Data Nodes"
+            P[Primary Shard]
+            WR[Write Replica]
+        end
+        
+        subgraph "Search Nodes"
+            SR1[Search Replica 1]
+            SR2[Search Replica 2]
+        end
+        
+        subgraph "Remote Store"
+            RS[(Segment Storage)]
+        end
+    end
+    
+    WT[Write Traffic] --> P
+    P --> RS
+    RS --> SR1
+    RS --> SR2
+    ST[Search Traffic] --> SR1
+    ST --> SR2
+    P -.-> WR
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Indexing Flow"
+        I[Index Request] --> P[Primary Shard]
+        P --> F[Flush to Remote Store]
+        F --> WR[Write Replica Sync]
+    end
+    
+    subgraph "Search Flow"
+        S[Search Request] --> R{Routing Decision}
+        R -->|strict=true| SR[Search Replicas Only]
+        R -->|strict=false| ANY[Any Available Shard]
+    end
+    
+    subgraph "Scale-to-Zero Flow"
+        E[Enable search_only] --> SYNC[Sync to Remote Store]
+        SYNC --> BLOCK[Apply search_only Block]
+        BLOCK --> REMOVE[Remove Primary & Write Replicas]
+        REMOVE --> KEEP[Keep Search Replicas Active]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Search Replica | Read-only replica dedicated to search queries, cannot be promoted to primary |
+| Write Replica | Traditional replica that can be promoted to primary for high availability |
+| Search Node | Node with `search` role that hosts search replicas |
+| Scale API | REST API to enable/disable search-only mode |
+| Remote Store | Centralized storage for segment data enabling replica synchronization |
+
+### Configuration
+
+| Setting | Description | Default | Scope |
+|---------|-------------|---------|-------|
+| `index.number_of_search_replicas` | Number of search replicas for an index | `0` | Index |
+| `index.auto_expand_search_replicas` | Auto-expand search replicas (e.g., `0-3`, `0-all`) | `false` | Index |
+| `cluster.routing.search_only.strict` | Route search only to search replicas when enabled | `true` | Cluster |
+| `cluster.remote_store.state.enabled` | Enable remote cluster state for recovery | `false` | Cluster |
+
+### Usage Example
+
+#### Setting Up Workload Separation
+
+```yaml
+# opensearch.yml - Configure search node
+node.name: searcher-node1
+node.roles: [ search ]
+
+# Enable remote store
+node.attr.remote_store.segment.repository: "my-repository"
+node.attr.remote_store.translog.repository: "my-repository"
+node.attr.remote_store.state.repository: "my-repository"
+```
+
+#### Creating Index with Search Replicas
+
+```bash
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "number_of_shards": 1,
+      "number_of_replicas": 1,
+      "number_of_search_replicas": 2,
+      "auto_expand_search_replicas": "0-3"
+    }
+  }
+}
+```
+
+#### Enabling Search-Only Mode
+
+```bash
+# Scale down to search-only (remove primary and write replicas)
+POST /my-index/_scale
+{
+  "search_only": true
+}
+
+# Restore normal operations
+POST /my-index/_scale
+{
+  "search_only": false
+}
+```
+
+## Limitations
+
+- Requires remote store to be enabled
+- Search replicas cannot be promoted to primary shards
+- Auto-expand only considers nodes with the `search` role
+- Search-only mode blocks all write operations on the index
+- Recovery behavior depends on remote store state configuration
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17299](https://github.com/opensearch-project/OpenSearch/pull/17299) | Scale-to-zero (search_only mode) support |
+| v3.0.0 | [#17741](https://github.com/opensearch-project/OpenSearch/pull/17741) | AutoExpand for SearchReplica |
+| v3.0.0 | [#17803](https://github.com/opensearch-project/OpenSearch/pull/17803) | Search Only strict routing setting |
+| v2.17.0 | [#15368](https://github.com/opensearch-project/OpenSearch/pull/15368) | Initial search replica implementation |
+| v2.17.0 | [#15445](https://github.com/opensearch-project/OpenSearch/pull/15445) | Pull-based replica support |
+
+## References
+
+- [Issue #15306](https://github.com/opensearch-project/OpenSearch/issues/15306): META - Reader/Writer Separation
+- [Issue #16720](https://github.com/opensearch-project/OpenSearch/issues/16720): Scale to Zero feature request
+- [Issue #17310](https://github.com/opensearch-project/OpenSearch/issues/17310): Auto-expand-replica for search replicas
+- [Issue #17424](https://github.com/opensearch-project/OpenSearch/issues/17424): Strict routing for search replicas
+- [Documentation: Scale API](https://docs.opensearch.org/3.0/api-reference/index-apis/scale/)
+- [Documentation: Separate Index and Search Workloads](https://docs.opensearch.org/3.0/tuning-your-cluster/separate-index-and-search-workloads/)
+- [Documentation: Index Settings](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/index-settings/)
+- [Blog: Improve OpenSearch cluster performance by separating search and indexing workloads](https://opensearch.org/blog/improve-opensearch-cluster-performance-by-separating-search-and-indexing-workloads/)
+
+## Change History
+
+- **v3.0.0** (2025-04-08): Added scale-to-zero support, auto-expand search replicas, and strict routing setting
+- **v2.17.0** (2024-09): Initial experimental implementation with search replicas and pull-based replication

--- a/docs/releases/v3.0.0/features/opensearch/search-replica-reader-writer-separation.md
+++ b/docs/releases/v3.0.0/features/opensearch/search-replica-reader-writer-separation.md
@@ -1,0 +1,152 @@
+# Search Replica & Reader-Writer Separation
+
+## Summary
+
+OpenSearch 3.0.0 introduces significant enhancements to the reader-writer separation feature, enabling scale-to-zero deployments and improved workload isolation. These changes allow users to designate indexes as search-only, automatically scale search replicas based on cluster size, and control search request routing behavior.
+
+## Details
+
+### What's New in v3.0.0
+
+This release adds three key capabilities to the reader-writer separation feature:
+
+1. **Scale-to-Zero (Search-Only Mode)**: New `_scale` API to enable/disable search-only mode on indexes
+2. **Auto-Expand Search Replicas**: New `index.auto_expand_search_replicas` setting for automatic scaling
+3. **Strict Search Routing**: New `cluster.routing.search_only.strict` setting to control search request routing
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Normal Mode"
+        P1[Primary Shard]
+        R1[Write Replica]
+        SR1[Search Replica]
+        WT[Write Traffic] --> P1
+        P1 --> R1
+        ST1[Search Traffic] --> SR1
+    end
+    
+    subgraph "Search-Only Mode"
+        SR2[Search Replica 1]
+        SR3[Search Replica 2]
+        ST2[Search Traffic] --> SR2
+        ST2 --> SR3
+        Note[Primary & Write Replicas Scaled Down]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ScaleAction` | REST action handler for the `_scale` API |
+| `SearchOnlyBlockService` | Manages search-only index blocks |
+| `AutoExpandSearchReplicas` | Handles automatic search replica scaling |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.auto_expand_search_replicas` | Auto-expand search replicas based on search nodes (e.g., `0-3`, `0-all`) | `false` |
+| `cluster.routing.search_only.strict` | When `true`, route search requests only to search replicas | `true` |
+
+#### API Changes
+
+**New Scale API**
+
+```
+POST /<index>/_scale
+{
+  "search_only": true | false
+}
+```
+
+- `search_only: true`: Enables search-only mode, scales down primary and write replicas
+- `search_only: false`: Disables search-only mode, restores primary and write replicas
+
+### Usage Example
+
+#### Enable Search-Only Mode
+
+```bash
+# Enable search-only mode for an index
+POST /my-index/_scale
+{
+  "search_only": true
+}
+```
+
+#### Configure Auto-Expand Search Replicas
+
+```bash
+# Create index with auto-expanding search replicas
+PUT /my-index
+{
+  "settings": {
+    "index": {
+      "number_of_shards": 1,
+      "number_of_replicas": 1,
+      "number_of_search_replicas": 1,
+      "auto_expand_search_replicas": "0-3"
+    }
+  }
+}
+```
+
+#### Configure Strict Routing
+
+```bash
+# Allow fallback to primary/write replicas if search replicas unavailable
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.routing.search_only.strict": false
+  }
+}
+```
+
+### Migration Notes
+
+- Requires remote store to be enabled for search-only mode
+- Set `cluster.remote_store.state.enabled: true` for seamless search replica recovery
+- Search replicas are allocated only to nodes with the `search` role
+
+### Search Replica Recovery Scenarios
+
+| Scenario | Remote Store State | Persistent Data | Recovery Behavior |
+|----------|-------------------|-----------------|-------------------|
+| Normal restart | Enabled | Yes | Seamless recovery |
+| No persistent data | Enabled | No | Auto-recovery from remote store |
+| No persistent data | Disabled | No | Requires manual `_remotestore/_restore` |
+
+## Limitations
+
+- Search-only mode requires remote store to be enabled
+- Search replicas cannot be promoted to primary shards
+- Auto-expand search replicas only considers nodes with the `search` role
+- When all search replicas are unassigned and strict routing is enabled, search requests fail with a clear error message
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17299](https://github.com/opensearch-project/OpenSearch/pull/17299) | Scale-to-zero (search_only mode) with Reader/Writer Separation |
+| [#17741](https://github.com/opensearch-project/OpenSearch/pull/17741) | Support AutoExpand for SearchReplica |
+| [#17803](https://github.com/opensearch-project/OpenSearch/pull/17803) | Added Search Only strict routing setting |
+
+## References
+
+- [Issue #15306](https://github.com/opensearch-project/OpenSearch/issues/15306): META - Reader/Writer Separation
+- [Issue #16720](https://github.com/opensearch-project/OpenSearch/issues/16720): Scale to Zero feature request
+- [Issue #17310](https://github.com/opensearch-project/OpenSearch/issues/17310): Auto-expand-replica for search replicas
+- [Issue #17424](https://github.com/opensearch-project/OpenSearch/issues/17424): Strict routing for search replicas
+- [Documentation: Scale API](https://docs.opensearch.org/3.0/api-reference/index-apis/scale/)
+- [Documentation: Separate Index and Search Workloads](https://docs.opensearch.org/3.0/tuning-your-cluster/separate-index-and-search-workloads/)
+- [Blog: Improve OpenSearch cluster performance by separating search and indexing workloads](https://opensearch.org/blog/improve-opensearch-cluster-performance-by-separating-search-and-indexing-workloads/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/search-replica-reader-writer-separation.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -53,6 +53,7 @@
 - [Tiered Caching](features/opensearch/tiered-caching.md)
 - [Track Total Hits](features/opensearch/track-total-hits.md)
 - [Wildcard Field](features/opensearch/wildcard-field.md)
+- [Search Replica & Reader-Writer Separation](features/opensearch/search-replica-reader-writer-separation.md)
 
 ## opensearch-dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Search Replica & Reader-Writer Separation feature in OpenSearch v3.0.0.

### Changes in v3.0.0
- **Scale-to-Zero (Search-Only Mode)**: New `_scale` API to enable/disable search-only mode on indexes
- **Auto-Expand Search Replicas**: New `index.auto_expand_search_replicas` setting for automatic scaling
- **Strict Search Routing**: New `cluster.routing.search_only.strict` setting to control search request routing

### Related PRs
- [#17299](https://github.com/opensearch-project/OpenSearch/pull/17299): Scale-to-zero support
- [#17741](https://github.com/opensearch-project/OpenSearch/pull/17741): AutoExpand for SearchReplica
- [#17803](https://github.com/opensearch-project/OpenSearch/pull/17803): Search Only strict routing setting

### Files Added
- `docs/releases/v3.0.0/features/opensearch/search-replica-reader-writer-separation.md` (Release report)
- `docs/features/opensearch/search-replica-reader-writer-separation.md` (Feature report)

Closes #240