### PR TITLE
Enhance MkDocs configuration and add dev agent scope restrictions

### DIFF
--- a/.kiro/agents/prompts/dev.md
+++ b/.kiro/agents/prompts/dev.md
@@ -6,7 +6,14 @@ You are a development engineer responsible for maintaining and improving this to
 - Code changes to `run.py`, `mcp_server.py`
 - Agent configuration and prompt improvements
 - Bug fixes and feature additions
-- Documentation updates
+- Configuration updates (`mkdocs.yml`, `requirements.txt`)
+- Workflow updates (`.github/workflows/`)
+- Static assets (`docs/stylesheets/`, `docs/javascripts/`)
+
+## Scope Restrictions
+**DO NOT modify** report content files:
+- `docs/features/**/*.md` → use `refactor` or `investigate` agent
+- `docs/releases/**/*.md` → use `refactor` or `investigate` agent
 
 ## Mode
 Interactive. Continue conversation until user exits with `/quit`.

--- a/docs/404.md
+++ b/docs/404.md
@@ -1,0 +1,9 @@
+# Page Not Found
+
+The page you're looking for doesn't exist.
+
+## Suggestions
+- [Home](index.md)
+- [Features](features/index.md)
+- [Releases](releases/index.md)
+- Use the search bar above

--- a/docs/javascripts/ai-translate.js
+++ b/docs/javascripts/ai-translate.js
@@ -1,0 +1,36 @@
+document.addEventListener('DOMContentLoaded', function() {
+  const languages = ['Japanese', 'Chinese', 'Korean', 'Spanish', 'French', 'German'];
+  const services = {
+    'ChatGPT': (text, lang) => `https://chat.openai.com/?q=${encodeURIComponent(`Translate the following to ${lang}:\n\n${text}`)}`,
+    'Claude': (text, lang) => `https://claude.ai/new?q=${encodeURIComponent(`Translate the following to ${lang}:\n\n${text}`)}`,
+    'Gemini': (text, lang) => `https://gemini.google.com/app?q=${encodeURIComponent(`Translate the following to ${lang}:\n\n${text}`)}`
+  };
+
+  // Create UI
+  const container = document.createElement('div');
+  container.className = 'ai-translate';
+  container.innerHTML = `
+    <select class="ai-translate-lang">
+      ${languages.map(l => `<option value="${l}">${l}</option>`).join('')}
+    </select>
+    <select class="ai-translate-service">
+      ${Object.keys(services).map(s => `<option value="${s}">${s}</option>`).join('')}
+    </select>
+    <button class="ai-translate-btn">Translate with AI</button>
+  `;
+
+  // Insert after article header
+  const article = document.querySelector('article');
+  if (article) {
+    const h1 = article.querySelector('h1');
+    if (h1) h1.after(container);
+  }
+
+  // Handle click
+  container.querySelector('.ai-translate-btn').addEventListener('click', function() {
+    const lang = container.querySelector('.ai-translate-lang').value;
+    const service = container.querySelector('.ai-translate-service').value;
+    const content = article ? article.innerText.substring(0, 8000) : '';
+    window.open(services[service](content, lang), '_blank');
+  });
+});

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -15,3 +15,34 @@
   --md-primary-fg-color: #3A8FD6;
   --md-accent-fg-color: #00CED1;
 }
+
+
+/* Mermaid diagram responsive */
+.mermaid {
+  max-width: 100%;
+  overflow-x: auto;
+}
+
+
+/* AI Translate UI */
+.ai-translate {
+  display: flex;
+  gap: 0.5rem;
+  margin: 1rem 0;
+  flex-wrap: wrap;
+}
+.ai-translate select,
+.ai-translate button {
+  padding: 0.4rem 0.8rem;
+  border-radius: 4px;
+  border: 1px solid var(--md-default-fg-color--lighter);
+  font-size: 0.8rem;
+}
+.ai-translate button {
+  background: var(--md-primary-fg-color);
+  color: white;
+  cursor: pointer;
+}
+.ai-translate button:hover {
+  opacity: 0.9;
+}

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -1,0 +1,3 @@
+# Tags
+
+Browse features and releases by category.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,9 @@
 site_name: OpenSearch Feature Explorer
 site_description: Feature analysis and release notes documentation for OpenSearch
 site_url: https://tkykenmt.github.io/opensearch-feature-explorer/
+repo_url: https://github.com/tkykenmt/opensearch-feature-explorer
+repo_name: tkykenmt/opensearch-feature-explorer
+edit_uri: edit/main/docs/
 
 docs_dir: docs
 site_dir: site
@@ -26,11 +29,22 @@ theme:
     - navigation.tabs
     - navigation.sections
     - navigation.expand
+    - navigation.instant
+    - navigation.top
+    - navigation.indexes
+    - toc.integrate
+    - header.autohide
     - search.highlight
+    - search.suggest
+    - search.share
     - content.code.copy
+    - content.tabs.link
 
 extra_css:
   - stylesheets/extra.css
+
+extra_javascript:
+  - javascripts/ai-translate.js
 
 markdown_extensions:
   - pymdownx.superfences:
@@ -45,7 +59,23 @@ markdown_extensions:
   - tables
 
 plugins:
-  - search
+  - search:
+      lang:
+        - en
+        - ja
+      separator: '[\s\-\.]+'
+  - social
+  - meta
+  - git-revision-date-localized:
+      type: date
+      fallback_to_build_date: true
+  - tags:
+      tags_file: tags.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/tkykenmt/opensearch-feature-explorer
 
 nav:
   - Home: index.md

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,7 @@
 mkdocs-material
 pymdown-extensions
+
+pillow
+cairosvg
+
+mkdocs-git-revision-date-localized-plugin


### PR DESCRIPTION
## Summary
MkDocs Material theme enhancements and dev agent scope clarification.

## Changes
- **Navigation**: instant, top button, indexes, TOC integration, header autohide
- **Search**: suggestions, share, Japanese support
- **SEO**: social cards, meta tags, git revision date, edit link
- **Tags**: plugin configured with tags.md
- **AI Translation**: on-demand translation button (ChatGPT/Claude/Gemini)
- **404**: custom error page
- **Dev agent**: scope restriction to exclude report files

## Closes
- #1589 - MkDocs Material theme configuration
- #1714 - SEO: Sitemap and meta tags
- #1716 - Last updated date and edit link
- #1717 - Custom 404 page
- #1744 - AI-powered on-demand translation
- #1715 - Navigation (config part only, split to #1946, #1947)