### PR TITLE
docs: add remote-shards-balance report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-searchable-snapshots.md
+++ b/docs/features/opensearch/opensearch-searchable-snapshots.md
@@ -1,0 +1,90 @@
+---
+tags:
+  - opensearch
+---
+# Searchable Snapshots
+
+## Summary
+
+Searchable snapshots allow querying data directly from snapshot repositories without fully restoring indexes to cluster storage. This feature enables cost-effective access to historical data by keeping index data in remote storage while maintaining search capability.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph Cluster
+        SN[Search Nodes]
+        DN[Data Nodes]
+    end
+    subgraph "Remote Storage"
+        SR[Snapshot Repository]
+    end
+    
+    SN -->|Read on demand| SR
+    DN -->|Regular indexes| DN
+    SN -->|Cache| SN
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Search Nodes | Nodes with `search` role that handle searchable snapshot queries |
+| RemoteShardsBalancer | Balances searchable snapshot shards across search nodes |
+| File Cache | Local cache for frequently accessed snapshot data |
+| Snapshot Repository | Remote storage (S3, Azure, GCS, etc.) containing snapshot data |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `node.roles` | Must include `search` for searchable snapshot support | - |
+| `node.search.cache.size` | Size of local file cache for search nodes | - |
+| `cluster.filecache.remote_data_ratio` | Max ratio of remote data to local cache | 5 |
+
+### Usage Example
+
+Create a searchable snapshot index by restoring with `remote_snapshot` storage type:
+
+```json
+POST /_snapshot/my-repository/my-snapshot/_restore
+{
+  "storage_type": "remote_snapshot",
+  "indices": "my-index"
+}
+```
+
+Verify the index is a searchable snapshot:
+
+```json
+GET /my-index/_settings?pretty
+```
+
+Response shows `"type": "remote_snapshot"` in store settings.
+
+## Limitations
+
+- Searchable snapshot indexes are read-only
+- Higher query latency compared to local indexes due to remote data access
+- Remote storage costs may apply for data retrieval
+- Requires dedicated search nodes for optimal performance
+- k-NN support limited to NMSLIB and Faiss engines (from v2.18)
+
+## Change History
+
+- **v2.19.0** (2025-01-07): Fixed RemoteShardsBalancer calculation bug that caused incorrect shard distribution in clusters with mixed node types
+- **v2.18.0**: Added k-NN index support for NMSLIB and Faiss engines
+
+## References
+
+### Documentation
+
+- [Searchable Snapshots](https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#15335](https://github.com/opensearch-project/OpenSearch/pull/15335) | Fix remote shards balance calculation |

--- a/docs/releases/v2.19.0/features/opensearch/remote-shards-balance.md
+++ b/docs/releases/v2.19.0/features/opensearch/remote-shards-balance.md
@@ -1,0 +1,67 @@
+---
+tags:
+  - opensearch
+---
+# Remote Shards Balance Fix
+
+## Summary
+
+Fixed a bug in `RemoteShardsBalancer` that caused incorrect shard rebalancing calculations for searchable snapshot indexes in clusters with mixed node types (search nodes and dedicated data nodes).
+
+## Details
+
+### What's New in v2.19.0
+
+The `RemoteShardsBalancer` component, responsible for balancing searchable snapshot index shards across search nodes, had a calculation error that prevented proper shard distribution.
+
+### Technical Changes
+
+The bug was in the `balance()` method of `RemoteShardsBalancer.java`. The original formula for calculating average primary shards per node was:
+
+```
+(totalNumberOfRemotePrimaryShards + totalNumberOfUnassignedShards) / totalNumberOfRoutingNodes
+```
+
+This formula had two problems:
+1. It counted ALL unassigned shards instead of only remote (searchable snapshot) unassigned shards
+2. It divided by the total number of routing nodes instead of only remote-capable (search) nodes
+
+The fix corrects the formula to:
+
+```
+(totalNumberOfRemotePrimaryShards + totalNumberOfUnassignedRemoteShards) / totalNumberOfRemoteCapableNodes
+```
+
+### Code Changes
+
+In `RemoteShardsBalancer.java`:
+- Added filtering to count only unassigned primary shards that belong to the `REMOTE_CAPABLE` routing pool
+- Changed the divisor from `routingNodes.size()` to `remoteRoutingNodes.size()` to use only remote-capable nodes
+
+```java
+int unassignedRemotePrimaryShardCount = 0;
+for (ShardRouting shard : routingNodes.unassigned()) {
+    if (RoutingPool.REMOTE_CAPABLE.equals(RoutingPool.getShardPool(shard, allocation)) && shard.primary()) {
+        unassignedRemotePrimaryShardCount++;
+    }
+}
+totalPrimaryShardCount += unassignedRemotePrimaryShardCount;
+final int avgPrimaryPerNode = (totalPrimaryShardCount + remoteRoutingNodes.size() - 1) / remoteRoutingNodes.size();
+```
+
+## Limitations
+
+- This fix only affects clusters using searchable snapshots with dedicated search nodes
+- Clusters without mixed node types (search + data nodes) were not affected by the original bug
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#15335](https://github.com/opensearch-project/OpenSearch/pull/15335) | Fix remote shards balance | [#15302](https://github.com/opensearch-project/OpenSearch/issues/15302) |
+
+### Documentation
+
+- [Searchable Snapshots](https://docs.opensearch.org/2.19/tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot/)

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -8,6 +8,7 @@
 - gRPC Settings
 - Match Only Text Field
 - Multi-Search Request Cancellation Fix
+- Remote Shards Balance Fix
 - Workload Management Logging
 
 ### opensearch-dashboards


### PR DESCRIPTION
## Summary

Adds documentation for the Remote Shards Balance fix in OpenSearch v2.19.0.

### Reports Created
- Release report: `docs/releases/v2.19.0/features/opensearch/remote-shards-balance.md`
- Feature report: `docs/features/opensearch/opensearch-searchable-snapshots.md` (new)

### Key Changes in v2.19.0
- Fixed `RemoteShardsBalancer` calculation bug that caused incorrect shard distribution
- The bug affected clusters with mixed node types (search nodes + data nodes)
- Corrected formula now properly counts only remote unassigned shards and divides by remote-capable nodes

### Related
- Closes #2058
- OpenSearch PR: [#15335](https://github.com/opensearch-project/OpenSearch/pull/15335)
- OpenSearch Issue: [#15302](https://github.com/opensearch-project/OpenSearch/issues/15302)