### PR TITLE
refactor: update file naming conventions and add existing file check

### DIFF
--- a/.kiro/agents/prompts/investigate.md
+++ b/.kiro/agents/prompts/investigate.md
@@ -121,6 +121,28 @@ After loading the target Issue, check for duplicates:
      - Close the Issue using `update_issue` with `state: "closed"`
    - Continue investigation with the current Issue
 
+## Step 1.5: Check Existing Files
+
+Before creating new files, search for existing reports:
+
+### Search with GitHub MCP
+Use `search_code` to find existing reports:
+```
+search_code(q="{feature-name} repo:{owner}/{repo} path:docs/features")
+```
+
+Also search by key terms:
+```
+search_code(q="{key-term} repo:{owner}/{repo} path:docs/features extension:md")
+```
+
+### Decision
+- **Exact match found**: Update existing file (don't create new)
+- **Related file found**: Consider merging or add cross-reference
+- **No match**: Create new file with proper naming convention
+
+**IMPORTANT**: Never create a new file if an existing file covers the same feature.
+
 ## Step 2: Deep Investigation
 
 **IMPORTANT**: Thoroughly read ALL sources. Don't just list references - actually fetch and analyze their content.

--- a/.kiro/agents/prompts/refactor.md
+++ b/.kiro/agents/prompts/refactor.md
@@ -119,19 +119,16 @@ Related categories:
 
 ## File Naming
 
-### Directory = Context
-Don't repeat directory name in filename:
-- Bad: `security/security-plugin.md`
-- Good: `security/overview.md`
+### Prefix Rules
+Include repository/plugin name prefix for searchability:
 
-### File Patterns
-| Pattern | Purpose |
-|---------|---------|
-| `index.md` | Directory listing |
-| `overview.md` | Plugin/feature overview |
-| `{feature}.md` | Main feature doc |
-| `configuration.md` | Config reference |
-| `api.md` | API reference |
+| File Type | Pattern | Example |
+|-----------|---------|---------|
+| Main feature doc | `{repo}/{repo}.md` | `security/security.md` |
+| Sub-feature | `{repo}/{repo}-{aspect}.md` | `security/security-jwt.md` |
+| Directory index | `{repo}/index.md` | `security/index.md` |
+
+Repository name = OpenSearch plugin/component repository name (e.g., `security`, `k-nn`, `ml-commons`, `neural-search`)
 
 ### Avoid Temporal Files
 Merge into main doc's Change History:

--- a/.kiro/steering/opensearch-knowledge.md
+++ b/.kiro/steering/opensearch-knowledge.md
@@ -313,27 +313,33 @@ Use `web_fetch` to retrieve full content from returned URLs.
 
 ## File Naming Conventions
 
-### Prefix with Feature/Plugin Name
-Include feature/plugin name prefix for searchability:
+### Prefix Rules
+Include repository/plugin name prefix for searchability and context independence:
+
+| File Type | Pattern | Example |
+|-----------|---------|---------|
+| Main feature doc | `{repo}/{repo}.md` | `security/security.md` |
+| Sub-feature | `{repo}/{repo}-{aspect}.md` | `security/security-jwt.md` |
+| Directory index | `{repo}/index.md` | `security/index.md` |
+
+Repository name = OpenSearch plugin/component repository name (e.g., `security`, `k-nn`, `ml-commons`, `neural-search`)
+
 ```
 # Good - searchable, identifiable
-security/security-plugin.md
-security/security-configuration.md
-sql/sql-ppl-engine.md
+security/security.md
+security/security-jwt-authentication.md
+k-nn/k-nn-performance.md
+ml-commons/ml-commons-agent-framework.md
 
 # Avoid - ambiguous without context
 security/overview.md
-security/configuration.md
+security/plugin.md
 ```
 
-### File Type Patterns
-| Pattern | Purpose | Example |
-|---------|---------|---------|
-| `index.md` | Directory overview/listing | `sql/index.md` |
-| `{feature}.md` | Main feature doc | `sql/calcite-query-engine.md` |
-| `{feature}-{aspect}.md` | Feature aspect | `sql/ppl-query-optimization.md` |
-| `configuration.md` | Configuration reference | `security/configuration.md` |
-| `api.md` | API reference | `k-nn/api.md` |
+### Rationale
+- Searchability: Prefix makes files findable across the codebase
+- Context independence: File name alone identifies the feature
+- Consistency: All feature-related files share the same prefix
 
 ### Avoid Temporal Files
 Don't create separate files for version-specific content:


### PR DESCRIPTION
## Changes

- Unify file naming rules to use repository name prefix for searchability
- Add Step 1.5 to investigate agent for existing file search using GitHub MCP `search_code`
- Remove conflicting 'directory = context' rule from refactor agent

## Files Changed
- `.kiro/steering/opensearch-knowledge.md`
- `.kiro/agents/prompts/investigate.md`
- `.kiro/agents/prompts/refactor.md`