### PR TITLE
docs: add Skills Plugin Compatibility report for v3.0.0

### DIFF
--- a/docs/features/skills/skills-tools.md
+++ b/docs/features/skills/skills-tools.md
@@ -163,6 +163,8 @@ The `type` parameter (defaults to `Opensearch`) is passed to the LLM model as `d
 | v3.1.0 | [#587](https://github.com/opensearch-project/skills/pull/587) | Add data source type parameter to PPLTool for Spark/S3 support |
 | v3.1.0 | [#581](https://github.com/opensearch-project/skills/pull/581) | Fix fields bug in PPL tool (multi-field mapping support) |
 | v3.1.0 | [#575](https://github.com/opensearch-project/skills/pull/575) | Fix conflict in dependency versions |
+| v3.0.0 | [#553](https://github.com/opensearch-project/skills/pull/553) | Support phasing off SecurityManager usage in favor of Java Agent |
+| v3.0.0 | [#549](https://github.com/opensearch-project/skills/pull/549) | Add attributes to tools to adapt the upstream changes |
 | v3.0.0 | [#547](https://github.com/opensearch-project/skills/pull/547) | Add WebSearchTool |
 | v3.0.0 | [#541](https://github.com/opensearch-project/skills/pull/541) | Fix PPLTool empty list bug |
 | v3.0.0 | [#529](https://github.com/opensearch-project/skills/pull/529) | Update ML Commons dependencies |
@@ -186,5 +188,5 @@ The `type` parameter (defaults to `Opensearch`) is passed to the LLM model as `d
 - **v3.3.0** (2026-01-11): Added LogPatternAnalysisTool for intelligent log pattern detection with sequence analysis and time-based comparison; added DataDistributionTool for statistical distribution analysis with divergence calculation; enhanced PPLTool to include mappings, current_time, and os_version when passing to SageMaker; fixed WebSearchTool using AsyncHttpClient from ml-commons; fixed DataDistributionTool to remove baselinePercentage when no baseline provided
 - **v3.2.0** (2026-01-11): Added index schema merging for PPLTool when using index patterns (merges mappings from all matching indexes); added error message masking in PPLTool to redact SageMaker ARNs and AWS account numbers; standardized parameter handling across all tools using `extractInputParameters` utility
 - **v3.1.0** (2025-05-06): Added data source type parameter (`datasourceType`) to PPLTool for Spark/S3 data source support; fixed PPLTool fields bug to properly expose multi-field mappings (e.g., `a.keyword`) to LLM for aggregation queries; fixed httpclient5 dependency version conflict in build.gradle, applied Spotless code formatting to WebSearchTool
-- **v3.0.0** (2025-02-25): Added WebSearchTool, fixed PPLTool empty list bug, updated dependencies, enhanced developer guide
+- **v3.0.0** (2025-02-25): Added WebSearchTool, fixed PPLTool empty list bug, updated dependencies, enhanced developer guide; added `attributes` field to all tool classes for ML Commons Plan-Execute-Reflect agent compatibility ([#549](https://github.com/opensearch-project/skills/pull/549)); added Java Agent plugin support for SecurityManager deprecation ([#553](https://github.com/opensearch-project/skills/pull/553))
 - **v2.18.0** (2024-11-12): Added LogPatternTool for log pattern analysis, added customizable prompt support for CreateAnomalyDetectorTool

--- a/docs/releases/v3.0.0/features/skills/skills-plugin-compatibility.md
+++ b/docs/releases/v3.0.0/features/skills/skills-plugin-compatibility.md
@@ -1,0 +1,83 @@
+# Skills Plugin Compatibility
+
+## Summary
+
+OpenSearch 3.0.0 includes compatibility updates for the Skills plugin to support upstream changes in ML Commons and the transition from Java SecurityManager to Java Agent. These changes ensure the Skills plugin tools work correctly with the new Plan-Execute-Reflect agent type and the modernized security model.
+
+## Details
+
+### What's New in v3.0.0
+
+Two key compatibility updates were made to the Skills plugin:
+
+1. **Tool Attributes Support**: Added `attributes` field to all tool classes to adapt to changes in ML Commons that introduced function calling interface for agents
+2. **Java Agent Support**: Added support for running plugin tests under Java Agent instead of the deprecated SecurityManager
+
+### Technical Changes
+
+#### Tool Attributes Addition
+
+The ML Commons [PR #3716](https://github.com/opensearch-project/ml-commons/pull/3716) introduced a new Plan-Execute-Reflect agent type with function calling interface. This required all tools to support an `attributes` field for enhanced tool metadata.
+
+**Affected Tool Classes:**
+
+| Tool Class | Change |
+|------------|--------|
+| `AbstractRetrieverTool` | Added `attributes` field |
+| `CreateAlertTool` | Added `attributes` with getter/setter |
+| `CreateAnomalyDetectorTool` | Added `attributes` field |
+| `LogPatternTool` | Added `attributes` field |
+| `PPLTool` | Added `attributes` field |
+| `RAGTool` | Added `attributes` field |
+| `SearchAlertsTool` | Added `attributes` with getter/setter |
+| `SearchAnomalyDetectorsTool` | Added `attributes` with getter/setter |
+| `SearchAnomalyResultsTool` | Added `attributes` with getter/setter |
+| `SearchMonitorsTool` | Added `attributes` with getter/setter |
+| `WebSearchTool` | Added `attributes` field |
+
+**Code Change Example:**
+```java
+// Added to tool classes
+@Getter
+@Setter
+private Map<String, Object> attributes;
+```
+
+#### Java Agent Plugin Support
+
+Java's SecurityManager is deprecated and being phased out. OpenSearch 3.0.0 introduces Java Agent as the replacement security mechanism. The Skills plugin was updated to support running tests under Java Agent.
+
+**Build Configuration Change:**
+```gradle
+apply plugin: 'opensearch.java-agent'
+```
+
+This allows the plugin tests to execute under the new Java Agent security model, ensuring compatibility with OpenSearch 3.0.0's modernized security infrastructure.
+
+### Migration Notes
+
+- **No user action required**: These are internal compatibility changes
+- Tools continue to work as before with existing agent configurations
+- The `attributes` field is optional and used internally by the agent framework
+
+## Limitations
+
+- These changes are purely for compatibility; no new user-facing features are added
+- The `attributes` field usage is determined by the ML Commons agent framework
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#549](https://github.com/opensearch-project/skills/pull/549) | Add attributes to tools to adapt the upstream changes |
+| [#553](https://github.com/opensearch-project/skills/pull/553) | Support phasing off SecurityManager usage in favor of Java Agent |
+
+## References
+
+- [ML Commons PR #3716](https://github.com/opensearch-project/ml-commons/pull/3716): Plan, Execute and Reflect Agent Type (upstream change)
+- [Tools Documentation](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/tools/index/): Official tools documentation
+- [Plan-Execute-Reflect Agent](https://docs.opensearch.org/3.0/ml-commons-plugin/agents-tools/agents/plan-execute-reflect/): Agent documentation
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/skills/skills-tools.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -238,6 +238,7 @@
 ## skills
 
 - [Skills / Tools Bugfixes and Enhancements](features/skills/skills-tools-bugfixes.md)
+- [Skills Plugin Compatibility](features/skills/skills-plugin-compatibility.md)
 
 ## security-analytics
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Skills Plugin Compatibility updates in OpenSearch v3.0.0.

### Changes

**Release Report Created:**
- `docs/releases/v3.0.0/features/skills/skills-plugin-compatibility.md`

**Feature Report Updated:**
- `docs/features/skills/skills-tools.md` - Added v3.0.0 compatibility changes to Change History and Related PRs

### Key Changes in v3.0.0

1. **Tool Attributes Support** ([#549](https://github.com/opensearch-project/skills/pull/549))
   - Added `attributes` field to all tool classes
   - Required for ML Commons Plan-Execute-Reflect agent compatibility

2. **Java Agent Support** ([#553](https://github.com/opensearch-project/skills/pull/553))
   - Added `opensearch.java-agent` plugin support
   - Enables tests to run under Java Agent instead of deprecated SecurityManager

### Related Issue
Closes #209