### PR TITLE
docs: add Security Dependency Bumps report for v3.0.0

### DIFF
--- a/docs/features/security/security-plugin-dependencies.md
+++ b/docs/features/security/security-plugin-dependencies.md
@@ -106,6 +106,19 @@ Dependency updates in the Security plugin follow this process:
 | v3.1.0 | [#5371](https://github.com/opensearch-project/security/pull/5371) | Bump junit-jupiter 5.12.2 → 5.13.1 |
 | v3.1.0 | [#5292](https://github.com/opensearch-project/security/pull/5292) | Bump jackson-databind |
 | v3.1.0 | [#2231](https://github.com/opensearch-project/security-dashboards-plugin/pull/2231) | Fix CVE-2024-52798 |
+| v3.0.0 | [#5203](https://github.com/opensearch-project/security/pull/5203) | Bump spring_version 6.2.4 → 6.2.5 |
+| v3.0.0 | [#5202](https://github.com/opensearch-project/security/pull/5202) | Bump bouncycastle_version 1.78 → 1.80 |
+| v3.0.0 | [#5231](https://github.com/opensearch-project/security/pull/5231) | Bump google-java-format 1.25.2 → 1.26.0 |
+| v3.0.0 | [#5230](https://github.com/opensearch-project/security/pull/5230) | Bump open_saml_shib_version 9.1.3 → 9.1.4 |
+| v3.0.0 | [#5229](https://github.com/opensearch-project/security/pull/5229) | Bump randomizedtesting-runner 2.8.2 → 2.8.3 |
+| v3.0.0 | [#5227](https://github.com/opensearch-project/security/pull/5227) | Bump open_saml_version 5.1.3 → 5.1.4 |
+| v3.0.0 | [#5244](https://github.com/opensearch-project/security/pull/5244) | Bump asm 9.7.1 → 9.8 |
+| v3.0.0 | [#5246](https://github.com/opensearch-project/security/pull/5246) | Bump nebula.ospackage 11.11.1 → 11.11.2 |
+| v3.0.0 | [#5245](https://github.com/opensearch-project/security/pull/5245) | Bump error_prone_annotations 2.36.0 → 2.37.0 |
+| v3.0.0 | [#5267](https://github.com/opensearch-project/security/pull/5267) | Bump commons-io 2.18.0 → 2.19.0 |
+| v3.0.0 | [#5266](https://github.com/opensearch-project/security/pull/5266) | Bump commons-text 1.13.0 → 1.13.1 |
+| v3.0.0 | [#5268](https://github.com/opensearch-project/security/pull/5268) | Bump junit-jupiter-api 5.12.1 → 5.12.2 |
+| v3.0.0 | [#5265](https://github.com/opensearch-project/security/pull/5265) | Bump failureaccess 1.0.2 → 1.0.3 |
 | v2.18.0 | [#4738](https://github.com/opensearch-project/security/pull/4738) | Bump snappy-java 1.1.10.6 → 1.1.10.7 |
 | v2.18.0 | [#4736](https://github.com/opensearch-project/security/pull/4736) | Bump gradle.test-retry 1.5.10 → 1.6.0 |
 | v2.18.0 | [#4750](https://github.com/opensearch-project/security/pull/4750) | Bump commons-io 2.16.1 → 2.17.0 |
@@ -129,4 +142,5 @@ Dependency updates in the Security plugin follow this process:
 
 - **v3.3.0** (2026-01-14): Security fix for CVE-2025-53864 (nimbus-jose-jwt), plus 24 dependency updates including Spring 6.2.11, JJWT 0.13.0, Guava 33.5.0, and CI tooling updates
 - **v3.1.0** (2025-06-03): Major dependency updates including Bouncy Castle 1.81, Kafka 4.0.0, Spring 6.2.7, Guava 33.4.8, JUnit 5.13.1, and CVE-2024-52798 fix
+- **v3.0.0** (2025-02-25): 13 dependency updates including Spring 6.2.5, Bouncy Castle 1.80, OpenSAML 5.1.4/9.1.4, ASM 9.8, Commons IO 2.19.0, JUnit Jupiter 5.12.2
 - **v2.18.0** (2024-10-22): Updated snappy-java, gradle.test-retry, commons-io, scala-library, checker-qual, and logback-classic

--- a/docs/releases/v3.0.0/features/security/security-dependency-bumps.md
+++ b/docs/releases/v3.0.0/features/security/security-dependency-bumps.md
@@ -1,0 +1,73 @@
+# Security Dependency Bumps
+
+## Summary
+
+OpenSearch Security plugin v3.0.0 includes 13 dependency version bumps to keep the plugin up-to-date with the latest library versions. These updates improve security, stability, and compatibility with newer Java versions.
+
+## Details
+
+### What's New in v3.0.0
+
+This release includes routine dependency updates managed by Dependabot, covering security libraries, testing frameworks, and utility libraries.
+
+### Dependency Updates
+
+| Dependency | Previous Version | New Version | Category |
+|------------|------------------|-------------|----------|
+| Spring Framework | 6.2.4 | 6.2.5 | Core Framework |
+| Bouncy Castle | 1.78 | 1.80 | Cryptography |
+| Google Java Format | 1.25.2 | 1.26.0 | Code Quality |
+| OpenSAML (Shibboleth) | 9.1.3 | 9.1.4 | SAML Authentication |
+| OpenSAML | 5.1.3 | 5.1.4 | SAML Authentication |
+| Randomized Testing Runner | 2.8.2 | 2.8.3 | Testing |
+| ASM | 9.7.1 | 9.8 | Bytecode Manipulation |
+| Nebula OS Package | 11.11.1 | 11.11.2 | Build Tools |
+| Error Prone Annotations | 2.36.0 | 2.37.0 | Code Quality |
+| Commons IO | 2.18.0 | 2.19.0 | Utilities |
+| Commons Text | 1.13.0 | 1.13.1 | Utilities |
+| JUnit Jupiter API | 5.12.1 | 5.12.2 | Testing |
+| Guava Failure Access | 1.0.2 | 1.0.3 | Utilities |
+
+### Key Updates
+
+#### Bouncy Castle 1.80
+The cryptography library update to version 1.80 includes security improvements and bug fixes for cryptographic operations used in TLS/SSL and certificate handling.
+
+#### Spring Framework 6.2.5
+Spring Framework update includes bug fixes for `PathMatchingResourcePatternResolver` and improvements to reactive transaction management.
+
+#### OpenSAML Updates
+Both OpenSAML versions (5.1.4 and Shibboleth 9.1.4) include maintenance updates for SAML-based authentication flows.
+
+## Limitations
+
+- These are maintenance updates with no new features
+- No breaking changes expected from these dependency bumps
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#5203](https://github.com/opensearch-project/security/pull/5203) | Bump spring_version from 6.2.4 to 6.2.5 |
+| [#5202](https://github.com/opensearch-project/security/pull/5202) | Bump bouncycastle_version from 1.78 to 1.80 |
+| [#5231](https://github.com/opensearch-project/security/pull/5231) | Bump google-java-format from 1.25.2 to 1.26.0 |
+| [#5230](https://github.com/opensearch-project/security/pull/5230) | Bump open_saml_shib_version from 9.1.3 to 9.1.4 |
+| [#5229](https://github.com/opensearch-project/security/pull/5229) | Bump randomizedtesting-runner from 2.8.2 to 2.8.3 |
+| [#5227](https://github.com/opensearch-project/security/pull/5227) | Bump open_saml_version from 5.1.3 to 5.1.4 |
+| [#5244](https://github.com/opensearch-project/security/pull/5244) | Bump org.ow2.asm:asm from 9.7.1 to 9.8 |
+| [#5246](https://github.com/opensearch-project/security/pull/5246) | Bump nebula.ospackage from 11.11.1 to 11.11.2 |
+| [#5245](https://github.com/opensearch-project/security/pull/5245) | Bump error_prone_annotations from 2.36.0 to 2.37.0 |
+| [#5267](https://github.com/opensearch-project/security/pull/5267) | Bump commons-io from 2.18.0 to 2.19.0 |
+| [#5266](https://github.com/opensearch-project/security/pull/5266) | Bump commons-text from 1.13.0 to 1.13.1 |
+| [#5268](https://github.com/opensearch-project/security/pull/5268) | Bump junit-jupiter-api from 5.12.1 to 5.12.2 |
+| [#5265](https://github.com/opensearch-project/security/pull/5265) | Bump failureaccess from 1.0.2 to 1.0.3 |
+
+## References
+
+- [OpenSearch Security Repository](https://github.com/opensearch-project/security)
+- [Bouncy Castle Release Notes](https://www.bouncycastle.org/releasenotes.html)
+- [Spring Framework 6.2.5 Release](https://github.com/spring-projects/spring-framework/releases/tag/v6.2.5)
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/security/security-plugin-dependencies.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -118,6 +118,7 @@
 - [Security Plugin Bugfixes for Release 3.0](features/security/release-3-0-bugfixes.md)
 - [Security Plugin Changes](features/security/security-plugin-changes.md)
 - [Security Code Quality & Testing](features/security/security-code-quality-testing.md)
+- [Security Dependency Bumps](features/security/security-dependency-bumps.md)
 - [Systemd Security Configurations](features/security/systemd-security-configurations.md)
 
 ## dashboards-flow-framework


### PR DESCRIPTION
## Summary
Add documentation for Security Dependency Bumps in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/security/security-dependency-bumps.md`
- Feature report: `docs/features/security/security-plugin-dependencies.md` (updated)

### Key Changes in v3.0.0
- Spring Framework 6.2.4 → 6.2.5
- Bouncy Castle 1.78 → 1.80
- OpenSAML 5.1.3 → 5.1.4 and Shibboleth 9.1.3 → 9.1.4
- ASM 9.7.1 → 9.8
- Commons IO 2.18.0 → 2.19.0
- JUnit Jupiter 5.12.1 → 5.12.2
- Plus 7 additional dependency updates

### Resources Used
- PRs: #5203, #5202, #5231, #5230, #5229, #5227, #5244, #5246, #5245, #5267, #5266, #5268, #5265

Closes #206