### PR TITLE
refactor: remove duplicate templates from prompts, reference DEVELOPMENT.md

### DIFF
--- a/.kiro/agents/prompts/generate-release-docs.md
+++ b/.kiro/agents/prompts/generate-release-docs.md
@@ -30,60 +30,18 @@ For each feature with changes in target version:
    - Related PRs for this version
    - Configuration added in this version
    - Components added in this version
-3. Create `docs/releases/v{version}/features/{feature-name}.md`
+3. Create `docs/releases/v{version}/features/{repo}/{feature-name}.md` following the **Release Report Template in DEVELOPMENT.md**
 
-### Release Report Template
-
-```markdown
-# {Feature Name} - v{version} Changes
-
-## Summary
-Brief description of what changed in this version.
-(Extract from Change History entry)
-
-## Details
-
-### What's New in v{version}
-- Change 1
-- Change 2
-
-### Technical Changes
-
-#### New/Modified Components
-| Component | Description |
-|-----------|-------------|
-(Only components added/modified in this version)
-
-#### New/Modified Configuration
-| Setting | Description | Default |
-|---------|-------------|---------|
-(Only settings added/modified in this version)
-
-### Usage Example
-```json
-// Example specific to this version's changes
-```
-
-## Related PRs
-| PR | Description |
-|----|-------------|
-(Only PRs for this version)
-```
+Key points:
+- Include YAML frontmatter with `tags: [{repo}]`
+- Focus on delta (what's new in this version)
+- No internal `.md` links
 
 ### Step 4: Create Release Index
 
 Create `docs/releases/v{version}/index.md`:
-
-```markdown
-# OpenSearch v{version}
-
-## Feature Reports
-
-| Feature | Description |
-|---------|-------------|
-| {Feature 1} | Brief description |
-| {Feature 2} | Brief description |
-```
+- List feature reports (plain text, no links)
+- Group by repository
 
 ### Step 5: Commit and Push
 

--- a/.kiro/agents/prompts/investigate.md
+++ b/.kiro/agents/prompts/investigate.md
@@ -189,60 +189,12 @@ Create `docs/releases/v{version}/features/{repository-name}/{item-name}.md`:
 
 This is the **primary output** - a focused report on what changed in THIS version.
 
-### Release Report Template
-```markdown
-# {Item Name}
+**Follow the Release Report Template in DEVELOPMENT.md.**
 
-## Summary
-What this release item adds/changes and why it matters.
-Focus on the delta - what's new in this version specifically.
-
-## Details
-
-### What's New in v{version}
-Specific changes introduced in this version.
-
-### Technical Changes
-
-#### Architecture Changes
-```mermaid
-graph TB
-    ...
-```
-(Only if architecture changed)
-
-#### New Components
-| Component | Description |
-|-----------|-------------|
-
-#### New Configuration
-| Setting | Description | Default |
-|---------|-------------|---------|
-
-#### API Changes
-New or modified APIs.
-
-### Usage Example
-```json
-// Example showing new functionality
-```
-
-### Migration Notes
-Steps to adopt this change (if applicable).
-
-## Limitations
-Known limitations specific to this release.
-
-## References
-
-### Pull Requests
-| PR | Description | Related Issue |
-|----|-------------|---------------|
-| [#1234](url) | Main implementation | [#1000](url) |
-
-### Documentation
-- [Feature Documentation](url)
-```
+Key points:
+- Include YAML frontmatter with `tags: [{repo}]`
+- Focus on delta (what's new in this version)
+- No internal `.md` links
 
 ### Update Release Index
 After creating the release report, update `docs/releases/v{version}/index.md`:
@@ -261,20 +213,12 @@ For bugfix category items:
 4. Do NOT create a new feature report for bug fixes
 
 ### For new-feature (feature report doesn't exist):
-Create `docs/features/{repository-name}/{feature-name}.md` following the template in steering/opensearch-knowledge.md:
-- Summary section (accessible overview)
-- Details section (technical depth)
-- Architecture diagram
-- Components table
-- Configuration table
-- Usage examples
-- Limitations
-- Change History (starting with this version, sorted by version descending)
-- References section with subsections:
-  - Documentation
-  - Blog Posts
-  - Pull Requests (table with Version, PR, Description, Related Issue)
-  - Issues (Design / RFC)
+Create `docs/features/{repository-name}/{feature-name}.md` following the **Feature Report Template in DEVELOPMENT.md**.
+
+Key points:
+- Include YAML frontmatter with `tags: [{repo}]`
+- Summary, Details, Limitations, Change History, References sections
+- No internal `.md` links
 
 ### For update-feature (feature report exists):
 1. Read existing `docs/features/{repository-name}/{feature-name}.md`

--- a/.kiro/agents/prompts/summarize.md
+++ b/.kiro/agents/prompts/summarize.md
@@ -19,65 +19,18 @@ Use GitHub MCP `get_file_contents` to fetch.
 
 ### Step 3: Create Release Summary
 
-Create `docs/releases/v{version}/summary.md`:
+Create `docs/releases/v{version}/summary.md` following the **Release Summary Template in DEVELOPMENT.md**.
 
-```markdown
-# OpenSearch v{version} Release Summary
-
-## Summary
-Overview of this release: major themes, key features, overall impact.
-Written for all readers - accessible yet informative.
-
-## Highlights
-
-```mermaid
-graph TB
-    subgraph "Key Changes in v{version}"
-        A[Feature 1]
-        B[Feature 2]
-        C[Improvement 1]
-    end
-```
-
-## New Features
-
-| Feature | Description | Report |
-|---------|-------------|--------|
-| {Name} | {Brief description from release report} | {item-name} |
-
-## Improvements
-
-| Area | Description | Report |
-|------|-------------|--------|
-| {Area} | {Brief description} | {item-name} |
-
-## Bug Fixes
-
-| Fix | Description | PR |
-|-----|-------------|-----|
-| {Fix} | {Description} | [#{number}]({url}) |
-
-## Breaking Changes
-
-| Change | Migration | Report |
-|--------|-----------|--------|
-| {Change} | {Migration steps} | {item-name} |
-
-## Dependencies
-
-Notable dependency updates from release notes.
-
-## References
-
-- [Official Release Notes]({release_notes_url})
-- [Feature Reports](features/)
-```
+Key points:
+- Summary, Highlights (Mermaid), New Features, Improvements, Bug Fixes, Breaking Changes, References
+- No internal `.md` links in tables
+- External links (GitHub PRs) are allowed
 
 ### Step 4: Update Release Index
 
-Update `docs/releases/v{version}/index.md` to include summary reference:
-
-```markdown
+Update `docs/releases/v{version}/index.md`:
+- Add reference to summary
+- List feature reports (plain text, no links)
 # OpenSearch v{version}
 
 - Release Summary
@@ -129,7 +82,7 @@ git checkout $ORIGINAL_BRANCH
 - This agent does NOT investigate individual features
 - It aggregates existing release reports into a summary
 - If release reports are missing, note them and suggest running `investigate`
-- Focus on providing a high-level overview with links to detailed reports
+- Focus on providing a high-level overview
 
 ## Output Files
 


### PR DESCRIPTION
## Summary
Remove duplicate templates from prompts and reference DEVELOPMENT.md instead.

## Changes
- `investigate.md`: Remove release/feature report templates (-78 lines)
- `summarize.md`: Remove summary template (-65 lines)
- `generate-release-docs.md`: Remove release report template (-56 lines)

All prompts now say "Follow the X Template in DEVELOPMENT.md" instead of duplicating the template.

## Why
- DEVELOPMENT.md is the SSoT
- Duplicate templates lead to inconsistency when updating
- Reduces maintenance burden