### PR TITLE
docs: add plugin-system report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-plugin-system.md
+++ b/docs/features/opensearch/opensearch-plugin-system.md
@@ -1,0 +1,124 @@
+---
+tags:
+  - opensearch
+---
+# Plugin System
+
+## Summary
+
+OpenSearch's plugin system allows extending core functionality through installable plugins. Plugins can depend on and extend other plugins through the Service Provider Interface (SPI). The system supports both required and optional plugin dependencies.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Plugin Installation"
+        Install[opensearch-plugin install]
+        Validate[Validate Dependencies]
+        Load[Load Plugin]
+    end
+    
+    subgraph "Dependency Resolution"
+        Required[Required Dependencies]
+        Optional[Optional Dependencies]
+    end
+    
+    Install --> Validate
+    Validate --> Required
+    Validate --> Optional
+    Required -->|Missing| Error[Installation Fails]
+    Optional -->|Missing| Warn[Warning + Continue]
+    Required -->|Present| Load
+    Optional -->|Present| Load
+    Warn --> Load
+```
+
+### Plugin Configuration
+
+Plugins declare their metadata and dependencies in the build configuration:
+
+```groovy
+opensearchplugin {
+    name 'my-plugin'
+    description 'My OpenSearch Plugin'
+    classname 'org.opensearch.example.MyPlugin'
+    extendedPlugins = [
+        'required-plugin',           // Required dependency
+        'optional-plugin;optional=true'  // Optional dependency
+    ]
+}
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `PluginInfo` | Stores plugin metadata including name, version, dependencies |
+| `PluginsService` | Manages plugin lifecycle: discovery, loading, initialization |
+| `ExtensiblePlugin` | Interface for plugins that can be extended by other plugins |
+
+### Configuration Options
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `extendedPlugins` | List of plugins this plugin extends | `[]` |
+| `;optional=true` suffix | Marks an extended plugin as optional | Required (no suffix) |
+
+### Plugin Dependency Types
+
+| Type | Syntax | Behavior if Missing |
+|------|--------|---------------------|
+| Required | `'plugin-name'` | Installation fails with error |
+| Optional | `'plugin-name;optional=true'` | Warning logged, installation continues |
+
+### Usage Example
+
+A plugin extending the Security plugin optionally:
+
+```groovy
+// build.gradle
+opensearchplugin {
+    name 'opensearch-my-plugin'
+    description 'Plugin with optional Security integration'
+    classname 'org.opensearch.myplugin.MyPlugin'
+    extendedPlugins = ['opensearch-security;optional=true']
+}
+```
+
+```java
+// MyPlugin.java
+public class MyPlugin extends Plugin {
+    
+    @Override
+    public void onIndexModule(IndexModule indexModule) {
+        // Check if Security plugin is available
+        if (securityPluginAvailable()) {
+            // Use Security SPI for resource sharing
+            registerWithSecurity();
+        }
+        // Core functionality works regardless
+    }
+}
+```
+
+## Limitations
+
+- Optional dependencies require the plugin to handle missing dependency cases gracefully
+- Features depending on optional plugins will not function when those plugins are absent
+- Plugin developers must test both scenarios (with and without optional dependencies)
+
+## Change History
+
+- **v2.19.0** (2025-01-28): Added support for optional extended plugins via `;optional=true` syntax
+
+## References
+
+### Documentation
+- [Installing plugins](https://docs.opensearch.org/latest/install-and-configure/plugins/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#16909](https://github.com/opensearch-project/OpenSearch/pull/16909) | Allow extended plugins to be optional |

--- a/docs/releases/v2.19.0/features/opensearch/plugin-system.md
+++ b/docs/releases/v2.19.0/features/opensearch/plugin-system.md
@@ -1,0 +1,76 @@
+---
+tags:
+  - opensearch
+---
+# Plugin System
+
+## Summary
+
+OpenSearch v2.19.0 introduces support for optional extended plugins, allowing plugins to declare dependencies on other plugins as optional rather than required. This enables plugins to extend functionality from other plugins (like the Security plugin) without requiring those plugins to be installed.
+
+## Details
+
+### What's New in v2.19.0
+
+This release adds a new syntax for declaring optional plugin dependencies in the `extendedPlugins` configuration. Previously, when a plugin extended another plugin through SPI (Service Provider Interface), the extended plugin was required to be installed. Now plugins can mark extended plugins as optional.
+
+### Configuration
+
+Plugins can declare optional dependencies using the new syntax in their build configuration:
+
+```groovy
+opensearchplugin {
+    name 'opensearch-plugin'
+    description 'OpenSearch Plugin'
+    classname 'org.opensearch.example.ExamplePlugin'
+    extendedPlugins = ['opensearch-security;optional=true']
+}
+```
+
+The `;optional=true` suffix indicates that the dependency is optional.
+
+### Technical Changes
+
+| Component | Change |
+|-----------|--------|
+| `PluginInfo` | Added `optionalExtendedPlugins` field to track which extended plugins are optional |
+| `PluginInfo` | Added `isExtendedPluginOptional(String)` method to check if a specific extended plugin is optional |
+| `PluginsService` | Modified to warn instead of fail when optional dependencies are missing |
+| `PluginsService` | Updated JAR hell checking to skip optional missing plugins |
+| `PluginsService` | Updated plugin loading to skip optional missing plugins |
+
+### Behavior
+
+When installing a plugin with optional dependencies:
+
+1. If the optional dependency is not installed, a warning is displayed:
+   ```
+   WARN  org.opensearch.plugins.PluginsService - Missing plugin [opensearch-security], dependency of [my-plugin]
+   WARN  org.opensearch.plugins.PluginsService - Some features of this plugin may not function without the dependencies being installed.
+   ```
+
+2. Installation proceeds successfully
+3. Features requiring the optional dependency will not be available
+
+When the optional dependency is installed, all features work normally.
+
+### Use Case: Plugin Resource Sharing
+
+The primary motivation for this feature is to enable the Security plugin to offer a SPI for resource sharing. Other plugins can extend the Security plugin to share resources, but since Security is optional, plugins need to work both with and without it installed.
+
+This enables scenarios like:
+- Plugins sharing resources through Security's SPI when Security is installed
+- Same plugins functioning (without resource sharing) when Security is not installed
+
+## Limitations
+
+- Optional dependencies only affect installation and loading behavior
+- Features requiring the optional plugin will not work if the plugin is not installed
+- The plugin developer must handle the case where optional dependencies are missing
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16909](https://github.com/opensearch-project/OpenSearch/pull/16909) | Allow extended plugins to be optional | Enables plugin resource sharing use-case |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch
 - Auto Date Histogram Bug Fix
+- Plugin System
 - Sort Field Merging
 - Inner Hits Optimization
 - CI Fixes


### PR DESCRIPTION
## Summary

Adds documentation for the Plugin System feature in OpenSearch v2.19.0.

### Changes
- Release report: `docs/releases/v2.19.0/features/opensearch/plugin-system.md`
- Feature report: `docs/features/opensearch/opensearch-plugin-system.md`
- Updated release index

### Feature Overview
OpenSearch v2.19.0 introduces support for optional extended plugins, allowing plugins to declare dependencies on other plugins as optional rather than required. This enables plugins to extend functionality from other plugins (like the Security plugin) without requiring those plugins to be installed.

### Key Changes
- New `;optional=true` syntax for declaring optional plugin dependencies
- Warning instead of error when optional dependencies are missing
- Enables plugin resource sharing use-case with Security plugin

### References
- PR: https://github.com/opensearch-project/OpenSearch/pull/16909

Closes #2041