### PR TITLE
docs: add ip-field report for v2.19.0

### DIFF
--- a/docs/features/opensearch/ip-field.md
+++ b/docs/features/opensearch/ip-field.md
@@ -1,0 +1,76 @@
+---
+tags:
+  - opensearch
+---
+# IP Field Type
+
+## Summary
+
+The IP field type stores IP addresses in IPv4 or IPv6 format. It supports exact matching, CIDR notation queries, and range queries. IP fields can be configured with indexing, doc_values, or both for different query performance characteristics.
+
+## Details
+
+### Configuration
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `boost` | Floating-point value for relevance scoring weight | `1.0` |
+| `doc_values` | Store on disk for aggregations, sorting, scripting | `true` |
+| `ignore_malformed` | Ignore malformed values without throwing exception | `false` |
+| `index` | Whether the field should be searchable | `true` |
+| `null_value` | Value to use in place of `null` | `null` |
+| `store` | Store field value separately from `_source` | `false` |
+
+### Query Types
+
+| Query Type | Description | Example |
+|------------|-------------|---------|
+| Term | Exact IP match | `"term": {"ip": "192.168.1.1"}` |
+| Term (CIDR) | IP range via CIDR notation | `"term": {"ip": "192.168.0.0/24"}` |
+| Range | IP address range | `"range": {"ip": {"gte": "192.168.0.0", "lte": "192.168.255.255"}}` |
+
+### Doc Values Only Configuration
+
+When storage optimization is needed, IP fields can be configured with `index: false` and `doc_values: true`:
+
+```json
+{
+  "mappings": {
+    "properties": {
+      "ip_address": {
+        "type": "ip",
+        "index": false,
+        "doc_values": true
+      }
+    }
+  }
+}
+```
+
+This configuration:
+- Reduces index size by not creating inverted index
+- Still allows searching via doc_values (slower but functional)
+- Supports aggregations, sorting, and scripting
+
+## Limitations
+
+- Doc_values-only queries use slower query implementations
+- IPv4 addresses are internally stored as IPv6-mapped addresses
+- CIDR notation queries on doc_values-only fields may have performance implications
+
+## Change History
+
+- **v2.19.0** (2025-01-14): Fixed CIDR notation (IP mask) searching for doc_values-only IP fields ([#16628](https://github.com/opensearch-project/OpenSearch/pull/16628))
+- **v2.12.0** (2024-01-30): Added support for searching IP fields with only doc_values enabled ([#11508](https://github.com/opensearch-project/OpenSearch/pull/11508))
+- **v1.0.0**: Initial implementation of IP field type
+
+## References
+
+### Documentation
+- [IP address field type](https://docs.opensearch.org/latest/field-types/supported-field-types/ip/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#16628](https://github.com/opensearch-project/OpenSearch/pull/16628) | Fix doc_values only IP field searching for masks |
+| v2.12.0 | [#11508](https://github.com/opensearch-project/OpenSearch/pull/11508) | Enable doc_values-only searching for IP fields |

--- a/docs/releases/v2.19.0/features/opensearch/ip-field.md
+++ b/docs/releases/v2.19.0/features/opensearch/ip-field.md
@@ -1,0 +1,70 @@
+---
+tags:
+  - opensearch
+---
+# IP Field
+
+## Summary
+
+Fixed an edge case where doc_values-only IP fields (with `index: false`) could not be searched using CIDR notation (IP masks). Previously, queries like `192.168.0.1/24` on doc_values-only IP fields were silently ignored and returned no results.
+
+## Details
+
+### What's New in v2.19.0
+
+This release fixes IP mask (CIDR notation) searching for IP fields configured with only doc_values enabled (`index: false`). The fix ensures that term queries, terms queries, and range queries all work correctly when searching IP fields using CIDR notation on doc_values-only fields.
+
+### Technical Changes
+
+The `IpFieldMapper.java` was refactored to properly handle doc_values-only queries:
+
+| Query Type | Before v2.19.0 | After v2.19.0 |
+|------------|----------------|---------------|
+| Term query with CIDR | Silently ignored | Uses `SortedSetDocValuesField.newSlowRangeQuery` |
+| Terms query | Only worked with indexed fields | Supports doc_values via `newSlowSetQuery` |
+| Range query | Partial support | Full support with `IndexOrDocValuesQuery` |
+
+The implementation now:
+1. Extracts lower and upper bounds from `PointRangeQuery` for CIDR notation
+2. Creates appropriate `SortedSetDocValuesField` queries for doc_values-only fields
+3. Uses `IndexOrDocValuesQuery` when both index and doc_values are available
+
+### Example
+
+```json
+PUT testindex
+{
+  "mappings": {
+    "properties": {
+      "ip_address": {
+        "type": "ip",
+        "index": false,
+        "doc_values": true
+      }
+    }
+  }
+}
+
+GET testindex/_search
+{
+  "query": {
+    "term": {
+      "ip_address": "192.168.0.1/24"
+    }
+  }
+}
+```
+
+## Limitations
+
+- Doc_values-only queries use "slow" query implementations (`newSlowRangeQuery`, `newSlowSetQuery`) which may have performance implications for large datasets compared to indexed fields
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16628](https://github.com/opensearch-project/OpenSearch/pull/16628) | Fix `doc_values` only (`index:false`) IP field searching for masks | [#11508](https://github.com/opensearch-project/OpenSearch/pull/11508) |
+
+### Documentation
+- [IP address field type](https://docs.opensearch.org/2.19/field-types/supported-field-types/ip/)

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch
 - Auto Date Histogram Bug Fix
+- IP Field
 - CI Fixes
 - Cluster State
 - Deprecation Logger Cache Bound


### PR DESCRIPTION
## Summary

Adds documentation for IP Field fix in OpenSearch v2.19.0.

### Reports Created
- Release report: `docs/releases/v2.19.0/features/opensearch/ip-field.md`
- Feature report: `docs/features/opensearch/ip-field.md`

### Key Changes in v2.19.0
- Fixed CIDR notation (IP mask) searching for doc_values-only IP fields
- Term, terms, and range queries now work correctly with `index: false` IP fields

### References
- PR: [#16628](https://github.com/opensearch-project/OpenSearch/pull/16628)
- Related: [#11508](https://github.com/opensearch-project/OpenSearch/pull/11508)

Closes #2052