### PR TITLE
docs: add list-shards-api report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-list-apis-paginated.md
+++ b/docs/features/opensearch/opensearch-list-apis-paginated.md
@@ -195,6 +195,7 @@ curl -X PUT "localhost:9200/_cluster/settings" -H 'Content-Type: application/jso
 
 ## Change History
 
+- **v2.19.0** (2024-12-10): Fixed `_list/shards` API failing with `index_closed_exception` when closed indices are present
 - **v2.18.0** (2024-10-22): Initial implementation with `_list/indices`, `_list/shards` APIs and cat API response limits
 
 
@@ -208,6 +209,7 @@ curl -X PUT "localhost:9200/_cluster/settings" -H 'Content-Type: application/jso
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v2.19.0 | [#16606](https://github.com/opensearch-project/OpenSearch/pull/16606) | Fix _list/shards API failing when closed indices are present | [#16626](https://github.com/opensearch-project/OpenSearch/issues/16626) |
 | v2.18.0 | [#14718](https://github.com/opensearch-project/OpenSearch/pull/14718) | Implementing pagination for `_cat/indices` API | [#14258](https://github.com/opensearch-project/OpenSearch/issues/14258) |
 | v2.18.0 | [#14641](https://github.com/opensearch-project/OpenSearch/pull/14641) | Implementing pagination for `_cat/shards` | [#14257](https://github.com/opensearch-project/OpenSearch/issues/14257) |
 | v2.18.0 | [#15986](https://github.com/opensearch-project/OpenSearch/pull/15986) | Add changes to block calls in cat shards, indices and segments based on dynamic limit settings | [#15954](https://github.com/opensearch-project/OpenSearch/issues/15954) |

--- a/docs/releases/v2.19.0/features/opensearch/list-shards-api.md
+++ b/docs/releases/v2.19.0/features/opensearch/list-shards-api.md
@@ -1,0 +1,54 @@
+---
+tags:
+  - opensearch
+---
+# List Shards API
+
+## Summary
+
+Fixed a bug in the `_list/shards` API that caused `index_closed_exception` errors when clusters contained closed indices. The API now properly handles closed indices by filtering them out before fetching index statistics, while still including closed shards in the response without stats.
+
+## Details
+
+### What's New in v2.19.0
+
+The `_list/shards` API (introduced in v2.18.0) failed with `index_closed_exception` when any closed indices existed in the cluster. This occurred because the pagination strategy passed concrete index names directly to `TransportIndicesStatsAction`, which uses `IndicesOptions.strictExpandOpenAndForbidClosed()` by default.
+
+### Technical Changes
+
+The fix modifies `TransportCatShardsAction` to filter out closed indices before calling `TransportIndicesStatsAction`:
+
+```java
+private String[] filterClosedIndices(ClusterState clusterState, List<String> strategyIndices) {
+    return strategyIndices.stream().filter(index -> {
+        IndexMetadata metadata = clusterState.metadata().indices().get(index);
+        return metadata != null && metadata.getState().equals(IndexMetadata.State.CLOSE) == false;
+    }).toArray(String[]::new);
+}
+```
+
+### Behavior After Fix
+
+| Query | Behavior |
+|-------|----------|
+| `/_list/shards` (default) | Returns all shards including closed indices; stats only for open indices |
+| `/_list/shards/closed-index` | Returns closed shards without stats (no error) |
+| `/_list/shards/closed-index*` | Returns empty (wildcards don't expand to closed indices) |
+| `/_list/shards/open-index` | Returns shards with full stats |
+
+This behavior now matches `_cat/shards` API behavior for consistency.
+
+## Limitations
+
+- Closed indices appear in shard listings but without statistics (docs count, store size, etc.)
+- Wildcard patterns do not expand to match closed or hidden indices (consistent with `_cat/shards`)
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16606](https://github.com/opensearch-project/OpenSearch/pull/16606) | Fixing _list/shards API for closed indices | [#16626](https://github.com/opensearch-project/OpenSearch/issues/16626) |
+
+### Issues
+- [#16626](https://github.com/opensearch-project/OpenSearch/issues/16626): [BUG] _list/shards API failing with index_closed_exception

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -6,6 +6,7 @@
 - Auto Date Histogram Bug Fix
 - CI Fixes
 - gRPC Settings
+- List Shards API
 - Match Only Text Field
 - Multi-Search Request Cancellation Fix
 - Remote Shards Balance Fix


### PR DESCRIPTION
## Summary

Adds documentation for the List Shards API bug fix in OpenSearch v2.19.0.

### Changes
- Created release report: `docs/releases/v2.19.0/features/opensearch/list-shards-api.md`
- Updated feature report: `docs/features/opensearch/opensearch-list-apis-paginated.md` (added v2.19.0 change history and PR reference)
- Updated release index: `docs/releases/v2.19.0/index.md`

### Key Findings
- Fixed `_list/shards` API failing with `index_closed_exception` when closed indices are present
- The fix filters out closed indices before fetching `IndicesStats` while still including closed shards in the response
- Behavior now matches `_cat/shards` API for consistency

### References
- PR: [opensearch-project/OpenSearch#16606](https://github.com/opensearch-project/OpenSearch/pull/16606)
- Issue: [opensearch-project/OpenSearch#16626](https://github.com/opensearch-project/OpenSearch/issues/16626)