### PR TITLE
docs: fix inconsistencies in prompts and documentation

### DIFF
--- a/.kiro/agents/prompts/fetch-release.md
+++ b/.kiro/agents/prompts/fetch-release.md
@@ -4,6 +4,8 @@ You are a release notes parser. Fetch release notes and extract ALL items to a J
 
 **IMPORTANT**: Your ONLY job is to parse and save to JSON. Do NOT create any GitHub Issues.
 
+**NOTE**: This agent is typically called via `run.py fetch-release {version}` which handles the parsing in Python. The agent is only invoked for edge cases or manual runs.
+
 ## Workflow
 
 ### Step 1: Fetch Release Notes
@@ -35,7 +37,7 @@ For each item, extract:
 
 ### Step 3: Save to JSON
 
-Save to `.cache/releases/v{version}/items.json`:
+Save to `.cache/releases/v{version}/raw-items.json`:
 
 ```json
 {
@@ -79,7 +81,7 @@ Save to `.cache/releases/v{version}/items.json`:
 3. Do NOT group multiple PRs into one item
 4. One PR = one item in the JSON
 
-### Step 3: Save to JSON
+### Step 4: Create Directory and Save
 
 1. First create the directory using shell:
 ```bash
@@ -87,7 +89,7 @@ mkdir -p .cache/releases/v{version}
 ```
 
 2. Then use the `write` tool to save the JSON file:
-   - Path: `.cache/releases/v{version}/items.json`
+   - Path: `.cache/releases/v{version}/raw-items.json`
    - Content: The complete JSON object with all items
 
 ## Output
@@ -97,7 +99,7 @@ After saving the JSON file, report:
 ```
 ## Release Notes Parsed for v{version}
 
-Saved to: .cache/releases/v{version}/items.json
+Saved to: .cache/releases/v{version}/raw-items.json
 
 ### Summary
 - Total items: {count}
@@ -107,6 +109,6 @@ Saved to: .cache/releases/v{version}/items.json
 - Bug Fixes: {count}
 
 ### Next Steps
-Create tracking Issue:
-  python run.py planner {version}
+Group items:
+  python run.py group-release {version} --all
 ```

--- a/.kiro/agents/prompts/group-release.md
+++ b/.kiro/agents/prompts/group-release.md
@@ -4,7 +4,7 @@ You are a release notes grouper. Group raw items into feature groups.
 
 ## Input
 
-Read `.cache/releases/v{version}/batch.json`:
+Read `.cache/releases/v{version}/batch.json` (created by run.py from `raw-items.json`):
 ```json
 {
   "items": [

--- a/.kiro/agents/prompts/review-release.md
+++ b/.kiro/agents/prompts/review-release.md
@@ -4,7 +4,7 @@ You are a release notes reviewer. Review the parsed JSON, fix issues, and group 
 
 ## Input
 
-A JSON file at `.cache/releases/v{version}/items.json` containing parsed release notes.
+A JSON file at `.cache/releases/v{version}/raw-items.json` containing parsed release notes.
 
 ## Tasks
 
@@ -114,5 +114,5 @@ Use lowercase, hyphenated names:
 - Bug Fixes: {count} groups
 - Deprecations: {count} groups
 
-Saved to: .cache/releases/v{version}/items.json
+Saved to: .cache/releases/v{version}/raw-items.json
 ```

--- a/.kiro/steering/opensearch-knowledge.md
+++ b/.kiro/steering/opensearch-knowledge.md
@@ -45,9 +45,9 @@ Store fetched data in `.cache/` to avoid redundant API calls.
 ```
 .cache/
   releases/{version}/
-    release-notes-build.md       # From opensearch-build
-    release-notes-core.md        # From OpenSearch
-    release-notes-dashboards.md  # From OpenSearch-Dashboards
+    raw-items.json               # Parsed release items (from fetch-release)
+    batch.json                   # Current batch for group-release
+    groups.json                  # Grouped items (from group-release)
     prs/
       {number}.json              # Merged PRs only
     issues/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -11,20 +11,23 @@ opensearch-feature-explorer/
 ├── requirements.txt          # Python dependencies
 ├── mkdocs.yml                # MkDocs configuration
 ├── .kiro/
-│   └── agents/
-│       ├── *.json            # Agent configurations
-│       └── prompts/
-│           ├── base.md       # Shared knowledge
-│           └── *.md          # Agent-specific prompts
+│   ├── agents/
+│   │   ├── *.json            # Agent configurations
+│   │   └── prompts/
+│   │       └── *.md          # Agent-specific prompts
+│   └── steering/
+│       └── opensearch-knowledge.md  # Shared knowledge
 ├── data/                     # Persistent data
 │   └── releases/v{version}/
 │       └── groups.json
 ├── .cache/                   # Temporary cache
 │   └── releases/v{version}/
-│       ├── items.json
+│       ├── raw-items.json
+│       ├── batch.json
+│       ├── groups.json
 │       └── prs/, issues/
 └── docs/                     # Generated documentation
-    ├── features/             # Cumulative feature docs
+    ├── features/{repo}/      # Cumulative feature docs
     └── releases/v{version}/  # Version-specific docs
 ```
 

--- a/README.md
+++ b/README.md
@@ -34,11 +34,15 @@ graph TB
 
 | Agent | Description |
 |-------|-------------|
-| **fetch-release** | Fetch release notes → parse and save all items to JSON cache |
-| **planner** | Read JSON cache → create tracking Issue with all items |
+| **fetch-release** | Fetch release notes → parse and save all items to `raw-items.json` |
+| **group-release** | Group raw items into feature groups → save to `groups.json` |
+| **review-groups** | Review and refine groups (split over-aggregated, merge related) |
+| **planner** | Create GitHub Project and Issues from `groups.json` |
 | **create-issues** | Create individual investigation Issues from tracking Issue |
 | **investigate** | Deep investigation (4 modes: Issue, PR, Feature, Interactive Q&A) |
 | **summarize** | Aggregate release reports into release summary |
+| **generate-release-docs** | Generate release docs from existing feature documents |
+| **refactor** | Batch structural changes to existing reports |
 | **translate** | Translate reports to other languages |
 | **dev** | Development and maintenance of this tool itself |
 
@@ -73,9 +77,10 @@ gh auth login -s read:org,repo,workflow,project
 | Issue (group) | `[{category}] {group_name}` | `[feature] Star Tree Index` |
 | Label (release) | `release/v{version}` | `release/v3.0.0` |
 | Label (status) | `status/{status}` | `status/todo`, `status/done` |
+| Cache directory | `.cache/releases/v{version}/` | `.cache/releases/v3.0.0/` |
 | Data directory | `data/releases/v{version}/` | `data/releases/v3.0.0/` |
-| Release report | `docs/releases/v{version}/{group-name}.md` | `docs/releases/v3.0.0/star-tree-index.md` |
-| Feature report | `docs/features/{feature-name}.md` | `docs/features/star-tree-index.md` |
+| Release report | `docs/releases/v{version}/features/{repo}/{item-name}.md` | `docs/releases/v3.0.0/features/opensearch/star-tree-index.md` |
+| Feature report | `docs/features/{repo}/{feature-name}.md` | `docs/features/opensearch/star-tree-index.md` |
 
 ## Setup
 


### PR DESCRIPTION
## Summary
Fix inconsistencies between prompts, steering files, and documentation.

## Changes
- **README.md**: Add all 11 agents to table, update naming conventions with cache directory and repo-based paths
- **DEVELOPMENT.md**: Fix project structure (`base.md` → `steering/opensearch-knowledge.md`, `items.json` → `raw-items.json`)
- **steering/opensearch-knowledge.md**: Fix cache structure to match actual implementation
- **fetch-release.md**: Fix output filename to `raw-items.json`, update next steps
- **group-release.md**: Clarify `batch.json` is created from `raw-items.json`
- **review-release.md**: Fix input/output filename to `raw-items.json`