### PR TITLE
docs: add grpc-settings report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-grpc-transport--services.md
+++ b/docs/features/opensearch/opensearch-grpc-transport--services.md
@@ -278,6 +278,7 @@ Documents in gRPC requests must be Base64 encoded:
 - **v3.2.0** (2026-01-14): GA release - moved to module, plugin extensibility, proper gRPC status codes, removed experimental designation
 - **v3.1.0** (2026-01-14): Performance optimization with pass-by-reference pattern, package reorganization
 - **v3.0.0** (2025-05-06): Initial implementation with DocumentService (Bulk) and SearchService (Search), TLS support
+- **v2.19.0** (2025-01-21): Setting rename from `aux.transport.experimental-transport-grpc.ports` to `aux.transport.experimental-transport-grpc.port` for consistency, HTTP terminology cleanup in variable names
 
 
 ## References
@@ -332,6 +333,7 @@ Documents in gRPC requests must be Base64 encoded:
 | v3.0.0 | [#17727](https://github.com/opensearch-project/OpenSearch/pull/17727) | Add DocumentService and Bulk gRPC endpoint v1 | [#16784](https://github.com/opensearch-project/OpenSearch/issues/16784) |
 | v3.0.0 | [#17830](https://github.com/opensearch-project/OpenSearch/pull/17830) | SearchService and Search gRPC endpoint v1 | [#16783](https://github.com/opensearch-project/OpenSearch/issues/16783) |
 | v3.0.0 | [#17888](https://github.com/opensearch-project/OpenSearch/pull/17888) | Add terms query support in Search gRPC endpoint | [#16783](https://github.com/opensearch-project/OpenSearch/issues/16783) |
+| v2.19.0 | [#17037](https://github.com/opensearch-project/OpenSearch/pull/17037) | Fix GRPC AUX_TRANSPORT_PORT setting name and remove HTTP terminology | [#16556](https://github.com/opensearch-project/OpenSearch/issues/16556) |
 
 ### Issues (Design / RFC)
 - [Issue #16787](https://github.com/opensearch-project/OpenSearch/issues/16787): gRPC Transport tracking issue

--- a/docs/releases/v2.19.0/features/opensearch/grpc-settings.md
+++ b/docs/releases/v2.19.0/features/opensearch/grpc-settings.md
@@ -1,0 +1,66 @@
+---
+tags:
+  - opensearch
+---
+# gRPC Settings
+
+## Summary
+
+This release fixes inconsistencies in gRPC transport settings naming and removes lingering HTTP terminology from the codebase. The setting `aux.transport.experimental-transport-grpc.ports` is renamed to `aux.transport.experimental-transport-grpc.port` for consistency with other OpenSearch port settings like `http.port`.
+
+## Details
+
+### What's New in v2.19.0
+
+**Setting Rename:**
+The auxiliary transport port setting has been renamed for consistency:
+
+| Before | After |
+|--------|-------|
+| `aux.transport.experimental-transport-grpc.ports` | `aux.transport.experimental-transport-grpc.port` |
+
+**Terminology Cleanup:**
+Internal variable names in `Netty4GrpcServerTransport.java` have been corrected:
+
+| Before | After |
+|--------|-------|
+| `httpBindHost` | `grpcBindHost` |
+| `httpPublishHost` | `grpcPublishHost` |
+
+**Debug Logging:**
+Added debug logging for gRPC transport settings during initialization to aid troubleshooting.
+
+### Technical Changes
+
+The following files were modified:
+
+| File | Change |
+|------|--------|
+| `NetworkPlugin.java` | Renamed `AUX_TRANSPORT_PORTS` to `AUX_TRANSPORT_PORT`, changed affix from `ports` to `port` |
+| `Netty4GrpcServerTransport.java` | Updated setting reference, fixed variable names, added debug logging |
+| `GrpcPlugin.java` | Updated import and setting reference |
+| `Security.java` | Updated setting reference for socket permissions |
+
+### Migration
+
+If you are using the gRPC transport plugin with a custom port configuration, update your `opensearch.yml`:
+
+```yaml
+# Before (v2.18.0 and earlier)
+aux.transport.experimental-transport-grpc.ports: 9400-9500
+
+# After (v2.19.0+)
+aux.transport.experimental-transport-grpc.port: 9400-9500
+```
+
+## Limitations
+
+- This is a breaking change for users who configured custom gRPC ports using the old setting name
+- The gRPC transport remains experimental in v2.19.0
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#17037](https://github.com/opensearch-project/OpenSearch/pull/17037) | Fix GRPC AUX_TRANSPORT_PORT and SETTING_GRPC_PORT settings and remove lingering HTTP terminology | [#16556](https://github.com/opensearch-project/OpenSearch/issues/16556) |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -5,6 +5,7 @@
 ### opensearch
 - Auto Date Histogram Bug Fix
 - CI Fixes
+- gRPC Settings
 - Workload Management Logging
 
 ### opensearch-dashboards


### PR DESCRIPTION
## Summary

Documents the gRPC settings deprecation/fix in OpenSearch v2.19.0.

### Changes
- **Release report**: `docs/releases/v2.19.0/features/opensearch/grpc-settings.md`
- **Feature report**: Updated `docs/features/opensearch/opensearch-grpc-transport--services.md` with v2.19.0 change history

### Key Changes in v2.19.0
- Setting renamed from `aux.transport.experimental-transport-grpc.ports` to `aux.transport.experimental-transport-grpc.port`
- HTTP terminology cleanup in variable names (`httpBindHost` → `grpcBindHost`)
- Added debug logging for gRPC transport settings

### References
- PR: opensearch-project/OpenSearch#17037
- Issue: opensearch-project/OpenSearch#16556

Closes #2062