### PR TITLE
docs: add fetch-source-context report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-derived-source.md
+++ b/docs/features/opensearch/opensearch-derived-source.md
@@ -156,6 +156,7 @@ Search latency may increase by 10-100% depending on the number of documents retr
 
 - **v3.2.0** (2026-01-10): Integration across get/search/recovery paths - Added DerivedSourceDirectoryReader, DerivedSourceLeafReader, DerivedSourceStoredFieldsReader, TranslogOperationHelper; Added dynamic `index.derived_source.translog.enabled` setting; Fixed flaky test issues from reverted PR #18054; Added Star-Tree mapper compatibility
 - **v3.1.0** (2026-01-10): Initial implementation - Added derive source support for basic field types including Date, Number, Boolean, IP, Keyword, Text, Geo Point, Constant Keyword, Scaled Float, and Wildcard
+- **v2.19.0** (2025-01-24): Propagate source includes/excludes to FieldsVisitor - Added `includes()` and `excludes()` methods to `FieldsVisitor` class; `FetchPhase` now passes `FetchSourceContext` filtering parameters to `FieldsVisitor`; Enables derived source implementations to skip reconstruction of excluded fields
 
 
 ## References
@@ -171,6 +172,7 @@ Search latency may increase by 10-100% depending on the number of documents retr
 |---------|-----|-------------|---------------|
 | v3.2.0 | [#18565](https://github.com/opensearch-project/OpenSearch/pull/18565) | Add integration of derived source feature across various paths like get/search/recovery | [#17073](https://github.com/opensearch-project/OpenSearch/issues/17073) |
 | v3.1.0 | [#17759](https://github.com/opensearch-project/OpenSearch/pull/17759) | Adding support for derive source feature and implementing it for various type of field mappers | [#17073](https://github.com/opensearch-project/OpenSearch/issues/17073) |
+| v2.19.0 | [#17080](https://github.com/opensearch-project/OpenSearch/pull/17080) | Propagate includes and excludes from fetchSourceContext to FieldsVisitor | [k-NN #2377](https://github.com/opensearch-project/k-NN/issues/2377) |
 
 ### Issues (Design / RFC)
 - [Issue #17073](https://github.com/opensearch-project/OpenSearch/issues/17073): Add support for deriving source field in FieldMapper

--- a/docs/releases/v2.19.0/features/opensearch/fetch-source-context.md
+++ b/docs/releases/v2.19.0/features/opensearch/fetch-source-context.md
@@ -1,0 +1,92 @@
+---
+tags:
+  - opensearch
+---
+# Fetch Source Context
+
+## Summary
+
+This enhancement propagates `sourceIncludes` and `sourceExcludes` fields from `FetchSourceContext` to `FieldsVisitor`, enabling downstream components to access source filtering information during document retrieval. This is a foundational change that supports the Derived Source feature by allowing the system to skip reconstruction of vector fields that will be excluded from the response.
+
+## Details
+
+### What's New in v2.19.0
+
+The `FieldsVisitor` class now carries source include/exclude information from the search context, making it available to lower-level components during the fetch phase.
+
+### Technical Changes
+
+#### FieldsVisitor Enhancements
+
+New constructors and accessor methods were added to `FieldsVisitor`:
+
+| Method | Description |
+|--------|-------------|
+| `FieldsVisitor(boolean loadSource, String[] includes, String[] excludes)` | Constructor accepting source filtering parameters |
+| `includes()` | Returns array of fields to include in source |
+| `excludes()` | Returns array of fields to exclude from source |
+
+#### FetchPhase Integration
+
+The `FetchPhase.createStoredFieldsVisitor()` method now passes `FetchSourceContext` includes/excludes to the `FieldsVisitor`:
+
+```java
+return new FieldsVisitor(
+    loadSource,
+    context.hasFetchSourceContext() ? context.fetchSourceContext().includes() : null,
+    context.hasFetchSourceContext() ? context.fetchSourceContext().excludes() : null
+);
+```
+
+### Use Case: Derived Source Optimization
+
+This change addresses an open question from the Derived Source RFC (k-NN #2377): how to avoid reconstructing vectors that will be filtered out anyway.
+
+When a user excludes vector fields from the source:
+```json
+POST some_index/_search
+{
+  "_source": {
+    "excludes": ["my_vector1"]
+  }
+}
+```
+
+The `FieldsVisitor` now carries this exclusion information, allowing derived source implementations to skip expensive vector reconstruction for excluded fields.
+
+### Architecture
+
+```mermaid
+flowchart TB
+    A[Search Request] --> B[FetchSourceContext]
+    B --> C{includes/excludes?}
+    C -->|Yes| D[Pass to FieldsVisitor]
+    C -->|No| E[Empty arrays]
+    D --> F[FieldsVisitor.includes/excludes]
+    E --> F
+    F --> G[StoredFieldsReader]
+    G --> H{Derived Source?}
+    H -->|Yes| I[Skip excluded fields reconstruction]
+    H -->|No| J[Normal source retrieval]
+```
+
+## Limitations
+
+- This change only propagates the filtering information; actual filtering still occurs at higher levels
+- The optimization benefit is realized when combined with Derived Source feature
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#17080](https://github.com/opensearch-project/OpenSearch/pull/17080) | Propagate includes and excludes from fetchSourceContext to FieldsVisitor | [k-NN #2377](https://github.com/opensearch-project/k-NN/issues/2377) |
+
+### Related Issues
+
+- [k-NN #2377](https://github.com/opensearch-project/k-NN/issues/2377) - RFC: Derived Source for Vectors
+
+### Documentation
+
+- [Source field](https://docs.opensearch.org/2.19/field-types/metadata-fields/source/) - OpenSearch documentation on _source field filtering

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -5,6 +5,7 @@
 ### opensearch
 - Auto Date Histogram Bug Fix
 - Dependency Updates
+- Fetch Source Context
 - Gradle Version Catalog
 - Sliced Search Optimization
 - Plugin System


### PR DESCRIPTION
## Summary

This PR adds documentation for the Fetch Source Context enhancement in OpenSearch v2.19.0.

### Changes
- Created release report: `docs/releases/v2.19.0/features/opensearch/fetch-source-context.md`
- Updated feature report: `docs/features/opensearch/opensearch-derived-source.md` (added v2.19.0 to Change History and References)
- Updated release index: `docs/releases/v2.19.0/index.md`

### Feature Overview
PR [#17080](https://github.com/opensearch-project/OpenSearch/pull/17080) propagates `sourceIncludes` and `sourceExcludes` fields from `FetchSourceContext` to `FieldsVisitor`, enabling downstream components to access source filtering information during document retrieval. This is a foundational change that supports the Derived Source feature.

### Related Issue
- Closes #2036