### PR TITLE
docs: add remote-repository-validation report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-remote-repository-validation.md
+++ b/docs/features/opensearch/opensearch-remote-repository-validation.md
@@ -1,0 +1,93 @@
+---
+tags:
+  - opensearch
+---
+# Remote Repository Validation
+
+## Summary
+
+Remote repository validation ensures that repository metadata in the cluster state is consistent with the RepositoriesService during node join operations. This validation is part of the cluster manager's responsibility when processing node joins that include remote store repository configurations.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Node Join Flow"
+        NJ[Node Join Request] --> JTE[JoinTaskExecutor]
+        JTE --> RSNS[RemoteStoreNodeService]
+        RSNS --> URM[updateRepositoriesMetadata]
+        URM --> RS[RepositoriesService]
+        RS --> VAL{Validate Repository}
+    end
+    
+    subgraph "Validation"
+        VAL -->|Exists| CHECK[Check Settings]
+        VAL -->|Missing| SKIP[Skip Validation]
+        CHECK --> EVSRU[ensureValidSystemRepositoryUpdate]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `JoinTaskExecutor` | Executes node join tasks on the cluster manager |
+| `RemoteStoreNodeService` | Handles remote store node operations including repository metadata updates |
+| `RepositoriesService` | Manages repository lifecycle and provides repository access |
+
+### Validation Process
+
+When a node with remote store repositories joins the cluster:
+
+1. `JoinTaskExecutor` invokes `RemoteStoreNodeService.updateRepositoriesMetadata()`
+2. For each repository in the joining node's metadata:
+   - Check if repository already exists in cluster state
+   - If exists, verify it's also present in RepositoriesService
+   - Validate that restricted system repository settings haven't changed
+3. If validation passes, merge repository metadata into cluster state
+
+### Configuration
+
+Remote store repositories are configured via node attributes in `opensearch.yml`:
+
+```yaml
+# Remote cluster state repository
+node.attr.remote_store.state.repository: my-remote-state-repo
+node.attr.remote_store.repository.my-remote-state-repo.type: s3
+node.attr.remote_store.repository.my-remote-state-repo.settings.bucket: my-bucket
+
+# Remote routing table repository
+node.attr.remote_store.routing_table.repository: my-routing-repo
+node.attr.remote_store.repository.my-routing-repo.type: s3
+node.attr.remote_store.repository.my-routing-repo.settings.bucket: my-bucket
+```
+
+## Limitations
+
+- Repository validation depends on RepositoriesService being in sync with cluster state
+- In edge cases where publish succeeds but commit fails, validation may be skipped
+
+## Change History
+
+- **v2.19.0** (2024-12-10): Added defensive handling for RepositoriesService out-of-sync scenarios during node joins ([#16763](https://github.com/opensearch-project/OpenSearch/pull/16763))
+
+## References
+
+### Documentation
+
+- [Remote-backed storage](https://docs.opensearch.org/2.19/tuning-your-cluster/availability-and-recovery/remote-store/index/)
+- [Remote cluster state](https://docs.opensearch.org/2.19/tuning-your-cluster/availability-and-recovery/remote-store/remote-cluster-state/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#16763](https://github.com/opensearch-project/OpenSearch/pull/16763) | Skip remote-repositories validations for node-joins when RepositoriesService is not in sync with cluster-state |
+
+### Issues
+
+| Issue | Description |
+|-------|-------------|
+| [#16762](https://github.com/opensearch-project/OpenSearch/issues/16762) | Commit Failures During Node Joins with Repositories Configured Result in Persistent NullPointerExceptions |

--- a/docs/releases/v2.19.0/features/opensearch/remote-repository-validation.md
+++ b/docs/releases/v2.19.0/features/opensearch/remote-repository-validation.md
@@ -1,0 +1,74 @@
+---
+tags:
+  - opensearch
+---
+# Remote Repository Validation
+
+## Summary
+
+This fix addresses a critical bug where NullPointerExceptions occurred during node joins when the RepositoriesService was not synchronized with the cluster state. The issue manifested when a cluster state publish operation succeeded but the commit operation failed, leaving the repository metadata in an inconsistent state.
+
+## Details
+
+### What's New in v2.19.0
+
+The fix skips remote repository validations during node joins when the RepositoriesService is detected to be out of sync with the cluster state metadata.
+
+### Problem Background
+
+When a new node with repository metadata joins a cluster:
+
+1. The cluster manager publishes an updated cluster state containing the new node and its repository metadata
+2. If the publish succeeds but the commit fails (due to network disruption or leader term issues), the cluster state is updated but cluster-state appliers are not executed
+3. This results in the RepositoriesService not being updated with the new repository information
+4. When a new cluster manager is elected, it attempts to verify repository metadata but encounters a NullPointerException because the repository object doesn't exist in the RepositoriesService
+
+```mermaid
+sequenceDiagram
+    participant NewNode as New Node (with repos)
+    participant CM as Cluster Manager
+    participant RS as RepositoriesService
+    participant CS as Cluster State
+
+    NewNode->>CM: Join request with repository metadata
+    CM->>CS: Publish cluster state (SUCCESS)
+    CM->>RS: Commit cluster state (FAILS)
+    Note over RS: RepositoriesService NOT updated
+    Note over CS: Cluster state HAS repository metadata
+    
+    CM->>CM: Steps down
+    Note over CM: New CM elected
+    CM->>RS: Verify repository
+    RS-->>CM: NullPointerException (repo not found)
+```
+
+### Technical Changes
+
+The fix modifies `RemoteStoreNodeService.updateRepositoriesMetadata()` to catch `RepositoryMissingException` when checking if a repository exists in the RepositoriesService. When this exception is caught, the validation is skipped with a warning log:
+
+```
+Skipping repositories metadata checks: Remote repository [{name}] is in the cluster state 
+but not present in the repository service.
+```
+
+Additionally, an assertion was added to `RepositoriesService.ensureValidSystemRepositoryUpdate()` to explicitly check that the repository object is not null before accessing its methods.
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `RemoteStoreNodeService.java` | Added try-catch for `RepositoryMissingException` to skip validation when repo not in service |
+| `RepositoriesService.java` | Added assertion to verify repository is not null |
+
+## Limitations
+
+- This is a defensive fix that handles the edge case gracefully rather than preventing the root cause
+- The warning log should be monitored as it indicates a cluster state inconsistency occurred
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16763](https://github.com/opensearch-project/OpenSearch/pull/16763) | Skip remote-repositories validations for node-joins when RepositoriesService is not in sync with cluster-state | [#16762](https://github.com/opensearch-project/OpenSearch/issues/16762) |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -9,6 +9,7 @@
 - List Shards API
 - Match Only Text Field
 - Multi-Search Request Cancellation Fix
+- Remote Repository Validation
 - Remote Shards Balance Fix
 - Workload Management Logging
 


### PR DESCRIPTION
## Summary

Adds documentation for the Remote Repository Validation fix in OpenSearch v2.19.0.

### Reports Created
- Release report: `docs/releases/v2.19.0/features/opensearch/remote-repository-validation.md`
- Feature report: `docs/features/opensearch/opensearch-remote-repository-validation.md`

### Key Changes in v2.19.0
- Added defensive handling for RepositoriesService out-of-sync scenarios during node joins
- Prevents NullPointerExceptions when cluster state publish succeeds but commit fails

### References
- PR: opensearch-project/OpenSearch#16763
- Issue: opensearch-project/OpenSearch#16762

Closes #2056