### PR TITLE
docs: add CVE Fixes & Dependency Updates (Batch 2) report for v3.0.0

### DIFF
--- a/docs/features/multi-plugin/cve-fixes-dependency-updates.md
+++ b/docs/features/multi-plugin/cve-fixes-dependency-updates.md
@@ -102,17 +102,30 @@ No user configuration required. Dependency updates are applied automatically dur
 | v3.0.0 | [#558](https://github.com/opensearch-project/dashboards-reporting/pull/558) | reporting | CVE fix for babel/helpers |
 | v3.0.0 | [#1374](https://github.com/opensearch-project/index-management/pull/1374) | index-management | Bump nebula.ospackage |
 | v3.0.0 | [#338](https://github.com/opensearch-project/dashboards-notifications/pull/338) | notifications | Bump cypress |
+| v3.0.0 | [#3484](https://github.com/opensearch-project/sql/pull/3484) | sql | CVE-2024-57699: Fix json-smart vulnerability |
+| v3.0.0 | [#5173](https://github.com/opensearch-project/security/pull/5173) | security | Bump Spring version (CVE-2024-38827) |
+| v3.0.0 | [#2196](https://github.com/opensearch-project/security-dashboards-plugin/pull/2196) | security-dashboards | Bump xlm-crypto and elliptic |
+| v3.0.0 | [#2200](https://github.com/opensearch-project/security-dashboards-plugin/pull/2200) | security-dashboards | Bump babel to 7.27.0 |
+| v3.0.0 | [#2232](https://github.com/opensearch-project/security-dashboards-plugin/pull/2232) | security-dashboards | Bump express to 5.1.0 |
+| v3.0.0 | [#1077](https://github.com/opensearch-project/reporting/pull/1077) | reporting | Update gradle to 8.12.0 (JDK 23 support) |
+| v3.0.0 | [#5148](https://github.com/opensearch-project/security/pull/5148) | security | Bump Gradle to 8.13 |
+| v3.0.0 | [#5204](https://github.com/opensearch-project/security/pull/5204) | security | Bump logback-classic to 1.5.18 |
+| v3.0.0 | [#5205](https://github.com/opensearch-project/security/pull/5205) | security | Bump guava to 33.4.6-jre |
 
 ## References
 
 - [CVE-2024-4067 (GHSA-952p-6rrq-rcjv)](https://github.com/advisories/GHSA-952p-6rrq-rcjv): micromatch ReDoS vulnerability
 - [CVE-2024-4068](https://nvd.nist.gov/vuln/detail/CVE-2024-4068): braces DoS vulnerability
+- [CVE-2024-38827](https://nvd.nist.gov/vuln/detail/CVE-2024-38827): Spring Security authorization bypass
+- [CVE-2024-57699](https://advisories.opensearch.org/advisories/CVE-2024-57699): json-smart vulnerability (High severity)
 - [CVE-2025-27789](https://nvd.nist.gov/vuln/detail/CVE-2025-27789): @babel/runtime vulnerability
 - [CVE-2025-26791](https://nvd.nist.gov/vuln/detail/CVE-2025-26791): jspdf vulnerability
+- [CVE-2025-29774](https://nvd.nist.gov/vuln/detail/CVE-2025-29774): xml-crypto signature verification bypass
+- [CVE-2025-29775](https://nvd.nist.gov/vuln/detail/CVE-2025-29775): xml-crypto signature verification bypass
 - [CVE-2025-29907](https://nvd.nist.gov/vuln/detail/CVE-2025-29907): jspdf vulnerability
 - [GHSA-vjh7-7g9h-fjfh](https://github.com/advisories/GHSA-vjh7-7g9h-fjfh): elliptic vulnerability
 
 ## Change History
 
-- **v3.0.0** (2025-05-06): Multiple CVE fixes across alerting, security, anomaly-detection, reporting, index-management, and notifications plugins
+- **v3.0.0** (2025-05-06): Multiple CVE fixes across alerting, security, anomaly-detection, reporting, index-management, notifications, sql, and security-dashboards plugins. Includes CVE-2024-57699 (json-smart), CVE-2024-38827 (Spring), and JDK 23 compatibility updates.
 - **v2.17.0** (2024-09-17): CVE-2024-4067 and CVE-2024-4068 fixes across anomaly-detection-dashboards, alerting-dashboards, security-dashboards, and dashboards-observability

--- a/docs/releases/v3.0.0/features/multi-plugin/cve-fixes-dependency-updates-batch2.md
+++ b/docs/releases/v3.0.0/features/multi-plugin/cve-fixes-dependency-updates-batch2.md
@@ -1,0 +1,147 @@
+# CVE Fixes & Dependency Updates (Batch 2)
+
+## Summary
+
+OpenSearch v3.0.0 includes additional security fixes and dependency updates across the learning, security, reporting, and sql plugins. This batch focuses on addressing critical CVEs including json-smart, Spring framework, and various frontend library vulnerabilities, along with Gradle and JDK 23 compatibility updates.
+
+## Details
+
+### What's New in v3.0.0
+
+This batch of updates addresses multiple security vulnerabilities and ensures compatibility with JDK 23 through Gradle updates across several OpenSearch plugins.
+
+### Technical Changes
+
+#### CVEs Addressed
+
+| CVE | Severity | Description | Affected Component | Fix |
+|-----|----------|-------------|-------------------|-----|
+| CVE-2024-57699 | High | json-smart vulnerability allowing denial of service | sql | Upgrade json-smart dependency |
+| CVE-2024-38827 | - | Spring Security authorization bypass | security | Bump Spring version |
+| CVE-2025-27789 | - | @babel/runtime vulnerability | security-dashboards | Bump babel to 7.27.0 |
+| CVE-2025-29774 | - | xml-crypto signature verification bypass | security-dashboards | Bump xlm-crypto |
+| CVE-2025-29775 | - | xml-crypto signature verification bypass | security-dashboards | Bump xlm-crypto |
+| GHSA-vjh7-7g9h-fjfh | - | elliptic ECDSA signature malleability | security-dashboards | Bump elliptic |
+
+#### Dependency Updates by Repository
+
+##### Learning (ml-commons)
+| Dependency | Change | Purpose |
+|------------|--------|---------|
+| http5client | Use core's dependency | Address http5client CVE |
+
+##### Security Plugin
+| Dependency | Old Version | New Version | Purpose |
+|------------|-------------|-------------|---------|
+| commons jar | - | Updated | CVE fixes |
+| Gradle | < 8.10.2 | 8.10.2 | JDK 23 support |
+| Gradle | 8.10.2 | 8.13 | Further updates |
+| Spring | - | Updated | CVE-2024-38827 fix |
+| awaitility | 4.2.2 | 4.3.0 | Dependency update |
+| spring-kafka-test | 3.3.2 | 3.3.4 | Dependency update |
+| junit-jupiter | 5.11.4 | 5.12.2 | Dependency update |
+| logback-classic | 1.5.16 | 1.5.18 | Security update |
+| checker-qual | 3.49.0 | 3.49.2 | Dependency update |
+| mockito-core | 5.15.2 | 5.17.0 | Dependency update |
+| camel-xmlsecurity | 3.22.3 | 3.22.4 | Dependency update |
+| guava | 33.4.0-jre | 33.4.6-jre | Dependency update |
+
+##### Security Dashboards Plugin
+| Dependency | Change | Purpose |
+|------------|--------|---------|
+| xlm-crypto | Bumped | CVE-2025-29774, CVE-2025-29775 |
+| elliptic | Bumped | GHSA-vjh7-7g9h-fjfh |
+| typescript | Removed | Dependency cleanup |
+| babel | Bumped to 7.27.0 | CVE-2025-27789 |
+| express | Bumped to 5.1.0 | Security update |
+
+##### Reporting Plugin
+| Dependency | Old Version | New Version | Purpose |
+|------------|-------------|-------------|---------|
+| Gradle | < 8.12.0 | 8.12.0 | JDK 23 support |
+
+##### SQL Plugin
+| Dependency | Change | Purpose |
+|------------|--------|---------|
+| json-smart | Updated | CVE-2024-57699 fix |
+
+### JDK 23 Support
+
+Multiple plugins received Gradle updates to support JDK 23:
+
+```mermaid
+graph TB
+    subgraph "JDK 23 Compatibility Updates"
+        A[Gradle Updates] --> B[security: 8.10.2 → 8.13]
+        A --> C[reporting: 8.12.0]
+        A --> D[security: JDK23 workflow fixes]
+    end
+```
+
+### Migration Notes
+
+These are dependency-only changes with no breaking API changes. Users upgrading to v3.0.0 will automatically benefit from these security fixes.
+
+## Limitations
+
+- Some plugins (like reporting) note that detekt is not yet supporting JDK 23, so workflow updates may follow separately.
+
+## Related PRs
+
+### Learning (ml-commons)
+| PR | Description |
+|----|-------------|
+| [#171](https://github.com/opensearch-project/ml-commons/pull/171) | [Backport 3.0] Address http5client CVE, use core's dependency |
+
+### Security Plugin
+| PR | Description |
+|----|-------------|
+| [#1481](https://github.com/opensearch-project/security/pull/1481) | Updated commons jar with CVE fixes |
+| [#1492](https://github.com/opensearch-project/security/pull/1492) | Update gradle 8.10.2 and support jdk23 |
+| [#1494](https://github.com/opensearch-project/security/pull/1494) | Fix security-enabled test workflow for 3.0-alpha1 |
+| [#1270](https://github.com/opensearch-project/security/pull/1270) | Fix CVE |
+| [#1276](https://github.com/opensearch-project/security/pull/1276) | Fix CVE 2025 27789 |
+| [#1278](https://github.com/opensearch-project/security/pull/1278) | Fix CVE-2025 27789 |
+| [#5126](https://github.com/opensearch-project/security/pull/5126) | Bump org.awaitility:awaitility from 4.2.2 to 4.3.0 |
+| [#5125](https://github.com/opensearch-project/security/pull/5125) | Bump org.springframework.kafka:spring-kafka-test from 3.3.2 to 3.3.4 |
+| [#5127](https://github.com/opensearch-project/security/pull/5127) | Bump org.junit.jupiter:junit-jupiter from 5.11.4 to 5.12.2 |
+| [#5148](https://github.com/opensearch-project/security/pull/5148) | Bump Gradle to 8.13 |
+| [#5149](https://github.com/opensearch-project/security/pull/5149) | Bump ch.qos.logback:logback-classic from 1.5.16 to 1.5.17 |
+| [#5173](https://github.com/opensearch-project/security/pull/5173) | Bump Spring version to fix CVE-2024-38827 |
+| [#5162](https://github.com/opensearch-project/security/pull/5162) | Bump org.checkerframework:checker-qual from 3.49.0 to 3.49.2 |
+| [#5161](https://github.com/opensearch-project/security/pull/5161) | Bump org.mockito:mockito-core from 5.15.2 to 5.17.0 |
+| [#5163](https://github.com/opensearch-project/security/pull/5163) | Bump org.apache.camel:camel-xmlsecurity from 3.22.3 to 3.22.4 |
+| [#5205](https://github.com/opensearch-project/security/pull/5205) | Bump com.google.guava:guava from 33.4.0-jre to 33.4.6-jre |
+| [#5204](https://github.com/opensearch-project/security/pull/5204) | Bump ch.qos.logback:logback-classic from 1.5.17 to 1.5.18 |
+
+### Security Dashboards Plugin
+| PR | Description |
+|----|-------------|
+| [#2196](https://github.com/opensearch-project/security-dashboards-plugin/pull/2196) | Bump xlm-crypto and elliptic |
+| [#2198](https://github.com/opensearch-project/security-dashboards-plugin/pull/2198) | Remove typescript dependency |
+| [#2200](https://github.com/opensearch-project/security-dashboards-plugin/pull/2200) | Bump babel to 7.27.0 |
+| [#2232](https://github.com/opensearch-project/security-dashboards-plugin/pull/2232) | Bump express to 5.1.0 |
+
+### Reporting Plugin
+| PR | Description |
+|----|-------------|
+| [#1077](https://github.com/opensearch-project/reporting/pull/1077) | Update gradle version to 8.12.0 for JDK23 support |
+
+### SQL Plugin
+| PR | Description |
+|----|-------------|
+| [#3484](https://github.com/opensearch-project/sql/pull/3484) | CVE-2024-57699 High: Fix json-smart vulnerability |
+
+## References
+
+- [CVE-2024-57699](https://advisories.opensearch.org/advisories/CVE-2024-57699): json-smart vulnerability (High severity)
+- [CVE-2024-38827](https://nvd.nist.gov/vuln/detail/CVE-2024-38827): Spring Security authorization bypass
+- [CVE-2025-29774](https://nvd.nist.gov/vuln/detail/CVE-2025-29774): xml-crypto signature verification bypass
+- [CVE-2025-29775](https://nvd.nist.gov/vuln/detail/CVE-2025-29775): xml-crypto signature verification bypass
+- [GHSA-vjh7-7g9h-fjfh](https://github.com/advisories/GHSA-vjh7-7g9h-fjfh): elliptic ECDSA signature malleability
+- [Issue #3485](https://github.com/opensearch-project/sql/issues/3485): SQL json-smart CVE tracking
+- [Issue #3747](https://github.com/opensearch-project/opensearch-build/issues/3747): JDK 23 support tracking
+
+## Related Feature Report
+
+- [CVE Fixes & Dependency Updates (Batch 1)](cve-fixes-dependency-updates.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -152,6 +152,7 @@
 
 - [CI/CD & Testing Infrastructure](features/multi-plugin/ci-cd-testing-infrastructure.md)
 - [CVE Fixes & Dependency Updates](features/multi-plugin/cve-fixes-dependency-updates.md)
+- [CVE Fixes & Dependency Updates (Batch 2)](features/multi-plugin/cve-fixes-dependency-updates-batch2.md)
 - [JDK 21 & Java Agent Migration](features/multi-plugin/jdk-21-java-agent-migration.md)
 - [Version Bumps & Release Notes](features/multi-plugin/version-bumps-release-notes.md)
 


### PR DESCRIPTION
## Summary

This PR adds documentation for CVE Fixes & Dependency Updates (Batch 2) for OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/multi-plugin/cve-fixes-dependency-updates-batch2.md`
- Feature report: Updated `docs/features/multi-plugin/cve-fixes-dependency-updates.md`

### Key Changes in v3.0.0 (Batch 2)

**CVEs Addressed:**
- CVE-2024-57699 (High): json-smart vulnerability in SQL plugin
- CVE-2024-38827: Spring Security authorization bypass
- CVE-2025-29774/CVE-2025-29775: xml-crypto signature verification bypass
- GHSA-vjh7-7g9h-fjfh: elliptic ECDSA signature malleability

**JDK 23 Support:**
- Gradle updates across security (8.10.2 → 8.13) and reporting (8.12.0) plugins

**Repositories Affected:**
- learning (ml-commons)
- security
- security-dashboards-plugin
- reporting
- sql

Closes #203