### PR TITLE
docs: add Arrow Flight RPC report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -22,6 +22,7 @@
 - [Aggregation Optimizations](opensearch/aggregation-optimizations.md)
 - [Alias Write Index Policy](opensearch/alias-write-index-policy.md)
 - [Approximation Framework](opensearch/approximation-framework.md)
+- [Arrow Flight RPC](opensearch/arrow-flight-rpc.md)
 - [BooleanQuery Rewrite Optimizations](opensearch/booleanquery-rewrite-optimizations.md)
 - [Aggregation Task Cancellation](opensearch/aggregation-task-cancellation.md)
 - [Async Shard Batch Fetch](opensearch/async-shard-batch-fetch.md)

--- a/docs/features/opensearch/arrow-flight-rpc.md
+++ b/docs/features/opensearch/arrow-flight-rpc.md
@@ -1,0 +1,238 @@
+# Arrow Flight RPC
+
+## Summary
+
+Arrow Flight RPC is a high-performance data transfer framework for OpenSearch that leverages Apache Arrow's columnar memory format and Flight RPC protocol. It enables efficient streaming communication between cluster nodes by eliminating serialization/deserialization overhead through zero-copy data transfer, making it ideal for large result sets, real-time data streaming, and high-throughput analytics workloads.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph Client["Client Layer"]
+        CA[Client Application]
+        AFC[Arrow Flight Client]
+    end
+    
+    subgraph Coordinator["Coordinator Node"]
+        CN[Coordinator]
+        SM[Stream Manager]
+        CM[Client Manager]
+        PP[Proxy Producer]
+    end
+    
+    subgraph DataNodes["Data Nodes"]
+        subgraph DN1["Data Node 1"]
+            FS1[Flight Server]
+            SP1[Stream Producer]
+            BA1[Buffer Allocator]
+        end
+        subgraph DN2["Data Node 2"]
+            FS2[Flight Server]
+            SP2[Stream Producer]
+            BA2[Buffer Allocator]
+        end
+    end
+    
+    CA -->|Query| CN
+    CN --> SM
+    SM --> CM
+    CM -->|Flight RPC| FS1
+    CM -->|Flight RPC| FS2
+    FS1 --> SP1
+    FS2 --> SP2
+    SP1 --> BA1
+    SP2 --> BA2
+    PP -->|Proxy Stream| FS1
+    PP -->|Proxy Stream| FS2
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph Query["Query Execution"]
+        Q[Search Query]
+        C[Coordinator]
+    end
+    
+    subgraph Streaming["Arrow Flight Streaming"]
+        REG[Register Stream]
+        PROD[Stream Producer]
+        BATCH[Batch Job]
+        FLUSH[Flush Signal]
+    end
+    
+    subgraph Transfer["Data Transfer"]
+        VSR[VectorSchemaRoot]
+        FLIGHT[Flight RPC]
+        READER[Stream Reader]
+    end
+    
+    subgraph Result["Result Assembly"]
+        PARTIAL[Partial Results]
+        MERGE[Merge Results]
+        RESP[Response]
+    end
+    
+    Q --> C
+    C --> REG
+    REG --> PROD
+    PROD --> BATCH
+    BATCH --> VSR
+    VSR --> FLUSH
+    FLUSH --> FLIGHT
+    FLIGHT --> READER
+    READER --> PARTIAL
+    PARTIAL --> MERGE
+    MERGE --> RESP
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `FlightStreamPlugin` | Main plugin class that bootstraps Arrow Flight server and client infrastructure |
+| `FlightServer` | Arrow Flight server implementation handling streaming requests on data nodes |
+| `ClientManager` | Manages pool of Flight clients for efficient internode communication |
+| `StreamManager` | Central interface for registering, managing, and accessing data streams |
+| `StreamProducer` | Interface for producing Arrow data in batches with backpressure support |
+| `StreamReader` | Interface for consuming Arrow data streams with blocking batch loading |
+| `StreamTicket` | Ticket for identifying and accessing registered streams |
+| `StreamTicketFactory` | Factory for creating stream tickets |
+| `BatchedJob` | Job interface for producing stream data in batches |
+| `FlushSignal` | Signal mechanism for coordinating producer-consumer data flow |
+| `ServerConfig` | Configuration holder for Netty server and allocator settings |
+| `SslContextProvider` | Provider for TLS/SSL context in secure Flight communication |
+| `ProxyStreamProducer` | Proxy stream connecting clients to the correct data node holding the stream |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `opensearch.experimental.feature.transport.stream.enabled` | Enable Arrow Flight streaming transport | `false` |
+| `arrow.flight.publish_host` | Host address for Flight server publishing | Node IP |
+| `arrow.flight.bind_host` | Host address for Flight server binding | Node IP |
+| `transport.stream.type.default` | Transport stream type (`FLIGHT` or `FLIGHT-SECURE`) | - |
+| `flight.ssl.enable` | Enable SSL/TLS for Flight connections | `false` |
+| `http.type` | HTTP transport type (`reactor-netty4` or `reactor-netty4-secure`) | - |
+
+### Usage Example
+
+#### Plugin Installation
+
+```bash
+# Install required plugins
+bin/opensearch-plugin install transport-reactor-netty4
+bin/opensearch-plugin install arrow-flight-rpc
+```
+
+#### JVM Configuration (jvm.options)
+
+```
+-Dio.netty.allocator.numDirectArenas=1
+-Dio.netty.noUnsafe=false
+-Dio.netty.tryUnsafe=true
+-Dio.netty.tryReflectionSetAccessible=true
+--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
+```
+
+#### OpenSearch Configuration (opensearch.yml)
+
+```yaml
+# Enable experimental streaming feature
+opensearch.experimental.feature.transport.stream.enabled: true
+
+# HTTP transport type
+http.type: reactor-netty4        # For non-secure clusters
+# http.type: reactor-netty4-secure # For secure clusters
+
+# Flight server network settings (multi-node clusters)
+arrow.flight.publish_host: 192.168.1.10
+arrow.flight.bind_host: 192.168.1.10
+
+# Security settings (if security enabled)
+transport.stream.type.default: FLIGHT-SECURE
+flight.ssl.enable: true
+transport.ssl.enforce_hostname_verification: false
+```
+
+#### Enable Streaming via API
+
+```json
+PUT /_cluster/settings
+{
+    "persistent": {
+        "plugins.ml_commons.stream_enabled": true
+    }
+}
+```
+
+#### Implementing a Stream Producer
+
+```java
+public class MyStreamProducer implements StreamProducer<VectorSchemaRoot, BufferAllocator> {
+    
+    @Override
+    public VectorSchemaRoot createRoot(BufferAllocator allocator) {
+        // Define schema and create VectorSchemaRoot
+        Schema schema = new Schema(Arrays.asList(
+            Field.nullable("id", new ArrowType.Int(64, true)),
+            Field.nullable("value", new ArrowType.Utf8())
+        ));
+        return VectorSchemaRoot.create(schema, allocator);
+    }
+    
+    @Override
+    public BatchedJob<VectorSchemaRoot> createJob(BufferAllocator allocator) {
+        return (root, flushSignal) -> {
+            // Populate data in batches
+            while (hasMoreData()) {
+                populateBatch(root);
+                flushSignal.awaitConsumer(timeout);
+            }
+        };
+    }
+    
+    @Override
+    public int estimatedRowCount() {
+        return 1000;
+    }
+    
+    @Override
+    public String getAction() {
+        return "my_stream_action";
+    }
+}
+```
+
+## Limitations
+
+- **Experimental Feature**: Currently behind a feature flag, not recommended for production
+- **Plugin Dependencies**: Requires `transport-reactor-netty4` plugin to be installed
+- **JVM Requirements**: Specific JVM options required for Arrow memory management
+- **Security Integration**: Requires security plugin changes for SSL context building
+- **Certificate Hot Reload**: Not yet supported for Flight SSL certificates
+- **Performance Tuning**: Default configurations need tuning based on workload benchmarks
+- **Partitioned Streams**: Support for partitioned streams is planned but not yet implemented
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#16962](https://github.com/opensearch-project/OpenSearch/pull/16962) | Arrow Flight RPC plugin with Flight server bootstrap logic and client for internode communication |
+| v3.0.0 | [#16691](https://github.com/opensearch-project/OpenSearch/pull/16691) | Library changes containing POJOs and Arrow vector APIs |
+
+## References
+
+- [Issue #16679](https://github.com/opensearch-project/OpenSearch/issues/16679): META - Streams using Apache Arrow and Flight
+- [Issue #16963](https://github.com/opensearch-project/OpenSearch/issues/16963): Arrow Flight server and client bootstrap logic
+- [Issue #17065](https://github.com/opensearch-project/OpenSearch/issues/17065): General purpose FlightProducer
+- [Blog: OpenSearch and Apache Arrow](https://opensearch.org/blog/opensearch-and-apache-arrow-a-tour-of-the-archery-range/): Overview of Arrow Flight integration
+- [Apache Arrow](https://arrow.apache.org/): Apache Arrow project homepage
+- [Arrow Flight](https://arrow.apache.org/docs/format/Flight.html): Arrow Flight RPC documentation
+
+## Change History
+
+- **v3.0.0** (2025-02-20): Initial implementation with Flight server bootstrap logic and client for internode communication

--- a/docs/releases/v3.0.0/features/opensearch/arrow-flight-rpc.md
+++ b/docs/releases/v3.0.0/features/opensearch/arrow-flight-rpc.md
@@ -1,0 +1,151 @@
+# Arrow Flight RPC
+
+## Summary
+
+OpenSearch 3.0.0 introduces the Arrow Flight RPC plugin, enabling high-performance data transfer using Apache Arrow Flight protocol. This experimental feature provides efficient streaming communication between data nodes and coordinator nodes, eliminating serialization/deserialization overhead through zero-copy data transfer.
+
+## Details
+
+### What's New in v3.0.0
+
+The Arrow Flight RPC plugin introduces a new transport layer for OpenSearch that leverages Apache Arrow's columnar memory format and Flight RPC framework for efficient data streaming.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph Client
+        C[Client Application]
+    end
+    subgraph Coordinator["Coordinator Node"]
+        CN[Coordinator]
+        FM[Flight Manager]
+        CM[Client Manager]
+    end
+    subgraph DataNodes["Data Nodes"]
+        DN1[Data Node 1]
+        DN2[Data Node 2]
+        FS1[Flight Server]
+        FS2[Flight Server]
+    end
+    
+    C -->|Query| CN
+    CN --> FM
+    FM -->|Flight RPC| FS1
+    FM -->|Flight RPC| FS2
+    FS1 --> DN1
+    FS2 --> DN2
+    CM -->|Manage Connections| FS1
+    CM -->|Manage Connections| FS2
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `FlightStreamPlugin` | Main plugin class that bootstraps Arrow Flight server and client |
+| `FlightServer` | Arrow Flight server implementation for handling streaming requests |
+| `ClientManager` | Manages pool of Flight clients for internode communication |
+| `StreamManager` | Interface for registering and managing data streams |
+| `StreamProducer` | Interface for producing Arrow data batches |
+| `StreamReader` | Interface for consuming Arrow data streams |
+| `ServerConfig` | Configuration for Netty server and allocator settings |
+| `SslContextProvider` | TLS/SSL context provider for secure Flight communication |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `opensearch.experimental.feature.transport.stream.enabled` | Enable Arrow Flight streaming | `false` |
+| `arrow.flight.publish_host` | Host address for Flight server publishing | Node IP |
+| `arrow.flight.bind_host` | Host address for Flight server binding | Node IP |
+| `transport.stream.type.default` | Transport stream type (`FLIGHT` or `FLIGHT-SECURE`) | - |
+| `flight.ssl.enable` | Enable SSL for Flight connections | `false` |
+
+#### JVM Options Required
+
+```
+-Dio.netty.allocator.numDirectArenas=1
+-Dio.netty.noUnsafe=false
+-Dio.netty.tryUnsafe=true
+-Dio.netty.tryReflectionSetAccessible=true
+--add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED
+```
+
+### Usage Example
+
+#### Installation
+
+```bash
+bin/opensearch-plugin install transport-reactor-netty4
+bin/opensearch-plugin install arrow-flight-rpc
+```
+
+#### Configuration (opensearch.yml)
+
+```yaml
+# Enable experimental streaming feature
+opensearch.experimental.feature.transport.stream.enabled: true
+
+# HTTP transport type (choose based on security settings)
+http.type: reactor-netty4        # security disabled
+# http.type: reactor-netty4-secure # security enabled
+
+# Multi-node cluster settings
+arrow.flight.publish_host: <node-ip>
+arrow.flight.bind_host: <node-ip>
+
+# Security-enabled cluster settings
+transport.stream.type.default: FLIGHT-SECURE
+flight.ssl.enable: true
+transport.ssl.enforce_hostname_verification: false
+```
+
+#### Enable ML Commons Streaming
+
+```json
+PUT /_cluster/settings
+{
+    "persistent": {
+        "plugins.ml_commons.stream_enabled": true
+    }
+}
+```
+
+### Migration Notes
+
+This is a new experimental feature. To adopt:
+
+1. Install required plugins (`transport-reactor-netty4` and `arrow-flight-rpc`)
+2. Add JVM options for Arrow memory management
+3. Configure `opensearch.yml` with Flight settings
+4. Enable streaming via cluster settings API
+
+## Limitations
+
+- **Experimental Status**: Feature is behind a feature flag and not recommended for production use
+- **Plugin Dependencies**: Requires `transport-reactor-netty4` plugin
+- **JVM Configuration**: Requires specific JVM options for Netty and Arrow memory
+- **Security Plugin Changes**: Requires security plugin updates for SSL context building ([security#5011](https://github.com/opensearch-project/security/issues/5011))
+- **Certificate Hot Reload**: Not yet supported ([#16965](https://github.com/opensearch-project/OpenSearch/issues/16965))
+- **Default Tuning**: Server, client, and allocator configs need tuning after benchmarks ([#16966](https://github.com/opensearch-project/OpenSearch/issues/16966))
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16962](https://github.com/opensearch-project/OpenSearch/pull/16962) | Arrow Flight RPC plugin with Flight server bootstrap logic and client for internode communication |
+
+## References
+
+- [Issue #16963](https://github.com/opensearch-project/OpenSearch/issues/16963): Arrow Flight server and client bootstrap logic feature request
+- [Issue #16679](https://github.com/opensearch-project/OpenSearch/issues/16679): META - Streams using Apache Arrow and Flight
+- [Blog: OpenSearch and Apache Arrow](https://opensearch.org/blog/opensearch-and-apache-arrow-a-tour-of-the-archery-range/): Overview of Arrow Flight integration
+- [Apache Arrow](https://arrow.apache.org/): Apache Arrow project homepage
+- [Arrow Flight](https://arrow.apache.org/docs/format/Flight.html): Arrow Flight RPC documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/arrow-flight-rpc.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -13,6 +13,7 @@
 
 ## opensearch
 
+- [Arrow Flight RPC](features/opensearch/arrow-flight-rpc.md)
 - [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)
 - [Cluster Management](features/opensearch/cluster-management.md)
 - [Rule-Based Auto-Tagging](features/opensearch/rule-based-auto-tagging.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Arrow Flight RPC feature introduced in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/arrow-flight-rpc.md`
- Feature report: `docs/features/opensearch/arrow-flight-rpc.md`

### Key Changes in v3.0.0
- Arrow Flight RPC plugin with Flight server bootstrap logic
- Client manager for internode communication
- SSL/TLS support for secure Flight connections
- Integration with Auxiliary Transport framework

### Resources Used
- PR: [#16962](https://github.com/opensearch-project/OpenSearch/pull/16962)
- Issue: [#16963](https://github.com/opensearch-project/OpenSearch/issues/16963)
- Meta Issue: [#16679](https://github.com/opensearch-project/OpenSearch/issues/16679)
- Blog: [OpenSearch and Apache Arrow](https://opensearch.org/blog/opensearch-and-apache-arrow-a-tour-of-the-archery-range/)

Closes #225