### PR TITLE
docs: add snapshot-restore-settings report for v2.19.0

### DIFF
--- a/docs/features/opensearch/snapshot-restore-settings.md
+++ b/docs/features/opensearch/snapshot-restore-settings.md
@@ -1,0 +1,130 @@
+---
+tags:
+  - opensearch
+---
+# Snapshot Restore Settings
+
+## Summary
+
+OpenSearch provides mechanisms to control which index settings can be modified or removed during snapshot restore operations. This includes built-in protection for critical settings and an extensible `UnmodifiableOnRestore` property that plugins can use to protect their own settings.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Restore Request"
+        A[index_settings] --> C[RestoreService]
+        B[ignore_index_settings] --> C
+    end
+    subgraph "Validation"
+        C --> D{USER_UNMODIFIABLE_SETTINGS?}
+        C --> E{USER_UNREMOVABLE_SETTINGS?}
+        C --> F{UnmodifiableOnRestore?}
+    end
+    subgraph "Result"
+        D -->|Yes| G[SnapshotRestoreException]
+        E -->|Yes| G
+        F -->|Yes| G
+        D -->|No| H[Apply Settings]
+        E -->|No| H
+        F -->|No| H
+    end
+```
+
+### Setting Protection Categories
+
+| Category | Can Modify | Can Remove | Examples |
+|----------|-----------|------------|----------|
+| `USER_UNMODIFIABLE_SETTINGS` | No | No | `index.uuid`, `index.creation_date`, `index.remote_store.enabled` |
+| `USER_UNREMOVABLE_SETTINGS` | Yes | No | `index.number_of_replicas`, `index.auto_expand_replicas` |
+| `UnmodifiableOnRestore` | No | No | `index.number_of_shards`, `index.version.created` |
+
+### UnmodifiableOnRestore Property
+
+The `UnmodifiableOnRestore` property can be applied to any index-scoped setting to prevent modification during restore:
+
+```java
+Setting.intSetting(
+    SETTING_NUMBER_OF_SHARDS,
+    defaultNumShards,
+    1,
+    maxNumShards,
+    Property.IndexScope,
+    Property.Final,
+    Property.UnmodifiableOnRestore
+);
+```
+
+#### Constraints
+
+- Must have `Property.IndexScope`
+- Cannot have `Property.Dynamic`
+- Validated at setting registration time
+
+### Configuration
+
+#### Restore API Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `index_settings` | Settings to override during restore |
+| `ignore_index_settings` | Settings to ignore (use cluster defaults) |
+
+#### Example Restore Request
+
+```json
+POST /_snapshot/my-repository/snapshot-1/_restore
+{
+  "indices": "my-index",
+  "index_settings": {
+    "index.number_of_replicas": 2
+  },
+  "ignore_index_settings": [
+    "index.refresh_interval"
+  ]
+}
+```
+
+### Protected Settings Reference
+
+#### Always Protected (Cannot Modify or Remove)
+
+- `index.uuid`
+- `index.creation_date`
+- `index.history_uuid`
+- `index.remote_store.enabled`
+- `index.remote_store.segment.repository`
+- `index.remote_store.translog.repository`
+- `index.number_of_shards` (UnmodifiableOnRestore)
+- `index.version.created` (UnmodifiableOnRestore)
+
+#### Cannot Remove Only
+
+- `index.number_of_replicas`
+- `index.auto_expand_replicas`
+- `index.number_of_search_only_replicas`
+
+## Limitations
+
+- Settings protection only applies during snapshot restore operations
+- Does not affect index creation or update settings API
+- Plugin settings must explicitly add `UnmodifiableOnRestore` property
+
+## Change History
+
+- **v2.19.0** (2025-01-24): Added `UnmodifiableOnRestore` setting property for extensible setting protection during restore
+
+## References
+
+### Documentation
+
+- [Snapshot Restore Documentation](https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/)
+- [Restore Snapshot API](https://docs.opensearch.org/latest/api-reference/snapshots/restore-snapshot/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#16957](https://github.com/opensearch-project/OpenSearch/pull/16957) | Added new Setting property UnmodifiableOnRestore to prevent updating settings on restore snapshot |

--- a/docs/releases/v2.19.0/features/opensearch/snapshot-restore-settings.md
+++ b/docs/releases/v2.19.0/features/opensearch/snapshot-restore-settings.md
@@ -1,0 +1,85 @@
+---
+tags:
+  - opensearch
+---
+# Snapshot Restore Settings
+
+## Summary
+
+OpenSearch v2.19.0 introduces a new `UnmodifiableOnRestore` setting property that prevents certain index settings from being modified or removed during snapshot restore operations. This enhancement provides better data integrity protection by ensuring critical settings remain unchanged when restoring indexes from snapshots.
+
+## Details
+
+### What's New in v2.19.0
+
+A new `Setting.Property.UnmodifiableOnRestore` property has been added to the OpenSearch settings framework. Settings marked with this property cannot be:
+- Modified via `index_settings` parameter during restore
+- Removed via `ignore_index_settings` parameter during restore
+
+### Technical Changes
+
+#### New Setting Property
+
+The `UnmodifiableOnRestore` property is added to the `Setting.Property` enum:
+
+```java
+/**
+ * Mark this setting as immutable on snapshot restore
+ * i.e. the setting will not be allowed to be removed or modified during restore
+ */
+UnmodifiableOnRestore
+```
+
+#### Settings Now Protected
+
+The following settings are now marked as `UnmodifiableOnRestore`:
+
+| Setting | Description |
+|---------|-------------|
+| `index.number_of_shards` | Number of primary shards for the index |
+| `index.version.created` | Version of OpenSearch that created the index |
+
+#### Validation Rules
+
+- `UnmodifiableOnRestore` settings must have `IndexScope` property
+- `UnmodifiableOnRestore` settings cannot be `Dynamic`
+- Attempting to modify or remove these settings during restore throws `SnapshotRestoreException`
+
+### Error Messages
+
+When attempting to modify an `UnmodifiableOnRestore` setting:
+```
+cannot modify UnmodifiableOnRestore setting [index.number_of_shards] on restore
+```
+
+When attempting to remove an `UnmodifiableOnRestore` setting:
+```
+cannot remove UnmodifiableOnRestore setting [index.number_of_shards] on restore
+```
+
+### Use Case
+
+This feature was primarily introduced to support the k-NN plugin's requirement to make `index.knn` setting immutable during snapshot restore. The k-NN plugin can now mark its settings with `UnmodifiableOnRestore` to prevent users from accidentally changing the k-NN configuration when restoring indexes.
+
+## Limitations
+
+- Only applies to index-scoped settings
+- Cannot be combined with `Dynamic` property
+- Existing `USER_UNREMOVABLE_SETTINGS` and `USER_UNMODIFIABLE_SETTINGS` lists in `RestoreService` continue to function independently
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16957](https://github.com/opensearch-project/OpenSearch/pull/16957) | Added new Setting property UnmodifiableOnRestore to prevent updating settings on restore snapshot | [k-NN#2334](https://github.com/opensearch-project/k-NN/issues/2334) |
+
+### Related Issues
+
+- [k-NN#2334](https://github.com/opensearch-project/k-NN/issues/2334) - Original issue requesting immutable k-NN settings
+- [#17019](https://github.com/opensearch-project/OpenSearch/issues/17019) - Related OpenSearch issue
+
+### Documentation
+
+- [Snapshot Restore Documentation](https://docs.opensearch.org/2.19/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/)

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -9,6 +9,7 @@
 - Gradle Version Catalog
 - Sliced Search Optimization
 - Plugin System
+- Snapshot Restore Settings
 - Sort Field Merging
 - Inner Hits Optimization
 - CI Fixes


### PR DESCRIPTION
## Summary

This PR adds documentation for the Snapshot Restore Settings feature introduced in OpenSearch v2.19.0.

### Reports Created
- Release report: `docs/releases/v2.19.0/features/opensearch/snapshot-restore-settings.md`
- Feature report: `docs/features/opensearch/snapshot-restore-settings.md`

### Key Changes in v2.19.0
- Added new `UnmodifiableOnRestore` setting property to prevent modifying/removing certain settings during snapshot restore
- Settings marked with this property (`index.number_of_shards`, `index.version.created`) cannot be changed via `index_settings` or `ignore_index_settings` during restore
- Provides extensibility for plugins (like k-NN) to protect their settings during restore operations

### Source
- PR: [#16957](https://github.com/opensearch-project/OpenSearch/pull/16957)