### PR TITLE
docs: add numeric types report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -195,6 +195,7 @@
 - [Transport Nodes Action Optimization](opensearch/transport-nodes-action-optimization.md)
 - [Transport Actions API](opensearch/transport-actions-api.md)
 - [Unified Highlighter](opensearch/unified-highlighter.md)
+- [Unsigned Long](opensearch/unsigned-long.md)
 - [Warm Storage Tiering](opensearch/warm-storage-tiering.md)
 - [Wildcard Field](opensearch/wildcard-field.md)
 - [Workload Management](opensearch/workload-management.md)

--- a/docs/features/opensearch/unsigned-long.md
+++ b/docs/features/opensearch/unsigned-long.md
@@ -1,0 +1,175 @@
+# Unsigned Long Field Type
+
+## Summary
+
+The `unsigned_long` field type is a numeric field type that represents an unsigned 64-bit integer with a minimum value of 0 and a maximum value of 2⁶⁴ − 1 (18446744073709551615). This field type was introduced in OpenSearch 2.8 to support use cases requiring values larger than the signed `long` type can represent.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Unsigned Long Processing"
+        A[Document with unsigned_long field] --> B[Field Mapper]
+        B --> C[SortedUnsignedLongDocValuesSetQuery]
+        C --> D[UnsignedLongHashSet]
+        D --> E[Doc Values Storage]
+    end
+    
+    subgraph "Query Processing"
+        F[Terms Query] --> G[NumberFieldMapper]
+        G --> H[termsQuery method]
+        H --> I[SortedUnsignedLongDocValuesSetQuery]
+        I --> J[UnsignedLongHashSet]
+        J --> K[Query Results]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    A[String/Number Input] --> B[Parse as BigInteger]
+    B --> C[Convert to long bits]
+    C --> D[Store in Doc Values]
+    D --> E[Query with unsigned comparison]
+    E --> F[Return as String/BigInteger]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `NumberFieldMapper.NumberType.UNSIGNED_LONG` | Field type definition for unsigned_long |
+| `SortedUnsignedLongDocValuesSetQuery` | Query implementation for terms queries on unsigned_long |
+| `UnsignedLongHashSet` | Hash set with proper unsigned long comparison for doc values |
+| `Numbers` | Utility class with unsigned long constants and conversion methods |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `type` | Field type | `unsigned_long` |
+| `store` | Store field value separately | `false` |
+| `index` | Index the field for searching | `true` |
+| `doc_values` | Enable doc values for sorting/aggregations | `true` |
+| `null_value` | Value to use for null fields | `null` |
+| `ignore_malformed` | Ignore malformed values | `false` |
+
+### Usage Example
+
+#### Index Mapping
+
+```json
+PUT my_index
+{
+  "mappings": {
+    "properties": {
+      "counter": {
+        "type": "unsigned_long"
+      }
+    }
+  }
+}
+```
+
+#### Indexing Documents
+
+```json
+PUT my_index/_doc/1
+{
+  "counter": 10223372036854775807
+}
+```
+
+#### Terms Query
+
+```json
+POST my_index/_search
+{
+  "query": {
+    "terms": {
+      "counter": [
+        "9223372036854775814",
+        "9223372036854775812",
+        "1"
+      ]
+    }
+  }
+}
+```
+
+#### Range Query
+
+```json
+POST my_index/_search
+{
+  "query": {
+    "range": {
+      "counter": {
+        "gte": 10223372036854775807
+      }
+    }
+  }
+}
+```
+
+#### Aggregations
+
+```json
+POST my_index/_search
+{
+  "aggs": {
+    "counter_terms": {
+      "terms": {
+        "field": "counter"
+      }
+    }
+  }
+}
+```
+
+#### Scripting
+
+In scripts, `unsigned_long` fields are returned as `BigInteger`:
+
+```json
+POST my_index/_search
+{
+  "query": {
+    "bool": {
+      "filter": {
+        "script": {
+          "script": "BigInteger amount = doc['counter'].value; return amount.compareTo(BigInteger.ZERO) > 0;"
+        }
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Cannot be used as an index sort field (in `sort.field` index setting)
+- When aggregations are performed across different numeric types and one is `unsigned_long`, values are converted to `double` with potential precision loss
+- Stored fields are returned as strings
+- Decimal parts are truncated if supplied
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17207](https://github.com/opensearch-project/OpenSearch/pull/17207) | Fix unsigned long sorting assertion in LongHashSet |
+| v2.8.0 | - | Initial implementation of unsigned_long field type |
+
+## References
+
+- [Issue #17206](https://github.com/opensearch-project/OpenSearch/issues/17206): Bug report for LongHashSet assertion error
+- [Unsigned Long Documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/unsigned-long/): Official documentation
+- [Numeric Field Types](https://docs.opensearch.org/3.0/field-types/supported-field-types/numeric/): Overview of all numeric types
+
+## Change History
+
+- **v3.0.0** (2025-03-05): Fixed bug where terms queries on unsigned_long fields with values > Long.MAX_VALUE caused assertion errors. Introduced `UnsignedLongHashSet` class with proper unsigned comparison.
+- **v2.8.0**: Initial implementation of unsigned_long field type.

--- a/docs/releases/v3.0.0/features/opensearch/numeric-types.md
+++ b/docs/releases/v3.0.0/features/opensearch/numeric-types.md
@@ -1,0 +1,110 @@
+# Numeric Types
+
+## Summary
+
+This release fixes a critical bug in the handling of unsigned long values in `LongHashSet`, which caused assertion errors when performing terms queries on `unsigned_long` fields with values exceeding the signed long range. The fix introduces a new `UnsignedLongHashSet` class that correctly handles unsigned comparisons.
+
+## Details
+
+### What's New in v3.0.0
+
+A bug was discovered where the `LongHashSet` class used signed comparison (`value >= previousValue`) to validate sorted order, which fails for unsigned long values. When querying `unsigned_long` fields with values greater than `Long.MAX_VALUE` (9223372036854775807), the assertion would fail with "values must be provided in sorted order" error.
+
+### Technical Changes
+
+#### Problem
+
+The original `LongHashSet.java` used signed long comparison:
+```java
+assert value >= previousValue : "values must be provided in sorted order";
+```
+
+This fails for unsigned long values because Java's `long` type is signed. For example:
+- `9223372036854775814` (unsigned) is stored as a negative signed value
+- When sorted as signed values, these appear out of order
+
+#### Solution
+
+A new `UnsignedLongHashSet` class was created that uses `Long.compareUnsigned()` for proper unsigned comparison:
+
+```java
+assert Long.compareUnsigned(value, previousValue) >= 0 : "values must be provided in sorted order";
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `UnsignedLongHashSet` | Hash set optimized for unsigned long doc values with proper unsigned comparison |
+| `DocValuesUnsignedLongHashSetTests` | Test suite for the new hash set implementation |
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before Fix"
+        A1[SortedUnsignedLongDocValuesSetQuery] --> B1[LongHashSet]
+        B1 --> C1[Signed Comparison]
+        C1 --> D1[AssertionError for large values]
+    end
+    
+    subgraph "After Fix"
+        A2[SortedUnsignedLongDocValuesSetQuery] --> B2[UnsignedLongHashSet]
+        B2 --> C2[Unsigned Comparison]
+        C2 --> D2[Correct handling]
+    end
+```
+
+### Usage Example
+
+The fix is transparent to users. Terms queries on `unsigned_long` fields now work correctly:
+
+```json
+PUT test_index
+{
+  "mappings": {
+    "properties": {
+      "stat": {
+        "type": "unsigned_long"
+      }
+    }
+  }
+}
+
+POST test_index/_search
+{
+  "query": {
+    "terms": {
+      "stat": [
+        "9223372036854775814",
+        "9223372036854775812",
+        "1"
+      ]
+    }
+  }
+}
+```
+
+### Migration Notes
+
+No migration required. This is a bug fix that makes `unsigned_long` fields work as expected.
+
+## Limitations
+
+- The `unsigned_long` field type still cannot be used as an index sort field
+- Aggregations across mixed numeric types with `unsigned_long` may lose precision due to `double` conversion
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17207](https://github.com/opensearch-project/OpenSearch/pull/17207) | Fix Bug - Handle unsigned long in sorting order assertion of LongHashSet |
+
+## References
+
+- [Issue #17206](https://github.com/opensearch-project/OpenSearch/issues/17206): Bug report - Sorted Order Assertion in LongHashSet.java is incorrect
+- [Unsigned Long Documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/unsigned-long/): Official docs for unsigned_long field type
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/unsigned-long.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -41,6 +41,7 @@
 - [Lucene Similarity](features/opensearch/lucene-similarity.md)
 - [Merge & Segment Settings](features/opensearch/merge-segment-settings.md)
 - [Node Stats & API Fixes](features/opensearch/node-stats-and-api-fixes.md)
+- [Numeric Types](features/opensearch/numeric-types.md)
 - [Query & Aggregation Fixes](features/opensearch/query-and-aggregation-fixes.md)
 - [Query Performance Optimizations](features/opensearch/query-performance-optimizations.md)
 - [Node Roles & Configuration](features/opensearch/node-roles-and-configuration.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Numeric Types fix in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/numeric-types.md`
- Feature report: `docs/features/opensearch/unsigned-long.md`

### Key Changes in v3.0.0
- Fixed bug where terms queries on `unsigned_long` fields with values > `Long.MAX_VALUE` caused assertion errors
- Introduced new `UnsignedLongHashSet` class with proper unsigned comparison using `Long.compareUnsigned()`
- Updated `SortedUnsignedLongDocValuesSetQuery` to use the new hash set

### Related
- PR: [opensearch-project/OpenSearch#17207](https://github.com/opensearch-project/OpenSearch/pull/17207)
- Issue: [opensearch-project/OpenSearch#17206](https://github.com/opensearch-project/OpenSearch/issues/17206)
- Closes #232