### PR TITLE
docs: add Star Tree Index report for v2.19.0

### DIFF
--- a/docs/features/opensearch/opensearch-star-tree-index.md
+++ b/docs/features/opensearch/opensearch-star-tree-index.md
@@ -210,8 +210,8 @@ POST /logs/_search
 - **v3.2.0** (2025-09-16): Added DLS/FLS/Field Masking security integration (disables star-tree for restricted users), IP field search support, star-tree search statistics (query count, time, current)
 - **v3.1.0** (2025-06-10): Production-ready status, removed feature flag, added index-level setting, date range query support, nested bucket aggregations
 - **v3.0.0** (2025-05-12): Added boolean query support, terms aggregations, range aggregations, unsigned-long support
-- **v2.19** (2024-12-10): Added date histogram aggregations, term/terms/range query support
-- **v2.18** (2024-10-22): Initial experimental release with metric aggregations (sum, min, max, avg, value_count)
+- **v2.19.0** (2025-01-21): Added keyword field support, IP field support (indexing), object field support, date histogram with metric sub-aggregations, extensible query/field type framework
+- **v2.18.0** (2024-10-22): Initial experimental release with metric aggregations (sum, min, max, avg, value_count)
 
 
 ## References
@@ -238,6 +238,11 @@ POST /logs/_search
 | v3.0.0 | [#17275](https://github.com/opensearch-project/OpenSearch/pull/17275) | Unsigned-long query support | [#15231](https://github.com/opensearch-project/OpenSearch/issues/15231) |
 | v3.0.0 | [#17273](https://github.com/opensearch-project/OpenSearch/pull/17273) | Range aggregations | [#16553](https://github.com/opensearch-project/OpenSearch/issues/16553) |
 | v3.0.0 | [#17165](https://github.com/opensearch-project/OpenSearch/pull/17165) | Terms aggregations (keyword/numeric) | [#16551](https://github.com/opensearch-project/OpenSearch/issues/16551) |
+| v2.19.0 | [#17137](https://github.com/opensearch-project/OpenSearch/pull/17137) | Extensible design for query and field type support | [#16537](https://github.com/opensearch-project/OpenSearch/issues/16537) |
+| v2.19.0 | [#16728](https://github.com/opensearch-project/OpenSearch/pull/16728) | Support object fields in star-tree index | [#16730](https://github.com/opensearch-project/OpenSearch/issues/16730) |
+| v2.19.0 | [#16674](https://github.com/opensearch-project/OpenSearch/pull/16674) | Date histogram with metric aggregation | [#16552](https://github.com/opensearch-project/OpenSearch/issues/16552) |
+| v2.19.0 | [#16641](https://github.com/opensearch-project/OpenSearch/pull/16641) | IP field support in star tree indexing | [#16642](https://github.com/opensearch-project/OpenSearch/issues/16642) |
+| v2.19.0 | [#16233](https://github.com/opensearch-project/OpenSearch/pull/16233) | Keyword field support in star-tree index | [#16232](https://github.com/opensearch-project/OpenSearch/issues/16232) |
 | v2.18.0 | [#15289](https://github.com/opensearch-project/OpenSearch/pull/15289) | Initial metric aggregations with/without term query | [#15257](https://github.com/opensearch-project/OpenSearch/issues/15257) |
 
 ### Issues (Design / RFC)

--- a/docs/releases/v2.19.0/features/opensearch/star-tree-index.md
+++ b/docs/releases/v2.19.0/features/opensearch/star-tree-index.md
@@ -1,0 +1,150 @@
+---
+tags:
+  - opensearch
+---
+# Star Tree Index
+
+## Summary
+
+OpenSearch v2.19.0 significantly expands star-tree index capabilities with support for additional field types (keyword, IP, object fields), date histogram aggregations with metric sub-aggregations, and an extensible query/field type framework. These enhancements enable star-tree to handle more diverse data models and complex aggregation patterns.
+
+## Details
+
+### What's New in v2.19.0
+
+#### Keyword Field Support
+Star-tree index now supports keyword fields as dimensions. Users can include keyword fields in `ordered_dimensions` for grouping and filtering. Metrics remain numeric-only.
+
+```json
+{
+  "mappings": {
+    "composite": {
+      "my_star_tree": {
+        "type": "star_tree",
+        "config": {
+          "ordered_dimensions": [
+            { "name": "status" },
+            { "name": "method" }
+          ],
+          "metrics": [
+            { "name": "latency", "stats": ["avg", "max"] }
+          ]
+        }
+      }
+    },
+    "properties": {
+      "status": { "type": "integer" },
+      "method": { "type": "keyword" },
+      "latency": { "type": "float" }
+    }
+  }
+}
+```
+
+#### IP Field Support
+IP address fields can now be used as dimensions in star-tree indexes, enabling efficient aggregations over network traffic data.
+
+```json
+{
+  "ordered_dimensions": [
+    { "name": "client_ip" },
+    { "name": "status" }
+  ]
+}
+```
+
+#### Object Field Support
+Object fields with nested properties are now supported. Reference nested fields using dot notation (e.g., `nested.status`, `geoip.country_name`). Array values within object fields are still blocked.
+
+```json
+{
+  "mappings": {
+    "composite": {
+      "startree1": {
+        "type": "star_tree",
+        "config": {
+          "ordered_dimensions": [
+            { "name": "nested.status" },
+            { "name": "geoip.country_name" }
+          ],
+          "metrics": [
+            { "name": "nested.status" }
+          ]
+        }
+      }
+    },
+    "properties": {
+      "nested": {
+        "properties": {
+          "status": { "type": "integer" }
+        }
+      },
+      "geoip": {
+        "properties": {
+          "country_name": { "type": "keyword" }
+        }
+      }
+    }
+  }
+}
+```
+
+#### Date Histogram with Metric Aggregations
+Star-tree can now resolve date histogram aggregations with nested metric sub-aggregations. The implementation uses `StarTreeBucketCollector` to handle bucket collection without traditional Lucene document traversal.
+
+```json
+{
+  "size": 0,
+  "aggs": {
+    "by_month": {
+      "date_histogram": {
+        "field": "@timestamp",
+        "calendar_interval": "month"
+      },
+      "aggs": {
+        "sum_status": {
+          "sum": { "field": "status" }
+        }
+      }
+    }
+  }
+}
+```
+
+#### Extensible Query and Field Type Framework
+A new extensible design enables adding support for different query types and field types:
+
+- `DimensionFilterMapper`: Maps star-tree supported fields and queries
+- `StarTreeFilterProvider`: Converts user queries (QueryBuilder) to star-tree traversal filters
+- Supports term, terms, and range queries on numeric and keyword fields
+
+### Technical Changes
+
+| Component | Change |
+|-----------|--------|
+| `StarTreeBucketCollector` | New interface for collecting star-tree entries into aggregation buckets |
+| `DimensionFilterMapper` | Maps field types to appropriate dimension filters |
+| `StarTreeFilterProvider` | Converts QueryBuilder to star-tree traversal filters |
+| Keyword iterator | End-to-end support for keyword fields including flush, merge, and file format |
+| IP field support | Dimension support for IP address fields |
+| Object field support | Dot notation access to nested object properties |
+
+## Limitations
+
+- Keyword fields supported only as dimensions, not metrics
+- Object fields do not support array values
+- Date histogram support limited to specific query shapes
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#16233](https://github.com/opensearch-project/OpenSearch/pull/16233) | Support for keyword fields in star-tree index | [#16232](https://github.com/opensearch-project/OpenSearch/issues/16232) |
+| [#16641](https://github.com/opensearch-project/OpenSearch/pull/16641) | Changes to support IP field in star tree indexing | [#16642](https://github.com/opensearch-project/OpenSearch/issues/16642) |
+| [#16728](https://github.com/opensearch-project/OpenSearch/pull/16728) | Support object fields in star-tree index | [#16730](https://github.com/opensearch-project/OpenSearch/issues/16730) |
+| [#16674](https://github.com/opensearch-project/OpenSearch/pull/16674) | Resolving Date histogram with metric aggregation using star-tree | [#16552](https://github.com/opensearch-project/OpenSearch/issues/16552) |
+| [#17137](https://github.com/opensearch-project/OpenSearch/pull/17137) | Extensible design to support different query and field type | [#16537](https://github.com/opensearch-project/OpenSearch/issues/16537), [#16538](https://github.com/opensearch-project/OpenSearch/issues/16538), [#16539](https://github.com/opensearch-project/OpenSearch/issues/16539) |
+
+### Documentation
+- [Star-tree index documentation](https://docs.opensearch.org/2.19/search-plugins/star-tree-index/)

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -43,6 +43,7 @@
 - Snapshot Repository
 - Snapshot Restore Settings
 - Sort Field Merging
+- Star Tree Index
 - System Indices
 - Template Query
 - Tiered Caching Bug Fixes


### PR DESCRIPTION
## Summary

Adds release report for Star Tree Index enhancements in OpenSearch v2.19.0.

## Changes

### Release Report
- Created `docs/releases/v2.19.0/features/opensearch/star-tree-index.md`

### Feature Report
- Updated `docs/features/opensearch/opensearch-star-tree-index.md` with v2.19.0 changes and PRs

### Release Index
- Added Star Tree Index to `docs/releases/v2.19.0/index.md`

## Key Changes in v2.19.0

- **Keyword field support**: Keyword fields can now be used as dimensions
- **IP field support**: IP address fields supported as dimensions for network data
- **Object field support**: Nested object properties accessible via dot notation
- **Date histogram aggregations**: Date histogram with metric sub-aggregations
- **Extensible framework**: New `DimensionFilterMapper` and `StarTreeFilterProvider` for query/field type extensibility

## PRs Investigated

| PR | Description |
|----|-------------|
| #16233 | Support for keyword fields in star-tree index |
| #16641 | Changes to support IP field in star tree indexing |
| #16728 | Support object fields in star-tree index |
| #16674 | Resolving Date histogram with metric aggregation using star-tree |
| #17137 | Extensible design to support different query and field type |

Closes #2016