### PR TITLE
docs: add systemd-security-configurations report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -174,6 +174,7 @@
 - [Secure Transport Settings](opensearch/secure-transport-settings.md)
 - [Security Manager Replacement](opensearch/security-manager-replacement.md)
 - [Segment Replication](opensearch/segment-replication.md)
+- [Systemd Security Configurations](opensearch/systemd-security-configurations.md)
 - [Segment Warmer](opensearch/segment-warmer.md)
 - [Semantic Version Field Type](opensearch/semantic-version-field-type.md)
 - [Settings Management](opensearch/settings-management.md)

--- a/docs/features/opensearch/systemd-security-configurations.md
+++ b/docs/features/opensearch/systemd-security-configurations.md
@@ -1,0 +1,220 @@
+# Systemd Security Configurations
+
+## Summary
+
+OpenSearch provides systemd security configurations to strengthen operating system-level security on Linux distributions. These configurations use native Linux security mechanisms including seccomp system call filtering, capability restrictions, filesystem isolation, and namespace controls to sandbox the OpenSearch process. This feature is part of the broader Java Security Manager (JSM) replacement strategy, working alongside the Java agent to provide comprehensive security.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Linux Operating System"
+        Systemd[systemd Service Manager]
+        Kernel[Linux Kernel]
+        Seccomp[seccomp-bpf]
+        Cgroups[Control Groups]
+    end
+    subgraph "Security Layers"
+        SyscallFilter[System Call Filtering]
+        CapRestrict[Capability Restrictions]
+        FSIsolation[Filesystem Isolation]
+        NSIsolation[Namespace Isolation]
+        MemProtect[Memory Protection]
+    end
+    subgraph "OpenSearch Process"
+        JVM[JVM Process]
+        Agent[Java Agent]
+        Core[OpenSearch Core]
+        Plugins[Plugins]
+        PA[Performance Analyzer]
+    end
+    Systemd --> SyscallFilter
+    Systemd --> CapRestrict
+    Systemd --> FSIsolation
+    Systemd --> NSIsolation
+    Systemd --> MemProtect
+    SyscallFilter --> Seccomp
+    CapRestrict --> Kernel
+    FSIsolation --> Kernel
+    NSIsolation --> Kernel
+    MemProtect --> Kernel
+    Seccomp --> JVM
+    Kernel --> JVM
+    JVM --> Agent
+    Agent --> Core
+    Agent --> Plugins
+    JVM --> PA
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[OpenSearch Process Starts] --> B[systemd Applies Security Directives]
+    B --> C[seccomp Filter Installed]
+    B --> D[Capabilities Dropped]
+    B --> E[Filesystem Mounts Configured]
+    B --> F[Namespaces Restricted]
+    C --> G[System Calls Filtered]
+    G --> H{Allowed Call?}
+    H -->|Yes| I[Execute System Call]
+    H -->|No| J[Return EPERM]
+    D --> K[Privileged Operations Blocked]
+    E --> L[Read/Write Access Controlled]
+    F --> M[Process Isolation Enforced]
+```
+
+### Components
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| `opensearch.service` | `distribution/packages/src/common/systemd/` | Main systemd unit file with security directives |
+| `SystemdIntegTests.java` | `qa/systemd-test/` | Integration tests for systemd security configurations |
+| `terminate.sh` | `qa/systemd-test/src/test/resources/scripts/` | Test script for process termination protection |
+
+### Configuration
+
+#### System Call Filtering
+
+| Directive | Value | Purpose |
+|-----------|-------|---------|
+| `SystemCallFilter` | `@system-service` | Allow standard service system calls |
+| `SystemCallFilter` | `~@reboot` | Block reboot-related calls |
+| `SystemCallFilter` | `~@swap` | Block swap management calls |
+| `SystemCallFilter` | `seccomp mincore madvise mlock mlock2 munlock` | Allow memory management for JVM |
+| `SystemCallFilter` | `get_mempolicy sched_getaffinity sched_setaffinity fcntl` | Allow scheduling and file control |
+| `SystemCallErrorNumber` | `EPERM` | Return permission denied for blocked calls |
+| `SystemCallArchitectures` | `native` | Allow only native architecture calls |
+
+#### Capability Restrictions
+
+| Capability Removed | Reason |
+|--------------------|--------|
+| `CAP_SYS_ADMIN` | Prevents various privileged system operations |
+| `CAP_SYS_PTRACE` | Prevents process tracing/debugging |
+| `CAP_NET_ADMIN` | Prevents network configuration changes |
+| `CAP_BLOCK_SUSPEND` | Prevents blocking system suspend |
+| `CAP_LEASE` | Prevents file lease establishment |
+| `CAP_SYS_PACCT` | Prevents process accounting configuration |
+| `CAP_SYS_TTY_CONFIG` | Prevents TTY configuration |
+
+#### Filesystem Access
+
+| Directive | Paths | Purpose |
+|-----------|-------|---------|
+| `ReadWritePaths` | `/var/log/opensearch` | Log file storage |
+| `ReadWritePaths` | `/var/lib/opensearch` | Data storage |
+| `ReadWritePaths` | `/dev/shm/` | Shared memory for Performance Analyzer |
+| `ReadWritePaths` | `/etc/opensearch` | Configuration files |
+| `ReadWritePaths` | `/mnt/snapshots` | Snapshot storage |
+| `ReadOnlyPaths` | `/etc/os-release`, `/proc/self/mountinfo` | System information |
+| `ReadOnlyPaths` | `/sys/fs/cgroup/*` | Control group statistics |
+
+#### Process Protection
+
+| Directive | Value | Purpose |
+|-----------|-------|---------|
+| `ProtectSystem` | `full` | Make `/usr`, `/boot`, `/etc` read-only |
+| `PrivateTmp` | `true` | Isolate `/tmp` and `/var/tmp` |
+| `NoNewPrivileges` | `true` | Prevent privilege escalation |
+| `ProtectKernelModules` | `true` | Prevent kernel module loading |
+| `ProtectKernelTunables` | `true` | Prevent sysctl modifications |
+| `ProtectKernelLogs` | `true` | Prevent kernel log access |
+| `ProtectControlGroups` | `true` | Prevent cgroup modifications |
+| `ProtectHostname` | `true` | Prevent hostname changes |
+| `ProtectClock` | `true` | Prevent system clock changes |
+| `ProtectProc` | `invisible` | Hide other processes in /proc |
+| `RestrictNamespaces` | `true` | Prevent namespace creation |
+| `RestrictSUIDSGID` | `true` | Prevent SUID/SGID file creation |
+| `RestrictRealtime` | `true` | Prevent realtime scheduling |
+| `LockPersonality` | `true` | Prevent ABI personality changes |
+| `KeyringMode` | `private` | Isolate kernel keyring |
+
+#### Network Restrictions
+
+| Directive | Value | Purpose |
+|-----------|-------|---------|
+| `RestrictAddressFamilies` | `AF_INET AF_INET6 AF_UNIX` | Allow only IPv4, IPv6, and Unix sockets |
+
+### Usage Example
+
+#### Viewing Active Security Settings
+
+```bash
+# Check systemd security settings
+systemctl show opensearch --property=ProtectSystem,PrivateTmp,NoNewPrivileges,RestrictNamespaces
+
+# Verify seccomp is enabled for the process
+PID=$(systemctl show --property=MainPID opensearch | cut -d= -f2)
+grep Seccomp /proc/$PID/status
+# Output: Seccomp: 2 (filter mode)
+
+# Check process limits
+cat /proc/$PID/limits | grep -E "Max processes|Max open files"
+```
+
+#### Customizing Security Settings
+
+```bash
+# Create override directory
+sudo mkdir -p /etc/systemd/system/opensearch.service.d/
+
+# Add custom paths for snapshots
+cat << EOF | sudo tee /etc/systemd/system/opensearch.service.d/custom-paths.conf
+[Service]
+ReadWritePaths=/custom/snapshot/path
+EOF
+
+# Reload and restart
+sudo systemctl daemon-reload
+sudo systemctl restart opensearch
+```
+
+#### Integration Test Validation
+
+```java
+// Test that seccomp is enabled
+public void testSeccompEnabled() throws IOException, InterruptedException {
+    String seccomp = executeCommand("grep \"^Seccomp:\" /proc/" + opensearchPid + "/status");
+    int seccompValue = Integer.parseInt(seccomp.split(":\\s*")[1].trim());
+    assertNotEquals("Seccomp should be enabled", 0, seccompValue);
+}
+
+// Test that reboot syscall is blocked
+public void testRebootSysCall() throws IOException, InterruptedException {
+    String result = executeCommand("sudo su opensearch -c 'kill -s SIGHUP 1' 2>&1 || echo 'Operation not permitted'");
+    assertTrue("Reboot system call should be blocked", result.contains("Operation not permitted"));
+}
+```
+
+## Limitations
+
+- Only available on Linux distributions using systemd as the init system
+- Security rules apply at process level, not per-plugin
+- Custom data paths require manual systemd override configuration
+- Some monitoring and debugging tools may require additional capabilities
+- Container deployments may need different security configurations
+- Not applicable to Windows or macOS deployments
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#17107](https://github.com/opensearch-project/security/pull/17107) | Add systemd configurations to strengthen OS core security |
+| v3.0.0 | [#17410](https://github.com/opensearch-project/OpenSearch/pull/17410) | Added integ tests for systemd configs |
+| v3.0.0 | [#17641](https://github.com/opensearch-project/OpenSearch/pull/17641) | Fix systemd integTest on deb regarding path ownership check |
+
+## References
+
+- [Issue #17614](https://github.com/opensearch-project/OpenSearch/issues/17614): Bug fix for deb package ownership check
+- [Issue #1687](https://github.com/opensearch-project/OpenSearch/issues/1687): Original JSM replacement discussion
+- [Blog: Finding a replacement for JSM in OpenSearch 3.0](https://opensearch.org/blog/finding-a-replacement-for-jsm-in-opensearch-3-0/)
+- [systemd.exec documentation](https://www.freedesktop.org/software/systemd/man/systemd.exec.html)
+- [seccomp documentation](https://man7.org/linux/man-pages/man2/seccomp.2.html)
+- [Linux Capabilities](https://man7.org/linux/man-pages/man7/capabilities.7.html)
+
+## Change History
+
+- **v3.0.0** (2025-04-09): Initial implementation with comprehensive systemd hardening

--- a/docs/releases/v3.0.0/features/security/systemd-security-configurations.md
+++ b/docs/releases/v3.0.0/features/security/systemd-security-configurations.md
@@ -1,0 +1,163 @@
+# Systemd Security Configurations
+
+## Summary
+
+OpenSearch 3.0.0 introduces systemd security configurations to strengthen OS-level security. This feature provides process-level sandboxing using native Linux security mechanisms including seccomp system call filtering, capability restrictions, and filesystem access controls. These configurations work alongside the Java agent to replace the deprecated Java Security Manager (JSM).
+
+## Details
+
+### What's New in v3.0.0
+
+OpenSearch 3.0.0 ships with a hardened systemd unit file (`opensearch.service`) that applies comprehensive security restrictions to the OpenSearch process. This is part of the two-pronged strategy to replace JSM: the Java agent handles plugin-level access control, while systemd hardening provides operating system-level protection.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Linux OS"
+        Systemd[systemd Service Manager]
+        Kernel[Linux Kernel]
+    end
+    subgraph "Security Controls"
+        Seccomp[seccomp Filters]
+        Caps[Capability Restrictions]
+        FS[Filesystem Isolation]
+        NS[Namespace Isolation]
+    end
+    subgraph "OpenSearch Process"
+        JVM[JVM]
+        Agent[Java Agent]
+        Core[OpenSearch Core]
+        Plugins[Plugins]
+    end
+    Systemd --> Seccomp
+    Systemd --> Caps
+    Systemd --> FS
+    Systemd --> NS
+    Seccomp --> Kernel
+    Caps --> Kernel
+    FS --> Kernel
+    NS --> Kernel
+    Kernel --> JVM
+    JVM --> Agent
+    Agent --> Core
+    Agent --> Plugins
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `opensearch.service` | Hardened systemd unit file with security directives |
+| `SystemdIntegTests.java` | Integration tests validating systemd security configurations |
+| `terminate.sh` | Test script for process termination protection |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `SystemCallFilter` | Restricts system calls via seccomp | `@system-service`, `~@reboot`, `~@swap` |
+| `CapabilityBoundingSet` | Blocks dangerous Linux capabilities | Removes `CAP_SYS_ADMIN`, `CAP_SYS_PTRACE`, `CAP_NET_ADMIN` |
+| `ReadWritePaths` | Directories with write access | `/var/log/opensearch`, `/var/lib/opensearch`, `/dev/shm/` |
+| `ReadOnlyPaths` | Read-only system paths | `/etc/os-release`, `/proc/self/mountinfo`, cgroup paths |
+| `ProtectSystem` | System directory protection | `full` |
+| `PrivateTmp` | Isolated temporary directory | `true` |
+| `NoNewPrivileges` | Prevent privilege escalation | `true` |
+| `ProtectKernelModules` | Prevent kernel module loading | `true` |
+| `ProtectKernelTunables` | Prevent sysctl modifications | `true` |
+| `RestrictNamespaces` | Restrict namespace creation | `true` |
+| `LockPersonality` | Prevent ABI personality changes | `true` |
+
+#### System Call Filtering
+
+The systemd unit file uses seccomp to restrict system calls:
+
+```ini
+# Allow system service calls
+SystemCallFilter=@system-service
+# Block reboot-related calls
+SystemCallFilter=~@reboot
+# Block swap-related calls
+SystemCallFilter=~@swap
+# Allow memory management calls needed by OpenSearch
+SystemCallFilter=seccomp mincore madvise mlock mlock2 munlock
+SystemCallFilter=get_mempolicy sched_getaffinity sched_setaffinity fcntl
+# Return EPERM for blocked calls
+SystemCallErrorNumber=EPERM
+```
+
+#### Capability Restrictions
+
+```ini
+# Remove dangerous capabilities
+CapabilityBoundingSet=~CAP_BLOCK_SUSPEND
+CapabilityBoundingSet=~CAP_LEASE
+CapabilityBoundingSet=~CAP_SYS_PACCT
+CapabilityBoundingSet=~CAP_SYS_TTY_CONFIG
+CapabilityBoundingSet=~CAP_SYS_ADMIN ~CAP_SYS_PTRACE ~CAP_NET_ADMIN
+```
+
+#### Filesystem Access Controls
+
+```ini
+# Read-write paths for OpenSearch data
+ReadWritePaths=/var/log/opensearch
+ReadWritePaths=/var/lib/opensearch
+ReadWritePaths=/dev/shm/
+ReadWritePaths=-/etc/opensearch
+ReadWritePaths=-/mnt/snapshots
+
+# Read-only system information
+ReadOnlyPaths=-/etc/os-release -/usr/lib/os-release -/etc/system-release
+ReadOnlyPaths=/proc/self/mountinfo /proc/diskstats
+ReadOnlyPaths=/proc/self/cgroup /sys/fs/cgroup/cpu /sys/fs/cgroup/memory
+```
+
+### Usage Example
+
+The systemd security configurations are automatically applied when OpenSearch is installed via RPM or DEB packages and managed by systemd:
+
+```bash
+# Start OpenSearch with systemd (security configs applied automatically)
+sudo systemctl start opensearch
+
+# Verify security settings are active
+sudo systemctl show opensearch --property=ProtectSystem,PrivateTmp,NoNewPrivileges
+
+# Check seccomp status for the process
+grep Seccomp /proc/$(systemctl show --property=MainPID opensearch | cut -d= -f2)/status
+```
+
+### Migration Notes
+
+- Systemd security configurations are automatically applied for new installations
+- Existing installations upgrading to 3.0.0 will receive the new unit file
+- Custom systemd overrides may need adjustment if they conflict with security settings
+- Snapshot paths outside default locations require adding to `ReadWritePaths`
+
+## Limitations
+
+- Only available on Linux distributions using systemd as the init system
+- Security rules apply at process level, not per-plugin
+- Custom data paths require manual configuration in systemd overrides
+- Some monitoring tools may require additional capabilities
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17107](https://github.com/opensearch-project/security/pull/17107) | Add systemd configurations to strengthen OS core security |
+| [#17410](https://github.com/opensearch-project/OpenSearch/pull/17410) | Added integ tests for systemd configs |
+| [#17641](https://github.com/opensearch-project/OpenSearch/pull/17641) | Fix systemd integTest on deb regarding path ownership check |
+
+## References
+
+- [Issue #17614](https://github.com/opensearch-project/OpenSearch/issues/17614): Bug fix for deb package ownership check
+- [Blog: Finding a replacement for JSM in OpenSearch 3.0](https://opensearch.org/blog/finding-a-replacement-for-jsm-in-opensearch-3-0/)
+- [systemd.exec documentation](https://www.freedesktop.org/software/systemd/man/systemd.exec.html)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/systemd-security-configurations.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -112,6 +112,7 @@
 - [Security Plugin Bugfixes](features/security/security-plugin-bugfixes.md)
 - [Security Plugin Bugfixes for Release 3.0](features/security/release-3-0-bugfixes.md)
 - [Security Plugin Changes](features/security/security-plugin-changes.md)
+- [Systemd Security Configurations](features/security/systemd-security-configurations.md)
 
 ## dashboards-flow-framework
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Systemd Security Configurations feature introduced in OpenSearch 3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/security/systemd-security-configurations.md`
- Feature report: `docs/features/opensearch/systemd-security-configurations.md`

### Key Changes in v3.0.0
- Hardened systemd unit file with comprehensive security directives
- seccomp system call filtering to restrict kernel interfaces
- Capability restrictions to block dangerous Linux capabilities
- Filesystem isolation with ReadWritePaths/ReadOnlyPaths
- Process protection with PrivateTmp, NoNewPrivileges, ProtectSystem
- Integration tests for systemd security configurations

### Related PRs
- [#17107](https://github.com/opensearch-project/security/pull/17107): Add systemd configurations to strengthen OS core security
- [#17410](https://github.com/opensearch-project/OpenSearch/pull/17410): Added integ tests for systemd configs
- [#17641](https://github.com/opensearch-project/OpenSearch/pull/17641): Fix systemd integTest on deb regarding path ownership check

### References
- [Blog: Finding a replacement for JSM in OpenSearch 3.0](https://opensearch.org/blog/finding-a-replacement-for-jsm-in-opensearch-3-0/)

Closes #220