### PR TITLE
docs: add search-replicas report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-search-replica-reader-writer-separation.md
+++ b/docs/features/opensearch/opensearch-search-replica-reader-writer-separation.md
@@ -140,7 +140,7 @@ POST /my-index/_scale
 ## Change History
 
 - **v3.0.0** (2025-04-08): Added scale-to-zero support, auto-expand search replicas, and strict routing setting
-- **v2.19.0** (2025-01-10): Limited to remote-store-enabled clusters only; updated recovery flow to use empty store recovery instead of peer recovery; excluded search replicas from in-sync allocation ID set
+- **v2.19.0** (2025-01-10): Added snapshot restore support with search replicas; added search replica stats to segment replication stats API; limited to remote-store-enabled clusters only; updated recovery flow to use empty store recovery instead of peer recovery; excluded search replicas from in-sync allocation ID set
 - **v2.17.0** (2024-09): Initial experimental implementation with search replicas and pull-based replication
 
 
@@ -160,6 +160,8 @@ POST /my-index/_scale
 | v3.0.0 | [#17299](https://github.com/opensearch-project/OpenSearch/pull/17299) | Scale-to-zero (search_only mode) support | [#15306](https://github.com/opensearch-project/OpenSearch/issues/15306) |
 | v3.0.0 | [#17741](https://github.com/opensearch-project/OpenSearch/pull/17741) | AutoExpand for SearchReplica | [#17310](https://github.com/opensearch-project/OpenSearch/issues/17310) |
 | v3.0.0 | [#17803](https://github.com/opensearch-project/OpenSearch/pull/17803) | Search Only strict routing setting | [#17424](https://github.com/opensearch-project/OpenSearch/issues/17424) |
+| v2.19.0 | [#16111](https://github.com/opensearch-project/OpenSearch/pull/16111) | Add support for restoring from snapshot with search replicas | [#15532](https://github.com/opensearch-project/OpenSearch/issues/15532) |
+| v2.19.0 | [#16678](https://github.com/opensearch-project/OpenSearch/pull/16678) | Add search replica stats to segment replication stats API | [#15534](https://github.com/opensearch-project/OpenSearch/issues/15534) |
 | v2.19.0 | [#16760](https://github.com/opensearch-project/OpenSearch/pull/16760) | Limit RW separation to remote store enabled clusters and update recovery flow | [#15952](https://github.com/opensearch-project/OpenSearch/issues/15952) |
 | v2.17.0 | [#15368](https://github.com/opensearch-project/OpenSearch/pull/15368) | Initial search replica implementation |   |
 | v2.17.0 | [#15445](https://github.com/opensearch-project/OpenSearch/pull/15445) | Pull-based replica support |   |

--- a/docs/releases/v2.19.0/features/opensearch/search-replicas.md
+++ b/docs/releases/v2.19.0/features/opensearch/search-replicas.md
@@ -1,0 +1,79 @@
+---
+tags:
+  - opensearch
+---
+# Search Replicas
+
+## Summary
+
+OpenSearch v2.19.0 enhances the Search Replicas feature with two key improvements: support for restoring indexes with search replicas from snapshots, and the addition of search replica statistics to the segment replication stats API. These changes improve operational capabilities for clusters using reader-writer separation.
+
+## Details
+
+### What's New in v2.19.0
+
+#### Snapshot Restore Support for Search Replicas
+
+Indexes with search replicas can now be restored from snapshots with proper validation rules:
+
+| Snapshot Replication Type | Restore Replication Type | Search Replicas Allowed |
+|---------------------------|--------------------------|-------------------------|
+| DOCUMENT | DOCUMENT | No |
+| DOCUMENT | SEGMENT | Yes |
+| SEGMENT (no search replicas) | DOCUMENT | Yes (must set to 0) |
+| SEGMENT (no search replicas) | SEGMENT | Yes |
+| SEGMENT (with search replicas) | DOCUMENT | Only if set to 0 |
+| SEGMENT (with search replicas) | SEGMENT | Yes |
+
+The restore operation validates compatibility between the snapshot's replication type and the target configuration. If restoring to document replication with search replicas > 0, the operation fails with a descriptive error.
+
+#### Search Replica Stats in Segment Replication API
+
+The segment replication stats API (`GET /_cat/segment_replication`) now includes statistics for search replicas:
+
+- `bytes_behind`: Bytes remaining to replicate from remote store
+- `current_replication_lag`: Current replication lag in milliseconds
+- `last_completed_replication_time`: Time of last completed replication
+
+Stats are computed by comparing the search replica's checkpoint with the latest checkpoint from the remote store, enabling monitoring of replication health for search replicas.
+
+### Technical Changes
+
+#### Snapshot Restore Validation
+
+The `RestoreService` class now includes validation logic in `validateReplicationTypeRestoreSettings()`:
+
+```java
+// Validation prevents restoring with search replicas when target is DOCUMENT replication
+if (restoreNumberOfSearchReplicas > 0 
+    && ReplicationType.DOCUMENT.equals(restoreReplicationType)) {
+    throw new SnapshotRestoreException(...);
+}
+```
+
+#### Search Replica Stats Computation
+
+The `TransportSegmentReplicationStatsAction` computes stats for search replicas by:
+
+1. Fetching the latest completed and ongoing replication states from `SegmentReplicationTargetService`
+2. Calculating bytes remaining from file details in the replication index
+3. Computing lag times from replication timers
+
+## Limitations
+
+- Snapshot restore with search replicas requires segment replication to be enabled
+- Search replica stats are only available when segment replication is active
+- Stats computation relies on remote store checkpoint information
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16111](https://github.com/opensearch-project/OpenSearch/pull/16111) | Add support for restoring from snapshot with search replicas | [#15532](https://github.com/opensearch-project/OpenSearch/issues/15532) |
+| [#16678](https://github.com/opensearch-project/OpenSearch/pull/16678) | Add search replica stats to segment replication stats API | [#15534](https://github.com/opensearch-project/OpenSearch/issues/15534) |
+
+### Related Issues
+- [#15306](https://github.com/opensearch-project/OpenSearch/issues/15306): META - Reader/Writer Separation
+- [#15532](https://github.com/opensearch-project/OpenSearch/issues/15532): Updates to restore from snapshot with added search replicas
+- [#15534](https://github.com/opensearch-project/OpenSearch/issues/15534): Update Segment replication stats APIs to support pull based architecture

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -30,6 +30,7 @@
 - Multi-Search Request Cancellation Fix
 - Plugin System
 - Reader Writer Separation
+- Search Replicas
 - Remote Repository Validation
 - Remote Shards Balance Fix
 - Remote State Manifest


### PR DESCRIPTION
## Summary

Adds documentation for Search Replicas enhancements in OpenSearch v2.19.0.

### Changes in v2.19.0
- **Snapshot Restore Support**: Indexes with search replicas can now be restored from snapshots with proper validation rules for replication type compatibility
- **Segment Replication Stats**: Search replica statistics (bytes_behind, current_replication_lag, last_completed_replication_time) are now included in the segment replication stats API

### Files Changed
- Created: `docs/releases/v2.19.0/features/opensearch/search-replicas.md`
- Updated: `docs/features/opensearch/opensearch-search-replica-reader-writer-separation.md` (Change History and PR references)
- Updated: `docs/releases/v2.19.0/index.md` (added Search Replicas entry)

### Related PRs
- [#16111](https://github.com/opensearch-project/OpenSearch/pull/16111): Add support for restoring from snapshot with search replicas
- [#16678](https://github.com/opensearch-project/OpenSearch/pull/16678): Add search replica stats to segment replication stats API

Closes #2017