### PR TITLE
docs: add cross-references between related features

### DIFF
--- a/docs/features/ml-commons/ml-commons-batch-ingestion.md
+++ b/docs/features/ml-commons/ml-commons-batch-ingestion.md
@@ -314,6 +314,7 @@ sequenceDiagram
 - **v2.17.0** (2024-09-17): Initial implementation with S3 and OpenAI data source support, JSONPath field mapping, and batch job status tracking
 
 ## Related Features
+- [Batch Ingestion (Ingest Pipeline)](../neural-search/neural-search-batch-ingestion.md) - Different feature: batch processing in ingest pipelines
 - [Neural Search](../neural-search/neural-search-agentic-search.md)
 - [Flow Framework](../flow-framework/flow-framework.md)
 - [AI Assistant (Dashboards)](../dashboards-assistant/dashboards-assistant.md)

--- a/docs/features/ml-commons/ml-commons-query-assist.md
+++ b/docs/features/ml-commons/ml-commons-query-assist.md
@@ -158,6 +158,7 @@ Query Assist provides clear feedback for different error scenarios:
 - **v2.13.0** (2024-02-20): Initial introduction of Query Assist in OpenSearch Dashboards
 
 ## Related Features
+- [Query Assistant (Dashboards UI)](../opensearch-dashboards/opensearch-dashboards-query-assistant.md)
 - [Neural Search](../neural-search/neural-search-agentic-search.md)
 - [Flow Framework](../flow-framework/flow-framework.md)
 - [AI Assistant (Dashboards)](../dashboards-assistant/dashboards-assistant.md)

--- a/docs/features/neural-search/neural-search-batch-ingestion.md
+++ b/docs/features/neural-search/neural-search-batch-ingestion.md
@@ -136,6 +136,7 @@ PUT /_ingest/pipeline/sparse-pipeline
 - **v2.14.0**: Initial batch ingestion feature introduced
 
 ## Related Features
+- [Batch Ingestion (Ingest Pipeline)](../neural-search/neural-search-batch-ingestion.md) - Different feature: batch processing in ingest pipelines
 - [ML Commons](../ml-commons/ml-commons-agentic-memory.md)
 - [k-NN Vector Search](../k-nn/k-nn-disk-based-vector-search.md)
 - [Search Relevance](../search-relevance/dashboards-observability-search-relevance-ci-tests.md)

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-query-assistant.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-query-assistant.md
@@ -135,6 +135,8 @@ Example natural language queries:
 - **v2.13** (2024): Initial implementation of OpenSearch Assistant toolkit
 
 ## Related Features
+- [Query Assist (ML Commons)](../ml-commons/ml-commons-query-assist.md)
+- [AI Assistant (Dashboards)](../dashboards-assistant/dashboards-assistant.md)
 - [OpenSearch Core](../opensearch/opensearch-actionplugin-rest-handler-wrapper.md)
 
 ## References


### PR DESCRIPTION
## Summary
Add cross-references between related features that have similar names but different functionality.

## Changes
- `ml-commons/query-assist` ↔ `dashboards/query-assistant` (same feature, different layers)
- `ml-commons/batch-ingestion` ↔ `neural-search/batch-ingestion` (different features, similar names)

Closes #1959
Closes #1960