### PR TITLE
docs: fix remaining internal links in prompts and steering

### DIFF
--- a/.kiro/agents/prompts/summarize.md
+++ b/.kiro/agents/prompts/summarize.md
@@ -75,17 +75,17 @@ Notable dependency updates from release notes.
 
 ### Step 4: Update Release Index
 
-Update `docs/releases/v{version}/index.md` to include link to summary:
+Update `docs/releases/v{version}/index.md` to include summary reference:
 
 ```markdown
 # OpenSearch v{version}
 
-- [Release Summary](summary.md)
+- Release Summary
 
 ## Feature Reports
 
-- [Feature 1](features/feature-1.md)
-- [Feature 2](features/feature-2.md)
+- Feature 1
+- Feature 2
 ...
 ```
 

--- a/.kiro/steering/opensearch-knowledge.md
+++ b/.kiro/steering/opensearch-knowledge.md
@@ -137,9 +137,6 @@ Known limitations specific to this release.
 
 ### Documentation
 - [Feature Documentation](url)
-
-## Related Feature Report
-- [Full feature documentation](../../features/{feature-name}.md)
 ```
 
 ### Feature Report Template (docs/features/{feature-name}.md)
@@ -219,7 +216,7 @@ graph TB
 ## New Features
 | Feature | Description | Report |
 |---------|-------------|--------|
-| {Name} | {Brief description} | [Details](features/{item-name}.md) |
+| {Name} | {Brief description} | {item-name} |
 
 ## Improvements
 | Area | Description | Report |


### PR DESCRIPTION
## Summary
Fix remaining internal `.md` links missed in PR #1972.

## Changes
- `summarize.md`: Remove links from release index template example
- `opensearch-knowledge.md`: Remove `Related Feature Report` section and table links from templates