### PR TITLE
docs: add ingest-pipeline-deprecation report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-ingest-pipeline-update.md
+++ b/docs/features/opensearch/opensearch-ingest-pipeline-update.md
@@ -1,0 +1,120 @@
+---
+tags:
+  - opensearch
+---
+# Ingest Pipeline Update Operation Behavior
+
+## Summary
+
+This document describes the behavior of ingest pipelines during document update operations in OpenSearch. The Update API has historically executed default and final ingest pipelines when updating existing documents, but this behavior is inconsistent with the Bulk API and can produce unexpected results. Starting in v2.19.0, this behavior is deprecated and will be removed in v3.0.0.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Update Operation Flow"
+        A[Update Request] --> B[TransportUpdateAction]
+        B --> C{Document Exists?}
+        C -->|Yes| D[Fetch Existing Doc]
+        C -->|No| E[Return Error]
+        D --> F[Merge with Update]
+        F --> G{Has Default/Final Pipeline?}
+        G -->|Yes, v2.19+| H[Emit Deprecation Warning]
+        G -->|No| I[Skip Warning]
+        H --> J[Execute Pipeline]
+        I --> K[Index Document]
+        J --> K
+    end
+```
+
+### Pipeline Execution by Operation Type
+
+| Operation | Default Pipeline | Final Pipeline | System Pipeline |
+|-----------|-----------------|----------------|-----------------|
+| Index | ✅ Executes | ✅ Executes | ✅ Executes |
+| Single Update | ⚠️ Deprecated | ⚠️ Deprecated | ✅ Executes |
+| Bulk Index | ✅ Executes | ✅ Executes | ✅ Executes |
+| Bulk Update | ❌ Does not execute | ❌ Does not execute | ✅ Executes |
+| Bulk Update (doc_as_upsert=true) | ✅ Executes | ✅ Executes | ✅ Executes |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.default_pipeline` | Pipeline to run on all index operations | `_none` |
+| `index.final_pipeline` | Pipeline that always runs after default pipeline | `_none` |
+
+### Usage Example
+
+#### Creating an Index with Pipeline
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index.default_pipeline": "my-pipeline"
+  }
+}
+```
+
+#### Update Operation (Triggers Deprecation Warning in v2.19.0+)
+
+```json
+POST /my-index/_update/1
+{
+  "doc": {
+    "field": "new_value"
+  }
+}
+```
+
+Response headers will include:
+```
+Warning: 299 OpenSearch "the index [my-index] has a default ingest pipeline or a final ingest pipeline, the support of the ingest pipelines for update operation causes unexpected result and will be removed in 3.0.0"
+```
+
+#### Alternative: Use Index Operation
+
+```json
+PUT /my-index/_doc/1
+{
+  "field": "new_value",
+  "other_field": "preserved_value"
+}
+```
+
+#### Alternative: Use Bulk with doc_as_upsert
+
+```json
+POST /_bulk
+{"update": {"_index": "my-index", "_id": "1"}}
+{"doc": {"field": "new_value"}, "doc_as_upsert": true}
+```
+
+## Limitations
+
+- Update operations cannot explicitly specify a pipeline parameter
+- The deprecation warning cannot be suppressed in v2.19.0
+- System ingest pipelines (v3.1.0+) always execute on updates, regardless of this deprecation
+
+## Change History
+
+- **v3.0.0** (planned): Remove ingest pipeline execution for update operations entirely
+- **v2.19.0** (2024-12-02): Deprecated ingest pipeline execution for update operations with warning
+
+## References
+
+### Documentation
+- [Update Document API](https://docs.opensearch.org/latest/api-reference/document-apis/update-document/): Official API documentation
+- [Ingest Pipelines](https://docs.opensearch.org/latest/ingest-pipelines/): Ingest pipeline overview
+- [Blog: Making ingestion smarter](https://opensearch.org/blog/making-ingestion-smarter-system-ingest-pipelines-in-opensearch/): Discusses update operation behavior with system pipelines
+
+### Pull Requests
+| Version | PR | Description | Related Issue |
+|---------|-----|-------------|---------------|
+| v2.19.0 | [#16712](https://github.com/opensearch-project/OpenSearch/pull/16712) | Deprecate performing update operation with default pipeline or final pipeline | [#16663](https://github.com/opensearch-project/OpenSearch/issues/16663) |
+
+### Issues
+- [#16663](https://github.com/opensearch-project/OpenSearch/issues/16663): Bug report - Ingest pipeline bulk update issue

--- a/docs/releases/v2.19.0/features/opensearch/ingest-pipeline-deprecation.md
+++ b/docs/releases/v2.19.0/features/opensearch/ingest-pipeline-deprecation.md
@@ -1,0 +1,75 @@
+---
+tags:
+  - opensearch
+---
+# Ingest Pipeline Deprecation for Update Operations
+
+## Summary
+
+OpenSearch v2.19.0 deprecates the execution of default and final ingest pipelines during Update API operations. When an index has a `default_pipeline` or `final_pipeline` configured and an update operation is performed on an existing document, OpenSearch now emits a deprecation warning. This behavior will be removed entirely in v3.0.0.
+
+## Details
+
+### What's New in v2.19.0
+
+The Update API does not officially support ingest pipelines. However, when an index has a default or final pipeline configured and a document exists, the pipeline was being executed during update operations. This behavior was inconsistent with the Bulk API (which does not trigger pipelines for update operations) and could produce unexpected results.
+
+Starting in v2.19.0:
+- Update operations on indexes with `default_pipeline` or `final_pipeline` settings emit a deprecation warning
+- The warning message: `the index [<index-name>] has a default ingest pipeline or a final ingest pipeline, the support of the ingest pipelines for update operation causes unexpected result and will be removed in 3.0.0`
+- The pipeline still executes (for backward compatibility), but users are warned to adjust their workflows
+
+### Technical Changes
+
+The change was implemented in `TransportUpdateAction.java`:
+
+```java
+final Settings indexSettings = indexService.getIndexSettings().getSettings();
+if (IndexSettings.DEFAULT_PIPELINE.exists(indexSettings) || 
+    IndexSettings.FINAL_PIPELINE.exists(indexSettings)) {
+    deprecationLogger.deprecate(
+        "update_operation_with_ingest_pipeline",
+        "the index [" + indexRequest.index() + 
+        "] has a default ingest pipeline or a final ingest pipeline, " +
+        "the support of the ingest pipelines for update operation causes " +
+        "unexpected result and will be removed in 3.0.0"
+    );
+}
+```
+
+### Behavior Comparison
+
+| Operation | v2.18.0 and earlier | v2.19.0 | v3.0.0 (planned) |
+|-----------|---------------------|---------|------------------|
+| Index with default/final pipeline | Pipeline executes | Pipeline executes | Pipeline executes |
+| Update with default/final pipeline | Pipeline executes (silently) | Pipeline executes + warning | Pipeline does NOT execute |
+| Bulk update with default/final pipeline | Pipeline does NOT execute | Pipeline does NOT execute | Pipeline does NOT execute |
+
+### Migration Guidance
+
+If your application relies on ingest pipelines being executed during update operations:
+
+1. **Review your update workflows**: Identify any update operations that depend on pipeline processing
+2. **Consider alternatives**:
+   - Use index operations instead of updates when pipeline processing is needed
+   - Implement the transformation logic in your application before sending updates
+   - Use the Bulk API with `doc_as_upsert: true` if you need pipeline execution
+3. **Test with v3.0.0**: Before upgrading to v3.0.0, test your application to ensure update operations work correctly without pipeline execution
+
+## Limitations
+
+- The deprecation warning is emitted for every update operation on affected indexes, which may increase log volume
+- No configuration option to suppress the warning while maintaining the deprecated behavior
+
+## References
+
+### Documentation
+- [Update Document API](https://docs.opensearch.org/2.19/api-reference/document-apis/update-document/): Official documentation with deprecation notice
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16712](https://github.com/opensearch-project/OpenSearch/pull/16712) | Deprecate performing update operation with default pipeline or final pipeline | [#16663](https://github.com/opensearch-project/OpenSearch/issues/16663) |
+
+### Issues
+- [#16663](https://github.com/opensearch-project/OpenSearch/issues/16663): Bug report about inconsistent ingest pipeline behavior between Update API and Bulk API

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -9,6 +9,7 @@
 - Deprecation Logger Cache Bound
 - gRPC Settings
 - Index Settings API
+- Ingest Pipeline Deprecation
 - IP Field
 - List Shards API
 - Match Only Text Field


### PR DESCRIPTION
## Summary

Adds documentation for the ingest pipeline deprecation feature in OpenSearch v2.19.0.

### Reports Created
- Release report: `docs/releases/v2.19.0/features/opensearch/ingest-pipeline-deprecation.md`
- Feature report: `docs/features/opensearch/opensearch-ingest-pipeline-update.md`

### Key Changes in v2.19.0
- Update operations on indexes with `default_pipeline` or `final_pipeline` now emit a deprecation warning
- This behavior will be removed in v3.0.0 to align with Bulk API behavior

### Resources Used
- PR: [#16712](https://github.com/opensearch-project/OpenSearch/pull/16712)
- Issue: [#16663](https://github.com/opensearch-project/OpenSearch/issues/16663)
- Docs: https://docs.opensearch.org/2.19/api-reference/document-apis/update-document/

Closes #2045