### PR TITLE
docs: add Security Manager Replacement (Java Agent) report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -168,6 +168,7 @@
 - [Search Tie-breaking](opensearch/search-tie-breaking.md)
 - [Secure Aux Transport Settings](opensearch/secure-aux-transport-settings.md)
 - [Secure Transport Settings](opensearch/secure-transport-settings.md)
+- [Security Manager Replacement](opensearch/security-manager-replacement.md)
 - [Segment Replication](opensearch/segment-replication.md)
 - [Segment Warmer](opensearch/segment-warmer.md)
 - [Semantic Version Field Type](opensearch/semantic-version-field-type.md)

--- a/docs/features/opensearch/security-manager-replacement.md
+++ b/docs/features/opensearch/security-manager-replacement.md
@@ -1,0 +1,200 @@
+# Security Manager Replacement
+
+## Summary
+
+OpenSearch replaces the deprecated Java Security Manager (JSM) with a custom Java agent-based security model. This change ensures OpenSearch remains compatible with JDK 24+ where JSM will be fully removed, while maintaining plugin sandboxing capabilities and enabling future adoption of virtual threads. The replacement uses a two-pronged approach: a Java agent for plugin-level access control and systemd hardening for operating system-level protection.
+
+## Details
+
+### Background
+
+Java Security Manager (JSM) has been deprecated since JDK 17 (JEP 411) and is scheduled for full removal in JDK 24 (JEP 486). OpenSearch historically relied on JSM to sandbox plugins and prevent them from performing privileged actions without explicit administrator approval. The deprecation of JSM required OpenSearch to find alternative security mechanisms.
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Distribution"
+        JVM[JVM with Java Agent]
+        Core[OpenSearch Core]
+        Plugins[Plugins]
+    end
+    subgraph "Java Agent Security"
+        Agent[opensearch-agent.jar]
+        Bootstrap[Agent Bootstrap]
+        Interceptors[Interceptors]
+        PolicyParser[Policy Parser]
+    end
+    subgraph "Interceptor Types"
+        Socket[SocketChannelInterceptor]
+        File[FileInterceptor]
+        Exit[SystemExitInterceptor]
+        Halt[RuntimeHaltInterceptor]
+    end
+    subgraph "Policy Management"
+        AgentPolicy[AgentPolicy]
+        PluginPolicy[plugin-security.policy]
+        SecurityPolicy[security.policy]
+    end
+    subgraph "OS Level Security"
+        Systemd[systemd Hardening]
+        Seccomp[seccomp Filters]
+        Capabilities[Capability Restrictions]
+    end
+    JVM --> Agent
+    Agent --> Bootstrap
+    Agent --> Interceptors
+    Interceptors --> Socket
+    Interceptors --> File
+    Interceptors --> Exit
+    Interceptors --> Halt
+    Socket --> AgentPolicy
+    File --> AgentPolicy
+    Exit --> AgentPolicy
+    Halt --> AgentPolicy
+    PolicyParser --> PluginPolicy
+    PolicyParser --> SecurityPolicy
+    PluginPolicy --> AgentPolicy
+    SecurityPolicy --> AgentPolicy
+    Core --> Systemd
+    Plugins --> Systemd
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Plugin performs privileged operation] --> B[Java Agent intercepts call]
+    B --> C[StackWalker captures call stack]
+    C --> D[Extract ProtectionDomains from stack]
+    D --> E[Load policy for codebase]
+    E --> F{Permission granted?}
+    F -->|Yes| G[Allow operation]
+    F -->|No| H[Throw SecurityException]
+    
+    subgraph "Stack Walking"
+        C --> I[Filter JDK frames]
+        I --> J[Identify caller codebases]
+        J --> D
+    end
+```
+
+### Components
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| `Agent` | `libs/agent-sm/agent` | Main Java agent with ByteBuddy instrumentation |
+| `AgentPolicy` | `libs/agent-sm/bootstrap` | Central policy management and permission checking |
+| `SocketChannelInterceptor` | `libs/agent-sm/agent` | Intercepts socket connection attempts |
+| `FileInterceptor` | `libs/agent-sm/agent` | Intercepts file system operations |
+| `SystemExitInterceptor` | `libs/agent-sm/agent` | Intercepts `System.exit()` calls |
+| `RuntimeHaltInterceptor` | `libs/agent-sm/agent` | Intercepts `Runtime.halt()` calls |
+| `PolicyFile` | `libs/secure-sm` | Custom policy parser compatible with JDK 24+ |
+| `StackCallerChainExtractor` | `libs/agent-sm/agent` | Extracts ProtectionDomains from call stack |
+| `AccessController` | `libs/agent-sm/agent-policy` | Replacement for `java.security.AccessController` |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `-javaagent:agent/opensearch-agent.jar` | JVM argument to attach the Java agent | Enabled for JDK 21+ |
+| `plugin-security.policy` | Per-plugin permission definitions | Plugin-specific |
+| `security.policy` | Core OpenSearch permissions | Bundled with distribution |
+
+### Intercepted Operations
+
+| Operation | Interceptor | Permission Required |
+|-----------|-------------|---------------------|
+| Socket connect | `SocketChannelInterceptor` | `java.net.SocketPermission "host:port", "connect,resolve"` |
+| Unix domain socket | `SocketChannelInterceptor` | `java.net.NetPermission "accessUnixDomainSocket"` |
+| File read/write | `FileInterceptor` | `java.io.FilePermission "path", "read,write"` |
+| System.exit() | `SystemExitInterceptor` | Allowed only for whitelisted classes |
+| Runtime.halt() | `RuntimeHaltInterceptor` | Allowed only for whitelisted classes |
+
+### Usage Example
+
+#### Plugin Security Policy
+
+```java
+// plugin-security.policy
+grant {
+  // Network permissions
+  permission java.net.SocketPermission "*", "connect,resolve";
+  permission java.net.NetPermission "accessUnixDomainSocket";
+  
+  // File permissions
+  permission java.io.FilePermission "${user.home}/-", "read";
+  permission java.io.FilePermission "/tmp/-", "read,write,delete";
+  
+  // Runtime permissions
+  permission java.lang.RuntimePermission "getClassLoader";
+  permission java.lang.RuntimePermission "setContextClassLoader";
+}
+```
+
+#### Privileged Action in Plugin Code
+
+```java
+import org.opensearch.secure_sm.AccessController;
+
+// Execute privileged file operation
+byte[] content = AccessController.doPrivileged(() -> {
+    return Files.readAllBytes(Path.of("/tmp/myfile"));
+});
+
+// Execute privileged network operation
+AccessController.doPrivileged(() -> {
+    HttpClient client = HttpClient.newHttpClient();
+    client.send(request, HttpResponse.BodyHandlers.ofString());
+});
+```
+
+### systemd Hardening
+
+For Linux distributions using systemd, OpenSearch applies additional OS-level protections:
+
+| Directive | Purpose |
+|-----------|---------|
+| `SystemCallFilter` | Restricts kernel interfaces via seccomp |
+| `ReadOnlyPaths` | Protects critical system files |
+| `ReadWritePaths` | Limits write access to necessary directories |
+| `InaccessiblePaths` | Blocks access to sensitive paths |
+| `CapabilityBoundingSet` | Blocks dangerous Linux capabilities |
+| `PrivateTmp` | Isolates temporary files |
+| `NoNewPrivileges` | Prevents privilege escalation |
+| `ProtectSystem` | Protects system directories |
+
+## Limitations
+
+- The Java agent focuses on high-risk operations (file I/O, network, process termination)
+- Not all JSM permission types are covered (e.g., reflection permissions)
+- systemd hardening is only available on Linux distributions using systemd
+- Virtual threads do not carry permissions (by JDK design)
+- systemd rules apply at process level, not per-plugin
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17724](https://github.com/opensearch-project/OpenSearch/pull/17724) | Create initial Java Agent to intercept Socket::connect calls |
+| v3.0.0 | [#17746](https://github.com/opensearch-project/OpenSearch/pull/17746) | Enhance Java Agent to intercept System::exit |
+| v3.0.0 | [#17753](https://github.com/opensearch-project/OpenSearch/pull/17753) | Add a policy parser for Java agent security policies |
+| v3.0.0 | [#17757](https://github.com/opensearch-project/OpenSearch/pull/17757) | Enhance Java Agent to intercept Runtime::halt |
+| v3.0.0 | [#17760](https://github.com/opensearch-project/OpenSearch/pull/17760) | Implement File Interceptor and add integration tests |
+| v3.0.0 | [#17861](https://github.com/opensearch-project/OpenSearch/pull/17861) | Phase off SecurityManager usage in favor of Java Agent |
+
+## References
+
+- [Issue #1687](https://github.com/opensearch-project/OpenSearch/issues/1687): Original JSM replacement discussion
+- [Issue #17658](https://github.com/opensearch-project/OpenSearch/issues/17658): Parent issue for Security Manager replacement
+- [Issue #17659](https://github.com/opensearch-project/OpenSearch/issues/17659): Add support of Java policies
+- [Issue #17660](https://github.com/opensearch-project/OpenSearch/issues/17660): Create initial Java Agent to intercept Socket::connect calls
+- [Issue #17662](https://github.com/opensearch-project/OpenSearch/issues/17662): Phase off SecurityManager usage in favor of Java Agent
+- [JEP 411](https://openjdk.org/jeps/411): Deprecate the Security Manager for Removal
+- [JEP 486](https://openjdk.org/jeps/486): Permanently Disable the Security Manager
+- [JEP 444](https://openjdk.org/jeps/444): Virtual Threads
+- [Blog: Finding a replacement for JSM in OpenSearch 3.0](https://opensearch.org/blog/finding-a-replacement-for-jsm-in-opensearch-3-0/)
+
+## Change History
+
+- **v3.0.0** (2025-04-09): Initial implementation replacing Java Security Manager with Java agent

--- a/docs/releases/v3.0.0/features/opensearch/security-manager-replacement-java-agent.md
+++ b/docs/releases/v3.0.0/features/opensearch/security-manager-replacement-java-agent.md
@@ -1,0 +1,120 @@
+# Security Manager Replacement (Java Agent)
+
+## Summary
+
+OpenSearch 3.0.0 replaces the deprecated Java Security Manager (JSM) with a custom Java agent for security enforcement. This change prepares OpenSearch for JDK 24+ where JSM will be fully removed, while maintaining plugin sandboxing capabilities and enabling future adoption of virtual threads.
+
+## Details
+
+### What's New in v3.0.0
+
+OpenSearch 3.0.0 introduces a complete replacement for the Java Security Manager using a two-pronged approach:
+
+1. **Java Agent**: A custom agent that intercepts privileged operations (socket connections, file access, process termination) and validates permissions against policy files
+2. **systemd Hardening**: Operating system-level protections for Linux distributions using systemd
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Process"
+        Core[OpenSearch Core]
+        Plugin[Plugins]
+    end
+    subgraph "Java Agent"
+        Agent[opensearch-agent.jar]
+        SI[Socket Interceptor]
+        FI[File Interceptor]
+        EI[Exit/Halt Interceptor]
+        PP[Policy Parser]
+    end
+    subgraph "Policy Layer"
+        Policy[plugin-security.policy]
+        AgentPolicy[AgentPolicy]
+    end
+    Core --> Agent
+    Plugin --> Agent
+    Agent --> SI
+    Agent --> FI
+    Agent --> EI
+    SI --> AgentPolicy
+    FI --> AgentPolicy
+    EI --> AgentPolicy
+    PP --> Policy
+    Policy --> AgentPolicy
+```
+
+#### New Components
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| `Agent` | `libs/agent-sm/agent` | Main Java agent entry point with ByteBuddy instrumentation |
+| `AgentPolicy` | `libs/agent-sm/bootstrap` | Policy management and permission checking |
+| `SocketChannelInterceptor` | `libs/agent-sm/agent` | Intercepts `Socket::connect` calls |
+| `FileInterceptor` | `libs/agent-sm/agent` | Intercepts file system operations |
+| `SystemExitInterceptor` | `libs/agent-sm/agent` | Intercepts `System::exit` calls |
+| `RuntimeHaltInterceptor` | `libs/agent-sm/agent` | Intercepts `Runtime::halt` calls |
+| `PolicyFile` | `libs/secure-sm` | Custom policy parser for JDK 24+ compatibility |
+| `StackCallerChainExtractor` | `libs/agent-sm/agent` | Extracts ProtectionDomains from call stack |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `-javaagent:agent/opensearch-agent.jar` | JVM argument to attach the Java agent | Enabled in jvm.options for JDK 21+ |
+
+### Usage Example
+
+Plugin developers continue using the same `plugin-security.policy` format:
+
+```java
+// plugin-security.policy
+grant {
+  permission java.net.SocketPermission "*", "connect,resolve";
+  permission java.io.FilePermission "/tmp/-", "read,write";
+}
+```
+
+The Java agent automatically enforces these permissions at runtime.
+
+### Migration Notes
+
+1. **No code changes required for most plugins**: The `plugin-security.policy` format remains unchanged
+2. **Remove JSM-specific code**: Code using `System.setSecurityManager()` should be removed
+3. **Update AccessController usage**: Replace `java.security.AccessController.doPrivileged()` with `org.opensearch.secure_sm.AccessController.doPrivileged()` (see [AccessController feature](../../../features/opensearch/java-agent-accesscontroller.md))
+4. **Breaking change warning**: Third-party plugins may need updates due to changes in security verification
+
+## Limitations
+
+- The Java agent focuses on high-risk operations (file I/O, network, process termination)
+- Not all JSM permission types are covered (e.g., reflection permissions are delegated to systemd)
+- systemd hardening is only available on Linux distributions using systemd
+- Virtual threads do not carry permissions (by design in JDK)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17724](https://github.com/opensearch-project/OpenSearch/pull/17724) | Create initial Java Agent to intercept Socket::connect calls |
+| [#17746](https://github.com/opensearch-project/OpenSearch/pull/17746) | Enhance Java Agent to intercept System::exit |
+| [#17753](https://github.com/opensearch-project/OpenSearch/pull/17753) | Add a policy parser for Java agent security policies |
+| [#17757](https://github.com/opensearch-project/OpenSearch/pull/17757) | Enhance Java Agent to intercept Runtime::halt |
+| [#17760](https://github.com/opensearch-project/OpenSearch/pull/17760) | Implement File Interceptor and add integration tests |
+| [#17861](https://github.com/opensearch-project/OpenSearch/pull/17861) | Phase off SecurityManager usage in favor of Java Agent |
+
+## References
+
+- [Issue #17658](https://github.com/opensearch-project/OpenSearch/issues/17658): Parent issue for Security Manager replacement
+- [Issue #17659](https://github.com/opensearch-project/OpenSearch/issues/17659): Add support of Java policies
+- [Issue #17660](https://github.com/opensearch-project/OpenSearch/issues/17660): Create initial Java Agent to intercept Socket::connect calls
+- [Issue #17662](https://github.com/opensearch-project/OpenSearch/issues/17662): Phase off SecurityManager usage in favor of Java Agent
+- [Issue #1687](https://github.com/opensearch-project/OpenSearch/issues/1687): Original JSM replacement discussion
+- [JEP 411](https://openjdk.org/jeps/411): Deprecate the Security Manager for Removal
+- [JEP 486](https://openjdk.org/jeps/486): Permanently Disable the Security Manager
+- [Blog: Finding a replacement for JSM in OpenSearch 3.0](https://opensearch.org/blog/finding-a-replacement-for-jsm-in-opensearch-3-0/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/security-manager-replacement.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -14,6 +14,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)
+- [Security Manager Replacement (Java Agent)](features/opensearch/security-manager-replacement-java-agent.md)
 - [Bulk API Changes](features/opensearch/bulk-api-changes.md)
 - [DocValues Optimization](features/opensearch/docvalues-optimization.md)
 - [Concurrent Segment Search Auto Mode Default](features/opensearch/concurrent-segment-search.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security Manager Replacement (Java Agent) feature in OpenSearch 3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/security-manager-replacement-java-agent.md`
- Feature report: `docs/features/opensearch/security-manager-replacement.md`

### Key Changes in v3.0.0
- Replaced deprecated Java Security Manager (JSM) with custom Java agent
- Implemented interceptors for socket connections, file operations, and process termination
- Added custom policy parser for JDK 24+ compatibility
- Maintained backward compatibility with existing `plugin-security.policy` format

### Related PRs
- #17724: Create initial Java Agent to intercept Socket::connect calls
- #17746: Enhance Java Agent to intercept System::exit
- #17753: Add a policy parser for Java agent security policies
- #17757: Enhance Java Agent to intercept Runtime::halt
- #17760: Implement File Interceptor and add integration tests
- #17861: Phase off SecurityManager usage in favor of Java Agent

Closes #238