### PR TITLE
docs: add shard management report for v3.0.0

### DIFF
--- a/docs/features/opensearch/shard-allocation.md
+++ b/docs/features/opensearch/shard-allocation.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Shard allocation in OpenSearch determines how shards are distributed across cluster nodes. The `BalancedShardsAllocator` uses a `WeightFunction` to calculate optimal node weights based on configurable balance factors. This feature includes settings for primary shard balancing, which helps distribute primary shards evenly across nodes for better performance and fault tolerance.
+Shard allocation in OpenSearch determines how shards are distributed across cluster nodes. The `BalancedShardsAllocator` uses a `WeightFunction` to calculate optimal node weights based on configurable balance factors. This feature includes settings for primary shard balancing and explicit limits on primary shards per node, which helps distribute primary shards evenly across nodes for better performance and fault tolerance—particularly important for segment replication clusters.
 
 ## Details
 
@@ -17,6 +17,12 @@ graph TB
         WF --> RC[RebalanceConstraints]
     end
     
+    subgraph "Allocation Deciders"
+        SLAD[ShardsLimitAllocationDecider]
+        SLAD --> TSL[Total Shards Limit]
+        SLAD --> PSL[Primary Shards Limit]
+    end
+    
     subgraph "Constraint Types"
         AC --> ISPN[INDEX_SHARD_PER_NODE_BREACH]
         AC --> IPSB[INDEX_PRIMARY_SHARD_BALANCE]
@@ -27,6 +33,7 @@ graph TB
     
     subgraph "Allocation Decision"
         WF --> |weight calculation| AD[Allocation Decision]
+        SLAD --> |limit check| AD
         AD --> N1[Node 1]
         AD --> N2[Node 2]
         AD --> N3[Node N]
@@ -55,8 +62,12 @@ Where:
 | `AllocationConstraints` | Constraints applied during initial shard allocation |
 | `RebalanceConstraints` | Constraints applied during shard rebalancing |
 | `LocalShardsBalancer` | Performs actual allocation and rebalancing operations |
+| `ShardsLimitAllocationDecider` | Enforces hard limits on shards and primary shards per node |
+| `RelocatingShardsBucket` | Tracks relocating shards separately for accurate counting |
 
 ### Configuration
+
+#### Balance Settings
 
 | Setting | Description | Default |
 |---------|-------------|---------|
@@ -66,7 +77,16 @@ Where:
 | `cluster.routing.allocation.balance.prefer_primary` | Enable primary shard balancing | `false` |
 | `cluster.routing.allocation.rebalance.primary.enable` | Enable primary shard rebalancing | `false` |
 | `cluster.routing.allocation.rebalance.primary.buffer` | Buffer for primary shard rebalancing | `0.10` |
-| `cluster.routing.allocation.primary_constraint.threshold` | Threshold for primary constraint | `10` |
+| `cluster.routing.allocation.primary_constraint.threshold` | Weight added by primary constraints | `10` |
+
+#### Shard Limit Settings
+
+| Setting | Description | Default | Scope |
+|---------|-------------|---------|-------|
+| `cluster.routing.allocation.total_shards_per_node` | Maximum total shards per node | `-1` (unlimited) | Cluster |
+| `cluster.routing.allocation.total_primary_shards_per_node` | Maximum primary shards per node (remote store only) | `-1` (unlimited) | Cluster |
+| `index.routing.allocation.total_shards_per_node` | Maximum shards per node for an index | `-1` (unlimited) | Index |
+| `index.routing.allocation.total_primary_shards_per_node` | Maximum primary shards per node for an index (remote store only) | `-1` (unlimited) | Index |
 
 ### Usage Example
 
@@ -83,14 +103,37 @@ PUT /_cluster/settings
 }
 ```
 
-Adjust balance factors for specific workloads:
+Limit primary shards per node at cluster level (requires remote store):
 
 ```json
 PUT /_cluster/settings
 {
   "persistent": {
-    "cluster.routing.allocation.balance.shard": 0.50,
-    "cluster.routing.allocation.balance.index": 0.50
+    "cluster.routing.allocation.total_primary_shards_per_node": 3
+  }
+}
+```
+
+Limit primary shards per node for a specific index:
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index.routing.allocation.total_primary_shards_per_node": 1,
+    "index.number_of_shards": 6,
+    "index.number_of_replicas": 1
+  }
+}
+```
+
+Adjust primary constraint weight:
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.routing.allocation.primary_constraint.threshold": 20
   }
 }
 ```
@@ -100,15 +143,21 @@ PUT /_cluster/settings
 - Primary shard balancing is best-effort and may not achieve perfect distribution in all scenarios
 - Enabling primary shard balance does not guarantee equal primary shards on each node, especially during failover
 - Changing `prefer_primary` to `false` after enabling does not trigger redistribution
+- Primary shard limit settings (`total_primary_shards_per_node`) require remote store to be enabled
+- Setting limits too low may result in unassigned shards
 
 ## Related PRs
 
 | Version | PR | Description |
 |---------|-----|-------------|
 | v3.4.0 | [#19012](https://github.com/opensearch-project/OpenSearch/pull/19012) | Fix WeightFunction constraint reset bug |
+| v3.0.0 | [#17295](https://github.com/opensearch-project/OpenSearch/pull/17295) | Add cluster and index level settings to limit total primary shards per node |
+| v3.0.0 | [#16471](https://github.com/opensearch-project/OpenSearch/pull/16471) | Add setting to adjust the primary constraint weights |
 
 ## References
 
+- [Issue #17293](https://github.com/opensearch-project/OpenSearch/issues/17293): Feature request for primary shard count constraint
+- [Issue #16470](https://github.com/opensearch-project/OpenSearch/issues/16470): Bug report for high primary shard weight causing uneven distribution
 - [Issue #13429](https://github.com/opensearch-project/OpenSearch/issues/13429): Bug report for constraint reset issue
 - [Cluster Settings Documentation](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/cluster-settings/): Official cluster routing allocation settings
 - [Segment Replication Documentation](https://docs.opensearch.org/3.0/tuning-your-cluster/availability-and-recovery/segment-replication/index/): Recommended settings for segment replication
@@ -116,3 +165,4 @@ PUT /_cluster/settings
 ## Change History
 
 - **v3.4.0** (2025-10-10): Fixed bug where allocation and rebalance constraints were incorrectly reset when updating balance factors
+- **v3.0.0** (2025-05-13): Added primary shard limit settings (`total_primary_shards_per_node`) at cluster and index levels for remote store clusters; Added `primary_constraint.threshold` setting to adjust primary constraint weights

--- a/docs/releases/v3.0.0/features/opensearch/shard-management.md
+++ b/docs/releases/v3.0.0/features/opensearch/shard-management.md
@@ -1,0 +1,124 @@
+# Shard Management
+
+## Summary
+
+OpenSearch 3.0.0 introduces new cluster and index level settings to limit the total number of primary shards per node. These settings provide explicit control over primary shard distribution, addressing CPU skew issues in segment replication clusters where primary shards perform CPU-intensive segment creation.
+
+## Details
+
+### What's New in v3.0.0
+
+Two major enhancements to shard management:
+
+1. **Primary Shard Limit Settings**: New settings to constrain primary shards per node at both cluster and index levels
+2. **Primary Constraint Weight Adjustment**: A setting to tune the weight applied by primary balance constraints during allocation
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Shard Allocation Decision"
+        SR[ShardRouting] --> SLAD[ShardsLimitAllocationDecider]
+        SLAD --> TSC{Total Shards Check}
+        SLAD --> PSC{Primary Shards Check}
+        
+        TSC --> |cluster.routing.allocation.total_shards_per_node| CD1[Cluster Decision]
+        TSC --> |index.routing.allocation.total_shards_per_node| ID1[Index Decision]
+        
+        PSC --> |cluster.routing.allocation.total_primary_shards_per_node| CD2[Cluster Primary Decision]
+        PSC --> |index.routing.allocation.total_primary_shards_per_node| ID2[Index Primary Decision]
+    end
+    
+    subgraph "RoutingNode Tracking"
+        RN[RoutingNode] --> NOS[numberOfOwningShards]
+        RN --> NOPS[numberOfOwningPrimaryShards]
+        RN --> NOSFI[numberOfOwningShardsForIndex]
+        RN --> NOPSFI[numberOfOwningPrimaryShardsForIndex]
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `RelocatingShardsBucket` | Tracks relocating shards and primary shards separately for accurate counting |
+| `numberOfOwningPrimaryShards()` | New method in `RoutingNode` to count non-relocating primary shards |
+| `numberOfOwningPrimaryShardsForIndex()` | New method to count primary shards per index on a node |
+| `getIndexTotalPrimaryShardsPerNodeLimit()` | New method in `IndexMetadata` to retrieve index-level primary shard limit |
+
+#### New Configuration
+
+| Setting | Description | Default | Scope |
+|---------|-------------|---------|-------|
+| `cluster.routing.allocation.total_primary_shards_per_node` | Maximum primary shards per node cluster-wide | `-1` (unlimited) | Cluster |
+| `index.routing.allocation.total_primary_shards_per_node` | Maximum primary shards per node for an index | `-1` (unlimited) | Index |
+| `cluster.routing.allocation.primary_constraint.threshold` | Weight added by primary constraints during allocation | `10` | Cluster |
+
+### Usage Example
+
+Limit primary shards per node at cluster level (requires remote store enabled):
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.routing.allocation.total_primary_shards_per_node": 3
+  }
+}
+```
+
+Limit primary shards per node for a specific index:
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index.routing.allocation.total_primary_shards_per_node": 1,
+    "index.number_of_shards": 6,
+    "index.number_of_replicas": 1
+  }
+}
+```
+
+Adjust primary constraint weight for allocation decisions:
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.routing.allocation.primary_constraint.threshold": 20
+  }
+}
+```
+
+### Migration Notes
+
+- The primary shard limit settings (`total_primary_shards_per_node`) are only applicable for **remote store enabled clusters**
+- Attempting to use these settings on non-remote-store clusters will result in an `IllegalArgumentException`
+- Existing `total_shards_per_node` settings continue to work for all cluster types
+
+## Limitations
+
+- Primary shard limit settings require remote store to be enabled on the cluster
+- Setting limits too low may result in unassigned primary shards if nodes cannot accommodate them
+- The constraint weight setting affects both allocation and rebalancing decisions
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17295](https://github.com/opensearch-project/OpenSearch/pull/17295) | Add cluster and index level settings to limit total primary shards per node |
+| [#16471](https://github.com/opensearch-project/OpenSearch/pull/16471) | Add setting to adjust the primary constraint weights |
+
+## References
+
+- [Issue #17293](https://github.com/opensearch-project/OpenSearch/issues/17293): Feature request for primary shard count constraint
+- [Issue #16470](https://github.com/opensearch-project/OpenSearch/issues/16470): Bug report for high primary shard weight causing uneven distribution
+- [Cluster Settings Documentation](https://docs.opensearch.org/3.0/install-and-configure/configuring-opensearch/cluster-settings/): Official cluster routing allocation settings
+- [Documentation Issue #9301](https://github.com/opensearch-project/documentation-website/issues/9301): Public documentation for primary shard limit settings
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/shard-allocation.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -68,6 +68,7 @@
 - [Search Replica & Reader-Writer Separation](features/opensearch/search-replica-reader-writer-separation.md)
 - [Search Utilities](features/opensearch/search-utilities.md)
 - [Segment Replication](features/opensearch/segment-replication.md)
+- [Shard Management](features/opensearch/shard-management.md)
 
 ## opensearch-dashboards
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Shard Management improvements in OpenSearch v3.0.0.

### Changes

**Release Report** (`docs/releases/v3.0.0/features/opensearch/shard-management.md`):
- Documents new cluster and index level settings to limit primary shards per node
- Documents the primary constraint weight adjustment setting
- Includes architecture diagram, configuration tables, and usage examples

**Feature Report Update** (`docs/features/opensearch/shard-allocation.md`):
- Updated to include v3.0.0 changes
- Added new configuration settings for primary shard limits
- Added new components (RelocatingShardsBucket, etc.)
- Updated Change History

### Key Features Documented

1. **Primary Shard Limit Settings** (PR #17295):
   - `cluster.routing.allocation.total_primary_shards_per_node`
   - `index.routing.allocation.total_primary_shards_per_node`
   - Only applicable for remote store enabled clusters

2. **Primary Constraint Weight** (PR #16471):
   - `cluster.routing.allocation.primary_constraint.threshold`
   - Adjusts weight added by primary constraints during allocation

### Related Issue
Closes #223