### PR TITLE
docs: add multi-search-request report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-multi-search-api.md
+++ b/docs/features/opensearch/opensearch-multi-search-api.md
@@ -144,6 +144,7 @@ GET _msearch/template
 
 ## Change History
 
+- **v2.19.0** (2025-02-18): Fixed task cancellation handling - queued search requests are now properly stopped when the parent `_msearch` task is cancelled
 - **v2.18.0** (2024-10-22): Added `status` field to Multi-Search Template API responses for consistency with Multi-Search API
 
 
@@ -157,6 +158,7 @@ GET _msearch/template
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v2.19.0 | [#17005](https://github.com/opensearch-project/OpenSearch/pull/17005) | Fix task cancellation handling for _msearch API | [#17004](https://github.com/opensearch-project/OpenSearch/issues/17004) |
 | v2.18.0 | [#16265](https://github.com/opensearch-project/OpenSearch/pull/16265) | Fix multi-search with template doesn't return status code | [#11133](https://github.com/opensearch-project/OpenSearch/issues/11133) |
 
 ### Issues (Design / RFC)

--- a/docs/releases/v2.19.0/features/opensearch/multi-search-request.md
+++ b/docs/releases/v2.19.0/features/opensearch/multi-search-request.md
@@ -1,0 +1,61 @@
+---
+tags:
+  - opensearch
+---
+# Multi-Search Request Cancellation Fix
+
+## Summary
+
+Fixed a bug where the `_msearch` API would continue executing queued search requests even after the parent task was cancelled. With this fix, OpenSearch now properly stops processing remaining search requests when the multi-search task is cancelled or times out.
+
+## Details
+
+### What's New in v2.19.0
+
+The Multi-Search API executes multiple search requests concurrently up to `max_concurrent_searches`, queuing additional requests to run as earlier ones complete. Prior to this fix, if the parent `_msearch` task was cancelled (due to timeout or explicit cancellation), the queued requests would still be executed, causing:
+
+1. Unnecessary resource consumption
+2. `TaskCancelledException` errors with stack traces
+3. "Zombie" `indices:data/read/msearch` tasks that never complete
+
+### Technical Changes
+
+The fix adds cancellation checking in `TransportMultiSearchAction`:
+
+```mermaid
+flowchart TB
+    A[Search Request Completes] --> B{More Requests Queued?}
+    B -->|Yes| C{Parent Task Cancelled?}
+    C -->|No| D[Execute Next Request]
+    C -->|Yes| E[Drain Queue with TaskCancelledException]
+    E --> F[Return Partial Results]
+    B -->|No| G[Finish and Return Results]
+    D --> A
+```
+
+Key implementation details:
+- Added `isCancelled()` method to check parent task status via `TaskManager`
+- When cancellation detected, remaining queued requests are drained
+- Each drained request receives a `TaskCancelledException` response
+- Response counter is properly decremented to ensure clean completion
+
+### Changed Files
+
+| File | Change |
+|------|--------|
+| `TransportMultiSearchAction.java` | Added cancellation check and queue draining logic |
+
+## Limitations
+
+- Requests already in-flight when cancellation occurs will complete normally
+- Only affects queued requests that haven't started execution
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#17005](https://github.com/opensearch-project/OpenSearch/pull/17005) | Stop processing search requests when _msearch is canceled | [#17004](https://github.com/opensearch-project/OpenSearch/issues/17004) |
+
+### Issues
+- [#17004](https://github.com/opensearch-project/OpenSearch/issues/17004): Bug report describing the cancellation handling issue

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -6,6 +6,7 @@
 - Auto Date Histogram Bug Fix
 - CI Fixes
 - gRPC Settings
+- Multi-Search Request Cancellation Fix
 - Workload Management Logging
 
 ### opensearch-dashboards


### PR DESCRIPTION
## Summary

Documents the Multi-Search API task cancellation fix in v2.19.0.

### Changes
- Created release report: `docs/releases/v2.19.0/features/opensearch/multi-search-request.md`
- Updated feature report: `docs/features/opensearch/opensearch-multi-search-api.md`
- Updated release index

### Key Fix
Fixed a bug where the `_msearch` API would continue executing queued search requests even after the parent task was cancelled. The fix adds proper cancellation checking in `TransportMultiSearchAction` to drain remaining queued requests when the parent task is cancelled.

### References
- PR: opensearch-project/OpenSearch#17005
- Issue: opensearch-project/OpenSearch#17004

Closes #2061