### PR TITLE
fix: unify path placeholders to {repo} across all prompts

### DIFF
--- a/.kiro/agents/prompts/create-issues.md
+++ b/.kiro/agents/prompts/create-issues.md
@@ -58,8 +58,8 @@ Title: [{category}] {Item Name} (v{version})
 - PR: #{pr_number}
 
 ## Deliverables
-1. **Release Report**: `docs/releases/v{version}/features/{repository}/{item-name}.md`
-2. **Feature Report**: `docs/features/{repository}/{feature-name}.md`
+1. **Release Report**: `docs/releases/v{version}/features/{repo}/{item-name}.md`
+2. **Feature Report**: `docs/features/{repo}/{feature-name}.md`
 
 ## Tasks
 - [ ] Investigate PR and related issues

--- a/.kiro/agents/prompts/generate-release-docs.md
+++ b/.kiro/agents/prompts/generate-release-docs.md
@@ -10,7 +10,7 @@ You are a release document generator. Extract version-specific changes from exis
 
 ### Step 1: Scan Feature Documents
 
-1. List all `docs/features/*.md` files (excluding index.md and language variants)
+1. List all `docs/features/{repo}/*.md` files (excluding index.md and language variants)
 2. For each file, read the Change History section
 3. Identify features that have changes for the target version
 
@@ -74,7 +74,7 @@ Create PR and merge, then return to original branch.
 docs/releases/v{version}/
 ├── index.md
 └── features/
-    ├── {feature-1}.md
-    ├── {feature-2}.md
-    └── ...
+    └── {repo}/
+        ├── {feature-1}.md
+        └── {feature-2}.md
 ```

--- a/.kiro/agents/prompts/investigate.md
+++ b/.kiro/agents/prompts/investigate.md
@@ -185,7 +185,7 @@ Save to `.cache/releases/{version}/`:
 - If repository not specified in Issue, determine from the main PR's repository
 - For items spanning multiple repositories, use the primary repository
 
-Create `docs/releases/v{version}/features/{repository-name}/{item-name}.md`:
+Create `docs/releases/v{version}/features/{repo}/{item-name}.md`:
 
 This is the **primary output** - a focused report on what changed in THIS version.
 
@@ -213,7 +213,7 @@ For bugfix category items:
 4. Do NOT create a new feature report for bug fixes
 
 ### For new-feature (feature report doesn't exist):
-Create `docs/features/{repository-name}/{feature-name}.md` following the **Feature Report Template in DEVELOPMENT.md**.
+Create `docs/features/{repo}/{feature-name}.md` following the **Feature Report Template in DEVELOPMENT.md**.
 
 Key points:
 - Include YAML frontmatter with `tags: [{repo}]`
@@ -221,7 +221,7 @@ Key points:
 - No internal `.md` links
 
 ### For update-feature (feature report exists):
-1. Read existing `docs/features/{repository-name}/{feature-name}.md`
+1. Read existing `docs/features/{repo}/{feature-name}.md`
 2. Check the highest version already documented in Change History
 3. If investigating an **older version** than what's documented:
    - **Do NOT overwrite** existing specs with older behavior (e.g., config defaults, API signatures)
@@ -301,8 +301,8 @@ Post completion comment:
 ## Investigation Complete
 
 ### Reports Created
-- Release report: `docs/releases/v{version}/features/{repository-name}/{item-name}.md`
-- Feature report: `docs/features/{repository-name}/{feature-name}.md` (created/updated)
+- Release report: `docs/releases/v{version}/features/{repo}/{item-name}.md`
+- Feature report: `docs/features/{repo}/{feature-name}.md` (created/updated)
 
 ### Summary
 {Brief summary of findings}

--- a/.kiro/agents/prompts/planner.md
+++ b/.kiro/agents/prompts/planner.md
@@ -101,8 +101,8 @@ Title: [{category}] {group_name}
 
 ## Tasks
 - [ ] Investigate PRs
-- [ ] Create release report: `docs/releases/v{version}/{group-name}.md`
-- [ ] Update feature report: `docs/features/{feature-name}.md`
+- [ ] Create release report: `docs/releases/v{version}/features/{repo}/{group-name}.md`
+- [ ] Update feature report: `docs/features/{repo}/{feature-name}.md`
 ```
 
 Labels: `release/v{version}`, `status/todo`

--- a/.kiro/agents/prompts/translate.md
+++ b/.kiro/agents/prompts/translate.md
@@ -29,12 +29,12 @@ You are a technical document translator. Translate OpenSearch feature/release re
 ## Workflow
 
 ### For Feature Report Translation
-1. Read `docs/features/{feature}.md`
+1. Read `docs/features/{repo}/{feature}.md`
 2. Translate following the rules
-3. Save as `docs/features/{feature}.{lang}.md`
+3. Save as `docs/features/{repo}/{feature}.{lang}.md`
 
 ### For Release Report Translation
-1. Read all files in `docs/releases/v{version}/`
+1. Read all files in `docs/releases/v{version}/features/{repo}/`
 2. Translate each file
 3. Save with appropriate suffix
 


### PR DESCRIPTION
## Summary
Unify path placeholders to `{repo}` across all prompts.

## Changes
- `investigate.md`: `{repository-name}` → `{repo}`
- `translate.md`: Add `{repo}` to feature/release paths
- `generate-release-docs.md`: Add `{repo}` to scan path and output structure
- `planner.md`: Add `{repo}` to task paths
- `create-issues.md`: Fix deliverables paths to use `{repo}`

## Why
Inconsistent placeholders (`{repository-name}`, `{repository}`, `{repo}`) and missing `{repo}` directory in paths caused confusion and potential errors.