### PR TITLE
docs: add auto-date-histogram report for v2.19.0

### DIFF
--- a/docs/features/opensearch/auto-date-histogram.md
+++ b/docs/features/opensearch/auto-date-histogram.md
@@ -1,0 +1,108 @@
+---
+tags:
+  - opensearch
+---
+# Auto Date Histogram Aggregation
+
+## Summary
+
+The `auto_date_histogram` aggregation automatically creates date histogram buckets based on a target number of buckets and the time range of the data. Unlike the standard `date_histogram` aggregation where you specify a fixed interval, `auto_date_histogram` dynamically selects the most appropriate interval to achieve the desired bucket count.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Auto Date Histogram Flow"
+        Query[Search Query] --> Agg[AutoDateHistogramAggregator]
+        Agg --> Rounding[Rounding Selection]
+        Rounding --> Collect[Document Collection]
+        Collect --> Buckets[Bucket Creation]
+    end
+    
+    subgraph "Rounding Intervals"
+        R1[Seconds]
+        R2[Minutes]
+        R3[Hours]
+        R4[Days]
+        R5[Weeks]
+        R6[Months]
+        R7[Years]
+    end
+    
+    Rounding --> R1
+    Rounding --> R2
+    Rounding --> R3
+    Rounding --> R4
+    Rounding --> R5
+    Rounding --> R6
+    Rounding --> R7
+```
+
+### Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `field` | Date field to aggregate on | Required |
+| `buckets` | Target number of buckets | 10 |
+| `time_zone` | Timezone for bucket boundaries | UTC |
+| `format` | Date format for bucket keys | Date field format |
+| `minimum_interval` | Minimum interval to use | `second` |
+
+### Usage Example
+
+```json
+GET /logs/_search
+{
+  "size": 0,
+  "aggs": {
+    "logs_over_time": {
+      "auto_date_histogram": {
+        "field": "timestamp",
+        "buckets": 10,
+        "time_zone": "America/New_York"
+      }
+    }
+  }
+}
+```
+
+### Rounding Intervals
+
+The aggregation automatically selects from these intervals (in order of granularity):
+
+1. Seconds (1, 5, 10, 30)
+2. Minutes (1, 5, 10, 30)
+3. Hours (1, 3, 12)
+4. Days (1, 7)
+5. Months (1, 3)
+6. Years (1, 5, 10, 20, 50, 100)
+
+### Filter Rewrite Optimization
+
+The aggregation includes a filter rewrite optimization that examines pre-aggregated document counts in BKD tree structures instead of collecting documents individually. This optimization:
+
+- Improves performance for large datasets
+- Only applies when certain conditions are met (no scripts, no missing values, date field type)
+- Is disabled for non-UTC timezones (as of v2.19.0) to ensure correctness
+
+## Limitations
+
+- The filter rewrite optimization is disabled for non-UTC timezones
+- The actual number of buckets may differ from the target based on data distribution
+- Timezone-aware queries may have slightly reduced performance compared to UTC queries
+
+## Change History
+
+- **v2.19.0** (2025-01-28): Fixed assertion failure when using `time_zone` parameter with filter rewrite optimization ([#17023](https://github.com/opensearch-project/OpenSearch/pull/17023))
+
+## References
+
+### Documentation
+- [Auto-interval date histogram](https://docs.opensearch.org/latest/aggregations/bucket/auto-interval-date-histogram/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#17023](https://github.com/opensearch-project/OpenSearch/pull/17023) | Fix auto date histogram rounding assertion bug |

--- a/docs/releases/v2.19.0/features/opensearch/auto-date-histogram.md
+++ b/docs/releases/v2.19.0/features/opensearch/auto-date-histogram.md
@@ -1,0 +1,60 @@
+---
+tags:
+  - opensearch
+---
+# Auto Date Histogram Bug Fix
+
+## Summary
+
+Fixed an assertion failure in the `auto_date_histogram` aggregation that occurred when using the `time_zone` parameter with certain data distributions. The bug caused clusters running with assertions enabled to crash when the filter rewrite optimization interacted with timezone-aware rounding.
+
+## Details
+
+### What's New in v2.19.0
+
+The fix ensures that the filter rewrite optimization path correctly handles timezone-aware rounding by:
+
+1. Preventing `preparedRounding` from shrinking during segment collection
+2. Excluding non-UTC timezones from the filter rewrite optimization path
+3. Adding proper bounds checking for timezone transitions (e.g., daylight saving time)
+
+### Technical Changes
+
+The `auto_date_histogram` aggregation uses a filter rewrite optimization that pre-aggregates document counts from BKD tree structures instead of collecting documents individually. This optimization updates the `preparedRounding` based on segment min/max values.
+
+The bug occurred when:
+- Documents were indexed one-by-one (creating multiple segments)
+- A non-UTC timezone was specified (e.g., `America/New_York`)
+- The timezone crossed transitions like daylight saving time
+
+In this scenario, the prepared rounding could shrink between segments, causing bucket keys from previous segments to fall outside the bounds of the newly prepared rounding structure.
+
+#### Key Code Changes
+
+| File | Change |
+|------|--------|
+| `Rounding.java` | Added `isUTC()` method to check timezone |
+| `AutoDateHistogramAggregator.java` | Ensured `preparedRounding` never shrinks; added detailed comments |
+| `DateHistogramAggregatorBridge.java` | Added UTC check to disable optimization for non-UTC timezones |
+| `CompositeAggregator.java` | Added UTC check for composite aggregation date histogram source |
+
+### Affected Aggregations
+
+- `auto_date_histogram` with `time_zone` parameter
+- `date_histogram` with `time_zone` parameter (via filter rewrite)
+- `composite` aggregation with date histogram source and timezone
+
+## Limitations
+
+- The filter rewrite optimization is now disabled for non-UTC timezones, which may result in slightly slower performance for timezone-aware date histogram queries
+- This is a trade-off for correctness over performance
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#17023](https://github.com/opensearch-project/OpenSearch/pull/17023) | Fix auto date histogram rounding assertion bug | [#16932](https://github.com/opensearch-project/OpenSearch/issues/16932) |
+
+### Documentation
+- [Auto-interval date histogram](https://docs.opensearch.org/2.19/aggregations/bucket/auto-interval-date-histogram/)

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -2,6 +2,9 @@
 
 ## Features
 
+### opensearch
+- Auto Date Histogram Bug Fix
+
 ### opensearch-dashboards
 - Dashboards Health Checks
 - Data Source Association


### PR DESCRIPTION
## Summary

Added documentation for the auto_date_histogram aggregation bug fix in OpenSearch v2.19.0.

### Reports Created
- Release report: `docs/releases/v2.19.0/features/opensearch/auto-date-histogram.md`
- Feature report: `docs/features/opensearch/auto-date-histogram.md`

### Key Changes in v2.19.0
- Fixed assertion failure when using `time_zone` parameter with filter rewrite optimization
- Disabled filter rewrite optimization for non-UTC timezones to ensure correctness
- Added `isUTC()` method to Rounding class for timezone checking

### Related
- Resolves investigation Issue #2065
- OpenSearch PR: [#17023](https://github.com/opensearch-project/OpenSearch/pull/17023)
- OpenSearch Issue: [#16932](https://github.com/opensearch-project/OpenSearch/issues/16932)