### PR TITLE
docs: add extensions-framework report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -85,6 +85,7 @@
 - [Engine API](opensearch/engine-api.md)
 - [Engine Config](opensearch/engine-config.md)
 - [Engine Optimization Fixes](opensearch/engine-optimization-fixes.md)
+- [Extensions Framework](opensearch/extensions-framework.md)
 - [Locale Provider](opensearch/locale-provider.md)
 - [HTTP API](opensearch/http-api.md)
 - [Jackson & Query Limits](opensearch/jackson--query-limits.md)

--- a/docs/features/opensearch/extensions-framework.md
+++ b/docs/features/opensearch/extensions-framework.md
@@ -1,0 +1,187 @@
+# Extensions Framework
+
+## Summary
+
+The Extensions Framework provides a way to extend OpenSearch functionality through isolated, independently running processes. Unlike plugins that run within the OpenSearch process, extensions run as separate processes or on remote nodes, offering better isolation, independent scaling, and cleaner interfaces. The framework includes security features for authentication token handling, enabling extensions to act on behalf of users and maintain their own identity.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Cluster"
+        Core[OpenSearch Core]
+        IM[IdentityService]
+        TM[TokenManager]
+        EM[ExtensionsManager]
+        RSA[RestSendToExtensionAction]
+        TS[TransportService]
+    end
+    
+    subgraph "Extension Process"
+        EXT[Extension]
+        SDK[OpenSearch SDK]
+        SAT[Service Account Token]
+        OBO[OBO Token Handler]
+        RC[REST Client]
+    end
+    
+    Core --> IM
+    IM --> TM
+    Core --> EM
+    EM --> TS
+    TS <-->|Transport Protocol| SDK
+    EM -->|Initialize + SA Token| EXT
+    RSA -->|REST Request + OBO Token| EXT
+    TM -->|issueServiceAccountToken| SAT
+    TM -->|issueOnBehalfOfToken| OBO
+    RC -->|Authenticated Requests| Core
+```
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    subgraph "Extension Initialization"
+        A[Extension Starts] --> B[Connect to OpenSearch]
+        B --> C[Receive InitializeExtensionRequest]
+        C --> D[Extract Service Account Token]
+        D --> E[Store Token for System Index Access]
+    end
+    
+    subgraph "User Request Flow"
+        F[User REST Request] --> G[OpenSearch Receives Request]
+        G --> H[Generate OBO Token]
+        H --> I[Forward to Extension with Token]
+        I --> J[Extension Processes Request]
+        J --> K[Extension Uses OBO Token for OpenSearch Calls]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ExtensionsManager` | Manages extension lifecycle, initialization, and communication |
+| `IdentityService` | Provides identity and token management services |
+| `TokenManager` | Interface for issuing and validating authentication tokens |
+| `OnBehalfOfClaims` | Claims for OBO tokens (audience, subject, expiration) |
+| `AuthToken` | Base interface for authentication tokens |
+| `BasicAuthToken` | Basic authentication token implementation |
+| `BearerAuthToken` | Bearer token implementation |
+| `RestSendToExtensionAction` | REST handler for forwarding requests to extensions |
+| `InitializeExtensionRequest` | Request sent to initialize an extension |
+| `RestActionsRequestHandler` | Handles extension REST action registration |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `opensearch.experimental.feature.extensions.enabled` | Enable extensions feature | `false` |
+| Extension-specific settings | Defined by individual extensions | Varies |
+
+### Token Types
+
+#### Service Account Token
+
+- Issued during extension initialization
+- Represents the extension's identity
+- Used for accessing extension's reserved system indices
+- Generated using `TokenManager.issueServiceAccountToken(extensionId)`
+
+#### On Behalf Of (OBO) Token
+
+- Generated for each user request forwarded to an extension
+- Contains claims about the original user
+- Enables extensions to act with user's permissions
+- Generated using `TokenManager.issueOnBehalfOfToken(subject, claims)`
+
+### Usage Example
+
+**Extension Registration (extensions.yml)**:
+
+```yaml
+extensions:
+  - name: my-extension
+    uniqueId: my-extension-id
+    hostAddress: 127.0.0.1
+    port: 4532
+    version: 1.0.0
+    opensearchVersion: 3.0.0
+    minimumCompatibleVersion: 3.0.0
+```
+
+**Token Manager Implementation**:
+
+```java
+public class ShiroTokenManager implements TokenManager {
+    
+    @Override
+    public AuthToken issueOnBehalfOfToken(Subject subject, OnBehalfOfClaims claims) {
+        String password = generatePassword();
+        byte[] rawEncoded = Base64.getUrlEncoder()
+            .encode((claims.getAudience() + ":" + password).getBytes(UTF_8));
+        String header = "Basic " + new String(rawEncoded, UTF_8);
+        BasicAuthToken token = new BasicAuthToken(header);
+        shiroTokenPasswordMap.put(token, password);
+        return token;
+    }
+    
+    @Override
+    public AuthToken issueServiceAccountToken(String audience) {
+        String password = generatePassword();
+        byte[] rawEncoded = Base64.getUrlEncoder().withoutPadding()
+            .encode((audience + ":" + password).getBytes(UTF_8));
+        String header = "Basic " + new String(rawEncoded, UTF_8);
+        BasicAuthToken token = new BasicAuthToken(header);
+        shiroTokenPasswordMap.put(token, password);
+        return token;
+    }
+}
+```
+
+**OnBehalfOfClaims**:
+
+```java
+public class OnBehalfOfClaims {
+    private final String audience;    // Extension ID
+    private final String subject;     // User principal name
+    private final Long expiration;    // Token expiration time
+    private final Long not_before;    // Token valid from
+    private final Long issued_at;     // Token issue time
+    
+    // Default expiration: 5 minutes from issue time
+    public OnBehalfOfClaims(String aud, String subject) {
+        this(aud, subject, System.currentTimeMillis() / 1000 + 300);
+    }
+}
+```
+
+## Limitations
+
+- Extensions framework is experimental and not recommended for production use
+- Token rotation for service accounts is not yet implemented
+- Security plugin implementation of token interfaces is pending
+- Extensions cannot yet run in a horizontally scaled configuration
+- Real-time anomaly detection support in extensions is still in development
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#8679](https://github.com/opensearch-project/OpenSearch/pull/8679) | Implement on behalf of token passing for extensions |
+| v3.0.0 | [#9618](https://github.com/opensearch-project/OpenSearch/pull/9618) | Provide service accounts tokens to extensions |
+
+## References
+
+- [Issue #2764](https://github.com/opensearch-project/security/issues/2764): Determine how auth tokens are forwarded to Extensions
+- [Issue #3176](https://github.com/opensearch-project/security/issues/3176): Issue and ferry a Service Account Token to an Extension on bootstrap
+- [Extensions Documentation](https://docs.opensearch.org/3.0/developer-documentation/extensions/): Official OpenSearch extensions documentation
+- [Introducing Extensions Blog](https://opensearch.org/blog/introducing-extensions-for-opensearch/): Blog post introducing extensions architecture
+- [OpenSearch SDK Java](https://github.com/opensearch-project/opensearch-sdk-java): Java SDK for building extensions
+- [Extension Design Documentation](https://opensearch-project.github.io/opensearch-sdk-java/DESIGN.html): Detailed design documentation
+
+## Change History
+
+- **v3.0.0** (2024-09-17): Added On Behalf Of token passing and Service Account token issuance for extensions

--- a/docs/releases/v3.0.0/features/opensearch/extensions-framework.md
+++ b/docs/releases/v3.0.0/features/opensearch/extensions-framework.md
@@ -1,0 +1,142 @@
+# Extensions Framework
+
+## Summary
+
+OpenSearch 3.0.0 enhances the Extensions Framework with improved security token handling for extensions. Two key features were added: "On Behalf Of" (OBO) token passing for user authentication delegation, and Service Account token issuance for extension identity management. These changes enable extensions to securely interact with OpenSearch on behalf of users and access their own system indices.
+
+## Details
+
+### What's New in v3.0.0
+
+The Extensions Framework received significant security enhancements to support authentication and authorization for extensions running as separate processes:
+
+1. **On Behalf Of Token Passing** - Extensions can now receive authentication tokens that represent the original user making a request, enabling proper authorization when extensions interact with OpenSearch.
+
+2. **Service Account Tokens** - Extensions receive a dedicated service account token during initialization, allowing them to authenticate as themselves when accessing their reserved system indices.
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Core"
+        IM[IdentityService]
+        TM[TokenManager]
+        EM[ExtensionsManager]
+        RSA[RestSendToExtensionAction]
+    end
+    
+    subgraph "Extension Process"
+        EXT[Extension]
+        SAT[Service Account Token]
+        OBO[OBO Token Handler]
+    end
+    
+    IM --> TM
+    EM --> IM
+    EM -->|InitializeExtensionRequest| EXT
+    EM -->|Service Account Token| SAT
+    RSA -->|OBO Token| OBO
+    TM -->|issueServiceAccountToken| SAT
+    TM -->|issueOnBehalfOfToken| OBO
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `OnBehalfOfClaims` | Claims class for OBO tokens containing audience, subject, expiration, and timing information |
+| `issueOnBehalfOfToken()` | TokenManager method to generate OBO tokens for user delegation |
+| `issueServiceAccountToken()` | TokenManager method to generate service account tokens for extensions |
+| `InitializeExtensionRequest.serviceAccountHeader` | New field to pass service account token during extension initialization |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| N/A | Token generation is automatic during extension initialization | - |
+
+#### API Changes
+
+**TokenManager Interface**
+
+New methods added to `TokenManager`:
+
+```java
+// Issue an On Behalf Of token for user delegation
+public AuthToken issueOnBehalfOfToken(Subject subject, OnBehalfOfClaims claims);
+
+// Issue a service account token for extension identity
+public AuthToken issueServiceAccountToken(String audience);
+
+// Authenticate a provided token
+public Subject authenticateToken(AuthToken authToken);
+```
+
+**AuthToken Interface**
+
+New method added:
+
+```java
+// Get the token value for use in HTTP Authorization header
+String asAuthHeaderValue();
+```
+
+### Usage Example
+
+Extensions automatically receive their service account token during initialization:
+
+```java
+// In extension initialization handler
+public void handleInitializeExtensionRequest(InitializeExtensionRequest request) {
+    // Service account token is provided in the request
+    String serviceAccountToken = request.getServiceAccountHeader();
+    
+    // Use this token to authenticate requests to OpenSearch
+    // for accessing extension's reserved system indices
+}
+```
+
+For REST requests forwarded to extensions, OBO tokens are generated automatically:
+
+```java
+// OpenSearch core generates OBO token for each request
+TokenManager tokenManager = identityService.getTokenManager();
+Subject subject = identityService.getSubject();
+OnBehalfOfClaims claims = new OnBehalfOfClaims(
+    extensionId,           // audience
+    subject.getPrincipal().getName()  // subject
+);
+String oboToken = tokenManager.issueOnBehalfOfToken(subject, claims).asAuthHeaderValue();
+```
+
+### Migration Notes
+
+- Extensions must be updated to handle the new `serviceAccountHeader` field in `InitializeExtensionRequest`
+- The `ExtensionsManager` constructor now requires an `IdentityService` parameter
+- Token encoding changed from standard Base64 to URL-safe Base64 for compatibility
+
+## Limitations
+
+- Extensions framework remains experimental in v3.0.0
+- Service account token rotation is not yet implemented
+- Security plugin implementation of the token interfaces is pending
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#8679](https://github.com/opensearch-project/OpenSearch/pull/8679) | Implement on behalf of token passing for extensions |
+| [#9618](https://github.com/opensearch-project/OpenSearch/pull/9618) | Provide service accounts tokens to extensions |
+
+## References
+
+- [Issue #2764](https://github.com/opensearch-project/security/issues/2764): Determine how auth tokens are forwarded to Extensions
+- [Issue #3176](https://github.com/opensearch-project/security/issues/3176): Issue and ferry a Service Account Token to an Extension on bootstrap
+- [Extensions Documentation](https://docs.opensearch.org/3.0/developer-documentation/extensions/): Official OpenSearch extensions documentation
+- [Introducing Extensions Blog](https://opensearch.org/blog/introducing-extensions-for-opensearch/): Blog post introducing extensions architecture
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/extensions-framework.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -14,6 +14,7 @@
 ## opensearch
 
 - [Arrow Flight RPC](features/opensearch/arrow-flight-rpc.md)
+- [Extensions Framework](features/opensearch/extensions-framework.md)
 - [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)
 - [Cluster Management](features/opensearch/cluster-management.md)
 - [Configuration Utilities](features/opensearch/configuration-utilities.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Extensions Framework enhancements in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/extensions-framework.md`
- Feature report: `docs/features/opensearch/extensions-framework.md`

### Key Changes in v3.0.0
- **On Behalf Of Token Passing** - Extensions can receive authentication tokens representing the original user
- **Service Account Tokens** - Extensions receive dedicated service account tokens during initialization

### Related PRs
- [#8679](https://github.com/opensearch-project/OpenSearch/pull/8679): Implement on behalf of token passing for extensions
- [#9618](https://github.com/opensearch-project/OpenSearch/pull/9618): Provide service accounts tokens to extensions

### Related Issues
- [security#2764](https://github.com/opensearch-project/security/issues/2764): Determine how auth tokens are forwarded to Extensions
- [security#3176](https://github.com/opensearch-project/security/issues/3176): Issue and ferry a Service Account Token to an Extension on bootstrap

Closes #217