### PR TITLE
docs: add date-sorting report for v2.19.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -4,4 +4,5 @@ Cumulative feature documentation across all versions.
 
 ## opensearch
 
+- Date Field Sorting
 - GetStats API

--- a/docs/features/opensearch/opensearch-date-sorting.md
+++ b/docs/features/opensearch/opensearch-date-sorting.md
@@ -1,0 +1,104 @@
+---
+tags:
+  - opensearch
+---
+# Date Field Sorting
+
+## Summary
+
+OpenSearch supports sorting search results by date fields. Date values are stored internally as epoch milliseconds (long values), enabling efficient sorting operations. Starting from v2.19.0, OpenSearch includes overflow prevention to handle extreme date values safely during sorting.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Date Field Processing"
+        A[Date String] --> B[DateFieldMapper]
+        B --> C[Resolution.convert]
+        C --> D[clampToValidRange]
+        D --> E[Epoch Milliseconds]
+    end
+    subgraph "Sort Operation"
+        E --> F[SortedNumericDocValues]
+        F --> G[Sort Comparator]
+        G --> H[Sorted Results]
+    end
+```
+
+### Date Resolution
+
+OpenSearch date fields support two resolutions:
+
+| Resolution | Storage | Range |
+|------------|---------|-------|
+| MILLISECONDS | Epoch milliseconds (long) | -292275055 to +292278994 years |
+| NANOSECONDS | Epoch nanoseconds (long) | 1677-09-21 to 2262-04-11 |
+
+### Sorting Configuration
+
+Date fields can be sorted using the standard sort syntax:
+
+```json
+{
+  "sort": [
+    {
+      "date_field": {
+        "order": "asc",
+        "missing": "_last"
+      }
+    }
+  ]
+}
+```
+
+| Parameter | Description | Values |
+|-----------|-------------|--------|
+| `order` | Sort direction | `asc`, `desc` |
+| `missing` | Handling for missing values | `_first`, `_last`, or a specific value |
+| `unmapped_type` | Type to use if field is unmapped | `date` |
+
+### Overflow Prevention (v2.19.0+)
+
+The `DateUtils.clampToMillisRange()` method ensures date values stay within the valid epoch millisecond range:
+
+```java
+public static Instant clampToMillisRange(Instant instant) {
+    if (instant.isBefore(INSTANT_LONG_MIN_VALUE)) {
+        return INSTANT_LONG_MIN_VALUE;
+    }
+    if (instant.isAfter(INSTANT_LONG_MAX_VALUE)) {
+        return INSTANT_LONG_MAX_VALUE;
+    }
+    return instant;
+}
+```
+
+## Limitations
+
+- Extreme date values outside the epoch millisecond range are clamped, which may affect sort precision
+- Sorting on date fields with many missing values may have performance implications
+- Date math expressions in sort are not supported; use scripted sorting for complex date calculations
+
+## Change History
+
+- **v2.19.0** (2025-01-14): Added overflow prevention for extreme date values during sorting ([#16812](https://github.com/opensearch-project/OpenSearch/pull/16812))
+
+## References
+
+### Documentation
+
+- [Date field type](https://docs.opensearch.org/latest/field-types/supported-field-types/date/)
+- [Sort results](https://docs.opensearch.org/latest/search-plugins/searching-data/sort/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#16812](https://github.com/opensearch-project/OpenSearch/pull/16812) | Overflow prevention when handling date values |
+
+### Related Issues
+
+- [#16709](https://github.com/opensearch-project/OpenSearch/issues/16709) - arithmetic_exception: long overflow while running sort query on date field
+- [#5713](https://github.com/opensearch-project/OpenSearch/issues/5713) - Random arithmetic_exception - "long overflow" errors

--- a/docs/releases/v2.19.0/features/opensearch/date-sorting.md
+++ b/docs/releases/v2.19.0/features/opensearch/date-sorting.md
@@ -1,0 +1,58 @@
+---
+tags:
+  - opensearch
+---
+# Date Sorting Overflow Prevention
+
+## Summary
+
+OpenSearch v2.19.0 adds overflow prevention when handling extreme date values during sorting operations. This fix prevents `arithmetic_exception: long overflow` errors that occurred intermittently when sorting on date fields containing extreme values or when documents had missing date values.
+
+## Details
+
+### What's New in v2.19.0
+
+A new `clampToMillisRange()` method was added to `DateUtils` that clamps `Instant` values to the valid epoch millisecond range (`Long.MIN_VALUE` to `Long.MAX_VALUE`). This method is now called during date field conversion to prevent overflow when converting extreme date values to epoch milliseconds.
+
+### Technical Changes
+
+The fix modifies the `DateFieldMapper.Resolution.MILLISECONDS` enum to clamp date values before conversion:
+
+| Component | Change |
+|-----------|--------|
+| `DateUtils.java` | Added `clampToMillisRange()` method that clamps `Instant` to valid epoch millisecond range |
+| `DateFieldMapper.java` | Modified `MILLISECONDS.convert()` to call `clampToValidRange()` before `toEpochMilli()` |
+| `DateFieldMapper.java` | Updated `MILLISECONDS.clampToValidRange()` to use `DateUtils.clampToMillisRange()` |
+
+### Root Cause
+
+The overflow occurred when:
+1. Sorting on date fields with extreme values (e.g., dates far in the past or future)
+2. Documents with missing date values where `missing: "_last"` or `missing: "_first"` was specified
+3. The internal conversion from `Instant` to epoch milliseconds exceeded `Long.MAX_VALUE` or went below `Long.MIN_VALUE`
+
+### Clamping Behavior
+
+| Condition | Result |
+|-----------|--------|
+| Date before `Long.MIN_VALUE` epoch millis | Clamped to `Instant.ofEpochMilli(Long.MIN_VALUE)` |
+| Date after `Long.MAX_VALUE` epoch millis | Clamped to `Instant.ofEpochMilli(Long.MAX_VALUE)` |
+| Date within valid range | Returned as-is |
+
+## Limitations
+
+- Extreme date values outside the valid epoch millisecond range will be clamped, which may affect sort order precision for such edge cases
+- This fix applies only to millisecond resolution date fields; nanosecond resolution fields have separate handling
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16812](https://github.com/opensearch-project/OpenSearch/pull/16812) | Overflow prevention when handling date values | [#16709](https://github.com/opensearch-project/OpenSearch/issues/16709), [#5713](https://github.com/opensearch-project/OpenSearch/issues/5713) |
+
+### Related Issues
+
+- [#16709](https://github.com/opensearch-project/OpenSearch/issues/16709) - arithmetic_exception: long overflow while running sort query on date field
+- [#5713](https://github.com/opensearch-project/OpenSearch/issues/5713) - Random arithmetic_exception - "long overflow" errors

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch
 - Auto Date Histogram Bug Fix
+- Date Sorting Overflow Prevention
 - Bitmap Filtering Performance Improvement
 - Build Infrastructure
 - CI Fixes


### PR DESCRIPTION
## Summary

Add documentation for Date Sorting Overflow Prevention feature in OpenSearch v2.19.0.

### Reports Created
- Release report: `docs/releases/v2.19.0/features/opensearch/date-sorting.md`
- Feature report: `docs/features/opensearch/opensearch-date-sorting.md`

### Key Changes in v2.19.0
- Added `clampToMillisRange()` method to `DateUtils` to prevent overflow
- Modified `DateFieldMapper.Resolution.MILLISECONDS` to clamp values before conversion
- Fixes intermittent `arithmetic_exception: long overflow` errors when sorting on date fields

### Related
- Closes #2026
- PR: opensearch-project/OpenSearch#16812
- Issues: opensearch-project/OpenSearch#16709, opensearch-project/OpenSearch#5713