### PR TITLE
docs: add workspace-enhancements report for v2.19.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-workspace.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-workspace.md
@@ -172,7 +172,7 @@ opensearch_security.multitenancy.enabled: false
 - **v3.4.0** (2026-02-18): Removed restriction requiring data source selection during workspace creation; workspaces can now be created without associated data sources
 - **v3.3.0** (2026-01-14): Added batch delete method for workspaces with improved error handling and detailed success/failure notifications
 - **v3.0.0** (2025-05-06): Bug fixes for saved object isolation, recent items error filtering, and stale workspace error handling
-- **v2.19.0** (2025-01-09): Added two-step loading for data source association modal, improving performance when data sources have many direct query connections
+- **v2.19.0** (2025-01-09): Added dismissible get started section for overview pages; optimized recent items with workspace deletion filtering; refactored bulk_get permission handler for better error responses; added privacy levels for workspace access control; enabled category-based search for Dev Tools; added two-step loading for data source association modal
 - **v2.18.0** (2024-11-05): Major feature additions including workspace-level UI settings, collaborator management system (WorkspaceCollaboratorTypesService, AddCollaboratorsModal, Collaborators Page), data connection integration, global search bar in left nav, ACL auditor for permission bypass detection; 14 bug fixes for UI/UX improvements
 
 
@@ -196,6 +196,11 @@ opensearch_security.multitenancy.enabled: false
 | v3.0.0 | [#9346](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9346) | Filter out recent items with errors | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v3.0.0 | [#9478](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9478) | Add error handling page for stale workspace state |   |
 | v2.19.0 | [#8999](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8999) | Add two-steps loading for associating data sources |   |
+| v2.19.0 | [#8874](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8874) | Support dismiss get started for search/essential/analytics overview page |   |
+| v2.19.0 | [#8900](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8900) | Optimize recent items and filter out items whose workspace is deleted |   |
+| v2.19.0 | [#8906](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8906) | Refactor bulk_get handler in permission wrapper for better error handling |   |
+| v2.19.0 | [#8907](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8907) | Add privacy levels to the workspace |   |
+| v2.19.0 | [#8920](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8920) | Support search dev tools by its category name |   |
 | v2.18.0 | [#8500](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8500) | Workspace-level UI settings and hide non-global settings | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v2.18.0 | [#8594](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8594) | Add workspace collaborators page |   |
 | v2.18.0 | [#8486](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8486) | Add WorkspaceCollaboratorTypesService and AddCollaboratorsModal |   |

--- a/docs/releases/v2.19.0/features/opensearch-dashboards/workspace-enhancements.md
+++ b/docs/releases/v2.19.0/features/opensearch-dashboards/workspace-enhancements.md
@@ -1,0 +1,62 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Workspace Enhancements
+
+## Summary
+
+OpenSearch Dashboards v2.19.0 introduces several workspace enhancements focused on user experience improvements, including dismissible get started sections, optimized recent items handling, improved permission error handling, privacy level settings, and enhanced search functionality by category name.
+
+## Details
+
+### What's New in v2.19.0
+
+#### Dismissible Get Started Section
+Users can now dismiss the "Get Started" section on workspace overview pages (Search, Essential, and Analytics use cases). This provides a cleaner interface for experienced users who no longer need onboarding guidance.
+
+#### Optimized Recent Items
+- Internal users now emit app updaters, reducing extra requests for recent items
+- Items from deleted workspaces are automatically filtered out from the recent items list
+- Improved performance by eliminating unnecessary API calls
+
+#### Improved Permission Error Handling
+The `bulk_get` handler in the permission wrapper has been refactored to return responses with errors instead of throwing exceptions. This fixes index pattern fetch errors in the Discover dataset modal, providing a better user experience when accessing resources with permission restrictions.
+
+#### Privacy Levels for Workspaces
+New privacy settings allow workspace administrators to configure user permissions at multiple touchpoints:
+- Workspace creation page
+- Workspace details page
+- Collaborators page
+
+Additionally, collaborator input validation now prevents single `*` wildcard input for security purposes.
+
+#### Category-Based Search for Dev Tools
+Users can now search for Dev Tools applications by their category name. For example, searching "dev tools" will match all sub-applications under the Dev Tools category, making it easier to discover related functionality.
+
+### Technical Changes
+
+| Change | Description |
+|--------|-------------|
+| Get Started Dismissal | Added settings button to overview pages for dismissing get started cards |
+| Recent Items Optimization | Updated internal users to emit app updaters; added workspace deletion filtering |
+| Permission Wrapper Refactor | Changed `bulk_get` handler to return error responses instead of throwing |
+| Privacy Settings | Added privacy level configuration to workspace create/details/collaborators pages |
+| Category Search | Extended search functionality to match applications by category name |
+
+## Limitations
+
+- Privacy settings require the Security plugin to be properly configured
+- Category search only works when workspace and new home page features are enabled
+- Dismissed get started sections are stored per-user and cannot be reset through the UI
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#8874](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8874) | Support dismiss get started for search/essential/analytics overview page | |
+| [#8900](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8900) | Optimize recent items and filter out items whose workspace is deleted | |
+| [#8906](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8906) | Refactor bulk_get handler in permission wrapper when item has permission error | |
+| [#8907](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8907) | Add privacy levels to the workspace | |
+| [#8920](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8920) | Support search dev tools by its category name | |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -4,3 +4,4 @@
 
 ### opensearch-dashboards
 - Data Source Association
+- Workspace Enhancements


### PR DESCRIPTION
## Summary

Investigation of GitHub Issue #2070 - Workspace Enhancements for OpenSearch Dashboards v2.19.0.

## Changes

### Release Report Created
- `docs/releases/v2.19.0/features/opensearch-dashboards/workspace-enhancements.md`

### Feature Report Updated
- `docs/features/opensearch-dashboards/opensearch-dashboards-workspace.md`
  - Added v2.19.0 changes to Change History
  - Added 5 new PRs to References section

## Key Changes in v2.19.0

- **Dismissible Get Started Section**: Users can dismiss the "Get Started" section on workspace overview pages
- **Optimized Recent Items**: Reduced API calls and filter out items from deleted workspaces
- **Improved Permission Error Handling**: Refactored bulk_get handler to return error responses instead of throwing
- **Privacy Levels**: New privacy settings for workspace access control at creation, details, and collaborators pages
- **Category-Based Search**: Search Dev Tools applications by category name

## PRs Investigated
- #8874 - Dismiss get started for overview pages
- #8900 - Optimize recent items
- #8906 - Refactor bulk_get permission handler
- #8907 - Add privacy levels
- #8920 - Category-based search for Dev Tools

Closes #2070