### PR TITLE
docs: add flat-object-field report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-flat-object-field.md
+++ b/docs/features/opensearch/opensearch-flat-object-field.md
@@ -182,6 +182,7 @@ This is more efficient than loading the entire `_source` when you only need spec
 ## Change History
 
 - **v3.0.0** (2025-02-11): Added ability to retrieve values from DocValues in flat_object subfields using `docvalue_fields` parameter with dot notation.
+- **v2.19.0** (2025-01-28): Added support for searching from DocValues using `termQuery` and `termQueryCaseInsensitive` even when `index=false`. Improved parsing performance by reducing two-pass parsing to single-pass, achieving up to 16% latency reduction at p99.9.
 - **v2.18.0** (2024-10-22): Added IndexOrDocValuesQuery optimization for improved query performance. Delegated query generation to KeywordFieldType to reduce code duplication. Enabled wildcard query support. Fixed infinite loop bug when flat_object field receives invalid token types.
 - **v2.7.0** (2023-04-18): Initial implementation of flat_object field type.
 
@@ -199,6 +200,8 @@ This is more efficient than loading the entire `_source` when you only need spec
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
 | v3.0.0 | [#16802](https://github.com/opensearch-project/OpenSearch/pull/16802) | Added ability to retrieve value from DocValues in flat_object field | [#16742](https://github.com/opensearch-project/OpenSearch/issues/16742) |
+| v2.19.0 | [#16974](https://github.com/opensearch-project/OpenSearch/pull/16974) | Support searching from doc_value using termQueryCaseInsensitive/termQuery | [#16973](https://github.com/opensearch-project/OpenSearch/issues/16973) |
+| v2.19.0 | [#16297](https://github.com/opensearch-project/OpenSearch/pull/16297) | Improve flat_object field parsing performance (two-pass to single-pass) | - |
 | v2.18.0 | [#14383](https://github.com/opensearch-project/OpenSearch/pull/14383) | Use IndexOrDocValuesQuery to optimize query, delegate to KeywordFieldType | [#11635](https://github.com/opensearch-project/OpenSearch/issues/11635) |
 | v2.18.0 | [#15985](https://github.com/opensearch-project/OpenSearch/pull/15985) | Fix infinite loop when parsing invalid token types | [#15982](https://github.com/opensearch-project/OpenSearch/issues/15982) |
 | v2.7.0 | - | Initial implementation of flat_object field type |   |

--- a/docs/releases/v2.19.0/features/opensearch/flat-object-field.md
+++ b/docs/releases/v2.19.0/features/opensearch/flat-object-field.md
@@ -1,0 +1,96 @@
+---
+tags:
+  - opensearch
+---
+# Flat Object Field Enhancements
+
+## Summary
+
+OpenSearch v2.19.0 brings significant improvements to the `flat_object` field type, including support for searching from DocValues using `termQuery` and `termQueryCaseInsensitive` even when `index=false`, and a major performance optimization that reduces JSON parsing from two passes to a single pass.
+
+## Details
+
+### What's New in v2.19.0
+
+#### 1. DocValues-Based Term Query Support
+
+Previously, `flat_object` and `keyword` fields could not be searched using `termQuery` or `termQueryCaseInsensitive` when `index=false`. This was inconsistent with numeric fields which supported DocValues-based searching. In v2.19.0, this limitation is removed.
+
+**Key Changes:**
+- `termQuery` now falls back to DocValues when the field is not indexed but has DocValues enabled
+- `termQueryCaseInsensitive` supports case-insensitive searching via DocValues using automaton queries
+- Both `flat_object` and `keyword` field types benefit from this enhancement
+
+**Example:**
+```json
+PUT /test-index
+{
+  "mappings": {
+    "properties": {
+      "metadata": {
+        "type": "flat_object"
+      }
+    }
+  }
+}
+
+// Case-insensitive term query now works even with index=false
+GET /test-index/_search
+{
+  "query": {
+    "term": {
+      "metadata.labels.name": {
+        "value": "ABC",
+        "case_insensitive": true
+      }
+    }
+  }
+}
+```
+
+#### 2. Single-Pass Parsing Performance Optimization
+
+The `flat_object` field parsing has been optimized from a two-pass approach to a single-pass approach, significantly improving indexing performance.
+
+**Benchmark Results (noaa workload with `station` field as `flat_object`):**
+
+| Metric | Baseline | Contender | Improvement |
+|--------|----------|-----------|-------------|
+| Mean Throughput | 142,195 docs/s | 144,423 docs/s | +1.6% |
+| Median Throughput | 143,126 docs/s | 146,146 docs/s | +2.1% |
+| 90th percentile latency | 544.9 ms | 505.0 ms | -7.3% |
+| 99th percentile latency | 1,225.6 ms | 1,162.6 ms | -5.1% |
+| 99.9th percentile latency | 1,867.9 ms | 1,568.1 ms | -16.0% |
+
+**Technical Changes:**
+- Removed `JsonToStringXContentParser` class (two-pass parsing)
+- Integrated parsing directly into `FlatObjectFieldMapper`
+- Simplified internal field handling by removing separate `ValueFieldMapper` and `ValueAndPathFieldMapper` classes
+- Improved code maintainability by consolidating parsing logic
+
+### Technical Changes
+
+| Component | Change |
+|-----------|--------|
+| `FlatObjectFieldMapper` | Refactored to use single-pass parsing, removed nested mapper classes |
+| `KeywordFieldMapper` | Added `termQuery` and `termQueryCaseInsensitive` support for DocValues-only fields |
+| `JsonToStringXContentParser` | Removed (functionality merged into FlatObjectFieldMapper) |
+| `DocValueFetcher` | Updated to handle flat_object DocValue format |
+
+## Limitations
+
+- DocValues retrieval still requires full dot-path notation (root field not supported)
+- Aggregations on subfields using dot notation remain unsupported
+- Painless scripting for subfield value retrieval is not supported
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16974](https://github.com/opensearch-project/OpenSearch/pull/16974) | Support searching from doc_value using termQueryCaseInsensitive/termQuery in flat_object/keyword field | [#16973](https://github.com/opensearch-project/OpenSearch/issues/16973) |
+| [#16297](https://github.com/opensearch-project/OpenSearch/pull/16297) | Improve flat_object field parsing performance by reducing two passes to a single pass | - |
+| [#16802](https://github.com/opensearch-project/OpenSearch/pull/16802) | Added ability to retrieve value from DocValues in flat_object field | [#16742](https://github.com/opensearch-project/OpenSearch/issues/16742) |
+
+### Documentation
+- [Flat object documentation](https://docs.opensearch.org/latest/field-types/supported-field-types/flat-object/)

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch
 - Auto Date Histogram Bug Fix
+- Flat Object Field
 - GetStats API
 - Bitmap Filtering Performance Improvement
 - Template Query


### PR DESCRIPTION
## Summary

This PR adds documentation for the Flat Object Field enhancements in OpenSearch v2.19.0.

### Changes
- Created release report: `docs/releases/v2.19.0/features/opensearch/flat-object-field.md`
- Updated feature report: `docs/features/opensearch/opensearch-flat-object-field.md`
- Updated release index: `docs/releases/v2.19.0/index.md`

### Key Features in v2.19.0
1. **DocValues-Based Term Query Support**: `termQuery` and `termQueryCaseInsensitive` now work on `flat_object` and `keyword` fields even when `index=false`
2. **Single-Pass Parsing Performance**: Reduced JSON parsing from two passes to single pass, achieving up to 16% latency reduction at p99.9

### Related PRs
- [#16974](https://github.com/opensearch-project/OpenSearch/pull/16974): Support searching from doc_value using termQueryCaseInsensitive/termQuery
- [#16297](https://github.com/opensearch-project/OpenSearch/pull/16297): Improve flat_object field parsing performance
- [#16802](https://github.com/opensearch-project/OpenSearch/pull/16802): Added ability to retrieve value from DocValues

Closes #2031