### PR TITLE
docs: add search-response-headers report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-search-response-headers.md
+++ b/docs/features/opensearch/opensearch-search-response-headers.md
@@ -1,0 +1,98 @@
+---
+tags:
+  - opensearch
+---
+# Search Response Headers
+
+## Summary
+
+OpenSearch manages HTTP response headers for search requests to balance internal resource tracking needs with client-facing response efficiency. The `TASK_RESOURCE_USAGE` header, introduced for shard-level resource tracking, is now filtered from client responses to prevent excessive header overhead while maintaining internal monitoring capabilities.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Search Request Flow"
+        A[Client Request] --> B[Coordinator Node]
+        B --> C[Data Nodes]
+        C --> D[Shard Tasks]
+        D --> E[Resource Tracking]
+        E --> F[TASK_RESOURCE_USAGE Header]
+    end
+    
+    subgraph "Response Processing"
+        F --> G[SearchTaskRequestOperationsListener]
+        G --> H[Refresh Coordinator Stats]
+        H --> I[Remove Internal Headers]
+        I --> J[Client Response]
+    end
+    
+    subgraph "Internal Usage"
+        F --> K[Query Insights]
+        F --> L[Task Management]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SearchTaskRequestOperationsListener` | Listener that handles search request lifecycle events and header cleanup |
+| `TaskResourceTrackingService` | Service that tracks task resource usage and manages the `TASK_RESOURCE_USAGE` header |
+| `ThreadContext` | Thread-local context that stores request/response headers |
+| `DefaultRestChannel` | REST channel that copies thread context headers to HTTP response |
+
+### Header Format
+
+The `TASK_RESOURCE_USAGE` header (when present internally) contains:
+
+```json
+{
+  "action": "indices:data/read/search[phase/query]",
+  "taskId": 898,
+  "parentTaskId": 865,
+  "nodeId": "Ld-7uLOxQPOnDjnCnSuFRQ",
+  "taskResourceUsage": {
+    "cpu_time_in_nanos": 22979000,
+    "memory_in_bytes": 2000624
+  }
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `action` | The search action being performed |
+| `taskId` | Unique identifier for the task |
+| `parentTaskId` | ID of the parent task (coordinator) |
+| `nodeId` | Node where the task executed |
+| `cpu_time_in_nanos` | CPU time consumed by the task |
+| `memory_in_bytes` | Memory used by the task |
+
+### Usage
+
+Resource usage data is available through:
+
+1. **Query Insights Plugin**: Aggregates resource usage for top N queries monitoring
+2. **Task Management API**: Shows resource stats for running tasks
+3. **Search Backpressure**: Uses resource tracking for admission control
+
+## Limitations
+
+- The `TASK_RESOURCE_USAGE` header is not exposed to clients (removed in v2.19.0)
+- Resource tracking adds minimal overhead to search operations
+- Resource stats are only available for tasks that support resource tracking
+
+## Change History
+
+- **v2.19.0** (2024-11-01): Removed `TASK_RESOURCE_USAGE` header from client-facing search responses to reduce header overhead and improve latency
+- **v2.15.0** (2024-06-07): Introduced shard-level resource usage tracking with `TASK_RESOURCE_USAGE` header for query-level resource monitoring
+
+## References
+
+### Pull Requests
+| Version | PR | Description | Related Issue |
+|---------|-----|-------------|---------------|
+| v2.19.0 | [#16532](https://github.com/opensearch-project/OpenSearch/pull/16532) | Remove resource usages object from search response headers | - |
+| v2.15.0 | [#13172](https://github.com/opensearch-project/OpenSearch/pull/13172) | Query-level resource usages tracking | [#12399](https://github.com/opensearch-project/OpenSearch/issues/12399) |

--- a/docs/releases/v2.19.0/features/opensearch/search-response-headers.md
+++ b/docs/releases/v2.19.0/features/opensearch/search-response-headers.md
@@ -1,0 +1,75 @@
+---
+tags:
+  - opensearch
+---
+# Search Response Headers
+
+## Summary
+
+This change removes the `TASK_RESOURCE_USAGE` header from HTTP search responses. The header was previously added to responses by the shard-level resource usage tracking feature introduced in v2.15.0, but it caused excessive headers to be sent to clients, potentially impacting latency.
+
+## Details
+
+### What's New in v2.19.0
+
+The `TASK_RESOURCE_USAGE` header is now explicitly removed from search response headers before sending the response to the client. This header contained shard-level task resource usage information (CPU time, memory usage) that was intended for internal query-level resource tracking but was inadvertently exposed to clients.
+
+### Technical Changes
+
+The fix modifies the search request lifecycle to clean up internal headers:
+
+```mermaid
+flowchart TB
+    A[Search Request] --> B[Query Execution]
+    B --> C[Shard Tasks Track Resources]
+    C --> D[TASK_RESOURCE_USAGE Header Added]
+    D --> E[onRequestEnd Called]
+    E --> F[Refresh Coordinator Stats]
+    F --> G[Remove TASK_RESOURCE_USAGE Header]
+    G --> H[Send Response to Client]
+```
+
+Key changes:
+- `SearchTaskRequestOperationsListener.onRequestEnd()` now calls `removeTaskResourceUsage()` after refreshing coordinator stats
+- `SearchTaskRequestOperationsListener.onRequestFailure()` also removes the header on failures
+- New `ThreadContext.removeResponseHeader()` method enables header removal
+- New `TaskResourceTrackingService.removeTaskResourceUsage()` method encapsulates the cleanup
+
+### Before/After Comparison
+
+**Before (v2.15.0 - v2.18.x):**
+```
+HTTP/1.1 200 OK
+TASK_RESOURCE_USAGE: {"action":"indices:data/read/search[phase/query]","taskId":898,"parentTaskId":865,"nodeId":"Ld-7uLOxQPOnDjnCnSuFRQ","taskResourceUsage":{"cpu_time_in_nanos":22979000,"memory_in_bytes":2000624}}
+X-OpenSearch-Version: OpenSearch/3.0.0-SNAPSHOT (opensearch)
+content-type: application/json; charset=UTF-8
+```
+
+**After (v2.19.0+):**
+```
+HTTP/1.1 200 OK
+X-OpenSearch-Version: OpenSearch/3.0.0-SNAPSHOT (opensearch)
+content-type: application/json; charset=UTF-8
+```
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `SearchTaskRequestOperationsListener.java` | Added header cleanup in `onRequestEnd()` and `onRequestFailure()` |
+| `ThreadContext.java` | Added `removeResponseHeader()` method |
+| `TaskResourceTrackingService.java` | Added `removeTaskResourceUsage()` method |
+
+## Limitations
+
+- The resource usage data is still collected internally for Query Insights and other monitoring features
+- This change only affects the HTTP response headers sent to clients
+- Internal cluster communication is not affected
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16532](https://github.com/opensearch-project/OpenSearch/pull/16532) | Remove resource usages object from search response headers | - |
+| [#13172](https://github.com/opensearch-project/OpenSearch/pull/13172) | Query-level resource usages tracking (original feature) | [#12399](https://github.com/opensearch-project/OpenSearch/issues/12399) |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -14,6 +14,7 @@
 - Multi-Search Request Cancellation Fix
 - Remote Repository Validation
 - Remote Shards Balance Fix
+- Search Response Headers
 - Searchable Snapshot Bug Fixes
 - Tiered Caching Bug Fixes
 - Unsigned Long Field


### PR DESCRIPTION
## Summary

This PR adds documentation for the Search Response Headers deprecation change in OpenSearch v2.19.0.

### Changes
- **Release Report**: `docs/releases/v2.19.0/features/opensearch/search-response-headers.md`
- **Feature Report**: `docs/features/opensearch/opensearch-search-response-headers.md`
- **Release Index**: Updated to include the new feature

### Key Findings

The `TASK_RESOURCE_USAGE` header has been removed from HTTP search responses in v2.19.0. This header was originally introduced in v2.15.0 (PR #13172) for shard-level resource usage tracking to support Query Insights, but it was inadvertently exposed to clients, causing excessive headers and potential latency impact.

**Technical Changes:**
- `SearchTaskRequestOperationsListener` now removes the header in `onRequestEnd()` and `onRequestFailure()`
- New `ThreadContext.removeResponseHeader()` method enables header removal
- New `TaskResourceTrackingService.removeTaskResourceUsage()` method encapsulates cleanup

### Related
- Closes #2049
- PR: [opensearch-project/OpenSearch#16532](https://github.com/opensearch-project/OpenSearch/pull/16532)
- Original feature PR: [opensearch-project/OpenSearch#13172](https://github.com/opensearch-project/OpenSearch/pull/13172)