### PR TITLE
docs: add search-utilities report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -199,6 +199,7 @@
 - [Wildcard Field](opensearch/wildcard-field.md)
 - [Workload Management](opensearch/workload-management.md)
 - [XContent Filtering](opensearch/xcontent-filtering.md)
+- [XContent Transform](opensearch/xcontent-transform.md)
 - [Hierarchical & ACL-aware Routing](opensearch/hierarchical-acl-aware-routing.md)
 - [Temporal Routing](opensearch/temporal-routing.md)
 - [Terms Lookup Query](opensearch/terms-lookup-query.md)

--- a/docs/features/opensearch/xcontent-transform.md
+++ b/docs/features/opensearch/xcontent-transform.md
@@ -1,0 +1,207 @@
+# XContent Transform
+
+## Summary
+
+XContent Transform provides a depth-first search (DFS) transformation utility for nested map structures in OpenSearch. The `XContentMapValues.transform()` method enables field-specific transformations on document content while preserving the overall structure, including empty objects in arrays. This is essential for features like k-NN's derived source, which masks vector fields to reduce storage overhead.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "XContent Transform System"
+        A[Source Map] --> B[Build Transformer Trie]
+        B --> C[Initialize Stack]
+        C --> D[DFS Traversal]
+        D --> E{Match Path?}
+        E -->|Yes| F[Apply Transformer]
+        E -->|No| G[Continue Traversal]
+        F --> H[Transformed Map]
+        G --> D
+    end
+    
+    subgraph "Transformer Trie"
+        T1[root] --> T2[field1]
+        T1 --> T3[nested]
+        T3 --> T4[field2]
+        T2 --> T5["$transformer"]
+        T4 --> T6["$transformer"]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Source Map] --> B{In-Place?}
+    B -->|Yes| C[Use Original]
+    B -->|No| D[Create Copy]
+    C --> E[Build Trie from Paths]
+    D --> E
+    E --> F[Push to Stack]
+    F --> G[Pop Context]
+    G --> H{Stack Empty?}
+    H -->|No| I[Process Entry]
+    I --> J{Has Transformer?}
+    J -->|Yes| K[Apply & Set Value]
+    J -->|No| L{Is Nested?}
+    L -->|Map| M[Push Map Context]
+    L -->|List| N[Process List Items]
+    L -->|Leaf| O[Skip]
+    K --> G
+    M --> G
+    N --> G
+    O --> G
+    H -->|Yes| P[Return Result]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `XContentMapValues.transform()` | Core utility method for DFS transformation |
+| `TransformContext` | Internal class holding map and trie state during traversal |
+| Transformer Trie | Path-based lookup structure built from transformer map |
+| `TRANSFORMER_TRIE_LEAF_KEY` | Special key (`$transformer`) marking transformer functions in trie |
+
+### Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `transformers` | Map from dot-notation path to transformer function | Required |
+| `inPlace` | Whether to modify source directly or create a copy | Required |
+
+### API Methods
+
+```java
+// Transform with explicit source
+Map<String, Object> transform(
+    Map<String, Object> source,
+    Map<String, Function<Object, Object>> transformers,
+    boolean inPlace
+)
+
+// Get reusable transform function
+Function<Map<String, Object>, Map<String, Object>> transform(
+    Map<String, Function<Object, Object>> transformers,
+    boolean inPlace
+)
+```
+
+### Path Matching
+
+| Pattern | Example | Behavior |
+|---------|---------|----------|
+| Simple field | `"field"` | Transforms top-level `field` |
+| Nested path | `"parent.child"` | Transforms `child` under `parent` |
+| Deep nesting | `"a.b.c"` | Transforms `c` under `a.b` |
+| Array handling | `"items.value"` | Transforms `value` in each item of `items` array |
+
+### Key Differences from filter()
+
+| Aspect | `filter()` | `transform()` |
+|--------|-----------|---------------|
+| Purpose | Include/exclude fields | Transform field values |
+| Empty objects | Removed from arrays | Preserved |
+| Wildcards | Supported | Not supported |
+| Output | Filtered structure | Same structure, transformed values |
+| Use case | Security filtering | Value masking/conversion |
+
+### Usage Example
+
+```java
+// Define transformers for vector fields
+Map<String, Function<Object, Object>> transformers = Map.of(
+    "embedding", v -> "[MASKED]",
+    "nested.vector", v -> List.of(0.0f)  // Replace with placeholder
+);
+
+// Original document
+Map<String, Object> source = Map.of(
+    "title", "Document",
+    "embedding", List.of(0.1f, 0.2f, 0.3f, 0.4f),
+    "nested", Map.of(
+        "vector", List.of(0.5f, 0.6f),
+        "other", "preserved"
+    )
+);
+
+// Transform (create copy)
+Map<String, Object> result = XContentMapValues.transform(source, transformers, false);
+
+// Result:
+// {
+//   "title": "Document",
+//   "embedding": "[MASKED]",
+//   "nested": {
+//     "vector": [0.0],
+//     "other": "preserved"
+//   }
+// }
+```
+
+### Nested Array Handling
+
+```java
+// Transformers work on nested arrays
+Map<String, Function<Object, Object>> transformers = Map.of(
+    "items.vector", v -> "[MASKED]"
+);
+
+Map<String, Object> source = Map.of(
+    "items", List.of(
+        Map.of("vector", List.of(1, 2), "name", "a"),
+        Map.of("vector", List.of(3, 4), "name", "b"),
+        Map.of("name", "c")  // No vector - preserved as-is
+    )
+);
+
+Map<String, Object> result = XContentMapValues.transform(source, transformers, false);
+
+// Result: items array structure preserved, vectors masked
+// [
+//   {"vector": "[MASKED]", "name": "a"},
+//   {"vector": "[MASKED]", "name": "b"},
+//   {"name": "c"}
+// ]
+```
+
+### Reusable Transform Function
+
+```java
+// Create reusable transformer for batch processing
+Function<Map<String, Object>, Map<String, Object>> transformer = 
+    XContentMapValues.transform(
+        Map.of("vector", v -> "[MASKED]"),
+        false  // create copies
+    );
+
+// Apply to multiple documents
+List<Map<String, Object>> results = documents.stream()
+    .map(transformer)
+    .collect(Collectors.toList());
+```
+
+## Limitations
+
+- No wildcard pattern support (exact paths only)
+- For overlapping paths (e.g., `"test"` and `"test.nested"`), only the shorter path's transformer is applied
+- Transformer functions must handle null values if fields may be null
+- In-place mode modifies the original map; use with caution
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17612](https://github.com/opensearch-project/OpenSearch/pull/17612) | Add dfs transformation function in XContentMapValues |
+
+## References
+
+- [Issue #2377](https://github.com/opensearch-project/k-NN/issues/2377): RFC - Derived Source for Vectors (motivation)
+- [XContentMapValues.java](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/common/xcontent/support/XContentMapValues.java): Core implementation
+- [XContent Filtering](xcontent-filtering.md): Related filtering functionality
+
+## Change History
+
+- **v3.0.0** (2025-03-20): Initial implementation for k-NN derived source support

--- a/docs/releases/v3.0.0/features/opensearch/search-utilities.md
+++ b/docs/releases/v3.0.0/features/opensearch/search-utilities.md
@@ -1,0 +1,117 @@
+# Search Utilities
+
+## Summary
+
+OpenSearch 3.0.0 adds a new depth-first search (DFS) transformation function to `XContentMapValues`, enabling efficient in-place or copy-based transformations of nested map structures. This utility is primarily designed to support the k-NN plugin's derived source feature, which removes vectors from `_source` to reduce storage overhead while maintaining full OpenSearch functionality.
+
+## Details
+
+### What's New in v3.0.0
+
+A new `transform()` method has been added to `XContentMapValues` that performs depth-first traversal on maps, applying field-specific transformations along the way. This enables plugins to efficiently modify nested document structures without altering the overall map hierarchy.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "XContentMapValues.transform()"
+        Input[Source Map] --> Trie[Build Transformer Trie]
+        Trie --> Stack[Initialize Stack]
+        Stack --> DFS[Depth-First Traversal]
+        DFS --> Apply[Apply Transformers]
+        Apply --> Output[Transformed Map]
+    end
+    
+    subgraph "Use Case: k-NN Derived Source"
+        Vector[Vector Field] --> Mask[Mask/Transform]
+        Mask --> Smaller[Smaller Representation]
+        Smaller --> Storage[Reduced Storage]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `XContentMapValues.transform()` | Static method that applies field-specific transformations via DFS traversal |
+| `TransformContext` | Internal class holding map and trie state during traversal |
+| Transformer Trie | Path-based lookup structure for efficient transformer matching |
+
+#### New API
+
+```java
+// Transform with copy
+Map<String, Object> transform(
+    Map<String, Object> source,
+    Map<String, Function<Object, Object>> transformers,
+    boolean inPlace
+)
+
+// Get reusable transform function
+Function<Map<String, Object>, Map<String, Object>> transform(
+    Map<String, Function<Object, Object>> transformers,
+    boolean inPlace
+)
+```
+
+| Parameter | Description |
+|-----------|-------------|
+| `source` | Source map to transform |
+| `transformers` | Map from dot-notation path to transformer function |
+| `inPlace` | If true, modify source directly; if false, create a copy |
+
+### Usage Example
+
+```java
+// Define transformers for specific paths
+Map<String, Function<Object, Object>> transformers = Map.of(
+    "vector_field", v -> "[MASKED]",
+    "nested.vector", v -> "[MASKED]"
+);
+
+// Transform a document map
+Map<String, Object> source = Map.of(
+    "title", "Document",
+    "vector_field", List.of(0.1, 0.2, 0.3),
+    "nested", Map.of("vector", List.of(0.4, 0.5))
+);
+
+// Create transformed copy
+Map<String, Object> result = XContentMapValues.transform(source, transformers, false);
+// Result: {"title": "Document", "vector_field": "[MASKED]", "nested": {"vector": "[MASKED]"}}
+```
+
+### Key Features
+
+- **Path-based transformers**: Use dot notation (e.g., `"nested.field"`) to target specific fields
+- **Nested structure support**: Handles deeply nested maps and lists of maps
+- **In-place or copy mode**: Choose between modifying the original or creating a new map
+- **Shortest path wins**: For overlapping paths, only the shorter path's transformer is applied
+- **Preserves structure**: Unlike `filter()`, empty objects in arrays are not removed
+
+### Migration Notes
+
+This is a new utility method with no breaking changes. Existing code using `XContentMapValues.filter()` continues to work unchanged.
+
+## Limitations
+
+- Transformers are applied based on exact path matching; wildcard patterns are not supported
+- The transformer function receives the current value and must return the transformed value
+- For overlapping paths (e.g., `"test"` and `"test.nested"`), only the shorter path's transformer is applied
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17612](https://github.com/opensearch-project/OpenSearch/pull/17612) | Add dfs transformation function in XContentMapValues |
+
+## References
+
+- [Issue #2377](https://github.com/opensearch-project/k-NN/issues/2377): RFC - Derived Source for Vectors
+- [k-NN PR #2583](https://github.com/opensearch-project/k-NN/pull/2583): Related k-NN implementation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/xcontent-transform.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -58,6 +58,7 @@
 - [Track Total Hits](features/opensearch/track-total-hits.md)
 - [Wildcard Field](features/opensearch/wildcard-field.md)
 - [Search Replica & Reader-Writer Separation](features/opensearch/search-replica-reader-writer-separation.md)
+- [Search Utilities](features/opensearch/search-utilities.md)
 
 ## opensearch-dashboards
 


### PR DESCRIPTION
## Summary

Adds documentation for the Search Utilities feature in OpenSearch 3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/search-utilities.md`
- Feature report: `docs/features/opensearch/xcontent-transform.md`

### Key Changes in v3.0.0
- New `XContentMapValues.transform()` method for depth-first traversal transformations
- Supports in-place or copy-based transformations
- Preserves nested structure including empty objects in arrays
- Enables k-NN derived source feature for storage optimization

### Related
- Closes #235
- PR: [opensearch-project/OpenSearch#17612](https://github.com/opensearch-project/OpenSearch/pull/17612)
- Issue: [opensearch-project/k-NN#2377](https://github.com/opensearch-project/k-NN/issues/2377)