### PR TITLE
docs: add deprecation-logger report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-deprecation-logger.md
+++ b/docs/features/opensearch/opensearch-deprecation-logger.md
@@ -1,0 +1,124 @@
+---
+tags:
+  - opensearch
+---
+# Deprecation Logger
+
+## Summary
+
+The Deprecation Logger is an internal OpenSearch component that logs warnings when clients use deprecated API features. It helps operators identify deprecated usage patterns before upgrading to new versions where those features may be removed.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Request Processing"
+        A[Client Request] --> B[REST Handler]
+        B --> C{Deprecated API?}
+        C -->|Yes| D[DeprecationLogger]
+        C -->|No| E[Normal Processing]
+    end
+    
+    subgraph "Deprecation Logging"
+        D --> F[DeprecatedMessage]
+        F --> G{Already Logged?}
+        G -->|No| H[Log Warning]
+        G -->|Yes| I[Skip]
+        H --> J[Deprecation Log File]
+    end
+    
+    subgraph "Deduplication Cache"
+        F --> K[keyDedupeCache]
+        K --> L[key + X-Opaque-Id]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `DeprecationLogger` | Main logger class that wraps Log4j2 for deprecation-specific logging |
+| `DeprecatedMessage` | Log message class that carries deprecation context including `X-Opaque-Id` |
+| `keyDedupeCache` | Thread-safe set for deduplicating log messages |
+
+### Configuration
+
+Deprecation logging can be configured through cluster settings:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `logger.deprecation.level` | Log level for deprecation messages | `WARN` |
+
+Configure via Cluster Settings API:
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "logger.deprecation.level": "WARN"
+  }
+}
+```
+
+Or in `opensearch.yml`:
+```yaml
+logger.deprecation.level: WARN
+```
+
+### Deduplication Mechanism
+
+The deprecation logger deduplicates messages to prevent log flooding. Messages are deduplicated based on:
+- **Message key**: A unique identifier for the deprecation warning
+- **X-Opaque-Id**: The client-provided request identifier header
+
+This means the same deprecation warning is logged only once per unique combination of message key and `X-Opaque-Id`.
+
+### Log Output
+
+Deprecation logs are written to:
+- `logs/opensearch_deprecation.log` (plain text)
+- `logs/opensearch_deprecation.json` (JSON format)
+
+Example log entry:
+```
+[2024-12-03T19:59:46,000][WARN][o.o.d.a.ActionModule] [node1] Deprecated API usage detected...
+```
+
+### Usage Example
+
+Internal usage within OpenSearch code:
+```java
+private static final DeprecationLogger deprecationLogger = DeprecationLogger.getLogger(MyClass.class);
+
+// Log a deprecation warning
+deprecationLogger.deprecate("my_deprecated_feature", "This feature is deprecated and will be removed in a future version");
+```
+
+## Limitations
+
+- **Cache Size Limit** (v2.19.0+): The deduplication cache is limited to 16,384 entries. Once reached, new unique deprecation messages are suppressed.
+- **No Cache Expiration**: Cached entries persist for the node's lifetime; there is no TTL or automatic cleanup.
+- **Not Configurable**: The cache size limit (16,384) is hardcoded and cannot be changed via configuration.
+
+## Change History
+
+- **v2.19.0** (2025-01-21): Fixed unbounded memory usage by adding a 16,384 entry limit to the deduplication cache. Added optimization to skip cache operations when deprecation logging is disabled.
+
+## References
+
+### Documentation
+
+- [OpenSearch Logs Documentation](https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/logs/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#16724](https://github.com/opensearch-project/OpenSearch/pull/16724) | Bound the size of cache in deprecation logger |
+
+### Related Issues
+
+| Issue | Description |
+|-------|-------------|
+| [#16702](https://github.com/opensearch-project/OpenSearch/issues/16702) | [BUG] DeprecationLogger - Unbounded memory usage |

--- a/docs/releases/v2.19.0/features/opensearch/deprecation-logger.md
+++ b/docs/releases/v2.19.0/features/opensearch/deprecation-logger.md
@@ -1,0 +1,84 @@
+---
+tags:
+  - opensearch
+---
+# Deprecation Logger Cache Bound
+
+## Summary
+
+In v2.19.0, OpenSearch fixes a memory leak in the deprecation logger by bounding the size of the deduplication cache. Previously, the cache used to track logged deprecation messages could grow without limit, potentially causing out-of-memory (OOM) errors when clients sent requests with unique `X-Opaque-Id` headers.
+
+## Details
+
+### What's New in v2.19.0
+
+The deprecation logger uses a deduplication mechanism to prevent the same deprecation warning from being logged multiple times. This mechanism tracks logged messages using a combination of the message key and the `X-Opaque-Id` request header.
+
+**Problem**: The previous implementation used an unbounded `ConcurrentHashMap` to store these keys. When clients sent requests with unique `X-Opaque-Id` values per request, the cache would grow indefinitely, eventually causing memory exhaustion.
+
+**Solution**: The fix introduces two key changes:
+
+1. **Cache Size Limit**: A maximum cache size of 16,384 entries (`MAX_DEDUPE_CACHE_ENTRIES`) is enforced. Once this limit is reached, new deprecation messages are treated as "already logged" to prevent further cache growth.
+
+2. **Logger Enabled Check**: Before creating a `DeprecatedMessage` object and checking the cache, the code now verifies if the deprecation logger is enabled. This optimization skips unnecessary overhead when deprecation logging is disabled.
+
+### Technical Changes
+
+**DeprecatedMessage.java**:
+```java
+// Maximum cache size constant
+static final int MAX_DEDUPE_CACHE_ENTRIES = 16_384;
+
+public boolean isAlreadyLogged() {
+    if (keyDedupeCache.contains(keyWithXOpaqueId)) {
+        return true;
+    }
+    if (keyDedupeCache.size() >= MAX_DEDUPE_CACHE_ENTRIES) {
+        // Stop logging if max size is breached
+        return true;
+    }
+    return !keyDedupeCache.add(keyWithXOpaqueId);
+}
+```
+
+**DeprecationLogger.java**:
+```java
+public DeprecationLoggerBuilder withDeprecation(String key, String msg, Object[] params) {
+    // Check if logger is enabled first to skip overhead
+    if (logger.isEnabled(DEPRECATION)) {
+        DeprecatedMessage deprecationMessage = new DeprecatedMessage(key, HeaderWarning.getXOpaqueId(), msg, params);
+        if (!deprecationMessage.isAlreadyLogged()) {
+            logger.log(DEPRECATION, deprecationMessage);
+        }
+    }
+    return this;
+}
+```
+
+### Behavior After Cache Limit
+
+When the cache reaches 16,384 entries:
+- New unique deprecation messages will not be logged
+- Existing cached messages continue to be deduplicated correctly
+- No additional memory is consumed
+- Historical logs will already contain extensive deprecation warnings at this point
+
+## Limitations
+
+- Once the cache limit is reached, new unique deprecation warnings are silently suppressed
+- The cache is not cleared automatically; it persists for the lifetime of the node
+- The 16,384 entry limit is hardcoded and not configurable
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16724](https://github.com/opensearch-project/OpenSearch/pull/16724) | Bound the size of cache in deprecation logger | [#16702](https://github.com/opensearch-project/OpenSearch/issues/16702) |
+
+### Related Issues
+
+| Issue | Description |
+|-------|-------------|
+| [#16702](https://github.com/opensearch-project/OpenSearch/issues/16702) | [BUG] DeprecationLogger - Unbounded memory usage |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -5,6 +5,7 @@
 ### opensearch
 - Auto Date Histogram Bug Fix
 - CI Fixes
+- Deprecation Logger Cache Bound
 - gRPC Settings
 - List Shards API
 - Match Only Text Field


### PR DESCRIPTION
## Summary

Add documentation for the Deprecation Logger cache bound fix in OpenSearch v2.19.0.

### Reports Created
- Release report: `docs/releases/v2.19.0/features/opensearch/deprecation-logger.md`
- Feature report: `docs/features/opensearch/opensearch-deprecation-logger.md`

### Key Changes in v2.19.0
- Fixed unbounded memory usage in deprecation logger by adding a 16,384 entry limit to the deduplication cache
- Added optimization to skip cache operations when deprecation logging is disabled

### Resources Used
- PR: [#16724](https://github.com/opensearch-project/OpenSearch/pull/16724)
- Issue: [#16702](https://github.com/opensearch-project/OpenSearch/issues/16702)
- Docs: [OpenSearch Logs](https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/logs/)