### PR TITLE
docs: add gRPC Transport report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-grpc-transport--services.md
+++ b/docs/features/opensearch/opensearch-grpc-transport--services.md
@@ -278,7 +278,7 @@ Documents in gRPC requests must be Base64 encoded:
 - **v3.2.0** (2026-01-14): GA release - moved to module, plugin extensibility, proper gRPC status codes, removed experimental designation
 - **v3.1.0** (2026-01-14): Performance optimization with pass-by-reference pattern, package reorganization
 - **v3.0.0** (2025-05-06): Initial implementation with DocumentService (Bulk) and SearchService (Search), TLS support
-- **v2.19.0** (2025-01-21): Setting rename from `aux.transport.experimental-transport-grpc.ports` to `aux.transport.experimental-transport-grpc.port` for consistency, HTTP terminology cleanup in variable names
+- **v2.19.0** (2025-01-21): Initial auxiliary transport framework and experimental gRPC transport plugin with health check and service discovery; setting rename from `aux.transport.experimental-transport-grpc.ports` to `aux.transport.experimental-transport-grpc.port`
 
 
 ## References
@@ -334,6 +334,7 @@ Documents in gRPC requests must be Base64 encoded:
 | v3.0.0 | [#17830](https://github.com/opensearch-project/OpenSearch/pull/17830) | SearchService and Search gRPC endpoint v1 | [#16783](https://github.com/opensearch-project/OpenSearch/issues/16783) |
 | v3.0.0 | [#17888](https://github.com/opensearch-project/OpenSearch/pull/17888) | Add terms query support in Search gRPC endpoint | [#16783](https://github.com/opensearch-project/OpenSearch/issues/16783) |
 | v2.19.0 | [#17037](https://github.com/opensearch-project/OpenSearch/pull/17037) | Fix GRPC AUX_TRANSPORT_PORT setting name and remove HTTP terminology | [#16556](https://github.com/opensearch-project/OpenSearch/issues/16556) |
+| v2.19.0 | [#16534](https://github.com/opensearch-project/OpenSearch/pull/16534) | Introduce framework for auxiliary transports and experimental gRPC transport plugin | - |
 
 ### Issues (Design / RFC)
 - [Issue #16787](https://github.com/opensearch-project/OpenSearch/issues/16787): gRPC Transport tracking issue

--- a/docs/releases/v2.19.0/features/opensearch/grpc-transport.md
+++ b/docs/releases/v2.19.0/features/opensearch/grpc-transport.md
@@ -1,0 +1,129 @@
+---
+tags:
+  - opensearch
+---
+# gRPC Transport
+
+## Summary
+
+OpenSearch v2.19.0 introduces a framework for auxiliary transports and an experimental gRPC transport plugin. This enables pluggable transport implementations that run in parallel to the existing HTTP and native transport servers, with gRPC as the first implementation. The gRPC transport provides a high-performance, binary-encoded communication protocol using protocol buffers.
+
+## Details
+
+### What's New in v2.19.0
+
+**Auxiliary Transport Framework:**
+A new pluggable framework allows multiple transport implementations to run alongside the default HTTP transport. Key components:
+
+| Component | Description |
+|-----------|-------------|
+| `AuxTransport` | Abstract base class for auxiliary transports with lifecycle management |
+| `NetworkPlugin.getAuxTransports()` | Plugin extension point to register auxiliary transports |
+| `AUX_TRANSPORT_TYPES_SETTING` | Setting to enable specific auxiliary transports |
+
+**Experimental gRPC Transport Plugin:**
+The `transport-grpc` plugin implements gRPC as an auxiliary transport:
+
+| Feature | Description |
+|---------|-------------|
+| gRPC Server | Netty4-based gRPC server implementation |
+| Health Check | Built-in `grpc.health.v1.Health/Check` service |
+| Service Discovery | Built-in `list` service for discovering available services |
+| Default Port Range | `9400-9500` |
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Node"
+        HTTP[HTTP Transport<br/>Port 9200]
+        Native[Native Transport<br/>Port 9300]
+        AUX[Auxiliary Transports]
+        
+        subgraph AUX
+            GRPC[gRPC Transport<br/>Port 9400]
+            Future[Future Transports...]
+        end
+        
+        Core[OpenSearch Core]
+    end
+    
+    Client1[REST Client] --> HTTP
+    Client2[Node Client] --> Native
+    Client3[gRPC Client] --> GRPC
+    
+    HTTP --> Core
+    Native --> Core
+    GRPC --> Core
+```
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `aux.transport.types` | List of auxiliary transports to enable | `[]` |
+| `aux.transport.experimental-transport-grpc.port` | Port range for gRPC transport | `9400-9500` |
+
+### Enabling gRPC Transport
+
+Add to `opensearch.yml`:
+
+```yaml
+aux.transport.types: [experimental-transport-grpc]
+aux.transport.experimental-transport-grpc.port: 9400-9500
+```
+
+Or run with the plugin installed:
+
+```bash
+./gradlew run -PinstalledPlugins="['transport-grpc']"
+```
+
+### Testing gRPC Services
+
+Use `grpcurl` to interact with the gRPC server:
+
+```bash
+# List available services
+grpcurl -plaintext localhost:9400 list
+
+# Health check
+grpcurl -plaintext localhost:9400 grpc.health.v1.Health/Check
+```
+
+### Technical Implementation
+
+The implementation adds:
+
+| File | Purpose |
+|------|---------|
+| `AuxTransport.java` | Abstract base class defining auxiliary transport lifecycle |
+| `NetworkPlugin.java` | Extended with `getAuxTransports()` method |
+| `GrpcPlugin.java` | Plugin entry point registering gRPC transport |
+| `Netty4GrpcServerTransport.java` | gRPC server implementation using Netty4 |
+
+Key settings defined in `AuxTransport`:
+
+```java
+public static final String AUX_SETTINGS_PREFIX = "aux.transport.";
+public static final String AUX_TRANSPORT_TYPES_KEY = AUX_SETTINGS_PREFIX + "types";
+public static final String AUX_PORT_DEFAULTS = "9400-9500";
+```
+
+## Limitations
+
+- **Experimental status**: The gRPC transport is marked as experimental
+- **Limited services**: Only health check and service discovery available in v2.19.0
+- **No API endpoints**: Document and search APIs added in later versions (v3.0.0+)
+- **Manual installation**: Requires explicit plugin installation and configuration
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16534](https://github.com/opensearch-project/OpenSearch/pull/16534) | Introduce framework for auxiliary transports and experimental gRPC transport plugin | - |
+
+### Related RFCs
+- [opensearch-api-specification#677](https://github.com/opensearch-project/opensearch-api-specification/issues/677): Generation of protobuf files from API specification
+- [opensearch-api-specification#653](https://github.com/opensearch-project/opensearch-api-specification/issues/653): Protobuf generation RFC

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -20,6 +20,7 @@
 - Cluster State
 - Deprecation Logger Cache Bound
 - gRPC Settings
+- gRPC Transport
 - Index Settings API
 - Ingest Pipeline Deprecation
 - IP Field


### PR DESCRIPTION
## Summary
Add release report for gRPC Transport framework introduction in v2.19.0.

## Changes
- Created release report: `docs/releases/v2.19.0/features/opensearch/grpc-transport.md`
- Updated feature report: `docs/features/opensearch/opensearch-grpc-transport--services.md`
  - Added v2.19.0 initial framework introduction to Change History
  - Added PR #16534 to References
- Updated release index: `docs/releases/v2.19.0/index.md`

## Key Changes in v2.19.0
- Introduced auxiliary transport framework (`AuxTransport` base class)
- Added `NetworkPlugin.getAuxTransports()` extension point
- Implemented experimental gRPC transport plugin with:
  - Netty4-based gRPC server
  - Health check service (`grpc.health.v1.Health/Check`)
  - Service discovery (`list`)
  - Default port range: 9400-9500

## Resources Used
- PR: #16534
- Source files: `AuxTransport.java`, `NetworkPlugin.java`, `GrpcPlugin.java`

Closes #2030