### PR TITLE
docs: add pull-based ingestion report for v3.0.0

### DIFF
--- a/docs/features/opensearch/pull-based-ingestion.md
+++ b/docs/features/opensearch/pull-based-ingestion.md
@@ -270,10 +270,21 @@ When settings are updated:
 | v3.1.0 | [#18250](https://github.com/opensearch-project/OpenSearch/pull/18250) | Transient failure retries and create mode |
 | v3.1.0 | [#18280](https://github.com/opensearch-project/OpenSearch/pull/18280) | Cluster write block support |
 | v3.1.0 | [#18332](https://github.com/opensearch-project/OpenSearch/pull/18332) | Consumer reset in Resume API |
-| v3.0.0 | [#16927](https://github.com/opensearch-project/OpenSearch/issues/16927) | Initial pull-based ingestion implementation |
+| v3.0.0 | [#16958](https://github.com/opensearch-project/OpenSearch/pull/16958) | Core pull-based ingestion engine, APIs, and Kafka plugin |
+| v3.0.0 | [#17354](https://github.com/opensearch-project/OpenSearch/pull/17354) | Offset management with rewind by offset/timestamp support |
+| v3.0.0 | [#17427](https://github.com/opensearch-project/OpenSearch/pull/17427) | Error handling strategies (DROP and BLOCK) |
+| v3.0.0 | [#17615](https://github.com/opensearch-project/OpenSearch/pull/17615) | Kinesis plugin support |
+| v3.0.0 | [#17631](https://github.com/opensearch-project/OpenSearch/pull/17631) | Ingestion management APIs (pause, resume, get state) |
+| v3.0.0 | [#17768](https://github.com/opensearch-project/OpenSearch/pull/17768) | Disable index API for ingestion engine |
+| v3.0.0 | [#17822](https://github.com/opensearch-project/OpenSearch/pull/17822) | Update and delete support with auto-generated IDs |
+| v3.0.0 | [#17863](https://github.com/opensearch-project/OpenSearch/pull/17863) | Configurable maxPollSize and pollTimeout |
+| v3.0.0 | [#17918](https://github.com/opensearch-project/OpenSearch/pull/17918) | External versioning support for out-of-order updates |
+| v3.0.0 | [#17912](https://github.com/opensearch-project/OpenSearch/pull/17912) | Multi-threaded writer support with configurable processor threads |
 
 ## References
 
+- [Issue #16495](https://github.com/opensearch-project/OpenSearch/issues/16495): RFC - Streaming ingestion (pull based)
+- [Issue #16929](https://github.com/opensearch-project/OpenSearch/issues/16929): Pull-based ingestion tracking issue
 - [Issue #19591](https://github.com/opensearch-project/OpenSearch/issues/19591): Duplicate/old message skipping bug
 - [Issue #19723](https://github.com/opensearch-project/OpenSearch/issues/19723): File-based ingestion flaky test
 - [Issue #19287](https://github.com/opensearch-project/OpenSearch/issues/19287): All-active mode feature request
@@ -291,4 +302,4 @@ When settings are updated:
 - **v3.3.0**: Added all-active ingestion mode enabling replica shards to independently ingest from streaming sources. Fixed ingestion state XContent serialization for remote cluster state compatibility. Fixed lag metric calculation when streaming source is empty. Fixed pause state initialization during replica promotion. Added fail-fast behavior for mapper/parsing errors.
 - **v3.2.0**: Added `ingestion-fs` plugin for file-based ingestion, enabling local testing without Kafka/Kinesis setup. Files follow `${base_directory}/${stream}/${shard_id}.ndjson` convention.
 - **v3.1.0**: Added lag metrics, error metrics, configurable queue size, transient failure retries, create mode, cluster write block support, consumer reset in Resume API. Breaking change: renamed `REWIND_BY_OFFSET`/`REWIND_BY_TIMESTAMP` to `RESET_BY_OFFSET`/`RESET_BY_TIMESTAMP`.
-- **v3.0.0**: Initial implementation with Kafka and Kinesis support, pause/resume APIs, basic metrics.
+- **v3.0.0**: Initial experimental implementation with core ingestion engine, Kafka plugin (`ingestion-kafka`), and Kinesis plugin (`ingestion-kinesis`). Added offset management with rewind by offset/timestamp support. Introduced error handling strategies (DROP and BLOCK). Added ingestion management APIs (pause, resume, get state). Implemented update and delete operations with auto-generated IDs for upserts. Added external versioning support for handling out-of-order updates from streaming sources. Introduced multi-threaded writer support with configurable `num_processor_threads`. Added configurable `maxPollSize` and `pollTimeout` settings. Disabled traditional REST API indexing for pull-based indexes.

--- a/docs/releases/v3.0.0/features/opensearch/pull-based-ingestion.md
+++ b/docs/releases/v3.0.0/features/opensearch/pull-based-ingestion.md
@@ -1,0 +1,206 @@
+# Pull-based Ingestion
+
+## Summary
+
+Pull-based ingestion is a new experimental feature in OpenSearch 3.0.0 that enables OpenSearch to ingest data directly from streaming sources like Apache Kafka and Amazon Kinesis. Instead of clients pushing data via REST APIs, OpenSearch pulls data from streams, providing exactly-once ingestion semantics and native backpressure handling.
+
+## Details
+
+### What's New in v3.0.0
+
+OpenSearch 3.0.0 introduces the foundational pull-based ingestion framework with:
+
+- Core ingestion engine and APIs
+- Kafka plugin (`ingestion-kafka`)
+- Kinesis plugin (`ingestion-kinesis`)
+- Offset management with rewind support
+- Error handling strategies (DROP and BLOCK)
+- Ingestion management APIs (pause, resume, get state)
+- Update and delete operations support
+- External versioning support
+- Multi-threaded writer support
+- Configurable poll settings
+
+### Technical Changes
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph "Streaming Sources"
+        Kafka[Apache Kafka]
+        Kinesis[Amazon Kinesis]
+    end
+    
+    subgraph "OpenSearch Pull-based Ingestion"
+        Consumer[Ingestion Consumer]
+        Poller[Stream Poller]
+        Queue[Blocking Queue]
+        Processor[Message Processor]
+        Engine[Ingestion Engine]
+    end
+    
+    subgraph "Storage"
+        Lucene[Lucene Index]
+        RemoteStore[Remote Store]
+    end
+    
+    Kafka --> Consumer
+    Kinesis --> Consumer
+    Consumer --> Poller
+    Poller --> Queue
+    Queue --> Processor
+    Processor --> Engine
+    Engine --> Lucene
+    Lucene --> RemoteStore
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `IngestionEngine` | Specialized engine for pull-based ingestion, manages stream poller lifecycle |
+| `DefaultStreamPoller` | Polls messages from streaming source, handles pause/resume |
+| `MessageProcessorRunnable` | Processes messages from internal queue with configurable threads |
+| `IngestionShardConsumer` | Interface for source-specific consumers (Kafka, Kinesis) |
+| `ingestion-kafka` plugin | Kafka consumer implementation |
+| `ingestion-kinesis` plugin | Kinesis consumer implementation |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `ingestion_source.type` | Streaming source type (`kafka` or `kinesis`) | Required |
+| `ingestion_source.pointer.init.reset` | Initial position (`earliest`, `latest`, `rewind_by_offset`, `rewind_by_timestamp`) | `earliest` |
+| `ingestion_source.pointer.init.reset.value` | Value for offset/timestamp rewind | Required for rewind modes |
+| `ingestion_source.error_strategy` | Error handling (`DROP` or `BLOCK`) | `DROP` |
+| `ingestion_source.max_batch_size` | Maximum records per poll | - |
+| `ingestion_source.poll.timeout` | Poll timeout | - |
+| `ingestion_source.num_processor_threads` | Number of processor threads | 1 |
+| `ingestion_source.param.topic` | Kafka topic name | Required for Kafka |
+| `ingestion_source.param.bootstrap_servers` | Kafka bootstrap servers | Required for Kafka |
+| `ingestion_source.param.stream` | Kinesis stream name | Required for Kinesis |
+| `ingestion_source.param.region` | AWS region | Required for Kinesis |
+
+#### API Changes
+
+**Create Index with Pull-based Ingestion**
+```json
+PUT /my-index
+{
+  "settings": {
+    "ingestion_source": {
+      "type": "kafka",
+      "pointer.init.reset": "earliest",
+      "param": {
+        "topic": "test",
+        "bootstrap_servers": "localhost:9092"
+      }
+    },
+    "index.number_of_shards": 1,
+    "index.replication.type": "SEGMENT"
+  }
+}
+```
+
+**Pause Ingestion**
+```
+POST /<index>/ingestion/_pause
+```
+
+**Resume Ingestion**
+```
+POST /<index>/ingestion/_resume
+```
+
+**Get Ingestion State**
+```
+GET /<index>/ingestion/_state
+```
+
+### Usage Example
+
+```json
+PUT /logs-kafka
+{
+  "settings": {
+    "ingestion_source": {
+      "type": "kafka",
+      "pointer.init.reset": "earliest",
+      "error_strategy": "DROP",
+      "num_processor_threads": 2,
+      "param": {
+        "topic": "application-logs",
+        "bootstrap_servers": "kafka:9092"
+      }
+    },
+    "index.number_of_shards": 3,
+    "index.number_of_replicas": 1,
+    "index.replication.type": "SEGMENT"
+  },
+  "mappings": {
+    "properties": {
+      "timestamp": { "type": "date" },
+      "message": { "type": "text" },
+      "level": { "type": "keyword" }
+    }
+  }
+}
+```
+
+**Message Format**
+```json
+{"_id":"1", "_source":{"timestamp":"2025-01-01T00:00:00Z", "message":"Log entry", "level":"INFO"}}
+{"_id":"2", "_version":"1", "_source":{"timestamp":"2025-01-01T00:00:01Z", "message":"Another entry", "level":"WARN"}, "_op_type":"index"}
+{"_id":"1", "_version":"2", "_op_type":"delete"}
+```
+
+### Migration Notes
+
+Pull-based ingestion is an experimental feature in v3.0.0. To use it:
+
+1. Install the appropriate ingestion plugin:
+   ```bash
+   bin/opensearch-plugin install ingestion-kafka
+   # or
+   bin/opensearch-plugin install ingestion-kinesis
+   ```
+
+2. Enable segment replication with remote-backed storage (required)
+
+3. Create indexes with `ingestion_source` settings - existing indexes cannot be converted
+
+## Limitations
+
+- Experimental feature - not recommended for production
+- Requires segment replication with remote-backed storage
+- Cannot convert existing push-based indexes to pull-based
+- Index shards must be >= stream partitions
+- Traditional REST API ingestion disabled for pull-based indexes
+- Partial upserts not supported
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#16958](https://github.com/opensearch-project/OpenSearch/pull/16958) | Core pull-based ingestion engine, APIs, and Kafka plugin |
+| [#17354](https://github.com/opensearch-project/OpenSearch/pull/17354) | Offset management with rewind by offset/timestamp support |
+| [#17427](https://github.com/opensearch-project/OpenSearch/pull/17427) | Error handling strategies (DROP and BLOCK) |
+| [#17615](https://github.com/opensearch-project/OpenSearch/pull/17615) | Kinesis plugin support |
+| [#17631](https://github.com/opensearch-project/OpenSearch/pull/17631) | Ingestion management APIs (pause, resume, get state) |
+| [#17768](https://github.com/opensearch-project/OpenSearch/pull/17768) | Disable index API for ingestion engine |
+| [#17822](https://github.com/opensearch-project/OpenSearch/pull/17822) | Update and delete support |
+| [#17863](https://github.com/opensearch-project/OpenSearch/pull/17863) | Configurable maxPollSize and pollTimeout |
+| [#17918](https://github.com/opensearch-project/OpenSearch/pull/17918) | External versioning support |
+| [#17912](https://github.com/opensearch-project/OpenSearch/pull/17912) | Multi-threaded writer support |
+
+## References
+
+- [Issue #16495](https://github.com/opensearch-project/OpenSearch/issues/16495): RFC - Streaming ingestion (pull based)
+- [Issue #16929](https://github.com/opensearch-project/OpenSearch/issues/16929): Pull-based ingestion tracking issue
+- [Documentation](https://docs.opensearch.org/3.0/api-reference/document-apis/pull-based-ingestion/): Pull-based ingestion
+- [Documentation](https://docs.opensearch.org/3.0/api-reference/document-apis/pull-based-ingestion-management/): Pull-based ingestion management
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/pull-based-ingestion.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -70,6 +70,7 @@
 - [Search Utilities](features/opensearch/search-utilities.md)
 - [Segment Replication](features/opensearch/segment-replication.md)
 - [Shard Management](features/opensearch/shard-management.md)
+- [Pull-based Ingestion](features/opensearch/pull-based-ingestion.md)
 
 ## opensearch-dashboards
 


### PR DESCRIPTION
## Summary

This PR adds the release report for Pull-based Ingestion feature in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/pull-based-ingestion.md`
- Feature report: Updated `docs/features/opensearch/pull-based-ingestion.md` with detailed v3.0.0 PRs

### Key Changes in v3.0.0
- Core pull-based ingestion engine and APIs
- Kafka plugin (`ingestion-kafka`) and Kinesis plugin (`ingestion-kinesis`)
- Offset management with rewind by offset/timestamp support
- Error handling strategies (DROP and BLOCK)
- Ingestion management APIs (pause, resume, get state)
- Update and delete operations support
- External versioning support for out-of-order updates
- Multi-threaded writer support with configurable processor threads
- Configurable maxPollSize and pollTimeout settings

### Resources Used
- Issue #221: [v3.0.0] Pull-based Ingestion
- PR #16958: Core ingestion engine
- PR #17354: Offset management
- PR #17427: Error handling
- PR #17615: Kinesis plugin
- PR #17631: Management APIs
- PR #17822: Update/delete support
- PR #17918: Versioning support
- PR #17912: Multi-threaded writer
- Documentation: https://docs.opensearch.org/3.0/api-reference/document-apis/pull-based-ingestion/