### PR TITLE
docs: add flat-object DocValues retrieval report for v3.0.0

### DIFF
--- a/docs/features/opensearch/flat-object-field.md
+++ b/docs/features/opensearch/flat-object-field.md
@@ -131,6 +131,37 @@ GET /products/_search
 }
 ```
 
+### DocValues Retrieval (v3.0.0+)
+
+Starting from v3.0.0, you can retrieve specific subfield values from DocValues using the `docvalue_fields` parameter:
+
+```json
+// Retrieve specific subfield value from DocValues
+GET /products/_search
+{
+  "_source": false,
+  "stored_fields": "_none_",
+  "docvalue_fields": ["metadata.tags.color"]
+}
+
+// Response
+{
+  "hits": {
+    "hits": [
+      {
+        "_index": "products",
+        "_id": "1",
+        "fields": {
+          "metadata.tags.color": ["black"]
+        }
+      }
+    ]
+  }
+}
+```
+
+This is more efficient than loading the entire `_source` when you only need specific field values.
+
 ## Limitations
 
 - Only accepts JSON objects as values (not arrays, strings, or numbers directly)
@@ -142,17 +173,20 @@ GET /products/_search
 - No filtering by subfields
 - Painless scripting not supported for retrieving subfield values
 - Maximum field value length in dot notation is 2²⁴ − 1
+- DocValues retrieval requires full dot-path notation (root field not supported)
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.0.0 | [#16802](https://github.com/opensearch-project/OpenSearch/pull/16802) | Added ability to retrieve value from DocValues in flat_object field |
 | v2.18.0 | [#14383](https://github.com/opensearch-project/OpenSearch/pull/14383) | Use IndexOrDocValuesQuery to optimize query, delegate to KeywordFieldType |
 | v2.18.0 | [#15985](https://github.com/opensearch-project/OpenSearch/pull/15985) | Fix infinite loop when parsing invalid token types |
 | v2.7.0 | - | Initial implementation of flat_object field type |
 
 ## References
 
+- [Issue #16742](https://github.com/opensearch-project/OpenSearch/issues/16742): Feature request for DocValues retrieval
 - [Issue #11537](https://github.com/opensearch-project/OpenSearch/issues/11537): Feature request for IndexOrDocValuesQuery support
 - [Issue #11635](https://github.com/opensearch-project/OpenSearch/issues/11635): Bug report for code duplication in query generation
 - [Issue #15982](https://github.com/opensearch-project/OpenSearch/issues/15982): Bug report for infinite loop with invalid tokens
@@ -162,5 +196,6 @@ GET /products/_search
 
 ## Change History
 
+- **v3.0.0** (2025-02-11): Added ability to retrieve values from DocValues in flat_object subfields using `docvalue_fields` parameter with dot notation.
 - **v2.18.0** (2024-10-22): Added IndexOrDocValuesQuery optimization for improved query performance. Delegated query generation to KeywordFieldType to reduce code duplication. Enabled wildcard query support. Fixed infinite loop bug when flat_object field receives invalid token types.
 - **v2.7.0** (2023-04-18): Initial implementation of flat_object field type.

--- a/docs/releases/v3.0.0/features/opensearch/flat-object-docvalues.md
+++ b/docs/releases/v3.0.0/features/opensearch/flat-object-docvalues.md
@@ -1,0 +1,136 @@
+# Flat Object Field Type: DocValues Retrieval
+
+## Summary
+
+OpenSearch 3.0.0 adds the ability to retrieve values from DocValues in `flat_object` fields. Previously, while `flat_object` fields stored DocValues, there was no way to retrieve specific subfield values using the `docvalue_fields` parameter in search requests. This enhancement enables efficient field value retrieval without loading the entire `_source` document.
+
+## Details
+
+### What's New in v3.0.0
+
+This release adds DocValues retrieval support for `flat_object` subfields, allowing users to fetch specific nested values using dot notation in `docvalue_fields` queries. This is particularly useful when documents have many fields but only a few values need to be retrieved, as DocValues access is more efficient than stored fields for this use case.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Search Request"
+        REQ[Search Request] --> DVF[docvalue_fields: issue.labels.name]
+    end
+    
+    subgraph "DocValue Retrieval"
+        DVF --> MAPPER[FlatObjectFieldMapper]
+        MAPPER --> FORMAT[FlatObjectDocValueFormat]
+        FORMAT --> FILTER{Prefix Match?}
+        FILTER -->|Yes| EXTRACT[Extract Value]
+        FILTER -->|No| SKIP[Skip Entry]
+        EXTRACT --> RESULT[Return Value]
+    end
+    
+    subgraph "Response"
+        RESULT --> FIELDS[fields: issue.labels.name: abc]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `FlatObjectDocValueFormat` | Inner class that formats DocValues for flat_object fields, filtering by path prefix |
+| `DOC_VALUE_NO_MATCH` | Sentinel object used to skip non-matching DocValue entries |
+
+#### Key Implementation Details
+
+The implementation introduces a custom `DocValueFormat` for flat_object fields:
+
+1. **Path-based filtering**: When retrieving DocValues, the format filters entries by checking if the stored value starts with the expected path prefix (e.g., `field.field.name=`)
+2. **Value extraction**: Matching entries have their prefix stripped to return only the actual value
+3. **Non-matching entries**: Entries that don't match the requested path return a sentinel `DOC_VALUE_NO_MATCH` object, which is filtered out by `DocValueFetcher`
+
+#### Modified Files
+
+| File | Change |
+|------|--------|
+| `FlatObjectFieldMapper.java` | Added `FlatObjectDocValueFormat` class and `docValueFormat()` method |
+| `DocValueFetcher.java` | Added filtering for `DOC_VALUE_NO_MATCH` sentinel values |
+
+### Usage Example
+
+```json
+// Create index with flat_object field
+PUT /test-index/
+{
+  "mappings": {
+    "properties": {
+      "issue": {
+        "type": "flat_object"
+      }
+    }
+  }
+}
+
+// Index document
+PUT /test-index/_doc/1
+{
+  "issue": {
+    "number": "123456",
+    "labels": {
+      "name": "bug",
+      "version": "2.1"
+    }
+  }
+}
+
+// Retrieve specific subfield value from DocValues
+GET /test-index/_search
+{
+  "_source": false,
+  "stored_fields": "_none_",
+  "docvalue_fields": ["issue.labels.name"]
+}
+
+// Response
+{
+  "hits": {
+    "hits": [
+      {
+        "_index": "test-index",
+        "_id": "1",
+        "fields": {
+          "issue.labels.name": ["bug"]
+        }
+      }
+    ]
+  }
+}
+```
+
+### Migration Notes
+
+- DocValues retrieval requires specifying the full dot-path to the subfield (e.g., `issue.labels.name`)
+- Root-level flat_object fields do not support DocValues retrieval; only subfields with dot notation are supported
+- This feature is backward compatible; existing flat_object fields automatically support DocValues retrieval
+
+## Limitations
+
+- DocValues retrieval is not supported for the root flat_object field itself (e.g., `issue`), only for subfields with dot notation
+- Custom formats and time zones are not supported for flat_object DocValues
+- Aggregations on flat_object subfields remain unsupported
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16802](https://github.com/opensearch-project/OpenSearch/pull/16802) | Added ability to retrieve value from DocValues in a flat_object field |
+
+## References
+
+- [Issue #16742](https://github.com/opensearch-project/OpenSearch/issues/16742): Feature request for DocValues retrieval in flat_object fields
+- [Flat object documentation](https://docs.opensearch.org/3.0/field-types/supported-field-types/flat-object/): Official documentation
+- [DocValues vs Stored Fields](https://sease.io/2020/03/docvalues-vs-stored-fields-apache-solr-features-and-performance-smackdown.html): Performance comparison
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/flat-object-field.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -22,6 +22,7 @@
 - [Deprecated Code Cleanup](features/opensearch/deprecated-code-cleanup.md)
 - [Field Type Fixes](features/opensearch/field-type-fixes.md)
 - [Field Types](features/opensearch/field-types.md)
+- [Flat Object DocValues Retrieval](features/opensearch/flat-object-docvalues.md)
 - [Cluster Permissions](features/opensearch/cluster-permissions.md)
 - [gRPC Transport & Services](features/opensearch/grpc-transport--services.md)
 - [Mapping Transformer](features/opensearch/mapping-transformer.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the flat_object DocValues retrieval feature introduced in OpenSearch 3.0.0.

### Changes

**Release Report** (`docs/releases/v3.0.0/features/opensearch/flat-object-docvalues.md`):
- Documents the new ability to retrieve values from DocValues in flat_object fields
- Explains the technical implementation including `FlatObjectDocValueFormat` class
- Provides usage examples with `docvalue_fields` parameter
- Lists limitations and migration notes

**Feature Report Update** (`docs/features/opensearch/flat-object-field.md`):
- Added v3.0.0 entry to Change History
- Added DocValues retrieval usage example
- Updated Related PRs table with PR #16802
- Added reference to Issue #16742

**Release Index Update** (`docs/releases/v3.0.0/index.md`):
- Added link to the new flat-object-docvalues.md report

### Key Feature Details

OpenSearch 3.0.0 enables retrieving specific subfield values from flat_object fields using DocValues, which is more efficient than loading the entire `_source` document when only specific values are needed.

Resolves #231