### PR TITLE
docs: add segment replication report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-segment-replication.md
+++ b/docs/features/opensearch/opensearch-segment-replication.md
@@ -70,6 +70,8 @@ flowchart TB
 | `cluster.indices.replication.strategy` | Default replication type for new indexes | `DOCUMENT` |
 | `cluster.index.restrict.replication.type` | Enforce cluster-level replication type | `false` |
 | `segrep.pressure.enabled` | Enable segment replication backpressure | `false` |
+| `segrep.pressure.checkpoint.limit` | Max checkpoints replica can fall behind before backpressure | `30` (v2.19.0+), `4` (earlier) |
+| `segrep.pressure.time.limit` | Max time replica can lag before backpressure | `5m` |
 | `cluster.routing.allocation.balance.prefer_primary` | Balance primary shards across nodes | `false` |
 | `indices.publish_check_point.retry_timeout` | Retry timeout for publish checkpoint action (v3.0.0+) | `5m` |
 
@@ -128,6 +130,7 @@ GET _cat/segment_replication?v
 - **v3.3.0** (2025-09-09): Fixed NullPointerException in SegmentReplicator.getSegmentReplicationStats() caused by race condition; Fixed reference count control in NRTReplicationEngine#acquireLastIndexCommit to prevent NoSuchFileException
 - **v3.2.0** (2025-07-01): Fixed replication lag computation to use epoch-based timestamps and corrected checkpoint pruning logic
 - **v3.0.0** (2025-05-13): Implemented shard-level stats computation on replicas; Fixed skewed lag metric when same checkpoint published twice; Increased default segment counter step size from 10 to 100,000; Added configurable publish checkpoint retry timeout setting
+- **v2.19.0** (2025-01-21): Increased default `segrep.pressure.checkpoint.limit` from 4 to 30 for better alignment with time limit on remote-backed clusters; Added granular remote publication failure statistics (`incoming_publication_failed_count`) separate from download failure stats
 
 
 ## References
@@ -150,6 +153,8 @@ GET _cat/segment_replication?v
 | v3.0.0 | [#17831](https://github.com/opensearch-project/OpenSearch/pull/17831) | Avoid skewed segment replication lag metric | [#10764](https://github.com/opensearch-project/OpenSearch/issues/10764) |
 | v3.0.0 | [#17568](https://github.com/opensearch-project/OpenSearch/pull/17568) | Increase the default segment counter step size when replica promoting | [#17566](https://github.com/opensearch-project/OpenSearch/issues/17566) |
 | v3.0.0 | [#17749](https://github.com/opensearch-project/OpenSearch/pull/17749) | Add cluster setting for retry timeout of publish checkpoint tx action | [#17595](https://github.com/opensearch-project/OpenSearch/issues/17595) |
+| v2.19.0 | [#16577](https://github.com/opensearch-project/OpenSearch/pull/16577) | Increase segrep pressure checkpoint default limit to 30 | - |
+| v2.19.0 | [#16682](https://github.com/opensearch-project/OpenSearch/pull/16682) | Add stats for remote publication failure and move download failure stats | - |
 
 ### Issues (Design / RFC)
 - [Issue #19213](https://github.com/opensearch-project/OpenSearch/issues/19213): Bug report for NRTReplicationEngine file deletion issue

--- a/docs/releases/v2.19.0/features/opensearch/segment-replication.md
+++ b/docs/releases/v2.19.0/features/opensearch/segment-replication.md
@@ -1,0 +1,72 @@
+---
+tags:
+  - opensearch
+---
+# Segment Replication
+
+## Summary
+
+OpenSearch v2.19.0 includes two improvements to segment replication: an increased default checkpoint limit for backpressure and new granular statistics for remote publication failures.
+
+## Details
+
+### What's New in v2.19.0
+
+#### Increased Checkpoint Limit Default
+
+The default value for `segrep.pressure.checkpoint.limit` has been increased from 4 to 30. This change aligns the checkpoint limit with the time limit setting (`segrep.pressure.time.limit` = 5 minutes) for remote-backed clusters.
+
+**Rationale**: For remote-backed clusters, the recommended refresh interval is 10+ seconds (vs. 1 second default) due to segment upload costs. With the previous default of 4 checkpoints and a 10-second refresh interval, replicas could only lag 40 seconds before triggering backpressure rejections—far below the 5-minute time limit. The new default of 30 checkpoints allows approximately 300 seconds (5 minutes) of lag, matching the time limit.
+
+| Setting | Old Default | New Default |
+|---------|-------------|-------------|
+| `segrep.pressure.checkpoint.limit` | 4 | 30 |
+
+#### Granular Remote Publication Statistics
+
+New statistics have been added to separate remote download failures from overall remote publication failures:
+
+```json
+{
+  "remote_full_download": {
+    "success_count": 1,
+    "failed_count": 0,
+    "total_time_in_millis": 4,
+    "incoming_publication_failed_count": 0,
+    "checksum_validation_failed_count": 0
+  },
+  "remote_diff_download": {
+    "success_count": 2,
+    "failed_count": 0,
+    "total_time_in_millis": 12,
+    "incoming_publication_failed_count": 0,
+    "checksum_validation_failed_count": 0
+  }
+}
+```
+
+**New Metrics**:
+
+| Metric | Description |
+|--------|-------------|
+| `incoming_publication_failed_count` | Count of failures during the incoming publication flow (separate from download failures) |
+| `failed_count` | Now accurately reflects download-specific failures only |
+
+### Technical Changes
+
+- `RemoteDownloadStats` class extended with `incoming_publication_failed_count` field
+- Download failure stats moved to `RemoteClusterStateService` download methods for accurate tracking
+- New methods added: `fullIncomingPublicationFailed()` and `diffIncomingPublicationFailed()`
+
+## Limitations
+
+- The increased checkpoint limit may allow replicas to fall further behind before backpressure kicks in
+- Users with custom checkpoint limits should review their settings after upgrade
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16577](https://github.com/opensearch-project/OpenSearch/pull/16577) | Increase segrep pressure checkpoint default limit to 30 | - |
+| [#16682](https://github.com/opensearch-project/OpenSearch/pull/16682) | Add stats for remote publication failure and move download failure stats to remote methods | - |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -37,6 +37,7 @@
 - Search Response Headers
 - Searchable Snapshot Bug Fixes
 - Security Transport NIO
+- Segment Replication
 - Sliced Search Optimization
 - Snapshot Repository
 - Snapshot Restore Settings


### PR DESCRIPTION
## Summary

Adds documentation for Segment Replication improvements in OpenSearch v2.19.0.

## Changes

### Release Report
- Created `docs/releases/v2.19.0/features/opensearch/segment-replication.md`

### Feature Report Update
- Updated `docs/features/opensearch/opensearch-segment-replication.md` with v2.19.0 changes

## Key Changes in v2.19.0

1. **Increased checkpoint limit default**: `segrep.pressure.checkpoint.limit` increased from 4 to 30 to align with time limit for remote-backed clusters
2. **Granular remote publication stats**: New `incoming_publication_failed_count` metric separates publication failures from download failures

## PRs Investigated
- [#16577](https://github.com/opensearch-project/OpenSearch/pull/16577) - Increase segrep pressure checkpoint default limit to 30
- [#16682](https://github.com/opensearch-project/OpenSearch/pull/16682) - Add stats for remote publication failure

Closes #2018