### PR TITLE
docs: add script-enhancements report for v2.19.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -7,3 +7,4 @@ Cumulative feature documentation across all versions.
 - Append Only Indices
 - Date Field Sorting
 - GetStats API
+- Painless Script Hashing Methods

--- a/docs/features/opensearch/painless-script-hashing.md
+++ b/docs/features/opensearch/painless-script-hashing.md
@@ -1,0 +1,122 @@
+---
+tags:
+  - opensearch
+---
+# Painless Script Hashing Methods
+
+## Summary
+
+OpenSearch provides `sha1()` and `sha256()` augmentation methods for strings in Painless scripts, enabling cryptographic hashing of field values during document processing. These methods are available in ingest and update script contexts.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Painless Script Contexts"
+        Ingest[Ingest Context]
+        Update[Update Context]
+    end
+    subgraph "Augmentation Methods"
+        SHA1["sha1()"]
+        SHA256["sha256()"]
+    end
+    subgraph "Operations"
+        Pipeline[Ingest Pipeline]
+        UpdateDoc[Update Document]
+        Reindex[Reindex]
+        UpdateByQuery[Update by Query]
+    end
+    Ingest --> SHA1
+    Ingest --> SHA256
+    Update --> SHA1
+    Update --> SHA256
+    Pipeline --> Ingest
+    UpdateDoc --> Update
+    Reindex --> Update
+    UpdateByQuery --> Update
+```
+
+### Available Methods
+
+| Method | Return Type | Description |
+|--------|-------------|-------------|
+| `sha1()` | String | Returns SHA-1 hash of the string (40 hex characters) |
+| `sha256()` | String | Returns SHA-256 hash of the string (64 hex characters) |
+
+### Script Contexts
+
+| Context | Available Since | Use Cases |
+|---------|-----------------|-----------|
+| Ingest | 1.0 | Ingest pipelines |
+| Update | 2.19.0 | Update, reindex, update_by_query |
+
+### Usage Examples
+
+**Ingest pipeline processor:**
+```json
+PUT _ingest/pipeline/hash_pipeline
+{
+  "processors": [
+    {
+      "script": {
+        "source": "ctx.url_hash = ctx.url.sha256()"
+      }
+    }
+  ]
+}
+```
+
+**Update document:**
+```json
+POST /index/_update/1
+{
+  "script": {
+    "source": "ctx._source.hash = ctx._source.field.sha256()"
+  }
+}
+```
+
+**Reindex with custom ID:**
+```json
+POST /_reindex
+{
+  "source": { "index": "src" },
+  "dest": { "index": "dest" },
+  "script": {
+    "source": "ctx._id = ctx._source.url.sha256()"
+  }
+}
+```
+
+### Implementation Details
+
+The hashing methods are implemented as augmentation methods in `org.opensearch.painless.api.Augmentation` class. They are registered via allowlist files for each script context:
+
+- `org.opensearch.ingest.txt` - Ingest context
+- `org.opensearch.update.txt` - Update context (added in v2.19.0)
+
+## Limitations
+
+- Only available for `java.lang.String` type
+- Not available in search, aggregation, or other script contexts
+- Hash output is always lowercase hexadecimal
+
+## Change History
+
+- **v2.19.0** (2025-02-25): Extended `sha1()` and `sha256()` methods to update script context, enabling use in update, reindex, and update_by_query operations
+
+## References
+
+### Documentation
+- [Script processor](https://docs.opensearch.org/latest/ingest-pipelines/processors/script/)
+- [Update by query](https://docs.opensearch.org/latest/api-reference/document-apis/update-by-query/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#16923](https://github.com/opensearch-project/OpenSearch/pull/16923) | Update script supports sha1() and sha256() methods |
+
+### Related Issues
+- [#16423](https://github.com/opensearch-project/OpenSearch/issues/16423) - Request to enable sha256() in reindex scripts

--- a/docs/releases/v2.19.0/features/opensearch/script-enhancements.md
+++ b/docs/releases/v2.19.0/features/opensearch/script-enhancements.md
@@ -1,0 +1,84 @@
+---
+tags:
+  - opensearch
+---
+# Script Enhancements
+
+## Summary
+
+OpenSearch 2.19.0 extends the availability of `sha1()` and `sha256()` string hashing methods in Painless scripts to the update context. Previously, these methods were only available in ingest pipelines; now they can be used in update, reindex, and update_by_query operations.
+
+## Details
+
+### What's New in v2.19.0
+
+The `sha1()` and `sha256()` augmentation methods for `java.lang.String` are now available in the update script context. This enables hashing string values during document updates without requiring a separate ingest pipeline.
+
+### Supported Operations
+
+| Operation | sha1()/sha256() Support |
+|-----------|------------------------|
+| Ingest pipeline | Yes (existing) |
+| Update document | Yes (new in v2.19.0) |
+| Reindex | Yes (new in v2.19.0) |
+| Update by query | Yes (new in v2.19.0) |
+
+### Usage Examples
+
+**Update document with hashed field:**
+```json
+POST /test_index/_update/1
+{
+  "script": {
+    "lang": "painless",
+    "source": "ctx._source.url_hash = ctx._source.url.sha256()"
+  }
+}
+```
+
+**Reindex with hashed document ID:**
+```json
+POST /_reindex
+{
+  "source": {
+    "index": "source_index"
+  },
+  "dest": {
+    "index": "dest_index"
+  },
+  "script": {
+    "lang": "painless",
+    "source": "ctx._id = ctx._source.url.sha256()"
+  }
+}
+```
+
+**Update by query with hashing:**
+```json
+POST /my_index/_update_by_query
+{
+  "script": {
+    "lang": "painless",
+    "source": "ctx._source.user_sha1 = ctx._source.user.sha1(); ctx._source.user_sha256 = ctx._source.user.sha256()"
+  }
+}
+```
+
+### Technical Implementation
+
+The change adds a new allowlist file `org.opensearch.update.txt` that registers the `sha1()` and `sha256()` augmentation methods from `org.opensearch.painless.api.Augmentation` for the `UpdateScript.CONTEXT`. This follows the same pattern used for ingest scripts.
+
+## Limitations
+
+- The hashing methods are only available for `java.lang.String` types
+- Other script contexts (e.g., search scripts, aggregation scripts) do not have access to these methods
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16923](https://github.com/opensearch-project/OpenSearch/pull/16923) | Update script supports java.lang.String.sha1() and java.lang.String.sha256() methods | [#16423](https://github.com/opensearch-project/OpenSearch/issues/16423) |
+
+### Related Issues
+- [#16423](https://github.com/opensearch-project/OpenSearch/issues/16423) - BUG: dynamic method [java.lang.String, sha256/0] not available in _reindex Painless script

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -43,6 +43,7 @@
 - Tiered Caching Bug Fixes
 - Unsigned Long Field
 - Workload Management Logging
+- Script Enhancements
 
 ### opensearch-dashboards
 - Dashboards Health Checks


### PR DESCRIPTION
## Summary

Adds documentation for Script Enhancements feature in OpenSearch v2.19.0.

### Changes
- Release report: `docs/releases/v2.19.0/features/opensearch/script-enhancements.md`
- Feature report: `docs/features/opensearch/painless-script-hashing.md`
- Updated release index and features index

### Feature Overview
OpenSearch 2.19.0 extends the availability of `sha1()` and `sha256()` string hashing methods in Painless scripts to the update context. Previously, these methods were only available in ingest pipelines; now they can be used in update, reindex, and update_by_query operations.

### Related
- PR: opensearch-project/OpenSearch#16923
- Issue: opensearch-project/OpenSearch#16423
- Investigation Issue: #2023