### PR TITLE
docs: add ci-fixes report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-ci-infrastructure.md
+++ b/docs/features/opensearch/opensearch-ci-infrastructure.md
@@ -1,0 +1,87 @@
+---
+tags:
+  - opensearch
+---
+# CI Infrastructure
+
+## Summary
+
+OpenSearch uses Gradle-based CI infrastructure for code formatting, testing, and build automation. The Spotless plugin enforces consistent code formatting using Eclipse JDT formatter across the codebase.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "CI Pipeline"
+        GH[GitHub Actions]
+        GH --> BUILD[Gradle Build]
+    end
+    
+    subgraph "Code Formatting"
+        BUILD --> SPOT[Spotless Plugin]
+        SPOT --> ECLIPSE[Eclipse JDT Formatter]
+        ECLIPSE --> P2[P2 Mirror]
+        P2 --> |Download| ARTIFACTS[Eclipse Artifacts]
+    end
+    
+    subgraph "Configuration"
+        FMT[formatting.gradle]
+        CFG[formatterConfig.xml]
+        FMT --> SPOT
+        CFG --> ECLIPSE
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `gradle/formatting.gradle` | Spotless plugin configuration for code formatting |
+| `buildSrc/formatterConfig.xml` | Eclipse JDT formatter configuration file |
+| Spotless Plugin | Gradle plugin for code formatting enforcement |
+| Eclipse JDT Formatter | Java code formatter from Eclipse IDE |
+| P2 Mirror | Eclipse artifact repository mirror |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `eclipse().configFile` | Path to Eclipse formatter configuration | `buildSrc/formatterConfig.xml` |
+| `eclipse().withP2Mirrors()` | P2 mirror configuration for artifact downloads | `mirror.umd.edu/eclipse` (v2.19.0+) |
+| `trimTrailingWhitespace()` | Remove trailing whitespace | Enabled |
+| `endWithNewline()` | Ensure files end with newline | Enabled |
+
+### Usage Example
+
+Running code formatting check:
+```bash
+./gradlew spotlessCheck
+```
+
+Applying code formatting:
+```bash
+./gradlew spotlessApply
+```
+
+## Limitations
+
+- Eclipse JDT formatter downloads depend on external mirror availability
+- Formatting rules are specific to Eclipse JDT and may differ from other formatters
+- Large codebase formatting can be time-consuming
+
+## Change History
+
+- **v2.19.0** (2025-02-11): Added P2 mirror configuration to resolve Eclipse download failures
+
+## References
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#17172](https://github.com/opensearch-project/OpenSearch/pull/17172) | Fix failing CI's with `Failed to load eclipse jdt formatter` |
+
+### External References
+- [Spotless Gradle Plugin](https://github.com/diffplug/spotless): Code formatting plugin
+- [diffplug/spotless#1783](https://github.com/diffplug/spotless/issues/1783): Eclipse download failure issue

--- a/docs/releases/v2.19.0/features/opensearch/ci-fixes.md
+++ b/docs/releases/v2.19.0/features/opensearch/ci-fixes.md
@@ -1,0 +1,45 @@
+---
+tags:
+  - opensearch
+---
+# CI Fixes
+
+## Summary
+
+Fixed failing CI builds caused by Eclipse JDT formatter download failures by configuring a P2 mirror for the Spotless Gradle plugin.
+
+## Details
+
+### What's New in v2.19.0
+
+The CI pipeline was experiencing intermittent failures with the error `Failed to load eclipse jdt formatter`. This occurred because the Spotless Gradle plugin was unable to download the Eclipse JDT formatter from the primary Eclipse download server (`download.eclipse.org`).
+
+### Technical Changes
+
+The fix adds a P2 mirror configuration to the Spotless Eclipse formatter setup in `gradle/formatting.gradle`:
+
+```groovy
+// Before
+eclipse().configFile rootProject.file('buildSrc/formatterConfig.xml')
+
+// After
+eclipse().withP2Mirrors(Map.of("https://download.eclipse.org/", "https://mirror.umd.edu/eclipse/")).configFile rootProject.file('buildSrc/formatterConfig.xml')
+```
+
+This change redirects Eclipse artifact downloads to the University of Maryland mirror, which provides more reliable availability than the primary Eclipse download server.
+
+### Root Cause
+
+The issue was tracked in the Spotless project (diffplug/spotless#1783). The primary Eclipse download server occasionally experiences connectivity issues or timeouts, causing CI builds to fail when attempting to download the Eclipse JDT formatter artifacts.
+
+## Limitations
+
+- The fix relies on a single mirror (mirror.umd.edu). If this mirror becomes unavailable, CI builds could still fail.
+- This is a workaround for upstream infrastructure issues in the Eclipse download servers.
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#17172](https://github.com/opensearch-project/OpenSearch/pull/17172) | Fix failing CI's with `Failed to load eclipse jdt formatter` | [diffplug/spotless#1783](https://github.com/diffplug/spotless/issues/1783) |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch
 - Auto Date Histogram Bug Fix
+- CI Fixes
 
 ### opensearch-dashboards
 - Dashboards Health Checks


### PR DESCRIPTION
## Summary

Adds documentation for CI fixes in OpenSearch v2.19.0.

### Reports Created
- Release report: `docs/releases/v2.19.0/features/opensearch/ci-fixes.md`
- Feature report: `docs/features/opensearch/opensearch-ci-infrastructure.md` (new)

### Key Changes in v2.19.0
- Added P2 mirror configuration to Spotless plugin to resolve Eclipse JDT formatter download failures
- Redirects Eclipse artifact downloads to University of Maryland mirror for improved reliability

### Source PR
- [opensearch-project/OpenSearch#17172](https://github.com/opensearch-project/OpenSearch/pull/17172)

Closes #2064