### PR TITLE
docs: add getstats-api report for v2.19.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -1,0 +1,7 @@
+# OpenSearch Features
+
+Cumulative feature documentation across all versions.
+
+## opensearch
+
+- GetStats API

--- a/docs/features/opensearch/opensearch-getstats-api.md
+++ b/docs/features/opensearch/opensearch-getstats-api.md
@@ -1,0 +1,86 @@
+---
+tags:
+  - opensearch
+---
+# GetStats API
+
+## Summary
+
+The `GetStats` class provides statistics about document retrieval ("get") operations in OpenSearch. It is part of the Index Stats API response and tracks metrics such as total get operations, time spent, and counts for existing vs. missing documents.
+
+## Details
+
+### Overview
+
+When you retrieve a document by ID using the Get Document API, OpenSearch tracks statistics about these operations. The `GetStats` class aggregates these metrics and exposes them through the Index Stats API (`GET /<index>/_stats/get`).
+
+### Response Fields
+
+| Field | Description |
+|-------|-------------|
+| `total` | Total number of get operations |
+| `time` | Human-readable time spent on get operations (when `?human` is enabled) |
+| `time_in_millis` | Time spent on get operations in milliseconds |
+| `exists_total` | Number of successful get operations (document found) |
+| `exists_time` | Human-readable time for successful gets |
+| `exists_time_in_millis` | Time for successful gets in milliseconds |
+| `missing_total` | Number of get operations where document was not found |
+| `missing_time` | Human-readable time for missing document gets |
+| `missing_time_in_millis` | Time for missing document gets in milliseconds |
+| `current` | Number of get operations currently in progress |
+
+### Usage Example
+
+```bash
+# Get stats for all indexes
+GET /_stats/get
+
+# Get stats for a specific index with human-readable values
+GET /my-index/_stats/get?human
+
+# Filter response to show only get stats
+GET /my-index/_stats?human&filter_path=_all.primaries.get
+```
+
+**Example Response:**
+```json
+{
+  "_all": {
+    "primaries": {
+      "get": {
+        "total": 100,
+        "time": "50ms",
+        "time_in_millis": 50,
+        "exists_total": 95,
+        "exists_time": "45ms",
+        "exists_time_in_millis": 45,
+        "missing_total": 5,
+        "missing_time": "5ms",
+        "missing_time_in_millis": 5,
+        "current": 0
+      }
+    }
+  }
+}
+```
+
+## Limitations
+
+- Statistics are reset when a shard moves to a different node
+- The deprecated `getTime` field (present in versions prior to v2.19.0) will be removed in a future major version
+
+## Change History
+
+- **v2.19.0** (2025-01-17): Added new `time` field and deprecated `getTime` field to fix naming inconsistency ([#17009](https://github.com/opensearch-project/OpenSearch/pull/17009))
+
+## References
+
+### Documentation
+
+- [Index Stats API](https://docs.opensearch.org/latest/api-reference/index-apis/stats/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#17009](https://github.com/opensearch-project/OpenSearch/pull/17009) | Fix getTime field name to time in GetStats |

--- a/docs/releases/v2.19.0/features/opensearch/getstats-api.md
+++ b/docs/releases/v2.19.0/features/opensearch/getstats-api.md
@@ -1,0 +1,74 @@
+---
+tags:
+  - opensearch
+---
+# GetStats API
+
+## Summary
+
+In v2.19.0, the `GetStats` class was updated to fix a long-standing field naming inconsistency. A new `time` field was added to replace the incorrectly named `getTime` field in the Index Stats API response. The `getTime` field is now deprecated and will be removed in a future version.
+
+## Details
+
+### What's New in v2.19.0
+
+The Index Stats API returns statistics about index operations, including "get" operations (document retrieval by ID). When using the `?human` parameter, the API returns human-readable time values alongside millisecond values.
+
+Prior to this fix, the human-readable field for get operation time was incorrectly named `getTime` instead of `time`. This inconsistency originated from a refactoring error nearly twelve years ago (pre-fork from Elasticsearch).
+
+### Technical Changes
+
+The `GetStats.java` class was modified to:
+
+1. Add a new `time` field that correctly follows the naming convention used by other stats fields
+2. Deprecate the `getTime` field with `@Deprecated(forRemoval = true)` annotation
+3. Output both fields during the deprecation period for backward compatibility
+
+**Before (v2.18.0 and earlier):**
+```json
+{
+  "get": {
+    "total": 0,
+    "getTime": "0s",
+    "time_in_millis": 0,
+    ...
+  }
+}
+```
+
+**After (v2.19.0+):**
+```json
+{
+  "get": {
+    "total": 0,
+    "time": "0s",
+    "getTime": "0s",
+    "time_in_millis": 0,
+    ...
+  }
+}
+```
+
+### Migration Guide
+
+- Update any code that parses the `getTime` field to use the new `time` field instead
+- Both fields are available during the deprecation period
+- The `getTime` field will be removed in a future major version
+
+## Limitations
+
+- The deprecated `getTime` field will continue to be returned alongside `time` until it is removed in a future version
+- Clients should migrate to using the `time` field before the deprecation period ends
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#17009](https://github.com/opensearch-project/OpenSearch/pull/17009) | Fix getTime field name to time in GetStats | [#16894](https://github.com/opensearch-project/OpenSearch/issues/16894) |
+
+### Related Resources
+
+- [Index Stats API Documentation](https://docs.opensearch.org/2.19/api-reference/index-apis/stats/)
+- [OpenSearch API Specification PR #785](https://github.com/opensearch-project/opensearch-api-specification/pull/785)

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch
 - Auto Date Histogram Bug Fix
+- GetStats API
 - Bitmap Filtering Performance Improvement
 - Template Query
 - Dependency Updates


### PR DESCRIPTION
## Summary

Adds documentation for the GetStats API field naming fix in OpenSearch v2.19.0.

### Changes
- **Release report**: `docs/releases/v2.19.0/features/opensearch/getstats-api.md`
- **Feature report**: `docs/features/opensearch/opensearch-getstats-api.md`
- **Features index**: `docs/features/index.md` (created)
- **Release index**: Updated to include GetStats API

### Key Points
- The `GetStats` class was updated to fix a long-standing field naming inconsistency
- A new `time` field was added to replace the incorrectly named `getTime` field
- The `getTime` field is now deprecated with `@Deprecated(forRemoval = true)`
- Both fields are returned during the deprecation period for backward compatibility

### Related
- Resolves investigation Issue #2032
- OpenSearch PR: [#17009](https://github.com/opensearch-project/OpenSearch/pull/17009)
- OpenSearch Issue: [#16894](https://github.com/opensearch-project/OpenSearch/issues/16894)