### PR TITLE
docs: add k-NN Derived Source & Codec Refactoring report for v3.0.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -554,6 +554,7 @@
 - [k-NN Query Rescore](k-nn/k-nn-query-rescore.md)
 - [k-NN Space Type Configuration](k-nn/k-nn-space-type-configuration.md)
 - [k-NN Memory Optimized Warmup](k-nn/k-nn-memory-optimized-warmup.md)
+- [k-NN Derived Source & Codec Refactoring](k-nn/k-nn-derived-source-codec-refactoring.md)
 - [Lucene On Faiss (Memory Optimized Search)](k-nn/lucene-on-faiss.md)
 - [Remote Vector Index Build](k-nn/remote-vector-index-build.md)
 

--- a/docs/features/k-nn/k-nn-derived-source-codec-refactoring.md
+++ b/docs/features/k-nn/k-nn-derived-source-codec-refactoring.md
@@ -1,0 +1,201 @@
+# k-NN Derived Source & Codec Refactoring
+
+## Summary
+
+The k-NN plugin's derived source feature enables significant storage savings by avoiding duplicate storage of vector data in the `_source` field. Instead of storing vectors in both `_source` and the vector index files, derived source stores a compact mask in `_source` and reconstructs vectors on-demand from the FlatVectorsFormat files (.vec). This can reduce storage by up to 50% or more for vector-heavy workloads. The codec refactoring introduces a `backwards_codecs` package for managing legacy codecs and consolidates field mappers into a unified `EngineFieldMapper`.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Document Storage"
+        A[Original Document] --> B{Derived Source?}
+        B -->|Enabled| C[_source with mask]
+        B -->|Disabled| D[_source with vectors]
+        C --> E[.fdt files - smaller]
+        D --> F[.fdt files - larger]
+    end
+    
+    subgraph "Vector Storage"
+        G[Vector Data] --> H[.vec files]
+        G --> I[.hnsw/.faiss files]
+    end
+    
+    subgraph "Document Retrieval"
+        J[Search Request] --> K{Need vectors?}
+        K -->|Yes| L[Read mask + .vec]
+        L --> M[Reconstruct document]
+        K -->|No| N[Return masked doc]
+    end
+```
+
+### Data Flow
+
+```mermaid
+flowchart LR
+    subgraph Ingestion
+        A[Index Request] --> B[Parse Document]
+        B --> C[Extract Vectors]
+        C --> D[Create Mask]
+        D --> E[Store _source with mask]
+        C --> F[Store in .vec]
+        C --> G[Build ANN Index]
+    end
+    
+    subgraph Retrieval
+        H[Fetch Request] --> I[Read _source]
+        I --> J[Detect Mask]
+        J --> K[Read .vec]
+        K --> L[Replace Mask]
+        L --> M[Return Document]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `KNN10010DerivedSourceStoredFieldsFormat` | Custom StoredFieldsFormat that intercepts _source reads/writes |
+| `EngineFieldMapper` | Unified field mapper for FAISS, Lucene, and NMSLIB engines |
+| `ModelFieldMapper` | Field mapper for pre-trained model configurations |
+| `FlatFieldMapper` | Field mapper for non-ANN vector indexing |
+| `backwards_codecs` package | Contains read-only legacy codecs for backward compatibility |
+| `KNN9120Codec` | Legacy codec for reading pre-3.0 segments |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.knn.derived_source.enabled` | Enable derived source for vector fields | `false` |
+| `index.knn.derived_source.translog.enabled` | Enable derived source in translog | `true` (when derived_source enabled) |
+
+### Usage Example
+
+```json
+PUT my-knn-index
+{
+  "settings": {
+    "index": {
+      "knn": true,
+      "knn.derived_source.enabled": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 128,
+        "method": {
+          "name": "hnsw",
+          "space_type": "l2",
+          "engine": "faiss",
+          "parameters": {
+            "ef_construction": 256,
+            "m": 16
+          }
+        }
+      },
+      "title": {
+        "type": "text"
+      }
+    }
+  }
+}
+```
+
+### Storage Comparison
+
+Based on experiments with 10K 128-dimensional vectors:
+
+| Configuration | Total Size | _source Size | Savings |
+|---------------|------------|--------------|---------|
+| Default | 24.3 MB | 14.6 MB | - |
+| ZSTD Compression | 18.3 MB | 8.64 MB | 25% |
+| Derived Source | ~12 MB | ~0.5 MB | 50%+ |
+
+### Codec Architecture
+
+```mermaid
+graph TB
+    subgraph "Current Codec (v3.0.0)"
+        A[KNNCodec] --> B[KNN10010Codec]
+        B --> C[DerivedSourceStoredFieldsFormat]
+        B --> D[KNNVectorsFormat]
+    end
+    
+    subgraph "Backwards Codecs"
+        E[KNN9120Codec] --> F[Legacy StoredFieldsFormat]
+        E --> G[Legacy VectorsFormat]
+    end
+    
+    H[Segment Reader] --> I{Codec Version?}
+    I -->|Current| A
+    I -->|Legacy| E
+```
+
+### Field Mapper Hierarchy
+
+```mermaid
+classDiagram
+    class KNNVectorFieldMapper {
+        <<abstract>>
+        +parseCreateField()
+        +contentType()
+    }
+    
+    class EngineFieldMapper {
+        +engine: KNNEngine
+        +spaceType: SpaceType
+        +methodParameters: Map
+    }
+    
+    class ModelFieldMapper {
+        +modelId: String
+    }
+    
+    class FlatFieldMapper {
+        +dimension: int
+    }
+    
+    KNNVectorFieldMapper <|-- EngineFieldMapper
+    KNNVectorFieldMapper <|-- ModelFieldMapper
+    KNNVectorFieldMapper <|-- FlatFieldMapper
+```
+
+## Limitations
+
+- Derived source requires all vector fields to support reconstruction from .vec files
+- Operation-based recovery may be slower with derived source enabled
+- Nested document handling requires segment-level migration during merges
+- NMSLIB engine is blocked for new index creation in v3.0.0+
+- Deprecated index-level settings (`ef_construction`, `m`, `space_type`) are removed
+
+## Related PRs
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.0.0 | [#2606](https://github.com/opensearch-project/k-NN/pull/2606) | Switch derived source from field attributes to segment attribute |
+| v3.0.0 | [#2612](https://github.com/opensearch-project/k-NN/pull/2612) | Migrate derived source from filter to mask |
+| v3.0.0 | [#2646](https://github.com/opensearch-project/k-NN/pull/2646) | Consolidate MethodFieldMapper and LuceneFieldMapper into EngineFieldMapper |
+| v3.0.0 | [#2541](https://github.com/opensearch-project/k-NN/pull/2541) | Small Refactor Post Lucene 10.0.1 upgrade |
+| v3.0.0 | [#2546](https://github.com/opensearch-project/k-NN/pull/2546) | Refactor codec to leverage backwards_codecs |
+| v3.0.0 | [#2573](https://github.com/opensearch-project/k-NN/pull/2573) | Blocking Index Creation using NMSLIB |
+| v3.0.0 | [#2575](https://github.com/opensearch-project/k-NN/pull/2575) | Improve Streaming Compatibility Issue for MethodComponentContext |
+| v3.0.0 | [#2564](https://github.com/opensearch-project/k-NN/pull/2564) | 3.0.0 Breaking Changes For KNN |
+
+## References
+
+- [Issue #2377](https://github.com/opensearch-project/k-NN/issues/2377): RFC - Derived Source for Vectors
+- [Issue #2539](https://github.com/opensearch-project/k-NN/issues/2539): Introduce backwards_codecs to manage older codecs
+- [Issue #2631](https://github.com/opensearch-project/k-NN/issues/2631): Merge MethodFieldMapper and LuceneFieldMapper into EngineFieldMapper
+- [Issue #2640](https://github.com/opensearch-project/k-NN/issues/2640): Remove doc values for lucene engine
+- [Blog: Save up to 2x on storage with derived source](https://opensearch.org/blog/save-up-to-2x-on-storage-with-derived-source/)
+- [Documentation: k-NN vector field type](https://docs.opensearch.org/3.0/field-types/supported-field-types/knn-vector/)
+- [Documentation: Source field - Derived source](https://docs.opensearch.org/3.0/field-types/metadata-fields/source/#derived-source)
+- [Documentation: Breaking changes](https://docs.opensearch.org/3.0/breaking-changes/)
+
+## Change History
+
+- **v3.0.0** (2025-05-13): Initial implementation - derived source mask approach, codec refactoring, field mapper consolidation, NMSLIB deprecation, removal of deprecated settings

--- a/docs/releases/v3.0.0/features/k-nn/derived-source-codec-refactoring.md
+++ b/docs/releases/v3.0.0/features/k-nn/derived-source-codec-refactoring.md
@@ -1,0 +1,170 @@
+# k-NN Derived Source & Codec Refactoring
+
+## Summary
+
+OpenSearch 3.0.0 introduces significant refactoring to the k-NN plugin's derived source handling and codec implementation. These changes improve storage efficiency, simplify the codebase architecture, and remove deprecated features as part of the major version upgrade. The refactoring includes migrating derived source from a filter-based to a mask-based approach, consolidating field mappers, introducing a backwards_codecs package for legacy codec management, and removing deprecated settings and NMSLIB support for new index creation.
+
+## Details
+
+### What's New in v3.0.0
+
+#### Derived Source Improvements
+
+The derived source feature for k-NN vectors underwent two major refactoring phases:
+
+1. **Segment Attribute Migration** (PR #2606): Switched from storing derived source information in field attributes to segment attributes. This simplifies mapper logic and provides access to nested scope information via the mapper service.
+
+2. **Filter to Mask Migration** (PR #2612): Changed the approach from filtering vector fields out of source to replacing them with a smaller mask representation. When vectors need to be retrieved, the mask is replaced with actual vectors from the FlatVectorsFormat files (.vec). This makes handling nested documents significantly easier.
+
+#### Codec Refactoring
+
+The codec management system was restructured to follow Lucene's patterns:
+
+- Introduced `backwards_codecs` package for read-only legacy codecs
+- Removed old codecs no longer supported in OpenSearch 3.0
+- Simplified `KNNCodecVersion` class to track only the latest version
+- Removed `KNNFormatFacade` in favor of direct constructor calls
+
+#### Field Mapper Consolidation
+
+Merged `MethodFieldMapper` and `LuceneFieldMapper` into a unified `EngineFieldMapper`:
+
+- Reduces code duplication between native engines (FAISS/NMSLIB) and Lucene
+- Changed default value for docValues to reduce storage overhead
+- Creates cleaner architecture with three mapper types:
+  - `EngineFieldMapper`: Full engine specifications
+  - `ModelFieldMapper`: Pre-trained model configurations
+  - `FlatFieldMapper`: Non-ANN indexing
+
+#### Breaking Changes
+
+Several deprecated features were removed:
+
+| Removed Setting | Migration Path |
+|-----------------|----------------|
+| `knn.plugin.enabled` | Plugin is always enabled when installed |
+| `index.knn.algo_param.ef_construction` | Use mapping-level parameters |
+| `index.knn.algo_param.m` | Use mapping-level parameters |
+| `index.knn.space_type` | Use mapping-level `space_type` |
+| NMSLIB new index creation | Use FAISS or Lucene engine |
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Before v3.0.0"
+        A1[MethodFieldMapper] --> C1[Native Engines]
+        A2[LuceneFieldMapper] --> C2[Lucene Engine]
+        D1[Field Attributes] --> E1[Derived Source Info]
+        F1[Filter Approach] --> G1[Remove vectors from source]
+    end
+    
+    subgraph "v3.0.0"
+        B1[EngineFieldMapper] --> C3[All Engines]
+        D2[Segment Attributes] --> E2[Derived Source Info]
+        F2[Mask Approach] --> G2[Replace vectors with mask]
+    end
+```
+
+#### Derived Source Data Flow
+
+```mermaid
+flowchart TB
+    A[Document Ingestion] --> B{Derived Source Enabled?}
+    B -->|Yes| C[Replace vectors with mask in _source]
+    B -->|No| D[Store full _source]
+    C --> E[Store mask in StoredFields]
+    E --> F[Store vectors in .vec files]
+    
+    G[Document Retrieval] --> H{Need vectors?}
+    H -->|Yes| I[Read mask from _source]
+    I --> J[Read vectors from .vec]
+    J --> K[Replace mask with vectors]
+    K --> L[Return reconstructed document]
+    H -->|No| M[Return document with mask]
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `backwards_codecs` package | Contains read-only legacy codecs for BWC |
+| `KNN9120Codec` | Backwards compatible codec for pre-3.0 segments |
+| `EngineFieldMapper` | Unified field mapper for all k-NN engines |
+| `KNN10010DerivedSourceStoredFieldsFormat` | New stored fields format with mask support |
+
+### Migration Notes
+
+#### For Users with NMSLIB Indices
+
+Existing NMSLIB indices will continue to work for reading and searching. However, new index creation with NMSLIB is blocked. To migrate:
+
+1. Create a new index using FAISS or Lucene engine
+2. Reindex data from the NMSLIB index to the new index
+3. Delete the old NMSLIB index
+
+#### For Users with Deprecated Settings
+
+Remove the following settings from your index configurations:
+- `index.knn.algo_param.ef_construction`
+- `index.knn.algo_param.m`
+- `index.knn.space_type`
+
+Use mapping-level parameters instead:
+
+```json
+{
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 128,
+        "method": {
+          "name": "hnsw",
+          "space_type": "l2",
+          "engine": "faiss",
+          "parameters": {
+            "ef_construction": 256,
+            "m": 16
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- NMSLIB engine cannot be used for new index creation (existing indices remain readable)
+- Derived source mask approach requires segment migration during merges for pre-3.0 segments
+- Operation-based recovery may be slower when derived source is enabled
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#2606](https://github.com/opensearch-project/k-NN/pull/2606) | Switch derived source from field attributes to segment attribute |
+| [#2612](https://github.com/opensearch-project/k-NN/pull/2612) | Migrate derived source from filter to mask |
+| [#2646](https://github.com/opensearch-project/k-NN/pull/2646) | Consolidate MethodFieldMapper and LuceneFieldMapper into EngineFieldMapper |
+| [#2541](https://github.com/opensearch-project/k-NN/pull/2541) | Small Refactor Post Lucene 10.0.1 upgrade |
+| [#2546](https://github.com/opensearch-project/k-NN/pull/2546) | Refactor codec to leverage backwards_codecs |
+| [#2573](https://github.com/opensearch-project/k-NN/pull/2573) | Blocking Index Creation using NMSLIB |
+| [#2575](https://github.com/opensearch-project/k-NN/pull/2575) | Improve Streaming Compatibility Issue for MethodComponentContext |
+| [#2564](https://github.com/opensearch-project/k-NN/pull/2564) | 3.0.0 Breaking Changes For KNN |
+
+## References
+
+- [Issue #2377](https://github.com/opensearch-project/k-NN/issues/2377): RFC - Derived Source for Vectors
+- [Issue #2539](https://github.com/opensearch-project/k-NN/issues/2539): Introduce backwards_codecs to manage older codecs
+- [Issue #2631](https://github.com/opensearch-project/k-NN/issues/2631): Merge MethodFieldMapper and LuceneFieldMapper into EngineFieldMapper
+- [Issue #2640](https://github.com/opensearch-project/k-NN/issues/2640): Remove doc values for lucene engine
+- [Blog: Save up to 2x on storage with derived source](https://opensearch.org/blog/save-up-to-2x-on-storage-with-derived-source/)
+- [Documentation: k-NN vector field type](https://docs.opensearch.org/3.0/field-types/supported-field-types/knn-vector/)
+- [Documentation: Breaking changes](https://docs.opensearch.org/3.0/breaking-changes/)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/k-nn/k-nn-derived-source-codec-refactoring.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -202,6 +202,7 @@
 - [Explain API Support](features/k-nn/explain-api-support.md)
 - [Lucene On Faiss (Memory Optimized Search)](features/k-nn/lucene-on-faiss.md)
 - [Remote Vector Index Build](features/k-nn/remote-vector-index-build.md)
+- [Derived Source & Codec Refactoring](features/k-nn/derived-source-codec-refactoring.md)
 
 ## learning
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the k-NN Derived Source & Codec Refactoring changes in OpenSearch v3.0.0.

## Changes

### Release Report
- `docs/releases/v3.0.0/features/k-nn/derived-source-codec-refactoring.md`

### Feature Report
- `docs/features/k-nn/k-nn-derived-source-codec-refactoring.md`

## Key Topics Covered

1. **Derived Source Improvements**
   - Migration from field attributes to segment attributes
   - Filter to mask approach migration for better nested document handling
   - Storage savings of 50%+ for vector-heavy workloads

2. **Codec Refactoring**
   - Introduction of `backwards_codecs` package
   - Removal of legacy codecs not supported in 3.0
   - Simplified `KNNCodecVersion` class

3. **Field Mapper Consolidation**
   - Merged `MethodFieldMapper` and `LuceneFieldMapper` into `EngineFieldMapper`
   - Reduced code duplication
   - Changed default docValues behavior

4. **Breaking Changes**
   - NMSLIB blocked for new index creation
   - Removed deprecated index-level settings (`ef_construction`, `m`, `space_type`)
   - Removed `knn.plugin.enabled` setting

## Related Issue
Closes #208