### PR TITLE
docs: remove internal .md links from agent prompts

### DIFF
--- a/.kiro/agents/prompts/generate-release-docs.md
+++ b/.kiro/agents/prompts/generate-release-docs.md
@@ -68,9 +68,6 @@ Brief description of what changed in this version.
 | PR | Description |
 |----|-------------|
 (Only PRs for this version)
-
-## Related Feature Report
-- [Full feature documentation](../../features/{feature-name}.md)
 ```
 
 ### Step 4: Create Release Index
@@ -84,8 +81,8 @@ Create `docs/releases/v{version}/index.md`:
 
 | Feature | Description |
 |---------|-------------|
-| [{Feature 1}](features/{feature-1}.md) | Brief description |
-| [{Feature 2}](features/{feature-2}.md) | Brief description |
+| {Feature 1} | Brief description |
+| {Feature 2} | Brief description |
 ```
 
 ### Step 5: Commit and Push

--- a/.kiro/agents/prompts/investigate.md
+++ b/.kiro/agents/prompts/investigate.md
@@ -242,15 +242,12 @@ Known limitations specific to this release.
 
 ### Documentation
 - [Feature Documentation](url)
-
-## Related Feature Report
-- [Full feature documentation](../../../features/{repository-name}/{feature-name}.md)
 ```
 
 ### Update Release Index
 After creating the release report, update `docs/releases/v{version}/index.md`:
 1. Create if not exists with header
-2. Add link to new report in appropriate section, grouped by repository
+2. Add feature name (plain text, no internal link) in appropriate section, grouped by repository
 
 ## Step 4: Update/Create Feature Report (SECONDARY OUTPUT)
 
@@ -301,7 +298,7 @@ Create `docs/features/{repository-name}/{feature-name}.md` following the templat
 After creating/updating a feature report, update `docs/features/index.md`:
 1. Read current index.md
 2. Group features by repository subfolder
-3. If feature not listed, add `- [Feature Title]({repository-name}/{feature-name}.md)` under the appropriate repository section
+3. If feature not listed, add `- {Feature Title}` (plain text, no link) under the appropriate repository section
 4. Keep the header and description intact
 
 ## Step 5: Commit and Push

--- a/.kiro/agents/prompts/summarize.md
+++ b/.kiro/agents/prompts/summarize.md
@@ -43,13 +43,13 @@ graph TB
 
 | Feature | Description | Report |
 |---------|-------------|--------|
-| {Name} | {Brief description from release report} | [Details](features/{item-name}.md) |
+| {Name} | {Brief description from release report} | {item-name} |
 
 ## Improvements
 
 | Area | Description | Report |
 |------|-------------|--------|
-| {Area} | {Brief description} | [Details](features/{item-name}.md) |
+| {Area} | {Brief description} | {item-name} |
 
 ## Bug Fixes
 
@@ -61,7 +61,7 @@ graph TB
 
 | Change | Migration | Report |
 |--------|-----------|--------|
-| {Change} | {Migration steps} | [Details](features/{item-name}.md) |
+| {Change} | {Migration steps} | {item-name} |
 
 ## Dependencies
 


### PR DESCRIPTION
## Summary
Remove internal `.md` links from agent prompt templates to prevent new documents from being generated with internal links.

## Changes
- `investigate.md`: Remove `Related Feature Report` section, change index update to plain text
- `summarize.md`: Remove `.md` links from summary tables (New Features, Improvements, Breaking Changes)
- `generate-release-docs.md`: Remove `Related Feature Report` section and index links

## Context
PR #1968 removed internal links from existing documents. This PR ensures new documents won't recreate them.