### PR TITLE
docs: add synonym-analyzer report for v2.19.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -8,3 +8,4 @@ Cumulative feature documentation across all versions.
 - Date Field Sorting
 - GetStats API
 - Painless Script Hashing Methods
+- Synonym Analyzer Configuration

--- a/docs/features/opensearch/synonym-analyzer.md
+++ b/docs/features/opensearch/synonym-analyzer.md
@@ -1,0 +1,136 @@
+---
+tags:
+  - opensearch
+---
+# Synonym Analyzer Configuration
+
+## Summary
+
+The `synonym_analyzer` setting allows users to specify a custom analyzer for parsing synonym files in the `synonym` and `synonym_graph` token filters. This enables complex analyzer chains that include filters incompatible with synonym parsing (such as `word_delimiter_graph` or `hunspell`) to work correctly with synonym expansion.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Analyzer Chain"
+        A[Tokenizer] --> B[Token Filter 1]
+        B --> C[Token Filter 2]
+        C --> D[Synonym Filter]
+        D --> E[Flatten Graph]
+    end
+    
+    subgraph "Synonym Parsing"
+        F[Synonym File] --> G[synonym_analyzer]
+        G --> H[Parsed Synonyms]
+        H --> D
+    end
+```
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `synonym_analyzer` | Name of the analyzer to use for parsing synonym rules | Uses preceding filters in chain |
+| `synonyms` | Inline synonym rules | - |
+| `synonyms_path` | Path to synonym file | - |
+| `format` | Synonym format (`solr` or `wordnet`) | `solr` |
+| `expand` | Whether to expand equivalent synonyms | `true` |
+| `lenient` | Ignore exceptions when loading rules | `false` |
+
+### Usage Example
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "analysis": {
+      "filter": {
+        "custom_word_delimiter": {
+          "type": "word_delimiter_graph",
+          "generate_word_parts": true,
+          "catenate_all": true,
+          "split_on_numerics": false,
+          "split_on_case_change": false
+        },
+        "custom_hunspell_stemmer": {
+          "type": "hunspell",
+          "locale": "en_US"
+        },
+        "custom_synonym_graph_filter": {
+          "type": "synonym_graph",
+          "synonyms": [
+            "laptop => notebook",
+            "smartphone, mobile phone, cell phone => smartphone"
+          ],
+          "synonym_analyzer": "standard"
+        }
+      },
+      "analyzer": {
+        "text_analyzer": {
+          "type": "custom",
+          "tokenizer": "whitespace",
+          "filter": [
+            "lowercase",
+            "custom_word_delimiter",
+            "custom_hunspell_stemmer",
+            "custom_synonym_graph_filter",
+            "flatten_graph"
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+### How It Works
+
+1. Without `synonym_analyzer`: OpenSearch builds a temporary analyzer from the tokenizer and all token filters preceding the synonym filter to parse synonym rules
+2. With `synonym_analyzer`: OpenSearch uses the specified analyzer directly to parse synonym rules, bypassing the preceding filters
+
+This separation allows incompatible filters (those that produce token graphs or modify positions) to be used before synonym filters without causing parsing errors.
+
+### Supported Filters
+
+The following filters are known to cause issues when placed before synonym filters without using `synonym_analyzer`:
+
+| Filter | Issue |
+|--------|-------|
+| `word_delimiter_graph` | Produces token graphs |
+| `hunspell` | Modifies token positions |
+| `common_grams` | Produces token graphs |
+| `ngram` | Produces multiple tokens |
+| `edge_ngram` | Produces multiple tokens |
+| `shingle` | Produces token graphs |
+| `fingerprint` | Modifies token stream |
+
+## Limitations
+
+- The `synonym_analyzer` must reference a valid, pre-defined analyzer
+- Built-in analyzers (`standard`, `simple`, `whitespace`, etc.) can be used
+- Custom analyzers must be defined in the same index settings
+- The analyzer should produce tokens compatible with the synonym format
+
+## Change History
+
+- **v2.19.0** (2024-11-12): Added `synonym_analyzer` configuration setting for `synonym` and `synonym_graph` filters
+
+## References
+
+### Documentation
+
+- [Synonym Token Filter](https://docs.opensearch.org/latest/analyzers/token-filters/synonym/)
+- [Synonym Graph Token Filter](https://docs.opensearch.org/latest/analyzers/token-filters/synonym-graph/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#16488](https://github.com/opensearch-project/OpenSearch/pull/16488) | Add new configuration setting `synonym_analyzer` for `synonym` and `synonym_graph` filters |
+
+### Related Issues
+
+- [#16263](https://github.com/opensearch-project/OpenSearch/issues/16263) - Token Filter Order: word_delimiter_graph and synonym_graph
+- [#16530](https://github.com/opensearch-project/OpenSearch/issues/16530) - Using synonym filter after hunspell

--- a/docs/releases/v2.19.0/features/opensearch/synonym-analyzer.md
+++ b/docs/releases/v2.19.0/features/opensearch/synonym-analyzer.md
@@ -1,0 +1,84 @@
+---
+tags:
+  - opensearch
+---
+# Synonym Analyzer
+
+## Summary
+
+OpenSearch v2.19.0 introduces a new `synonym_analyzer` configuration setting for the `synonym` and `synonym_graph` token filters. This setting allows users to specify a custom analyzer for reading and parsing synonym files, solving compatibility issues when using certain token filters (like `word_delimiter_graph` or `hunspell`) before synonym expansion.
+
+## Details
+
+### What's New in v2.19.0
+
+The `synonym_analyzer` parameter enables users to specify a separate analyzer for parsing synonym rules, independent of the analyzer chain where the synonym filter is used. This addresses a long-standing limitation where certain token filters could not be used before synonym filters due to token graph parsing restrictions.
+
+### Problem Solved
+
+Previously, when using filters like `word_delimiter_graph` or `hunspell` before `synonym_graph`, users encountered errors such as:
+
+```
+Token filter [custom_word_delimiter] cannot be used to parse synonyms
+```
+
+This occurred because OpenSearch used the preceding filters in the analyzer chain to parse the synonym file, and some filters (those producing token graphs or modifying token positions) are incompatible with synonym parsing.
+
+### Configuration
+
+The new `synonym_analyzer` parameter can be added to both `synonym` and `synonym_graph` filter configurations:
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "analysis": {
+      "filter": {
+        "custom_synonym_graph_filter": {
+          "type": "synonym_graph",
+          "synonyms_path": "synonyms.txt",
+          "synonym_analyzer": "standard"
+        }
+      },
+      "analyzer": {
+        "my_analyzer": {
+          "tokenizer": "whitespace",
+          "filter": [
+            "lowercase",
+            "custom_word_delimiter",
+            "custom_synonym_graph_filter",
+            "flatten_graph"
+          ]
+        }
+      }
+    }
+  }
+}
+```
+
+### Technical Changes
+
+The implementation modifies the `AnalysisPlugin` interface to provide access to the `AnalysisModule`, allowing synonym filters to look up analyzers by name from the analysis registry:
+
+- `SynonymTokenFilterFactory` now accepts an `AnalysisRegistry` parameter
+- `SynonymGraphTokenFilterFactory` inherits the same capability
+- When `synonym_analyzer` is specified, the filter uses that analyzer instead of building one from the preceding filters
+
+## Limitations
+
+- The `synonym_analyzer` must be a valid, registered analyzer name
+- If the specified analyzer doesn't exist, the filter falls back to the default behavior
+- The analyzer used for synonyms should be compatible with the synonym format being used
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16488](https://github.com/opensearch-project/OpenSearch/pull/16488) | Add new configuration setting `synonym_analyzer` for `synonym` and `synonym_graph` filters | [#16263](https://github.com/opensearch-project/OpenSearch/issues/16263), [#16530](https://github.com/opensearch-project/OpenSearch/issues/16530) |
+
+### Related Issues
+
+- [#16263](https://github.com/opensearch-project/OpenSearch/issues/16263) - Token Filter Order: word_delimiter_graph and synonym_graph
+- [#16530](https://github.com/opensearch-project/OpenSearch/issues/16530) - Using synonym filter after hunspell

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch
 - Append Only Indices
+- Synonym Analyzer
 - Auto Date Histogram Bug Fix
 - Date Sorting Overflow Prevention
 - Bitmap Filtering Performance Improvement


### PR DESCRIPTION
## Summary

This PR adds documentation for the Synonym Analyzer feature introduced in OpenSearch v2.19.0.

### Changes
- Added release report: `docs/releases/v2.19.0/features/opensearch/synonym-analyzer.md`
- Added feature report: `docs/features/opensearch/synonym-analyzer.md`
- Updated release index and features index

### Feature Overview
The `synonym_analyzer` configuration setting allows users to specify a custom analyzer for parsing synonym files in the `synonym` and `synonym_graph` token filters. This solves compatibility issues when using filters like `word_delimiter_graph` or `hunspell` before synonym expansion.

### Related
- Closes #2022
- PR: opensearch-project/OpenSearch#16488
- Issues: opensearch-project/OpenSearch#16263, opensearch-project/OpenSearch#16530