### PR TITLE
docs: add Remote Metadata Store Compatibility report for v3.0.0

### DIFF
--- a/docs/features/opensearch-remote-metadata-sdk/remote-metadata-sdk.md
+++ b/docs/features/opensearch-remote-metadata-sdk/remote-metadata-sdk.md
@@ -141,6 +141,7 @@ The following plugins support multi-tenancy with remote metadata storage:
 | v3.3.0 | [#236](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/236) | Throw exception on empty string for put request ID |
 | v3.3.0 | [#250](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/250) | Update argument type for ThreadContextAccess:doPrivileged |
 | v3.3.0 | [#254](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/254) | Use AccessController instead of ThreadContextAccess |
+| v3.0.0 | [#73](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/73) | Update o.o.client imports to o.o.transport.client for JPMS compatibility |
 | v3.0.0 | [#124](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/124) | Add a developer guide |
 | v3.0.0 | [#114](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/114) | Fix version conflict check for update |
 | v3.0.0 | [#121](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/121) | Use SdkClientDelegate's classloader for ServiceLoader |
@@ -174,5 +175,6 @@ The following plugins support multi-tenancy with remote metadata storage:
 
 - **v3.4.0** (2026-01-14): Add CMK support for encrypting/decrypting customer data in DynamoDB backend with STS role assumption for cross-account access (PRs #271, #295); Fix error when updating global model status (PR #291)
 - **v3.3.0** (2025-09-22): Added SeqNo/PrimaryTerm support for Put and Delete requests, RefreshPolicy and timeout configuration for write operations, empty string ID validation fix, and ThreadContextAccess API compatibility fixes (PRs #234, #244, #236, #250, #254)
+- **v3.0.0** (2025-05-06): Update `Client` import path from `org.opensearch.client.Client` to `org.opensearch.transport.client.Client` for JPMS compatibility with OpenSearch 3.0.0 (PR #73)
 - **v3.0.0** (2025-05-06): Bug fixes for version conflict detection, DynamoDB consistency, error handling, response passthrough, URL encoding, and request validation (PRs #114, #121, #128, #130, #141, #156, #157, #158)
 - **v3.0.0** (2025-05-06): Added developer guide with migration instructions (PR #124)

--- a/docs/releases/v3.0.0/features/opensearch-remote-metadata-sdk/remote-metadata-store-compatibility.md
+++ b/docs/releases/v3.0.0/features/opensearch-remote-metadata-sdk/remote-metadata-store-compatibility.md
@@ -1,0 +1,56 @@
+# Remote Metadata Store Compatibility
+
+## Summary
+
+This release item updates the OpenSearch Remote Metadata SDK to be compatible with OpenSearch 3.0.0 by refactoring the `Client` import path from `org.opensearch.client.Client` to `org.opensearch.transport.client.Client`. This change aligns with the JPMS (Java Platform Module System) refactoring in OpenSearch core that moved the client package to resolve split package issues.
+
+## Details
+
+### What's New in v3.0.0
+
+The Remote Metadata SDK required an import path update to maintain compatibility with OpenSearch 3.0.0. The OpenSearch core team refactored the `:server` module's `org.opensearch.client` package to `org.opensearch.transport.client` as part of JPMS support work.
+
+### Technical Changes
+
+#### Import Path Migration
+
+| Before (2.x) | After (3.0.0) |
+|--------------|---------------|
+| `org.opensearch.client.Client` | `org.opensearch.transport.client.Client` |
+
+#### Affected Files
+
+| File | Module |
+|------|--------|
+| `LocalClusterIndicesClient.java` | core |
+| `SdkClientFactory.java` | core |
+| `LocalClusterIndicesClientTests.java` | core (test) |
+| `SdkClientFactoryTests.java` | core (test) |
+| `AOSSdkClientFactoryTests.java` | aos-client (test) |
+| `DDBSdkClientFactoryTests.java` | ddb-client (test) |
+| `RemoteSdkClientFactoryTests.java` | remote-client (test) |
+
+### Migration Notes
+
+Plugin developers using the Remote Metadata SDK with OpenSearch 3.0.0 should ensure they are using the 3.0.0 version of the SDK. No code changes are required in consuming plugins as the SDK handles the client interface internally.
+
+## Limitations
+
+- This is a breaking change from OpenSearch 2.x - plugins must use the matching SDK version for their OpenSearch version
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [opensearch-remote-metadata-sdk#73](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/73) | Update o.o.client imports to o.o.transport.client |
+| [OpenSearch#17272](https://github.com/opensearch-project/OpenSearch/pull/17272) | [JPMS Support] Refactoring of `org.opensearch.client` from `:server` module |
+
+## References
+
+- [PR #73](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/73): Import path update
+- [OpenSearch PR #17272](https://github.com/opensearch-project/OpenSearch/pull/17272): JPMS refactoring in OpenSearch core
+- [Issue #8110](https://github.com/opensearch-project/OpenSearch/issues/8110): JPMS support tracking issue
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch-remote-metadata-sdk/remote-metadata-sdk.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -154,6 +154,7 @@
 
 ## opensearch-remote-metadata-sdk
 
+- [Remote Metadata Store Compatibility](features/opensearch-remote-metadata-sdk/remote-metadata-store-compatibility.md)
 - [Remote Metadata Store Documentation](features/opensearch-remote-metadata-sdk/remote-metadata-store-documentation.md)
 - [Remote Metadata Store Bugfixes](features/opensearch-remote-metadata-sdk/remote-metadata-store-bugfixes.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Remote Metadata Store Compatibility update in OpenSearch v3.0.0.

### Changes

- **Release Report**: `docs/releases/v3.0.0/features/opensearch-remote-metadata-sdk/remote-metadata-store-compatibility.md`
  - Documents the `Client` import path migration from `org.opensearch.client.Client` to `org.opensearch.transport.client.Client`
  - Explains the JPMS compatibility requirement with OpenSearch 3.0.0

- **Feature Report Update**: `docs/features/opensearch-remote-metadata-sdk/remote-metadata-sdk.md`
  - Added PR #73 to Related PRs table
  - Added entry to Change History

- **Release Index Update**: `docs/releases/v3.0.0/index.md`
  - Added link to new release report

### Related Issue

Closes #213

### Related PRs

- [opensearch-remote-metadata-sdk#73](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/73): Update o.o.client imports to o.o.transport.client
- [OpenSearch#17272](https://github.com/opensearch-project/OpenSearch/pull/17272): [JPMS Support] Refactoring of `org.opensearch.client` from `:server` module