### PR TITLE
docs: add frontmatter with tags to report templates

### DIFF
--- a/.kiro/steering/opensearch-knowledge.md
+++ b/.kiro/steering/opensearch-knowledge.md
@@ -88,8 +88,12 @@ Store fetched data in `.cache/` to avoid redundant API calls.
 
 ## Report Output Format
 
-### Release Report Template (docs/releases/v{version}/features/{item-name}.md)
+### Release Report Template (docs/releases/v{version}/features/{repo}/{item-name}.md)
 ```markdown
+---
+tags:
+  - {repo}
+---
 # {Item Name}
 
 ## Summary
@@ -139,8 +143,12 @@ Known limitations specific to this release.
 - [Feature Documentation](url)
 ```
 
-### Feature Report Template (docs/features/{feature-name}.md)
+### Feature Report Template (docs/features/{repo}/{feature-name}.md)
 ```markdown
+---
+tags:
+  - {repo}
+---
 # {Feature Name}
 
 ## Summary


### PR DESCRIPTION
## Summary
Add YAML frontmatter with tags to report templates in steering documentation.

## Changes
- Release Report Template: Add `tags: [{repo}]` frontmatter
- Feature Report Template: Add `tags: [{repo}]` frontmatter
- Fix path pattern to include `{repo}` directory

## Why
Without frontmatter in templates, new documents might be generated without tags, breaking the tag-based navigation.