### PR TITLE
docs: add remote cluster state download setting report for v3.0.0

### DIFF
--- a/docs/features/opensearch/remote-store.md
+++ b/docs/features/opensearch/remote-store.md
@@ -77,6 +77,7 @@ flowchart TB
 | `node.attr.remote_store.segment.repository` | Repository name for segment storage | - |
 | `node.attr.remote_store.translog.repository` | Repository name for translog storage | - |
 | `cluster.remote_store.pinned_timestamps.enabled` | Enable pinned timestamps feature | `false` |
+| `cluster.remote_state.download.serve_read_api.enabled` | Controls full cluster state download from remote on term mismatch | `true` |
 
 ### Usage Example
 
@@ -126,6 +127,7 @@ PUT /_cluster/settings
 |---------|-----|-------------|
 | v3.1.0 | [#18327](https://github.com/opensearch-project/OpenSearch/pull/18327) | Disabling _close API invocation during remote migration |
 | v3.1.0 | [#18256](https://github.com/opensearch-project/OpenSearch/pull/18256) | Apply cluster state metadata and routing table diff when building cluster state from remote |
+| v3.0.0 | [#16798](https://github.com/opensearch-project/OpenSearch/pull/16798) | Setting to disable full cluster state download from remote on term mismatch |
 
 ## References
 
@@ -138,3 +140,4 @@ PUT /_cluster/settings
 ## Change History
 
 - **v3.1.0** (2026-01-10): Added close index request rejection during migration; Fixed cluster state diff download failures during alias operations
+- **v3.0.0** (2024-12-16): Added `cluster.remote_state.download.serve_read_api.enabled` setting to control full cluster state download on term mismatch

--- a/docs/releases/v3.0.0/features/opensearch/remote-cluster-state-download-setting.md
+++ b/docs/releases/v3.0.0/features/opensearch/remote-cluster-state-download-setting.md
@@ -1,0 +1,65 @@
+# Remote Cluster State Download Setting
+
+## Summary
+
+Introduces a new cluster setting `cluster.remote_state.download.serve_read_api.enabled` to disable downloading full cluster state from remote storage on term mismatch. This prevents performance degradation in clusters with large numbers of indices where full cluster state downloads can occupy remote threadpools and delay cluster state update propagation.
+
+## Details
+
+### What's New in v3.0.0
+
+A new dynamic cluster setting allows operators to control whether nodes download full cluster state from remote storage when a term mismatch is detected.
+
+### Technical Changes
+
+#### Problem Addressed
+
+In clusters with large numbers of indices, fetching full cluster state on term mismatch causes:
+- Downloading too many files from remote storage
+- Remote threadpool saturation
+- Delayed cluster state update propagation from cluster manager
+- Node lag due to occupied threadpools
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.remote_state.download.serve_read_api.enabled` | Controls whether full cluster state download from remote is enabled on term mismatch | `true` |
+
+### Usage Example
+
+```bash
+# Disable full cluster state download on term mismatch
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.remote_state.download.serve_read_api.enabled": false
+  }
+}
+```
+
+### Migration Notes
+
+- This setting is dynamic and can be changed without cluster restart
+- Consider disabling in clusters with large numbers of indices experiencing cluster state propagation delays
+- Monitor remote threadpool utilization before and after changing this setting
+
+## Limitations
+
+- When disabled, nodes may have stale cluster state until the next successful cluster state update from the cluster manager
+- Only applicable to remote cluster state enabled clusters
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16798](https://github.com/opensearch-project/OpenSearch/pull/16798) | Introduce a setting to disable download of full cluster state from remote on term mismatch |
+
+## References
+
+- [Documentation Issue #8957](https://github.com/opensearch-project/documentation-website/issues/8957): Public documentation request
+- [Remote cluster state](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/remote-store/remote-cluster-state/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/remote-store.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -51,6 +51,7 @@
 - [Pipeline ID Limits](features/opensearch/pipeline-id-limits.md)
 - [Plugin System](features/opensearch/plugin-system.md)
 - [Refresh Task Scheduling](features/opensearch/refresh-task-scheduling.md)
+- [Remote Cluster State Download Setting](features/opensearch/remote-cluster-state-download-setting.md)
 - [Search Backpressure](features/opensearch/search-backpressure.md)
 - [Search Task Management](features/opensearch/search-task-management.md)
 - [Segment Warmer](features/opensearch/segment-warmer.md)


### PR DESCRIPTION
## Summary

Adds documentation for the new `cluster.remote_state.download.serve_read_api.enabled` setting introduced in OpenSearch 3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/remote-cluster-state-download-setting.md`
- Feature report: Updated `docs/features/opensearch/remote-store.md`

### Key Changes in v3.0.0
- New cluster setting to disable full cluster state download from remote on term mismatch
- Prevents performance degradation in clusters with large numbers of indices
- Addresses remote threadpool saturation and cluster state propagation delays

### Related
- PR: opensearch-project/OpenSearch#16798
- Issue: #230