### PR TITLE
docs: add Segment Replication report for v3.0.0

### DIFF
--- a/docs/features/opensearch/segment-replication.md
+++ b/docs/features/opensearch/segment-replication.md
@@ -67,6 +67,7 @@ flowchart TB
 | `cluster.index.restrict.replication.type` | Enforce cluster-level replication type | `false` |
 | `segrep.pressure.enabled` | Enable segment replication backpressure | `false` |
 | `cluster.routing.allocation.balance.prefer_primary` | Balance primary shards across nodes | `false` |
+| `indices.publish_check_point.retry_timeout` | Retry timeout for publish checkpoint action (v3.0.0+) | `5m` |
 
 ### Replication Metrics
 
@@ -125,6 +126,10 @@ GET _cat/segment_replication?v
 | v3.3.0 | [#19214](https://github.com/opensearch-project/OpenSearch/pull/19214) | Add reference count control in NRTReplicationEngine#acquireLastIndexCommit |
 | v3.3.0 | [#18997](https://github.com/opensearch-project/OpenSearch/pull/18997) | Fix NullPointerException in segment replicator |
 | v3.2.0 | [#18602](https://github.com/opensearch-project/OpenSearch/pull/18602) | Fix bugs in replication lag computation |
+| v3.0.0 | [#17055](https://github.com/opensearch-project/OpenSearch/pull/17055) | Implemented computation of segment replication stats at shard level |
+| v3.0.0 | [#17831](https://github.com/opensearch-project/OpenSearch/pull/17831) | Avoid skewed segment replication lag metric |
+| v3.0.0 | [#17568](https://github.com/opensearch-project/OpenSearch/pull/17568) | Increase the default segment counter step size when replica promoting |
+| v3.0.0 | [#17749](https://github.com/opensearch-project/OpenSearch/pull/17749) | Add cluster setting for retry timeout of publish checkpoint tx action |
 
 ## References
 
@@ -133,9 +138,14 @@ GET _cat/segment_replication?v
 - [CAT Segment Replication API](https://docs.opensearch.org/3.0/api-reference/cat/cat-segment-replication/): API for viewing metrics
 - [Issue #19213](https://github.com/opensearch-project/OpenSearch/issues/19213): Bug report for NRTReplicationEngine file deletion issue
 - [Issue #18437](https://github.com/opensearch-project/OpenSearch/issues/18437): Bug report for lag metric issue
+- [Issue #16801](https://github.com/opensearch-project/OpenSearch/issues/16801): Feature request for redefining segment replication metrics computation
+- [Issue #10764](https://github.com/opensearch-project/OpenSearch/issues/10764): Bug report for skewed lag metric
+- [Issue #17566](https://github.com/opensearch-project/OpenSearch/issues/17566): Feature request for increased segment counter step size
+- [Issue #17595](https://github.com/opensearch-project/OpenSearch/issues/17595): Bug report for segment replication stopping when publish checkpoint fails
 - [Segment Replication Blog](https://opensearch.org/blog/segment-replication/): Introduction blog post
 
 ## Change History
 
 - **v3.3.0** (2025-09-09): Fixed NullPointerException in SegmentReplicator.getSegmentReplicationStats() caused by race condition; Fixed reference count control in NRTReplicationEngine#acquireLastIndexCommit to prevent NoSuchFileException
 - **v3.2.0** (2025-07-01): Fixed replication lag computation to use epoch-based timestamps and corrected checkpoint pruning logic
+- **v3.0.0** (2025-05-13): Implemented shard-level stats computation on replicas; Fixed skewed lag metric when same checkpoint published twice; Increased default segment counter step size from 10 to 100,000; Added configurable publish checkpoint retry timeout setting

--- a/docs/releases/v3.0.0/features/opensearch/segment-replication.md
+++ b/docs/releases/v3.0.0/features/opensearch/segment-replication.md
@@ -1,0 +1,117 @@
+# Segment Replication Improvements
+
+## Summary
+
+OpenSearch 3.0.0 introduces significant improvements to segment replication, including shard-level stats computation, improved lag metrics accuracy, configurable checkpoint retry timeout, and increased segment counter step size for replica promotion. These changes enhance observability, reliability, and stability of segment replication in production environments.
+
+## Details
+
+### What's New in v3.0.0
+
+This release includes four key improvements to segment replication:
+
+1. **Shard-level stats computation** - Replication stats are now computed at the shard level on replicas instead of relying on the primary shard
+2. **Accurate lag metrics** - Fixed skewed replication lag metrics caused by duplicate checkpoint publishing
+3. **Configurable checkpoint retry timeout** - New cluster setting for publish checkpoint retry timeout with "never give up" retry strategy
+4. **Increased segment counter step size** - Default step size increased from 10 to 100,000 to prevent segment file name conflicts during replica promotion
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.0.0"
+        PS1[Primary Shard]
+        RS1A[Replica 1]
+        RS1B[Replica 2]
+        PS1 --> |Collect Stats| RS1A
+        PS1 --> |Collect Stats| RS1B
+        PS1 --> |Report Stats| API1[Stats API]
+    end
+    
+    subgraph "v3.0.0+"
+        PS2[Primary Shard]
+        RS2A[Replica 1]
+        RS2B[Replica 2]
+        SR[SegmentReplicator]
+        RS2A --> |Compute Own Stats| SR
+        RS2B --> |Compute Own Stats| SR
+        SR --> |Report Stats| API2[Stats API]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ReplicationCheckpointStats` | Tracks bytes behind and timestamp for each checkpoint version |
+| `IndexIOStreamHandlerFactory` | Factory interface for versioned stream handlers |
+| `RemoteSegmentMetadataHandlerFactory` | Factory for creating metadata handlers based on version |
+| `segmentReplicationStatsProvider` | Function to retrieve replication stats for a shard |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `indices.publish_check_point.retry_timeout` | Retry timeout for publish checkpoint action | `5m` |
+| `index.segment_counter_increment_step` | Segment counter step size when replica promoting | `100000` |
+
+#### API Changes
+
+Stats computation moved from primary to replica shards:
+- `/_nodes/stats` - Now reports stats from replica shards directly
+- `/_cluster/stats` - Aggregates stats from all replica shards
+- `/_stats` - Index-level stats computed at shard level
+
+### Usage Example
+
+Configure publish checkpoint retry timeout:
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "indices.publish_check_point.retry_timeout": "10m"
+  }
+}
+```
+
+Check segment replication stats (now computed at replica level):
+
+```
+GET _cat/segment_replication?v
+```
+
+### Migration Notes
+
+- Stats computation behavior changed: Primary shards no longer report replica stats; each replica reports its own stats
+- The `RemoteSegmentMetadata` version increased from 1 to 2 to include checkpoint timestamp
+- Existing indexes using segment replication will automatically benefit from these improvements
+
+## Limitations
+
+- The checkpoint retry timeout setting is cluster-wide and cannot be configured per-index
+- Stats computation requires replicas to be active; stats are empty for shards without active replicas
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17055](https://github.com/opensearch-project/OpenSearch/pull/17055) | Implemented computation of segment replication stats at shard level |
+| [#17831](https://github.com/opensearch-project/OpenSearch/pull/17831) | Avoid skewed segment replication lag metric |
+| [#17568](https://github.com/opensearch-project/OpenSearch/pull/17568) | Increase the default segment counter step size when replica promoting |
+| [#17749](https://github.com/opensearch-project/OpenSearch/pull/17749) | Add cluster setting for retry timeout of publish checkpoint tx action |
+
+## References
+
+- [Issue #16801](https://github.com/opensearch-project/OpenSearch/issues/16801): Feature request for redefining segment replication metrics computation
+- [Issue #10764](https://github.com/opensearch-project/OpenSearch/issues/10764): Bug report for skewed lag metric when same checkpoint published twice
+- [Issue #17566](https://github.com/opensearch-project/OpenSearch/issues/17566): Feature request for increased segment counter step size
+- [Issue #17595](https://github.com/opensearch-project/OpenSearch/issues/17595): Bug report for segment replication stopping when publish checkpoint fails
+- [Segment Replication Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/segment-replication/index/): Official documentation
+- [CAT Segment Replication API](https://docs.opensearch.org/3.0/api-reference/cat/cat-segment-replication/): API reference
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/segment-replication.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -60,6 +60,7 @@
 - [Wildcard Field](features/opensearch/wildcard-field.md)
 - [Search Replica & Reader-Writer Separation](features/opensearch/search-replica-reader-writer-separation.md)
 - [Search Utilities](features/opensearch/search-utilities.md)
+- [Segment Replication](features/opensearch/segment-replication.md)
 
 ## opensearch-dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for Segment Replication improvements in OpenSearch v3.0.0.

### Changes in v3.0.0

1. **Shard-level stats computation** (#17055) - Replication stats are now computed at the shard level on replicas instead of relying on the primary shard
2. **Accurate lag metrics** (#17831) - Fixed skewed replication lag metrics caused by duplicate checkpoint publishing
3. **Configurable checkpoint retry timeout** (#17749) - New cluster setting `indices.publish_check_point.retry_timeout` with "never give up" retry strategy
4. **Increased segment counter step size** (#17568) - Default step size increased from 10 to 100,000 to prevent segment file name conflicts during replica promotion

### Reports Created

- Release report: `docs/releases/v3.0.0/features/opensearch/segment-replication.md`
- Feature report: `docs/features/opensearch/segment-replication.md` (updated)

### Related Issues

- Resolves #233