### PR TITLE
docs: add inner-hits-optimization report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-inner-hits.md
+++ b/docs/features/opensearch/opensearch-inner-hits.md
@@ -1,0 +1,97 @@
+---
+tags:
+  - opensearch
+---
+# Inner Hits
+
+## Summary
+
+Inner hits allow retrieval of nested documents or child documents that matched a nested or parent-child query. When searching with nested objects or parent-join relationships, the matching inner documents are hidden by default. The `inner_hits` parameter exposes these matching documents in the search response.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Search Request"
+        Q[Query with inner_hits]
+    end
+    subgraph "Query Phase"
+        NQ[Nested Query]
+        IM[Inner Hits Matching]
+    end
+    subgraph "Fetch Phase"
+        IHP[Inner Hits Phase]
+        NI[Nested Identity Resolution]
+        DOC[Document Fetch]
+    end
+    Q --> NQ
+    NQ --> IM
+    IM --> IHP
+    IHP --> NI
+    NI --> DOC
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `InnerHitsContext` | Manages inner hit sub-contexts during search |
+| `InnerHitSubContext` | Base class for inner hit execution contexts |
+| `NestedInnerHitSubContext` | Specialized context for nested document inner hits |
+| `FetchPhase` | Executes inner hits retrieval during document fetch |
+| `DocumentMapper` | Resolves nested object mappers for inner hit documents |
+
+### Usage Example
+
+```json
+GET /my-index/_search
+{
+  "query": {
+    "nested": {
+      "path": "comments",
+      "query": {
+        "match": { "comments.text": "opensearch" }
+      },
+      "inner_hits": {
+        "size": 3,
+        "_source": ["comments.text", "comments.author"]
+      }
+    }
+  }
+}
+```
+
+### Inner Hits Options
+
+| Option | Description | Default |
+|--------|-------------|---------|
+| `name` | Name for the inner hit definition | Auto-generated |
+| `size` | Maximum number of inner hits to return | 3 |
+| `from` | Offset for inner hits pagination | 0 |
+| `sort` | Sort order for inner hits | By score |
+| `_source` | Source filtering for inner hits | All fields |
+| `highlight` | Highlighting configuration | None |
+
+## Limitations
+
+- Inner hits add overhead to query execution, especially with many nested documents
+- Each inner hit requires additional document fetches
+- Large `size` values can significantly impact performance
+
+## Change History
+
+- **v2.19.0** (2025-01-22): Performance optimization using BitSet caching and direct ObjectMapper lookup for nested inner hits
+
+## References
+
+### Documentation
+- [Inner Hits](https://docs.opensearch.org/latest/search-plugins/searching-data/inner-hits/)
+- [Nested Query](https://docs.opensearch.org/latest/query-dsl/joining/nested/)
+- [Nested Field Type](https://docs.opensearch.org/latest/field-types/supported-field-types/nested/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#16937](https://github.com/opensearch-project/OpenSearch/pull/16937) | Optimize innerhits query performance |

--- a/docs/releases/v2.19.0/features/opensearch/inner-hits-optimization.md
+++ b/docs/releases/v2.19.0/features/opensearch/inner-hits-optimization.md
@@ -1,0 +1,53 @@
+---
+tags:
+  - opensearch
+---
+# Inner Hits Optimization
+
+## Summary
+
+OpenSearch 2.19.0 introduces performance optimizations for inner hits queries used with nested documents. The optimization reduces redundant TermQuery executions by leveraging BitSet caching and direct ObjectMapper lookup for nested inner hit contexts.
+
+## Details
+
+### What's New in v2.19.0
+
+Inner hits queries on nested documents previously suffered from inefficient query execution patterns. The optimization addresses two key areas:
+
+1. **Fast ObjectMapper Lookup**: When the search context is a `NestedInnerHitSubContext`, the system now directly retrieves the `ObjectMapper` instead of iterating through all object mappers and executing TermQuery filters for each.
+
+2. **BitSet Caching for Child Filters**: Child filters (simple TermQueries) are now cached using `bitsetFilterCache`, eliminating redundant query executions during nested identity resolution.
+
+### Technical Changes
+
+| Component | Change |
+|-----------|--------|
+| `DocumentMapper.findNestedObjectMapper()` | Added fast path for `NestedInnerHitSubContext` to directly return the child ObjectMapper |
+| `DocumentMapper.containSubDocIdWithObjectMapper()` | New method using BitSet from `bitsetFilterCache` instead of Weight/Scorer |
+| `FetchPhase.getInternalNestedIdentity()` | Replaced Weight/Scorer iteration with BitSet lookup via `bitsetFilterCache` |
+| `NestedQueryBuilder.NestedInnerHitSubContext` | Made public and added `getChildObjectMapper()` accessor |
+
+### Performance Impact
+
+The optimization significantly reduces query latency for searches with `inner_hits` on nested documents, particularly when:
+- Documents contain many nested objects
+- Multiple inner hits are returned per parent document
+- The `_source` field is large
+
+In production environments with 80+ nested sub-documents per parent, fetch phase times improved from 3+ seconds to under 1 second.
+
+## Limitations
+
+- The optimization is specific to nested document inner hits; parent-child join inner hits are not affected
+- Performance gains are most noticeable with high nested document counts
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16937](https://github.com/opensearch-project/OpenSearch/pull/16937) | Optimize innerhits query performance | [#16878](https://github.com/opensearch-project/OpenSearch/issues/16878) |
+
+### Documentation
+- [Inner Hits](https://docs.opensearch.org/2.19/search-plugins/searching-data/inner-hits/)
+- [Nested Query](https://docs.opensearch.org/2.19/query-dsl/joining/nested/)

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch
 - Auto Date Histogram Bug Fix
+- Inner Hits Optimization
 - CI Fixes
 - Cluster State
 - Deprecation Logger Cache Bound


### PR DESCRIPTION
## Summary

Adds documentation for the Inner Hits Optimization feature in OpenSearch v2.19.0.

### Reports Created
- Release report: `docs/releases/v2.19.0/features/opensearch/inner-hits-optimization.md`
- Feature report: `docs/features/opensearch/opensearch-inner-hits.md`

### Key Changes in v2.19.0
- Fast ObjectMapper lookup for NestedInnerHitSubContext
- BitSet caching for child filters via bitsetFilterCache
- Significant performance improvement for nested document inner hits queries

### Source
- PR: [opensearch-project/OpenSearch#16937](https://github.com/opensearch-project/OpenSearch/pull/16937)
- Issue: [opensearch-project/OpenSearch#16878](https://github.com/opensearch-project/OpenSearch/issues/16878)