### PR TITLE
docs: add Version Bumps & Release Qualifiers (Batch 2) report for v3.0.0

### DIFF
--- a/docs/features/multi-plugin/version-bumps-release-notes.md
+++ b/docs/features/multi-plugin/version-bumps-release-notes.md
@@ -102,6 +102,21 @@ release-notes/
 | v3.0.0 | [#1843](https://github.com/opensearch-project/alerting/pull/1843) | alerting | Added 3.0 release notes |
 | v3.0.0 | [#775](https://github.com/opensearch-project/common-utils/pull/775) | common-utils | Update shadow plugin and bump to 3.0.0.0-alpha1 |
 | v3.0.0 | [#1384](https://github.com/opensearch-project/index-management/pull/1384) | index-management | Bump Version to 3.0.0-alpha1 |
+| v3.0.0 | [#154](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/154) | learning | Update 3.0.0 qualifier from alpha1 to beta1 |
+| v3.0.0 | [#169](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/169) | learning | Remove beta1 qualifier |
+| v3.0.0 | [#791](https://github.com/opensearch-project/performance-analyzer/pull/791) | performance | Bumps OS to 3.0.0-alpha1 and JDK 21 |
+| v3.0.0 | [#794](https://github.com/opensearch-project/performance-analyzer/pull/794) | performance | Bumps plugin version to 3.0.0.0-beta1 |
+| v3.0.0 | [#247](https://github.com/opensearch-project/query-insights/pull/247) | query | Bump version to 3.0.0-alpha1 & upgrade to gradle 8.10.2 |
+| v3.0.0 | [#290](https://github.com/opensearch-project/query-insights/pull/290) | query | Update 3.0.0 qualifier from alpha1 to beta1 |
+| v3.0.0 | [#329](https://github.com/opensearch-project/query-insights/pull/329) | query | Remove beta1 qualifier |
+| v3.0.0 | [#127](https://github.com/opensearch-project/dashboards-query-workbench/pull/127) | dashboards | Bump to 3.0.0-alpha1 |
+| v3.0.0 | [#154](https://github.com/opensearch-project/dashboards-query-workbench/pull/154) | dashboards | Update 3.0.0 qualifier from alpha1 to beta1 |
+| v3.0.0 | [#1073](https://github.com/opensearch-project/reporting/pull/1073) | reporting | Bump version 3.0.0-alpha1-SNAPSHOT |
+| v3.0.0 | [#1083](https://github.com/opensearch-project/reporting/pull/1083) | reporting | Bump version 3.0.0-beta1-SNAPSHOT |
+| v3.0.0 | [#1517](https://github.com/opensearch-project/security/pull/1517) | security | Increment version to 3.1.0-SNAPSHOT |
+| v3.0.0 | [#1519](https://github.com/opensearch-project/security/pull/1519) | security | Remove beta1 qualifier |
+| v3.0.0 | [#1500](https://github.com/opensearch-project/security/pull/1500) | security | Update version qualifier to beta1 |
+| v3.0.0 | [#1283](https://github.com/opensearch-project/security/pull/1283) | security | Increment version to 3.0.0.0 |
 | v2.18.0 | [#1718](https://github.com/opensearch-project/alerting/pull/1718) | alerting | Added 2.18.0 release notes |
 | v2.18.0 | [#750](https://github.com/opensearch-project/common-utils/pull/750) | common-utils | Added 2.18.0.0 release notes |
 | v2.18.0 | [#980](https://github.com/opensearch-project/notifications/pull/980) | notifications | Added 2.18.0 release notes |
@@ -124,6 +139,6 @@ release-notes/
 
 - **v3.2.0** (2026-01-11): Version bumps across 14 repositories (alerting, asynchronous-search, custom, index-management, ml-commons, notifications, observability, query, dashboards, reporting, security, learning, performance, system)
 - **v3.1.0** (2026-01-10): Version bumps across 11 repositories (alerting, asynchronous-search, common-utils, dashboards-notifications, notifications, reporting, index-management-dashboards, index-management, ml-commons, observability, sql, OpenSearch core)
-- **v3.0.0** (2025-05-06): Version bumps and release notes across 9 repositories (alerting, common-utils, index-management, notifications, security, sql, and dashboard plugins)
+- **v3.0.0** (2025-05-06): Version bumps and release notes across 15 repositories including batch 2 (learning, security, performance, query, dashboards, reporting) in addition to alerting, common-utils, index-management, notifications, security, sql, and dashboard plugins
 - **v2.18.0** (2024-11-05): Release notes across 5 repositories (alerting, common-utils, notifications, query-insights, security)
 - **v2.17.0** (2024-09-17): Version bumps and release notes across 12 repositories (alerting, anomaly-detection, asynchronous-search, common-utils, dashboards-notifications, index-management, job-scheduler, ml-commons, notifications, query-insights, security, sql)

--- a/docs/releases/v3.0.0/features/multi-plugin/version-bumps-release-qualifiers-batch2.md
+++ b/docs/releases/v3.0.0/features/multi-plugin/version-bumps-release-qualifiers-batch2.md
@@ -1,0 +1,94 @@
+# Version Bumps & Release Qualifiers (Batch 2)
+
+## Summary
+
+This release item covers version bump and release qualifier updates across 6 additional OpenSearch plugin repositories for the v3.0.0 release cycle. These changes ensure consistent versioning from alpha1 through beta1 to GA release, and prepare for the next development cycle with SNAPSHOT versions.
+
+## Details
+
+### What's New in v3.0.0
+
+Version bumps and qualifier updates were applied across 6 repositories:
+
+- **learning**: Learning to Rank plugin version progression
+- **security**: Security plugin version updates and qualifier removal
+- **performance**: Performance Analyzer version bumps including JDK 21 upgrade
+- **query**: Query Insights plugin version progression and Gradle upgrade
+- **dashboards**: Dashboards Query Workbench version updates
+- **reporting**: Reporting plugin version bumps
+
+### Technical Changes
+
+#### Version Progression
+
+| Phase | Version String | Qualifier |
+|-------|---------------|-----------|
+| Alpha | 3.0.0.0-alpha1 | alpha1 |
+| Beta | 3.0.0.0-beta1 | beta1 |
+| GA | 3.0.0.0 | (none) |
+| Post-GA | 3.1.0-SNAPSHOT | SNAPSHOT |
+
+#### Changes by Repository
+
+| Repository | PRs | Changes |
+|------------|-----|---------|
+| learning | 2 | alpha1 → beta1, remove beta1 qualifier |
+| security | 4 | Version increment, beta1 qualifier, remove qualifier, SNAPSHOT |
+| performance | 2 | alpha1 + JDK 21, beta1 |
+| query | 4 | alpha1 + Gradle 8.10.2, beta1, remove qualifier, SNAPSHOT |
+| dashboards | 2 | alpha1, beta1 |
+| reporting | 2 | alpha1-SNAPSHOT, beta1-SNAPSHOT |
+
+### Usage Example
+
+Version bump PRs typically modify `build.gradle` or `gradle.properties`:
+
+```groovy
+// Before (alpha1)
+version = '3.0.0.0-alpha1'
+
+// After (beta1)
+version = '3.0.0.0-beta1'
+
+// GA release
+version = '3.0.0.0'
+
+// Post-GA SNAPSHOT
+version = '3.1.0-SNAPSHOT'
+```
+
+## Limitations
+
+- Version bump PRs are routine maintenance with no functional changes
+- These changes must be coordinated with the release branch creation timeline
+
+## Related PRs
+
+| PR | Title | Repository |
+|----|-------|------------|
+| [#154](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/154) | Update 3.0.0 qualifier from alpha1 to beta1 | learning |
+| [#169](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/169) | Remove beta1 qualifier | learning |
+| [#791](https://github.com/opensearch-project/performance-analyzer/pull/791) | Bumps OS to 3.0.0-alpha1 and JDK 21 | performance |
+| [#794](https://github.com/opensearch-project/performance-analyzer/pull/794) | Bumps plugin version to 3.0.0.0-beta1 in PA | performance |
+| [#247](https://github.com/opensearch-project/query-insights/pull/247) | Bump version to 3.0.0-alpha1 & upgrade to gradle 8.10.2 | query |
+| [#290](https://github.com/opensearch-project/query-insights/pull/290) | Update 3.0.0 qualifier from alpha1 to beta1 | query |
+| [#329](https://github.com/opensearch-project/query-insights/pull/329) | Remove beta1 qualifier | query |
+| [#325](https://github.com/opensearch-project/query-insights/pull/325) | Increment version to 3.1.0-SNAPSHOT | query |
+| [#127](https://github.com/opensearch-project/dashboards-query-workbench/pull/127) | Bump to 3.0.0-alpha1 | dashboards |
+| [#154](https://github.com/opensearch-project/dashboards-query-workbench/pull/154) | Update 3.0.0 qualifier from alpha1 to beta1 | dashboards |
+| [#462](https://github.com/opensearch-project/sql/pull/462) | Bump dashboards query workbench to version 3.0.0.0-beta1 | query |
+| [#444](https://github.com/opensearch-project/sql/pull/444) | Bump dashboards query workbench to version 3.0.0.0-alpha1 | query |
+| [#1073](https://github.com/opensearch-project/reporting/pull/1073) | Bump version 3.0.0-alpha1-SNAPSHOT | reporting |
+| [#1083](https://github.com/opensearch-project/reporting/pull/1083) | Bump version 3.0.0-beta1-SNAPSHOT | reporting |
+| [#1517](https://github.com/opensearch-project/security/pull/1517) | Increment version to 3.1.0-SNAPSHOT | security |
+| [#1519](https://github.com/opensearch-project/security/pull/1519) | Remove beta1 qualifier | security |
+| [#1500](https://github.com/opensearch-project/security/pull/1500) | Update version qualifier to beta1 | security |
+| [#1283](https://github.com/opensearch-project/security/pull/1283) | Increment version to 3.0.0.0 | security |
+
+## References
+
+- [Issue #201](https://github.com/tkykenmt/opensearch-feature-explorer/issues/201): Tracking issue
+
+## Related Feature Report
+
+- [Full feature documentation](../../../../features/multi-plugin/version-bumps-release-notes.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -156,6 +156,7 @@
 - [JDK 21 & Java Agent Migration](features/multi-plugin/jdk-21-java-agent-migration.md)
 - [Java Agent / SecurityManager Migration (Batch 2)](features/multi-plugin/java-agent-securitymanager-migration-batch2.md)
 - [Version Bumps & Release Notes](features/multi-plugin/version-bumps-release-notes.md)
+- [Version Bumps & Release Qualifiers (Batch 2)](features/multi-plugin/version-bumps-release-qualifiers-batch2.md)
 
 ## opensearch-remote-metadata-sdk
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Version Bumps & Release Qualifiers (Batch 2) release item for OpenSearch v3.0.0.

## Changes

- Created release report: `docs/releases/v3.0.0/features/multi-plugin/version-bumps-release-qualifiers-batch2.md`
- Updated feature report: `docs/features/multi-plugin/version-bumps-release-notes.md` with batch 2 PRs
- Updated release index: `docs/releases/v3.0.0/index.md`

## Repositories Covered

- learning (2 PRs)
- security (4 PRs)
- performance (2 PRs)
- query (4 PRs)
- dashboards (2 PRs)
- reporting (2 PRs)

Closes #201