### PR TITLE
docs: add sort-field-merging report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-sort-field-merging.md
+++ b/docs/features/opensearch/opensearch-sort-field-merging.md
@@ -1,0 +1,97 @@
+---
+tags:
+  - opensearch
+---
+# Sort Field Merging
+
+## Summary
+
+Sort field merging handles the combination of search results from multiple shards when sorting by numeric fields. When indices have different numeric field types for the same field name, OpenSearch widens the sort field type to ensure correct comparison across all results.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Search Phase"
+        A[Query Shards] --> B[Collect TopDocs]
+        B --> C[Merge TopDocs]
+    end
+    subgraph "Sort Field Merging"
+        C --> D{Check Field Types}
+        D -->|Same Type| E[Use Original Type]
+        D -->|Different Types| F[Determine Widening Type]
+        F -->|All Integer| G[Widen to Long]
+        F -->|Has Float| H[Widen to Double]
+        G --> I[SortedWiderNumericSortField]
+        H --> I
+    end
+    I --> J[Merged Results]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SearchPhaseController` | Coordinates the merge of search results from multiple shards |
+| `SortedWiderNumericSortField` | Custom sort field that handles comparison of widened numeric types |
+| `IndexFieldData.XFieldComparatorSource` | Provides the reduced type for sort field comparison |
+
+### Supported Types
+
+| Original Type | Widened To | Notes |
+|---------------|------------|-------|
+| `long` | `Long` | When all fields are integer types |
+| `integer` | `Long` | When all fields are integer types |
+| `short` | `Long` | When all fields are integer types |
+| `byte` | `Long` | When all fields are integer types |
+| `double` | `Double` | When any field is floating-point |
+| `float` | `Double` | When any field is floating-point |
+| `half_float` | `Double` | When any field is floating-point |
+
+### Usage Example
+
+When searching across multiple indices with different field types:
+
+```json
+GET /index_long,index_integer/_search
+{
+  "query": { "match_all": {} },
+  "sort": [
+    { "numeric_field": { "order": "asc" } }
+  ]
+}
+```
+
+OpenSearch automatically detects the different field types and applies appropriate widening.
+
+## Limitations
+
+- `unsigned_long` fields are not supported for type widening and cannot be mixed with other numeric types
+- When mixing integer and floating-point types, precision loss may occur for very large integer values (> 2^53 - 1)
+- Custom sort field comparators may not be compatible with type widening
+
+## Change History
+
+- **v2.19.0** (2025-01-10): Fixed type widening to use `Long` for integer-only fields, preventing precision loss for large values ([#16881](https://github.com/opensearch-project/OpenSearch/pull/16881))
+- **v2.6.0**: Initial implementation of sort field widening using `Double` for all numeric types ([#6424](https://github.com/opensearch-project/OpenSearch/pull/6424))
+
+## References
+
+### Documentation
+
+- [Sort results](https://docs.opensearch.org/latest/search-plugins/searching-data/sort/) - OpenSearch documentation on sorting search results
+- [Numeric field types](https://docs.opensearch.org/latest/field-types/supported-field-types/numeric/) - Supported numeric field types
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#16881](https://github.com/opensearch-project/OpenSearch/pull/16881) | Use the correct type to widen the sort fields when merging top docs |
+| v2.6.0 | [#6424](https://github.com/opensearch-project/OpenSearch/pull/6424) | Initial sort field widening implementation |
+
+### Related Issues
+
+- [#16860](https://github.com/opensearch-project/OpenSearch/issues/16860) - Bug report for incorrect sorting with large values
+- [#6326](https://github.com/opensearch-project/OpenSearch/issues/6326) - Original issue for sort optimization

--- a/docs/releases/v2.19.0/features/opensearch/sort-field-merging.md
+++ b/docs/releases/v2.19.0/features/opensearch/sort-field-merging.md
@@ -1,0 +1,74 @@
+---
+tags:
+  - opensearch
+---
+# Sort Field Merging
+
+## Summary
+
+Fixed incorrect sorting behavior when merging top docs from multiple shards with different numeric field types. The fix ensures correct type widening is used when sort values exceed the maximum safe integer value for double precision.
+
+## Details
+
+### What's New in v2.19.0
+
+This release fixes a bug in the sort field merging logic during the search phase when combining results from multiple shards.
+
+### Problem
+
+When sorting across indices with different numeric field types (e.g., `long` and `integer`), OpenSearch previously used `double` to widen all sort fields. This caused incorrect sorting when values exceeded `2^53 - 1` (the maximum safe integer for double precision), as large `long` values would lose precision when converted to `double`.
+
+### Solution
+
+The `SearchPhaseController.createSort()` method was updated to:
+
+1. Detect the actual numeric type of sort fields using `IndexFieldData.XFieldComparatorSource.reducedType()`
+2. Use `Long` type for widening when all sort fields are integer types (long, integer, short, byte)
+3. Use `Double` type for widening only when floating-point types (double, float, half_float) are involved
+4. Create appropriate `SortedWiderNumericSortField` comparators based on the widened type
+
+### Technical Changes
+
+| Component | Change |
+|-----------|--------|
+| `SearchPhaseController` | Updated `createSort()` to determine correct widening type based on field types |
+| `SortedWiderNumericSortField` | Added type-specific comparators for `Long` and `Double` types |
+
+### Code Changes
+
+The key changes in `SearchPhaseController.java`:
+
+```java
+private static SortField.Type getSortType(SortField sortField) {
+    if (sortField.getComparatorSource() instanceof IndexFieldData.XFieldComparatorSource) {
+        return ((IndexFieldData.XFieldComparatorSource) sortField.getComparatorSource()).reducedType();
+    } else {
+        return sortField instanceof SortedNumericSortField
+            ? ((SortedNumericSortField) sortField).getNumericType()
+            : sortField.getType();
+    }
+}
+```
+
+The `SortedWiderNumericSortField` now uses type-specific comparators:
+
+- For `Long` type: `Comparator.comparingLong(Number::longValue)`
+- For `Double` type: `Comparator.comparingDouble(Number::doubleValue)`
+
+## Limitations
+
+- `unsigned_long` fields are not supported by widening sort since they cannot be used with other numeric types
+- When mixing integer and floating-point types, `Double` widening is still used (potential precision loss for very large integers)
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16881](https://github.com/opensearch-project/OpenSearch/pull/16881) | Use the correct type to widen the sort fields when merging top docs | [#16860](https://github.com/opensearch-project/OpenSearch/issues/16860) |
+
+### Related Issues
+
+- [#16860](https://github.com/opensearch-project/OpenSearch/issues/16860) - Use the correct type to widen the sort fields when merging top field docs
+- [#6326](https://github.com/opensearch-project/OpenSearch/issues/6326) - Original issue for sort optimization type widening

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch
 - Auto Date Histogram Bug Fix
+- Sort Field Merging
 - Inner Hits Optimization
 - CI Fixes
 - Cluster State


### PR DESCRIPTION
## Summary

Add documentation for the Sort Field Merging fix in OpenSearch v2.19.0.

### Reports Created
- Release report: `docs/releases/v2.19.0/features/opensearch/sort-field-merging.md`
- Feature report: `docs/features/opensearch/opensearch-sort-field-merging.md`

### Key Changes in v2.19.0
- Fixed type widening to use `Long` for integer-only fields, preventing precision loss for large values
- Updated `SearchPhaseController.createSort()` to determine correct widening type based on field types
- Added type-specific comparators in `SortedWiderNumericSortField`

### Resources
- PR: [#16881](https://github.com/opensearch-project/OpenSearch/pull/16881)
- Issue: [#16860](https://github.com/opensearch-project/OpenSearch/issues/16860)

Closes #2042