### PR TITLE
docs: add gradle-version-catalog report for v2.19.0

### DIFF
--- a/docs/features/opensearch/gradle-version-catalog.md
+++ b/docs/features/opensearch/gradle-version-catalog.md
@@ -1,0 +1,114 @@
+---
+tags:
+  - opensearch
+---
+# Gradle Version Catalog
+
+## Summary
+
+OpenSearch uses Gradle version catalog (`gradle/libs.versions.toml`) to centralize dependency version management. This enables automated dependency updates via Dependabot and provides a single source of truth for library versions across the project.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Version Catalog"
+        TOML[libs.versions.toml]
+        TOML --> V[versions]
+        TOML --> L[libraries]
+        TOML --> B[bundles]
+    end
+    subgraph "Build Files"
+        SBG[server/build.gradle]
+        PBG[plugins/build.gradle]
+    end
+    subgraph "Automation"
+        DB[Dependabot]
+    end
+    V --> L
+    L --> B
+    L --> SBG
+    B --> SBG
+    L --> PBG
+    TOML --> DB
+    DB -->|PRs| TOML
+```
+
+### Components
+
+| Component | Location | Description |
+|-----------|----------|-------------|
+| Version Catalog | `gradle/libs.versions.toml` | Centralized dependency definitions |
+| Versions Section | `[versions]` | Version number declarations |
+| Libraries Section | `[libraries]` | Individual library definitions |
+| Bundles Section | `[bundles]` | Grouped dependencies |
+
+### Configuration
+
+The version catalog file (`gradle/libs.versions.toml`) uses TOML format:
+
+```toml
+[versions]
+lucene = "9.12.0"
+log4j = "2.24.1"
+joda = "2.12.7"
+
+[libraries]
+lucene-core = { group = "org.apache.lucene", name = "lucene-core", version.ref = "lucene" }
+log4japi = { group = "org.apache.logging.log4j", name = "log4j-api", version.ref = "log4j" }
+jodatime = { group = "joda-time", name = "joda-time", version.ref = "joda" }
+
+[bundles]
+lucene = ["lucene-core", "lucene-analysis-common", "lucene-queries", ...]
+```
+
+### Usage Example
+
+In `build.gradle` files:
+
+```groovy
+dependencies {
+    // Single library
+    api libs.jodatime
+    api libs.log4japi
+    
+    // Bundle (multiple libraries)
+    api libs.bundles.lucene
+    
+    // Optional dependency
+    api libs.spatial4j, optional
+}
+```
+
+## Limitations
+
+- Migration is incremental; not all modules use the version catalog yet
+- Some dependencies may still be declared directly in `build.gradle` files
+- Plugin projects may require separate migration efforts
+
+## Change History
+
+- **v2.19.0** (2024-12-05): Expanded version catalog with `[libraries]` and `[bundles]` sections for server dependencies ([#16707](https://github.com/opensearch-project/OpenSearch/pull/16707))
+- **v2.18.0** (2024-10-28): Initial version catalog implementation, migrated from `buildSrc/version.properties` ([#16284](https://github.com/opensearch-project/OpenSearch/pull/16284))
+
+## References
+
+### Documentation
+
+- [Gradle Version Catalogs](https://docs.gradle.org/current/userguide/platforms.html)
+- [Dependabot Gradle Support](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#gradle)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#16707](https://github.com/opensearch-project/OpenSearch/pull/16707) | Make entries for dependencies from server/build.gradle to gradle version catalog |
+| v2.18.0 | [#16284](https://github.com/opensearch-project/OpenSearch/pull/16284) | Switch from buildSrc/version.properties to Gradle version catalog |
+
+### Issues
+
+| Issue | Description |
+|-------|-------------|
+| [#3782](https://github.com/opensearch-project/OpenSearch/issues/3782) | Enable Dependabot for automated dependency upgrades |

--- a/docs/releases/v2.19.0/features/opensearch/gradle-version-catalog.md
+++ b/docs/releases/v2.19.0/features/opensearch/gradle-version-catalog.md
@@ -1,0 +1,97 @@
+---
+tags:
+  - opensearch
+---
+# Gradle Version Catalog
+
+## Summary
+
+OpenSearch v2.19.0 expands the Gradle version catalog (`gradle/libs.versions.toml`) by adding `[libraries]` and `[bundles]` sections for server dependencies. This enables Dependabot to perform automated dependency upgrades and simplifies dependency management across the project.
+
+## Details
+
+### What's New in v2.19.0
+
+This PR migrates dependencies from `server/build.gradle` to the centralized Gradle version catalog, building on the initial version catalog work from PR #16284.
+
+### Technical Changes
+
+#### Version Catalog Structure
+
+The `gradle/libs.versions.toml` file now includes three sections:
+
+| Section | Purpose |
+|---------|---------|
+| `[versions]` | Centralized version definitions |
+| `[libraries]` | Library dependency declarations |
+| `[bundles]` | Grouped dependencies for common use cases |
+
+#### New Library Definitions
+
+Added library entries for core server dependencies:
+
+- **Lucene libraries**: `lucene-core`, `lucene-analysis-common`, `lucene-backward-codecs`, `lucene-grouping`, `lucene-highlighter`, `lucene-join`, `lucene-memory`, `lucene-misc`, `lucene-queries`, `lucene-queryparser`, `lucene-sandbox`, `lucene-spatial-extras`, `lucene-spatial3d`, `lucene-suggest`
+- **Logging**: `log4japi`, `log4jjul`, `log4jcore`
+- **Utilities**: `jodatime`, `tdigest`, `hdrhistogram`, `jna`, `jzlib`, `roaringbitmap`
+- **Spatial**: `spatial4j`, `jtscore`
+- **Reactive**: `reactorcore`, `reactivestreams`
+- **Serialization**: `protobuf`, `jakartaannotation`
+
+#### Lucene Bundle
+
+A new `lucene` bundle groups all Lucene dependencies:
+
+```toml
+[bundles]
+lucene = [
+    "lucene-core",
+    "lucene-analysis-common",
+    "lucene-backward-codecs",
+    "lucene-grouping",
+    "lucene-highlighter",
+    "lucene-join",
+    "lucene-memory",
+    "lucene-misc",
+    "lucene-queries",
+    "lucene-queryparser",
+    "lucene-sandbox",
+    "lucene-spatial-extras",
+    "lucene-spatial3d",
+    "lucene-suggest"
+]
+```
+
+#### Build.gradle Migration
+
+Dependencies in `server/build.gradle` now use catalog references:
+
+```groovy
+// Before
+api "org.apache.lucene:lucene-core:${versions.lucene}"
+api "joda-time:joda-time:${versions.joda}"
+
+// After
+api libs.bundles.lucene
+api libs.jodatime
+```
+
+### Benefits
+
+1. **Automated Dependency Updates**: Dependabot can now create PRs for dependency upgrades
+2. **Centralized Version Management**: Single source of truth for dependency versions
+3. **Simplified Build Files**: Cleaner `build.gradle` files using catalog references
+4. **Bundle Support**: Group related dependencies for easier management
+
+## Limitations
+
+- This PR covers `server/build.gradle` dependencies only; other modules may still use traditional dependency declarations
+- Plugins and other subprojects may need separate migration efforts
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16707](https://github.com/opensearch-project/OpenSearch/pull/16707) | Make entries for dependencies from server/build.gradle to gradle version catalog | Follow-up to #16284 |
+| [#16284](https://github.com/opensearch-project/OpenSearch/pull/16284) | Switch from buildSrc/version.properties to Gradle version catalog | Resolves #3782 |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch
 - Auto Date Histogram Bug Fix
+- Gradle Version Catalog
 - Sliced Search Optimization
 - Plugin System
 - Sort Field Merging


### PR DESCRIPTION
## Summary

Adds documentation for the Gradle Version Catalog feature in OpenSearch v2.19.0.

### Reports Created
- Release report: `docs/releases/v2.19.0/features/opensearch/gradle-version-catalog.md`
- Feature report: `docs/features/opensearch/gradle-version-catalog.md`

### Key Changes in v2.19.0
- Expanded version catalog with `[libraries]` and `[bundles]` sections
- Migrated server/build.gradle dependencies to version catalog
- Enables Dependabot automated dependency upgrades

### Related
- Closes #2039
- PR: opensearch-project/OpenSearch#16707