### PR TITLE
docs: add Query Performance Optimizations report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -132,6 +132,7 @@
 - [Query Cache](opensearch/query-cache.md)
 - [Query Coordinator Context](opensearch/query-coordinator-context.md)
 - [Query Optimization](opensearch/query-optimization.md)
+- [Query Performance Optimizations](opensearch/query-performance-optimizations.md)
 - [Query Phase Plugin Extension](opensearch/query-phase-plugin-extension.md)
 - [Query Phase Result Consumer](opensearch/query-phase-result-consumer.md)
 - [Query Rewriting](opensearch/query-rewriting.md)

--- a/docs/features/opensearch/filter-rewrite-optimization.md
+++ b/docs/features/opensearch/filter-rewrite-optimization.md
@@ -205,7 +205,7 @@ GET /logs/_search
 | v3.4.0 | [#19933](https://github.com/opensearch-project/OpenSearch/pull/19933) | Add bulk collect API for filter rewrite sub-aggregation optimization |
 | v3.4.0 | [#20009](https://github.com/opensearch-project/OpenSearch/pull/20009) | Allow collectors take advantage of preaggregated data using collectRange API |
 | v3.4.0 | [#20067](https://github.com/opensearch-project/OpenSearch/pull/20067) | Bulk collection logic for metrics and cardinality aggregations |
-| v2.x | [#17447](https://github.com/opensearch-project/OpenSearch/pull/17447) | Support sub agg in filter rewrite optimization (initial implementation) |
+| v3.0.0 | [#17447](https://github.com/opensearch-project/OpenSearch/pull/17447) | Support sub agg in filter rewrite optimization (initial implementation) |
 
 ## References
 

--- a/docs/features/opensearch/query-performance-optimizations.md
+++ b/docs/features/opensearch/query-performance-optimizations.md
@@ -1,0 +1,205 @@
+# Query Performance Optimizations
+
+## Summary
+
+Query performance optimizations in OpenSearch encompass a collection of enhancements that improve search latency, aggregation speed, and overall query execution efficiency. These optimizations target different aspects of query processing including term query execution, match_all query short-circuiting, aggregation filter rewriting, and keyword field scoring.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Query Layer Optimizations"
+        Query[Search Query] --> Parser[Query Parser]
+        Parser --> Rewriter[Query Rewriter]
+        
+        Rewriter --> TQ[Terms Query]
+        Rewriter --> MAQ[Match All Query]
+        Rewriter --> KTQ[Keyword Term Query]
+        
+        TQ --> |"Pre-sorted terms"| TISQ[TermInSetQuery]
+        MAQ --> |"With sort"| AMAQ[ApproximateMatchAllQuery]
+        KTQ --> |"useSimilarity=false"| CSQ[ConstantScoreQuery]
+    end
+    
+    subgraph "Aggregation Layer Optimizations"
+        Agg[Aggregation Request] --> Check{Filter Rewrite Eligible?}
+        Check --> |"Yes"| FR[Filter Rewrite Path]
+        Check --> |"No"| Standard[Standard Collection]
+        
+        FR --> BKD[BKD Tree Traversal]
+        BKD --> Ranges[Range Buckets]
+        Ranges --> SubAgg[Sub-Aggregation Collection]
+    end
+    
+    subgraph "Execution"
+        TISQ --> Exec[Query Executor]
+        AMAQ --> Exec
+        CSQ --> Exec
+        SubAgg --> Exec
+        Standard --> Exec
+        Exec --> Results[Search Results]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Terms Query Optimization"
+        Terms[Terms Array] --> Sort{Already Sorted?}
+        Sort --> |"Yes"| Direct[Direct to TermInSetQuery]
+        Sort --> |"No"| SortOp[Sort Operation]
+        SortOp --> Direct
+    end
+    
+    subgraph "ApproximateMatchAllQuery"
+        MA[Match All + Sort] --> Bound[Add Bounded Range]
+        Bound --> APR[ApproximatePointRangeQuery]
+        APR --> Collect{Collected 10K?}
+        Collect --> |"Yes"| Stop[Short Circuit]
+        Collect --> |"No"| Continue[Continue Collection]
+    end
+    
+    subgraph "Filter Rewrite Sub-Aggregation"
+        Range[Range Aggregation] --> Traverse[BKD Tree Traversal]
+        Traverse --> DocIds[DocIdSet per Bucket]
+        DocIds --> Defer[Deferred Sub-Agg Collection]
+        Defer --> Metrics[Metric Aggregations]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `TermInSetQuery` | Lucene query for matching multiple terms efficiently |
+| `ApproximateMatchAllQuery` | Wrapper that adds bounded range to match_all for early termination |
+| `ApproximatePointRangeQuery` | Point range query that short-circuits after collecting sufficient docs |
+| `SubAggRangeCollector` | Collector that builds DocIdSets for deferred sub-aggregation processing |
+| `ConstantScoreQuery` | Query wrapper that returns constant score instead of BM25 |
+| `useSimilarity` | Keyword field parameter controlling scoring behavior |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `useSimilarity` | Enable BM25 scoring for keyword term queries | `false` (v3.0.0+) |
+| `index.max_terms_count` | Maximum terms allowed in terms query | 65,536 |
+
+### Usage Examples
+
+#### Keyword Field Mapping
+
+```json
+// Default behavior (v3.0.0+): No scoring, faster queries
+PUT /my-index
+{
+  "mappings": {
+    "properties": {
+      "status": {
+        "type": "keyword"
+      }
+    }
+  }
+}
+
+// Opt-in to BM25 scoring (slower, but provides relevance scores)
+PUT /my-index
+{
+  "mappings": {
+    "properties": {
+      "category": {
+        "type": "keyword",
+        "useSimilarity": true
+      }
+    }
+  }
+}
+```
+
+#### Terms Query (Benefits from Pre-sorted Optimization)
+
+```json
+GET /products/_search
+{
+  "query": {
+    "terms": {
+      "product_id": ["A001", "A002", "A003", "B001", "B002"]
+    }
+  }
+}
+```
+
+#### Match All with Sort (Benefits from ApproximateMatchAllQuery)
+
+```json
+GET /logs/_search
+{
+  "query": {
+    "match_all": {}
+  },
+  "sort": [
+    { "@timestamp": "desc" }
+  ],
+  "size": 100
+}
+```
+
+#### Date Histogram with Sub-Aggregations (Benefits from Filter Rewrite)
+
+```json
+GET /metrics/_search
+{
+  "size": 0,
+  "aggs": {
+    "by_minute": {
+      "date_histogram": {
+        "field": "@timestamp",
+        "fixed_interval": "1m"
+      },
+      "aggs": {
+        "avg_cpu": { "avg": { "field": "cpu_usage" } },
+        "max_memory": { "max": { "field": "memory_usage" } },
+        "min_latency": { "min": { "field": "latency" } }
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- **ApproximateMatchAllQuery**: Only applies when sorting on numeric fields with point values indexed
+- **Filter Rewrite Sub-Aggregation**: 
+  - Works best with dense data (many documents per bucket)
+  - May add overhead for sparse datasets
+  - Does not support composite aggregations
+  - Requires match_all or range query on the aggregation field
+- **Keyword Scoring**: Disabling scoring changes result ordering for multi-term queries that previously relied on IDF
+- **Terms Query**: Pre-sorted optimization only helps when input terms are already sorted
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17714](https://github.com/opensearch-project/OpenSearch/pull/17714) | Pass in-order terms as sorted to TermInSetQuery |
+| v3.0.0 | [#17772](https://github.com/opensearch-project/OpenSearch/pull/17772) | Add ApproximateMatchAllQuery for match_all with sort |
+| v3.0.0 | [#17447](https://github.com/opensearch-project/OpenSearch/pull/17447) | Support sub agg in filter rewrite optimization |
+| v3.0.0 | [#17889](https://github.com/opensearch-project/OpenSearch/pull/17889) | Disable scoring of keyword term search by default |
+
+## References
+
+- [Issue #12602](https://github.com/opensearch-project/OpenSearch/issues/12602): Proposal for sub-aggregation support in filter rewrite
+- [Issue #17823](https://github.com/opensearch-project/OpenSearch/issues/17823): Keyword term search performance regression since 2.18
+- [Issue #13788](https://github.com/opensearch-project/OpenSearch/issues/13788): ApproximatePointRangeQuery for range queries
+- [Forum Discussion](https://forum.opensearch.org/t/avoid-re-sorting-when-initializing-terminsetquery/23865): TermInSetQuery sorting overhead
+- [Lucene Issue #14445](https://github.com/apache/lucene/issues/14445): Keyword term query performance regression
+- [Terms Query Documentation](https://docs.opensearch.org/3.0/query-dsl/term/terms/)
+- [Date Histogram Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/date-histogram/)
+- [Filter Results Documentation](https://docs.opensearch.org/3.0/search-plugins/filter-search/)
+
+## Change History
+
+- **v3.0.0** (2025-04): Added ApproximateMatchAllQuery, sub-aggregation support in filter rewrite, disabled keyword term scoring by default, and pre-sorted terms optimization for TermInSetQuery

--- a/docs/features/opensearch/terms-query.md
+++ b/docs/features/opensearch/terms-query.md
@@ -150,6 +150,7 @@ flowchart LR
 | v3.4.0 | [#19350](https://github.com/opensearch-project/OpenSearch/pull/19350) | Pack terms once for keyword fields with index and docValues |
 | v3.4.0 | [#17714](https://github.com/opensearch-project/OpenSearch/pull/17714) | Pass in-order terms as sorted to TermInSetQuery |
 | v3.3.0 | [#19587](https://github.com/opensearch-project/OpenSearch/pull/19587) | Fix rewriting terms query with consecutive whole numbers |
+| v3.0.0 | [#17714](https://github.com/opensearch-project/OpenSearch/pull/17714) | Pass in-order terms as sorted to TermInSetQuery |
 | v2.17.0 | - | Added bitmap filtering support |
 
 ## References

--- a/docs/releases/v3.0.0/features/opensearch/query-performance-optimizations.md
+++ b/docs/releases/v3.0.0/features/opensearch/query-performance-optimizations.md
@@ -1,0 +1,140 @@
+# Query Performance Optimizations
+
+## Summary
+
+OpenSearch 3.0.0 introduces several query performance optimizations that significantly improve search latency and aggregation performance. Key improvements include faster `terms_query` execution by avoiding redundant sorting, approximate `match_all` queries with sort optimization, extended filter rewrite optimization for sub-aggregations, and disabled scoring for keyword term searches by default.
+
+## Details
+
+### What's New in v3.0.0
+
+This release bundles four distinct performance optimizations:
+
+1. **Faster terms_query with pre-sorted terms** - Avoids re-sorting when terms are already in order
+2. **ApproximateMatchAllQuery** - Short-circuits match_all queries with sorts after collecting sufficient documents
+3. **Sub-aggregation support in filter rewrite** - Extends filter rewrite optimization to work with nested aggregations
+4. **Disabled keyword term scoring** - Eliminates unnecessary BM25 scoring overhead for keyword field searches
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Query Optimizations"
+        TQ[Terms Query] --> |"Pre-sorted"| TISQ[TermInSetQuery]
+        MAQ[Match All Query] --> |"With Sort"| AMAQ[ApproximateMatchAllQuery]
+        AMAQ --> APR[ApproximatePointRangeQuery]
+        APR --> |"Short circuit"| Results[Top N Results]
+    end
+    
+    subgraph "Aggregation Optimizations"
+        Agg[Range/Date Aggregation] --> FR{Filter Rewrite?}
+        FR --> |"Yes"| BKD[BKD Tree Traversal]
+        BKD --> SubAgg[Sub-Aggregations]
+        SubAgg --> |"DocIdSet per bucket"| Collect[Deferred Collection]
+    end
+    
+    subgraph "Keyword Scoring"
+        KW[Keyword Term Query] --> |"useSimilarity=false"| Const[ConstantScoreQuery]
+        KW --> |"useSimilarity=true"| BM25[BM25 Scoring]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ApproximateMatchAllQuery` | Wraps match_all queries with bounded range for early termination |
+| `SubAggRangeCollector` | Collects DocIdSets per bucket for deferred sub-aggregation processing |
+| `useSimilarity` parameter | New keyword field mapping parameter to control scoring behavior |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `useSimilarity` | Enable BM25 scoring for keyword term queries | `false` |
+
+### Usage Example
+
+#### Keyword Field with Scoring Control
+
+```json
+PUT /my-index/_mapping
+{
+  "properties": {
+    "status": {
+      "type": "keyword",
+      "useSimilarity": false
+    }
+  }
+}
+```
+
+#### Date Histogram with Sub-Aggregations (Benefits from Filter Rewrite)
+
+```json
+GET /logs/_search
+{
+  "size": 0,
+  "aggs": {
+    "by_hour": {
+      "date_histogram": {
+        "field": "@timestamp",
+        "fixed_interval": "1h"
+      },
+      "aggs": {
+        "avg_response": { "avg": { "field": "response_time" } },
+        "max_latency": { "max": { "field": "latency" } }
+      }
+    }
+  }
+}
+```
+
+### Performance Improvements
+
+| Optimization | Workload | Improvement |
+|--------------|----------|-------------|
+| Sub-agg filter rewrite | Big5 (dense data) | 700-1500ms faster |
+| Keyword term scoring disabled | Big5 term query | 10ms vs 200ms (20x faster) |
+| ApproximateMatchAllQuery | Match all with sort | Short-circuits after 10,000 docs |
+| Pre-sorted terms | Terms query | Avoids O(n log n) sort overhead |
+
+### Migration Notes
+
+**Breaking Change**: Keyword term queries now return a constant score of 1.0 by default instead of BM25-calculated scores. If your application relies on keyword term scoring for relevance ranking:
+
+1. Set `useSimilarity: true` in field mapping to restore previous behavior
+2. Or wrap queries in `constant_score` explicitly for consistent behavior
+
+## Limitations
+
+- `ApproximateMatchAllQuery` only applies when sorting on a numeric field with point values
+- Filter rewrite sub-aggregation optimization works best with dense data (many docs per bucket)
+- For sparse data, the optimization may add overhead due to BKD tree traversal costs
+- Composite aggregations are not supported by filter rewrite optimization
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17714](https://github.com/opensearch-project/OpenSearch/pull/17714) | Pass in-order terms as sorted to TermInSetQuery |
+| [#17772](https://github.com/opensearch-project/OpenSearch/pull/17772) | Add ApproximateMatchAllQuery for match_all with sort |
+| [#17447](https://github.com/opensearch-project/OpenSearch/pull/17447) | Support sub agg in filter rewrite optimization |
+| [#17889](https://github.com/opensearch-project/OpenSearch/pull/17889) | Disable scoring of keyword term search by default |
+
+## References
+
+- [Issue #12602](https://github.com/opensearch-project/OpenSearch/issues/12602): Proposal for sub-aggregation support in filter rewrite
+- [Issue #17823](https://github.com/opensearch-project/OpenSearch/issues/17823): Keyword term search performance regression since 2.18
+- [Forum Discussion](https://forum.opensearch.org/t/avoid-re-sorting-when-initializing-terminsetquery/23865): TermInSetQuery sorting overhead
+- [Lucene Issue #14445](https://github.com/apache/lucene/issues/14445): Keyword term query performance regression
+- [Terms Query Documentation](https://docs.opensearch.org/3.0/query-dsl/term/terms/)
+- [Date Histogram Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/date-histogram/)
+
+## Related Feature Reports
+
+- [Terms Query](../../../features/opensearch/terms-query.md)
+- [Filter Rewrite Optimization](../../../features/opensearch/filter-rewrite-optimization.md)
+- [Query Performance Optimizations](../../../features/opensearch/query-performance-optimizations.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -39,6 +39,7 @@
 - [Merge & Segment Settings](features/opensearch/merge-segment-settings.md)
 - [Node Stats & API Fixes](features/opensearch/node-stats-and-api-fixes.md)
 - [Query & Aggregation Fixes](features/opensearch/query-and-aggregation-fixes.md)
+- [Query Performance Optimizations](features/opensearch/query-performance-optimizations.md)
 - [Node Roles & Configuration](features/opensearch/node-roles-and-configuration.md)
 - [Node Roles Configuration (Environment Variables)](features/opensearch/node-roles-configuration.md)
 - [Nodes Info API Changes](features/opensearch/nodes-info-api-changes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for Query Performance Optimizations in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/query-performance-optimizations.md`
- Feature report: `docs/features/opensearch/query-performance-optimizations.md`

### Key Changes in v3.0.0

1. **Faster terms_query with pre-sorted terms** (#17714) - Avoids re-sorting when terms are already in order
2. **ApproximateMatchAllQuery** (#17772) - Short-circuits match_all queries with sorts after collecting sufficient documents
3. **Sub-aggregation support in filter rewrite** (#17447) - Extends filter rewrite optimization to work with nested aggregations
4. **Disabled keyword term scoring** (#17889) - Eliminates unnecessary BM25 scoring overhead for keyword field searches

### Performance Improvements

| Optimization | Improvement |
|--------------|-------------|
| Sub-agg filter rewrite | 700-1500ms faster on dense data |
| Keyword term scoring disabled | 20x faster (10ms vs 200ms) |
| ApproximateMatchAllQuery | Short-circuits after 10,000 docs |

### Related Issue
Closes #239