### PR TITLE
docs: add tiered-caching report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-tiered-caching.md
+++ b/docs/features/opensearch/opensearch-tiered-caching.md
@@ -113,7 +113,7 @@ GET /_nodes/stats/caches/request_cache?level=tier
 
 - **v3.3.0** (2025-11-18): Fixed query execution exception handling; ensures proper cleanup of concurrent request tracking map when exceptions occur
 - **v3.0.0** (2025-05-06): Single cache manager for disk caches reduces CPU overhead; took-time policy extended to guard heap tier
-- **v2.19.0** (2025-02-11): Disk cache partitioning with read/write locks for improved concurrency
+- **v2.19.0** (2025-02-25): Fixed cache stats API accuracy when shards are closed; Fixed max size settings not working with pluggable caching; Deprecated `indices.requests.cache.size` setting
 - **v2.18.0** (2024-11-05): Segmented cache architecture with configurable segments; query recomputation moved outside write lock; new settings for segment count and per-tier sizes
 - **v2.14.0** (2024-05-14): Initial experimental tiered caching support for request cache
 - **v2.13.0** (2024-04-02): cache-ehcache plugin introduced for disk cache implementation
@@ -134,7 +134,8 @@ GET /_nodes/stats/caches/request_cache?level=tier
 | v3.3.0 | [#19000](https://github.com/opensearch-project/OpenSearch/pull/19000) | Handle query execution exception |   |
 | v3.0.0 | [#17513](https://github.com/opensearch-project/OpenSearch/pull/17513) | Single cache manager for all ehcache disk caches |   |
 | v3.0.0 | [#17190](https://github.com/opensearch-project/OpenSearch/pull/17190) | Took-time threshold guards heap tier as well as disk tier | [#16162](https://github.com/opensearch-project/OpenSearch/issues/16162) |
-| v2.19.0 | - | Disk cache partitioning for improved concurrency |   |
+| v2.19.0 | [#16560](https://github.com/opensearch-project/OpenSearch/pull/16560) | Fix TieredSpilloverCache stats when shards are closed | [#16559](https://github.com/opensearch-project/OpenSearch/issues/16559) |
+| v2.19.0 | [#16636](https://github.com/opensearch-project/OpenSearch/pull/16636) | Fix max size settings with pluggable caching | [#16631](https://github.com/opensearch-project/OpenSearch/issues/16631) |
 | v2.18.0 | [#16047](https://github.com/opensearch-project/OpenSearch/pull/16047) | Segmented cache changes for improved concurrency | [#13989](https://github.com/opensearch-project/OpenSearch/issues/13989) |
 | v2.14.0 | - | Initial tiered caching support (experimental) |   |
 | v2.13.0 | - | cache-ehcache plugin introduced |   |

--- a/docs/releases/v2.19.0/features/opensearch/tiered-caching.md
+++ b/docs/releases/v2.19.0/features/opensearch/tiered-caching.md
@@ -1,0 +1,76 @@
+---
+tags:
+  - opensearch
+---
+# Tiered Caching Bug Fixes
+
+## Summary
+
+OpenSearch 2.19.0 includes two bug fixes for the Tiered Spillover Cache feature that address issues with cache statistics accuracy and maximum size settings when pluggable caching is enabled.
+
+## Details
+
+### What's New in v2.19.0
+
+#### Fix 1: Cache Stats API Accuracy (PR #16560)
+
+Fixed a bug where the total stats for TieredSpilloverCache were decremented incorrectly when shards were closed. Previously, misses and evictions from both the heap and disk tier were subtracted from the total, but this was incorrect behavior.
+
+When the disk tier is enabled, only disk-tier misses and evictions should count towards the cache total. The fix ensures that only disk-tier statistics are subtracted when removing dimension statistics, maintaining consistency between tier-level and total statistics.
+
+Key changes:
+- Modified `TieredSpilloverCache.invalidate()` to properly handle stats removal
+- Updated `TieredSpilloverCacheStatsHolder.removeDimensions()` to correctly aggregate stats across tiers
+- Added comprehensive unit tests for `TieredSpilloverCacheStatsHolder`
+
+#### Fix 2: Maximum Size Settings (PR #16636)
+
+Fixed a bug where cache maximum size settings were not working correctly when pluggable caching was enabled. The issue occurred because:
+
+1. Cache implementations like `OpenSearchOnHeapCache` were changed to allow the config value to override their setting value (to support TieredSpilloverCache segments)
+2. However, `IndicesRequestCache` was also putting its default 1% heap size value into the cache config
+3. This caused the implementation-specific size settings to be ignored
+
+The fix ensures that:
+- When pluggable caching is OFF: `IndicesRequestCache` puts max size into config (backward compatibility)
+- When pluggable caching is ON: Cache implementations use their own size settings
+- TieredSpilloverCache size settings (`tiered_spillover.onheap.store.size` and `tiered_spillover.disk.store.size`) always take precedence over individual tier implementation settings
+
+### Technical Changes
+
+| Component | Change |
+|-----------|--------|
+| `TieredSpilloverCache` | Fixed stats decrement logic in `invalidate()` method |
+| `TieredSpilloverCacheStatsHolder` | Added `removeDimensions()` override for proper tier handling |
+| `IndicesRequestCache` | Only sets max size in config when pluggable caching is disabled |
+| `CacheService` | Added `pluggableCachingEnabled()` helper method |
+| `OpenSearchOnHeapCache` | Updated to use `CacheService.pluggableCachingEnabled()` |
+| `EhcacheDiskCache` | Added documentation clarifying setting behavior with tiered cache |
+
+### Setting Deprecation
+
+The `indices.requests.cache.size` setting is now deprecated when pluggable caching is enabled. Users should use implementation-specific settings instead:
+
+| Setting | Description |
+|---------|-------------|
+| `indices.requests.cache.tiered_spillover.onheap.store.size` | On-heap tier size in tiered cache |
+| `indices.requests.cache.tiered_spillover.disk.store.size` | Disk tier size in tiered cache |
+| `indices.requests.cache.opensearch_onheap.size` | On-heap cache size (standalone) |
+| `indices.requests.cache.ehcache_disk.max_size_in_bytes` | Disk cache size (standalone) |
+
+## Limitations
+
+- These fixes only affect clusters with the pluggable caching feature flag enabled (`opensearch.experimental.feature.pluggable.caching.enabled`)
+- The `indices.requests.cache.size` setting will be removed in a future release
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16560](https://github.com/opensearch-project/OpenSearch/pull/16560) | Fix TieredSpilloverCache stats not adding correctly when shards are closed | [#16559](https://github.com/opensearch-project/OpenSearch/issues/16559) |
+| [#16636](https://github.com/opensearch-project/OpenSearch/pull/16636) | Fix cache maximum size settings not working properly with pluggable caching | [#16631](https://github.com/opensearch-project/OpenSearch/issues/16631) |
+
+### Documentation
+- [Tiered Cache](https://docs.opensearch.org/2.19/search-plugins/caching/tiered-cache/)
+- [Index Request Cache](https://docs.opensearch.org/2.19/search-plugins/caching/request-cache/)

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -11,6 +11,7 @@
 - Multi-Search Request Cancellation Fix
 - Remote Repository Validation
 - Remote Shards Balance Fix
+- Tiered Caching Bug Fixes
 - Workload Management Logging
 
 ### opensearch-dashboards


### PR DESCRIPTION
## Summary

Add release report for Tiered Caching bug fixes in OpenSearch v2.19.0.

### Changes
- Created release report: `docs/releases/v2.19.0/features/opensearch/tiered-caching.md`
- Updated feature report: `docs/features/opensearch/opensearch-tiered-caching.md`
- Updated release index

### Bug Fixes Documented
1. **PR #16560**: Fixed TieredSpilloverCache stats not adding correctly when shards are closed
2. **PR #16636**: Fixed cache maximum size settings not working properly with pluggable caching

### Related Issue
Closes #2055