### PR TITLE
docs: add query-builders report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -129,6 +129,7 @@
 - [Profiler](opensearch/profiler.md)
 - [Pull-based Ingestion](opensearch/pull-based-ingestion.md)
 - [Query Bug Fixes](opensearch/query-bug-fixes.md)
+- [Query Builders](opensearch/query-builders.md)
 - [Query & Aggregation Fixes](opensearch/query-and-aggregation-fixes.md)
 - [Query Cache](opensearch/query-cache.md)
 - [Query Coordinator Context](opensearch/query-coordinator-context.md)

--- a/docs/features/opensearch/query-builders.md
+++ b/docs/features/opensearch/query-builders.md
@@ -1,0 +1,133 @@
+# Query Builders
+
+## Summary
+
+The Query Builders feature provides a fluent Java API for constructing OpenSearch queries programmatically. In OpenSearch 3.0.0, a new `filter()` method was added to the `QueryBuilder` interface, enabling developers to combine filters with any query builder in a chainable manner without manually wrapping queries in `BoolQueryBuilder`.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "QueryBuilder Interface"
+        QB[QueryBuilder]
+        QB -->|defines| FM[filter method]
+        QB -->|defines| TQ[toQuery method]
+        QB -->|defines| RW[rewrite method]
+    end
+    
+    subgraph "Implementations"
+        AQB[AbstractQueryBuilder]
+        BQB[BoolQueryBuilder]
+        CSQB[ConstantScoreQueryBuilder]
+        MQB[MatchQueryBuilder]
+        TQB[TermQueryBuilder]
+        RQB[RangeQueryBuilder]
+    end
+    
+    QB --> AQB
+    AQB --> BQB
+    AQB --> CSQB
+    AQB --> MQB
+    AQB --> TQB
+    AQB --> RQB
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Filter Application"
+        Q[Original Query]
+        F[Filter Query]
+        
+        Q --> |filter method| D{Query Type?}
+        D -->|BoolQueryBuilder| B1[Add to filterClauses]
+        D -->|ConstantScoreQueryBuilder| B2[Combine with inner filter]
+        D -->|Other QueryBuilder| B3[Wrap in BoolQueryBuilder]
+        
+        B1 --> R1[Return modified BoolQueryBuilder]
+        B2 --> R2[Return new ConstantScoreQueryBuilder]
+        B3 --> R3[Return new BoolQueryBuilder]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `QueryBuilder` | Interface defining the contract for all query builders |
+| `AbstractQueryBuilder` | Base class providing common functionality including default `filter()` implementation |
+| `BoolQueryBuilder` | Compound query builder with `must`, `should`, `must_not`, and `filter` clauses |
+| `ConstantScoreQueryBuilder` | Wraps a filter query and assigns a constant score |
+
+### API Methods
+
+| Method | Class | Description |
+|--------|-------|-------------|
+| `filter(QueryBuilder filter)` | `QueryBuilder` | Combines a filter with the query builder |
+| `validateFilterParams(QueryBuilder filter)` | `AbstractQueryBuilder` | Static method to validate filter parameters |
+| `must(QueryBuilder query)` | `BoolQueryBuilder` | Adds a must clause |
+| `should(QueryBuilder query)` | `BoolQueryBuilder` | Adds a should clause |
+| `mustNot(QueryBuilder query)` | `BoolQueryBuilder` | Adds a must_not clause |
+
+### Usage Examples
+
+#### Basic Filter Application
+
+```java
+// Apply a filter to any query builder
+QueryBuilder query = QueryBuilders.matchQuery("content", "opensearch")
+    .filter(QueryBuilders.termQuery("status", "active"));
+
+// Result: BoolQueryBuilder with must(matchQuery) + filter(termQuery)
+```
+
+#### Chaining Multiple Filters with BoolQueryBuilder
+
+```java
+BoolQueryBuilder query = new BoolQueryBuilder()
+    .must(QueryBuilders.matchQuery("title", "search"))
+    .filter(QueryBuilders.termQuery("category", "tech"))
+    .filter(QueryBuilders.rangeQuery("date").gte("2024-01-01"))
+    .filter(QueryBuilders.termQuery("published", true));
+```
+
+#### ConstantScoreQueryBuilder with Filter
+
+```java
+ConstantScoreQueryBuilder query = new ConstantScoreQueryBuilder(
+    QueryBuilders.termQuery("type", "article")
+).filter(QueryBuilders.termQuery("featured", true));
+```
+
+#### Null Filter Handling
+
+```java
+// Null filters are safely ignored
+QueryBuilder query = QueryBuilders.matchQuery("field", "value")
+    .filter(null);  // Returns original query unchanged
+```
+
+## Limitations
+
+- `SpanGapQueryBuilder` does not support the `filter()` method and throws `UnsupportedOperationException`
+- When `filter()` is called on non-Bool query builders, a new `BoolQueryBuilder` is created, which may affect object identity comparisons
+- Filter context queries do not contribute to relevance scoring
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17409](https://github.com/opensearch-project/OpenSearch/pull/17409) | Add filter function for AbstractQueryBuilder, BoolQueryBuilder, ConstantScoreQueryBuilder |
+
+## References
+
+- [Query and filter context](https://docs.opensearch.org/3.0/query-dsl/query-filter-context/): Understanding query vs filter context
+- [Boolean query](https://docs.opensearch.org/3.0/query-dsl/compound/bool/): Boolean query documentation
+- [Constant score query](https://docs.opensearch.org/3.0/query-dsl/compound/constant-score/): Constant score query documentation
+
+## Change History
+
+- **v3.0.0** (2025-03-03): Added `filter()` method to `QueryBuilder` interface with implementations in `AbstractQueryBuilder`, `BoolQueryBuilder`, and `ConstantScoreQueryBuilder`

--- a/docs/releases/v3.0.0/features/opensearch/query-builders.md
+++ b/docs/releases/v3.0.0/features/opensearch/query-builders.md
@@ -1,0 +1,117 @@
+# Query Builders
+
+## Summary
+
+OpenSearch 3.0.0 introduces a new `filter()` method to the Query Builder API, enabling developers to programmatically combine filters with query builders in a fluent, chainable manner. This enhancement simplifies query construction by providing a unified approach to adding filter clauses across different query builder types.
+
+## Details
+
+### What's New in v3.0.0
+
+The PR adds a `filter()` method to the `QueryBuilder` interface and implements it in:
+- `AbstractQueryBuilder` - Base implementation that wraps the query in a `BoolQueryBuilder`
+- `BoolQueryBuilder` - Adds filter directly to existing filter clauses
+- `ConstantScoreQueryBuilder` - Combines filter with the inner filter builder
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Query Builder Hierarchy"
+        QB[QueryBuilder Interface]
+        AQB[AbstractQueryBuilder]
+        BQB[BoolQueryBuilder]
+        CSQB[ConstantScoreQueryBuilder]
+        OQB[Other Query Builders]
+    end
+    
+    QB -->|filter method| AQB
+    AQB -->|inherits| BQB
+    AQB -->|inherits| CSQB
+    AQB -->|inherits| OQB
+    
+    subgraph "Filter Behavior"
+        F1[filter on AbstractQueryBuilder]
+        F2[filter on BoolQueryBuilder]
+        F3[filter on ConstantScoreQueryBuilder]
+    end
+    
+    F1 -->|wraps in| BQB
+    F2 -->|adds to filterClauses| BQB
+    F3 -->|combines with inner filter| CSQB
+```
+
+#### New API Methods
+
+| Class | Method | Behavior |
+|-------|--------|----------|
+| `QueryBuilder` | `filter(QueryBuilder filter)` | Interface method for combining filters |
+| `AbstractQueryBuilder` | `filter(QueryBuilder filter)` | Wraps query in `BoolQueryBuilder` with `must` + `filter` |
+| `AbstractQueryBuilder` | `validateFilterParams(QueryBuilder filter)` | Static validation helper |
+| `BoolQueryBuilder` | `filter(QueryBuilder filter)` | Adds filter to existing `filterClauses` list |
+| `ConstantScoreQueryBuilder` | `filter(QueryBuilder filter)` | Combines filter with inner filter builder |
+
+#### Behavior Changes
+
+| Query Builder Type | Previous Behavior | New Behavior |
+|-------------------|-------------------|--------------|
+| `BoolQueryBuilder.filter(null)` | Throws `IllegalArgumentException` | Returns `this` unchanged |
+| Any `QueryBuilder.filter(filter)` | Not available | Returns query with filter combined |
+
+### Usage Example
+
+```java
+// Before: Manual bool query construction
+BoolQueryBuilder boolQuery = new BoolQueryBuilder();
+boolQuery.must(QueryBuilders.matchQuery("title", "opensearch"));
+boolQuery.filter(QueryBuilders.termQuery("status", "published"));
+
+// After: Fluent filter chaining
+QueryBuilder query = QueryBuilders.matchQuery("title", "opensearch")
+    .filter(QueryBuilders.termQuery("status", "published"));
+```
+
+For `BoolQueryBuilder`, filters are added directly:
+
+```java
+BoolQueryBuilder boolQuery = new BoolQueryBuilder()
+    .must(QueryBuilders.matchQuery("title", "opensearch"))
+    .filter(QueryBuilders.termQuery("status", "published"))
+    .filter(QueryBuilders.rangeQuery("date").gte("2024-01-01"));
+```
+
+For `ConstantScoreQueryBuilder`:
+
+```java
+ConstantScoreQueryBuilder csQuery = new ConstantScoreQueryBuilder(
+    QueryBuilders.termQuery("category", "tech")
+).filter(QueryBuilders.termQuery("active", true));
+```
+
+### Migration Notes
+
+- The `BoolQueryBuilder.filter(null)` behavior has changed from throwing an exception to returning `this` unchanged
+- Existing code using `BoolQueryBuilder.filter()` will continue to work
+- The new `filter()` method on other query builders provides a convenient alternative to manual `BoolQueryBuilder` wrapping
+
+## Limitations
+
+- `SpanGapQueryBuilder` throws `UnsupportedOperationException` when `filter()` is called, as span queries don't support filtering
+- The `filter()` method returns a new `BoolQueryBuilder` for most query types, which may affect reference equality checks
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17409](https://github.com/opensearch-project/OpenSearch/pull/17409) | Add filter function for AbstractQueryBuilder, BoolQueryBuilder, ConstantScoreQueryBuilder |
+
+## References
+
+- [Query and filter context](https://docs.opensearch.org/3.0/query-dsl/query-filter-context/): Official documentation on query vs filter context
+- [Boolean query](https://docs.opensearch.org/3.0/query-dsl/compound/bool/): Boolean query documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/query-builders.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -45,6 +45,7 @@
 - [Node Stats & API Fixes](features/opensearch/node-stats-and-api-fixes.md)
 - [Numeric Types](features/opensearch/numeric-types.md)
 - [Query & Aggregation Fixes](features/opensearch/query-and-aggregation-fixes.md)
+- [Query Builders](features/opensearch/query-builders.md)
 - [Query Performance Optimizations](features/opensearch/query-performance-optimizations.md)
 - [Node Roles & Configuration](features/opensearch/node-roles-and-configuration.md)
 - [Node Roles Configuration (Environment Variables)](features/opensearch/node-roles-configuration.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Query Builders enhancement in OpenSearch 3.0.0.

### Changes
- **Release Report**: `docs/releases/v3.0.0/features/opensearch/query-builders.md`
- **Feature Report**: `docs/features/opensearch/query-builders.md`
- Updated release and feature indexes

### Key Changes in v3.0.0
- Added `filter()` method to `QueryBuilder` interface
- Implemented in `AbstractQueryBuilder`, `BoolQueryBuilder`, and `ConstantScoreQueryBuilder`
- Enables fluent filter chaining on any query builder
- Changed `BoolQueryBuilder.filter(null)` behavior from throwing exception to returning `this`

### Related Issue
Closes #226