### PR TITLE
docs: add searchable-snapshot report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-searchable-snapshot.md
+++ b/docs/features/opensearch/opensearch-searchable-snapshot.md
@@ -1,0 +1,103 @@
+---
+tags:
+  - opensearch
+---
+# Searchable Snapshots
+
+## Summary
+
+Searchable Snapshots allow querying data directly from snapshot repositories without fully restoring indexes to cluster storage. Data is fetched on-demand at search time, enabling cost-effective access to historical data stored in lower-cost object storage like Amazon S3.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph Cluster
+        SN[Search Node]
+        FC[File Cache]
+    end
+    subgraph "Snapshot Repository"
+        SR[Remote Storage<br/>S3/Azure/GCS]
+    end
+    
+    Query --> SN
+    SN --> FC
+    FC -->|Cache Miss| SR
+    SR -->|Download Block| FC
+    FC -->|Return Data| SN
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Search Node | Node with `search` role that handles searchable snapshot queries |
+| File Cache | Local cache for frequently accessed data segments |
+| Transfer Manager | Manages blob fetching from remote snapshot repository |
+| Remote Segment Store | Remote storage for segment data (S3, Azure, GCS) |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `node.roles` | Must include `search` for searchable snapshot support | - |
+| `node.search.cache.size` | Size of local cache for snapshot data | 80% of available storage (dedicated search node) |
+| `cluster.filecache.remote_data_ratio` | Maximum ratio of remote data to local cache | Recommended: 5 |
+
+### Usage Example
+
+#### Configure a Search Node
+
+```yaml
+node.name: snapshots-node
+node.roles: [ search ]
+node.search.cache.size: 50gb
+```
+
+#### Restore as Searchable Snapshot
+
+```json
+POST /_snapshot/my-repository/my-snapshot/_restore
+{
+  "storage_type": "remote_snapshot",
+  "indices": "my-index"
+}
+```
+
+#### Verify Index Type
+
+```json
+GET /my-index/_settings?pretty
+```
+
+Response shows `"store": { "type": "remote_snapshot" }` for searchable snapshot indexes.
+
+## Limitations
+
+- Searchable snapshot indexes are read-only
+- Higher search latency compared to local indexes due to remote data fetching
+- Remote object stores may charge per-request fees
+- Searching remote data impacts performance of other queries on the same node
+- k-NN indexes support searchable snapshots only for NMSLIB and Faiss engines (v2.18+)
+- Searchable snapshots are not supported inside shallow copy snapshots
+
+## Change History
+
+- **v2.19.0** (2025-01-14): Bug fixes for alias rollover, scripted query permissions, and shallow copy snapshots on closed indexes
+- **v2.18.0**: Added k-NN index support for NMSLIB and Faiss engines
+- **v2.7.0**: Initial searchable snapshots feature
+
+## References
+
+### Documentation
+- [Searchable Snapshots](https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot/)
+- [Shallow Snapshots](https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/remote-store/snapshot-interoperability/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#16483](https://github.com/opensearch-project/OpenSearch/pull/16483) | Rollover alias supports restored searchable snapshot index |
+| v2.19.0 | [#16544](https://github.com/opensearch-project/OpenSearch/pull/16544) | Fix scripted query permissions for remote snapshots |
+| v2.19.0 | [#16868](https://github.com/opensearch-project/OpenSearch/pull/16868) | Fix shallow copy snapshot failures on closed index |

--- a/docs/releases/v2.19.0/features/opensearch/searchable-snapshot.md
+++ b/docs/releases/v2.19.0/features/opensearch/searchable-snapshot.md
@@ -1,0 +1,69 @@
+---
+tags:
+  - opensearch
+---
+# Searchable Snapshot Bug Fixes
+
+## Summary
+
+OpenSearch v2.19.0 includes three bug fixes for the Searchable Snapshot feature, addressing issues with alias rollover operations, scripted query permissions, and shallow copy snapshot failures on closed indexes.
+
+## Details
+
+### What's New in v2.19.0
+
+#### Rollover Alias Support for Restored Searchable Snapshot Indexes
+
+Previously, when using ISM (Index State Management) to rollover aliases that included restored searchable snapshot indexes, the operation would fail with a `FORBIDDEN/13/remote index is read-only` error. This occurred because the rollover operation checked all indexes using the alias and was blocked by the `METADATA_WRITE` block on read-only searchable snapshot indexes.
+
+The fix excludes searchable snapshot indexes from the `checkBlock` validation during `_aliases` and `_rollover` API operations, allowing rollover to proceed correctly.
+
+#### Scripted Query Permissions Fix
+
+Searches on searchable snapshot indexes that included scripted queries (e.g., Painless scripts in aggregations) would fail with `AccessControlException` errors. The issue occurred because:
+
+1. Scripted queries run in a different security context
+2. The `TransferManager` needed elevated permissions when calling `getIndexInput()` on cache entries
+3. File I/O operations for downloading blobs from remote snapshot stores required additional permissions
+
+The fix wraps the `cacheEntry.getIndexInput()` call in a privileged block, granting the necessary permissions for disk I/O operations when fetching blobs from remote snapshots.
+
+#### Shallow Copy Snapshot Fix for Closed Indexes
+
+Shallow copy snapshots were failing for remote-store backed indexes that had been closed, with the error:
+```
+java.nio.file.NoSuchFileException: Metadata file is not present for given primary term <X> and generation <Y>
+```
+
+Root cause:
+- When an index is closed, a new segment file is created during read-only engine recovery
+- This new segment file is not uploaded to remote store (no refresh listener available)
+- Shallow snapshots try to find the latest segment generation on remote store, which fails
+
+The fix takes snapshots using the last successfully uploaded segment generation by fetching the latest metadata file from the remote directory and acquiring a lock on that commit generation.
+
+### Technical Changes
+
+| Component | Change |
+|-----------|--------|
+| `MetadataCreateIndexService` | Exclude searchable snapshot indexes from block checks during alias/rollover operations |
+| `TransferManager` | Add privileged block for `getIndexInput()` calls during blob fetching |
+| `SnapshotShardsService` | Use last uploaded segment generation for shallow copy snapshots on closed indexes |
+
+## Limitations
+
+- Searchable snapshot indexes remain read-only; write operations will still fail
+- The shallow copy snapshot fix applies only to remote-store backed indexes
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16483](https://github.com/opensearch-project/OpenSearch/pull/16483) | Rollover alias supports restored searchable snapshot index | [#16419](https://github.com/opensearch-project/OpenSearch/issues/16419) |
+| [#16544](https://github.com/opensearch-project/OpenSearch/pull/16544) | Make cacheEntry.getIndexInput() privileged when fetching blobs from remote snapshot | [#16542](https://github.com/opensearch-project/OpenSearch/issues/16542) |
+| [#16868](https://github.com/opensearch-project/OpenSearch/pull/16868) | Fix Shallow copy snapshot failures on closed index | [#13805](https://github.com/opensearch-project/OpenSearch/issues/13805) |
+
+### Documentation
+- [Searchable Snapshots](https://docs.opensearch.org/2.19/tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot/)
+- [Shallow Snapshots](https://docs.opensearch.org/2.19/tuning-your-cluster/availability-and-recovery/remote-store/snapshot-interoperability/)

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -14,6 +14,7 @@
 - Multi-Search Request Cancellation Fix
 - Remote Repository Validation
 - Remote Shards Balance Fix
+- Searchable Snapshot Bug Fixes
 - Tiered Caching Bug Fixes
 - Workload Management Logging
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Searchable Snapshot bug fixes in OpenSearch v2.19.0.

### Reports Created
- Release report: `docs/releases/v2.19.0/features/opensearch/searchable-snapshot.md`
- Feature report: `docs/features/opensearch/opensearch-searchable-snapshot.md` (new)

### Key Changes in v2.19.0
- Fix rollover alias support for restored searchable snapshot indexes (#16483)
- Fix scripted query permissions when fetching blobs from remote snapshots (#16544)
- Fix shallow copy snapshot failures on closed indexes (#16868)

### Resources Used
- PR: #16483, #16544, #16868
- Issues: #16419, #16542, #13805
- Docs: https://docs.opensearch.org/2.19/tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot/