### PR TITLE
docs: add system-indices report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-system-indices.md
+++ b/docs/features/opensearch/opensearch-system-indices.md
@@ -1,0 +1,95 @@
+---
+tags:
+  - opensearch
+---
+# System Indices
+
+## Summary
+
+System indices are special indices used internally by OpenSearch and its plugins to store configuration, state, and operational data. They are protected from direct user access and have special handling to ensure cluster stability and security.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Index Creation Flow"
+        Request[Create Index Request]
+        Check{Is System Index?}
+        Templates[Apply Index Templates]
+        NoTemplates[Skip Templates]
+        Create[Create Index]
+    end
+    
+    Request --> Check
+    Check -->|Yes| NoTemplates
+    Check -->|No| Templates
+    NoTemplates --> Create
+    Templates --> Create
+    
+    subgraph "Cluster State Publication"
+        CM[Cluster Manager]
+        Diff[IndexMetadataDiff]
+        Follower[Follower Nodes]
+    end
+    
+    CM -->|Publish| Diff
+    Diff -->|Apply| Follower
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SystemIndices` | Registry of system index descriptors, provides `isSystemIndex()` check |
+| `SystemIndexPlugin` | Plugin interface for declaring system indices via `getSystemIndexDescriptors()` |
+| `IndexMetadata.isSystem` | Flag indicating whether an index is a system index |
+| `MetadataCreateIndexService` | Handles index creation, includes system index template bypass |
+
+### Configuration
+
+System indices are typically configured through the Security plugin:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.system_indices.enabled` | Enable system index protection | `true` |
+| `plugins.security.system_indices.indices` | List of protected system index patterns | Plugin-specific |
+
+### Common System Indices
+
+| Index Pattern | Plugin | Purpose |
+|---------------|--------|---------|
+| `.opendistro_security` | Security | Security configuration |
+| `.opensearch-observability` | Observability | Observability objects |
+| `.plugins-ml-*` | ML Commons | ML model data |
+| `.opensearch-notifications-*` | Notifications | Notification channels |
+
+### Behavior
+
+1. **Template Exclusion**: System indices bypass all index template matching during creation
+2. **Access Protection**: Direct access to system indices generates deprecation warnings (will be blocked in future versions)
+3. **Cluster State Consistency**: The `isSystem` flag is properly propagated during cluster state publication
+
+## Limitations
+
+- System index protection requires the Security plugin to be installed and configured
+- Plugins must explicitly register their indices as system indices via `SystemIndexPlugin.getSystemIndexDescriptors()`
+- During rolling upgrades, temporary inconsistencies may occur if plugins retroactively declare indices as system indices
+
+## Change History
+
+- **v2.19.0** (2024-12-17): Fixed index template application to system indices; Fixed `isSystem` flag consistency during cluster state publication
+
+## References
+
+### Documentation
+
+- [System indexes](https://docs.opensearch.org/latest/security/configuration/system-indices/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#16418](https://github.com/opensearch-project/OpenSearch/pull/16418) | Ensure index templates are not applied to system indices |
+| v2.19.0 | [#16644](https://github.com/opensearch-project/OpenSearch/pull/16644) | Ensure consistency of system flag on IndexMetadata after diff is applied |

--- a/docs/releases/v2.19.0/features/opensearch/system-indices.md
+++ b/docs/releases/v2.19.0/features/opensearch/system-indices.md
@@ -1,0 +1,69 @@
+---
+tags:
+  - opensearch
+---
+# System Indices
+
+## Summary
+
+OpenSearch v2.19.0 introduces two important fixes for system indices handling: preventing index templates from being applied to system indices, and ensuring consistency of the `isSystem` flag on IndexMetadata across cluster nodes during rolling upgrades.
+
+## Details
+
+### What's New in v2.19.0
+
+#### Index Template Exclusion for System Indices
+
+System indices are now protected from user-defined index templates. Previously, composable index templates with wildcard patterns (e.g., `*`) could inadvertently apply mappings to system indices, potentially causing mapping conflicts that prevented index creation or even node startup.
+
+The fix adds a check in `MetadataCreateIndexService.applyCreateIndexRequest()` that bypasses all template matching for system indices:
+
+```java
+// Do not apply any templates to system indices
+if (systemIndices.isSystemIndex(name)) {
+    return applyCreateIndexRequestWithNoTemplates(currentState, request, silent, metadataTransformer);
+}
+```
+
+This ensures system indices are created with only their explicitly defined mappings, regardless of any matching index templates.
+
+#### IndexMetadata System Flag Consistency
+
+Fixed a bug where the `isSystem` flag on IndexMetadata could become inconsistent between cluster manager and follower nodes during rolling upgrades. This occurred when plugins retroactively declared indices as system indices (via `SystemIndexPlugin.getSystemIndexDescriptors`).
+
+The root cause was in `IndexMetadataDiff.apply()`, which incorrectly used the previous metadata's `isSystem` value instead of the value from the incoming diff:
+
+```java
+// Before (incorrect)
+builder.system(part.isSystem);
+
+// After (correct)
+builder.system(isSystem);
+```
+
+### Technical Changes
+
+| Component | Change |
+|-----------|--------|
+| `MetadataCreateIndexService` | Added `applyCreateIndexRequestWithNoTemplates()` method to bypass template matching for system indices |
+| `IndexMetadata.IndexMetadataDiff` | Fixed `apply()` method to use `isSystem` from diff instead of previous metadata |
+| `SystemIndexRestIT` | Added integration test `testSystemIndexCreatedWithoutAnyTemplates()` |
+| `IndexMetadataTests` | Added unit test `testIndicesMetadataDiffSystemFlagFlipped()` |
+
+## Limitations
+
+- The template exclusion applies only to system indices identified by `SystemIndices.isSystemIndex()`. Custom indices not registered as system indices will still have templates applied.
+- The IndexMetadata fix requires all nodes to be upgraded to v2.19.0+ for full consistency during cluster state publication.
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16418](https://github.com/opensearch-project/OpenSearch/pull/16418) | Ensure index templates are not applied to system indices | [#16340](https://github.com/opensearch-project/OpenSearch/issues/16340) |
+| [#16644](https://github.com/opensearch-project/OpenSearch/pull/16644) | Ensure consistency of system flag on IndexMetadata after diff is applied | [#16643](https://github.com/opensearch-project/OpenSearch/issues/16643) |
+
+### Documentation
+
+- [System indexes](https://docs.opensearch.org/2.19/security/configuration/system-indices/)

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -16,6 +16,7 @@
 - Remote Shards Balance Fix
 - Search Response Headers
 - Searchable Snapshot Bug Fixes
+- System Indices
 - Tiered Caching Bug Fixes
 - Unsigned Long Field
 - Workload Management Logging


### PR DESCRIPTION
## Summary

Adds documentation for System Indices improvements in OpenSearch v2.19.0.

## Changes

### Release Report
- `docs/releases/v2.19.0/features/opensearch/system-indices.md`

### Feature Report
- `docs/features/opensearch/opensearch-system-indices.md` (new)

## Key Changes in v2.19.0

1. **Index Template Exclusion**: System indices now bypass all index template matching during creation, preventing mapping conflicts
2. **IndexMetadata Consistency**: Fixed `isSystem` flag propagation during cluster state publication to ensure consistency across nodes during rolling upgrades

## Related PRs
- [#16418](https://github.com/opensearch-project/OpenSearch/pull/16418) - Ensure index templates are not applied to system indices
- [#16644](https://github.com/opensearch-project/OpenSearch/pull/16644) - Ensure consistency of system flag on IndexMetadata after diff is applied

Closes #2048"