### PR TITLE
docs: add Query Workbench Dashboards report for v3.0.0

### DIFF
--- a/docs/features/dashboards-query-workbench/query-workbench.md
+++ b/docs/features/dashboards-query-workbench/query-workbench.md
@@ -111,6 +111,9 @@ source=orders
 
 | Version | PR | Description |
 |---------|-----|-------------|
+| v3.0.0 | [#130](https://github.com/opensearch-project/dashboards-query-workbench/pull/130) | Update packages and tsconfig |
+| v3.0.0 | [#133](https://github.com/opensearch-project/dashboards-query-workbench/pull/133) | Update form validations and tests for acceleration |
+| v3.0.0 | [#139](https://github.com/opensearch-project/dashboards-query-workbench/pull/139) | Updates 2.x branch with opensearch-spark changes |
 | v2.18.0 | [#401](https://github.com/opensearch-project/dashboards-query-workbench/pull/401) | Fix workbench routes to support modal mounting |
 | v2.18.0 | [#408](https://github.com/opensearch-project/dashboards-query-workbench/pull/408) | Added error handling for API calls |
 | v2.17.0 | [#370](https://github.com/opensearch-project/dashboards-query-workbench/pull/370) | Use smaller and compressed variants of buttons and form components |
@@ -124,5 +127,6 @@ source=orders
 
 ## Change History
 
+- **v3.0.0** (2025-02-25): Maintenance updates including dependency bumps (glob-parent, @babel/helpers, @babel/runtime), CI/CD improvements (actions/cache v4), and Cypress test enhancements
 - **v2.18.0** (2024-11-12): Bug fixes for modal mounting support and MDS error handling
 - **v2.17.0** (2024-09-17): UI improvements with smaller and compressed button/form variants for better consistency

--- a/docs/releases/v3.0.0/features/dashboards-query-workbench/query-workbench-dashboards.md
+++ b/docs/releases/v3.0.0/features/dashboards-query-workbench/query-workbench-dashboards.md
@@ -1,0 +1,72 @@
+# Query Workbench Dashboards
+
+## Summary
+
+OpenSearch 3.0.0 includes maintenance updates for the Query Workbench Dashboards plugin, focusing on dependency updates, CI/CD improvements, and bug fixes. These changes ensure compatibility with OpenSearch 3.0.0 and improve build stability.
+
+## Details
+
+### What's New in v3.0.0
+
+This release focuses on infrastructure and dependency maintenance rather than new features:
+
+- **Dependency Updates**: Updated multiple npm packages including `glob-parent`, `@babel/helpers`, `@babel/runtime` to address security vulnerabilities and compatibility issues
+- **CI/CD Improvements**: Upgraded GitHub Actions cache to v4 and improved Cypress test stability
+- **Build Fixes**: Removed `package-lock.json` to resolve dependency conflicts and updated `package.json` configurations
+- **Test Improvements**: Enhanced Cypress tests for dynamic column validation
+
+### Technical Changes
+
+#### Dependency Updates (dashboards-query-workbench)
+
+| PR | Change | Purpose |
+|----|--------|---------|
+| #126 | Updated package.json | General package updates |
+| #130 | Upgrade actions/cache to v4 | CI workflow improvement |
+| #133 | Delete package-lock.json | Resolve dependency conflicts |
+| #134 | Updated glob-parent version | Security fix |
+| #139 | Update @babel/helpers | Compatibility update |
+| #148 | Update default time range to 1h | UX improvement |
+| #156 | Update babel/runtime version | Compatibility update |
+| #168 | Improved Cypress test for dynamic column | Test stability |
+
+#### CI/CD Updates (query-workbench)
+
+| PR | Change | Purpose |
+|----|--------|---------|
+| #463 | Remove cypress version | Use OpenSearch Dashboards version |
+| #460 | Remove download JSON feature | Feature removal |
+| #459 | Minor CI updates and workflow fixes | Build stability |
+| #441 | Update yarn.lock for cross-spawn | Dependency update |
+| #453 | Update CIs to install job-scheduler plugin | Test environment fix |
+
+### Migration Notes
+
+No migration steps required. These are maintenance updates that do not change the Query Workbench user interface or functionality.
+
+## Limitations
+
+- No new features introduced in this release
+- Changes are primarily infrastructure and dependency updates
+
+## Related PRs
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#126](https://github.com/opensearch-project/dashboards-query-workbench/pull/126) | dashboards-query-workbench | Updated package.json |
+| [#130](https://github.com/opensearch-project/dashboards-query-workbench/pull/130) | dashboards-query-workbench | Upgrade actions/cache to v4 |
+| [#133](https://github.com/opensearch-project/dashboards-query-workbench/pull/133) | dashboards-query-workbench | Delete package-lock.json |
+| [#134](https://github.com/opensearch-project/dashboards-query-workbench/pull/134) | dashboards-query-workbench | Updated glob-parent version |
+| [#139](https://github.com/opensearch-project/dashboards-query-workbench/pull/139) | dashboards-query-workbench | Update @babel/helpers |
+| [#148](https://github.com/opensearch-project/dashboards-query-workbench/pull/148) | dashboards-query-workbench | Update default time range to 1h |
+| [#156](https://github.com/opensearch-project/dashboards-query-workbench/pull/156) | dashboards-query-workbench | Update babel/runtime version |
+| [#168](https://github.com/opensearch-project/dashboards-query-workbench/pull/168) | dashboards-query-workbench | Improved Cypress test for dynamic column |
+
+## References
+
+- [Query Workbench Documentation](https://docs.opensearch.org/3.0/dashboards/query-workbench/)
+- [GitHub Issue #205](https://github.com/tkykenmt/opensearch-feature-explorer/issues/205): Tracking issue
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/dashboards-query-workbench/query-workbench.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -198,6 +198,10 @@
 
 - [AI Assistant / Chatbot](features/dashboards-assistant/ai-assistant-chatbot.md)
 
+## dashboards-query-workbench
+
+- [Query Workbench Dashboards](features/dashboards-query-workbench/query-workbench-dashboards.md)
+
 ## k-nn
 
 - [Vector Search (k-NN)](features/k-nn/vector-search-k-nn.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for Query Workbench Dashboards updates in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/dashboards-query-workbench/query-workbench-dashboards.md`
- Feature report: `docs/features/dashboards-query-workbench/query-workbench.md` (updated)

### Key Changes in v3.0.0
- Dependency updates (glob-parent, @babel/helpers, @babel/runtime)
- CI/CD improvements (actions/cache v4)
- Build fixes (package-lock.json removal)
- Cypress test improvements for dynamic column validation

### Related Issue
Closes #205