### PR TITLE
docs: add Rule-Based Auto-Tagging report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -198,6 +198,7 @@
 - [Warm Storage Tiering](opensearch/warm-storage-tiering.md)
 - [Wildcard Field](opensearch/wildcard-field.md)
 - [Workload Management](opensearch/workload-management.md)
+- [Rule-Based Auto-Tagging](opensearch/rule-based-auto-tagging.md)
 - [XContent Filtering](opensearch/xcontent-filtering.md)
 - [XContent Transform](opensearch/xcontent-transform.md)
 - [Hierarchical & ACL-aware Routing](opensearch/hierarchical-acl-aware-routing.md)

--- a/docs/features/opensearch/rule-based-auto-tagging.md
+++ b/docs/features/opensearch/rule-based-auto-tagging.md
@@ -1,0 +1,232 @@
+# Rule-Based Auto-Tagging
+
+## Summary
+
+Rule-Based Auto-Tagging is an OpenSearch feature that automatically assigns feature values to incoming queries based on configurable rules. It enables automatic query categorization by matching request attributes (such as index patterns) against predefined rules, eliminating the need for manual query tagging.
+
+The primary use case is integration with Workload Management, where rules can automatically route queries to specific workload groups based on the indexes they target.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Request Processing"
+        Request[Incoming Request]
+        Extractor[Attribute Extractors]
+    end
+    
+    subgraph "Rule Engine"
+        RPS[Rule Processing Service]
+        Factory[AttributeValueStore Factory]
+        AVS1[Attribute Value Store 1]
+        AVS2[Attribute Value Store N]
+    end
+    
+    subgraph "Storage Layer"
+        Trie1[Patricia Trie]
+        Trie2[Patricia Trie]
+        Index[Rules System Index]
+    end
+    
+    subgraph "Core Schema"
+        Rule[Rule]
+        Attr[Attribute]
+        FT[FeatureType]
+        Registry[AutoTagging Registry]
+    end
+    
+    Request --> Extractor
+    Extractor --> RPS
+    RPS --> Factory
+    Factory --> AVS1
+    Factory --> AVS2
+    AVS1 --> Trie1
+    AVS2 --> Trie2
+    
+    Rule --> Attr
+    Rule --> FT
+    FT --> Registry
+    
+    Index -.-> RPS
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Rule Creation"
+        Create[Create Rule via API]
+        Validate[Validate Rule]
+        Store[Store in Index]
+        Load[Load to Memory]
+    end
+    
+    subgraph "Query Processing"
+        Query[Search Query]
+        Extract[Extract Attributes]
+        Lookup[Lookup Matching Rules]
+        Evaluate[Evaluate Label]
+        Apply[Apply Feature Value]
+    end
+    
+    Create --> Validate --> Store --> Load
+    Query --> Extract --> Lookup --> Evaluate --> Apply
+    Load -.-> Lookup
+```
+
+### Components
+
+| Component | Package | Description |
+|-----------|---------|-------------|
+| `Rule` | `org.opensearch.autotagging` | Core rule object with description, attributes, feature type, and feature value |
+| `Attribute` | `org.opensearch.autotagging` | Interface for rule attributes with name and validation |
+| `FeatureType` | `org.opensearch.autotagging` | Interface defining feature categories and their allowed attributes |
+| `AutoTaggingRegistry` | `org.opensearch.autotagging` | Singleton registry for feature type management |
+| `RuleValidator` | `org.opensearch.autotagging` | Validates rule constraints and attribute values |
+| `AttributeValueStore` | `org.opensearch.rule.storage` | Interface for attribute value storage and retrieval |
+| `DefaultAttributeValueStore` | `org.opensearch.rule.storage` | Patricia Trie-based implementation with thread-safe operations |
+| `AttributeValueStoreFactory` | `org.opensearch.rule.storage` | Factory for creating per-attribute stores |
+| `InMemoryRuleProcessingService` | `org.opensearch.rule` | Service for rule management and label evaluation |
+| `AttributeExtractor` | `org.opensearch.rule.attribute_extractor` | Interface for extracting attributes from requests |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `MAX_DESCRIPTION_LENGTH` | Maximum characters for rule description | 256 |
+| `MAX_FEATURE_TYPE_NAME_LENGTH` | Maximum characters for feature type name | 30 |
+| `DEFAULT_MAX_ATTRIBUTE_VALUES` | Maximum number of values per attribute | 10 |
+| `DEFAULT_MAX_ATTRIBUTE_VALUE_LENGTH` | Maximum characters per attribute value | 100 |
+
+### Rule Schema
+
+A rule consists of:
+
+```json
+{
+  "_id": "auto-generated-id",
+  "description": "Human-readable description",
+  "<attribute_key>": ["value1", "value2"],
+  "<feature_type>": "feature_value",
+  "updated_at": "ISO-8601 timestamp"
+}
+```
+
+Example for workload management:
+
+```json
+{
+  "_id": "wi6VApYBoX5wstmtU_8l",
+  "description": "Route analytics queries",
+  "index_pattern": ["logs-*", "metrics-*"],
+  "workload_group": "analytics-group-id",
+  "updated_at": "2025-04-04T20:54:22.406Z"
+}
+```
+
+### API Reference
+
+#### Create Rule
+
+```
+PUT /_rules/{feature_type}
+POST /_rules/{feature_type}
+```
+
+#### Update Rule
+
+```
+PUT /_rules/{feature_type}/{_id}
+POST /_rules/{feature_type}/{_id}
+```
+
+#### Get Rules
+
+```
+GET /_rules/{feature_type}/{_id}
+GET /_rules/{feature_type}
+GET /_rules/{feature_type}?<attribute_key>=value1,value2
+GET /_rules/{feature_type}?search_after=<token>
+```
+
+#### Delete Rule
+
+```
+DELETE /_rules/{feature_type}/{_id}
+```
+
+### Usage Example
+
+```json
+// Create a rule
+PUT _rules/workload_group
+{
+  "description": "Route log queries to dedicated workload group",
+  "index_pattern": ["log*", "event*"],
+  "workload_group": "EITBzjFkQ6CA-semNWGtRQ"
+}
+
+// Update a rule
+PUT _rules/workload_group/wi6VApYBoX5wstmtU_8l
+{
+  "description": "Updated description",
+  "index_pattern": ["log*"]
+}
+
+// Get all rules for workload_group
+GET _rules/workload_group
+
+// Filter rules by attribute
+GET _rules/workload_group?index_pattern=log*
+
+// Delete a rule
+DELETE _rules/workload_group/wi6VApYBoX5wstmtU_8l
+```
+
+### Implementation Details
+
+#### Patricia Trie Storage
+
+The `DefaultAttributeValueStore` uses Apache Commons Collections' Patricia Trie for efficient prefix-based lookups:
+
+- O(k) lookup time where k is key length
+- Memory-efficient storage for string keys with common prefixes
+- Thread-safe with `ReentrantReadWriteLock`
+- Supports longest prefix matching for wildcard patterns
+
+#### Rule Evaluation Logic
+
+When evaluating a request:
+
+1. Extract attribute values from the request using `AttributeExtractor` implementations
+2. For each attribute, lookup matching rules in the corresponding `AttributeValueStore`
+3. If all attributes match the same feature value, return that value
+4. If no match or conflicting matches, return empty (use default behavior)
+
+## Limitations
+
+- Rules are evaluated in memory; large rule sets may impact memory usage
+- Prefix matching only (no suffix or regex patterns)
+- Single feature value per rule (cannot assign multiple workload groups)
+- All attribute conditions must match (AND logic, no OR support)
+- Feature types must be registered at startup
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17238](https://github.com/opensearch-project/OpenSearch/pull/17238) | Add rule schema for auto tagging |
+| v3.0.0 | [#17342](https://github.com/opensearch-project/OpenSearch/pull/17342) | Add in-memory attribute value store |
+| v3.0.0 | [#17365](https://github.com/opensearch-project/OpenSearch/pull/17365) | Add in-memory rule processing service |
+
+## References
+
+- [Issue #16797](https://github.com/opensearch-project/OpenSearch/issues/16797): RFC - Automated labeling of search requests
+- [Rule Lifecycle API Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/rule-based-autotagging/rule-lifecycle-api/)
+- [Workload Management Overview](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/workload-management/wlm-feature-overview/)
+
+## Change History
+
+- **v3.0.0** (2025-03-11): Initial implementation with rule schema, Patricia Trie-based storage, and rule processing service

--- a/docs/releases/v3.0.0/features/opensearch/rule-based-auto-tagging.md
+++ b/docs/releases/v3.0.0/features/opensearch/rule-based-auto-tagging.md
@@ -1,0 +1,153 @@
+# Rule-Based Auto-Tagging
+
+## Summary
+
+Rule-Based Auto-Tagging is a new feature in OpenSearch v3.0.0 that automatically assigns feature values (such as workload group IDs) to incoming queries based on specified attributes like index patterns. This enables automatic query categorization and management without manual intervention.
+
+## Details
+
+### What's New in v3.0.0
+
+This release introduces the foundational components for rule-based auto-tagging:
+
+1. **Rule Schema** - A flexible rule object model supporting single feature types with multiple attributes
+2. **In-Memory Attribute Value Store** - Patricia Trie-based storage for efficient prefix matching
+3. **Rule Processing Service** - Service for managing rules and evaluating labels for incoming requests
+4. **Rule Lifecycle API** - REST API for creating, updating, retrieving, and deleting rules
+
+### Technical Changes
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph "Rule-Based Auto-Tagging"
+        API[Rule Lifecycle API]
+        RPS[Rule Processing Service]
+        AVS[Attribute Value Store]
+        Registry[AutoTagging Registry]
+    end
+    
+    subgraph "Core Components"
+        Rule[Rule Object]
+        Attr[Attribute]
+        FT[FeatureType]
+    end
+    
+    subgraph "Storage"
+        Trie[Patricia Trie]
+        Index[Rules Index]
+    end
+    
+    API --> RPS
+    RPS --> AVS
+    AVS --> Trie
+    RPS --> Registry
+    Registry --> FT
+    Rule --> Attr
+    Rule --> FT
+    API --> Index
+```
+
+#### Data Flow
+
+```mermaid
+flowchart TB
+    Query[Incoming Query] --> Extract[Extract Attributes]
+    Extract --> Lookup[Lookup in Attribute Value Store]
+    Lookup --> Match{Match Found?}
+    Match -->|Yes| Apply[Apply Feature Value]
+    Match -->|No| Default[Use Default Behavior]
+    Apply --> Execute[Execute Query]
+    Default --> Execute
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `Rule` | Core object representing auto-tagging rules with description, attributes, feature type, and feature value |
+| `Attribute` | Interface for rule attributes (e.g., `index_pattern`) |
+| `FeatureType` | Interface defining feature categories (e.g., `workload_group`) |
+| `AutoTaggingRegistry` | Central registry for managing feature types |
+| `RuleValidator` | Validates rule constraints (description length, attribute values) |
+| `AttributeValueStore` | Interface for storing and retrieving attribute values |
+| `DefaultAttributeValueStore` | Patricia Trie-based implementation with prefix matching |
+| `InMemoryRuleProcessingService` | Service for rule management and label evaluation |
+| `AttributeExtractor` | Interface for extracting attributes from requests |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `MAX_DESCRIPTION_LENGTH` | Maximum rule description length | 256 |
+| `MAX_FEATURE_TYPE_NAME_LENGTH` | Maximum feature type name length | 30 |
+| `DEFAULT_MAX_ATTRIBUTE_VALUES` | Maximum values per attribute | 10 |
+| `DEFAULT_MAX_ATTRIBUTE_VALUE_LENGTH` | Maximum character length per attribute value | 100 |
+
+#### API Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `PUT/POST` | `/_rules/{feature_type}` | Create a rule |
+| `PUT/POST` | `/_rules/{feature_type}/{_id}` | Update a rule |
+| `GET` | `/_rules/{feature_type}/{_id}` | Get a specific rule |
+| `GET` | `/_rules/{feature_type}` | List rules for a feature type |
+| `DELETE` | `/_rules/{feature_type}/{_id}` | Delete a rule |
+
+### Usage Example
+
+Create a rule to assign queries targeting `log*` or `event*` indexes to a specific workload group:
+
+```json
+PUT _rules/workload_group
+{
+  "description": "Route log and event queries to analytics workload group",
+  "index_pattern": ["log*", "event*"],
+  "workload_group": "EITBzjFkQ6CA-semNWGtRQ"
+}
+```
+
+Response:
+```json
+{
+  "_id": "wi6VApYBoX5wstmtU_8l",
+  "description": "Route log and event queries to analytics workload group",
+  "index_pattern": ["log*", "event*"],
+  "workload_group": "EITBzjFkQ6CA-semNWGtRQ",
+  "updated_at": "2025-04-04T20:54:22.406Z"
+}
+```
+
+### Migration Notes
+
+This is a new feature with no migration required. To adopt:
+
+1. Identify query patterns that should be automatically categorized
+2. Create workload groups using the Workload Group Lifecycle API
+3. Define rules using the Rule Lifecycle API to map index patterns to workload groups
+
+## Limitations
+
+- Rules are stored in a system index and require cluster write access
+- Prefix matching uses Patricia Trie which is optimized for string prefixes
+- Each rule can have only one feature value but multiple attribute values
+- Rule evaluation requires all attribute conditions to match (AND logic)
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17238](https://github.com/opensearch-project/OpenSearch/pull/17238) | Add rule schema for auto tagging |
+| [#17342](https://github.com/opensearch-project/OpenSearch/pull/17342) | Add in-memory attribute value store |
+| [#17365](https://github.com/opensearch-project/OpenSearch/pull/17365) | Add in-memory rule processing service |
+
+## References
+
+- [Issue #16797](https://github.com/opensearch-project/OpenSearch/issues/16797): RFC - Automated labeling of search requests
+- [Rule Lifecycle API Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/rule-based-autotagging/rule-lifecycle-api/)
+- [Workload Management](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/workload-management/wlm-feature-overview/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/rule-based-auto-tagging.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -14,6 +14,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)
+- [Rule-Based Auto-Tagging](features/opensearch/rule-based-auto-tagging.md)
 - [Security Manager Replacement (Java Agent)](features/opensearch/security-manager-replacement-java-agent.md)
 - [Bulk API Changes](features/opensearch/bulk-api-changes.md)
 - [DocValues Optimization](features/opensearch/docvalues-optimization.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Rule-Based Auto-Tagging feature introduced in OpenSearch v3.0.0.

## Reports Created

- Release report: `docs/releases/v3.0.0/features/opensearch/rule-based-auto-tagging.md`
- Feature report: `docs/features/opensearch/rule-based-auto-tagging.md`

## Feature Overview

Rule-Based Auto-Tagging automatically assigns feature values (such as workload group IDs) to incoming queries based on specified attributes like index patterns. This enables automatic query categorization without manual intervention.

## Key Components

- Rule schema with single feature type and multiple attributes support
- Patricia Trie-based in-memory attribute value store for efficient prefix matching
- Rule processing service for managing rules and evaluating labels
- Rule Lifecycle API for CRUD operations

## Related PRs

- [#17238](https://github.com/opensearch-project/OpenSearch/pull/17238): Add rule schema for auto tagging
- [#17342](https://github.com/opensearch-project/OpenSearch/pull/17342): Add in-memory attribute value store
- [#17365](https://github.com/opensearch-project/OpenSearch/pull/17365): Add in-memory rule processing service

## References

- [Issue #16797](https://github.com/opensearch-project/OpenSearch/issues/16797): RFC - Automated labeling of search requests
- [Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/rule-based-autotagging/rule-lifecycle-api/)