### PR TITLE
docs: add AI Search Flows Dashboards bug fixes report for v3.0.0

### DIFF
--- a/docs/features/dashboards-flow-framework/ai-search-flows.md
+++ b/docs/features/dashboards-flow-framework/ai-search-flows.md
@@ -228,6 +228,8 @@ For flow agents, response filters are auto-configured for supported providers:
 | v3.0.0 | [#665](https://github.com/opensearch-project/dashboards-flow-framework/pull/665) | Add RAG + hybrid search preset |
 | v3.0.0 | [#676](https://github.com/opensearch-project/dashboards-flow-framework/pull/676) | Simplify ML processor forms |
 | v3.0.0 | [#610](https://github.com/opensearch-project/dashboards-flow-framework/pull/610) | Simplify RAG presets |
+| v3.0.0 | [#604](https://github.com/opensearch-project/dashboards-flow-framework/pull/604) | Refactor quick configure components; improve processor error handling |
+| v3.0.0 | [#605](https://github.com/opensearch-project/dashboards-flow-framework/pull/605) | Hide search query section when version is less than 2.19 |
 | v3.0.0 | [#602](https://github.com/opensearch-project/dashboards-flow-framework/pull/602) | Legacy preset integration |
 | v3.0.0 | [#701](https://github.com/opensearch-project/dashboards-flow-framework/pull/701) | Optional model inputs support |
 
@@ -245,4 +247,4 @@ For flow agents, response filters are auto-configured for supported providers:
 
 - **v3.4.0** (2026-01-14): Added agent summary visualization, memory integration for conversational search, simplified agent configuration with auto-inferred LLM interface, automatic response filters for flow agents, Firefox EuiSelect fixes
 - **v3.1.0** (2025-06-10): Major UI refactor with left panel navigation, integrated preview into inspector panel, added Semantic Search using Sparse Encoders template, configurable thread pool sizes
-- **v3.0.0** (2025-05-13): Renamed to "AI Search Flows", added RAG + hybrid search preset, simplified ML processor forms, improved state persistence, added processor reordering
+- **v3.0.0** (2025-05-13): Renamed to "AI Search Flows", added RAG + hybrid search preset, simplified ML processor forms, improved state persistence, added processor reordering, refactored quick configure components with Formik integration, improved processor error handling with dynamic error display, added version compatibility check to hide search query section for versions < 2.19.0

--- a/docs/releases/v3.0.0/features/dashboards-flow-framework/ai-search-flows-dashboards-bugfixes.md
+++ b/docs/releases/v3.0.0/features/dashboards-flow-framework/ai-search-flows-dashboards-bugfixes.md
@@ -1,0 +1,115 @@
+# AI Search Flows Dashboards Bug Fixes
+
+## Summary
+
+Bug fixes for the AI Search Flows Dashboards plugin (dashboards-flow-framework) in OpenSearch 3.0.0. These changes improve the quick configure modal UX, enhance processor error handling, and add version compatibility for the search query section.
+
+## Details
+
+### What's New in v3.0.0
+
+This release includes two key bug fixes that improve the user experience and version compatibility of the AI Search Flows plugin.
+
+### Technical Changes
+
+#### Quick Configure Component Refactoring (PR #604)
+
+The quick configure modal has been completely refactored to improve form management and validation:
+
+| Change | Description |
+|--------|-------------|
+| Formik Integration | Quick configure components now use Formik for form state management |
+| Required Model Selection | Models are now required for applicable presets (semantic search, hybrid search, RAG) |
+| Component Rename | `QuickConfigureInputs` renamed to `QuickConfigureOptionalFields` for clarity |
+| ModelField Reusability | `ModelField` component cleaned up and made reusable across the plugin |
+| Error Modal Improvement | "No model found" modal now shows once even for presets with multiple models |
+
+#### Processor Error Handling Improvements (PR #604)
+
+Enhanced error display for ingest and search pipeline processors:
+
+| Feature | Description |
+|---------|-------------|
+| Dynamic Error Messages | Processor-level errors shown dynamically in accordion header when closed |
+| Error Callout | Detailed error callout displayed when processor accordion is opened |
+| Multiple Error Support | Inspector's errors tab now supports rendering multiple errors |
+| State Management | Accordion open/closed state now persisted for better UX |
+
+#### Version Compatibility for Search Query Section (PR #605)
+
+Added version checking to hide the search query section for older OpenSearch versions:
+
+| Behavior | Description |
+|----------|-------------|
+| Version Check | Search query section hidden when OpenSearch version < 2.19.0 |
+| UI Cleanup | Removed unnecessary spacing between search_query and search_response sections |
+| Graceful Fallback | Defaults to showing the section if version check fails |
+
+### Code Changes
+
+#### Modified Components
+
+| File | Changes |
+|------|---------|
+| `quick_configure_modal.tsx` | Refactored to use Formik, added model validation |
+| `quick_configure_optional_fields.tsx` | New component for optional configuration fields |
+| `processors_list.tsx` | Added error display in accordion headers and callouts |
+| `tools.tsx` | Updated to support multiple error messages |
+| `errors.tsx` | Changed from single `errorMessage` to `errorMessages` array |
+| `search_inputs.tsx` | Added version check to conditionally show search query section |
+| `model_field.tsx` | Enhanced with additional props for reusability |
+| `workflow_inputs.tsx` | Added toast dismissal on "Test flow" button click |
+
+#### Removed Components
+
+| File | Reason |
+|------|--------|
+| `quick_configure_inputs.tsx` | Replaced by `quick_configure_optional_fields.tsx` |
+
+### Usage Example
+
+The improved quick configure modal now validates model selection:
+
+```typescript
+// Models are now required for non-custom presets
+const formSchemaObj = {
+  name: yup.string().required('Required'),
+  description: yup.string().optional(),
+  embeddingModel: yup.object({
+    id: yup.string().required('Required')
+  }),
+  llm: yup.object({
+    id: yup.string().required('Required')
+  })
+};
+```
+
+### Migration Notes
+
+- No migration required for end users
+- Plugin developers using `QuickConfigureInputs` should update to `QuickConfigureOptionalFields`
+- Error handling components now expect `errorMessages` array instead of single `errorMessage` string
+
+## Limitations
+
+- Version check for search query section requires async call to get effective version
+- Model selection is now mandatory for non-custom presets (previously optional)
+- Error display limited to processor-level errors; form validation errors shown separately
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#604](https://github.com/opensearch-project/dashboards-flow-framework/pull/604) | Refactor quick configure components; improve processor error handling |
+| [#605](https://github.com/opensearch-project/dashboards-flow-framework/pull/605) | Hide search query section when version is less than 2.19 |
+
+## References
+
+- [Issue #550](https://github.com/opensearch-project/dashboards-flow-framework/issues/550): Hide ProcessorList component for SEARCH_REQUEST when version < 2.19.0
+- [PR #586](https://github.com/opensearch-project/dashboards-flow-framework/pull/586): Previous UX updates (continuation)
+- [AI Search Flows Documentation](https://docs.opensearch.org/3.0/vector-search/ai-search/workflow-builder/)
+- [dashboards-flow-framework Repository](https://github.com/opensearch-project/dashboards-flow-framework)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-flow-framework/ai-search-flows.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -121,6 +121,7 @@
 ## dashboards-flow-framework
 
 - [AI Search Flows](features/dashboards-flow-framework/ai-search-flows.md)
+- [AI Search Flows Dashboards Bug Fixes](features/dashboards-flow-framework/ai-search-flows-dashboards-bugfixes.md)
 - [Dashboards BWC](features/dashboards-flow-framework/dashboards-bwc.md)
 - [Data Ingestion Dashboards](features/dashboards-flow-framework/data-ingestion-dashboards.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the AI Search Flows Dashboards bug fixes in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/dashboards-flow-framework/ai-search-flows-dashboards-bugfixes.md`
- Feature report: `docs/features/dashboards-flow-framework/ai-search-flows.md` (updated)

### Key Changes in v3.0.0

**PR #604 - Quick Configure Refactoring & Error Handling:**
- Refactored quick configure components to use Formik for form state management
- Models are now required for applicable presets (semantic search, hybrid search, RAG)
- Improved processor error handling with dynamic error display in accordion headers
- Enhanced Inspector's errors tab to support multiple errors

**PR #605 - Version Compatibility:**
- Hide search query section when OpenSearch version < 2.19.0
- Improved UI spacing between search_query and search_response sections

### Resources Used
- PR: [#604](https://github.com/opensearch-project/dashboards-flow-framework/pull/604)
- PR: [#605](https://github.com/opensearch-project/dashboards-flow-framework/pull/605)
- Issue: [#550](https://github.com/opensearch-project/dashboards-flow-framework/issues/550)
- Docs: https://docs.opensearch.org/3.0/vector-search/ai-search/workflow-builder/

Closes #214