### PR TITLE
docs: add security-transport-nio report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-secure-transport-settings.md
+++ b/docs/features/opensearch/opensearch-secure-transport-settings.md
@@ -74,7 +74,15 @@ flowchart TB
 |---------|-------------|---------|
 | `plugins.security_config.ssl_dual_mode_enabled` | Enable SSL dual mode for mixed SSL/non-SSL transport | `false` |
 | `plugins.security.ssl_only` | Run security plugin in SSL-only mode | `false` |
-| `http.type` | HTTP transport type (use `reactor-netty4-secure` for secure reactor netty) | `netty4` |
+| `http.type` | HTTP transport type | `netty4` |
+
+#### Supported Secure HTTP Transport Types
+
+| Transport Type | Description | Available Since |
+|----------------|-------------|-----------------|
+| `netty4-secure` | Netty4-based secure HTTP transport | v2.0.0 |
+| `reactor-netty4-secure` | Reactor Netty4-based secure HTTP transport | v2.18.0 |
+| `nio-http-transport-secure` | NIO-based secure HTTP transport | v2.19.0 |
 
 ### Interface Definitions
 
@@ -187,6 +195,7 @@ http.type: reactor-netty4-secure
 ## Change History
 
 - **v3.2.0** (2025-07-15): Added `SecureHttpTransportParameters` interface to `SecureHttpTransportSettingsProvider` for cleaner SSL configuration in Reactor Netty 4 HTTP transport
+- **v2.19.0** (2025-01-21): Added NIO secure HTTP transport support (`nio-http-transport-secure`) via PR #16474
 - **v2.18.0** (2024-10-29): Added `parameters()` method and `SecureTransportParameters` interface to support dynamic SSL dual mode settings
 
 
@@ -203,6 +212,7 @@ http.type: reactor-netty4-secure
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
 | v3.2.0 | [#18572](https://github.com/opensearch-project/OpenSearch/pull/18572) | Introduce SecureHttpTransportParameters experimental API | [#18559](https://github.com/opensearch-project/OpenSearch/issues/18559) |
+| v2.19.0 | [#16474](https://github.com/opensearch-project/OpenSearch/pull/16474) | Ensure support of the transport-nio by security plugin (HTTP) | [#13245](https://github.com/opensearch-project/OpenSearch/issues/13245) |
 | v2.18.0 | [#16387](https://github.com/opensearch-project/OpenSearch/pull/16387) | Add method to return dynamic SecureTransportParameters |   |
 | v2.18.0 | [#4820](https://github.com/opensearch-project/security/pull/4820) | Security plugin: propagate dual mode from cluster settings |   |
 

--- a/docs/releases/v2.19.0/features/opensearch/security-transport-nio.md
+++ b/docs/releases/v2.19.0/features/opensearch/security-transport-nio.md
@@ -1,0 +1,90 @@
+---
+tags:
+  - opensearch
+---
+# Security Transport NIO
+
+## Summary
+
+OpenSearch v2.19.0 adds secure HTTP transport support to the transport-nio plugin, enabling the security plugin to work with NIO-based HTTP transport. This allows users to configure `http.type: nio-http-transport-secure` for TLS/SSL-enabled HTTP connections using the NIO transport layer.
+
+## Details
+
+### What's New in v2.19.0
+
+The transport-nio plugin now provides a secure HTTP transport variant (`nio-http-transport-secure`) that integrates with the OpenSearch security plugin. Previously, secure HTTP transport was only available through the Netty4 transport implementation.
+
+### Technical Changes
+
+The implementation adds SSL/TLS support to the NIO HTTP server transport through several key changes:
+
+| Component | Change |
+|-----------|--------|
+| `NioHttpServerTransport` | Extended to accept `SecureHttpTransportSettingsProvider` for SSL configuration |
+| `HttpReadWriteHandler` | Added SSL engine support with header verification and decompression handlers |
+| `NettyAdaptor` | Modified to support SSL handler in the Netty pipeline |
+| `NioTransportPlugin` | Registered new `nio-http-transport-secure` transport type |
+| `SslUtils` | New utility class for creating default SSL engines |
+
+### Configuration
+
+To enable secure NIO HTTP transport, configure `opensearch.yml`:
+
+```yaml
+http.type: nio-http-transport-secure
+```
+
+The transport uses the security plugin's SSL configuration for certificate management.
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "NIO Transport Plugin"
+        NTP[NioTransportPlugin]
+        NHST[NioHttpServerTransport]
+        HRWH[HttpReadWriteHandler]
+        NA[NettyAdaptor]
+        SU[SslUtils]
+    end
+    
+    subgraph "Security Integration"
+        SHTP[SecureHttpTransportSettingsProvider]
+        SSLEngine[SSLEngine]
+    end
+    
+    NTP -->|registers| NHST
+    NHST -->|uses| SHTP
+    SHTP -->|provides| SSLEngine
+    NHST -->|creates| HRWH
+    HRWH -->|uses| NA
+    HRWH -->|uses| SSLEngine
+    NA -->|wraps| SslHandler
+    SU -->|creates default| SSLEngine
+```
+
+### Key Implementation Details
+
+1. **SSL Handler Integration**: The `NettyAdaptor` now accepts an optional `SslHandler` that is inserted into the Netty pipeline after the write captor
+2. **Header Verification**: Support for custom header verifiers through `TransportAdapterProvider`
+3. **Request Decompression**: Configurable decompressor providers for handling compressed requests
+4. **Default SSL Engine**: `SslUtils` provides fallback SSL engine creation with TLSv1.3, TLSv1.2, and TLSv1.1 protocols
+
+## Limitations
+
+- This feature focuses on HTTP transport only; inter-node transport security continues to use existing mechanisms
+- Requires the security plugin to be installed and configured for full TLS/SSL functionality
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16474](https://github.com/opensearch-project/OpenSearch/pull/16474) | Ensure support of the transport-nio by security plugin (HTTP) | [#13245](https://github.com/opensearch-project/OpenSearch/issues/13245) |
+
+### Related Issues
+- [#13245](https://github.com/opensearch-project/OpenSearch/issues/13245) - [transport] Ensure support of the transport-nio by security plugin (HTTP)
+- [#12903](https://github.com/opensearch-project/OpenSearch/issues/12903) - Parent issue for secure transport support
+
+### Documentation
+- [Network settings](https://docs.opensearch.org/2.19/install-and-configure/configuring-opensearch/network-settings/) - Transport configuration options

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -31,6 +31,7 @@
 - Remote State Manifest
 - Search Response Headers
 - Searchable Snapshot Bug Fixes
+- Security Transport NIO
 - Sliced Search Optimization
 - Snapshot Restore Settings
 - Sort Field Merging


### PR DESCRIPTION
## Summary

Adds documentation for the Security Transport NIO feature in OpenSearch v2.19.0.

### Reports Created
- Release report: `docs/releases/v2.19.0/features/opensearch/security-transport-nio.md`
- Feature report: Updated `docs/features/opensearch/opensearch-secure-transport-settings.md`

### Key Changes in v2.19.0
- Added secure HTTP transport support to the transport-nio plugin
- New transport type: `nio-http-transport-secure`
- Enables TLS/SSL for NIO-based HTTP connections
- Integrates with OpenSearch security plugin

### Investigation Notes
- The original Issue #2027 referenced PR #16474 in the security repository, but the PR is actually in the **OpenSearch core repository**
- PR #16474 adds SSL/TLS support to `NioHttpServerTransport` through `SecureHttpTransportSettingsProvider`

### Resources Used
- PR: [#16474](https://github.com/opensearch-project/OpenSearch/pull/16474)
- Issue: [#13245](https://github.com/opensearch-project/OpenSearch/issues/13245)

Closes #2027