### PR TITLE
docs: add configuration-utilities report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -46,6 +46,7 @@
 - [Composite Aggregation](opensearch/composite-aggregation.md)
 - [Composite Directory Factory](opensearch/composite-directory-factory.md)
 - [Concurrent Segment Search](opensearch/concurrent-segment-search.md)
+- [Configuration Utilities](opensearch/configuration-utilities.md)
 - [Context Aware Segments](opensearch/context-aware-segments.md)
 - [Crypto KMS Plugin](opensearch/crypto-kms-plugin.md)
 - [Custom Index Name Resolver](opensearch/custom-index-name-resolver.md)

--- a/docs/features/opensearch/configuration-utilities.md
+++ b/docs/features/opensearch/configuration-utilities.md
@@ -1,0 +1,132 @@
+# Configuration Utilities
+
+## Summary
+
+ConfigurationUtils is a core utility class in OpenSearch that provides standardized, type-safe methods for parsing configuration properties from `Map<String, Object>` structures. It simplifies configuration handling across OpenSearch components by offering consistent property extraction with built-in validation, type checking, and clear error messages.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Core Library"
+        CU[ConfigurationUtils]
+        OPE[OpenSearchParseException]
+    end
+    
+    subgraph "Configuration Sources"
+        Plugin[Plugin Config]
+        Ingest[Ingest Pipeline]
+        Source[Ingestion Source]
+    end
+    
+    subgraph "Output"
+        String[String Values]
+        Int[Integer Values]
+        Bool[Boolean Values]
+        Double[Double Values]
+    end
+    
+    Plugin --> CU
+    Ingest --> CU
+    Source --> CU
+    CU --> String
+    CU --> Int
+    CU --> Bool
+    CU --> Double
+    CU -.->|on error| OPE
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    Input[Configuration Map] --> Read[Read Property]
+    Read --> Check{Value Exists?}
+    Check -->|Yes| Type{Correct Type?}
+    Check -->|No| Default{Has Default?}
+    Default -->|Yes| Return[Return Default]
+    Default -->|No| Error[Throw Exception]
+    Type -->|Yes| Convert[Convert/Return Value]
+    Type -->|No| TypeError[Throw Type Exception]
+```
+
+### Components
+
+| Component | Package | Description |
+|-----------|---------|-------------|
+| `ConfigurationUtils` | `org.opensearch.core.util` | Main utility class with static methods for configuration parsing |
+| `ConfigurationUtilsTests` | `org.opensearch.core.util` | Test suite covering all parsing scenarios |
+
+### API Reference
+
+| Method | Parameters | Returns | Description |
+|--------|------------|---------|-------------|
+| `readStringProperty` | `config, name` | `String` | Read required string, throws if missing |
+| `readStringProperty` | `config, name, default` | `String` | Read string with fallback default |
+| `readOptionalStringProperty` | `config, name` | `String` | Read optional string, returns null if missing |
+| `readStringOrIntProperty` | `config, name, default` | `String` | Read string or int (converted to string) |
+| `readOptionalStringOrIntProperty` | `config, name` | `String` | Read optional string or int |
+| `readBooleanProperty` | `config, name, default` | `boolean` | Read boolean with default |
+| `readIntProperty` | `config, name, default` | `Integer` | Read integer with default |
+| `readDoubleProperty` | `config, name` | `Double` | Read required double |
+| `newConfigurationException` | `name, reason` | `OpenSearchException` | Create standardized exception |
+
+### Usage Example
+
+```java
+import org.opensearch.core.util.ConfigurationUtils;
+import java.util.Map;
+
+public class KafkaSourceConfig {
+    private static final String PROP_TOPIC = "topic";
+    private static final String PROP_BOOTSTRAP_SERVERS = "bootstrap_servers";
+    
+    private final String topic;
+    private final String bootstrapServers;
+
+    public KafkaSourceConfig(Map<String, Object> params) {
+        // Required properties - throws OpenSearchParseException if missing
+        this.topic = ConfigurationUtils.readStringProperty(params, PROP_TOPIC);
+        this.bootstrapServers = ConfigurationUtils.readStringProperty(params, PROP_BOOTSTRAP_SERVERS);
+    }
+    
+    public String getTopic() { return topic; }
+    public String getBootstrapServers() { return bootstrapServers; }
+}
+```
+
+### Error Messages
+
+The utility provides consistent, informative error messages:
+
+| Scenario | Error Message Format |
+|----------|---------------------|
+| Missing required property | `[propertyName] required property is missing` |
+| Wrong type (string expected) | `[propertyName] property isn't a string, but of type [actualType]` |
+| Wrong type (boolean expected) | `[propertyName] property isn't a boolean, but of type [actualType]` |
+| Invalid int conversion | `[propertyName] property cannot be converted to an int [value]` |
+| Invalid double conversion | `[propertyName] property cannot be converted to a double [value]` |
+
+## Limitations
+
+- Designed for flat configuration maps; does not support nested object parsing
+- Does not remove properties from the map after reading (unlike some ingest utilities)
+- No built-in support for list/array properties
+- No support for enum parsing
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17223](https://github.com/opensearch-project/OpenSearch/pull/17223) | Initial implementation |
+
+## References
+
+- [PR #17223](https://github.com/opensearch-project/OpenSearch/pull/17223): Implementation PR
+- [Ingest Processors](https://docs.opensearch.org/3.0/ingest-pipelines/processors/index-processors/): Related configuration patterns
+
+## Change History
+
+- **v3.0.0** (2025-02-05): Initial implementation - Added ConfigurationUtils to core library with support for string, boolean, int, and double property parsing

--- a/docs/releases/v3.0.0/features/opensearch/configuration-utilities.md
+++ b/docs/releases/v3.0.0/features/opensearch/configuration-utilities.md
@@ -1,0 +1,134 @@
+# Configuration Utilities
+
+## Summary
+
+OpenSearch 3.0.0 introduces `ConfigurationUtils`, a new utility class in the core library that provides standardized methods for parsing configuration maps. This utility simplifies configuration handling across OpenSearch components by offering type-safe property extraction with built-in validation and error handling.
+
+## Details
+
+### What's New in v3.0.0
+
+A new `ConfigurationUtils` class has been added to `org.opensearch.core.util` package, inspired by the existing `ConfigurationUtil` in the ingest package. This utility provides a consistent API for reading configuration properties from `Map<String, Object>` structures with proper type checking and error messages.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Configuration Parsing"
+        Config[Map&lt;String, Object&gt;]
+        CU[ConfigurationUtils]
+        Result[Typed Values]
+    end
+    
+    subgraph "Consumers"
+        Kafka[KafkaSourceConfig]
+        Future[Future Plugins]
+    end
+    
+    Config --> CU
+    CU --> Result
+    Result --> Kafka
+    Result --> Future
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ConfigurationUtils` | Core utility class for type-safe configuration parsing |
+| `ConfigurationUtilsTests` | Comprehensive test suite for the utility |
+
+#### API Methods
+
+| Method | Description |
+|--------|-------------|
+| `readStringProperty(config, name)` | Read required string property |
+| `readStringProperty(config, name, default)` | Read string with default value |
+| `readOptionalStringProperty(config, name)` | Read optional string (returns null if missing) |
+| `readStringOrIntProperty(config, name, default)` | Read string or int as string |
+| `readOptionalStringOrIntProperty(config, name)` | Read optional string or int |
+| `readBooleanProperty(config, name, default)` | Read boolean with default |
+| `readIntProperty(config, name, default)` | Read integer property |
+| `readDoubleProperty(config, name)` | Read required double property |
+| `newConfigurationException(name, reason)` | Create standardized parse exception |
+
+### Usage Example
+
+```java
+import org.opensearch.core.util.ConfigurationUtils;
+
+public class MyConfig {
+    private final String topic;
+    private final String servers;
+    private final int timeout;
+    private final boolean enabled;
+
+    public MyConfig(Map<String, Object> params) {
+        // Required string property - throws if missing
+        this.topic = ConfigurationUtils.readStringProperty(params, "topic");
+        
+        // Required string with default
+        this.servers = ConfigurationUtils.readStringProperty(params, "servers", "localhost:9092");
+        
+        // Integer with default
+        this.timeout = ConfigurationUtils.readIntProperty(params, "timeout", 30000);
+        
+        // Boolean with default
+        this.enabled = ConfigurationUtils.readBooleanProperty(params, "enabled", true);
+    }
+}
+```
+
+### Error Handling
+
+The utility provides clear, consistent error messages:
+
+```java
+// Missing required property
+ConfigurationUtils.readStringProperty(config, "missing");
+// Throws: OpenSearchParseException: [missing] required property is missing
+
+// Wrong type
+config.put("arr", Arrays.asList("1", "2"));
+ConfigurationUtils.readStringProperty(config, "arr");
+// Throws: OpenSearchParseException: [arr] property isn't a string, but of type [java.util.Arrays$ArrayList]
+```
+
+### Migration Notes
+
+Plugin developers can migrate from manual configuration parsing to use `ConfigurationUtils`:
+
+**Before:**
+```java
+this.topic = (String) Objects.requireNonNull(params.get("topic"));
+this.servers = (String) Objects.requireNonNull(params.get("bootstrap_servers"));
+```
+
+**After:**
+```java
+this.topic = ConfigurationUtils.readStringProperty(params, "topic");
+this.servers = ConfigurationUtils.readStringProperty(params, "bootstrap_servers");
+```
+
+## Limitations
+
+- The utility reads from configuration maps but does not remove properties (unlike some ingest processor utilities)
+- No support for complex nested object parsing - designed for flat configuration maps
+- List/array property parsing is not included in this initial implementation
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17223](https://github.com/opensearch-project/OpenSearch/pull/17223) | Added ConfigurationUtils to core for the ease of configuration parsing |
+
+## References
+
+- [PR #17223](https://github.com/opensearch-project/OpenSearch/pull/17223): Implementation PR
+- [Ingest Processors Documentation](https://docs.opensearch.org/3.0/ingest-pipelines/processors/index-processors/): Related ingest processor configuration patterns
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/configuration-utilities.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -16,6 +16,7 @@
 - [Arrow Flight RPC](features/opensearch/arrow-flight-rpc.md)
 - [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)
 - [Cluster Management](features/opensearch/cluster-management.md)
+- [Configuration Utilities](features/opensearch/configuration-utilities.md)
 - [Rule-Based Auto-Tagging](features/opensearch/rule-based-auto-tagging.md)
 - [Security Manager Replacement (Java Agent)](features/opensearch/security-manager-replacement-java-agent.md)
 - [Bulk API Changes](features/opensearch/bulk-api-changes.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Configuration Utilities feature introduced in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/configuration-utilities.md`
- Feature report: `docs/features/opensearch/configuration-utilities.md`

### Key Changes in v3.0.0
- Added `ConfigurationUtils` class to `org.opensearch.core.util` package
- Provides type-safe configuration parsing methods (string, boolean, int, double)
- Standardized error handling with clear exception messages
- Used by KafkaSourceConfig for pull-based ingestion

### Resources Used
- PR: [#17223](https://github.com/opensearch-project/OpenSearch/pull/17223)

Closes #222