### PR TITLE
docs: add Aggregations report for v3.0.0

### DIFF
--- a/docs/features/opensearch/aggregation-optimizations.md
+++ b/docs/features/opensearch/aggregation-optimizations.md
@@ -286,6 +286,9 @@ GET /taxi/_search
 | v3.3.0 | [#18978](https://github.com/opensearch-project/OpenSearch/pull/18978) | Rare terms aggregation precomputation |
 | v3.3.0 | [#18732](https://github.com/opensearch-project/OpenSearch/pull/18732) | String terms aggregation optimization |
 | v3.3.0 | [#19088](https://github.com/opensearch-project/OpenSearch/pull/19088) | Date histogram rounding optimization |
+| v3.0.0 | [#17312](https://github.com/opensearch-project/OpenSearch/pull/17312) | Introduce `execution_hint` for Cardinality aggregation |
+| v3.0.0 | [#14993](https://github.com/opensearch-project/OpenSearch/pull/14993) | Latency and memory allocation improvements to Multi Term Aggregation |
+| v3.0.0 | [#17252](https://github.com/opensearch-project/OpenSearch/pull/17252) | Improve performance of NumericTermAggregation by avoiding unnecessary sorting |
 
 ## References
 
@@ -297,13 +300,16 @@ GET /taxi/_search
 - [Issue #13122](https://github.com/opensearch-project/OpenSearch/issues/13122): Rare Terms Aggregation Performance Optimization
 - [Issue #18704](https://github.com/opensearch-project/OpenSearch/issues/18704): Optimize String terms agg
 - [Issue #10954](https://github.com/opensearch-project/OpenSearch/issues/10954): Use Collector.setWeight to improve aggregation performance
+- [Issue #16837](https://github.com/opensearch-project/OpenSearch/issues/16837): Use of Binary DocValue for high cardinality fields
 - [Cardinality Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/metric/cardinality/)
 - [Percentile Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/metric/percentile/)
 - [Rare Terms Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/rare-terms/)
 - [Terms Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/terms/)
 - [Date Histogram Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/date-histogram/)
+- [Multi-terms Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/multi-terms/)
 
 ## Change History
 
 - **v3.4.0** (2026-01): Added hybrid cardinality collector, filter rewrite + skip list for sub-aggregations, MergingDigest for percentiles, primitive arrays for matrix_stats, skip list for auto_date_histogram
 - **v3.3.0** (2026-01): Added precomputation for rare terms, quickselect for string terms, object reuse for date histogram
+- **v3.0.0** (2025-02): Added `execution_hint` parameter for cardinality aggregation, multi-term aggregation latency/memory improvements, numeric term aggregation sorting optimization

--- a/docs/releases/v3.0.0/features/opensearch/aggregations.md
+++ b/docs/releases/v3.0.0/features/opensearch/aggregations.md
@@ -1,0 +1,133 @@
+# Aggregations
+
+## Summary
+
+OpenSearch 3.0.0 introduces performance optimizations for aggregation operations, including a new `execution_hint` parameter for cardinality aggregation, latency and memory improvements for multi-term aggregations, and sorting optimizations for numeric term aggregations. These changes reduce query latency by 7-10 seconds for multi-term queries and eliminate unnecessary sorting overhead.
+
+## Details
+
+### What's New in v3.0.0
+
+Three key aggregation improvements are included in this release:
+
+1. **Cardinality Aggregation `execution_hint`**: New parameter to control how cardinality aggregation executes
+2. **Multi-Term Aggregation Performance**: Reduced latency and memory allocations
+3. **Numeric Term Aggregation Sorting**: Eliminated unnecessary heap sort operations
+
+### Technical Changes
+
+#### Architecture Changes
+
+```mermaid
+graph TB
+    subgraph "Cardinality Aggregation"
+        CA[Cardinality Request] --> EH{execution_hint?}
+        EH -->|ordinals| OC[OrdinalsCollector]
+        EH -->|direct| DC[DirectCollector]
+        EH -->|none| Auto[Auto-select based on heuristics]
+        Auto --> OC
+        Auto --> DC
+    end
+    
+    subgraph "Multi-Term Aggregation"
+        MTA[Multi-Term Request] --> CV[Collect Values]
+        CV --> CK[Generate Composite Keys]
+        CK --> BO[Add to BucketOrds]
+        BO --> Result[Aggregation Result]
+    end
+    
+    subgraph "Numeric Term Aggregation"
+        NTA[Numeric Term Request] --> PQ[Priority Queue]
+        PQ --> KO{Key Order?}
+        KO -->|Yes| Sort[Heap Sort Pop]
+        KO -->|No| Iter[Iterator - No Sort]
+        Sort --> NResult[Result]
+        Iter --> NResult
+    end
+```
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `ExecutionMode` | Enum with `DIRECT` and `ORDINALS` values for cardinality execution |
+| `execution_hint` parameter | New aggregation parameter accepting `"direct"` or `"ordinals"` |
+
+#### New Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `execution_hint` | Controls cardinality aggregation execution mode | Auto-select |
+
+### Usage Example
+
+#### Cardinality with execution_hint
+
+```json
+GET /logs/_search
+{
+  "size": 0,
+  "aggs": {
+    "unique_users": {
+      "cardinality": {
+        "field": "user_id.keyword",
+        "execution_hint": "ordinals"
+      }
+    }
+  }
+}
+```
+
+Valid values:
+- `ordinals`: Forces use of OrdinalsCollector (faster but uses more memory)
+- `direct`: Forces use of DirectCollector (slower but more memory-efficient)
+
+#### Multi-Term Aggregation (automatic optimization)
+
+```json
+GET /events/_search
+{
+  "size": 0,
+  "aggs": {
+    "by_fields": {
+      "multi_terms": {
+        "terms": [
+          { "field": "agent_name" },
+          { "field": "host_name" }
+        ]
+      }
+    }
+  }
+}
+```
+
+### Migration Notes
+
+- The `execution_hint` parameter is optional; existing queries continue to work with automatic selection
+- Multi-term and numeric term optimizations are automatic and require no configuration changes
+- For high-cardinality fields experiencing latency regression from OS 2.x, try `"execution_hint": "ordinals"`
+
+## Limitations
+
+- `execution_hint: "ordinals"` on non-ordinal fields (like numeric fields) has no effect
+- `execution_hint: "direct"` on ordinal fields has no effect
+- Ordinals use byte arrays sized by field cardinality; very high cardinality fields risk OOM errors
+- Multi-term aggregation still consumes more memory than single terms aggregation
+
+## Related PRs
+
+| PR | Description |
+|----|-------------|
+| [#17312](https://github.com/opensearch-project/OpenSearch/pull/17312) | Introduce `execution_hint` for Cardinality aggregation |
+| [#14993](https://github.com/opensearch-project/OpenSearch/pull/14993) | Latency and memory allocation improvements to Multi Term Aggregation queries |
+| [#17252](https://github.com/opensearch-project/OpenSearch/pull/17252) | Improve performance of NumericTermAggregation by avoiding unnecessary sorting |
+
+## References
+
+- [Issue #16837](https://github.com/opensearch-project/OpenSearch/issues/16837): Feature request for high cardinality field aggregation improvements
+- [Cardinality Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/metric/cardinality/): Official documentation with execution_hint details
+- [Multi-terms Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/bucket/multi-terms/): Multi-terms aggregation usage
+
+## Related Feature Report
+
+- [Full feature documentation](../../../features/opensearch/aggregation-optimizations.md)

--- a/docs/releases/v3.0.0/index.md
+++ b/docs/releases/v3.0.0/index.md
@@ -14,6 +14,7 @@
 
 ## opensearch
 
+- [Aggregations](features/opensearch/aggregations.md)
 - [Arrow Flight RPC](features/opensearch/arrow-flight-rpc.md)
 - [Extensions Framework](features/opensearch/extensions-framework.md)
 - [Automata & Regex Optimization](features/opensearch/automata-regex-optimization.md)


### PR DESCRIPTION
## Summary

This PR adds documentation for Aggregations improvements in OpenSearch v3.0.0.

### Reports Created
- Release report: `docs/releases/v3.0.0/features/opensearch/aggregations.md`
- Feature report: Updated `docs/features/opensearch/aggregation-optimizations.md`

### Key Changes in v3.0.0
- **Cardinality Aggregation `execution_hint`**: New parameter to control execution mode (`ordinals` or `direct`)
- **Multi-Term Aggregation Performance**: 7-10 second latency reduction, reduced memory allocations
- **Numeric Term Aggregation Sorting**: Eliminated unnecessary heap sort operations

### PRs Investigated
- [#17312](https://github.com/opensearch-project/OpenSearch/pull/17312): Introduce `execution_hint` for Cardinality aggregation
- [#14993](https://github.com/opensearch-project/OpenSearch/pull/14993): Latency and memory allocation improvements to Multi Term Aggregation
- [#17252](https://github.com/opensearch-project/OpenSearch/pull/17252): Improve performance of NumericTermAggregation by avoiding unnecessary sorting

### Resources Used
- [Cardinality Aggregation Documentation](https://docs.opensearch.org/3.0/aggregations/metric/cardinality/)
- [Issue #16837](https://github.com/opensearch-project/OpenSearch/issues/16837): Feature request for high cardinality field improvements