### PR TITLE
feat: update diagram direction guidelines for mobile

### DIFF
--- a/.kiro/steering/opensearch-knowledge.md
+++ b/.kiro/steering/opensearch-knowledge.md
@@ -159,7 +159,7 @@ graph TB
 
 ### Data Flow
 ```mermaid
-flowchart LR
+flowchart TB
     ...
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A tool to analyze OpenSearch release notes and generate detailed feature/release
 ## Overview
 
 ```mermaid
-graph LR
+graph TB
     subgraph Input
         RN[Release Notes]
         PR[Pull Requests]
@@ -102,7 +102,7 @@ Enable the following in your repository settings (Settings → General):
 Complete workflow for investigating a new OpenSearch release.
 
 ```mermaid
-flowchart LR
+flowchart TB
     A[release-investigate] --> B[(Release Reports)]
     A --> C[(Feature Reports)]
     A --> D[(Release Summary)]
@@ -118,7 +118,7 @@ python run.py release-investigate 3.0.0
 #### Step 1: Parse Release Notes
 
 ```mermaid
-flowchart LR
+flowchart TB
     A[fetch-release] --> B[(raw-items.json)]
     B --> C[group-release]
     C --> D[(groups.json)]
@@ -132,7 +132,7 @@ python run.py group-release 3.0.0 --all
 #### Step 2: Create GitHub Project & Issues
 
 ```mermaid
-flowchart LR
+flowchart TB
     A[(groups.json)] --> B[planner]
     B --> C[(GitHub Project)]
     B --> D[(Issues)]
@@ -145,7 +145,7 @@ python run.py planner 3.0.0
 #### Step 3: Investigate Each Issue
 
 ```mermaid
-flowchart LR
+flowchart TB
     A[(Issue)] --> B[investigate]
     B --> C[(Release Report)]
     B --> D[(Feature Report)]
@@ -160,7 +160,7 @@ python run.py batch-investigate --all
 #### Step 4: Create Release Summary
 
 ```mermaid
-flowchart LR
+flowchart TB
     A[(Release Reports)] --> B[summarize]
     B --> C[(Release Summary)]
 ```
@@ -176,7 +176,7 @@ python run.py summarize 3.0.0
 Quick investigation of a specific feature without full release workflow.
 
 ```mermaid
-flowchart LR
+flowchart TB
     A[PR Number] --> B[investigate]
     C[Feature Name] --> B
     B --> D[Feature Report]
@@ -198,7 +198,7 @@ python run.py investigate --feature "Star Tree"
 Explore features interactively with Q&A.
 
 ```mermaid
-flowchart LR
+flowchart TB
     A[investigate] --> B[Q&A Session]
     B --> C[Import URLs]
     C --> B


### PR DESCRIPTION
Partial fix for #1528

## Changes
- Change `flowchart LR` to `flowchart TB` in feature report template (`opensearch-knowledge.md`)
- Update all diagrams in `README.md` to use `TB` direction

## Direction Rules (already defined)
- Use `TB` (top-to-bottom) as default direction
- Use `LR` (left-to-right) only for simple flows with 3 or fewer nodes
- Always use `TB` when diagram contains subgraphs

## Remaining Work
- Convert existing LR diagrams in `docs/features/**/*.md` (~100 files)
- This can be done via batch script or incrementally