### PR TITLE
docs: add discover-enhancements report for v2.19.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-discover.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-discover.md
@@ -148,7 +148,7 @@ Requires ML agent configuration:
 - **v3.4.0** (2025-11-06): Added log pattern detection for Discover Summary - automatically uses specialized `os_data2summary_with_log_pattern` agent for log indexes
 - **v3.2.0** (2025-08-05): Fixed empty page issue when no index patterns exist, added Cypress tests for discover visualization
 - **v3.0.0** (2025-05-13): Added CSV export functionality, reorganized results display with ResultsActionBar, customizable summary panel title, experimental Data plugin `__enhance` API with resultsActionBar, and 6 bug fixes for saved search handling and workspace integration
-- **v2.19.0** (2025-01-14): Added indexed views framework to dataset selector, custom time filter logic per dataset type, and query editor bottom panel extension
+- **v2.19.0** (2025-01-14): Added indexed views framework to dataset selector, results canvas banner framework, data2summary agent validation, default query string framework, custom time filter logic per dataset type, query editor bottom panel extension, and Cypress test data attributes
 - **v2.18.0** (2024-11-05): Added AI-powered data summary panel, updated visual appearance, cache management in dataset selector, and 14 bug fixes for stability and usability
 
 
@@ -177,7 +177,10 @@ Requires ML agent configuration:
 | v3.0.0 | [#9529](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9529) | Correctly load saved search from snapshot URL | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v3.0.0 | [#9541](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9541) | Correctly load saved search query in query editor | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v3.0.0 | [#9465](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9465) | Prevent visiting Discover outside workspace | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
+| v2.19.0 | [#8682](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8682) | Add data test subject for discover cypress test |   |
+| v2.19.0 | [#8716](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8716) | Add data2summary agent check in data summary panel |   |
 | v2.19.0 | [#8851](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8851) | Indexed views framework - show indexed views in dataset selector |   |
+| v2.19.0 | [#8896](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8896) | Framework for default query string using dataset and language |   |
 | v2.19.0 | [#8932](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8932) | Support custom time filter logic based on dataset type |   |
 | v2.18.0 | [#8186](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8186) | Add data summary panel in discover |   |
 | v2.18.0 | [#8214](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8214) | Add cache time and refresh button to dataset selector | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |

--- a/docs/releases/v2.19.0/features/opensearch-dashboards/discover-enhancements.md
+++ b/docs/releases/v2.19.0/features/opensearch-dashboards/discover-enhancements.md
@@ -1,0 +1,83 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Discover Enhancements
+
+## Summary
+
+OpenSearch Dashboards v2.19.0 introduces several enhancements to the Discover application, including an indexed views framework for the dataset selector, a banner framework for the results canvas, data2summary agent validation for the summary panel, and a framework for default query strings based on dataset and language combinations.
+
+## Details
+
+### What's New in v2.19.0
+
+#### Indexed Views Framework
+
+A new framework enables dataset types to provide indexed views in the dataset selector. Indexed views are OpenSearch indexes created for external sources like S3, allowing users to query pre-indexed data for improved performance.
+
+Key components:
+- `DatasetIndexedViewsService` interface for fetching indexed views
+- `indexedViewsService` property in `DatasetTypeConfig`
+- "Query indexed view" toggle in the dataset configurator
+- Automatic data source connection resolution for indexed views
+
+```mermaid
+flowchart TB
+    A[Dataset Selector] --> B{Has Indexed Views?}
+    B -->|Yes| C[Show Toggle]
+    C --> D[Query indexed view]
+    D --> E[Select Indexed View]
+    E --> F[Query Index Instead of Source]
+    B -->|No| G[Direct Query]
+```
+
+#### Results Canvas Banner Framework
+
+A new extension point allows plugins to display banners at the top of the Discover results canvas. This framework supports:
+- Dynamic banner rendering based on dataset type
+- Actions related to the selected dataset (e.g., create indexed view prompts)
+- Entry points for indexed view selection when querying external sources
+
+#### Data2Summary Agent Check
+
+The data summary panel now validates the presence of the `data2summary` agent before displaying. If a query assistant agent exists but no summary agent is configured, the summary panel will not be shown.
+
+#### Default Query String Framework
+
+A new framework allows dataset types to provide default query strings based on the dataset and language combination. If not provided by the dataset type, the system falls back to language service defaults.
+
+### Technical Changes
+
+| Component | Change |
+|-----------|--------|
+| `Dataset` type | Added `sourceDatasetRef` property for indexed view references |
+| `DatasetTypeConfig` | Added `indexedViewsService` property |
+| `QueryEditorExtension` | Added `getBottomPanel` method and `bottomPanelContainer` |
+| `QueryEditorExtensionDependencies` | Added `query` and `fetchStatus` properties |
+| Dataset Selector | Icon now resolves from `sourceDatasetRef.type` for indexed views |
+| Configurator | Added indexed view selection UI with toggle switch |
+
+### Components Added
+
+| Component | Description |
+|-----------|-------------|
+| `DatasetIndexedViewsService` | Service interface for indexed view operations |
+| `DatasetIndexedView` | Type representing an indexed view with name property |
+| Bottom Panel Extension | New extension point below query editor |
+
+## Limitations
+
+- Indexed views framework requires dataset type configuration to implement `indexedViewsService`
+- Banner framework is only available when query enhancements are enabled
+- Data summary requires both query assistant and data2summary agents to be configured
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#8682](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8682) | Add data test subject for discover cypress test |   |
+| [#8716](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8716) | Add data2summary agent check in data summary panel |   |
+| [#8851](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8851) | Indexed views framework - banner and dataset selector |   |
+| [#8896](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8896) | Framework for default query string using dataset and language |   |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -5,5 +5,6 @@
 ### opensearch-dashboards
 - Data Source Association
 - Dataset Selector
+- Discover Enhancements
 - Numeric Precision Setting
 - Workspace Enhancements


### PR DESCRIPTION
## Summary

Adds documentation for Discover Enhancements in OpenSearch Dashboards v2.19.0.

### Changes
- Created release report: `docs/releases/v2.19.0/features/opensearch-dashboards/discover-enhancements.md`
- Updated feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-discover.md`
- Updated release index: `docs/releases/v2.19.0/index.md`

### Key Features Documented
- Indexed views framework for dataset selector
- Results canvas banner framework
- Data2summary agent validation for summary panel
- Default query string framework based on dataset and language
- Cypress test data attributes

### PRs Investigated
- #8682 - Add data test subject for discover cypress test
- #8716 - Add data2summary agent check in data summary panel
- #8851 - Indexed views framework
- #8896 - Default query string framework

Closes #2067