### PR TITLE
docs: add phone-search-analyzer report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-phone-analyzer.md
+++ b/docs/features/opensearch/opensearch-phone-analyzer.md
@@ -103,12 +103,21 @@ Output tokens: ["+41 60 555 12 34", "6055512", "41605551", "416055512",
 
 #### phone-search (Search Analyzer)
 
-Generates only basic tokens without n-grams for efficient search:
+Generates only basic tokens without n-grams for efficient search.
 
+**v2.19.0 and later:**
+```
+Input: "+41 60 555 12 34"
+Output tokens: ["+41 60 555 12 34", "41605551234"]
+```
+
+**Before v2.19.0:**
 ```
 Input: "+41 60 555 12 34"
 Output tokens: ["+41 60 555 12 34", "41 60 555 12 34", "41605551234", "605551234", "41"]
 ```
+
+Starting from v2.19.0, the `phone-search` analyzer no longer emits the `tel:`/`sip:` prefix, international calling code, extension numbers, or unformatted national number as separate tokens. This change improves search precision by avoiding false positive matches.
 
 ### Usage Example
 
@@ -163,6 +172,7 @@ Without a region, only numbers with international prefix (`+`) are fully parsed.
 
 ## Change History
 
+- **v2.19.0** (2025-01-10): `phone-search` analyzer no longer emits tel/sip prefix, international calling code, extension numbers, and unformatted input as tokens to improve search precision
 - **v2.18.0** (2024-10-22): Initial implementation with `phone` and `phone-search` analyzers/tokenizers
 
 
@@ -177,6 +187,7 @@ Without a region, only numbers with international prefix (`+`) are fully parsed.
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v2.19.0 | [#16993](https://github.com/opensearch-project/OpenSearch/pull/16993) | `phone-search` analyzer: don't emit sip/tel prefix, int'l prefix, extension & unformatted input | - |
 | v2.18.0 | [#15915](https://github.com/opensearch-project/OpenSearch/pull/15915) | Initial implementation of phone number analyzer | [#11326](https://github.com/opensearch-project/OpenSearch/issues/11326) |
 
 ### Issues (Design / RFC)

--- a/docs/releases/v2.19.0/features/opensearch/phone-search-analyzer.md
+++ b/docs/releases/v2.19.0/features/opensearch/phone-search-analyzer.md
@@ -1,0 +1,78 @@
+---
+tags:
+  - opensearch
+---
+# Phone Search Analyzer
+
+## Summary
+
+In v2.19.0, the `phone-search` analyzer behavior was changed to no longer emit certain tokens that could cause false positive matches. The analyzer now produces fewer, more precise tokens to improve search accuracy.
+
+## Details
+
+### What's New in v2.19.0
+
+The `phone-search` analyzer (used at search time) was modified to stop emitting the following tokens:
+
+| Token Type | Before v2.19.0 | After v2.19.0 |
+|------------|----------------|---------------|
+| `tel:` / `sip:` prefix | Emitted as separate token | Not emitted |
+| International calling code (e.g., `41`) | Emitted as separate token | Not emitted |
+| Extension numbers | Emitted as separate token | Not emitted |
+| Unformatted national number | Emitted as separate token | Not emitted |
+
+### Token Output Comparison
+
+**Before v2.19.0:**
+```
+Input: "tel:+441344840400"
+Tokens: ["tel:+441344840400", "tel:", "441344840400", "44", "1344840400"]
+```
+
+**After v2.19.0:**
+```
+Input: "tel:+441344840400"
+Tokens: ["tel:+441344840400", "441344840400"]
+```
+
+### Technical Changes
+
+The `PhoneNumberTermTokenizer` class was modified to conditionally emit tokens based on the `addNgrams` flag:
+
+- The `phone` analyzer (index time) continues to emit all tokens including n-grams
+- The `phone-search` analyzer (search time) now only emits:
+  - The original input
+  - The full number with country code (e.g., `441344840400`)
+
+### Rationale
+
+The previous behavior could cause unintended matches:
+
+- Emitting just the country code (`41`, `44`) would match all numbers from that country
+- Emitting the national number without country code could match numbers in different countries
+- Emitting `tel:` or `sip:` prefixes as tokens served no useful search purpose
+
+### Migration Impact
+
+This is a **breaking change** for existing indexes. After upgrading to v2.19.0:
+
+- Existing indexed documents retain their original tokens
+- New searches will produce fewer tokens
+- Some previously matching queries may no longer match
+
+**Recommendation**: Reindex documents after upgrading to ensure consistent behavior.
+
+## Limitations
+
+- This change affects only the `phone-search` analyzer, not the `phone` analyzer
+- Existing indexes need reindexing to benefit from the improved precision
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16993](https://github.com/opensearch-project/OpenSearch/pull/16993) | `phone-search` analyzer: don't emit sip/tel prefix, int'l prefix, extension & unformatted input | - |
+
+### Documentation
+- [Phone number analyzers](https://docs.opensearch.org/2.19/analyzers/supported-analyzers/phone-analyzers/)


### PR DESCRIPTION
## Summary
Add documentation for the `phone-search` analyzer behavior change in OpenSearch v2.19.0.

## Changes
- Created release report: `docs/releases/v2.19.0/features/opensearch/phone-search-analyzer.md`
- Updated feature report: `docs/features/opensearch/opensearch-phone-analyzer.md`

## Key Changes in v2.19.0
The `phone-search` analyzer no longer emits the following tokens:
- `tel:` / `sip:` prefix
- International calling code (e.g., `41`)
- Extension numbers
- Unformatted national number

This improves search precision by avoiding false positive matches.

## Related
- PR: [opensearch-project/OpenSearch#16993](https://github.com/opensearch-project/OpenSearch/pull/16993)
- Issue: #2060