### PR TITLE
docs: add append-only-indices report for v2.19.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -4,5 +4,6 @@ Cumulative feature documentation across all versions.
 
 ## opensearch
 
+- Append Only Indices
 - Date Field Sorting
 - GetStats API

--- a/docs/features/opensearch/append-only-indices.md
+++ b/docs/features/opensearch/append-only-indices.md
@@ -1,0 +1,131 @@
+---
+tags:
+  - opensearch
+---
+# Append Only Indices
+
+## Summary
+
+Append-only indices are a specialized index mode in OpenSearch that enforces document immutability by disabling all update and delete operations. This feature is optimized for time-series workloads such as logs, metrics, observability data, and security events where documents should never be modified after ingestion.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph "Client"
+        A[Bulk Request]
+    end
+    subgraph "Coordinator Node"
+        B[TransportBulkAction]
+        C{Validate Operations}
+    end
+    subgraph "Data Node"
+        D[IndexShard]
+        E[InternalEngine]
+        F[Translog]
+    end
+    A --> B
+    B --> C
+    C -->|Valid| D
+    C -->|Invalid| G[Reject]
+    D --> E
+    E --> F
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `INDEX_APPEND_ONLY_ENABLED_SETTING` | Index-scoped boolean setting to enable append-only mode |
+| `TransportBulkAction` | Validates operations at the transport layer before shard routing |
+| `InternalEngine` | Handles retry detection and prevents duplicate translog entries |
+| `AppendOnlyIndexOperationRetryException` | Exception for retry scenarios in append-only indices |
+
+### Configuration
+
+| Setting | Type | Default | Scope | Description |
+|---------|------|---------|-------|-------------|
+| `index.append_only.enabled` | Boolean | `false` | Index | Enables append-only mode. Final setting (cannot be changed after creation). |
+
+### Usage Example
+
+Create an append-only index:
+
+```json
+PUT /logs-2024
+{
+  "settings": {
+    "index.append_only.enabled": true,
+    "index.number_of_shards": 3,
+    "index.number_of_replicas": 1
+  }
+}
+```
+
+Index documents (auto-generated IDs only):
+
+```json
+POST /logs-2024/_bulk
+{"index": {}}
+{"timestamp": "2024-01-15T10:00:00Z", "message": "Application started", "level": "INFO"}
+{"index": {}}
+{"timestamp": "2024-01-15T10:00:01Z", "message": "Connection established", "level": "DEBUG"}
+```
+
+Rejected operations:
+
+```json
+# This will fail - custom document ID not allowed
+POST /logs-2024/_doc/custom-id
+{"message": "test"}
+
+# This will fail - updates not allowed
+POST /logs-2024/_update/abc123
+{"doc": {"message": "updated"}}
+
+# This will fail - deletes not allowed
+DELETE /logs-2024/_doc/abc123
+```
+
+### Use Cases
+
+1. **Log Analytics**: Immutable audit logs, application logs, security logs
+2. **Metrics and Observability**: Time-series metrics that should never be modified
+3. **Compliance**: Regulatory requirements for immutable records (audit trails, transactions)
+4. **Pre-computed Data Structures**: Foundation for features like Star Tree index where updates would be expensive
+
+### Benefits
+
+- **Data Integrity**: Guarantees documents cannot be altered after ingestion
+- **Performance Potential**: Enables future optimizations by eliminating update/delete overhead
+- **Reduced Memory Footprint**: Potential for version map optimizations (planned)
+- **Merge Optimization**: Allows for more aggressive merge policies (planned)
+
+## Limitations
+
+- Setting is final and cannot be changed after index creation
+- Custom document IDs are not supported
+- No current integration with data streams (may be added in future)
+- `_split` and `_shrink` API restrictions planned but not yet enforced
+
+## Change History
+
+- **v2.19.0** (2025-01-28): Initial implementation with basic append-only enforcement
+
+## References
+
+### Documentation
+
+- Official documentation pending
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#17039](https://github.com/opensearch-project/OpenSearch/pull/17039) | Add support for append only indices |
+
+### Related Issues
+
+- [#12886](https://github.com/opensearch-project/OpenSearch/issues/12886) - RFC: Append-only Indices

--- a/docs/releases/v2.19.0/features/opensearch/append-only-indices.md
+++ b/docs/releases/v2.19.0/features/opensearch/append-only-indices.md
@@ -1,0 +1,86 @@
+---
+tags:
+  - opensearch
+---
+# Append Only Indices
+
+## Summary
+
+OpenSearch 2.19.0 introduces append-only indices, a new index mode that disables update and delete operations on documents. This feature is designed for time-series use cases like logs, metrics, observability, and security events where documents are immutable after ingestion.
+
+## Details
+
+### What's New in v2.19.0
+
+Append-only indices provide a way to enforce document immutability at the index level. When enabled, the index rejects:
+- UPDATE operations
+- DELETE operations
+- UPSERT operations
+- UPDATE BY QUERY operations
+- DELETE BY QUERY operations
+- INDEX operations with custom document IDs
+
+### Configuration
+
+Enable append-only mode using the `index.append_only.enabled` setting:
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index.append_only.enabled": true
+  }
+}
+```
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `index.append_only.enabled` | Boolean | `false` | Enables append-only mode for the index. This is a final setting and cannot be changed after index creation. |
+
+### Technical Changes
+
+The implementation adds validation at multiple layers:
+
+```mermaid
+flowchart TB
+    subgraph "Request Flow"
+        A[Bulk Request] --> B{Append-Only Index?}
+        B -->|No| C[Normal Processing]
+        B -->|Yes| D{Operation Type?}
+        D -->|UPDATE/DELETE| E[Reject with Error]
+        D -->|INDEX with custom ID| E
+        D -->|INDEX without ID| F[Process Request]
+    end
+```
+
+Key implementation details:
+- `IndexMetadata.INDEX_APPEND_ONLY_ENABLED_SETTING`: New index-scoped setting with `Property.Final`
+- `TransportBulkAction`: Validates operations before routing to shards
+- `InternalEngine`: Handles retry scenarios for append-only indices without creating duplicate translog entries
+- `AppendOnlyIndexOperationRetryException`: New exception type for retry handling
+
+### Retry Handling
+
+For append-only indices, the engine detects retry scenarios by checking if a document with the same auto-generated ID already exists. Instead of creating a duplicate, it returns the existing document's version, preventing duplicate entries during network retries.
+
+## Limitations
+
+- The `index.append_only.enabled` setting is final and cannot be changed after index creation
+- Custom document IDs are not allowed; OpenSearch auto-generates IDs
+- `_split` and `_shrink` APIs may have restrictions (planned for future enforcement)
+- This is the initial implementation; future versions may add optimizations like:
+  - Automated rollovers
+  - Optimized merge policies
+  - Integration with writable warm storage
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#17039](https://github.com/opensearch-project/OpenSearch/pull/17039) | Add support for append only indices | [#12886](https://github.com/opensearch-project/OpenSearch/issues/12886) |
+
+### Related Issues
+
+- [#12886](https://github.com/opensearch-project/OpenSearch/issues/12886) - RFC: Append-only Indices

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -3,6 +3,7 @@
 ## Features
 
 ### opensearch
+- Append Only Indices
 - Auto Date Histogram Bug Fix
 - Date Sorting Overflow Prevention
 - Bitmap Filtering Performance Improvement


### PR DESCRIPTION
## Summary

Add documentation for Append Only Indices feature introduced in OpenSearch v2.19.0.

## Changes

- Release report: `docs/releases/v2.19.0/features/opensearch/append-only-indices.md`
- Feature report: `docs/features/opensearch/append-only-indices.md`
- Updated release index and features index

## Feature Overview

Append-only indices disable update and delete operations on documents, designed for time-series use cases like logs, metrics, and security events where documents should be immutable.

### Key Points
- New setting: `index.append_only.enabled` (final, cannot be changed after creation)
- Blocks UPDATE, DELETE, UPSERT, UPDATE BY QUERY, DELETE BY QUERY operations
- Blocks INDEX operations with custom document IDs
- Handles retry scenarios without creating duplicate translog entries

## References
- PR: https://github.com/opensearch-project/OpenSearch/pull/17039
- RFC Issue: https://github.com/opensearch-project/OpenSearch/issues/12886