### PR TITLE
docs: add ingest-pipeline report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-search-pipeline.md
+++ b/docs/features/opensearch/opensearch-search-pipeline.md
@@ -264,6 +264,7 @@ Response includes system-generated processor and factory statistics:
 
 - **v3.3.0** (2026-01-14): Added system-generated search pipeline support for automatic processor generation
 - **v3.2.0** (2026-01-14): Added support for specifying search pipeline in search template and msearch template APIs
+- **v2.19.0** (2025-01-28): Added `verbose_pipeline` parameter for debugging search pipeline processor execution
 - **v2.18.0** (2024-11-05): Added support for specifying search pipeline in msearch API request body
 
 
@@ -273,6 +274,7 @@ Response includes system-generated processor and factory statistics:
 - [Search Pipelines Documentation](https://docs.opensearch.org/latest/search-plugins/search-pipelines/index/): Official documentation
 - [Using a Search Pipeline](https://docs.opensearch.org/latest/search-plugins/search-pipelines/using-search-pipeline/): Usage guide
 - [Creating a Search Pipeline](https://docs.opensearch.org/latest/search-plugins/search-pipelines/creating-search-pipeline/): Creation guide
+- [Debugging a Search Pipeline](https://docs.opensearch.org/latest/search-plugins/search-pipelines/debugging-search-pipeline/): Debugging with verbose_pipeline
 - [Search Templates Documentation](https://docs.opensearch.org/latest/api-reference/search-apis/search-template/): Search template API
 - [Multi-Search Template Documentation](https://docs.opensearch.org/latest/api-reference/search-apis/msearch-template/): Msearch template API
 
@@ -286,9 +288,12 @@ Response includes system-generated processor and factory statistics:
 |---------|-----|-------------|---------------|
 | v3.3.0 | [#19128](https://github.com/opensearch-project/OpenSearch/pull/19128) | Added system-generated search pipeline support | [#18731](https://github.com/opensearch-project/OpenSearch/issues/18731) |
 | v3.2.0 | [#18564](https://github.com/opensearch-project/OpenSearch/pull/18564) | Added search pipeline support in search and msearch template | [#18508](https://github.com/opensearch-project/OpenSearch/issues/18508) |
+| v2.19.0 | [#16843](https://github.com/opensearch-project/OpenSearch/pull/16843) | Added verbose_pipeline parameter for debugging | [#14745](https://github.com/opensearch-project/OpenSearch/issues/14745) |
 | v2.18.0 | [#15923](https://github.com/opensearch-project/OpenSearch/pull/15923) | Added msearch API support for search pipeline name | [#15748](https://github.com/opensearch-project/OpenSearch/issues/15748) |
 
 ### Issues (Design / RFC)
 - [Issue #18731](https://github.com/opensearch-project/OpenSearch/issues/18731): Feature request for system-generated search pipeline
 - [Issue #18508](https://github.com/opensearch-project/OpenSearch/issues/18508): Feature request for search pipeline support in msearch template
+- [Issue #16705](https://github.com/opensearch-project/OpenSearch/issues/16705): RFC for tracking search pipeline execution (verbose_pipeline)
+- [Issue #14745](https://github.com/opensearch-project/OpenSearch/issues/14745): Feature request for verbose/debugging param in search pipelines
 - [Issue #15748](https://github.com/opensearch-project/OpenSearch/issues/15748): Feature request for msearch pipeline support

--- a/docs/releases/v2.19.0/features/opensearch/ingest-pipeline.md
+++ b/docs/releases/v2.19.0/features/opensearch/ingest-pipeline.md
@@ -1,0 +1,128 @@
+---
+tags:
+  - opensearch
+---
+# Ingest Pipeline - Verbose Pipeline Parameter
+
+## Summary
+
+OpenSearch 2.19.0 introduces the `verbose_pipeline` parameter for search pipelines, enabling detailed debugging and tracing of processor execution. When enabled, the search response includes a `processor_results` array containing input/output data, execution time, and status for each processor in the pipeline.
+
+## Details
+
+### What's New in v2.19.0
+
+The `verbose_pipeline` parameter provides transparency into search pipeline execution by tracking:
+
+- **Processor name and tag**: Identifies each processor in the pipeline
+- **Execution duration**: Time taken by each processor in milliseconds
+- **Input/output data**: The data before and after processor transformation
+- **Status**: Success or failure status of each processor
+- **Error messages**: Detailed error information when processors fail
+
+### Technical Changes
+
+#### New Parameter
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `verbose_pipeline` | Boolean | `false` | Enables detailed processor execution tracking |
+
+#### New Response Field
+
+When `verbose_pipeline=true`, the response includes:
+
+```json
+{
+  "processor_results": [
+    {
+      "processor_name": "filter_query",
+      "tag": "tag1",
+      "duration_millis": 288541,
+      "status": "success",
+      "input_data": { ... },
+      "output_data": { ... }
+    }
+  ]
+}
+```
+
+#### New Classes
+
+| Class | Description |
+|-------|-------------|
+| `ProcessorExecutionDetail` | Captures execution details for each processor |
+| `TrackingSearchRequestProcessorWrapper` | Wraps request processors to track execution |
+| `TrackingSearchResponseProcessorWrapper` | Wraps response processors to track execution |
+
+### Usage Examples
+
+#### With Query Parameter
+
+```
+GET /my_index/_search?search_pipeline=my_pipeline&verbose_pipeline=true
+```
+
+#### With Default Pipeline
+
+```json
+PUT /my_index/_settings
+{
+  "index.search.default_pipeline": "my_pipeline"
+}
+
+GET /my_index/_search?verbose_pipeline=true
+```
+
+#### With Temporary Pipeline
+
+```json
+POST /my_index/_search?verbose_pipeline=true
+{
+  "query": { "match": { "text_field": "search text" }},
+  "search_pipeline": {
+    "request_processors": [
+      {
+        "filter_query": {
+          "query": { "term": { "visibility": "public" }}
+        }
+      }
+    ]
+  }
+}
+```
+
+### Error Handling
+
+When `verbose_pipeline` is enabled, processor failures are logged but do not interrupt the search execution. The error details are captured in the `processor_results`:
+
+```json
+{
+  "processor_name": "rename_field",
+  "duration_millis": 0,
+  "status": "fail",
+  "error": "Document with id 1 is missing field message",
+  "input_data": [ ... ],
+  "output_data": null
+}
+```
+
+## Limitations
+
+- Enabling verbose mode adds computational overhead due to additional tracking
+- The `verbose_pipeline` parameter requires a search pipeline to be defined; using it without a pipeline throws an error
+- Input/output data serialization may increase response size significantly for large result sets
+
+## References
+
+### Documentation
+- [Debugging a Search Pipeline](https://docs.opensearch.org/2.19/search-plugins/search-pipelines/debugging-search-pipeline/)
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16843](https://github.com/opensearch-project/OpenSearch/pull/16843) | Add verbose pipeline parameter to output each processor's execution details | [#14745](https://github.com/opensearch-project/OpenSearch/issues/14745) |
+
+### Issues
+- [#14745](https://github.com/opensearch-project/OpenSearch/issues/14745): Feature request for verbose/debugging param in search pipelines
+- [#16705](https://github.com/opensearch-project/OpenSearch/issues/16705): RFC for tracking search pipeline execution

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -18,6 +18,7 @@
 - gRPC Settings
 - gRPC Transport
 - Index Settings API
+- Ingest Pipeline
 - Ingest Pipeline Deprecation
 - Inner Hits Optimization
 - IP Field


### PR DESCRIPTION
## Summary

This PR adds documentation for the `verbose_pipeline` parameter introduced in OpenSearch v2.19.0 for debugging search pipelines.

## Changes

### Release Report
- Created `docs/releases/v2.19.0/features/opensearch/ingest-pipeline.md`
  - Documents the new `verbose_pipeline` parameter
  - Explains processor execution tracking (input/output, duration, status)
  - Includes usage examples and error handling behavior

### Feature Report Update
- Updated `docs/features/opensearch/opensearch-search-pipeline.md`
  - Added v2.19.0 to Change History
  - Added PR #16843 to Pull Requests table
  - Added related issues (#14745, #16705)
  - Added debugging documentation link

### Release Index
- Updated `docs/releases/v2.19.0/index.md` to include "Ingest Pipeline"

## Key Feature Details

The `verbose_pipeline` parameter enables detailed debugging of search pipeline execution:
- Tracks processor name, tag, duration, status
- Captures input/output data for each processor
- Logs errors without interrupting search execution
- Works with default, specific, and temporary pipelines

## References
- PR: opensearch-project/OpenSearch#16843
- Issue: opensearch-project/OpenSearch#14745
- RFC: opensearch-project/OpenSearch#16705