### PR TITLE
docs: add observability-sop report for v2.19.0

### DIFF
--- a/docs/features/observability/observability-integrations.md
+++ b/docs/features/observability/observability-integrations.md
@@ -117,6 +117,7 @@ curl -O https://github.com/opensearch-project/opensearch-catalog/releases/downlo
 
 - **v3.4.0** (2026-01-14): Improved static file serving with image type validation and SVG sanitization
 - **v3.0.0** (2025-05-06): Improved error handling and test result quality for integration configuration parsing
+- **v2.19.0** (2025-01-09): Added comprehensive SOP documentation for Integration and Vended Dashboards Setup
 
 
 ## References
@@ -132,3 +133,4 @@ curl -O https://github.com/opensearch-project/opensearch-catalog/releases/downlo
 | v3.4.0 | [#2530](https://github.com/opensearch-project/dashboards-observability/pull/2530) | Clean up interface for integrations static serving |   |
 | v3.0.0 | [#2387](https://github.com/opensearch-project/dashboards-observability/pull/2387) | Improve error handling when setting up and reading a new integration |   |
 | v3.0.0 | [#2376](https://github.com/opensearch-project/dashboards-observability/pull/2376) | Improve the test results for Integrations internals |   |
+| v2.19.0 | [#2299](https://github.com/opensearch-project/dashboards-observability/pull/2299) | SOP for Integration and Vended Dashboards Setup |   |

--- a/docs/releases/v2.19.0/features/observability/observability-sop.md
+++ b/docs/releases/v2.19.0/features/observability/observability-sop.md
@@ -1,0 +1,83 @@
+---
+tags:
+  - observability
+---
+# Observability SOP
+
+## Summary
+
+Added comprehensive Standard Operating Procedure (SOP) documentation for Integration and Vended Dashboards Setup in OpenSearch. This documentation provides step-by-step guidance for developers creating custom OpenSearch integrations and dashboards.
+
+## Details
+
+### What's New in v2.19.0
+
+The PR adds extensive documentation covering the complete integration workflow:
+
+1. **Integration Process Overview**: Explains the sequential steps from raw log storage through dashboard creation
+2. **S3 Connection Integration**: Detailed setup for S3-based data sources
+3. **Table Creation**: SQL examples for creating external tables with proper schema definitions
+4. **Materialized View (MV) Creation**: Comprehensive guide for both full index and aggregated queries
+5. **Dashboard Creation**: Step-by-step instructions for creating visualizations and index patterns
+6. **Publishing to OpenSearch Catalog**: Guidelines for contributing integrations to the community
+
+### Key Documentation Sections
+
+| Section | Description |
+|---------|-------------|
+| General Principles | Field naming conventions and configuration alignment requirements |
+| Table Creation | External table creation with schema matching raw data |
+| MV Creation | Full index vs aggregated query approaches with trade-offs |
+| Dashboard Creation | Index pattern setup and visualization configuration |
+| Troubleshooting | Common issues and debugging strategies |
+
+### Integration Workflow
+
+```mermaid
+flowchart LR
+    A[Storage of Raw Logs] --> B[Table Creation]
+    subgraph S3[S3 Connection Integration]
+        direction LR
+        B --> C[Materialized View Creation]
+        C --> D[Dashboards Creation]
+    end
+```
+
+### MV Query Types
+
+The documentation covers two approaches for Materialized View creation:
+
+**Full Index Query**
+- Preserves all raw data details
+- Suitable for detailed analysis and auditing
+- Larger index size
+
+**Aggregated Query**
+- Uses time windowing (TUMBLE) for data summarization
+- Reduces storage requirements
+- Better for trend analysis and reporting
+
+### Naming Conventions
+
+The SOP establishes field naming standards:
+- Dot-notation for hierarchical fields (e.g., `aws.vpc.srcaddr`)
+- Descriptive prefixes for namespacing
+- Consistent abbreviations (src, dst)
+
+## Limitations
+
+- Documentation is specific to S3-based integrations
+- Aggregated MVs may not perform well with high-cardinality fields
+- Requires proper IAM permissions for S3 access
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#2299](https://github.com/opensearch-project/dashboards-observability/pull/2299) | SOP for Integration and Vended Dashboards Setup | - |
+
+### Documentation
+- [OpenSearch Spark Documentation](https://github.com/opensearch-project/opensearch-spark/blob/main/docs/index.md)
+- [OpenSearch Catalog Integration Guide](https://github.com/opensearch-project/opensearch-catalog/blob/main/docs/integrations/README.md)
+- [Creating Dashboards in OpenSearch](https://opensearch.org/docs/latest/dashboards/dashboard/index/)

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -65,3 +65,6 @@
 
 ### skills
 - CVE Fixes
+
+### observability
+- Observability SOP


### PR DESCRIPTION
## Summary\n\nAdds documentation for the Observability SOP (Standard Operating Procedure) for Integration and Vended Dashboards Setup.\n\n## Changes\n\n- Created release report: `docs/releases/v2.19.0/features/observability/observability-sop.md`\n- Updated feature report: `docs/features/observability/observability-integrations.md`\n- Updated release index: `docs/releases/v2.19.0/index.md`\n\n## Related\n\n- Issue: #2015\n- PR: opensearch-project/dashboards-observability#2299"