### PR TITLE
docs: add sliced-search-optimization report for v2.19.0

### DIFF
--- a/docs/features/opensearch/sliced-search-optimization.md
+++ b/docs/features/opensearch/sliced-search-optimization.md
@@ -1,0 +1,125 @@
+---
+tags:
+  - opensearch
+---
+# Sliced Search Optimization
+
+## Summary
+
+Sliced search optimization improves the efficiency of parallel scroll operations by filtering shards at the coordinator level before fanning out requests. This reduces the number of open scroll contexts and prevents resource exhaustion during large-scale data operations like `delete_by_query` or `update_by_query` with multiple slices.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph Client
+        R[Search Request with Slice]
+    end
+    
+    subgraph Coordinator
+        R --> P[Parse Slice Parameters]
+        P --> F[Filter Shards by Slice]
+        F --> D[Dispatch to Matching Shards]
+    end
+    
+    subgraph "Data Nodes"
+        D --> S1[Shard 0]
+        D --> S2[Shard 3]
+        D --> S3[Shard 6]
+    end
+```
+
+### How Sliced Search Works
+
+Sliced scroll allows parallel processing of large result sets by dividing the work across multiple slices. Each slice targets a subset of shards based on a deterministic mapping:
+
+```json
+GET index/_search?scroll=10m
+{
+  "slice": {
+    "id": 0,
+    "max": 3
+  },
+  "query": {
+    "match_all": {}
+  }
+}
+```
+
+### Slice-to-Shard Mapping
+
+The mapping between slices and shards depends on the relationship between `max` (number of slices) and `numShards`:
+
+| Condition | Mapping Logic |
+|-----------|---------------|
+| `max >= numShards` | Slices distributed over shards: `id % numShards == shardOrdinal` |
+| `max < numShards` | Shards distributed over slices: `shardOrdinal % max == id` |
+
+### Configuration
+
+No additional configuration is required. The optimization is automatically applied when using sliced scroll searches.
+
+### Usage Example
+
+Preview which shards will be targeted for a slice:
+
+```json
+GET test_index/_search_shards
+{
+  "slice": {
+    "id": 0,
+    "max": 3
+  }
+}
+```
+
+Response shows only the shards that will be queried:
+
+```json
+{
+  "shards": [
+    [{"index": "test_index", "shard": 0, ...}],
+    [{"index": "test_index", "shard": 3, ...}],
+    [{"index": "test_index", "shard": 6, ...}]
+  ]
+}
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SliceBuilder` | Builds slice configuration and determines shard matching |
+| `OperationRouting` | Routes search operations to appropriate shards with slice filtering |
+| `ClusterSearchShardsRequest` | Extended to support slice parameters |
+| `RestClusterSearchShardsAction` | Parses slice from request body |
+
+## Limitations
+
+- Sliced scroll is designed for batch processing, not real-time user queries
+- The default limit of 500 open scroll contexts per node still applies
+- Custom routing may affect slice-to-shard distribution
+- Sliced scroll maintains approximate point-in-time consistency across shards
+
+## Change History
+
+- **v2.19.0** (2025-01-14): Coordinator-level shard filtering to reduce scroll contexts ([#16771](https://github.com/opensearch-project/OpenSearch/pull/16771))
+
+## References
+
+### Documentation
+
+- [Scroll API](https://docs.opensearch.org/latest/api-reference/scroll/)
+- [Paginate Results](https://docs.opensearch.org/latest/search-plugins/searching-data/paginate/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#16771](https://github.com/opensearch-project/OpenSearch/pull/16771) | Filter shards for sliced search at coordinator |
+
+### Related Issues
+
+- [#16289](https://github.com/opensearch-project/OpenSearch/issues/16289) - delete_by_query with slices creates too many scroll contexts

--- a/docs/releases/v2.19.0/features/opensearch/sliced-search-optimization.md
+++ b/docs/releases/v2.19.0/features/opensearch/sliced-search-optimization.md
@@ -1,0 +1,97 @@
+---
+tags:
+  - opensearch
+---
+# Sliced Search Optimization
+
+## Summary
+
+OpenSearch v2.19.0 introduces an optimization for sliced scroll searches that significantly reduces the number of open scroll contexts. Previously, sliced searches fanned out to every shard and applied a `MatchNoDocsQuery` filter on non-matching shards. Now, the coordinator filters shards before routing, reducing open scroll contexts from `numShards × numSlices` to `max(numShards, numSlices)`.
+
+## Details
+
+### What's New in v2.19.0
+
+The optimization moves shard filtering from the data node level to the coordinator level. When a sliced search is executed, the coordinator now determines which shards belong to each slice before fanning out requests, avoiding unnecessary scroll context creation on shards that won't return results.
+
+### Technical Changes
+
+#### Coordinator-Level Shard Filtering
+
+The `OperationRouting.searchShards()` method now accepts a `SliceBuilder` parameter. When a slice is specified, shards are filtered based on the slice ID and maximum slice count:
+
+```java
+public boolean shardMatches(int shardOrdinal, int numShards) {
+    if (max >= numShards) {
+        // Slices are distributed over shards
+        return id % numShards == shardOrdinal;
+    }
+    // Shards are distributed over slices
+    return shardOrdinal % max == id;
+}
+```
+
+#### Search Shards API Enhancement
+
+The `_search_shards` API now accepts a request body with slice parameters, allowing users to preview which shards will be targeted for a given slice configuration:
+
+```json
+GET test_index/_search_shards
+{
+  "slice": {
+    "id": 0,
+    "max": 3
+  }
+}
+```
+
+#### Scroll Context Reduction
+
+| Scenario | Before v2.19.0 | After v2.19.0 |
+|----------|----------------|---------------|
+| 36 shards, 10 slices | 360 contexts | 36 contexts |
+| 10 shards, 36 slices | 360 contexts | 36 contexts |
+| 51 shards, 10 slices | 510 contexts | 51 contexts |
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph "Before v2.19.0"
+        A1[Coordinator] --> B1[All Shards]
+        B1 --> C1[MatchNoDocsQuery on non-matching]
+    end
+    
+    subgraph "After v2.19.0"
+        A2[Coordinator] --> F[Filter by Slice]
+        F --> B2[Matching Shards Only]
+    end
+```
+
+### Use Cases
+
+This optimization benefits:
+
+- `delete_by_query` with slices
+- `update_by_query` with slices
+- Sliced scroll searches for large data exports
+- Multi-tenant clusters with concurrent bulk operations
+
+## Limitations
+
+- The optimization applies only to shard-based slicing (default behavior)
+- Custom routing parameters are respected and may affect slice-to-shard mapping
+- The `_search_shards` API body parameter requires OpenSearch 2.19.0+
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16771](https://github.com/opensearch-project/OpenSearch/pull/16771) | Filter shards for sliced search at coordinator | [#16289](https://github.com/opensearch-project/OpenSearch/issues/16289) |
+
+### Documentation
+
+- [Scroll API](https://docs.opensearch.org/2.19/api-reference/scroll/)
+- [Paginate Results](https://docs.opensearch.org/2.19/search-plugins/searching-data/paginate/)

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch
 - Auto Date Histogram Bug Fix
+- Sliced Search Optimization
 - Plugin System
 - Sort Field Merging
 - Inner Hits Optimization


### PR DESCRIPTION
## Summary

This PR adds documentation for the Sliced Search Optimization feature introduced in OpenSearch v2.19.0.

## Changes

- **Release Report**: `docs/releases/v2.19.0/features/opensearch/sliced-search-optimization.md`
- **Feature Report**: `docs/features/opensearch/sliced-search-optimization.md`
- **Release Index**: Updated to include the new feature

## Key Points

- Coordinator-level shard filtering reduces scroll contexts from `numShards × numSlices` to `max(numShards, numSlices)`
- Benefits `delete_by_query`, `update_by_query`, and sliced scroll operations
- `_search_shards` API now accepts slice parameters in request body

## References

- PR: [opensearch-project/OpenSearch#16771](https://github.com/opensearch-project/OpenSearch/pull/16771)
- Issue: [opensearch-project/OpenSearch#16289](https://github.com/opensearch-project/OpenSearch/issues/16289)