### PR TITLE
docs: add Search Task Management report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -185,6 +185,7 @@
 - [Stream Input/Output](opensearch/stream-inputoutput.md)
 - [Subject Interface](opensearch/subject-interface.md)
 - [System Ingest Pipeline](opensearch/system-ingest-pipeline.md)
+- [Task Cancellation Monitoring](opensearch/task-cancellation-monitoring.md)
 - [Task Management](opensearch/task-management.md)
 - [Test Fixes](opensearch/test-fixes.md)
 - [Thread Context Permissions](opensearch/thread-context-permissions.md)

--- a/docs/features/opensearch/task-cancellation-monitoring.md
+++ b/docs/features/opensearch/task-cancellation-monitoring.md
@@ -1,0 +1,139 @@
+# Task Cancellation Monitoring
+
+## Summary
+
+Task Cancellation Monitoring is a service that tracks search tasks that have been cancelled but continue running beyond a configurable threshold. It provides visibility into "rogue queries" that consume resources after cancellation, helping operators identify and diagnose problematic search patterns. The service monitors both coordinator-level (`SearchTask`) and shard-level (`SearchShardTask`) tasks.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Task Manager"
+        TM[TaskManager] --> Events[Task Event Listeners]
+    end
+    
+    subgraph "Task Cancellation Monitoring Service"
+        Events --> TCMS[TaskCancellationMonitoringService]
+        TCMS --> Tracker[Cancelled Task Tracker]
+        Tracker --> SearchTask[SearchTask]
+        Tracker --> SearchShardTask[SearchShardTask]
+    end
+    
+    subgraph "Monitoring Loop"
+        Scheduler[Scheduled Thread] --> Check[Check Cancelled Tasks]
+        Check --> Duration{Running > Threshold?}
+        Duration -->|Yes| Count[Increment Counters]
+        Duration -->|No| Skip[Skip]
+    end
+    
+    subgraph "Stats Output"
+        Count --> Stats[TaskCancellationStats]
+        Stats --> NodeStats[Node Stats API]
+    end
+    
+    TCMS --> Scheduler
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Task Lifecycle"
+        Start[Task Started] --> Cancel[Task Cancelled]
+        Cancel --> Running{Still Running?}
+        Running -->|Yes| Track[Add to Tracker]
+        Running -->|No| Complete[Task Completed]
+    end
+    
+    subgraph "Monitoring"
+        Track --> Monitor[Periodic Check]
+        Monitor --> Threshold{Duration > Threshold?}
+        Threshold -->|Yes| LongRunning[Mark as Long-Running]
+        Threshold -->|No| Continue[Continue Monitoring]
+    end
+    
+    subgraph "Cleanup"
+        Complete --> Remove[Remove from Tracker]
+        LongRunning --> IncrementTotal[Increment Total Count]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `TaskCancellationMonitoringService` | Main service that monitors cancelled tasks and collects statistics |
+| `TaskCancellationStats` | Container for all task cancellation statistics |
+| `SearchTaskCancellationStats` | Statistics for coordinator-level search tasks |
+| `SearchShardTaskCancellationStats` | Statistics for shard-level search tasks |
+| `BaseSearchTaskCancellationStats` | Abstract base class with common statistics fields |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `task.cancellation.monitoring.enabled` | Enable/disable the monitoring service | `true` |
+| `task.cancellation.monitoring.interval` | Interval between monitoring checks | `1s` |
+| `task.cancellation.monitoring.duration_millis` | Duration threshold for considering a cancelled task as long-running | `10000` (10s) |
+
+### Statistics Fields
+
+| Field | Description |
+|-------|-------------|
+| `current_count_post_cancel` | Number of cancelled tasks currently still running beyond the threshold |
+| `total_count_post_cancel` | Total number of tasks that ran beyond the threshold after cancellation since node restart |
+
+### Usage Example
+
+```bash
+# Get task cancellation monitoring stats
+GET _nodes/stats
+
+# Response includes task_cancellation section
+{
+  "nodes": {
+    "node_id": {
+      "task_cancellation": {
+        "search_task": {
+          "current_count_post_cancel": 2,
+          "total_count_post_cancel": 15
+        },
+        "search_shard_task": {
+          "current_count_post_cancel": 5,
+          "total_count_post_cancel": 42
+        }
+      }
+    }
+  }
+}
+```
+
+### Interpreting Statistics
+
+- **High `current_count_post_cancel`**: Indicates active queries that are not responding to cancellation signals
+- **High `total_count_post_cancel`**: Suggests a pattern of problematic queries that may need investigation
+- **Ratio of search_task to search_shard_task**: Can help identify whether issues are at coordinator or shard level
+
+## Limitations
+
+- Statistics are reset when the node restarts
+- Only tracks `SearchTask` and `SearchShardTask` types (not other cancellable tasks)
+- Mixed-version clusters may have inconsistent statistics reporting
+- The service adds minimal overhead but does consume some resources for tracking
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17726](https://github.com/opensearch-project/OpenSearch/pull/17726) | Add tracking for long-running SearchTask post cancellation |
+
+## References
+
+- [Issue #17719](https://github.com/opensearch-project/OpenSearch/issues/17719): Track long running SearchTask post cancellation
+- [Search Backpressure Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/search-backpressure/): Related feature for search task management
+
+## Change History
+
+- **v3.0.0** (2025-05-06): Added SearchTask (coordinator-level) tracking alongside existing SearchShardTask tracking

--- a/docs/releases/v3.0.0/features/opensearch/search-task-management.md
+++ b/docs/releases/v3.0.0/features/opensearch/search-task-management.md
@@ -1,0 +1,115 @@
+# Search Task Management
+
+## Summary
+
+This release extends the Task Cancellation Monitoring Service to track long-running SearchTask (coordinator-level) tasks in addition to the existing SearchShardTask (shard-level) tracking. This enhancement enables operators to monitor "rogue queries" that continue running after cancellation at both the coordinator and shard levels.
+
+## Details
+
+### What's New in v3.0.0
+
+The `TaskCancellationMonitoringService` now tracks both `SearchTask` and `SearchShardTask` types. Previously, only `SearchShardTask` was monitored for post-cancellation behavior. This change provides visibility into queries that have been cancelled but continue consuming resources at the coordinator level.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Task Cancellation Monitoring"
+        Service[TaskCancellationMonitoringService]
+        Service --> SearchTask[SearchTask Tracking]
+        Service --> SearchShardTask[SearchShardTask Tracking]
+    end
+    
+    subgraph "Stats Output"
+        SearchTask --> SearchTaskStats[SearchTaskCancellationStats]
+        SearchShardTask --> ShardTaskStats[SearchShardTaskCancellationStats]
+        SearchTaskStats --> NodeStats[Node Stats API]
+        ShardTaskStats --> NodeStats
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `SearchTaskCancellationStats` | New class to hold cancellation statistics for coordinator-level search tasks |
+| `BaseSearchTaskCancellationStats` | New abstract base class providing common functionality for both task types |
+
+#### API Response Changes
+
+The `/_nodes/stats` API response now includes `search_task` statistics alongside the existing `search_shard_task`:
+
+```json
+{
+  "task_cancellation": {
+    "search_task": {
+      "current_count_post_cancel": 0,
+      "total_count_post_cancel": 5
+    },
+    "search_shard_task": {
+      "current_count_post_cancel": 0,
+      "total_count_post_cancel": 12
+    }
+  }
+}
+```
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| N/A | No new settings required - uses existing monitoring service configuration | - |
+
+### Usage Example
+
+```bash
+# Get task cancellation stats including SearchTask tracking
+GET _nodes/stats
+
+# Response includes task_cancellation section with both task types
+{
+  "nodes": {
+    "node_id": {
+      "task_cancellation": {
+        "search_task": {
+          "current_count_post_cancel": 2,
+          "total_count_post_cancel": 15
+        },
+        "search_shard_task": {
+          "current_count_post_cancel": 5,
+          "total_count_post_cancel": 42
+        }
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- No migration required
+- The new `search_task` field is automatically included in stats responses after upgrading to v3.0.0
+- Version compatibility is handled automatically - older nodes will not receive the new field
+
+## Limitations
+
+- Statistics are reset when the node restarts
+- Mixed-version clusters: nodes running versions prior to 3.0.0 will not report `search_task` statistics
+- The monitoring service must be enabled for tracking to occur
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17726](https://github.com/opensearch-project/OpenSearch/pull/17726) | Add tracking for long-running SearchTask post cancellation |
+
+## References
+
+- [Issue #17719](https://github.com/opensearch-project/OpenSearch/issues/17719): Track long running SearchTask post cancellation
+- [Search Backpressure Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/search-backpressure/): Related search backpressure feature
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/task-cancellation-monitoring.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -49,6 +49,7 @@
 - [Plugin System](features/opensearch/plugin-system.md)
 - [Refresh Task Scheduling](features/opensearch/refresh-task-scheduling.md)
 - [Search Backpressure](features/opensearch/search-backpressure.md)
+- [Search Task Management](features/opensearch/search-task-management.md)
 - [Segment Warmer](features/opensearch/segment-warmer.md)
 - [Star Tree Enhancements](features/opensearch/star-tree-enhancements.md)
 - [Stream Input/Output](features/opensearch/stream-inputoutput.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Search Task Management feature in OpenSearch v3.0.0.

### Changes

- **Release Report**: `docs/releases/v3.0.0/features/opensearch/search-task-management.md`
  - Documents the extension of TaskCancellationMonitoringService to track SearchTask (coordinator-level) in addition to SearchShardTask (shard-level)
  
- **Feature Report**: `docs/features/opensearch/task-cancellation-monitoring.md`
  - Comprehensive documentation of the Task Cancellation Monitoring feature
  - Architecture diagrams showing task tracking flow
  - Configuration options and usage examples

### Key Changes in v3.0.0

- Added `SearchTask` tracking to `TaskCancellationMonitoringService`
- New `SearchTaskCancellationStats` class for coordinator-level statistics
- Refactored common functionality into `BaseSearchTaskCancellationStats` base class
- Node Stats API now includes `search_task` section alongside `search_shard_task`

### Related

- Closes #236
- PR: opensearch-project/OpenSearch#17726
- Issue: opensearch-project/OpenSearch#17719