### PR TITLE
docs: add index-settings-api report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-index-settings.md
+++ b/docs/features/opensearch/opensearch-index-settings.md
@@ -163,6 +163,7 @@ PUT my-index/_settings
 ## Change History
 
 - **v3.4.0** (2025-01-15): Added custom creation_date setting and tier-aware shard limit validation
+- **v2.19.0** (2024-12-10): Fixed Get Index Settings API to show `number_of_routing_shards` when explicitly set at index creation
 - **v2.18.0** (2024-11-05): Fixed default value handling when `index.number_of_replicas` and `index.number_of_routing_shards` are set to `null`
 
 
@@ -176,6 +177,7 @@ PUT my-index/_settings
 |---------|-----|-------------|---------------|
 | v3.4.0 | [#19931](https://github.com/opensearch-project/OpenSearch/pull/19931) | Allow setting index.creation_date on index creation |   |
 | v3.4.0 | [#19532](https://github.com/opensearch-project/OpenSearch/pull/19532) | Add separate shard limit validation for local and remote indices | [#19610](https://github.com/opensearch-project/OpenSearch/issues/19610) |
+| v2.19.0 | [#16294](https://github.com/opensearch-project/OpenSearch/pull/16294) | Fix get index settings API doesn't show `number_of_routing_shards` when explicitly set | [#14199](https://github.com/opensearch-project/OpenSearch/issues/14199) |
 | v2.18.0 | [#14948](https://github.com/opensearch-project/OpenSearch/pull/14948) | Fix update settings with null replica not honoring cluster setting |   |
 | v2.18.0 | [#16331](https://github.com/opensearch-project/OpenSearch/pull/16331) | Fix wrong default value when setting routing shards to null | [#16327](https://github.com/opensearch-project/OpenSearch/issues/16327) |
 
@@ -183,3 +185,4 @@ PUT my-index/_settings
 - [Issue #19610](https://github.com/opensearch-project/OpenSearch/issues/19610): Feature request for tier-agnostic shard limit validation
 - [Issue #14810](https://github.com/opensearch-project/OpenSearch/issues/14810): Bug report for replica count default
 - [Issue #16327](https://github.com/opensearch-project/OpenSearch/issues/16327): Bug report for routing shards default
+- [Issue #14199](https://github.com/opensearch-project/OpenSearch/issues/14199): Bug report for missing `number_of_routing_shards` in Get Index Settings API

--- a/docs/releases/v2.19.0/features/opensearch/index-settings-api.md
+++ b/docs/releases/v2.19.0/features/opensearch/index-settings-api.md
@@ -1,0 +1,73 @@
+---
+tags:
+  - opensearch
+---
+# Index Settings API
+
+## Summary
+
+Fixed a bug where the `index.number_of_routing_shards` setting was not displayed in the Get Index Settings API response when it was explicitly set during index creation. Previously, users had to query `_cluster/state` to retrieve this value.
+
+## Details
+
+### What's New in v2.19.0
+
+The `index.number_of_routing_shards` setting is now properly returned by the Get Index Settings API (`GET {index}/_settings`) when it was explicitly specified at index creation time.
+
+### Background
+
+The `number_of_routing_shards` setting determines the number of routing shards used when splitting an index. This value is important for planning index split operations, as it defines the valid split factors and maximum number of splits possible.
+
+Prior to this fix:
+- The setting was stored in `IndexMetadata` but removed from the settings before persisting
+- Users could only retrieve the value via `GET _cluster/state` under `routing_num_shards`
+- The Get Index Settings API did not include this setting even when explicitly set
+
+### Technical Changes
+
+1. **IndexMetadata.java**: Added `Property.NotCopyableOnResize` to the `INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING` definition to prevent the setting from being copied during resize operations while allowing it to be persisted in index settings.
+
+2. **MetadataCreateIndexService.java**: Removed the code that explicitly stripped `INDEX_NUMBER_OF_ROUTING_SHARDS_SETTING` from the aggregated settings before building the index metadata.
+
+### Behavior
+
+| Scenario | Before v2.19.0 | After v2.19.0 |
+|----------|----------------|---------------|
+| Explicitly set `number_of_routing_shards` | Not shown in `_settings` | Shown in `_settings` |
+| Default `number_of_routing_shards` | Not shown | Not shown (expected) |
+
+### Usage Example
+
+```bash
+# Create index with explicit routing shards
+PUT /my-index
+{
+  "settings": {
+    "number_of_shards": 2,
+    "number_of_replicas": 1,
+    "number_of_routing_shards": 4
+  }
+}
+
+# Get settings - now shows number_of_routing_shards
+GET /my-index/_settings?flat_settings=true
+
+# Response includes:
+# "index.number_of_routing_shards": "4"
+```
+
+## Limitations
+
+- The setting is only shown when explicitly set at index creation time
+- Default/calculated values are not displayed (this is expected behavior)
+- This is a static setting and cannot be changed after index creation
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16294](https://github.com/opensearch-project/OpenSearch/pull/16294) | Fix get index settings API doesn't show `number_of_routing_shards` when explicitly set | [#14199](https://github.com/opensearch-project/OpenSearch/issues/14199) |
+
+### Issues
+- [#14199](https://github.com/opensearch-project/OpenSearch/issues/14199): Bug report describing the missing setting in API response

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -8,6 +8,7 @@
 - Cluster State
 - Deprecation Logger Cache Bound
 - gRPC Settings
+- Index Settings API
 - IP Field
 - List Shards API
 - Match Only Text Field


### PR DESCRIPTION
## Summary

Adds documentation for the Index Settings API fix in OpenSearch v2.19.0.

### Changes
- **Release report**: `docs/releases/v2.19.0/features/opensearch/index-settings-api.md`
- **Feature report update**: `docs/features/opensearch/opensearch-index-settings.md` (added v2.19.0 to Change History and References)
- **Release index update**: Added "Index Settings API" to v2.19.0 index

### Key Fix
Fixed a bug where `index.number_of_routing_shards` was not displayed in the Get Index Settings API response when explicitly set during index creation.

### Related
- OpenSearch PR: [#16294](https://github.com/opensearch-project/OpenSearch/pull/16294)
- OpenSearch Issue: [#14199](https://github.com/opensearch-project/OpenSearch/issues/14199)
- Investigation Issue: #2046