### PR TITLE
docs: add ip-field-terms-query report for v2.19.0

### DIFF
--- a/docs/features/opensearch/ip-field.md
+++ b/docs/features/opensearch/ip-field.md
@@ -60,6 +60,7 @@ This configuration:
 
 ## Change History
 
+- **v2.19.0** (2025-01-14): Enhanced `terms` query to support more than 1024 IP masks using `MultiRangeQuery` for indexed fields ([#16391](https://github.com/opensearch-project/OpenSearch/pull/16391))
 - **v2.19.0** (2025-01-14): Fixed CIDR notation (IP mask) searching for doc_values-only IP fields ([#16628](https://github.com/opensearch-project/OpenSearch/pull/16628))
 - **v2.12.0** (2024-01-30): Added support for searching IP fields with only doc_values enabled ([#11508](https://github.com/opensearch-project/OpenSearch/pull/11508))
 - **v1.0.0**: Initial implementation of IP field type
@@ -68,9 +69,11 @@ This configuration:
 
 ### Documentation
 - [IP address field type](https://docs.opensearch.org/latest/field-types/supported-field-types/ip/)
+- [Terms query](https://docs.opensearch.org/latest/query-dsl/term/terms/)
 
 ### Pull Requests
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.19.0 | [#16391](https://github.com/opensearch-project/OpenSearch/pull/16391) | Support more than 1024 IP masks in terms query |
 | v2.19.0 | [#16628](https://github.com/opensearch-project/OpenSearch/pull/16628) | Fix doc_values only IP field searching for masks |
 | v2.12.0 | [#11508](https://github.com/opensearch-project/OpenSearch/pull/11508) | Enable doc_values-only searching for IP fields |

--- a/docs/releases/v2.19.0/features/opensearch/ip-field-terms-query.md
+++ b/docs/releases/v2.19.0/features/opensearch/ip-field-terms-query.md
@@ -1,0 +1,95 @@
+---
+tags:
+  - opensearch
+---
+# IP Field Terms Query
+
+## Summary
+
+Enhanced the `terms` query for indexed IP fields to support more than 1024 IP masks (CIDR notation values) by using Lucene's `MultiRangeQuery` instead of `BooleanQuery`. This removes the max clause count limitation that previously caused queries with many IP masks to fail.
+
+## Details
+
+### What's New in v2.19.0
+
+Prior to this release, using a `terms` query on an IP field with more than 1024 CIDR notation values (e.g., `192.168.0.0/24`) would fail with a `TooManyClauses` error because each mask was converted to a clause in a `BooleanQuery`, which has a default limit of 1024 clauses.
+
+This enhancement refactors the `IpFieldMapper` to:
+1. Split input values into concrete IP addresses and CIDR masks
+2. Handle concrete IPs using `InetAddressPoint.newSetQuery` (efficient point query)
+3. Handle CIDR masks using `MultiRangeQuery` for indexed fields (no clause limit)
+4. Fall back to `BooleanQuery` only for doc_values-only fields (still subject to clause limit)
+
+### Technical Changes
+
+The `IpFieldMapper.IpFieldType.termsQuery()` method was refactored:
+
+| Component | Description |
+|-----------|-------------|
+| `splitIpsAndMasks()` | Separates input values into concrete IPs and CIDR masks |
+| `convertIps()` | Creates efficient point/set queries for concrete IP addresses |
+| `convertMasks()` | Creates `MultiRangeQuery` for indexed fields, range queries for doc_values |
+| `MultiIpRangeQueryBuilder` | New inner class extending `MultiRangeQuery.Builder` for IP ranges |
+
+```mermaid
+flowchart TB
+    A[terms query values] --> B[splitIpsAndMasks]
+    B --> C[Concrete IPs]
+    B --> D[CIDR Masks]
+    C --> E[InetAddressPoint.newSetQuery]
+    D --> F{Field indexed?}
+    F -->|Yes| G[MultiRangeQuery]
+    F -->|No| H[BooleanQuery with range clauses]
+    E --> I[Union with BooleanQuery SHOULD]
+    G --> I
+    H --> I
+    I --> J[ConstantScoreQuery]
+```
+
+### Query Behavior by Field Configuration
+
+| Field Config | Concrete IPs | CIDR Masks | Clause Limit |
+|--------------|--------------|------------|--------------|
+| Indexed + doc_values | `IndexOrDocValuesQuery` | `MultiRangeQuery` | None |
+| Indexed only | `InetAddressPoint.newSetQuery` | `MultiRangeQuery` | None |
+| Doc_values only | `SortedSetDocValuesField.newSlowSetQuery` | `BooleanQuery` with range clauses | 1024 |
+
+### Example
+
+```json
+GET logs/_search
+{
+  "query": {
+    "terms": {
+      "client_ip": [
+        "192.168.1.0/24",
+        "10.0.0.0/8",
+        "172.16.0.0/12",
+        "... more than 1024 CIDR masks ..."
+      ]
+    }
+  }
+}
+```
+
+This query now succeeds for indexed IP fields regardless of the number of CIDR masks.
+
+## Limitations
+
+- Doc_values-only IP fields (`index: false`) are still subject to the 1024 clause limit for CIDR masks
+- The enhancement only applies to `terms` queries; other query types are unaffected
+- Performance may vary based on the number and specificity of CIDR ranges
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16391](https://github.com/opensearch-project/OpenSearch/pull/16391) | Support more than 1024 IP/masks with indexed field | [#16200](https://github.com/opensearch-project/OpenSearch/issues/16200) |
+
+### Documentation
+- [IP address field type](https://docs.opensearch.org/2.19/field-types/supported-field-types/ip/)
+- [Terms query](https://docs.opensearch.org/2.19/query-dsl/term/terms/)
+
+### Related Resources
+- [Forum discussion: terms search gives error failed to create query maxclausecount is set to 1024](https://forum.opensearch.org/t/terms-search-gives-error-failed-to-create-query-maxclausecount-is-set-to-1024/21729/8)

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -17,6 +17,7 @@
 - Index Settings API
 - Ingest Pipeline Deprecation
 - IP Field
+- IP Field Terms Query
 - List Shards API
 - Match Only Text Field
 - Multi-Search Request Cancellation Fix


### PR DESCRIPTION
## Summary

Adds documentation for the IP Field Terms Query enhancement in OpenSearch v2.19.0.

## Changes

- Created release report: `docs/releases/v2.19.0/features/opensearch/ip-field-terms-query.md`
- Updated feature report: `docs/features/opensearch/ip-field.md` (added to Change History)
- Updated release index: `docs/releases/v2.19.0/index.md`

## Key Feature

This enhancement allows `terms` queries on indexed IP fields to support more than 1024 CIDR notation values (IP masks) by using Lucene's `MultiRangeQuery` instead of `BooleanQuery`, removing the max clause count limitation.

## Related

- Closes #2037
- PR: opensearch-project/OpenSearch#16391
- Issue: opensearch-project/OpenSearch#16200