### PR TITLE
docs: add numeric-precision-setting report for v2.19.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-numeric-precision.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-numeric-precision.md
@@ -1,0 +1,103 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Numeric Precision Setting
+
+## Summary
+
+The Numeric Precision Setting feature provides control over how OpenSearch Dashboards handles extremely large numbers (long numerals) that exceed JavaScript's safe integer limits. Users can enable extended precision for accurate handling of large values or disable it to optimize performance.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        UI[Advanced Settings UI]
+        UIS[UI Settings Service]
+        
+        subgraph "Plugins"
+            Console[Console Plugin]
+            Discover[Discover Plugin]
+            Data[Data Plugin]
+        end
+    end
+    
+    subgraph "OpenSearch"
+        API[OpenSearch API]
+    end
+    
+    UI --> UIS
+    UIS --> Console
+    UIS --> Discover
+    UIS --> Data
+    Console -->|withLongNumeralsSupport| API
+    Discover -->|withLongNumeralsSupport| API
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `data:withLongNumerals` | UI setting key that controls numeric precision behavior |
+| `UI_SETTINGS.DATA_WITH_LONG_NUMERALS` | Constant defined in the Data plugin for accessing the setting |
+| `IndexPatternsService.isLongNumeralsSupported()` | Method to check if long numerals support is enabled |
+| `withLongNumeralsSupport` | Request parameter passed to OpenSearch API calls |
+
+### Configuration
+
+| Setting | Key | Type | Default | Description |
+|---------|-----|------|---------|-------------|
+| Extend Numeric Precision | `data:withLongNumerals` | Boolean | `true` | Turn on for precise handling of extremely large numbers. Turn off to optimize performance when high precision for large values isn't required. |
+
+#### Configuration Methods
+
+1. **UI Configuration**: Stack Management → Advanced Settings → Data section
+2. **Configuration File** (`opensearch_dashboards.yml`):
+   ```yaml
+   data.withLongNumerals: true
+   ```
+
+### Usage Example
+
+When enabled (default), numeric values outside JavaScript's safe integer range are preserved with full precision:
+
+```json
+{
+  "long-max": 18014398509481982,
+  "long-min": -18014398509481982
+}
+```
+
+When disabled, these values may lose precision due to JavaScript's floating-point limitations:
+
+```json
+{
+  "long-max": 18014398509481984,
+  "long-min": -18014398509481984
+}
+```
+
+## Limitations
+
+- Disabling this setting causes precision loss for numeric values outside JavaScript's safe integer range (±9,007,199,254,740,991)
+- The setting is global and affects all queries and document views
+- Performance impact of enabling long numerals support depends on the volume and frequency of large numeric values in your data
+
+## Change History
+
+- **v2.19.0** (2025-01-21): Added configurable setting to toggle long numerals support on/off. Previously, long numerals support was always enabled.
+
+## References
+
+### Documentation
+
+- [Advanced Settings](https://docs.opensearch.org/2.19/dashboards/management/advanced-settings/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#8837](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8837) | Add setting to turn extending numeric precision on or off |

--- a/docs/releases/v2.19.0/features/opensearch-dashboards/numeric-precision-setting.md
+++ b/docs/releases/v2.19.0/features/opensearch-dashboards/numeric-precision-setting.md
@@ -1,0 +1,54 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Numeric Precision Setting
+
+## Summary
+
+OpenSearch Dashboards v2.19.0 introduces a new Advanced Setting called "Extend Numeric Precision" (`data:withLongNumerals`) that allows users to toggle the handling of extremely large numbers (long numerals) on or off. Previously, long numeral support was always enabled; now users can disable it to optimize performance when high precision for large values isn't required.
+
+## Details
+
+### What's New in v2.19.0
+
+A new UI setting has been added to the Advanced Settings page under the Data section:
+
+| Setting | Key | Default | Description |
+|---------|-----|---------|-------------|
+| Extend Numeric Precision | `data:withLongNumerals` | `true` (On) | Turn on for precise handling of extremely large numbers. Turn off to optimize performance when high precision for large values isn't required. |
+
+### Technical Changes
+
+The implementation modifies how OpenSearch Dashboards handles numeric values that exceed JavaScript's safe integer limits (`Number.MAX_SAFE_INTEGER` and `Number.MIN_SAFE_INTEGER`).
+
+#### Affected Components
+
+| Component | Change |
+|-----------|--------|
+| Console Plugin | Now reads `data:withLongNumerals` setting and passes `withLongNumeralsSupport` flag to API requests |
+| Discover Plugin | Document search and single document view respect the precision setting |
+| Data Plugin | Added `UI_SETTINGS.DATA_WITH_LONG_NUMERALS` constant and `isLongNumeralsSupported()` method to IndexPatternsService |
+
+#### Configuration
+
+The setting can be modified in:
+1. **OpenSearch Dashboards UI**: Stack Management → Advanced Settings → Data section
+2. **opensearch_dashboards.yml**: `data.withLongNumerals: true` or `false`
+
+### Bug Fix
+
+This PR also fixes a typo in the code that inspects values for large numerals in OpenSearch Dashboards and the JavaScript client.
+
+## Limitations
+
+- Disabling this setting may cause precision loss for numeric values outside JavaScript's safe integer range (±9,007,199,254,740,991)
+- The setting affects all queries and document views across the Dashboards application
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#8837](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8837) | Add setting to turn extending numeric precision on or off | - |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -5,4 +5,5 @@
 ### opensearch-dashboards
 - Data Source Association
 - Dataset Selector
+- Numeric Precision Setting
 - Workspace Enhancements


### PR DESCRIPTION
## Summary

Adds documentation for the Numeric Precision Setting feature introduced in OpenSearch Dashboards v2.19.0.

### Changes
- **Release Report**: `docs/releases/v2.19.0/features/opensearch-dashboards/numeric-precision-setting.md`
- **Feature Report**: `docs/features/opensearch-dashboards/opensearch-dashboards-numeric-precision.md`
- Updated release index

### Feature Overview
This feature adds a new Advanced Setting (`data:withLongNumerals`) that allows users to toggle the handling of extremely large numbers on or off. Previously, long numeral support was always enabled.

### Source PR
- [opensearch-project/OpenSearch-Dashboards#8837](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8837)

Closes #2068