### PR TITLE
docs: add dashboards-health-checks report for v2.19.0

### DIFF
--- a/docs/features/opensearch-dashboards/dashboards-health-checks.md
+++ b/docs/features/opensearch-dashboards/dashboards-health-checks.md
@@ -1,0 +1,98 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Dashboards Health Checks
+
+## Summary
+
+OpenSearch Dashboards performs periodic health checks to verify version compatibility between Dashboards and OpenSearch nodes. The health check system supports optimized mode that reduces cluster load by querying only local nodes when all nodes share the same cluster ID.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        HC[Health Check Service]
+        IC[Internal Client]
+    end
+    subgraph "OpenSearch Cluster"
+        CM[Cluster Manager]
+        N1[Node 1]
+        N2[Node 2]
+        N3[Node 3]
+    end
+    HC --> IC
+    IC -->|"local=true"| N1
+    IC -->|"local=true"| N2
+    IC -->|"local=true"| N3
+    N1 -.->|cluster state sync| CM
+    N2 -.->|cluster state sync| CM
+    N3 -.->|cluster state sync| CM
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ensure_opensearch_version.ts` | Core health check logic for version compatibility |
+| `getNodeId()` | Determines which nodes to query based on cluster ID attributes |
+| `pollOpenSearchNodesVersion()` | Periodic polling mechanism for version checks |
+
+### Configuration
+
+The optimized health check behavior is controlled by the `healthcheck` configuration:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `healthcheck.id` | Node attribute name for cluster ID grouping | - |
+| `healthcheck.filters` | Key-value pairs to filter out specific nodes | - |
+
+### How It Works
+
+1. **Node ID Resolution**: The `getNodeId()` function queries `_cluster/state/nodes` to retrieve cluster IDs
+2. **Cluster ID Comparison**: If all nodes share the same cluster ID, returns `_local` for optimized queries
+3. **Version Check**: Queries node info to verify OpenSearch version compatibility with Dashboards
+4. **Periodic Polling**: Runs at configured intervals to detect cluster changes
+
+### Optimized Health Check Flow
+
+```mermaid
+sequenceDiagram
+    participant D as Dashboards
+    participant L as Local Node
+    participant CM as Cluster Manager
+    
+    D->>L: GET _cluster/state/nodes?local=true
+    L-->>D: Node attributes (from local state)
+    
+    alt All nodes same cluster_id
+        D->>L: GET _nodes/_local/info
+        L-->>D: Local node info
+    else Different cluster_ids
+        D->>CM: GET _nodes/info
+        CM-->>D: All nodes info
+    end
+```
+
+## Limitations
+
+- Optimized health checks require `healthcheck.id` configuration
+- Local cluster state may lag behind cluster manager state (nodes removed after 90s timeout)
+- Filter configuration must match exact attribute values
+
+## Change History
+
+- **v2.19.0** (2024-11-18): Use local cluster state calls during health checks to reduce cluster manager load ([#8187](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8187))
+
+## References
+
+### Documentation
+- [Cluster Health API](https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-health/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#8187](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8187) | Use local clusterState call during healthchecks |

--- a/docs/releases/v2.19.0/features/opensearch-dashboards/dashboards-health-checks.md
+++ b/docs/releases/v2.19.0/features/opensearch-dashboards/dashboards-health-checks.md
@@ -1,0 +1,58 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Dashboards Health Checks
+
+## Summary
+
+OpenSearch Dashboards v2.19.0 optimizes health check operations by using local cluster state calls instead of querying the cluster manager node. This reduces load on the cluster manager, improving cluster stability for large deployments with many indices and shards.
+
+## Details
+
+### What's New in v2.19.0
+
+The health check mechanism in OpenSearch Dashboards has been updated to use local cluster state when retrieving node attributes for optimized health checks.
+
+**Before v2.19.0**: The `_cluster/state/nodes` API call was served by the cluster manager node, which could stress the cluster manager in large clusters.
+
+**After v2.19.0**: The same API call now uses `local=true` parameter, serving the request from the local node's cluster state instead.
+
+### Technical Changes
+
+The change modifies `src/core/server/opensearch/version_check/ensure_opensearch_version.ts`:
+
+```typescript
+const state = (await internalClient.cluster.state({
+  metric: 'nodes',
+  local: true,  // New parameter added
+  filter_path: [path],
+})) as ApiResponse;
+```
+
+### How It Works
+
+1. During health checks, Dashboards retrieves node attributes to determine if optimized health checks can be used
+2. The `_cluster/state/nodes` call now reads from the local node's cluster state
+3. Since cluster state is eventually consistent across nodes (with a 90-second timeout before lagging nodes are removed), this approach maintains correctness while reducing cluster manager load
+
+### Impact
+
+- **Reduced cluster manager load**: Health check requests no longer route to the cluster manager
+- **Better scalability**: Large clusters with many Dashboards instances benefit from distributed request handling
+- **Minimal latency impact**: Local cluster state may lag slightly but remains accurate for health check purposes
+
+## Limitations
+
+- Local cluster state may be slightly behind the cluster manager's state (typically milliseconds)
+- Nodes with significantly lagging cluster state are automatically removed from the cluster after 90 seconds
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#8187](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8187) | Use local clusterState call during healthchecks | - |
+
+### Documentation
+- [Cluster Health API](https://docs.opensearch.org/2.19/api-reference/cluster-api/cluster-health/) - `local` parameter documentation

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -3,6 +3,7 @@
 ## Features
 
 ### opensearch-dashboards
+- Dashboards Health Checks
 - Data Source Association
 - Dataset Selector
 - Discover Enhancements


### PR DESCRIPTION
## Summary

Adds documentation for the Dashboards Health Checks feature in OpenSearch Dashboards v2.19.0.

### Changes
- **Release report**: `docs/releases/v2.19.0/features/opensearch-dashboards/dashboards-health-checks.md`
- **Feature report**: `docs/features/opensearch-dashboards/dashboards-health-checks.md`
- Updated release index

### Key Changes in v2.19.0
- Health checks now use local cluster state (`local=true`) instead of querying the cluster manager
- Reduces load on cluster manager node in large clusters
- Improves cluster stability for deployments with many indices and shards

### Related
- Closes #2066
- PR: opensearch-project/OpenSearch-Dashboards#8187