### PR TITLE
docs: add dataset-selector report for v2.19.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-discover.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-discover.md
@@ -93,7 +93,7 @@ flowchart TB
 | Field Selector | Sidebar for selecting and filtering visible fields |
 | Document Table | Displays search results with expandable documents |
 | Saved Queries | Stores and loads frequently used queries |
-| Dataset Selector | Selects data source with cache management |
+| Dataset Selector | Selects data source with cache management and indexed views support |
 
 ### Configuration
 
@@ -148,6 +148,7 @@ Requires ML agent configuration:
 - **v3.4.0** (2025-11-06): Added log pattern detection for Discover Summary - automatically uses specialized `os_data2summary_with_log_pattern` agent for log indexes
 - **v3.2.0** (2025-08-05): Fixed empty page issue when no index patterns exist, added Cypress tests for discover visualization
 - **v3.0.0** (2025-05-13): Added CSV export functionality, reorganized results display with ResultsActionBar, customizable summary panel title, experimental Data plugin `__enhance` API with resultsActionBar, and 6 bug fixes for saved search handling and workspace integration
+- **v2.19.0** (2025-01-14): Added indexed views framework to dataset selector, custom time filter logic per dataset type, and query editor bottom panel extension
 - **v2.18.0** (2024-11-05): Added AI-powered data summary panel, updated visual appearance, cache management in dataset selector, and 14 bug fixes for stability and usability
 
 
@@ -176,6 +177,8 @@ Requires ML agent configuration:
 | v3.0.0 | [#9529](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9529) | Correctly load saved search from snapshot URL | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v3.0.0 | [#9541](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9541) | Correctly load saved search query in query editor | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v3.0.0 | [#9465](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9465) | Prevent visiting Discover outside workspace | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
+| v2.19.0 | [#8851](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8851) | Indexed views framework - show indexed views in dataset selector |   |
+| v2.19.0 | [#8932](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8932) | Support custom time filter logic based on dataset type |   |
 | v2.18.0 | [#8186](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8186) | Add data summary panel in discover |   |
 | v2.18.0 | [#8214](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8214) | Add cache time and refresh button to dataset selector | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v2.18.0 | [#8651](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8651) | Update the appearance of Discover |   |

--- a/docs/releases/v2.19.0/features/opensearch-dashboards/dataset-selector.md
+++ b/docs/releases/v2.19.0/features/opensearch-dashboards/dataset-selector.md
@@ -1,0 +1,109 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Dataset Selector
+
+## Summary
+
+OpenSearch Dashboards v2.19.0 enhances the Dataset Selector with two key features: support for indexed views in the dataset selection workflow, and custom time filter logic based on dataset type. These changes enable users to query pre-indexed views for faster performance and allow dataset types to control how time filters are applied.
+
+## Details
+
+### What's New in v2.19.0
+
+#### Indexed Views Framework
+
+The Dataset Selector now supports selecting indexed views as an alternative to querying raw external data sources. Indexed views are OpenSearch indexes created from external sources (like S3) that provide faster query performance.
+
+```mermaid
+flowchart TB
+    A[User Opens Dataset Selector] --> B[Select Data Source]
+    B --> C[Configure Dataset]
+    C --> D{Indexed Views Available?}
+    D -->|Yes| E[Toggle: Query indexed view]
+    D -->|No| F[Continue with raw data]
+    E --> G[Select from Available Indexed Views]
+    G --> H[Dataset configured with indexed view]
+    F --> I[Dataset configured with raw source]
+```
+
+Key components added:
+- `DatasetIndexedViewsService` interface for fetching indexed views
+- `indexedViewsService` property on `DatasetTypeConfig`
+- `sourceDatasetRef` property on `Dataset` to track the original source
+- UI toggle "Query indexed view" in the Configurator
+
+#### Custom Time Filter Logic
+
+Dataset types can now override the date picker behavior per language using `languageOverrides`. This allows external data sources to handle time filtering through their own search strategies rather than the default client-side approach.
+
+```typescript
+// DatasetTypeConfig with language overrides
+{
+  id: 's3',
+  title: 'S3',
+  languageOverrides: {
+    PPL: { hideDatePicker: false },  // Show date picker, but handle time filter in search strategy
+    SQL: { hideDatePicker: false }
+  },
+  meta: {
+    supportsTimeFilter: true
+  }
+}
+```
+
+The time filter is now passed to the search strategy via `timeRange` in the request body, allowing server-side time filtering.
+
+### Technical Changes
+
+#### New Interfaces
+
+| Interface | Description |
+|-----------|-------------|
+| `DatasetIndexedView` | Represents an indexed view with `name` property |
+| `DatasetIndexedViewsService` | Service for fetching indexed views and connected data sources |
+
+#### Dataset Type Configuration
+
+| Property | Description |
+|----------|-------------|
+| `languageOverrides` | Per-language configuration overrides |
+| `languageOverrides[lang].hideDatePicker` | Override date picker visibility for specific language |
+| `indexedViewsService` | Service for indexed view operations |
+
+#### Dataset Properties
+
+| Property | Description |
+|----------|-------------|
+| `sourceDatasetRef` | Reference to source dataset (id and type) when using indexed view |
+
+#### Search Interceptor Changes
+
+PPL and SQL search interceptors now:
+1. Check for `languageOverrides[language].hideDatePicker === false`
+2. Pass `timeRange` to the server when dataset handles time filtering
+3. Skip client-side time filter injection when dataset handles it
+
+### Banner Framework
+
+A new framework allows dataset types to display contextual banners in the Discover results canvas. This can be used to:
+- Show callouts for creating indexed views
+- Provide entry points to switch between indexed views
+- Display dataset-specific actions
+
+The banner is rendered via `QueryEditorExtension.getBottomPanel()`.
+
+## Limitations
+
+- Indexed views framework requires dataset type to implement `indexedViewsService`
+- Time filter override only works when `hideDatePicker: false` is explicitly set
+- Banner framework requires query editor extension configuration
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#8851](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8851) | Indexed views framework - show indexed views in dataset selector and add banner framework | New feature |
+| [#8932](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8932) | Support custom logic to insert time filter based on dataset type | Continues [#8917](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8917) |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -4,4 +4,5 @@
 
 ### opensearch-dashboards
 - Data Source Association
+- Dataset Selector
 - Workspace Enhancements


### PR DESCRIPTION
## Summary

Adds documentation for Dataset Selector enhancements in OpenSearch Dashboards v2.19.0.

### Changes
- **Release report**: `docs/releases/v2.19.0/features/opensearch-dashboards/dataset-selector.md`
- **Feature report update**: Updated `docs/features/opensearch-dashboards/opensearch-dashboards-discover.md` with v2.19.0 changes

### Key Features Documented
1. **Indexed Views Framework** (PR #8851)
   - Support for selecting indexed views in dataset selector
   - `DatasetIndexedViewsService` interface
   - Banner framework for Discover results canvas

2. **Custom Time Filter Logic** (PR #8932)
   - `languageOverrides` configuration for dataset types
   - Per-language date picker control
   - Server-side time filter handling

### Related Issue
Closes #2069