### PR TITLE
feat: restructure References section in reports

### DIFF
--- a/.kiro/agents/prompts/investigate.md
+++ b/.kiro/agents/prompts/investigate.md
@@ -211,15 +211,15 @@ Steps to adopt this change (if applicable).
 ## Limitations
 Known limitations specific to this release.
 
-## Related PRs
-| PR | Description |
-|----|-------------|
-| [#1234](url) | Main implementation |
-
 ## References
-- [Issue #1000](url): Feature request
-- [Documentation](url): Official docs
-- [Blog](url): Announcement blog
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#1234](url) | Main implementation | [#1000](url) |
+
+### Documentation
+- [Feature Documentation](url)
 
 ## Related Feature Report
 - [Full feature documentation](../../../features/{repository-name}/{feature-name}.md)
@@ -241,8 +241,12 @@ Create `docs/features/{repository-name}/{feature-name}.md` following the templat
 - Configuration table
 - Usage examples
 - Limitations
-- References (all PRs, Issues, docs, **blogs from search results**)
 - Change History (starting with this version, sorted by version descending)
+- References section with subsections:
+  - Documentation
+  - Blog Posts
+  - Pull Requests (table with Version, PR, Description, Related Issue)
+  - Issues (Design / RFC)
 
 ### For update-feature (feature report exists):
 1. Read existing `docs/features/{repository-name}/{feature-name}.md`

--- a/.kiro/steering/opensearch-knowledge.md
+++ b/.kiro/steering/opensearch-knowledge.md
@@ -128,14 +128,15 @@ Steps to adopt this change (if applicable).
 ## Limitations
 Known limitations specific to this release.
 
-## Related PRs
-| PR | Description |
-|----|-------------|
-| [#1234](url) | Main implementation |
-
 ## References
-- [Issue #1000](url): Feature request
-- [Documentation](url): Official docs
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#1234](url) | Main implementation | [#1000](url) |
+
+### Documentation
+- [Feature Documentation](url)
 
 ## Related Feature Report
 - [Full feature documentation](../../features/{feature-name}.md)
@@ -178,16 +179,28 @@ flowchart LR
 ## Limitations
 Known limitations or constraints
 
-## Related PRs
-| Version | PR | Description |
-|---------|-----|-------------|
-| v3.4.0 | [#1234](https://github.com/opensearch-project/OpenSearch/pull/1234) | Initial implementation |
+## Change History
+- **v3.5.0** (2024-01-15): Added feature X, performance improvements
+- **v3.4.0** (2023-10-01): Initial implementation
 
 ## References
-- [Issue #1000](https://github.com/opensearch-project/OpenSearch/issues/1000): Original feature request
 
-## Change History
-- **v3.4.0** (YYYY-MM-DD): Initial implementation
+### Documentation
+- [Feature Documentation](url)
+- [API Reference](url)
+
+### Blog Posts
+- [Feature Announcement](url)
+
+### Pull Requests
+| Version | PR | Description | Related Issue |
+|---------|-----|-------------|---------------|
+| v3.5.0 | [#2345](url) | Performance improvements | [#2300](url) |
+| v3.4.0 | [#1234](url) | Initial implementation | [#1000](url) |
+
+### Issues (Design / RFC)
+- [#1000](url): Original feature request
+- [#900](url): Design RFC
 ```
 
 ### Release Summary Template (docs/releases/v{version}/summary.md)


### PR DESCRIPTION
Closes #1747

## Changes
- Consolidate `Related PRs` and `References` into single `References` section
- Add subsections: Documentation, Blog Posts, Pull Requests, Issues (Design / RFC)
- Add `Related Issue` column to PR tables
- Move `Change History` before `References` in feature reports
- Update templates in:
  - `.kiro/steering/opensearch-knowledge.md`
  - `.kiro/agents/prompts/investigate.md`

## New Structure
```markdown
## Change History
- **v3.2.0** (date): ...

## References

### Documentation
- [Feature Documentation](url)

### Blog Posts
- [Announcement](url)

### Pull Requests
| Version | PR | Description | Related Issue |
|---------|-----|-------------|---------------|
| v3.2.0 | [#1234](url) | Implementation | [#1000](url) |

### Issues (Design / RFC)
- [#1000](url): Original feature request
```

## Migration Note
Existing reports will need to be updated separately (can be done incrementally).