### PR TITLE
docs: add cluster-state report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-remote-store.md
+++ b/docs/features/opensearch/opensearch-remote-store.md
@@ -129,6 +129,7 @@ PUT /_cluster/settings
 
 - **v3.1.0** (2026-01-10): Added close index request rejection during migration; Fixed cluster state diff download failures during alias operations
 - **v3.0.0** (2024-12-16): Added `cluster.remote_state.download.serve_read_api.enabled` setting to control full cluster state download on term mismatch
+- **v2.19.0** (2025-02-18): Fixed stale cluster state custom file deletion bug in `RemoteClusterStateCleanupManager`
 
 
 ## References
@@ -144,6 +145,7 @@ PUT /_cluster/settings
 | v3.1.0 | [#18327](https://github.com/opensearch-project/OpenSearch/pull/18327) | Disabling _close API invocation during remote migration | [#18328](https://github.com/opensearch-project/OpenSearch/issues/18328) |
 | v3.1.0 | [#18256](https://github.com/opensearch-project/OpenSearch/pull/18256) | Apply cluster state metadata and routing table diff when building cluster state from remote | [#18045](https://github.com/opensearch-project/OpenSearch/issues/18045) |
 | v3.0.0 | [#16798](https://github.com/opensearch-project/OpenSearch/pull/16798) | Setting to disable full cluster state download from remote on term mismatch | [#8957](https://github.com/opensearch-project/documentation-website/issues/8957) |
+| v2.19.0 | [#16670](https://github.com/opensearch-project/OpenSearch/pull/16670) | Fix stale cluster state custom file deletion | - |
 
 ### Issues (Design / RFC)
 - [Issue #18328](https://github.com/opensearch-project/OpenSearch/issues/18328): Reject close index requests during DocRep to SegRep migration

--- a/docs/releases/v2.19.0/features/opensearch/cluster-state.md
+++ b/docs/releases/v2.19.0/features/opensearch/cluster-state.md
@@ -1,0 +1,48 @@
+---
+tags:
+  - opensearch
+---
+# Cluster State
+
+## Summary
+
+Fixed a bug where stale cluster state custom files were not being deleted from remote storage when remote cluster state publication is enabled. The cleanup logic was incorrectly iterating over custom metadata map instead of cluster state custom map.
+
+## Details
+
+### What's New in v2.19.0
+
+This release fixes a bug in the `RemoteClusterStateCleanupManager` that prevented proper cleanup of stale cluster state custom files (such as snapshots and restore metadata) from remote storage.
+
+### Technical Changes
+
+The bug was in the `deleteClusterMetadata` method of `RemoteClusterStateCleanupManager`. When iterating over cluster state custom objects to identify stale files for deletion, the code was incorrectly calling `getCustomMetadataMap()` instead of `getClusterStateCustomMap()`:
+
+```java
+// Before (incorrect)
+clusterMetadataManifest.getCustomMetadataMap()
+    .values()
+    .stream()
+    .filter(u -> !filesToKeep.contains(u.getUploadedFilename()))
+    .forEach(u -> staleEphemeralAttributePaths.add(u.getUploadedFilename()));
+
+// After (correct)
+clusterMetadataManifest.getClusterStateCustomMap()
+    .values()
+    .stream()
+    .filter(u -> !filesToKeep.contains(u.getUploadedFilename()))
+    .forEach(u -> staleEphemeralAttributePaths.add(u.getUploadedFilename()));
+```
+
+This fix ensures that cluster state custom files (e.g., `snapshots`, `restore`) are properly identified and deleted during stale file cleanup.
+
+## Limitations
+
+- Only affects clusters with remote cluster state publication enabled (`cluster.remote_store.state.enabled: true`)
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16670](https://github.com/opensearch-project/OpenSearch/pull/16670) | Fix stale cluster state custom file deletion | - |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -5,6 +5,7 @@
 ### opensearch
 - Auto Date Histogram Bug Fix
 - CI Fixes
+- Cluster State
 - Deprecation Logger Cache Bound
 - gRPC Settings
 - List Shards API


### PR DESCRIPTION
## Summary\n\nAdds release report for the Cluster State bug fix in v2.19.0.\n\n### Changes\n- Created release report: `docs/releases/v2.19.0/features/opensearch/cluster-state.md`\n- Updated feature report: `docs/features/opensearch/opensearch-remote-store.md` (added v2.19.0 to Change History and References)\n- Updated release index: `docs/releases/v2.19.0/index.md`\n\n### Bug Fix Details\nFixed a bug in `RemoteClusterStateCleanupManager` where stale cluster state custom files (snapshots, restore metadata) were not being deleted from remote storage. The cleanup logic was incorrectly calling `getCustomMetadataMap()` instead of `getClusterStateCustomMap()`.\n\n### Related\n- PR: opensearch-project/OpenSearch#16670\n- Issue: #2053"