### PR TITLE
docs: add CVE fixes report for v2.19.0

### DIFF
--- a/docs/features/security/security-plugin-dependencies.md
+++ b/docs/features/security/security-plugin-dependencies.md
@@ -86,6 +86,7 @@ Dependency updates in the Security plugin follow this process:
 - **v3.3.0** (2026-01-14): Security fix for CVE-2025-53864 (nimbus-jose-jwt), plus 24 dependency updates including Spring 6.2.11, JJWT 0.13.0, Guava 33.5.0, and CI tooling updates
 - **v3.1.0** (2025-06-03): Major dependency updates including Bouncy Castle 1.81, Kafka 4.0.0, Spring 6.2.7, Guava 33.4.8, JUnit 5.13.1, and CVE-2024-52798 fix
 - **v3.0.0** (2025-02-25): 13 dependency updates including Spring 6.2.5, Bouncy Castle 1.80, OpenSAML 5.1.4/9.1.4, ASM 9.8, Commons IO 2.19.0, JUnit Jupiter 5.12.2
+- **v2.19.0** (2024-12-10): Security fixes for Cypress and cross-spawn dependencies
 - **v2.18.0** (2024-10-22): Updated snappy-java, gradle.test-retry, commons-io, scala-library, checker-qual, and logback-classic
 
 
@@ -144,6 +145,7 @@ Dependency updates in the Security plugin follow this process:
 | v3.0.0 | [#5266](https://github.com/opensearch-project/security/pull/5266) | Bump commons-text 1.13.0 → 1.13.1 |   |
 | v3.0.0 | [#5268](https://github.com/opensearch-project/security/pull/5268) | Bump junit-jupiter-api 5.12.1 → 5.12.2 |   |
 | v3.0.0 | [#5265](https://github.com/opensearch-project/security/pull/5265) | Bump failureaccess 1.0.2 → 1.0.3 |   |
+| v2.19.0 | [#1251](https://github.com/opensearch-project/security/pull/1251) | Bump cypress and cross-spawn version |   |
 | v2.18.0 | [#4738](https://github.com/opensearch-project/security/pull/4738) | Bump snappy-java 1.1.10.6 → 1.1.10.7 |   |
 | v2.18.0 | [#4736](https://github.com/opensearch-project/security/pull/4736) | Bump gradle.test-retry 1.5.10 → 1.6.0 |   |
 | v2.18.0 | [#4750](https://github.com/opensearch-project/security/pull/4750) | Bump commons-io 2.16.1 → 2.17.0 |   |

--- a/docs/features/skills/skills-plugin-dependencies.md
+++ b/docs/features/skills/skills-plugin-dependencies.md
@@ -70,6 +70,7 @@ The Skills plugin follows automated dependency management using Mend (formerly W
 - Test fixes may be needed when dependent plugins change their APIs
 
 ## Change History
+- **v2.19.0** (2024-12-10): Critical security fix for CVE-2022-36944 (scala-library 2.13.9), ByteBuddy 1.15.10 for module conflict resolution
 - **v2.18.0** (2024-10-29): Updated Mockito to 5.14.2, JUnit5 to 5.11.2, ByteBuddy to 1.15.4, Gradle to 8.10.2, Lombok plugin to 8.10.2; Fixed test failures from AnomalyDetector API changes
 
 
@@ -84,6 +85,8 @@ The Skills plugin follows automated dependency management using Mend (formerly W
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v2.19.0 | [#496](https://github.com/opensearch-project/skills/pull/496) | Update scala-library to v2.13.9 (CVE-2022-36944) | [#495](https://github.com/opensearch-project/skills/issues/495) |
+| v2.19.0 | [#466](https://github.com/opensearch-project/skills/pull/466) | Bump byte-buddy 1.15.4 → 1.15.10 |   |
 | v2.18.0 | [#427](https://github.com/opensearch-project/skills/pull/427) | Fix test failure due to external change |   |
 | v2.18.0 | [#437](https://github.com/opensearch-project/skills/pull/437) | Update mockito monorepo to v5.14.2 |   |
 | v2.18.0 | [#363](https://github.com/opensearch-project/skills/pull/363) | Update junit5 monorepo to v5.11.2 |   |

--- a/docs/releases/v2.19.0/features/security/cve-fixes.md
+++ b/docs/releases/v2.19.0/features/security/cve-fixes.md
@@ -1,0 +1,37 @@
+---
+tags:
+  - security
+---
+# CVE Fixes
+
+## Summary
+
+OpenSearch Security plugin v2.19.0 includes dependency updates to address security vulnerabilities and maintain compatibility with the OpenSearch ecosystem.
+
+## Details
+
+### What's New in v2.19.0
+
+This release includes security-related dependency updates:
+
+| Dependency | Update | Purpose |
+|------------|--------|---------|
+| Cypress | Version bump | Security fix for test framework |
+| cross-spawn | Version bump | Security fix for Node.js dependency |
+
+### Technical Changes
+
+- **PR #1251**: Bumped Cypress and cross-spawn versions to address security vulnerabilities in the test and build toolchain
+- **PR #1229**: Version increment to 2.19.0.0 for release alignment
+
+## Limitations
+
+- These are dependency updates only; no functional changes to the Security plugin
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#1251](https://github.com/opensearch-project/security/pull/1251) | Bump cypress and cross-spawn version | - |
+| [#1229](https://github.com/opensearch-project/security/pull/1229) | Increment version to 2.19.0.0 | - |

--- a/docs/releases/v2.19.0/features/skills/cve-fixes.md
+++ b/docs/releases/v2.19.0/features/skills/cve-fixes.md
@@ -1,0 +1,44 @@
+---
+tags:
+  - skills
+---
+# CVE Fixes
+
+## Summary
+
+OpenSearch Skills plugin v2.19.0 includes critical dependency updates to address security vulnerabilities, including a fix for CVE-2022-36944 (CVSS 9.8 Critical) in the Scala library.
+
+## Details
+
+### What's New in v2.19.0
+
+This release addresses security vulnerabilities through dependency updates:
+
+| Dependency | From | To | CVE | Severity |
+|------------|------|-----|-----|----------|
+| scala-library | 2.13.8 | 2.13.9 | CVE-2022-36944 | Critical (9.8) |
+| byte-buddy | 1.15.4 | 1.15.10 | - | Module conflict fix |
+
+### CVE-2022-36944
+
+A critical vulnerability in Scala library versions prior to 2.13.9 that could allow remote code execution through deserialization of malicious `LazyList` objects. The fix prevents `Function0` execution during `LazyList` deserialization.
+
+### Technical Changes
+
+- **PR #496**: Updated `org.scala-lang:scala-library` from 2.13.8 to 2.13.9 to fix CVE-2022-36944
+- **PR #466**: Bumped ByteBuddy from 1.15.4 to 1.15.10 to resolve module version conflicts introduced by OpenSearch core PR #16655
+
+## Limitations
+
+- These are dependency updates only; no functional changes to the Skills plugin
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#496](https://github.com/opensearch-project/skills/pull/496) | Update scala-library to v2.13.9 | [#495](https://github.com/opensearch-project/skills/issues/495) |
+| [#466](https://github.com/opensearch-project/skills/pull/466) | Bump byte-buddy from 1.15.4 to 1.15.10 | - |
+
+### Security Advisories
+- [CVE-2022-36944](https://www.mend.io/vulnerability-database/CVE-2022-36944) - Scala Library Remote Code Execution

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -46,3 +46,9 @@
 - Discover Enhancements
 - Numeric Precision Setting
 - Workspace Enhancements
+
+### security
+- CVE Fixes
+
+### skills
+- CVE Fixes


### PR DESCRIPTION
## Summary\n\nAdds release reports for CVE fixes in OpenSearch v2.19.0 for the security and skills plugins.\n\n## Changes\n\n### Release Reports Created\n- `docs/releases/v2.19.0/features/security/cve-fixes.md`\n- `docs/releases/v2.19.0/features/skills/cve-fixes.md`\n\n### Feature Reports Updated\n- `docs/features/security/security-plugin-dependencies.md` - Added v2.19.0 change history\n- `docs/features/skills/skills-plugin-dependencies.md` - Added v2.19.0 change history\n\n### Key Findings\n\n**Security Plugin:**\n- Cypress and cross-spawn version bumps for security fixes\n\n**Skills Plugin:**\n- CVE-2022-36944 fix (Critical 9.8 CVSS) - Scala library updated to 2.13.9\n- ByteBuddy updated to 1.15.10 for module conflict resolution\n\nCloses #2029"