### PR TITLE
chore: add DEVELOPMENT.md to doc-generating agents

### DIFF
--- a/.kiro/agents/generate-release-docs.json
+++ b/.kiro/agents/generate-release-docs.json
@@ -2,9 +2,16 @@
   "name": "generate-release-docs",
   "description": "Generate release documents from existing feature documents",
   "prompt": "You are a release document generator. Extract version-specific changes from existing feature documents and create release reports.",
-  "tools": ["@builtin", "@github"],
-  "allowedTools": ["@builtin", "@github"],
+  "tools": [
+    "@builtin",
+    "@github"
+  ],
+  "allowedTools": [
+    "@builtin",
+    "@github"
+  ],
   "resources": [
+    "file://DEVELOPMENT.md",
     "file://README.md",
     "file://.kiro/steering/**/*.md",
     "file://.kiro/agents/prompts/generate-release-docs.md"
@@ -12,7 +19,10 @@
   "mcpServers": {
     "github": {
       "command": "bash",
-      "args": ["-c", "GITHUB_PERSONAL_ACCESS_TOKEN=$(gh auth token) npx -y @modelcontextprotocol/server-github"]
+      "args": [
+        "-c",
+        "GITHUB_PERSONAL_ACCESS_TOKEN=$(gh auth token) npx -y @modelcontextprotocol/server-github"
+      ]
     }
   }
 }

--- a/.kiro/agents/investigate.json
+++ b/.kiro/agents/investigate.json
@@ -2,9 +2,18 @@
   "name": "investigate",
   "description": "Investigate a single feature and create/update feature reports",
   "prompt": "You are a feature investigator. Investigate release items based on GitHub Issues and create release/feature reports.",
-  "tools": ["@builtin", "@github", "@opensearch-docs"],
-  "allowedTools": ["@builtin", "@github", "@opensearch-docs"],
+  "tools": [
+    "@builtin",
+    "@github",
+    "@opensearch-docs"
+  ],
+  "allowedTools": [
+    "@builtin",
+    "@github",
+    "@opensearch-docs"
+  ],
   "resources": [
+    "file://DEVELOPMENT.md",
     "file://README.md",
     "file://.kiro/steering/**/*.md",
     "file://.kiro/agents/prompts/investigate.md"
@@ -12,11 +21,16 @@
   "mcpServers": {
     "opensearch-docs": {
       "command": "python",
-      "args": ["mcp_server.py"]
+      "args": [
+        "mcp_server.py"
+      ]
     },
     "github": {
       "command": "bash",
-      "args": ["-c", "GITHUB_PERSONAL_ACCESS_TOKEN=$(gh auth token) npx -y @modelcontextprotocol/server-github"]
+      "args": [
+        "-c",
+        "GITHUB_PERSONAL_ACCESS_TOKEN=$(gh auth token) npx -y @modelcontextprotocol/server-github"
+      ]
     }
   }
 }

--- a/.kiro/agents/refactor.json
+++ b/.kiro/agents/refactor.json
@@ -2,9 +2,16 @@
   "name": "refactor",
   "description": "Batch structural changes to existing reports",
   "prompt": "You are a refactor agent. Transform report files based on steering rules or Issue instructions.",
-  "tools": ["@builtin", "@github"],
-  "allowedTools": ["@builtin", "@github"],
+  "tools": [
+    "@builtin",
+    "@github"
+  ],
+  "allowedTools": [
+    "@builtin",
+    "@github"
+  ],
   "resources": [
+    "file://DEVELOPMENT.md",
     "file://README.md",
     "file://.kiro/steering/**/*.md",
     "file://.kiro/agents/prompts/refactor.md"
@@ -12,7 +19,10 @@
   "mcpServers": {
     "github": {
       "command": "bash",
-      "args": ["-c", "GITHUB_PERSONAL_ACCESS_TOKEN=$(gh auth token) npx -y @modelcontextprotocol/server-github"]
+      "args": [
+        "-c",
+        "GITHUB_PERSONAL_ACCESS_TOKEN=$(gh auth token) npx -y @modelcontextprotocol/server-github"
+      ]
     }
   }
 }

--- a/.kiro/agents/summarize.json
+++ b/.kiro/agents/summarize.json
@@ -2,9 +2,18 @@
   "name": "summarize",
   "description": "Create release summary from existing feature reports",
   "prompt": "You are a release summarizer. Create release summary by aggregating release reports.",
-  "tools": ["@builtin", "@github", "@opensearch-docs"],
-  "allowedTools": ["@builtin", "@github", "@opensearch-docs"],
+  "tools": [
+    "@builtin",
+    "@github",
+    "@opensearch-docs"
+  ],
+  "allowedTools": [
+    "@builtin",
+    "@github",
+    "@opensearch-docs"
+  ],
   "resources": [
+    "file://DEVELOPMENT.md",
     "file://README.md",
     "file://.kiro/steering/**/*.md",
     "file://.kiro/agents/prompts/summarize.md"
@@ -12,11 +21,16 @@
   "mcpServers": {
     "opensearch-docs": {
       "command": "python",
-      "args": ["mcp_server.py"]
+      "args": [
+        "mcp_server.py"
+      ]
     },
     "github": {
       "command": "bash",
-      "args": ["-c", "GITHUB_PERSONAL_ACCESS_TOKEN=$(gh auth token) npx -y @modelcontextprotocol/server-github"]
+      "args": [
+        "-c",
+        "GITHUB_PERSONAL_ACCESS_TOKEN=$(gh auth token) npx -y @modelcontextprotocol/server-github"
+      ]
     }
   }
 }

--- a/.kiro/agents/translate.json
+++ b/.kiro/agents/translate.json
@@ -2,9 +2,14 @@
   "name": "translate",
   "description": "Translate existing reports to other languages",
   "prompt": "You are a technical document translator. Translate OpenSearch feature/release reports.",
-  "tools": ["@builtin"],
-  "allowedTools": ["@builtin"],
+  "tools": [
+    "@builtin"
+  ],
+  "allowedTools": [
+    "@builtin"
+  ],
   "resources": [
+    "file://DEVELOPMENT.md",
     "file://README.md",
     "file://.kiro/steering/**/*.md",
     "file://.kiro/agents/prompts/translate.md"


### PR DESCRIPTION
## Summary
Add `DEVELOPMENT.md` to resources for document-generating agents.

## Changes
Added `file://DEVELOPMENT.md` to:
- `investigate.json`
- `summarize.json`
- `generate-release-docs.json`
- `refactor.json`
- `translate.json`

## Why
DEVELOPMENT.md is now the SSoT for document conventions. Agents that generate documents need access to these rules.