### PR TITLE
docs: add Alerting Improvements report for v3.0.0

### DIFF
--- a/docs/features/alerting-dashboards-plugin/alerting-summary-insights.md
+++ b/docs/features/alerting-dashboards-plugin/alerting-summary-insights.md
@@ -92,7 +92,7 @@ flowchart TB
 | `assistant.alertInsight.enabled` | Enable/disable alert insights | `false` | `opensearch_dashboards.yml` |
 | `DEFAULT_LOG_PATTERN_TOP_N` | Number of top log patterns | `3` | `constants.js` |
 | `DEFAULT_LOG_PATTERN_SAMPLE_SIZE` | Sample size for patterns | `20` | `constants.js` |
-| `DEFAULT_ACTIVE_ALERTS_TOP_N` | Max alerts in context | `10` | `constants.js` |
+| `DEFAULT_ACTIVE_ALERTS_AI_TOP_N` | Max alerts in AI summary context | `1` | `constants.js` |
 | `DEFAULT_DSL_QUERY_DATE_FORMAT` | DSL date format | `YYYY-MM-DDTHH:mm:ssZ` | `constants.js` |
 | `DEFAULT_PPL_QUERY_DATE_FORMAT` | PPL date format | `YYYY-MM-DD HH:mm:ss` | `constants.js` |
 
@@ -168,7 +168,7 @@ The feature translates DSL filters to PPL for log pattern analysis:
 - Log pattern analysis requires monitors created via visual editor
 - Requires dashboards-assistant plugin installation
 - LLM model must be deployed and configured
-- Context limited to 10 active alerts for token management
+- Only the latest active alert is included in AI summary context (v3.0.0+)
 - PPL patterns command required for log pattern extraction
 - Only first index supported for multi-index monitors
 
@@ -176,16 +176,18 @@ The feature translates DSL filters to PPL for log pattern analysis:
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.0.0 | [#1220](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1220) | Only use latest active alert for alert summary context |
 | v2.18.0 | [#996](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/996) | Context aware alert analysis |
 | v2.18.0 | [#1119](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1119) | Support top N log pattern data |
 
 ## References
 
 - [Issue #995](https://github.com/opensearch-project/alerting-dashboards-plugin/issues/995): Original feature request
-- [Alert Insights Documentation](https://docs.opensearch.org/2.18/dashboards/dashboards-assistant/alert-insight/): Official docs
+- [Alert Insights Documentation](https://docs.opensearch.org/3.0/dashboards/dashboards-assistant/alert-insight/): Official docs
 - [Flow Framework Templates](https://github.com/opensearch-project/flow-framework/tree/2.x/sample-templates): Agent templates
-- [OpenSearch Assistant Toolkit](https://docs.opensearch.org/2.18/ml-commons-plugin/opensearch-assistant/): Assistant overview
+- [OpenSearch Assistant Toolkit](https://docs.opensearch.org/3.0/ml-commons-plugin/opensearch-assistant/): Assistant overview
 
 ## Change History
 
+- **v3.0.0** (2025-01-07): Optimized alert context to use only latest active alert for AI summaries
 - **v2.18.0** (2024-11-05): Initial implementation with context-aware alert analysis and log pattern support

--- a/docs/releases/v3.0.0/features/alerting-dashboards-plugin/alerting-improvements.md
+++ b/docs/releases/v3.0.0/features/alerting-dashboards-plugin/alerting-improvements.md
@@ -1,0 +1,67 @@
+# Alerting Improvements
+
+## Summary
+
+This release includes a refactoring change to the alert summary context feature in the Alerting Dashboards Plugin. The change optimizes the alert context sent to AI agents by limiting it to only the latest active alert instead of multiple alerts, improving the relevance and focus of AI-generated summaries.
+
+## Details
+
+### What's New in v3.0.0
+
+The `DEFAULT_ACTIVE_ALERTS_TOP_N` constant has been renamed to `DEFAULT_ACTIVE_ALERTS_AI_TOP_N` and its value reduced from 10 to 1. This change ensures that when generating AI-powered alert summaries, only the most recent active alert is included in the context sent to the LLM.
+
+### Technical Changes
+
+#### Configuration Changes
+
+| Setting | Previous Value | New Value | Description |
+|---------|---------------|-----------|-------------|
+| `DEFAULT_ACTIVE_ALERTS_AI_TOP_N` | 10 (as `DEFAULT_ACTIVE_ALERTS_TOP_N`) | 1 | Number of active alerts included in AI summary context |
+
+#### Code Changes
+
+The change affects two files in the alerting-dashboards-plugin:
+
+1. `public/pages/Dashboard/utils/constants.js`:
+   - Renamed `DEFAULT_ACTIVE_ALERTS_TOP_N` to `DEFAULT_ACTIVE_ALERTS_AI_TOP_N`
+   - Changed value from 10 to 1
+
+2. `public/pages/Dashboard/utils/tableUtils.js`:
+   - Updated import to use new constant name
+   - Alert filtering now uses `DEFAULT_ACTIVE_ALERTS_AI_TOP_N`
+
+### Rationale
+
+By focusing on only the latest active alert:
+- AI summaries are more focused and relevant
+- Token usage is reduced when calling LLM APIs
+- The most current alert state is prioritized for analysis
+- Response quality improves by avoiding context dilution from older alerts
+
+### Usage Example
+
+The change is transparent to users. When viewing alert insights in OpenSearch Dashboards:
+
+1. Navigate to **OpenSearch Plugins > Alerting**
+2. Hover over alerts to see the sparkle icon
+3. Click to view the AI-generated summary based on the latest active alert
+
+## Limitations
+
+- Only the most recent active alert is analyzed for AI summaries
+- Historical alert context is not included in AI analysis
+- Requires dashboards-assistant plugin for AI features
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#1220](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1220) | Only use latest active alert for alert summary context |
+
+## References
+
+- [Alert Insights Documentation](https://docs.opensearch.org/3.0/dashboards/dashboards-assistant/alert-insight/): Official docs
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/alerting-dashboards-plugin/alerting-summary-insights.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -227,6 +227,10 @@
 
 - [Alerting Bugfixes](features/alerting/alerting-bugfixes.md)
 
+## alerting-dashboards-plugin
+
+- [Alerting Improvements](features/alerting-dashboards-plugin/alerting-improvements.md)
+
 ## query-insights
 
 - [Query Insights](features/query-insights/query-insights.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Alerting Improvements in OpenSearch v3.0.0.

### Changes

**Release Report Created:**
- `docs/releases/v3.0.0/features/alerting-dashboards-plugin/alerting-improvements.md`

**Feature Report Updated:**
- `docs/features/alerting-dashboards-plugin/alerting-summary-insights.md`
  - Updated configuration table with new constant name (`DEFAULT_ACTIVE_ALERTS_AI_TOP_N`)
  - Updated limitations section
  - Added v3.0.0 PR to related PRs table
  - Added v3.0.0 entry to change history

**Release Index Updated:**
- `docs/releases/v3.0.0/index.md` - Added alerting-dashboards-plugin section

### Key Changes in v3.0.0

- Renamed `DEFAULT_ACTIVE_ALERTS_TOP_N` to `DEFAULT_ACTIVE_ALERTS_AI_TOP_N`
- Reduced value from 10 to 1 to focus AI summaries on the latest active alert
- Improves relevance and reduces token usage for LLM-based alert analysis

### Related Issue

Closes #211