### PR TITLE
refactor: simplify tags to repository names only

### DIFF
--- a/docs/features/alerting-dashboards/alerting-dashboards-plugin-alerting-dashboards.md
+++ b/docs/features/alerting-dashboards/alerting-dashboards-plugin-alerting-dashboards.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/dashboards
-  - dashboards
-  - observability
-  - search
+  - alerting-dashboards
 ---
 # Alerting Dashboards Plugin
 

--- a/docs/features/alerting-dashboards/alerting-dashboards-plugin-alerting-summary-insights.md
+++ b/docs/features/alerting-dashboards/alerting-dashboards-plugin-alerting-summary-insights.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/dashboards
-  - dashboards
-  - indexing
-  - ml
-  - search
-  - sql
+  - alerting-dashboards
 ---
 # Alerting Summary & Insights
 

--- a/docs/features/alerting/alerting-ppl-alerting.md
+++ b/docs/features/alerting/alerting-ppl-alerting.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/server
-  - observability
-  - sql
+  - alerting
 ---
 # PPL Alerting
 

--- a/docs/features/alerting/alerting.md
+++ b/docs/features/alerting/alerting.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/server
-  - observability
-  - search
+  - alerting
 ---
 # Alerting
 

--- a/docs/features/anomaly-detection-dashboards/anomaly-detection-dashboards-plugin-anomaly-detection-daily-insights.md
+++ b/docs/features/anomaly-detection-dashboards/anomaly-detection-dashboards-plugin-anomaly-detection-daily-insights.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/dashboards
-  - dashboards
-  - indexing
-  - ml
+  - anomaly-detection-dashboards
 ---
 # Anomaly Detection Daily Insights
 

--- a/docs/features/anomaly-detection/anomaly-detection-admin-backend-role-bypass.md
+++ b/docs/features/anomaly-detection/anomaly-detection-admin-backend-role-bypass.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/server
-  - ml
-  - search
-  - security
+  - anomaly-detection
 ---
 # Anomaly Detection Admin Backend Role Bypass
 

--- a/docs/features/anomaly-detection/anomaly-detection-dependencies.md
+++ b/docs/features/anomaly-detection/anomaly-detection-dependencies.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/server
-  - ml
-  - security
+  - anomaly-detection
 ---
 # Anomaly Detection Dependencies
 

--- a/docs/features/anomaly-detection/anomaly-detection-dual-cluster-development.md
+++ b/docs/features/anomaly-detection/anomaly-detection-dual-cluster-development.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/server
-  - indexing
-  - ml
+  - anomaly-detection
 ---
 # Dual Cluster Development Environment
 

--- a/docs/features/anomaly-detection/anomaly-detection-forecasting.md
+++ b/docs/features/anomaly-detection/anomaly-detection-forecasting.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/server
-  - dashboards
-  - indexing
-  - ml
-  - observability
+  - anomaly-detection
 ---
 # Anomaly Detection Forecasting
 

--- a/docs/features/anomaly-detection/anomaly-detection-missing-data-handling.md
+++ b/docs/features/anomaly-detection/anomaly-detection-missing-data-handling.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/server
-  - ml
+  - anomaly-detection
 ---
 # Anomaly Detection Missing Data Handling
 

--- a/docs/features/anomaly-detection/anomaly-detection-remote-multi-index-support.md
+++ b/docs/features/anomaly-detection/anomaly-detection-remote-multi-index-support.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/server
-  - indexing
-  - ml
-  - search
+  - anomaly-detection
 ---
 # Anomaly Detection Remote/Multi-Index Support
 

--- a/docs/features/anomaly-detection/anomaly-detection.md
+++ b/docs/features/anomaly-detection/anomaly-detection.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/server
-  - dashboards
-  - indexing
-  - ml
+  - anomaly-detection
 ---
 # Anomaly Detection
 

--- a/docs/features/asynchronous-search/asynchronous-search.md
+++ b/docs/features/asynchronous-search/asynchronous-search.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - observability
-  - search
-  - security
+  - asynchronous-search
 ---
 # Asynchronous Search
 

--- a/docs/features/ci/ci-cd-build-improvements.md
+++ b/docs/features/ci/ci-cd-build-improvements.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - security
+  - ci
 ---
 # CI/CD & Build Improvements
 

--- a/docs/features/common-utils/common-utils-alerting-context-variables.md
+++ b/docs/features/common-utils/common-utils-alerting-context-variables.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - ml
+  - common-utils
 ---
 # Alerting Context Variables
 

--- a/docs/features/common-utils/common-utils.md
+++ b/docs/features/common-utils/common-utils.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - ml
-  - security
+  - common-utils
 ---
 # Common Utils
 

--- a/docs/features/common/common-pr-template-api-spec.md
+++ b/docs/features/common/common-pr-template-api-spec.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - common
 ---
 # PR Template API Specification Checkbox
 

--- a/docs/features/cross-cluster-replication/cross-cluster-replication.md
+++ b/docs/features/cross-cluster-replication/cross-cluster-replication.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/data
-  - component/server
-  - indexing
-  - ml
+  - cross-cluster-replication
 ---
 # Cross-Cluster Replication (CCR)
 

--- a/docs/features/custom-codecs/custom-codecs.md
+++ b/docs/features/custom-codecs/custom-codecs.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/data
-  - component/server
-  - indexing
-  - performance
-  - search
+  - custom-codecs
 ---
 # Custom Codecs
 

--- a/docs/features/dashboards-assistant/dashboards-assistant-ai-assistant-chatbot.md
+++ b/docs/features/dashboards-assistant/dashboards-assistant-ai-assistant-chatbot.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/dashboards
-  - dashboards
-  - ml
-  - search
+  - dashboards-assistant
 ---
 # AI Assistant / Chatbot
 

--- a/docs/features/dashboards-assistant/dashboards-assistant-ci-configuration.md
+++ b/docs/features/dashboards-assistant/dashboards-assistant-ci-configuration.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/dashboards
-  - dashboards
+  - dashboards-assistant
 ---
 # Dashboard Assistant CI Configuration
 

--- a/docs/features/dashboards-assistant/dashboards-assistant-text-to-visualization.md
+++ b/docs/features/dashboards-assistant/dashboards-assistant-text-to-visualization.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/dashboards
-  - dashboards
-  - ml
-  - search
-  - sql
+  - dashboards-assistant
 ---
 # Text to Visualization (t2viz)
 

--- a/docs/features/dashboards-assistant/dashboards-assistant.md
+++ b/docs/features/dashboards-assistant/dashboards-assistant.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/dashboards
-  - dashboards
-  - search
+  - dashboards-assistant
 ---
 # Dashboards Assistant
 

--- a/docs/features/dashboards-flow-framework/dashboards-flow-framework-ai-search-flows.md
+++ b/docs/features/dashboards-flow-framework/dashboards-flow-framework-ai-search-flows.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/dashboards
-  - dashboards
-  - indexing
-  - ml
-  - neural-search
-  - search
+  - dashboards-flow-framework
 ---
 # AI Search Flows
 

--- a/docs/features/dashboards-flow-framework/dashboards-flow-framework-backward-compatibility.md
+++ b/docs/features/dashboards-flow-framework/dashboards-flow-framework-backward-compatibility.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/dashboards
-  - dashboards
+  - dashboards-flow-framework
 ---
 # Backward Compatibility
 

--- a/docs/features/dashboards-flow-framework/dashboards-flow-framework-data-ingestion.md
+++ b/docs/features/dashboards-flow-framework/dashboards-flow-framework-data-ingestion.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/dashboards
-  - dashboards
-  - indexing
-  - k-nn
-  - ml
-  - search
+  - dashboards-flow-framework
 ---
 # Data Ingestion in OpenSearch Flow
 

--- a/docs/features/dashboards-maps/dashboards-maps-maps-geospatial.md
+++ b/docs/features/dashboards-maps/dashboards-maps-maps-geospatial.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/geo
-  - component/dashboards
-  - dashboards
-  - indexing
-  - search
+  - dashboards-maps
 ---
 # Maps & Geospatial
 

--- a/docs/features/dashboards-maps/dashboards-maps-maps-plugin-ui-updates.md
+++ b/docs/features/dashboards-maps/dashboards-maps-maps-plugin-ui-updates.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/geo
-  - component/dashboards
-  - dashboards
+  - dashboards-maps
 ---
 # Maps Plugin UI Updates
 

--- a/docs/features/dashboards-notifications/dashboards-notifications.md
+++ b/docs/features/dashboards-notifications/dashboards-notifications.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/dashboards
-  - dashboards
+  - dashboards-notifications
 ---
 # OpenSearch Dashboards Notifications
 

--- a/docs/features/dashboards-observability/dashboards-observability-ci-tests.md
+++ b/docs/features/dashboards-observability/dashboards-observability-ci-tests.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/dashboards
-  - dashboards
-  - indexing
-  - observability
-  - sql
+  - dashboards-observability
 ---
 # Dashboards Observability CI/Tests
 

--- a/docs/features/dashboards-observability/dashboards-observability-getting-started-workflows.md
+++ b/docs/features/dashboards-observability/dashboards-observability-getting-started-workflows.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/dashboards
-  - dashboards
-  - indexing
-  - observability
+  - dashboards-observability
 ---
 # Observability Getting Started Workflows
 

--- a/docs/features/dashboards-observability/dashboards-observability-observability-multi-data-source-support.md
+++ b/docs/features/dashboards-observability/dashboards-observability-observability-multi-data-source-support.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/dashboards
-  - dashboards
-  - observability
+  - dashboards-observability
 ---
 # Observability Multi-Data Source Support
 

--- a/docs/features/dashboards-observability/dashboards-observability-observability-notebooks.md
+++ b/docs/features/dashboards-observability/dashboards-observability-observability-notebooks.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/dashboards
-  - dashboards
-  - indexing
-  - ml
-  - search
-  - sql
+  - dashboards-observability
 ---
 # OpenSearch Dashboards Notebooks
 

--- a/docs/features/dashboards-observability/dashboards-observability-observability-traces.md
+++ b/docs/features/dashboards-observability/dashboards-observability-observability-traces.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/dashboards
-  - dashboards
-  - indexing
-  - ml
-  - observability
-  - performance
+  - dashboards-observability
 ---
 # Observability Traces
 

--- a/docs/features/dashboards-observability/dashboards-observability-observability-ui.md
+++ b/docs/features/dashboards-observability/dashboards-observability-observability-ui.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/dashboards
-  - dashboards
-  - observability
-  - search
-  - sql
+  - dashboards-observability
 ---
 # Observability UI
 

--- a/docs/features/dashboards-observability/dashboards-observability-observability-workspace-integration.md
+++ b/docs/features/dashboards-observability/dashboards-observability-observability-workspace-integration.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/dashboards
-  - dashboards
-  - indexing
-  - observability
+  - dashboards-observability
 ---
 # Observability Workspace Integration
 

--- a/docs/features/dashboards-observability/dashboards-observability-trace-analytics.md
+++ b/docs/features/dashboards-observability/dashboards-observability-trace-analytics.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/dashboards
-  - dashboards
-  - indexing
-  - ml
-  - observability
-  - performance
+  - dashboards-observability
 ---
 # Trace Analytics
 

--- a/docs/features/dashboards-query-workbench/dashboards-query-workbench-query-workbench.md
+++ b/docs/features/dashboards-query-workbench/dashboards-query-workbench-query-workbench.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - search
-  - sql
+  - dashboards-query-workbench
 ---
 # Query Workbench
 

--- a/docs/features/dashboards-reporting/dashboards-reporting.md
+++ b/docs/features/dashboards-reporting/dashboards-reporting.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/dashboards
-  - dashboards
-  - ml
+  - dashboards-reporting
 ---
 # OpenSearch Dashboards Reporting
 

--- a/docs/features/dashboards-search-relevance/dashboards-search-relevance-build-maintenance.md
+++ b/docs/features/dashboards-search-relevance/dashboards-search-relevance-build-maintenance.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/dashboards
-  - dashboards
-  - search
+  - dashboards-search-relevance
 ---
 # Dashboards Search Relevance Build Maintenance
 

--- a/docs/features/dashboards-search-relevance/dashboards-search-relevance-documentation-maintenance.md
+++ b/docs/features/dashboards-search-relevance/dashboards-search-relevance-documentation-maintenance.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/dashboards
-  - dashboards
-  - search
+  - dashboards-search-relevance
 ---
 # Documentation Maintenance
 

--- a/docs/features/dashboards-search-relevance/dashboards-search-relevance-repository-maintenance.md
+++ b/docs/features/dashboards-search-relevance/dashboards-search-relevance-repository-maintenance.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/dashboards
-  - ml
-  - security
+  - dashboards-search-relevance
 ---
 # Repository Maintenance
 

--- a/docs/features/dashboards-search-relevance/dashboards-search-relevance-search-comparison.md
+++ b/docs/features/dashboards-search-relevance/dashboards-search-relevance-search-comparison.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/dashboards
-  - dashboards
-  - indexing
-  - search
+  - dashboards-search-relevance
 ---
 # Search Comparison (Compare Search Results)
 

--- a/docs/features/flow-framework/flow-framework-access-control.md
+++ b/docs/features/flow-framework/flow-framework-access-control.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - ml
-  - search
-  - security
+  - flow-framework
 ---
 # Flow Framework Access Control
 

--- a/docs/features/flow-framework/flow-framework-connector-tools.md
+++ b/docs/features/flow-framework/flow-framework-connector-tools.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - ml
+  - flow-framework
 ---
 # Flow Framework Connector Tools
 

--- a/docs/features/flow-framework/flow-framework-text-to-visualization-templates.md
+++ b/docs/features/flow-framework/flow-framework-text-to-visualization-templates.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - dashboards
-  - ml
-  - search
-  - security
+  - flow-framework
 ---
 # Text-to-Visualization Templates
 

--- a/docs/features/flow-framework/flow-framework-utilities.md
+++ b/docs/features/flow-framework/flow-framework-utilities.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - indexing
-  - ml
-  - search
+  - flow-framework
 ---
 # Flow Framework Utilities
 

--- a/docs/features/flow-framework/flow-framework.md
+++ b/docs/features/flow-framework/flow-framework.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - indexing
-  - ml
+  - flow-framework
 ---
 # Flow Framework
 

--- a/docs/features/geospatial/geospatial-ip2geo.md
+++ b/docs/features/geospatial/geospatial-ip2geo.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/geo
-  - component/server
-  - indexing
-  - performance
+  - geospatial
 ---
 # IP2Geo Processor
 

--- a/docs/features/geospatial/geospatial-plugin.md
+++ b/docs/features/geospatial/geospatial-plugin.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/geo
-  - component/server
-  - indexing
-  - performance
-  - search
+  - geospatial
 ---
 # Geospatial Plugin
 

--- a/docs/features/index-management-dashboards/index-management-dashboards.md
+++ b/docs/features/index-management-dashboards/index-management-dashboards.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/data
-  - component/dashboards
-  - dashboards
-  - indexing
+  - index-management-dashboards
 ---
 # Index Management Dashboards
 

--- a/docs/features/index-management/index-management-snapshot-management.md
+++ b/docs/features/index-management/index-management-snapshot-management.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/data
-  - component/server
-  - indexing
+  - index-management
 ---
 # Snapshot Management
 

--- a/docs/features/index-management/index-management.md
+++ b/docs/features/index-management/index-management.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/data
-  - component/server
-  - indexing
+  - index-management
 ---
 # Index Management
 

--- a/docs/features/job-scheduler/job-scheduler.md
+++ b/docs/features/job-scheduler/job-scheduler.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/data
-  - component/server
-  - indexing
+  - job-scheduler
 ---
 # Job Scheduler
 

--- a/docs/features/k-nn/k-nn-avx512-support.md
+++ b/docs/features/k-nn/k-nn-avx512-support.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
   - k-nn
-  - performance
-  - search
 ---
 # k-NN AVX512 SIMD Support
 

--- a/docs/features/k-nn/k-nn-build.md
+++ b/docs/features/k-nn/k-nn-build.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
   - k-nn
-  - performance
-  - search
-  - security
 ---
 # k-NN Build Infrastructure
 

--- a/docs/features/k-nn/k-nn-byte-vector-support.md
+++ b/docs/features/k-nn/k-nn-byte-vector-support.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
   - k-nn
-  - search
 ---
 # k-NN Byte Vector Support
 

--- a/docs/features/k-nn/k-nn-derived-source-codec-refactoring.md
+++ b/docs/features/k-nn/k-nn-derived-source-codec-refactoring.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
   - k-nn
-  - search
 ---
 # k-NN Derived Source & Codec Refactoring
 

--- a/docs/features/k-nn/k-nn-disk-based-vector-search.md
+++ b/docs/features/k-nn/k-nn-disk-based-vector-search.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
   - k-nn
-  - search
 ---
 # Disk-Based Vector Search
 

--- a/docs/features/k-nn/k-nn-engine-enhancements.md
+++ b/docs/features/k-nn/k-nn-engine-enhancements.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
   - k-nn
-  - performance
-  - search
 ---
 # k-NN Engine Enhancements
 

--- a/docs/features/k-nn/k-nn-explain-api.md
+++ b/docs/features/k-nn/k-nn-explain-api.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
   - k-nn
-  - performance
-  - search
 ---
 # k-NN Explain API
 

--- a/docs/features/k-nn/k-nn-iterative-graph-build.md
+++ b/docs/features/k-nn/k-nn-iterative-graph-build.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
   - k-nn
-  - ml
-  - performance
 ---
 # k-NN Iterative Graph Build
 

--- a/docs/features/k-nn/k-nn-late-interaction.md
+++ b/docs/features/k-nn/k-nn-late-interaction.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
   - k-nn
-  - ml
-  - neural-search
-  - search
 ---
 # Late Interaction
 

--- a/docs/features/k-nn/k-nn-lucene-on-faiss.md
+++ b/docs/features/k-nn/k-nn-lucene-on-faiss.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
   - k-nn
-  - performance
-  - search
 ---
 # Lucene On Faiss (Memory Optimized Search)
 

--- a/docs/features/k-nn/k-nn-lucene-vector-integration.md
+++ b/docs/features/k-nn/k-nn-lucene-vector-integration.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
   - k-nn
-  - performance
-  - search
 ---
 # k-NN Lucene Vector Integration
 

--- a/docs/features/k-nn/k-nn-maximal-marginal-relevance-mmr.md
+++ b/docs/features/k-nn/k-nn-maximal-marginal-relevance-mmr.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
   - k-nn
-  - ml
-  - search
 ---
 # Maximal Marginal Relevance (MMR)
 

--- a/docs/features/k-nn/k-nn-memory-optimized-warmup.md
+++ b/docs/features/k-nn/k-nn-memory-optimized-warmup.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
   - k-nn
-  - performance
-  - search
 ---
 # k-NN Memory Optimized Warmup
 

--- a/docs/features/k-nn/k-nn-model-metadata.md
+++ b/docs/features/k-nn/k-nn-model-metadata.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
   - k-nn
-  - ml
-  - performance
-  - search
 ---
 # k-NN Model Metadata
 

--- a/docs/features/k-nn/k-nn-performance-engine.md
+++ b/docs/features/k-nn/k-nn-performance-engine.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
   - k-nn
-  - performance
-  - search
 ---
 # k-NN Performance & Engine
 

--- a/docs/features/k-nn/k-nn-query-rescore.md
+++ b/docs/features/k-nn/k-nn-query-rescore.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
   - k-nn
-  - search
 ---
 # k-NN Query Rescore
 

--- a/docs/features/k-nn/k-nn-remote-vector-index-build.md
+++ b/docs/features/k-nn/k-nn-remote-vector-index-build.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
   - k-nn
-  - search
 ---
 # Remote Vector Index Build
 

--- a/docs/features/k-nn/k-nn-space-type-configuration.md
+++ b/docs/features/k-nn/k-nn-space-type-configuration.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
   - k-nn
-  - search
 ---
 # k-NN Space Type Configuration
 

--- a/docs/features/k-nn/k-nn-vector-search-k-nn.md
+++ b/docs/features/k-nn/k-nn-vector-search-k-nn.md
@@ -1,14 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
   - k-nn
-  - ml
-  - neural-search
-  - observability
-  - performance
-  - search
 ---
 # Vector Search (k-NN)
 

--- a/docs/features/learning/learning-to-rank.md
+++ b/docs/features/learning/learning-to-rank.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - ml
-  - search
+  - learning
 ---
 # Learning to Rank
 

--- a/docs/features/ml-commons-dashboards/ml-commons-dashboards.md
+++ b/docs/features/ml-commons-dashboards/ml-commons-dashboards.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/dashboards
-  - dashboards
-  - ml
+  - ml-commons-dashboards
 ---
 # ML Commons Dashboards
 

--- a/docs/features/ml-commons/ml-commons-agent-framework.md
+++ b/docs/features/ml-commons/ml-commons-agent-framework.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - ml
-  - search
+  - ml-commons
 ---
 # ML Commons Agent Framework
 

--- a/docs/features/ml-commons/ml-commons-agentic-memory.md
+++ b/docs/features/ml-commons/ml-commons-agentic-memory.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - indexing
-  - k-nn
-  - ml
-  - neural-search
-  - search
+  - ml-commons
 ---
 # Agentic Memory
 

--- a/docs/features/ml-commons/ml-commons-batch-ingestion.md
+++ b/docs/features/ml-commons/ml-commons-batch-ingestion.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - indexing
-  - k-nn
-  - ml
-  - neural-search
-  - search
+  - ml-commons
 ---
 # ML Commons Batch Ingestion
 

--- a/docs/features/ml-commons/ml-commons-blueprints.md
+++ b/docs/features/ml-commons/ml-commons-blueprints.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - ml
-  - security
+  - ml-commons
 ---
 # ML Commons Connector Blueprints
 

--- a/docs/features/ml-commons/ml-commons-ci-cd.md
+++ b/docs/features/ml-commons/ml-commons-ci-cd.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - ml
-  - security
+  - ml-commons
 ---
 # ML Commons CI/CD
 

--- a/docs/features/ml-commons/ml-commons-configuration.md
+++ b/docs/features/ml-commons/ml-commons-configuration.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - indexing
-  - ml
+  - ml-commons
 ---
 # ML Commons Configuration
 

--- a/docs/features/ml-commons/ml-commons-connector-model-validation.md
+++ b/docs/features/ml-commons/ml-commons-connector-model-validation.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - indexing
-  - ml
-  - security
+  - ml-commons
 ---
 # ML Commons Connector and Model Validation
 

--- a/docs/features/ml-commons/ml-commons-connector.md
+++ b/docs/features/ml-commons/ml-commons-connector.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - ml
-  - security
+  - ml-commons
 ---
 # ML Commons Connector
 

--- a/docs/features/ml-commons/ml-commons-dependencies.md
+++ b/docs/features/ml-commons/ml-commons-dependencies.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - ml
+  - ml-commons
 ---
 # ML Commons Dependencies
 

--- a/docs/features/ml-commons/ml-commons-documentation-tutorials.md
+++ b/docs/features/ml-commons/ml-commons-documentation-tutorials.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - ml
-  - neural-search
-  - search
+  - ml-commons
 ---
 # ML Commons Documentation & Tutorials
 

--- a/docs/features/ml-commons/ml-commons-enhancements.md
+++ b/docs/features/ml-commons/ml-commons-enhancements.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - ml
-  - security
+  - ml-commons
 ---
 # ML Commons Enhancements
 

--- a/docs/features/ml-commons/ml-commons-error-handling.md
+++ b/docs/features/ml-commons/ml-commons-error-handling.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - ml
+  - ml-commons
 ---
 # ML Commons Error Handling
 

--- a/docs/features/ml-commons/ml-commons-global-resource-support.md
+++ b/docs/features/ml-commons/ml-commons-global-resource-support.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - indexing
-  - ml
-  - security
+  - ml-commons
 ---
 # Global Resource Support
 

--- a/docs/features/ml-commons/ml-commons-index-insight.md
+++ b/docs/features/ml-commons/ml-commons-index-insight.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - indexing
-  - ml
-  - performance
-  - search
+  - ml-commons
 ---
 # Index Insight
 

--- a/docs/features/ml-commons/ml-commons-mcp.md
+++ b/docs/features/ml-commons/ml-commons-mcp.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - ml
+  - ml-commons
 ---
 # ML Commons MCP (Model Context Protocol)
 

--- a/docs/features/ml-commons/ml-commons-memory-metadata.md
+++ b/docs/features/ml-commons/ml-commons-memory-metadata.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - indexing
-  - ml
-  - search
+  - ml-commons
 ---
 # ML Commons Memory Metadata
 

--- a/docs/features/ml-commons/ml-commons-metrics-framework.md
+++ b/docs/features/ml-commons/ml-commons-metrics-framework.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - ml
-  - observability
-  - performance
+  - ml-commons
 ---
 # Metrics Framework (ML Commons)
 

--- a/docs/features/ml-commons/ml-commons-ml-config-api.md
+++ b/docs/features/ml-commons/ml-commons-ml-config-api.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - indexing
-  - ml
-  - security
+  - ml-commons
 ---
 # ML Config API
 

--- a/docs/features/ml-commons/ml-commons-ml-inference-processor.md
+++ b/docs/features/ml-commons/ml-commons-ml-inference-processor.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - indexing
-  - ml
-  - neural-search
-  - search
+  - ml-commons
 ---
 # ML Inference Processor
 

--- a/docs/features/ml-commons/ml-commons-model-deployment.md
+++ b/docs/features/ml-commons/ml-commons-model-deployment.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - ml
-  - performance
+  - ml-commons
 ---
 # ML Commons Model Deployment
 

--- a/docs/features/ml-commons/ml-commons-model-inference.md
+++ b/docs/features/ml-commons/ml-commons-model-inference.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - ml
-  - search
+  - ml-commons
 ---
 # ML Commons Model & Inference
 

--- a/docs/features/ml-commons/ml-commons-multi-tenancy.md
+++ b/docs/features/ml-commons/ml-commons-multi-tenancy.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - indexing
-  - ml
-  - security
+  - ml-commons
 ---
 # ML Commons Multi-tenancy
 

--- a/docs/features/ml-commons/ml-commons-planexecutereflect-agent.md
+++ b/docs/features/ml-commons/ml-commons-planexecutereflect-agent.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - indexing
-  - ml
-  - search
+  - ml-commons
 ---
 # PlanExecuteReflect Agent
 

--- a/docs/features/ml-commons/ml-commons-query-assist.md
+++ b/docs/features/ml-commons/ml-commons-query-assist.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - dashboards
-  - indexing
-  - ml
-  - search
-  - sql
+  - ml-commons
 ---
 # Query Assist
 

--- a/docs/features/ml-commons/ml-commons-sparse-encoding.md
+++ b/docs/features/ml-commons/ml-commons-sparse-encoding.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - indexing
-  - ml
-  - neural-search
-  - search
+  - ml-commons
 ---
 # ML Commons Sparse Encoding
 

--- a/docs/features/ml-commons/ml-commons-stability.md
+++ b/docs/features/ml-commons/ml-commons-stability.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - indexing
-  - ml
-  - search
+  - ml-commons
 ---
 # ML Commons Stability and Reliability
 

--- a/docs/features/ml-commons/ml-commons-streaming-apis.md
+++ b/docs/features/ml-commons/ml-commons-streaming-apis.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - ml
+  - ml-commons
 ---
 # Streaming APIs
 

--- a/docs/features/ml-commons/ml-commons-tools.md
+++ b/docs/features/ml-commons/ml-commons-tools.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - indexing
-  - ml
-  - search
+  - ml-commons
 ---
 # ML Commons Tools
 

--- a/docs/features/multi-plugin/multi-plugin-build-infrastructure-gradle-jdk.md
+++ b/docs/features/multi-plugin/multi-plugin-build-infrastructure-gradle-jdk.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - indexing
+  - multi-plugin
 ---
 # Build Infrastructure (Gradle/JDK)
 

--- a/docs/features/multi-plugin/multi-plugin-ci-cd-testing-infrastructure.md
+++ b/docs/features/multi-plugin/multi-plugin-ci-cd-testing-infrastructure.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - indexing
-  - k-nn
-  - security
-  - sql
+  - multi-plugin
 ---
 # CI/CD & Testing Infrastructure
 

--- a/docs/features/multi-plugin/multi-plugin-dependency-bumps.md
+++ b/docs/features/multi-plugin/multi-plugin-dependency-bumps.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - security
+  - multi-plugin
 ---
 # Dependency Bumps
 

--- a/docs/features/multi-plugin/multi-plugin-gradle-9-compatibility.md
+++ b/docs/features/multi-plugin/multi-plugin-gradle-9-compatibility.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - indexing
+  - multi-plugin
 ---
 # Gradle 9 Compatibility
 

--- a/docs/features/multi-plugin/multi-plugin-header-redesign.md
+++ b/docs/features/multi-plugin/multi-plugin-header-redesign.md
@@ -1,13 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - dashboards
-  - indexing
-  - ml
-  - observability
-  - search
-  - security
+  - multi-plugin
 ---
 # Header Redesign
 

--- a/docs/features/multi-plugin/multi-plugin-jdk-21-java-agent-migration.md
+++ b/docs/features/multi-plugin/multi-plugin-jdk-21-java-agent-migration.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - k-nn
-  - ml
-  - search
-  - security
+  - multi-plugin
 ---
 # JDK 21 & Java Agent Migration
 

--- a/docs/features/multi-plugin/multi-plugin-look-and-feel-ui-improvements.md
+++ b/docs/features/multi-plugin/multi-plugin-look-and-feel-ui-improvements.md
@@ -1,13 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - dashboards
-  - indexing
-  - ml
-  - observability
-  - search
-  - security
+  - multi-plugin
 ---
 # Look & Feel UI Improvements
 

--- a/docs/features/multi-plugin/multi-plugin-maintainer-updates.md
+++ b/docs/features/multi-plugin/multi-plugin-maintainer-updates.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - dashboards
-  - indexing
-  - security
+  - multi-plugin
 ---
 # Maintainer Updates
 

--- a/docs/features/multi-plugin/multi-plugin-multi-data-source-support.md
+++ b/docs/features/multi-plugin/multi-plugin-multi-data-source-support.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - dashboards
-  - indexing
-  - ml
-  - search
-  - security
+  - multi-plugin
 ---
 # Multi-Data Source Support
 

--- a/docs/features/multi-plugin/multi-plugin-search-autocomplete.md
+++ b/docs/features/multi-plugin/multi-plugin-search-autocomplete.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - dashboards
-  - indexing
-  - search
-  - sql
+  - multi-plugin
 ---
 # Search Autocomplete
 

--- a/docs/features/multi-plugin/multi-plugin-testing-library-updates.md
+++ b/docs/features/multi-plugin/multi-plugin-testing-library-updates.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - dashboards
-  - indexing
+  - multi-plugin
 ---
 # Testing Library Updates
 

--- a/docs/features/multi-plugin/multi-plugin-version-bumps-release-notes.md
+++ b/docs/features/multi-plugin/multi-plugin-version-bumps-release-notes.md
@@ -1,14 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - dashboards
-  - indexing
-  - ml
-  - observability
-  - performance
-  - search
-  - security
+  - multi-plugin
 ---
 # Version Bumps & Release Notes
 

--- a/docs/features/multi-plugin/multi-plugin-version-increment.md
+++ b/docs/features/multi-plugin/multi-plugin-version-increment.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - indexing
-  - ml
-  - security
+  - multi-plugin
 ---
 # Version Increment
 

--- a/docs/features/neural-search/neural-search-agentic-search.md
+++ b/docs/features/neural-search/neural-search-agentic-search.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - ml
   - neural-search
-  - performance
-  - search
 ---
 # Agentic Search
 

--- a/docs/features/neural-search/neural-search-batch-ingestion.md
+++ b/docs/features/neural-search/neural-search-batch-ingestion.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - ml
   - neural-search
-  - performance
 ---
 # Batch Ingestion
 

--- a/docs/features/neural-search/neural-search-compatibility.md
+++ b/docs/features/neural-search/neural-search-compatibility.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - k-nn
-  - ml
   - neural-search
-  - search
 ---
 # Neural Search Compatibility
 

--- a/docs/features/neural-search/neural-search-dependencies.md
+++ b/docs/features/neural-search/neural-search-dependencies.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - k-nn
   - neural-search
-  - search
 ---
 # Neural Search Dependencies
 

--- a/docs/features/neural-search/neural-search-hybrid-query.md
+++ b/docs/features/neural-search/neural-search-hybrid-query.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
   - neural-search
-  - search
 ---
 # Hybrid Query
 

--- a/docs/features/neural-search/neural-search-neural-sparse-search.md
+++ b/docs/features/neural-search/neural-search-neural-sparse-search.md
@@ -1,13 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - k-nn
-  - ml
   - neural-search
-  - performance
-  - search
 ---
 # Neural Sparse Search
 

--- a/docs/features/neural-search/neural-search-reranking.md
+++ b/docs/features/neural-search/neural-search-reranking.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - ml
   - neural-search
-  - search
 ---
 # Neural Search Reranking
 

--- a/docs/features/neural-search/neural-search-rescore.md
+++ b/docs/features/neural-search/neural-search-rescore.md
@@ -1,13 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - k-nn
-  - ml
   - neural-search
-  - performance
-  - search
 ---
 # Neural Search Rescore
 

--- a/docs/features/neural-search/neural-search-seismic-sparse-ann.md
+++ b/docs/features/neural-search/neural-search-seismic-sparse-ann.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
   - neural-search
-  - performance
-  - search
 ---
 # SEISMIC Sparse ANN
 

--- a/docs/features/neural-search/neural-search-semantic-field.md
+++ b/docs/features/neural-search/neural-search-semantic-field.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - k-nn
-  - ml
   - neural-search
-  - search
 ---
 # Semantic Field
 

--- a/docs/features/neural-search/neural-search-semantic-highlighting.md
+++ b/docs/features/neural-search/neural-search-semantic-highlighting.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - ml
   - neural-search
-  - search
 ---
 # Semantic Highlighting
 

--- a/docs/features/neural-search/neural-search-stats.md
+++ b/docs/features/neural-search/neural-search-stats.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
   - neural-search
-  - performance
-  - search
 ---
 # Neural Search Stats
 

--- a/docs/features/neural-search/neural-search-text-chunking.md
+++ b/docs/features/neural-search/neural-search-text-chunking.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - ml
   - neural-search
-  - search
 ---
 # Text Chunking
 

--- a/docs/features/notifications/notifications-plugin.md
+++ b/docs/features/notifications/notifications-plugin.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/server
-  - dashboards
-  - indexing
-  - security
+  - notifications
 ---
 # Notifications Plugin
 

--- a/docs/features/observability/observability-cypress-updates.md
+++ b/docs/features/observability/observability-cypress-updates.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/server
-  - dashboards
   - observability
-  - search
-  - security
 ---
 # Observability Cypress Test Dependencies
 

--- a/docs/features/observability/observability-infrastructure.md
+++ b/docs/features/observability/observability-infrastructure.md
@@ -1,8 +1,5 @@
 ---
 tags:
-  - domain/observability
-  - component/server
-  - indexing
   - observability
 ---
 # Observability Infrastructure

--- a/docs/features/observability/observability-integrations.md
+++ b/docs/features/observability/observability-integrations.md
@@ -1,9 +1,5 @@
 ---
 tags:
-  - domain/observability
-  - component/server
-  - dashboards
-  - indexing
   - observability
 ---
 # Observability Integrations

--- a/docs/features/observability/observability-release-maintenance.md
+++ b/docs/features/observability/observability-release-maintenance.md
@@ -1,8 +1,5 @@
 ---
 tags:
-  - domain/observability
-  - component/server
-  - dashboards
   - observability
 ---
 # Observability Release Maintenance

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-ai-chat.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-ai-chat.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - ml
-  - search
+  - opensearch-dashboards
 ---
 # OpenSearch Dashboards AI Chat
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-async-query.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-async-query.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - indexing
-  - search
-  - sql
+  - opensearch-dashboards
 ---
 # Async Query
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-banner-plugin.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-banner-plugin.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
+  - opensearch-dashboards
 ---
 # Banner Plugin
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-bar-chart-enhancements.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-bar-chart-enhancements.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - performance
+  - opensearch-dashboards
 ---
 # Bar Chart Enhancements
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-content-management.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-content-management.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
+  - opensearch-dashboards
 ---
 # Content Management
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-cross-cluster-search.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-cross-cluster-search.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - indexing
-  - search
+  - opensearch-dashboards
 ---
 # Cross-Cluster Search in OpenSearch Dashboards
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-ai-insights.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-ai-insights.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - indexing
-  - ml
-  - search
+  - opensearch-dashboards
 ---
 # Dashboards AI Insights
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-ci-cd-documentation.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-ci-cd-documentation.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
+  - opensearch-dashboards
 ---
 # Dashboards CI/CD & Documentation
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-ci-tests.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-ci-tests.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
+  - opensearch-dashboards
 ---
 # Dashboards CI/Tests
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-code-quality-testing.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-code-quality-testing.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - performance
+  - opensearch-dashboards
 ---
 # Dashboards Code Quality & Testing
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-console.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-console.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - indexing
-  - search
+  - opensearch-dashboards
 ---
 # Dashboards Console (Dev Tools)
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-csp.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-csp.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - security
+  - opensearch-dashboards
 ---
 # Dashboards Content Security Policy (CSP)
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-cypress-testing.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-cypress-testing.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - search
+  - opensearch-dashboards
 ---
 # Dashboards Cypress Testing
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-features.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-features.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - performance
-  - search
-  - sql
+  - opensearch-dashboards
 ---
 # Dashboards Features
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-frontend-cleanup.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-frontend-cleanup.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
+  - opensearch-dashboards
 ---
 # Dashboards Frontend Cleanup
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-improvements.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-improvements.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - search
+  - opensearch-dashboards
 ---
 # Dashboards Improvements
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-maintenance.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-maintenance.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - search
+  - opensearch-dashboards
 ---
 # Dashboards Maintenance
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-ui-updates.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-ui-updates.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
+  - opensearch-dashboards
 ---
 # Dashboards UI Updates (OUI)
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-data-connections.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-data-connections.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - indexing
-  - search
+  - opensearch-dashboards
 ---
 # Data Connections
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-data-importer.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-data-importer.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - indexing
+  - opensearch-dashboards
 ---
 # Data Importer
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-data-source-permissions.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-data-source-permissions.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - security
+  - opensearch-dashboards
 ---
 # Data Source Permissions
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-data-source-selector.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-data-source-selector.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
+  - opensearch-dashboards
 ---
 # Data Source Selector
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dataset-explorer.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dataset-explorer.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - indexing
-  - observability
-  - search
+  - opensearch-dashboards
 ---
 # Dataset Explorer
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dataset-management.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dataset-management.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - indexing
+  - opensearch-dashboards
 ---
 # Dataset Management
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dependency-updates.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dependency-updates.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - performance
-  - security
+  - opensearch-dashboards
 ---
 # Dependency Updates (OpenSearch Dashboards)
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dev-tools.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dev-tools.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - search
+  - opensearch-dashboards
 ---
 # Dev Tools
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-discover.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-discover.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - indexing
-  - ml
-  - search
-  - sql
+  - opensearch-dashboards
 ---
 # Discover
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dompurify-sanitization.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dompurify-sanitization.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - security
+  - opensearch-dashboards
 ---
 # DOMPurify Sanitization
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dynamic-config.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dynamic-config.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - indexing
+  - opensearch-dashboards
 ---
 # Dynamic Config
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-experimental-features.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-experimental-features.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
+  - opensearch-dashboards
 ---
 # Experimental Features - User Personal Settings
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-explore-traces.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-explore-traces.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - observability
+  - opensearch-dashboards
 ---
 # Explore Traces
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-explore.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-explore.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - observability
-  - performance
-  - search
-  - sql
+  - opensearch-dashboards
 ---
 # Explore Plugin
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-global-search.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-global-search.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - search
+  - opensearch-dashboards
 ---
 # Global Search
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-i18n-localization.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-i18n-localization.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
+  - opensearch-dashboards
 ---
 # i18n & Localization
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-input-control-visualization.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-input-control-visualization.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
+  - opensearch-dashboards
 ---
 # Input Control Visualization
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-keyboard-shortcuts.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-keyboard-shortcuts.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
+  - opensearch-dashboards
 ---
 # Keyboard Shortcuts
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-monaco-editor.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-monaco-editor.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - search
-  - sql
+  - opensearch-dashboards
 ---
 # Monaco Editor
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-navigation.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-navigation.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - observability
-  - search
-  - security
+  - opensearch-dashboards
 ---
 # Navigation
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-osd-optimizer-cache.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-osd-optimizer-cache.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - performance
+  - opensearch-dashboards
 ---
 # OSD Optimizer Cache
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-oui.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-oui.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
+  - opensearch-dashboards
 ---
 # OpenSearch UI (OUI)
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-plugin-compatibility.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-plugin-compatibility.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - indexing
+  - opensearch-dashboards
 ---
 # Plugin Compatibility
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-query-assistant.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-query-assistant.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - indexing
-  - ml
-  - search
-  - sql
+  - opensearch-dashboards
 ---
 # Query Assistant
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-query-editor.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-query-editor.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - search
-  - sql
+  - opensearch-dashboards
 ---
 # Query Editor
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-query-enhancements.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-query-enhancements.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - indexing
-  - search
-  - sql
+  - opensearch-dashboards
 ---
 # Query Enhancements
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-sample-data.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-sample-data.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - indexing
-  - observability
+  - opensearch-dashboards
 ---
 # Sample Data
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-saved-query-ux.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-saved-query-ux.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - search
+  - opensearch-dashboards
 ---
 # Saved Query UX
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-tsvb-visualization.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-tsvb-visualization.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - indexing
-  - observability
-  - search
+  - opensearch-dashboards
 ---
 # TSVB Visualization
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-ui-settings.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-ui-settings.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
+  - opensearch-dashboards
 ---
 # UI Settings
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-vended-dashboard-progress.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-vended-dashboard-progress.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - indexing
-  - search
+  - opensearch-dashboards
 ---
 # Vended Dashboard Progress
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-webpack-and-build-performance.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-webpack-and-build-performance.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - indexing
-  - observability
-  - performance
+  - opensearch-dashboards
 ---
 # Webpack & Build Performance
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-workspace.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-workspace.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/dashboards
-  - dashboards
-  - search
+  - opensearch-dashboards
 ---
 # Workspace
 

--- a/docs/features/opensearch-remote-metadata-sdk/opensearch-remote-metadata-sdk-remote-metadata-sdk.md
+++ b/docs/features/opensearch-remote-metadata-sdk/opensearch-remote-metadata-sdk-remote-metadata-sdk.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch-remote-metadata-sdk
 ---
 # OpenSearch Remote Metadata SDK
 

--- a/docs/features/opensearch-system-templates/opensearch-system-templates-system-templates.md
+++ b/docs/features/opensearch-system-templates/opensearch-system-templates-system-templates.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - observability
-  - performance
+  - opensearch-system-templates
 ---
 # System Templates (Application-Based Configuration)
 

--- a/docs/features/opensearch/opensearch-actionplugin-rest-handler-wrapper.md
+++ b/docs/features/opensearch/opensearch-actionplugin-rest-handler-wrapper.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - security
+  - opensearch
 ---
 # ActionPlugin REST Handler Wrapper
 

--- a/docs/features/opensearch/opensearch-aggregation-optimizations.md
+++ b/docs/features/opensearch/opensearch-aggregation-optimizations.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
-  - search
+  - opensearch
 ---
 # Aggregation Optimizations
 

--- a/docs/features/opensearch/opensearch-aggregation-task-cancellation.md
+++ b/docs/features/opensearch/opensearch-aggregation-task-cancellation.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Aggregation Task Cancellation
 

--- a/docs/features/opensearch/opensearch-alias-write-index-policy.md
+++ b/docs/features/opensearch/opensearch-alias-write-index-policy.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Alias Write Index Policy
 

--- a/docs/features/opensearch/opensearch-approximation-framework.md
+++ b/docs/features/opensearch/opensearch-approximation-framework.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - dashboards
-  - performance
-  - search
+  - opensearch
 ---
 # Approximation Framework
 

--- a/docs/features/opensearch/opensearch-arrow-flight-rpc.md
+++ b/docs/features/opensearch/opensearch-arrow-flight-rpc.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
-  - search
+  - opensearch
 ---
 # Arrow Flight RPC
 

--- a/docs/features/opensearch/opensearch-async-shard-batch-fetch.md
+++ b/docs/features/opensearch/opensearch-async-shard-batch-fetch.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
+  - opensearch
 ---
 # Async Shard Batch Fetch
 

--- a/docs/features/opensearch/opensearch-async-shard-fetch-metrics.md
+++ b/docs/features/opensearch/opensearch-async-shard-fetch-metrics.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - observability
+  - opensearch
 ---
 # Async Shard Fetch Metrics
 

--- a/docs/features/opensearch/opensearch-automata-regex-optimization.md
+++ b/docs/features/opensearch/opensearch-automata-regex-optimization.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
-  - search
+  - opensearch
 ---
 # Automata & Regex Optimization
 

--- a/docs/features/opensearch/opensearch-azure-repository.md
+++ b/docs/features/opensearch/opensearch-azure-repository.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - security
+  - opensearch
 ---
 # Azure Repository Plugin
 

--- a/docs/features/opensearch/opensearch-booleanquery-rewrite-optimizations.md
+++ b/docs/features/opensearch/opensearch-booleanquery-rewrite-optimizations.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
-  - search
+  - opensearch
 ---
 # BooleanQuery Rewrite Optimizations
 

--- a/docs/features/opensearch/opensearch-bulk-api.md
+++ b/docs/features/opensearch/opensearch-bulk-api.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
+  - opensearch
 ---
 # Bulk API
 

--- a/docs/features/opensearch/opensearch-cardinality-aggregation.md
+++ b/docs/features/opensearch/opensearch-cardinality-aggregation.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - observability
-  - performance
-  - search
+  - opensearch
 ---
 # Cardinality Aggregation
 

--- a/docs/features/opensearch/opensearch-cat-indices-api.md
+++ b/docs/features/opensearch/opensearch-cat-indices-api.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - observability
-  - search
+  - opensearch
 ---
 # Cat Indices API
 

--- a/docs/features/opensearch/opensearch-client-api-enhancements.md
+++ b/docs/features/opensearch/opensearch-client-api-enhancements.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - ml
-  - search
+  - opensearch
 ---
 # Client API Enhancements
 

--- a/docs/features/opensearch/opensearch-cluster-info-resource-stats.md
+++ b/docs/features/opensearch/opensearch-cluster-info-resource-stats.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - observability
-  - performance
+  - opensearch
 ---
 # Cluster Info & Resource Stats
 

--- a/docs/features/opensearch/opensearch-cluster-management.md
+++ b/docs/features/opensearch/opensearch-cluster-management.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - observability
-  - performance
+  - opensearch
 ---
 # Cluster Management
 

--- a/docs/features/opensearch/opensearch-cluster-manager-metrics.md
+++ b/docs/features/opensearch/opensearch-cluster-manager-metrics.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - observability
-  - performance
+  - opensearch
 ---
 # Cluster Manager Metrics
 

--- a/docs/features/opensearch/opensearch-cluster-manager-throttling.md
+++ b/docs/features/opensearch/opensearch-cluster-manager-throttling.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
+  - opensearch
 ---
 # Cluster Manager Task Throttling
 

--- a/docs/features/opensearch/opensearch-cluster-permissions.md
+++ b/docs/features/opensearch/opensearch-cluster-permissions.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - security
+  - opensearch
 ---
 # Cluster Permissions
 

--- a/docs/features/opensearch/opensearch-cluster-state-allocation.md
+++ b/docs/features/opensearch/opensearch-cluster-state-allocation.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Cluster State & Allocation
 

--- a/docs/features/opensearch/opensearch-cluster-state-caching.md
+++ b/docs/features/opensearch/opensearch-cluster-state-caching.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
+  - opensearch
 ---
 # Cluster State Caching
 

--- a/docs/features/opensearch/opensearch-cluster-state-management.md
+++ b/docs/features/opensearch/opensearch-cluster-state-management.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Cluster State Management
 

--- a/docs/features/opensearch/opensearch-cluster-stats-api.md
+++ b/docs/features/opensearch/opensearch-cluster-stats-api.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - observability
-  - performance
+  - opensearch
 ---
 # Cluster Stats API
 

--- a/docs/features/opensearch/opensearch-clusterless-mode.md
+++ b/docs/features/opensearch/opensearch-clusterless-mode.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Clusterless Mode
 

--- a/docs/features/opensearch/opensearch-code-cleanup.md
+++ b/docs/features/opensearch/opensearch-code-cleanup.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
-  - search
+  - opensearch
 ---
 # Code Cleanup
 

--- a/docs/features/opensearch/opensearch-code-coverage-gradle.md
+++ b/docs/features/opensearch/opensearch-code-coverage-gradle.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - ml
+  - opensearch
 ---
 # Code Coverage (Gradle)
 

--- a/docs/features/opensearch/opensearch-combined-fields-query.md
+++ b/docs/features/opensearch/opensearch-combined-fields-query.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Combined Fields Query
 

--- a/docs/features/opensearch/opensearch-composite-aggregation.md
+++ b/docs/features/opensearch/opensearch-composite-aggregation.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Composite Aggregation
 

--- a/docs/features/opensearch/opensearch-composite-directory-factory.md
+++ b/docs/features/opensearch/opensearch-composite-directory-factory.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
+  - opensearch
 ---
 # Composite Directory Factory
 

--- a/docs/features/opensearch/opensearch-concurrent-segment-search.md
+++ b/docs/features/opensearch/opensearch-concurrent-segment-search.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
-  - search
+  - opensearch
 ---
 # Concurrent Segment Search
 

--- a/docs/features/opensearch/opensearch-configuration-utilities.md
+++ b/docs/features/opensearch/opensearch-configuration-utilities.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Configuration Utilities
 

--- a/docs/features/opensearch/opensearch-context-aware-segments.md
+++ b/docs/features/opensearch/opensearch-context-aware-segments.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
-  - search
+  - opensearch
 ---
 # Context Aware Segments
 

--- a/docs/features/opensearch/opensearch-core-dependencies.md
+++ b/docs/features/opensearch/opensearch-core-dependencies.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
-  - search
-  - security
+  - opensearch
 ---
 # OpenSearch Core Dependencies
 

--- a/docs/features/opensearch/opensearch-cross-cluster-settings.md
+++ b/docs/features/opensearch/opensearch-cross-cluster-settings.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
-  - security
+  - opensearch
 ---
 # Cross-Cluster Settings
 

--- a/docs/features/opensearch/opensearch-crypto-kms-plugin.md
+++ b/docs/features/opensearch/opensearch-crypto-kms-plugin.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Crypto KMS Plugin
 

--- a/docs/features/opensearch/opensearch-cryptography-security-libraries.md
+++ b/docs/features/opensearch/opensearch-cryptography-security-libraries.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - security
+  - opensearch
 ---
 # Cryptography & Security Libraries
 

--- a/docs/features/opensearch/opensearch-custom-index-name-resolver.md
+++ b/docs/features/opensearch/opensearch-custom-index-name-resolver.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Custom Index Name Resolver
 

--- a/docs/features/opensearch/opensearch-data-stream-index-template.md
+++ b/docs/features/opensearch/opensearch-data-stream-index-template.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - observability
+  - opensearch
 ---
 # Data Stream & Index Template
 

--- a/docs/features/opensearch/opensearch-date-format.md
+++ b/docs/features/opensearch/opensearch-date-format.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Date Format
 

--- a/docs/features/opensearch/opensearch-dependency-management.md
+++ b/docs/features/opensearch/opensearch-dependency-management.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
-  - security
+  - opensearch
 ---
 # Dependency Management
 

--- a/docs/features/opensearch/opensearch-deprecated-code-cleanup.md
+++ b/docs/features/opensearch/opensearch-deprecated-code-cleanup.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Deprecated Code Cleanup
 

--- a/docs/features/opensearch/opensearch-derived-fields.md
+++ b/docs/features/opensearch/opensearch-derived-fields.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Derived Fields
 

--- a/docs/features/opensearch/opensearch-derived-source.md
+++ b/docs/features/opensearch/opensearch-derived-source.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
-  - search
+  - opensearch
 ---
 # Derived Source
 

--- a/docs/features/opensearch/opensearch-docker-compose-v2-support.md
+++ b/docs/features/opensearch/opensearch-docker-compose-v2-support.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Docker Compose v2 Support
 

--- a/docs/features/opensearch/opensearch-docker-image-base.md
+++ b/docs/features/opensearch/opensearch-docker-image-base.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - security
+  - opensearch
 ---
 # Docker Image Base
 

--- a/docs/features/opensearch/opensearch-docrequest-refactoring.md
+++ b/docs/features/opensearch/opensearch-docrequest-refactoring.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - ml
-  - security
+  - opensearch
 ---
 # DocRequest Interface
 

--- a/docs/features/opensearch/opensearch-docvalues-optimization.md
+++ b/docs/features/opensearch/opensearch-docvalues-optimization.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
-  - search
+  - opensearch
 ---
 # DocValues Singleton Optimization
 

--- a/docs/features/opensearch/opensearch-dynamic-mapping.md
+++ b/docs/features/opensearch/opensearch-dynamic-mapping.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Dynamic Mapping
 

--- a/docs/features/opensearch/opensearch-dynamic-settings.md
+++ b/docs/features/opensearch/opensearch-dynamic-settings.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Dynamic Settings
 

--- a/docs/features/opensearch/opensearch-dynamic-threadpool-resize.md
+++ b/docs/features/opensearch/opensearch-dynamic-threadpool-resize.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Dynamic Threadpool Resize
 

--- a/docs/features/opensearch/opensearch-engine-api.md
+++ b/docs/features/opensearch/opensearch-engine-api.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Engine API
 

--- a/docs/features/opensearch/opensearch-engine-config.md
+++ b/docs/features/opensearch/opensearch-engine-config.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Engine Config
 

--- a/docs/features/opensearch/opensearch-extensions-framework.md
+++ b/docs/features/opensearch/opensearch-extensions-framework.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - security
+  - opensearch
 ---
 # Extensions Framework
 

--- a/docs/features/opensearch/opensearch-field-collapsing.md
+++ b/docs/features/opensearch/opensearch-field-collapsing.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Field Collapsing
 

--- a/docs/features/opensearch/opensearch-field-data-cache.md
+++ b/docs/features/opensearch/opensearch-field-data-cache.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
-  - search
+  - opensearch
 ---
 # Field Data Cache
 

--- a/docs/features/opensearch/opensearch-field-mapping.md
+++ b/docs/features/opensearch/opensearch-field-mapping.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Field Mapping
 

--- a/docs/features/opensearch/opensearch-file-cache.md
+++ b/docs/features/opensearch/opensearch-file-cache.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
-  - search
+  - opensearch
 ---
 # File Cache
 

--- a/docs/features/opensearch/opensearch-filter-field-type.md
+++ b/docs/features/opensearch/opensearch-filter-field-type.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # FilterFieldType
 

--- a/docs/features/opensearch/opensearch-filter-rewrite-optimization.md
+++ b/docs/features/opensearch/opensearch-filter-rewrite-optimization.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
-  - search
+  - opensearch
 ---
 # Filter Rewrite Optimization
 

--- a/docs/features/opensearch/opensearch-fips-compliance.md
+++ b/docs/features/opensearch/opensearch-fips-compliance.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - security
+  - opensearch
 ---
 # FIPS Compliance
 

--- a/docs/features/opensearch/opensearch-flat-object-field.md
+++ b/docs/features/opensearch/opensearch-flat-object-field.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Flat Object Field Type
 

--- a/docs/features/opensearch/opensearch-gradle-build-system.md
+++ b/docs/features/opensearch/opensearch-gradle-build-system.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Gradle Build System
 

--- a/docs/features/opensearch/opensearch-grok-processor.md
+++ b/docs/features/opensearch/opensearch-grok-processor.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Grok Processor
 

--- a/docs/features/opensearch/opensearch-grpc-transport--services.md
+++ b/docs/features/opensearch/opensearch-grpc-transport--services.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
-  - search
-  - security
+  - opensearch
 ---
 # gRPC Transport & Services
 

--- a/docs/features/opensearch/opensearch-hdfs-repository-kerberos.md
+++ b/docs/features/opensearch/opensearch-hdfs-repository-kerberos.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - security
+  - opensearch
 ---
 # HDFS Repository Kerberos Authentication
 

--- a/docs/features/opensearch/opensearch-hierarchical-acl-aware-routing.md
+++ b/docs/features/opensearch/opensearch-hierarchical-acl-aware-routing.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
-  - search
+  - opensearch
 ---
 # Hierarchical & ACL-aware Routing
 

--- a/docs/features/opensearch/opensearch-http-api.md
+++ b/docs/features/opensearch/opensearch-http-api.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - security
+  - opensearch
 ---
 # HTTP API
 

--- a/docs/features/opensearch/opensearch-http-client.md
+++ b/docs/features/opensearch/opensearch-http-client.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
-  - security
+  - opensearch
 ---
 # HTTP Client
 

--- a/docs/features/opensearch/opensearch-http2-support.md
+++ b/docs/features/opensearch/opensearch-http2-support.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # HTTP/2 Support
 

--- a/docs/features/opensearch/opensearch-identity-feature-flag-removal.md
+++ b/docs/features/opensearch/opensearch-identity-feature-flag-removal.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - security
+  - opensearch
 ---
 # Identity Feature Flag Removal
 

--- a/docs/features/opensearch/opensearch-index-output.md
+++ b/docs/features/opensearch/opensearch-index-output.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
+  - opensearch
 ---
 # Index Output Optimization
 

--- a/docs/features/opensearch/opensearch-index-refresh.md
+++ b/docs/features/opensearch/opensearch-index-refresh.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
+  - opensearch
 ---
 # Index Refresh
 

--- a/docs/features/opensearch/opensearch-index-settings.md
+++ b/docs/features/opensearch/opensearch-index-settings.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Index Settings
 

--- a/docs/features/opensearch/opensearch-jackson--query-limits.md
+++ b/docs/features/opensearch/opensearch-jackson--query-limits.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Jackson & Query Limits
 

--- a/docs/features/opensearch/opensearch-java-17-modernization.md
+++ b/docs/features/opensearch/opensearch-java-17-modernization.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Java 17 Modernization
 

--- a/docs/features/opensearch/opensearch-java-agent-accesscontroller.md
+++ b/docs/features/opensearch/opensearch-java-agent-accesscontroller.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - ml
-  - security
+  - opensearch
 ---
 # Java Agent AccessController
 

--- a/docs/features/opensearch/opensearch-java-runtime-and-jpms.md
+++ b/docs/features/opensearch/opensearch-java-runtime-and-jpms.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
+  - opensearch
 ---
 # Java Runtime & JPMS Support
 

--- a/docs/features/opensearch/opensearch-jdk-25-support.md
+++ b/docs/features/opensearch/opensearch-jdk-25-support.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
+  - opensearch
 ---
 # JDK 25 Support
 

--- a/docs/features/opensearch/opensearch-list-apis-paginated.md
+++ b/docs/features/opensearch/opensearch-list-apis-paginated.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # List APIs (Paginated)
 

--- a/docs/features/opensearch/opensearch-locale-provider.md
+++ b/docs/features/opensearch/opensearch-locale-provider.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Locale Provider
 

--- a/docs/features/opensearch/opensearch-lucene-10-upgrade.md
+++ b/docs/features/opensearch/opensearch-lucene-10-upgrade.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - k-nn
-  - performance
-  - search
+  - opensearch
 ---
 # Lucene 10 Upgrade
 

--- a/docs/features/opensearch/opensearch-lucene-integration.md
+++ b/docs/features/opensearch/opensearch-lucene-integration.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Lucene Integration
 

--- a/docs/features/opensearch/opensearch-lucene-similarity.md
+++ b/docs/features/opensearch/opensearch-lucene-similarity.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - ml
-  - search
+  - opensearch
 ---
 # Lucene Similarity
 

--- a/docs/features/opensearch/opensearch-lucene-upgrade.md
+++ b/docs/features/opensearch/opensearch-lucene-upgrade.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - k-nn
-  - performance
-  - search
-  - security
+  - opensearch
 ---
 # Lucene Upgrade
 

--- a/docs/features/opensearch/opensearch-mapping-transformer.md
+++ b/docs/features/opensearch/opensearch-mapping-transformer.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - ml
-  - neural-search
-  - search
+  - opensearch
 ---
 # Mapping Transformer
 

--- a/docs/features/opensearch/opensearch-maven-snapshots-publishing.md
+++ b/docs/features/opensearch/opensearch-maven-snapshots-publishing.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - security
+  - opensearch
 ---
 # Maven Snapshots Publishing
 

--- a/docs/features/opensearch/opensearch-merge-segment-settings.md
+++ b/docs/features/opensearch/opensearch-merge-segment-settings.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
-  - search
+  - opensearch
 ---
 # Merge & Segment Settings
 

--- a/docs/features/opensearch/opensearch-multi-search-api.md
+++ b/docs/features/opensearch/opensearch-multi-search-api.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Multi-Search API
 

--- a/docs/features/opensearch/opensearch-nested-aggregations.md
+++ b/docs/features/opensearch/opensearch-nested-aggregations.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Nested Aggregations
 

--- a/docs/features/opensearch/opensearch-netty-arena-settings.md
+++ b/docs/features/opensearch/opensearch-netty-arena-settings.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
+  - opensearch
 ---
 # Netty Arena Settings
 

--- a/docs/features/opensearch/opensearch-network-configuration.md
+++ b/docs/features/opensearch/opensearch-network-configuration.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - security
+  - opensearch
 ---
 # Network Configuration
 

--- a/docs/features/opensearch/opensearch-node-join-leave.md
+++ b/docs/features/opensearch/opensearch-node-join-leave.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Node Join/Leave
 

--- a/docs/features/opensearch/opensearch-node-roles-configuration.md
+++ b/docs/features/opensearch/opensearch-node-roles-configuration.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - ml
-  - performance
-  - search
+  - opensearch
 ---
 # Node Roles Configuration
 

--- a/docs/features/opensearch/opensearch-node-stats.md
+++ b/docs/features/opensearch/opensearch-node-stats.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - observability
-  - performance
+  - opensearch
 ---
 # Node Stats
 

--- a/docs/features/opensearch/opensearch-nodes-info-api.md
+++ b/docs/features/opensearch/opensearch-nodes-info-api.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - observability
-  - performance
-  - search
+  - opensearch
 ---
 # Nodes Info API
 

--- a/docs/features/opensearch/opensearch-normalizer-enhancements.md
+++ b/docs/features/opensearch/opensearch-normalizer-enhancements.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Normalizer Enhancements
 

--- a/docs/features/opensearch/opensearch-numeric-terms-aggregation-optimization.md
+++ b/docs/features/opensearch/opensearch-numeric-terms-aggregation-optimization.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
-  - search
+  - opensearch
 ---
 # Numeric Terms Aggregation Optimization
 

--- a/docs/features/opensearch/opensearch-offline-nodes.md
+++ b/docs/features/opensearch/opensearch-offline-nodes.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Offline Nodes (Background Tasks)
 

--- a/docs/features/opensearch/opensearch-oom-prevention.md
+++ b/docs/features/opensearch/opensearch-oom-prevention.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # OOM Prevention
 

--- a/docs/features/opensearch/opensearch-parallel-shard-refresh.md
+++ b/docs/features/opensearch/opensearch-parallel-shard-refresh.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Parallel Shard Refresh
 

--- a/docs/features/opensearch/opensearch-parent-child-query.md
+++ b/docs/features/opensearch/opensearch-parent-child-query.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - ml
-  - search
+  - opensearch
 ---
 # Parent-Child Query
 

--- a/docs/features/opensearch/opensearch-percentiles-aggregation.md
+++ b/docs/features/opensearch/opensearch-percentiles-aggregation.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - observability
-  - search
+  - opensearch
 ---
 # Percentiles Aggregation
 

--- a/docs/features/opensearch/opensearch-phone-analyzer.md
+++ b/docs/features/opensearch/opensearch-phone-analyzer.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Phone Number Analyzer
 

--- a/docs/features/opensearch/opensearch-pipeline-id-limits.md
+++ b/docs/features/opensearch/opensearch-pipeline-id-limits.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Pipeline ID Limits
 

--- a/docs/features/opensearch/opensearch-platform-support.md
+++ b/docs/features/opensearch/opensearch-platform-support.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Platform Support
 

--- a/docs/features/opensearch/opensearch-plugin-dependencies.md
+++ b/docs/features/opensearch/opensearch-plugin-dependencies.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - neural-search
+  - opensearch
 ---
 # Plugin Dependencies
 

--- a/docs/features/opensearch/opensearch-plugin-installation.md
+++ b/docs/features/opensearch/opensearch-plugin-installation.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - security
+  - opensearch
 ---
 # Plugin Installation
 

--- a/docs/features/opensearch/opensearch-plugin-testing-framework.md
+++ b/docs/features/opensearch/opensearch-plugin-testing-framework.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Plugin Testing Framework
 

--- a/docs/features/opensearch/opensearch-profiler.md
+++ b/docs/features/opensearch/opensearch-profiler.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
-  - search
+  - opensearch
 ---
 # Query Profiler
 

--- a/docs/features/opensearch/opensearch-pull-based-ingestion.md
+++ b/docs/features/opensearch/opensearch-pull-based-ingestion.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - observability
+  - opensearch
 ---
 # Pull-based Ingestion
 

--- a/docs/features/opensearch/opensearch-query-builders.md
+++ b/docs/features/opensearch/opensearch-query-builders.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Query Builders
 

--- a/docs/features/opensearch/opensearch-query-cache.md
+++ b/docs/features/opensearch/opensearch-query-cache.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
-  - search
+  - opensearch
 ---
 # Query Cache
 

--- a/docs/features/opensearch/opensearch-query-coordinator-context.md
+++ b/docs/features/opensearch/opensearch-query-coordinator-context.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - neural-search
-  - search
+  - opensearch
 ---
 # Query Coordinator Context
 

--- a/docs/features/opensearch/opensearch-query-optimization.md
+++ b/docs/features/opensearch/opensearch-query-optimization.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
-  - search
+  - opensearch
 ---
 # Query Optimization
 

--- a/docs/features/opensearch/opensearch-query-performance-optimizations.md
+++ b/docs/features/opensearch/opensearch-query-performance-optimizations.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
-  - search
+  - opensearch
 ---
 # Query Performance Optimizations
 

--- a/docs/features/opensearch/opensearch-query-phase-plugin-extension.md
+++ b/docs/features/opensearch/opensearch-query-phase-plugin-extension.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
-  - search
+  - opensearch
 ---
 # Query Phase Plugin Extension
 

--- a/docs/features/opensearch/opensearch-query-phase-result-consumer.md
+++ b/docs/features/opensearch/opensearch-query-phase-result-consumer.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Query Phase Result Consumer
 

--- a/docs/features/opensearch/opensearch-query-rewriting.md
+++ b/docs/features/opensearch/opensearch-query-rewriting.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
-  - search
+  - opensearch
 ---
 # Query Rewriting
 

--- a/docs/features/opensearch/opensearch-query-string-monitoring.md
+++ b/docs/features/opensearch/opensearch-query-string-monitoring.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - ml
-  - search
+  - opensearch
 ---
 # Query String Monitoring
 

--- a/docs/features/opensearch/opensearch-query-string-regex.md
+++ b/docs/features/opensearch/opensearch-query-string-regex.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Query String & Regex Queries
 

--- a/docs/features/opensearch/opensearch-randomness.md
+++ b/docs/features/opensearch/opensearch-randomness.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - security
+  - opensearch
 ---
 # Randomness
 

--- a/docs/features/opensearch/opensearch-reactor-netty-transport.md
+++ b/docs/features/opensearch/opensearch-reactor-netty-transport.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - security
+  - opensearch
 ---
 # Reactor Netty Transport
 

--- a/docs/features/opensearch/opensearch-refresh-task-scheduling.md
+++ b/docs/features/opensearch/opensearch-refresh-task-scheduling.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Refresh Task Scheduling
 

--- a/docs/features/opensearch/opensearch-reindex-api.md
+++ b/docs/features/opensearch/opensearch-reindex-api.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Reindex API
 

--- a/docs/features/opensearch/opensearch-remote-store-metadata-api.md
+++ b/docs/features/opensearch/opensearch-remote-store-metadata-api.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - observability
-  - performance
+  - opensearch
 ---
 # Remote Store Metadata API
 

--- a/docs/features/opensearch/opensearch-remote-store-metrics.md
+++ b/docs/features/opensearch/opensearch-remote-store-metrics.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - observability
-  - performance
-  - search
+  - opensearch
 ---
 # Remote Store Metrics
 

--- a/docs/features/opensearch/opensearch-remote-store.md
+++ b/docs/features/opensearch/opensearch-remote-store.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Remote Store
 

--- a/docs/features/opensearch/opensearch-replication.md
+++ b/docs/features/opensearch/opensearch-replication.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Replication
 

--- a/docs/features/opensearch/opensearch-repository-encryption.md
+++ b/docs/features/opensearch/opensearch-repository-encryption.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Repository Encryption
 

--- a/docs/features/opensearch/opensearch-repository-rate-limiters.md
+++ b/docs/features/opensearch/opensearch-repository-rate-limiters.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Repository Rate Limiters
 

--- a/docs/features/opensearch/opensearch-request-cache.md
+++ b/docs/features/opensearch/opensearch-request-cache.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
-  - search
+  - opensearch
 ---
 # Request Cache
 

--- a/docs/features/opensearch/opensearch-rescore-named-queries.md
+++ b/docs/features/opensearch/opensearch-rescore-named-queries.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - ml
-  - observability
-  - search
+  - opensearch
 ---
 # Rescore Named Queries
 

--- a/docs/features/opensearch/opensearch-resthandler-wrapper.md
+++ b/docs/features/opensearch/opensearch-resthandler-wrapper.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - security
+  - opensearch
 ---
 # RestHandler.Wrapper
 

--- a/docs/features/opensearch/opensearch-rule-based-auto-tagging.md
+++ b/docs/features/opensearch/opensearch-rule-based-auto-tagging.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Rule-Based Auto-Tagging
 

--- a/docs/features/opensearch/opensearch-s3-repository.md
+++ b/docs/features/opensearch/opensearch-s3-repository.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - security
+  - opensearch
 ---
 # S3 Repository
 

--- a/docs/features/opensearch/opensearch-scaled-float-field.md
+++ b/docs/features/opensearch/opensearch-scaled-float-field.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Scaled Float Field
 

--- a/docs/features/opensearch/opensearch-scripted-metric-aggregation.md
+++ b/docs/features/opensearch/opensearch-scripted-metric-aggregation.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - observability
-  - search
+  - opensearch
 ---
 # Scripted Metric Aggregation
 

--- a/docs/features/opensearch/opensearch-scroll-api.md
+++ b/docs/features/opensearch/opensearch-scroll-api.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - ml
-  - search
+  - opensearch
 ---
 # Scroll API
 

--- a/docs/features/opensearch/opensearch-search-api-enhancements.md
+++ b/docs/features/opensearch/opensearch-search-api-enhancements.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Search API Enhancements
 

--- a/docs/features/opensearch/opensearch-search-api-tracker.md
+++ b/docs/features/opensearch/opensearch-search-api-tracker.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - dashboards
-  - indexing
-  - search
+  - opensearch
 ---
 # Search API Tracker
 

--- a/docs/features/opensearch/opensearch-search-backpressure.md
+++ b/docs/features/opensearch/opensearch-search-backpressure.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Search Backpressure
 

--- a/docs/features/opensearch/opensearch-search-pipeline.md
+++ b/docs/features/opensearch/opensearch-search-pipeline.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - ml
-  - neural-search
-  - search
+  - opensearch
 ---
 # Search Pipeline
 

--- a/docs/features/opensearch/opensearch-search-replica-reader-writer-separation.md
+++ b/docs/features/opensearch/opensearch-search-replica-reader-writer-separation.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
-  - search
+  - opensearch
 ---
 # Search Replica & Reader-Writer Separation
 

--- a/docs/features/opensearch/opensearch-search-request-stats.md
+++ b/docs/features/opensearch/opensearch-search-request-stats.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - observability
-  - performance
-  - search
+  - opensearch
 ---
 # Search Request Stats
 

--- a/docs/features/opensearch/opensearch-search-scoring.md
+++ b/docs/features/opensearch/opensearch-search-scoring.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Search Scoring
 

--- a/docs/features/opensearch/opensearch-search-settings.md
+++ b/docs/features/opensearch/opensearch-search-settings.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
-  - search
-  - security
+  - opensearch
 ---
 # Search Settings
 

--- a/docs/features/opensearch/opensearch-search-shard-routing.md
+++ b/docs/features/opensearch/opensearch-search-shard-routing.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - observability
-  - performance
-  - search
+  - opensearch
 ---
 # Search Shard Routing
 

--- a/docs/features/opensearch/opensearch-search-tie-breaking.md
+++ b/docs/features/opensearch/opensearch-search-tie-breaking.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Search Tie-breaking (_shard_doc)
 

--- a/docs/features/opensearch/opensearch-secure-aux-transport-settings.md
+++ b/docs/features/opensearch/opensearch-secure-aux-transport-settings.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - security
+  - opensearch
 ---
 # Secure Aux Transport Settings
 

--- a/docs/features/opensearch/opensearch-secure-transport-settings.md
+++ b/docs/features/opensearch/opensearch-secure-transport-settings.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - security
+  - opensearch
 ---
 # Secure Transport Settings
 

--- a/docs/features/opensearch/opensearch-security-manager-replacement.md
+++ b/docs/features/opensearch/opensearch-security-manager-replacement.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - ml
-  - security
+  - opensearch
 ---
 # Security Manager Replacement
 

--- a/docs/features/opensearch/opensearch-segment-replication.md
+++ b/docs/features/opensearch/opensearch-segment-replication.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Segment Replication
 

--- a/docs/features/opensearch/opensearch-segment-warmer.md
+++ b/docs/features/opensearch/opensearch-segment-warmer.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
-  - search
+  - opensearch
 ---
 # Segment Warmer
 

--- a/docs/features/opensearch/opensearch-semantic-version-field-type.md
+++ b/docs/features/opensearch/opensearch-semantic-version-field-type.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - ml
-  - neural-search
-  - search
+  - opensearch
 ---
 # Semantic Version Field Type
 

--- a/docs/features/opensearch/opensearch-settings-management.md
+++ b/docs/features/opensearch/opensearch-settings-management.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Settings Management
 

--- a/docs/features/opensearch/opensearch-shard-allocation.md
+++ b/docs/features/opensearch/opensearch-shard-allocation.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
+  - opensearch
 ---
 # Shard Allocation
 

--- a/docs/features/opensearch/opensearch-skip-list.md
+++ b/docs/features/opensearch/opensearch-skip-list.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
-  - search
+  - opensearch
 ---
 # Skip List
 

--- a/docs/features/opensearch/opensearch-snapshot-restore-enhancements.md
+++ b/docs/features/opensearch/opensearch-snapshot-restore-enhancements.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
+  - opensearch
 ---
 # Snapshot Restore Enhancements
 

--- a/docs/features/opensearch/opensearch-source-field-matching.md
+++ b/docs/features/opensearch/opensearch-source-field-matching.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
-  - search
+  - opensearch
 ---
 # Source Field Matching
 

--- a/docs/features/opensearch/opensearch-star-tree-index.md
+++ b/docs/features/opensearch/opensearch-star-tree-index.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - dashboards
-  - indexing
-  - observability
-  - performance
-  - search
+  - opensearch
 ---
 # Star Tree Index
 

--- a/docs/features/opensearch/opensearch-stats-builder-pattern.md
+++ b/docs/features/opensearch/opensearch-stats-builder-pattern.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - observability
-  - performance
+  - opensearch
 ---
 # Stats Builder Pattern
 

--- a/docs/features/opensearch/opensearch-store-factory.md
+++ b/docs/features/opensearch/opensearch-store-factory.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Store Factory
 

--- a/docs/features/opensearch/opensearch-store-subdirectory-module.md
+++ b/docs/features/opensearch/opensearch-store-subdirectory-module.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Store Subdirectory Module
 

--- a/docs/features/opensearch/opensearch-stream-inputoutput.md
+++ b/docs/features/opensearch/opensearch-stream-inputoutput.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Stream Input/Output
 

--- a/docs/features/opensearch/opensearch-streaming-indexing.md
+++ b/docs/features/opensearch/opensearch-streaming-indexing.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Streaming Indexing
 

--- a/docs/features/opensearch/opensearch-streaming-transport-aggregation.md
+++ b/docs/features/opensearch/opensearch-streaming-transport-aggregation.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Streaming Transport & Aggregation
 

--- a/docs/features/opensearch/opensearch-subject-interface.md
+++ b/docs/features/opensearch/opensearch-subject-interface.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Subject Interface
 

--- a/docs/features/opensearch/opensearch-system-ingest-pipeline.md
+++ b/docs/features/opensearch/opensearch-system-ingest-pipeline.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - ml
-  - neural-search
+  - opensearch
 ---
 # System Ingest Pipeline
 

--- a/docs/features/opensearch/opensearch-systemd-security-configurations.md
+++ b/docs/features/opensearch/opensearch-systemd-security-configurations.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - ml
-  - performance
-  - security
+  - opensearch
 ---
 # Systemd Security Configurations
 

--- a/docs/features/opensearch/opensearch-task-cancellation-monitoring.md
+++ b/docs/features/opensearch/opensearch-task-cancellation-monitoring.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Task Cancellation Monitoring
 

--- a/docs/features/opensearch/opensearch-task-management.md
+++ b/docs/features/opensearch/opensearch-task-management.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Task Management
 

--- a/docs/features/opensearch/opensearch-temporal-routing.md
+++ b/docs/features/opensearch/opensearch-temporal-routing.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - observability
-  - performance
-  - search
+  - opensearch
 ---
 # Temporal Routing
 

--- a/docs/features/opensearch/opensearch-terms-lookup-query.md
+++ b/docs/features/opensearch/opensearch-terms-lookup-query.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Terms Lookup Query
 

--- a/docs/features/opensearch/opensearch-terms-query.md
+++ b/docs/features/opensearch/opensearch-terms-query.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
-  - search
+  - opensearch
 ---
 # Terms Query
 

--- a/docs/features/opensearch/opensearch-thread-context-permissions.md
+++ b/docs/features/opensearch/opensearch-thread-context-permissions.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - security
+  - opensearch
 ---
 # Thread Context Permissions
 

--- a/docs/features/opensearch/opensearch-thread-pool.md
+++ b/docs/features/opensearch/opensearch-thread-pool.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - k-nn
-  - performance
-  - search
+  - opensearch
 ---
 # Thread Pool
 

--- a/docs/features/opensearch/opensearch-tiered-caching.md
+++ b/docs/features/opensearch/opensearch-tiered-caching.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
-  - search
+  - opensearch
 ---
 # Tiered Caching
 

--- a/docs/features/opensearch/opensearch-translog.md
+++ b/docs/features/opensearch/opensearch-translog.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
+  - opensearch
 ---
 # Translog
 

--- a/docs/features/opensearch/opensearch-transport-actions-api.md
+++ b/docs/features/opensearch/opensearch-transport-actions-api.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
-  - security
+  - opensearch
 ---
 # Transport Actions API
 

--- a/docs/features/opensearch/opensearch-transport-nodes-action-optimization.md
+++ b/docs/features/opensearch/opensearch-transport-nodes-action-optimization.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - performance
+  - opensearch
 ---
 # Transport Nodes Action Optimization
 

--- a/docs/features/opensearch/opensearch-unified-highlighter.md
+++ b/docs/features/opensearch/opensearch-unified-highlighter.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
+  - opensearch
 ---
 # Unified Highlighter
 

--- a/docs/features/opensearch/opensearch-unsigned-long.md
+++ b/docs/features/opensearch/opensearch-unsigned-long.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Unsigned Long Field Type
 

--- a/docs/features/opensearch/opensearch-views.md
+++ b/docs/features/opensearch/opensearch-views.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
-  - sql
+  - opensearch
 ---
 # Views
 

--- a/docs/features/opensearch/opensearch-warm-storage-tiering.md
+++ b/docs/features/opensearch/opensearch-warm-storage-tiering.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - performance
+  - opensearch
 ---
 # Warm Storage Tiering
 

--- a/docs/features/opensearch/opensearch-wildcard-field.md
+++ b/docs/features/opensearch/opensearch-wildcard-field.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - observability
-  - search
+  - opensearch
 ---
 # Wildcard Field
 

--- a/docs/features/opensearch/opensearch-workload-management.md
+++ b/docs/features/opensearch/opensearch-workload-management.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - indexing
-  - search
+  - opensearch
 ---
 # Workload Management
 

--- a/docs/features/opensearch/opensearch-xcontent-filtering.md
+++ b/docs/features/opensearch/opensearch-xcontent-filtering.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - search
-  - security
+  - opensearch
 ---
 # XContent Filtering
 

--- a/docs/features/opensearch/opensearch-xcontent-transform.md
+++ b/docs/features/opensearch/opensearch-xcontent-transform.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/core
-  - component/server
-  - k-nn
-  - search
+  - opensearch
 ---
 # XContent Transform
 

--- a/docs/features/performance-analyzer/performance-analyzer.md
+++ b/docs/features/performance-analyzer/performance-analyzer.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/server
-  - dashboards
-  - ml
-  - observability
-  - performance
+  - performance-analyzer
 ---
 # Performance Analyzer
 

--- a/docs/features/query-insights/query-insights-dependencies.md
+++ b/docs/features/query-insights/query-insights-dependencies.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/server
-  - performance
-  - search
-  - security
+  - query-insights
 ---
 # Query Insights Plugin Dependencies
 

--- a/docs/features/query-insights/query-insights.md
+++ b/docs/features/query-insights/query-insights.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/observability
-  - component/server
-  - indexing
-  - observability
-  - performance
-  - search
+  - query-insights
 ---
 # Query Insights
 

--- a/docs/features/reporting/reporting-auto-version-management.md
+++ b/docs/features/reporting/reporting-auto-version-management.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - dashboards
-  - indexing
+  - reporting
 ---
 # AUTO Version Management
 

--- a/docs/features/reporting/reporting-ci-workflow.md
+++ b/docs/features/reporting/reporting-ci-workflow.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - dashboards
+  - reporting
 ---
 # CI/CD Workflow
 

--- a/docs/features/reporting/reporting-integration-test-stability.md
+++ b/docs/features/reporting/reporting-integration-test-stability.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - dashboards
-  - performance
+  - reporting
 ---
 # Integration Test Stability
 

--- a/docs/features/reporting/reporting-java-agent-migration.md
+++ b/docs/features/reporting/reporting-java-agent-migration.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - dashboards
-  - ml
-  - security
+  - reporting
 ---
 # Reporting Plugin Java Agent Migration
 

--- a/docs/features/reporting/reporting-plugin.md
+++ b/docs/features/reporting/reporting-plugin.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - dashboards
-  - indexing
-  - ml
-  - search
-  - security
+  - reporting
 ---
 # Reporting Plugin
 

--- a/docs/features/reporting/reporting-release-maintenance.md
+++ b/docs/features/reporting/reporting-release-maintenance.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - dashboards
-  - indexing
+  - reporting
 ---
 # Release Maintenance
 

--- a/docs/features/search-relevance/search-relevance-ci-tests.md
+++ b/docs/features/search-relevance/search-relevance-ci-tests.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - search
+  - search-relevance
 ---
 # Search Relevance CI/Tests
 

--- a/docs/features/search-relevance/search-relevance-scheduled-experiments.md
+++ b/docs/features/search-relevance/search-relevance-scheduled-experiments.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - dashboards
-  - performance
-  - search
+  - search-relevance
 ---
 # Scheduled Experiments
 

--- a/docs/features/search-relevance/search-relevance-security-integ-test-control.md
+++ b/docs/features/search-relevance/search-relevance-security-integ-test-control.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - search
-  - security
+  - search-relevance
 ---
 # Security Integration Test Control
 

--- a/docs/features/search-relevance/search-relevance-workbench.md
+++ b/docs/features/search-relevance/search-relevance-workbench.md
@@ -1,12 +1,6 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - dashboards
-  - indexing
-  - observability
-  - performance
-  - search
+  - search-relevance
 ---
 # Search Relevance Workbench
 

--- a/docs/features/security-analytics-dashboards/security-analytics-dashboards-plugin-security-analytics.md
+++ b/docs/features/security-analytics-dashboards/security-analytics-dashboards-plugin-security-analytics.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/security
-  - component/dashboards
-  - dashboards
-  - security
+  - security-analytics-dashboards
 ---
 # Security Analytics
 

--- a/docs/features/security-analytics-dashboards/security-analytics-dashboards-plugin.md
+++ b/docs/features/security-analytics-dashboards/security-analytics-dashboards-plugin.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/security
-  - component/dashboards
-  - dashboards
-  - security
+  - security-analytics-dashboards
 ---
 # Security Analytics Dashboards Plugin
 

--- a/docs/features/security-analytics/security-analytics-correlation-engine.md
+++ b/docs/features/security-analytics/security-analytics-correlation-engine.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - dashboards
-  - observability
-  - security
+  - security-analytics
 ---
 # Correlation Engine
 

--- a/docs/features/security-analytics/security-analytics-detectors.md
+++ b/docs/features/security-analytics/security-analytics-detectors.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - indexing
-  - search
-  - security
+  - security-analytics
 ---
 # Security Analytics Detectors
 

--- a/docs/features/security-analytics/security-analytics-system-indices.md
+++ b/docs/features/security-analytics/security-analytics-system-indices.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - dashboards
-  - indexing
-  - search
-  - security
+  - security-analytics
 ---
 # Security Analytics System Indices
 

--- a/docs/features/security-analytics/security-analytics-threat-intelligence.md
+++ b/docs/features/security-analytics/security-analytics-threat-intelligence.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - indexing
-  - ml
-  - search
-  - security
+  - security-analytics
 ---
 # Threat Intelligence
 

--- a/docs/features/security-dashboards/security-dashboards-plugin-security-dashboards-role-management.md
+++ b/docs/features/security-dashboards/security-dashboards-plugin-security-dashboards-role-management.md
@@ -1,10 +1,6 @@
 ---
 tags:
-  - domain/security
-  - component/dashboards
-  - dashboards
-  - indexing
-  - security
+  - security-dashboards
 ---
 # Security Dashboards Role Management
 

--- a/docs/features/security-dashboards/security-dashboards-plugin.md
+++ b/docs/features/security-dashboards/security-dashboards-plugin.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/security
-  - component/dashboards
-  - dashboards
-  - security
+  - security-dashboards
 ---
 # Security Dashboards Plugin
 

--- a/docs/features/security/security-accesscontroller-migration.md
+++ b/docs/features/security/security-accesscontroller-migration.md
@@ -1,8 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - ml
   - security
 ---
 # Security Plugin AccessController Migration

--- a/docs/features/security/security-alerting-comments-security.md
+++ b/docs/features/security/security-alerting-comments-security.md
@@ -1,8 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - search
   - security
 ---
 # Alerting Comments Security

--- a/docs/features/security/security-argon2-password-hashing.md
+++ b/docs/features/security/security-argon2-password-hashing.md
@@ -1,7 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
   - security
 ---
 # Argon2 Password Hashing

--- a/docs/features/security/security-auth-enhancements.md
+++ b/docs/features/security/security-auth-enhancements.md
@@ -1,7 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
   - security
 ---
 # Security Auth Enhancements

--- a/docs/features/security/security-auxiliary-transport-ssl.md
+++ b/docs/features/security/security-auxiliary-transport-ssl.md
@@ -1,7 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
   - security
 ---
 # Auxiliary Transport SSL

--- a/docs/features/security/security-cache-management.md
+++ b/docs/features/security/security-cache-management.md
@@ -1,8 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - performance
   - security
 ---
 # Security Cache Management

--- a/docs/features/security/security-ci-cd.md
+++ b/docs/features/security/security-ci-cd.md
@@ -1,7 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
   - security
 ---
 # Security CI/CD

--- a/docs/features/security/security-client-certificate-authentication.md
+++ b/docs/features/security/security-client-certificate-authentication.md
@@ -1,7 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
   - security
 ---
 # Client Certificate Authentication

--- a/docs/features/security/security-configuration-versioning.md
+++ b/docs/features/security/security-configuration-versioning.md
@@ -1,8 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - indexing
   - security
 ---
 # Security Configuration Versioning

--- a/docs/features/security/security-configuration.md
+++ b/docs/features/security/security-configuration.md
@@ -1,9 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - indexing
-  - ml
   - security
 ---
 # Security Configuration

--- a/docs/features/security/security-correlation-alerts.md
+++ b/docs/features/security/security-correlation-alerts.md
@@ -1,8 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - indexing
   - security
 ---
 # Correlation Alerts

--- a/docs/features/security/security-features.md
+++ b/docs/features/security/security-features.md
@@ -1,7 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
   - security
 ---
 # Security Features

--- a/docs/features/security/security-fips-compliance.md
+++ b/docs/features/security/security-fips-compliance.md
@@ -1,7 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
   - security
 ---
 # Security FIPS Compliance

--- a/docs/features/security/security-github-actions-updates.md
+++ b/docs/features/security/security-github-actions-updates.md
@@ -1,8 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - dashboards
   - security
 ---
 # GitHub Actions Updates

--- a/docs/features/security/security-jwt-authentication.md
+++ b/docs/features/security/security-jwt-authentication.md
@@ -1,7 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
   - security
 ---
 # JWT Authentication

--- a/docs/features/security/security-multi-tenancy.md
+++ b/docs/features/security/security-multi-tenancy.md
@@ -1,9 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - dashboards
-  - indexing
   - security
 ---
 # Multi-Tenancy

--- a/docs/features/security/security-performance-improvements.md
+++ b/docs/features/security/security-performance-improvements.md
@@ -1,8 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - performance
   - security
 ---
 # Security Performance Improvements

--- a/docs/features/security/security-permission-validation.md
+++ b/docs/features/security/security-permission-validation.md
@@ -1,8 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - search
   - security
 ---
 # Permission Validation

--- a/docs/features/security/security-permissions.md
+++ b/docs/features/security/security-permissions.md
@@ -1,9 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - indexing
-  - ml
   - security
 ---
 # Security Permissions

--- a/docs/features/security/security-plugin-dependencies.md
+++ b/docs/features/security/security-plugin-dependencies.md
@@ -1,7 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
   - security
 ---
 # Security Plugin Dependencies

--- a/docs/features/security/security-plugin-health-check.md
+++ b/docs/features/security/security-plugin-health-check.md
@@ -1,9 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - indexing
-  - performance
   - security
 ---
 # Security Plugin Health Check

--- a/docs/features/security/security-plugin.md
+++ b/docs/features/security/security-plugin.md
@@ -1,8 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - indexing
   - security
 ---
 # Security Plugin

--- a/docs/features/security/security-protobufs-version-sync.md
+++ b/docs/features/security/security-protobufs-version-sync.md
@@ -1,7 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
   - security
 ---
 # Protobufs Version Synchronization

--- a/docs/features/security/security-resource-access-control-framework.md
+++ b/docs/features/security/security-resource-access-control-framework.md
@@ -1,10 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - dashboards
-  - indexing
-  - ml
   - security
 ---
 # Resource Access Control Framework

--- a/docs/features/security/security-role-mapping.md
+++ b/docs/features/security/security-role-mapping.md
@@ -1,7 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
   - security
 ---
 # Security Role Mapping

--- a/docs/features/security/security-spiffe-x.509-svid-support.md
+++ b/docs/features/security/security-spiffe-x.509-svid-support.md
@@ -1,8 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - ml
   - security
 ---
 # SPIFFE X.509 SVID Support

--- a/docs/features/security/security-ssl-tls-compatibility.md
+++ b/docs/features/security/security-ssl-tls-compatibility.md
@@ -1,7 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
   - security
 ---
 # Security SSL/TLS Compatibility

--- a/docs/features/security/security-testing-framework.md
+++ b/docs/features/security/security-testing-framework.md
@@ -1,9 +1,5 @@
 ---
 tags:
-  - domain/security
-  - component/server
-  - indexing
-  - ml
   - security
 ---
 # Security Testing Framework

--- a/docs/features/skills/skills-plugin-dependencies.md
+++ b/docs/features/skills/skills-plugin-dependencies.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - ml
+  - skills
 ---
 # Skills Plugin Dependencies
 

--- a/docs/features/skills/skills-tools.md
+++ b/docs/features/skills/skills-tools.md
@@ -1,11 +1,6 @@
 ---
 tags:
-  - domain/ml
-  - component/server
-  - indexing
-  - ml
-  - search
-  - sql
+  - skills
 ---
 # Skills / Tools
 

--- a/docs/features/sql/sql-calcite-query-engine.md
+++ b/docs/features/sql/sql-calcite-query-engine.md
@@ -1,11 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - observability
-  - performance
-  - search
   - sql
 ---
 # Calcite Query Engine

--- a/docs/features/sql/sql-ci-tests.md
+++ b/docs/features/sql/sql-ci-tests.md
@@ -1,10 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - performance
-  - search
   - sql
 ---
 # SQL CI/Tests

--- a/docs/features/sql/sql-error-handling.md
+++ b/docs/features/sql/sql-error-handling.md
@@ -1,9 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - search
   - sql
 ---
 # SQL Error Handling

--- a/docs/features/sql/sql-flint-index-operations.md
+++ b/docs/features/sql/sql-flint-index-operations.md
@@ -1,9 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - search
   - sql
 ---
 # Flint Index Operations

--- a/docs/features/sql/sql-flint-query-scheduler.md
+++ b/docs/features/sql/sql-flint-query-scheduler.md
@@ -1,10 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - observability
-  - search
   - sql
 ---
 # Flint Query Scheduler

--- a/docs/features/sql/sql-pagination.md
+++ b/docs/features/sql/sql-pagination.md
@@ -1,8 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - search
   - sql
 ---
 # SQL Pagination

--- a/docs/features/sql/sql-pit-refactor.md
+++ b/docs/features/sql/sql-pit-refactor.md
@@ -1,8 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - search
   - sql
 ---
 # SQL Point in Time (PIT) Refactor

--- a/docs/features/sql/sql-plugin-maintenance.md
+++ b/docs/features/sql/sql-plugin-maintenance.md
@@ -1,10 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - search
-  - security
   - sql
 ---
 # SQL Plugin Maintenance

--- a/docs/features/sql/sql-ppl-aggregate-functions.md
+++ b/docs/features/sql/sql-ppl-aggregate-functions.md
@@ -1,8 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - search
   - sql
 ---
 # PPL Aggregate Functions

--- a/docs/features/sql/sql-ppl-commands-calcite.md
+++ b/docs/features/sql/sql-ppl-commands-calcite.md
@@ -1,10 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - neural-search
-  - performance
-  - search
   - sql
 ---
 # PPL Commands (Calcite)

--- a/docs/features/sql/sql-ppl-documentation.md
+++ b/docs/features/sql/sql-ppl-documentation.md
@@ -1,10 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - observability
-  - search
   - sql
 ---
 # PPL Documentation

--- a/docs/features/sql/sql-ppl-engine.md
+++ b/docs/features/sql/sql-ppl-engine.md
@@ -1,10 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - observability
-  - performance
-  - search
   - sql
 ---
 # SQL/PPL Engine

--- a/docs/features/sql/sql-ppl-eval-functions.md
+++ b/docs/features/sql/sql-ppl-eval-functions.md
@@ -1,10 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - observability
-  - search
   - sql
 ---
 # PPL Eval Functions

--- a/docs/features/sql/sql-ppl-patterns-command.md
+++ b/docs/features/sql/sql-ppl-patterns-command.md
@@ -1,9 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - ml
   - sql
 ---
 # PPL Patterns Command

--- a/docs/features/sql/sql-ppl-query-enhancements.md
+++ b/docs/features/sql/sql-ppl-query-enhancements.md
@@ -1,9 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - performance
-  - search
   - sql
 ---
 # PPL Query Enhancements

--- a/docs/features/sql/sql-ppl-query-optimization.md
+++ b/docs/features/sql/sql-ppl-query-optimization.md
@@ -1,10 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - observability
-  - performance
-  - search
   - sql
 ---
 # PPL Query Optimization

--- a/docs/features/sql/sql-ppl-rename-command.md
+++ b/docs/features/sql/sql-ppl-rename-command.md
@@ -1,8 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - search
   - sql
 ---
 # PPL Rename Command

--- a/docs/features/sql/sql-ppl-rex-and-regex-commands.md
+++ b/docs/features/sql/sql-ppl-rex-and-regex-commands.md
@@ -1,8 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - search
   - sql
 ---
 # PPL Rex and Regex Commands

--- a/docs/features/sql/sql-ppl-spath-command.md
+++ b/docs/features/sql/sql-ppl-spath-command.md
@@ -1,8 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - search
   - sql
 ---
 # PPL Spath Command

--- a/docs/features/sql/sql-ppl-timechart-command.md
+++ b/docs/features/sql/sql-ppl-timechart-command.md
@@ -1,10 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - observability
-  - performance
-  - search
   - sql
 ---
 # PPL Timechart Command

--- a/docs/features/sql/sql-security-lake-data-source.md
+++ b/docs/features/sql/sql-security-lake-data-source.md
@@ -1,10 +1,5 @@
 ---
 tags:
-  - domain/search
-  - component/server
-  - indexing
-  - search
-  - security
   - sql
 ---
 # Security Lake Data Source

--- a/docs/features/user-behavior-insights/user-behavior-insights-build.md
+++ b/docs/features/user-behavior-insights/user-behavior-insights-build.md
@@ -1,9 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - indexing
-  - search
+  - user-behavior-insights
 ---
 # User Behavior Insights Build Infrastructure
 

--- a/docs/features/user-behavior-insights/user-behavior-insights-data-generator.md
+++ b/docs/features/user-behavior-insights/user-behavior-insights-data-generator.md
@@ -1,8 +1,6 @@
 ---
 tags:
-  - domain/infra
-  - component/server
-  - search
+  - user-behavior-insights
 ---
 # User Behavior Insights Data Generator
 


### PR DESCRIPTION
## Summary
Simplify tag system to use repository names only.

## Changes
- Remove all `domain/*`, `component/*`, and topic tags
- Use repository name derived from file path as the single tag
- `docs/features/{repo}/` → tag: `{repo}`

## Before
```yaml
tags:
  - domain/core
  - component/server
  - indexing
  - search
  - performance
```

## After
```yaml
tags:
  - opensearch
```

## Rationale
- Simpler and more consistent
- Automatically derivable from file path
- Easier to maintain