### PR TITLE
docs: update steering/prompts for simplified tag system

### DIFF
--- a/.kiro/agents/prompts/refactor.md
+++ b/.kiro/agents/prompts/refactor.md
@@ -103,20 +103,6 @@ Consolidate when:
 4. Delete secondary file
 5. Update any references
 
-## Cross-References
-
-### Related Features Section
-```markdown
-## Related Features
-- [Feature Name](relative/path.md)
-```
-
-### Category Mappings
-Related categories:
-- neural-search ↔ ml-commons, k-nn
-- security ↔ security-dashboards-plugin
-- sql ↔ dashboards-query-workbench
-
 ## File Naming
 
 ### Prefix Rules

--- a/.kiro/steering/opensearch-knowledge.md
+++ b/.kiro/steering/opensearch-knowledge.md
@@ -361,34 +361,16 @@ docs/features/{repository-name}/
 - `alerting-dashboards-plugin/` → `alerting-dashboards/`
 - `security-dashboards-plugin/` → `security-dashboards/`
 
-## Domain Tag System
+## Tag System
 
-### Tag Structure
+Tags are derived from the file path. Each document has exactly one tag: the repository name.
+
 ```yaml
+# docs/features/{repo}/*.md → tag: {repo}
 tags:
-  # Domain (required, 1 or more)
-  - domain/search
-  - domain/ml
-  - domain/observability
-  - domain/security
-  - domain/data
-  - domain/geo
-  - domain/core
-  - domain/infra
-
-  # Component type (required, exactly 1)
-  - component/server
-  - component/dashboards
+  - opensearch      # for docs/features/opensearch/*.md
+  - k-nn            # for docs/features/k-nn/*.md
+  - neural-search   # for docs/features/neural-search/*.md
 ```
 
-### Domain Definitions
-| Domain | Description | Repositories |
-|--------|-------------|--------------|
-| `search` | Search & Query | k-nn, neural-search, sql, asynchronous-search, learning, search-relevance |
-| `ml` | Machine Learning & AI | ml-commons, flow-framework, skills |
-| `observability` | Monitoring & Analytics | alerting, anomaly-detection, notifications, observability, query-insights, performance-analyzer |
-| `security` | Security | security, security-analytics |
-| `data` | Data Management | index-management, cross-cluster-replication, custom-codecs, job-scheduler |
-| `geo` | Geospatial | geospatial |
-| `core` | Core Features | opensearch, common-utils, opensearch-remote-metadata-sdk |
-| `infra` | Infrastructure & CI | ci, multi-plugin, reporting, user-behavior-insights |
+No manual tag assignment needed - tags match the parent directory name.


### PR DESCRIPTION
## Summary
Update steering and prompt documentation to reflect the simplified tag system from PR #1969.

## Changes
- `opensearch-knowledge.md`: Remove Domain Tag System section, replace with simple repo-name tag rule
- `refactor.md`: Remove Related Features cross-reference guidance (sections were removed in PR #1968)

## Context
These docs were out of sync with the actual tag/link structure after the cleanup PRs.