### PR TITLE
docs: add snapshot-repository report for v2.19.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -8,4 +8,5 @@ Cumulative feature documentation across all versions.
 - Date Field Sorting
 - GetStats API
 - Painless Script Hashing Methods
+- Snapshot Repository
 - Synonym Analyzer Configuration

--- a/docs/features/opensearch/snapshot-repository.md
+++ b/docs/features/opensearch/snapshot-repository.md
@@ -1,0 +1,127 @@
+---
+tags:
+  - opensearch
+---
+# Snapshot Repository
+
+## Summary
+
+Snapshot repositories in OpenSearch provide storage locations for snapshots, supporting various backends including S3, Azure, GCS, HDFS, and shared file systems. The repository system includes caching mechanisms for repository metadata and supports both full remote store configurations and remote publication-only setups.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Snapshot Operations"
+        Create[Create Snapshot]
+        Restore[Restore Snapshot]
+        Clone[Clone Snapshot]
+        Status[Get Status]
+    end
+    
+    subgraph "Repository Layer"
+        Cache[Repository Data Cache]
+        BlobStore[BlobStoreRepository]
+    end
+    
+    subgraph "Storage Backends"
+        S3[S3 Repository]
+        Azure[Azure Repository]
+        FS[File System]
+        HDFS[HDFS Repository]
+    end
+    
+    Create --> BlobStore
+    Restore --> BlobStore
+    Clone --> BlobStore
+    Status --> BlobStore
+    
+    BlobStore --> Cache
+    Cache --> S3
+    Cache --> Azure
+    Cache --> FS
+    Cache --> HDFS
+```
+
+### Repository Data Cache
+
+The repository data cache stores compressed repository metadata to avoid repeated downloads during snapshot operations.
+
+#### Configuration
+
+| Setting | Description | Default | Type |
+|---------|-------------|---------|------|
+| `snapshot.repository_data.cache.threshold` | Maximum cache size as absolute value or heap percentage | 1% of heap (min 500KB) | Static |
+
+#### Cache Behavior
+
+- Data is compressed using DEFLATE before caching
+- Cache uses `SoftReference` for automatic memory management under heap pressure
+- Cache is bypassed when data exceeds the configured threshold
+- Warning logged when repository metadata exceeds 10x the threshold
+
+### Remote Repository Configuration
+
+OpenSearch supports two configuration prefixes for remote repositories:
+
+| Prefix | Purpose | Required Repositories |
+|--------|---------|----------------------|
+| `remote_store` | Full remote store | Segment, Translog, Cluster State |
+| `remote_publication` | Remote publication only | Cluster State, Routing Table |
+
+#### Node Attributes
+
+```yaml
+# Full remote store configuration
+node.attr.remote_store.segment.repository: my-segment-repo
+node.attr.remote_store.translog.repository: my-translog-repo
+node.attr.remote_store.state.repository: my-state-repo
+
+# Remote publication only configuration
+node.attr.remote_publication.state.repository: my-state-repo
+node.attr.remote_publication.routing_table.repository: my-routing-repo
+```
+
+### Repository Types
+
+| Type | Plugin | Use Case |
+|------|--------|----------|
+| `fs` | Built-in | Shared file system |
+| `s3` | repository-s3 | Amazon S3 |
+| `azure` | repository-azure | Azure Blob Storage |
+| `gcs` | repository-gcs | Google Cloud Storage |
+| `hdfs` | repository-hdfs | Hadoop HDFS |
+
+## Limitations
+
+- Cache threshold setting is static (requires node restart)
+- SoftReference eviction timing depends on JVM garbage collection
+- Repository metadata size grows with number of snapshots
+- Large repositories (>5MB metadata) may experience performance degradation
+
+## Change History
+
+- **v2.19.0** (2025-01-14): Added vertical scaling with configurable cache threshold and SoftReference; introduced `remote_publication` prefix for remote repository attributes
+- **v1.0.0**: Initial snapshot repository implementation
+
+## References
+
+### Documentation
+
+- [Register Snapshot Repository](https://docs.opensearch.org/latest/api-reference/snapshots/create-repository/)
+- [Get Snapshot Repository](https://docs.opensearch.org/latest/api-reference/snapshots/get-snapshot-repository/)
+- [Cleanup Snapshot Repository](https://docs.opensearch.org/latest/api-reference/snapshots/cleanup-snapshot-repository/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#16489](https://github.com/opensearch-project/OpenSearch/pull/16489) | Add vertical scaling and SoftReference for snapshot repository data cache |
+| v2.19.0 | [#16271](https://github.com/opensearch-project/OpenSearch/pull/16271) | Support prefix list for remote repository attributes |
+
+### Related Issues
+
+- [#16298](https://github.com/opensearch-project/OpenSearch/issues/16298) - Support vertical scaling for snapshot repository data cache limit
+- [#16390](https://github.com/opensearch-project/OpenSearch/issues/16390) - Introduce a new prefix for configuring remote publication repositories

--- a/docs/releases/v2.19.0/features/opensearch/snapshot-repository.md
+++ b/docs/releases/v2.19.0/features/opensearch/snapshot-repository.md
@@ -1,0 +1,99 @@
+---
+tags:
+  - opensearch
+---
+# Snapshot Repository
+
+## Summary
+
+OpenSearch 2.19.0 introduces two significant enhancements to snapshot repository functionality: vertical scaling support with SoftReference for the repository data cache, and a new `remote_publication` prefix for configuring remote publication repositories.
+
+## Details
+
+### Vertical Scaling for Repository Data Cache
+
+Previously, snapshot repository data was not cached if its compressed size exceeded a static 500KB limit. This caused repeated downloads during operations like clone, restore, and status checks, increasing latency. The limit did not adjust with vertical or horizontal scaling.
+
+#### New Configuration Setting
+
+A new setting `snapshot.repository_data.cache.threshold` allows users to configure the cache limit as a percentage of heap size or as an absolute value.
+
+| Setting | Description | Default | Range |
+|---------|-------------|---------|-------|
+| `snapshot.repository_data.cache.threshold` | Maximum threshold for snapshot repository data cache | `min(max(500KB, 1% of heap), Integer.MAX_VALUE - 8)` | 500KB to 1% of heap |
+
+#### SoftReference Implementation
+
+The cache now uses Java's `SoftReference` to allow the JVM to reclaim memory under pressure while still benefiting from caching when memory is available. This provides:
+
+- Automatic memory management under heap pressure
+- Better cache utilization on nodes with larger heaps
+- Reduced latency for snapshot operations when cache is available
+
+#### Warning Thresholds
+
+- Debug log when data exceeds configured threshold
+- Warning log when data exceeds `min(threshold * 10, Integer.MAX_VALUE - 8)` bytes
+
+### Remote Publication Repository Prefix
+
+A new `remote_publication` prefix is introduced for configuring remote publication repositories, enabling clusters to store only metadata remotely without being incorrectly identified as full remote store nodes.
+
+#### Configuration Prefixes
+
+| Prefix | Use Case |
+|--------|----------|
+| `remote_store` | Full remote store (segment + translog + state) |
+| `remote_publication` | Remote publication only (cluster state + routing table) |
+
+#### Node Attributes
+
+Nodes can now be configured with either prefix:
+- `remote_store.<repository-type>.repository.*`
+- `remote_publication.<repository-type>.repository.*`
+
+This allows migrating a remote publication cluster from remote store to local storage.
+
+## Technical Changes
+
+### Modified Classes
+
+| Class | Change |
+|-------|--------|
+| `BlobStoreRepository` | Added cache threshold setting, SoftReference wrapper |
+| `RemoteStoreNodeAttribute` | Support for multiple attribute prefixes |
+| `JoinTaskExecutor` | Updated repository compatibility checks |
+| `DiscoveryNode` | Updated remote store detection logic |
+
+### New Constants
+
+```java
+// Cache settings
+SNAPSHOT_REPOSITORY_DATA_CACHE_THRESHOLD_SETTING_NAME = "snapshot.repository_data.cache.threshold"
+SNAPSHOT_REPOSITORY_DATA_CACHE_THRESHOLD_DEFAULT_PERCENTAGE = 0.01
+CACHE_MIN_THRESHOLD = 500KB
+CACHE_MAX_THRESHOLD = min(max(500KB, 1% of heap), Integer.MAX_VALUE - 8)
+
+// Repository prefixes
+REMOTE_STORE_NODE_ATTRIBUTE_KEY_PREFIX = ["remote_store", "remote_publication"]
+```
+
+## Limitations
+
+- The `snapshot.repository_data.cache.threshold` setting is static and requires node restart to change
+- SoftReference behavior depends on JVM garbage collection, which may vary across implementations
+- The `remote_publication` prefix is intended for specific migration scenarios
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16489](https://github.com/opensearch-project/OpenSearch/pull/16489) | Add vertical scaling and SoftReference for snapshot repository data cache | [#16298](https://github.com/opensearch-project/OpenSearch/issues/16298) |
+| [#16271](https://github.com/opensearch-project/OpenSearch/pull/16271) | Support prefix list for remote repository attributes | [#16390](https://github.com/opensearch-project/OpenSearch/issues/16390) |
+
+### Documentation
+
+- [Register Snapshot Repository](https://docs.opensearch.org/2.19/api-reference/snapshots/create-repository/)
+- [Get Snapshot Repository](https://docs.opensearch.org/2.19/api-reference/snapshots/get-snapshot-repository/)

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -37,6 +37,7 @@
 - Searchable Snapshot Bug Fixes
 - Security Transport NIO
 - Sliced Search Optimization
+- Snapshot Repository
 - Snapshot Restore Settings
 - Sort Field Merging
 - System Indices


### PR DESCRIPTION
## Summary

Adds documentation for Snapshot Repository enhancements in OpenSearch v2.19.0.

### Key Changes in v2.19.0

1. **Vertical Scaling for Repository Data Cache** (PR #16489)
   - New `snapshot.repository_data.cache.threshold` setting
   - Cache size now scales with heap (default: 1% of heap, min 500KB)
   - SoftReference implementation for automatic memory management

2. **Remote Publication Repository Prefix** (PR #16271)
   - New `remote_publication` prefix for configuring remote publication repositories
   - Enables clusters to store only metadata remotely
   - Supports migration from remote store to local storage

### Reports Created
- Release report: `docs/releases/v2.19.0/features/opensearch/snapshot-repository.md`
- Feature report: `docs/features/opensearch/snapshot-repository.md`

### References
- PR #16489: Add vertical scaling and SoftReference for snapshot repository data cache
- PR #16271: Support prefix list for remote repository attributes
- Issue #16298: Support vertical scaling for snapshot repository data cache limit
- Issue #16390: Introduce a new prefix for configuring remote publication repositories