### PR TITLE
docs: add cluster management report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -34,6 +34,7 @@
 - [Client API Enhancements](opensearch/client-api-enhancements.md)
 - [Cluster Stats API](opensearch/cluster-stats-api.md)
 - [Cluster Info & Resource Stats](opensearch/cluster-info-resource-stats.md)
+- [Cluster Management](opensearch/cluster-management.md)
 - [Cluster Manager Metrics](opensearch/cluster-manager-metrics.md)
 - [Cluster State Caching](opensearch/cluster-state-caching.md)
 - [Cluster State & Allocation](opensearch/cluster-state-allocation.md)

--- a/docs/features/opensearch/cluster-management.md
+++ b/docs/features/opensearch/cluster-management.md
@@ -1,0 +1,121 @@
+# Cluster Management
+
+## Summary
+
+Cluster management in OpenSearch encompasses the coordination and optimization of cluster-wide operations, including task batching, shard allocation, and reroute scheduling. These internal mechanisms ensure efficient cluster state updates and recovery operations, particularly important for large-scale deployments with many shards.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Cluster Manager Node"
+        MS[MasterService]
+        TB[TaskBatcher]
+        CSE[ClusterStateExecutor]
+    end
+    
+    subgraph "Shard Allocation"
+        BSA[BalancedShardsAllocator]
+        SBGA[ShardsBatchGatewayAllocator]
+        RS[RerouteService]
+    end
+    
+    subgraph "Task Processing Flow"
+        Tasks[Cluster Tasks] --> TB
+        TB -->|Batch by Key| MS
+        MS --> CSE
+        CSE -->|State Change| Publish[Cluster State Publication]
+    end
+    
+    subgraph "Allocation Flow"
+        MS --> BSA
+        MS --> SBGA
+        BSA -->|Timeout| RS
+        SBGA -->|Timeout| RS
+        RS -->|Schedule| Tasks
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[Cluster Task Submitted] --> B[TaskBatcher Groups Tasks]
+    B --> C{Log Level?}
+    C -->|DEBUG| D[Generate Short Summary]
+    C -->|TRACE| E[Generate Long Summary]
+    D --> F[MasterService Processes]
+    E --> F
+    F --> G[Execute Cluster State Update]
+    G --> H{Allocator Timeout?}
+    H -->|Yes| I[Schedule Reroute]
+    H -->|No| J[Complete]
+    I -->|Priority Setting| K[RerouteService]
+    K --> A
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `MasterService` | Coordinates cluster state updates on the cluster manager node |
+| `TaskBatcher` | Batches cluster tasks by key for efficient processing |
+| `BalancedShardsAllocator` | Allocates shards across nodes for balanced distribution |
+| `ShardsBatchGatewayAllocator` | Batch allocator for existing shard recovery |
+| `RerouteService` | Schedules reroute operations for shard allocation |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.routing.allocation.balanced_shards_allocator.schedule_reroute.priority` | Priority for followup reroute when balanced allocator times out | `NORMAL` |
+| `cluster.routing.allocation.shards_batch_gateway_allocator.schedule_reroute.priority` | Priority for followup reroute when batch gateway allocator times out | `NORMAL` |
+
+Valid priority values: `NORMAL`, `HIGH`, `URGENT`
+
+### Usage Example
+
+Configure reroute priority for clusters experiencing task starvation:
+
+```yaml
+# opensearch.yml
+cluster.routing.allocation.balanced_shards_allocator.schedule_reroute.priority: high
+cluster.routing.allocation.shards_batch_gateway_allocator.schedule_reroute.priority: high
+```
+
+Dynamic configuration via API:
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.routing.allocation.balanced_shards_allocator.schedule_reroute.priority": "high",
+    "cluster.routing.allocation.shards_batch_gateway_allocator.schedule_reroute.priority": "high"
+  }
+}
+```
+
+## Limitations
+
+- Reroute priority settings only affect tasks triggered by allocator timeouts
+- DEBUG logging shows abbreviated task summaries; enable TRACE for full details
+- Priority escalation should be used cautiously as it may affect other cluster operations
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#14795](https://github.com/opensearch-project/OpenSearch/pull/14795) | Reduce logging in DEBUG for MasterService:run |
+| v3.0.0 | [#16445](https://github.com/opensearch-project/OpenSearch/pull/16445) | Change priority for scheduling reroute during timeout |
+
+## References
+
+- [Issue #12249](https://github.com/opensearch-project/OpenSearch/issues/12249): Reduce TaskBatcher excessive logging in DEBUG mode
+- [Cluster Allocation Explain API](https://docs.opensearch.org/3.0/api-reference/cluster-api/cluster-allocation/): Official documentation
+- [Creating a Cluster](https://docs.opensearch.org/3.0/tuning-your-cluster/): Cluster tuning guide
+
+## Change History
+
+- **v3.0.0** (2025-03-18): Added configurable reroute priority settings, optimized MasterService logging to reduce recovery time for large clusters

--- a/docs/releases/v3.0.0/features/opensearch/cluster-management.md
+++ b/docs/releases/v3.0.0/features/opensearch/cluster-management.md
@@ -1,0 +1,111 @@
+# Cluster Management
+
+## Summary
+
+OpenSearch 3.0.0 introduces cluster management improvements that optimize performance during cluster recovery and shard allocation. These changes reduce logging overhead in the MasterService and improve task scheduling priority for reroute operations, resulting in faster cluster recovery times for large-scale deployments.
+
+## Details
+
+### What's New in v3.0.0
+
+Two key improvements enhance cluster management performance:
+
+1. **Optimized MasterService Logging**: Reduces excessive DEBUG logging that was causing significant delays during cluster recovery with large numbers of shards
+2. **Configurable Reroute Priority**: Changes the default priority for scheduling reroute tasks during timeout from HIGH to NORMAL, with a new setting to adjust priority for problematic clusters
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Cluster Manager Node"
+        MS[MasterService]
+        TB[TaskBatcher]
+        BSA[BalancedShardsAllocator]
+        SBGA[ShardsBatchGatewayAllocator]
+    end
+    
+    subgraph "Task Processing"
+        TB -->|Short Summary| MS
+        TB -->|Long Summary<br/>TRACE only| MS
+    end
+    
+    subgraph "Reroute Scheduling"
+        BSA -->|Configurable Priority| RS[RerouteService]
+        SBGA -->|Configurable Priority| RS
+    end
+    
+    MS --> BSA
+    MS --> SBGA
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `taskSummaryGenerator` | Function that generates short or long task summaries on demand |
+| `buildShortSummary()` | Creates lightweight summary with batching key and task count |
+| `FOLLOW_UP_REROUTE_PRIORITY_SETTING` | Dynamic setting to control reroute task priority |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.routing.allocation.balanced_shards_allocator.schedule_reroute.priority` | Priority for followup reroute when allocator times out | `NORMAL` |
+| `cluster.routing.allocation.shards_batch_gateway_allocator.schedule_reroute.priority` | Priority for followup reroute when batch allocator times out | `NORMAL` |
+
+Valid values: `NORMAL`, `HIGH`, `URGENT`
+
+### Usage Example
+
+To raise reroute priority for clusters experiencing task starvation:
+
+```yaml
+# opensearch.yml or via Cluster Settings API
+cluster.routing.allocation.balanced_shards_allocator.schedule_reroute.priority: high
+cluster.routing.allocation.shards_batch_gateway_allocator.schedule_reroute.priority: high
+```
+
+Or dynamically:
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "cluster.routing.allocation.balanced_shards_allocator.schedule_reroute.priority": "high",
+    "cluster.routing.allocation.shards_batch_gateway_allocator.schedule_reroute.priority": "high"
+  }
+}
+```
+
+### Performance Impact
+
+- **MasterService Logging Optimization**: Saves approximately 10 minutes during recovery phase for clusters with 200K+ shards by deferring expensive task summary computation to TRACE level only
+- **Reroute Priority Change**: Prevents HIGH priority reroute tasks from starving NORMAL priority cluster tasks, improving overall cluster stability
+
+### Migration Notes
+
+- The default reroute priority changed from `HIGH` to `NORMAL`. For clusters that were relying on the previous HIGH priority behavior, explicitly set the priority to `high` using the new settings.
+- DEBUG logging now shows short summaries (batching key + count). Enable TRACE logging to see detailed task summaries.
+
+## Limitations
+
+- The new priority settings only affect reroute tasks triggered by allocator timeouts
+- Short summary format may provide less detail for debugging; use TRACE level for full task details
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#14795](https://github.com/opensearch-project/OpenSearch/pull/14795) | Reduce logging in DEBUG for MasterService:run |
+| [#16445](https://github.com/opensearch-project/OpenSearch/pull/16445) | Change priority for scheduling reroute during timeout |
+
+## References
+
+- [Issue #12249](https://github.com/opensearch-project/OpenSearch/issues/12249): Reduce TaskBatcher excessive logging in DEBUG mode
+- [Cluster Allocation Explain API](https://docs.opensearch.org/3.0/api-reference/cluster-api/cluster-allocation/): Official documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/cluster-management.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -14,6 +14,7 @@
 ## opensearch
 
 - [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)
+- [Cluster Management](features/opensearch/cluster-management.md)
 - [Rule-Based Auto-Tagging](features/opensearch/rule-based-auto-tagging.md)
 - [Security Manager Replacement (Java Agent)](features/opensearch/security-manager-replacement-java-agent.md)
 - [Bulk API Changes](features/opensearch/bulk-api-changes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Cluster Management improvements in OpenSearch v3.0.0.

## Changes

### Release Report
- `docs/releases/v3.0.0/features/opensearch/cluster-management.md`

### Feature Report
- `docs/features/opensearch/cluster-management.md`

## Key Changes in v3.0.0

1. **Optimized MasterService Logging** (PR #14795)
   - Reduces excessive DEBUG logging that caused ~10 minute delays during cluster recovery with 200K+ shards
   - Introduces short/long summary generation - detailed summaries only computed at TRACE level

2. **Configurable Reroute Priority** (PR #16445)
   - Changes default reroute priority from HIGH to NORMAL to prevent task starvation
   - Adds new dynamic settings to configure priority:
     - `cluster.routing.allocation.balanced_shards_allocator.schedule_reroute.priority`
     - `cluster.routing.allocation.shards_batch_gateway_allocator.schedule_reroute.priority`

## Related Issue
Closes #229