### PR TITLE
docs: add reader-writer-separation report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-search-replica-reader-writer-separation.md
+++ b/docs/features/opensearch/opensearch-search-replica-reader-writer-separation.md
@@ -140,6 +140,7 @@ POST /my-index/_scale
 ## Change History
 
 - **v3.0.0** (2025-04-08): Added scale-to-zero support, auto-expand search replicas, and strict routing setting
+- **v2.19.0** (2025-01-10): Limited to remote-store-enabled clusters only; updated recovery flow to use empty store recovery instead of peer recovery; excluded search replicas from in-sync allocation ID set
 - **v2.17.0** (2024-09): Initial experimental implementation with search replicas and pull-based replication
 
 
@@ -159,6 +160,7 @@ POST /my-index/_scale
 | v3.0.0 | [#17299](https://github.com/opensearch-project/OpenSearch/pull/17299) | Scale-to-zero (search_only mode) support | [#15306](https://github.com/opensearch-project/OpenSearch/issues/15306) |
 | v3.0.0 | [#17741](https://github.com/opensearch-project/OpenSearch/pull/17741) | AutoExpand for SearchReplica | [#17310](https://github.com/opensearch-project/OpenSearch/issues/17310) |
 | v3.0.0 | [#17803](https://github.com/opensearch-project/OpenSearch/pull/17803) | Search Only strict routing setting | [#17424](https://github.com/opensearch-project/OpenSearch/issues/17424) |
+| v2.19.0 | [#16760](https://github.com/opensearch-project/OpenSearch/pull/16760) | Limit RW separation to remote store enabled clusters and update recovery flow | [#15952](https://github.com/opensearch-project/OpenSearch/issues/15952) |
 | v2.17.0 | [#15368](https://github.com/opensearch-project/OpenSearch/pull/15368) | Initial search replica implementation |   |
 | v2.17.0 | [#15445](https://github.com/opensearch-project/OpenSearch/pull/15445) | Pull-based replica support |   |
 

--- a/docs/releases/v2.19.0/features/opensearch/reader-writer-separation.md
+++ b/docs/releases/v2.19.0/features/opensearch/reader-writer-separation.md
@@ -1,0 +1,74 @@
+---
+tags:
+  - opensearch
+---
+# Reader Writer Separation
+
+## Summary
+
+In v2.19.0, Reader-Writer Separation is now limited to remote-store-enabled clusters only. This change simplifies the architecture by removing support for document replication-based search replicas and updates the recovery flow for search replicas to use empty store recovery instead of peer recovery, eliminating primary shard communication during recovery.
+
+## Details
+
+### What's New in v2.19.0
+
+This release introduces significant changes to how search replicas are initialized and managed:
+
+1. **Remote Store Requirement**: Search replicas now require remote store to be enabled. The validation error message changed from requiring `SEGMENT` replication type to requiring `remote_store.enabled = true`.
+
+2. **Empty Store Recovery**: Search replicas now recover using `EmptyStoreRecoverySource` instead of `PeerRecoverySource`, syncing segments directly from remote store without primary communication.
+
+3. **In-Sync Allocation ID Exclusion**: Search replicas are excluded from the in-sync allocation ID set, ensuring primaries don't track or validate search replica presence.
+
+4. **Throttling Decider Updates**: The throttling allocation decider now handles search replicas specially, allowing remote-based search replicas to bypass outgoing recovery limits.
+
+### Technical Changes
+
+```mermaid
+flowchart TB
+    subgraph "Before v2.19.0"
+        A1[Search Replica] -->|Peer Recovery| P1[Primary Shard]
+        P1 -->|Segment Transfer| A1
+    end
+    
+    subgraph "v2.19.0+"
+        A2[Search Replica] -->|Empty Store Recovery| RS[Remote Store]
+        RS -->|Direct Segment Sync| A2
+        P2[Primary Shard] -.->|No Communication| A2
+    end
+```
+
+### Key Implementation Details
+
+| Change | Description |
+|--------|-------------|
+| Recovery Source | Changed from `PeerRecoverySource` to `EmptyStoreRecoverySource` for search replicas |
+| Validation | Now checks `SETTING_REMOTE_STORE_ENABLED` instead of `INDEX_REPLICATION_TYPE_SETTING` |
+| Allocation IDs | Search replicas excluded from `allAllocationIds` set in routing table |
+| Throttling | Remote-based search replicas bypass primary outgoing recovery limits |
+| Retention Leases | Search replicas filtered from peer recovery retention lease renewal |
+
+### Recovery Flow Changes
+
+The recovery flow for search replicas has been updated:
+
+1. **Initial Recovery**: Uses `EmptyStoreRecoverySource` to bootstrap from remote store
+2. **Existing Store Recovery**: After restart, uses `ExistingStoreRecoverySource` with local data
+3. **Remote Store Restore**: During restore operations, search replicas maintain their assignment if already allocated
+
+## Limitations
+
+- Search replicas are only supported on remote-store-enabled clusters
+- Document replication clusters cannot use search replicas
+- Search replicas cannot be promoted to primary shards
+- Requires segment replication to be enabled (implicit with remote store)
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16760](https://github.com/opensearch-project/OpenSearch/pull/16760) | Limit RW separation to remote store enabled clusters and update recovery flow | [#15952](https://github.com/opensearch-project/OpenSearch/issues/15952) |
+
+### Related Issues
+- [#15952](https://github.com/opensearch-project/OpenSearch/issues/15952): [RW Separation] Change search replica recovery flow

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -15,6 +15,7 @@
 - List Shards API
 - Match Only Text Field
 - Multi-Search Request Cancellation Fix
+- Reader Writer Separation
 - Remote Repository Validation
 - Remote Shards Balance Fix
 - Remote State Manifest


### PR DESCRIPTION
## Summary

This PR adds documentation for the Reader Writer Separation feature changes in OpenSearch v2.19.0.

### Changes
- Created release report: `docs/releases/v2.19.0/features/opensearch/reader-writer-separation.md`
- Updated feature report: `docs/features/opensearch/opensearch-search-replica-reader-writer-separation.md`
- Updated release index: `docs/releases/v2.19.0/index.md`

### Key Changes in v2.19.0
- Limited Reader-Writer Separation to remote-store-enabled clusters only
- Updated recovery flow to use empty store recovery instead of peer recovery
- Excluded search replicas from in-sync allocation ID set
- Updated throttling decider to handle remote-based search replicas

### References
- PR: [#16760](https://github.com/opensearch-project/OpenSearch/pull/16760)
- Issue: [#15952](https://github.com/opensearch-project/OpenSearch/issues/15952)

Closes #2043