### PR TITLE
docs: add views report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -201,6 +201,7 @@
 - [Transport Actions API](opensearch/transport-actions-api.md)
 - [Unified Highlighter](opensearch/unified-highlighter.md)
 - [Unsigned Long](opensearch/unsigned-long.md)
+- [Views](opensearch/views.md)
 - [Warm Storage Tiering](opensearch/warm-storage-tiering.md)
 - [Wildcard Field](opensearch/wildcard-field.md)
 - [Workload Management](opensearch/workload-management.md)

--- a/docs/features/opensearch/views.md
+++ b/docs/features/opensearch/views.md
@@ -1,0 +1,236 @@
+# Views
+
+## Summary
+
+Views is a feature that provides a virtual layer over one or more indices in OpenSearch, simplifying data access and manipulation. Similar to SQL views, OpenSearch Views allow users to create named projections that abstract the physical storage structure from search operations, enabling logical groupings of indices that can be queried as a single entity.
+
+Key benefits:
+- **Simplified access**: Query multiple indices through a single named endpoint
+- **Abstraction**: Separate data usage from physical storage structure
+- **Centralized management**: Define and manage index patterns in one place
+- **Flexibility**: Update view targets without changing client code
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Client Layer"
+        C[Client]
+    end
+    subgraph "OpenSearch Cluster"
+        subgraph "REST Layer"
+            RH[REST Handlers]
+        end
+        subgraph "Transport Layer"
+            CA[CreateViewAction]
+            GA[GetViewAction]
+            UA[UpdateViewAction]
+            DA[DeleteViewAction]
+            LA[ListViewNamesAction]
+            SA[SearchViewAction]
+        end
+        subgraph "Service Layer"
+            VS[ViewService]
+        end
+        subgraph "Cluster State"
+            VM[ViewMetadata]
+            V1[View 1]
+            V2[View 2]
+        end
+        subgraph "Data Layer"
+            I1[Index A]
+            I2[Index B]
+            I3[Index C]
+        end
+    end
+    C --> RH
+    RH --> CA
+    RH --> GA
+    RH --> UA
+    RH --> DA
+    RH --> LA
+    RH --> SA
+    CA --> VS
+    GA --> VS
+    UA --> VS
+    DA --> VS
+    LA --> VS
+    SA --> VS
+    VS --> VM
+    VM --> V1
+    VM --> V2
+    VS --> I1
+    VS --> I2
+    VS --> I3
+```
+
+### Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant REST as ActionHandler
+    participant CS as Cluster Metadata Store
+    participant Data as Indices
+
+    Client->>REST: View List/Get/Update/Create/Delete<br>/views or /views/{view_id}
+    REST->>CS: Query Views
+    alt Update/Create/Delete
+        CS->>CS: Refresh Cluster
+    end
+    CS-->>REST: Return
+    REST-->>Client: Return
+
+    Client->>REST: Search View<br>/views/{view_id}/_search
+    REST->>CS: Query Views
+    CS-->>REST: Return
+    REST->>REST: Rewrite Search Request
+    REST->>REST: Validate Search Request
+    REST->>Data: Search indices
+    Data-->>REST: Return
+    REST-->>Client: Return
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `View` | Core metadata class representing a view with name, description, timestamps, and targets |
+| `View.Target` | Represents a single index pattern target within a view |
+| `ViewMetadata` | Cluster metadata custom type for persisting views across the cluster |
+| `ViewService` | Central service handling all view operations (CRUD and search) |
+| `CreateViewAction` | Transport action for creating new views |
+| `DeleteViewAction` | Transport action for removing views |
+| `GetViewAction` | Transport action for retrieving view details |
+| `UpdateViewAction` | Transport action for modifying existing views |
+| `ListViewNamesAction` | Transport action for listing all view names |
+| `SearchViewAction` | Transport action for executing searches through views |
+| `RestViewAction` | Collection of REST handlers for all view endpoints |
+| `ViewNotFoundException` | Exception thrown when a requested view does not exist |
+| `ViewAlreadyExistsException` | Exception thrown when creating a view that already exists |
+
+### Configuration
+
+| Setting | Description | Default | Limits |
+|---------|-------------|---------|--------|
+| `name` | Unique identifier for the view | Required | Max 64 characters |
+| `description` | Optional description of the view | Empty string | Max 256 characters |
+| `targets` | List of index pattern targets | Required | Max 25 targets |
+| `targets[].indexPattern` | Index pattern for a target | Required | Max 64 characters |
+
+### REST API
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/views` | POST | Create a new view |
+| `/views/` | GET | List all view names |
+| `/views/{view_name}` | GET | Get view details |
+| `/views/{view_name}` | PUT | Update a view |
+| `/views/{view_name}` | DELETE | Delete a view |
+| `/views/{view_name}/_search` | GET/POST | Search through a view |
+
+### Usage Example
+
+#### Creating a View
+
+```json
+POST /views
+{
+  "name": "application-logs",
+  "description": "All application log indices",
+  "targets": [
+    { "indexPattern": "app-logs-*" },
+    { "indexPattern": "service-logs-*" }
+  ]
+}
+```
+
+Response:
+```json
+{
+  "view": {
+    "name": "application-logs",
+    "description": "All application log indices",
+    "createdAt": 1704067200000,
+    "modifiedAt": 1704067200000,
+    "targets": [
+      { "indexPattern": "app-logs-*" },
+      { "indexPattern": "service-logs-*" }
+    ]
+  }
+}
+```
+
+#### Searching Through a View
+
+```json
+POST /views/application-logs/_search
+{
+  "query": {
+    "bool": {
+      "must": [
+        { "match": { "level": "ERROR" } }
+      ],
+      "filter": [
+        { "range": { "@timestamp": { "gte": "now-1h" } } }
+      ]
+    }
+  },
+  "size": 100
+}
+```
+
+#### Listing Views
+
+```json
+GET /views/
+```
+
+Response:
+```json
+{
+  "views": ["application-logs", "security-events", "metrics"]
+}
+```
+
+#### Updating a View
+
+```json
+PUT /views/application-logs
+{
+  "description": "Updated: All application and service logs",
+  "targets": [
+    { "indexPattern": "app-logs-2024-*" },
+    { "indexPattern": "app-logs-2025-*" },
+    { "indexPattern": "service-logs-*" }
+  ]
+}
+```
+
+## Limitations
+
+- **Experimental API**: Views are marked as `@ExperimentalApi` and the API may change in future releases
+- **No scroll support**: Scroll queries are not supported when searching through views
+- **Read-only operations**: Views support search operations only; indexing must target indices directly
+- **No security integration**: Views do not currently integrate with document-level security (DLS) or field-level security (FLS)
+- **Target limits**: Maximum of 25 targets per view
+- **Name length**: View names limited to 64 characters
+- **Index pattern length**: Each target index pattern limited to 64 characters
+- **Description length**: View descriptions limited to 256 characters
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#11957](https://github.com/opensearch-project/OpenSearch/pull/11957) | Projected Views - Initial implementation |
+
+## References
+
+- [Issue #6181](https://github.com/opensearch-project/OpenSearch/issues/6181): RFC - Data projection with views
+- [Issue #3888](https://github.com/opensearch-project/security/issues/3888): Related security plugin issue for view-based access control
+
+## Change History
+
+- **v3.0.0** (2024-02-20): Initial implementation of Views feature with CRUD operations and search support

--- a/docs/releases/v3.0.0/features/opensearch/views.md
+++ b/docs/releases/v3.0.0/features/opensearch/views.md
@@ -1,0 +1,177 @@
+# Views
+
+## Summary
+
+Views is a new feature in OpenSearch 3.0.0 that provides a virtual layer over one or more indices, simplifying data access and manipulation. Views abstract the physical storage structure from search operations, allowing users to define logical groupings of indices that can be queried as a single entity.
+
+## Details
+
+### What's New in v3.0.0
+
+OpenSearch 3.0.0 introduces the Views feature as an experimental API. Views provide a way to create named projections over indices, similar to SQL views, enabling:
+
+- Logical grouping of multiple indices under a single name
+- Simplified search operations across related indices
+- Separation of data usage from physical storage structure
+- Centralized management of index patterns
+
+### Technical Changes
+
+#### Architecture
+
+```mermaid
+graph TB
+    subgraph Client
+        C[Client Request]
+    end
+    subgraph OpenSearch
+        subgraph "View Layer"
+            VA[View API]
+            VS[ViewService]
+            VM[ViewMetadata]
+        end
+        subgraph "Cluster State"
+            CS[Cluster Metadata]
+        end
+        subgraph "Data Layer"
+            I1[Index 1]
+            I2[Index 2]
+            I3[Index 3]
+        end
+    end
+    C --> VA
+    VA --> VS
+    VS --> VM
+    VM --> CS
+    VS --> I1
+    VS --> I2
+    VS --> I3
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `View` | Core metadata class representing a view with name, description, and targets |
+| `ViewMetadata` | Cluster metadata custom type for storing views |
+| `ViewService` | Service handling CRUD operations and search for views |
+| `CreateViewAction` | Transport action for creating views |
+| `DeleteViewAction` | Transport action for deleting views |
+| `GetViewAction` | Transport action for retrieving view details |
+| `UpdateViewAction` | Transport action for updating views |
+| `ListViewNamesAction` | Transport action for listing all view names |
+| `SearchViewAction` | Transport action for searching through a view |
+| `RestViewAction` | REST handlers for view API endpoints |
+
+#### New REST API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/views` | POST | Create a new view |
+| `/views` | GET | List all view names |
+| `/views/{view_name}` | GET | Get view details |
+| `/views/{view_name}` | PUT | Update a view |
+| `/views/{view_name}` | DELETE | Delete a view |
+| `/views/{view_name}/_search` | GET/POST | Search through a view |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| View name | Unique identifier for the view | Required, max 64 chars |
+| View description | Optional description | Empty string, max 256 chars |
+| View targets | List of index patterns | Required, max 25 targets |
+
+### Usage Example
+
+```json
+// Create a view
+POST /views
+{
+  "name": "http-logs",
+  "description": "All HTTP log indices",
+  "targets": [
+    { "indexPattern": "http-logs-*" }
+  ]
+}
+
+// Search through the view
+POST /views/http-logs/_search
+{
+  "query": {
+    "match": {
+      "status": "200"
+    }
+  }
+}
+
+// Get view details
+GET /views/http-logs
+
+// List all views
+GET /views/
+
+// Update a view
+PUT /views/http-logs
+{
+  "description": "Updated description",
+  "targets": [
+    { "indexPattern": "http-logs-2024-*" },
+    { "indexPattern": "http-logs-2025-*" }
+  ]
+}
+
+// Delete a view
+DELETE /views/http-logs
+```
+
+### Data Flow
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant REST as REST Handler
+    participant VS as ViewService
+    participant CS as Cluster State
+    participant Indices
+
+    Client->>REST: POST /views (create)
+    REST->>VS: createView()
+    VS->>CS: Store view metadata
+    CS-->>VS: Acknowledged
+    VS-->>REST: View created
+    REST-->>Client: Response
+
+    Client->>REST: POST /views/{name}/_search
+    REST->>VS: searchView()
+    VS->>CS: Get view metadata
+    CS-->>VS: View with targets
+    VS->>VS: Resolve index patterns
+    VS->>Indices: Execute search
+    Indices-->>VS: Search results
+    VS-->>REST: Results
+    REST-->>Client: Search response
+```
+
+## Limitations
+
+- **Experimental API**: The Views feature is marked as `@ExperimentalApi` and may change in future releases
+- **No scroll support**: Scroll queries are not supported when searching views
+- **Read-only**: Views are for search operations only; write operations must target indices directly
+- **No security integration**: Views do not yet integrate with document-level security or field-level security
+- **Maximum limits**: Views are limited to 25 targets, 64-character names, and 64-character index patterns
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#11957](https://github.com/opensearch-project/OpenSearch/pull/11957) | Projected Views - Initial implementation |
+
+## References
+
+- [Issue #6181](https://github.com/opensearch-project/OpenSearch/issues/6181): RFC - Data projection with views
+- [Issue #3888](https://github.com/opensearch-project/security/issues/3888): Related security plugin issue
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/opensearch/views.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -64,6 +64,7 @@
 - [Thread Context Permissions](features/opensearch/thread-context-permissions.md)
 - [Tiered Caching](features/opensearch/tiered-caching.md)
 - [Track Total Hits](features/opensearch/track-total-hits.md)
+- [Views](features/opensearch/views.md)
 - [Warm/Hot Tiering](features/opensearch/warm-hot-tiering.md)
 - [Wildcard Field](features/opensearch/wildcard-field.md)
 - [Search Replica & Reader-Writer Separation](features/opensearch/search-replica-reader-writer-separation.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Views feature introduced in OpenSearch 3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/views.md`
- Feature report: `docs/features/opensearch/views.md`

### Key Changes in v3.0.0
- New Views feature providing a virtual layer over indices
- CRUD operations for views (create, get, update, delete, list)
- Search through views with index pattern resolution
- REST API endpoints at `/views` and `/views/{view_name}`

### Resources Used
- PR: #11957 (opensearch-project/OpenSearch)
- Issue: #6181 (RFC - Data projection with views)

Closes #219