### PR TITLE
fix: add Mermaid JS CDN for diagram rendering

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,9 @@ theme:
 extra_css:
   - stylesheets/extra.css
 
+extra_javascript:
+  - https://unpkg.com/mermaid@10/dist/mermaid.min.js
+
 markdown_extensions:
   - pymdownx.superfences:
       custom_fences:


### PR DESCRIPTION
## Summary
Fix Mermaid diagrams not rendering on GitHub Pages.

## Changes
Add Mermaid JS CDN (`https://unpkg.com/mermaid@10/dist/mermaid.min.js`) to `extra_javascript` in mkdocs.yml.

The `pymdownx.superfences` extension generates the HTML structure, but the Mermaid JS library is needed to actually render the diagrams.