### PR TITLE
docs: add build-infrastructure report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-plugin-installation.md
+++ b/docs/features/opensearch/opensearch-plugin-installation.md
@@ -118,6 +118,7 @@ The verification process:
 
 - **v3.3.0** (2026-01-11): Added support for copying directories to plugin config folder during installation
 - **v3.1.0** (2026-01-10): Fixed signature verification failure caused by PGP public key change; added BouncyCastle FIPS provider initialization
+- **v2.19.0** (2024-12-05): Simplified SNAPSHOT plugin installation by removing staging hash requirement ([#16581](https://github.com/opensearch-project/OpenSearch/pull/16581))
 
 
 ## References
@@ -130,6 +131,7 @@ The verification process:
 |---------|-----|-------------|---------------|
 | v3.3.0 | [#19343](https://github.com/opensearch-project/OpenSearch/pull/19343) | Allow plugins to copy folders into their config dir during installation |   |
 | v3.1.0 | [#18147](https://github.com/opensearch-project/OpenSearch/pull/18147) | Fix native plugin installation error caused by PGP public key change | [#3747](https://github.com/opensearch-project/opensearch-build/issues/3747) |
+| v2.19.0 | [#16581](https://github.com/opensearch-project/OpenSearch/pull/16581) | Support installing plugin SNAPSHOTs with SNAPSHOT distribution | [opensearch-build#5096](https://github.com/opensearch-project/opensearch-build/issues/5096) |
 
 ### Issues (Design / RFC)
 - [Issue #5308](https://github.com/opensearch-project/opensearch-build/issues/5308): New PGP key for signing artifacts starting 3.0.0

--- a/docs/releases/v2.19.0/features/opensearch/build-infrastructure.md
+++ b/docs/releases/v2.19.0/features/opensearch/build-infrastructure.md
@@ -1,0 +1,66 @@
+---
+tags:
+  - opensearch
+---
+# Build Infrastructure
+
+## Summary
+
+OpenSearch v2.19.0 includes build infrastructure improvements focused on plugin installation for SNAPSHOT distributions. The `opensearch-plugin` CLI now supports installing SNAPSHOT versions of official plugins when running a SNAPSHOT distribution of OpenSearch.
+
+## Details
+
+### What's New in v2.19.0
+
+#### SNAPSHOT Plugin Installation Support
+
+Previously, installing official plugins on SNAPSHOT distributions required a staging hash system property (`opensearch.plugins.staging`). This created friction for developers testing SNAPSHOT builds.
+
+The new implementation simplifies this by:
+1. Detecting if the current OpenSearch build is a SNAPSHOT
+2. Automatically constructing the correct artifact URL for SNAPSHOT plugins
+3. Removing the staging hash requirement
+
+### Technical Changes
+
+| Component | Change |
+|-----------|--------|
+| `InstallPluginCommand` | Removed `PROPERTY_STAGING_ID` and `getStagingHash()` |
+| `InstallPluginCommand` | Simplified `getOpenSearchUrl()` to use `Build.CURRENT.getQualifiedVersion()` for SNAPSHOT builds |
+| URL Construction | Changed from `snapshots/plugins/{id}/{version}-{stagingHash}/` to `snapshots/plugins/{id}/{qualifiedVersion}/` |
+
+### URL Format Changes
+
+**Before (with staging hash):**
+```
+https://artifacts.opensearch.org/snapshots/plugins/analysis-icu/2.19.0-abc123/analysis-icu-2.19.0-SNAPSHOT.zip
+```
+
+**After (simplified):**
+```
+https://artifacts.opensearch.org/snapshots/plugins/analysis-icu/2.19.0-SNAPSHOT/analysis-icu-2.19.0-SNAPSHOT.zip
+```
+
+### Usage Example
+
+```bash
+# On a SNAPSHOT distribution, install plugins directly
+./bin/opensearch-plugin install analysis-icu
+./bin/opensearch-plugin install transport-reactor-netty4
+
+# No staging hash required - works automatically
+```
+
+## Limitations
+
+- Only applies to official OpenSearch plugins
+- Third-party plugins still require explicit URLs or Maven coordinates
+- SNAPSHOT artifacts must be available in the OpenSearch snapshots repository
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16581](https://github.com/opensearch-project/OpenSearch/pull/16581) | Support installing plugin SNAPSHOTs with SNAPSHOT distribution | Part of [opensearch-build#5096](https://github.com/opensearch-project/opensearch-build/issues/5096) |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -4,37 +4,38 @@
 
 ### opensearch
 - Auto Date Histogram Bug Fix
-- Flat Object Field
-- GetStats API
 - Bitmap Filtering Performance Improvement
-- Template Query
-- Dependency Updates
-- Fetch Source Context
-- Gradle Version Catalog
-- Sliced Search Optimization
-- Plugin System
-- Snapshot Restore Settings
-- Sort Field Merging
-- Inner Hits Optimization
+- Build Infrastructure
 - CI Fixes
 - Cluster State
+- Dependency Updates
 - Deprecation Logger Cache Bound
+- Fetch Source Context
+- Flat Object Field
+- GetStats API
+- Gradle Version Catalog
 - gRPC Settings
 - gRPC Transport
 - Index Settings API
 - Ingest Pipeline Deprecation
+- Inner Hits Optimization
 - IP Field
 - IP Field Terms Query
 - List Shards API
 - Match Only Text Field
 - Multi-Search Request Cancellation Fix
+- Plugin System
 - Reader Writer Separation
 - Remote Repository Validation
 - Remote Shards Balance Fix
 - Remote State Manifest
 - Search Response Headers
 - Searchable Snapshot Bug Fixes
+- Sliced Search Optimization
+- Snapshot Restore Settings
+- Sort Field Merging
 - System Indices
+- Template Query
 - Tiered Caching Bug Fixes
 - Unsigned Long Field
 - Workload Management Logging


### PR DESCRIPTION
## Summary\n\nAdds release report for Build Infrastructure improvements in OpenSearch v2.19.0.\n\n### Changes\n- Created `docs/releases/v2.19.0/features/opensearch/build-infrastructure.md`\n- Updated `docs/features/opensearch/opensearch-plugin-installation.md` with v2.19.0 SNAPSHOT plugin installation change\n- Updated `docs/releases/v2.19.0/index.md` to include Build Infrastructure\n\n### Key Feature\nSimplified SNAPSHOT plugin installation by removing the staging hash requirement (PR #16581).\n\nCloses #2028