### PR TITLE
docs: add skills-ci report for v2.19.0

### DIFF
--- a/docs/features/skills/skills-tools.md
+++ b/docs/features/skills/skills-tools.md
@@ -158,6 +158,7 @@ The `type` parameter (defaults to `Opensearch`) is passed to the LLM model as `d
 - **v3.2.0** (2026-01-11): Added index schema merging for PPLTool when using index patterns (merges mappings from all matching indexes); added error message masking in PPLTool to redact SageMaker ARNs and AWS account numbers; standardized parameter handling across all tools using `extractInputParameters` utility
 - **v3.1.0** (2025-05-06): Added data source type parameter (`datasourceType`) to PPLTool for Spark/S3 data source support; fixed PPLTool fields bug to properly expose multi-field mappings (e.g., `a.keyword`) to LLM for aggregation queries; fixed httpclient5 dependency version conflict in build.gradle, applied Spotless code formatting to WebSearchTool
 - **v3.0.0** (2025-02-25): Added WebSearchTool, fixed PPLTool empty list bug, updated dependencies, enhanced developer guide; added `attributes` field to all tool classes for ML Commons Plan-Execute-Reflect agent compatibility ([#549](https://github.com/opensearch-project/skills/pull/549)); added Java Agent plugin support for SecurityManager deprecation ([#553](https://github.com/opensearch-project/skills/pull/553)); fixed jar hell issue by creating thin SQL JAR with only `org/opensearch/sql/**` classes ([#545](https://github.com/opensearch-project/skills/pull/545))
+- **v2.19.0** (2025-01-16): Fixed GitHub Actions CI Linux build failures by using shared CI image workflow from opensearch-build; fixed RAGTool missing return statement when content generation is disabled; improved test error handling and logging
 - **v2.18.0** (2024-11-12): Added LogPatternTool for log pattern analysis, added customizable prompt support for CreateAnomalyDetectorTool
 
 
@@ -192,6 +193,7 @@ The `type` parameter (defaults to `Opensearch`) is passed to the LLM model as `d
 | v3.0.0 | [#541](https://github.com/opensearch-project/skills/pull/541) | Fix PPLTool empty list bug |   |
 | v3.0.0 | [#529](https://github.com/opensearch-project/skills/pull/529) | Update ML Commons dependencies |   |
 | v3.0.0 | [#521](https://github.com/opensearch-project/skills/pull/521) | Developer guide enhancement |   |
+| v2.19.0 | [#477](https://github.com/opensearch-project/skills/pull/477) | Fix github ci linux build and RAG tool missing return | [#445](https://github.com/opensearch-project/skills/issues/445) |
 | v2.18.0 | [#413](https://github.com/opensearch-project/skills/pull/413) | Add LogPatternTool |   |
 | v2.18.0 | [#399](https://github.com/opensearch-project/skills/pull/399) | Customizable prompt for CreateAnomalyDetectorTool | [#337](https://github.com/opensearch-project/skills/issues/337) |
 

--- a/docs/releases/v2.19.0/features/skills/ci-fixes.md
+++ b/docs/releases/v2.19.0/features/skills/ci-fixes.md
@@ -1,0 +1,69 @@
+---
+tags:
+  - skills
+---
+# Skills CI Fixes
+
+## Summary
+
+This release fixes GitHub Actions CI build failures on Linux and a missing return statement bug in RAGTool that could cause unexpected behavior when content generation is disabled.
+
+## Details
+
+### GitHub Actions CI Fix
+
+The Linux CI builds were failing due to GLIBC version incompatibilities with Node.js 20:
+
+```
+/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found
+/__e/node20/bin/node: /lib64/libstdc++.so.6: version `GLIBCXX_3.4.20' not found
+/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found
+```
+
+The fix updates the CI workflow to use the shared `get-ci-image-tag.yml` workflow from `opensearch-build` repository instead of manually fetching the CI image tag. This ensures consistent CI image usage across OpenSearch projects.
+
+**Key Changes:**
+- Replaced manual CI image tag fetching with reusable workflow from `opensearch-project/opensearch-build`
+- Updated GitHub Actions versions: `actions/checkout@v3` → `v4`, `actions/setup-java@v3` → `v4`
+- Updated `codecov/codecov-action@v1` → `v4`
+- Added proper container start commands using workflow outputs
+
+### RAGTool Missing Return Fix
+
+Fixed a bug in `RAGTool.java` where a missing `return` statement after calling `listener.onResponse(r)` when `enableContentGeneration` is `false` could cause the method to continue execution unexpectedly.
+
+```java
+// Before (buggy)
+if (!this.enableContentGeneration) {
+    listener.onResponse(r);
+    // Missing return - execution continues
+}
+
+// After (fixed)
+if (!this.enableContentGeneration) {
+    listener.onResponse(r);
+    return;  // Properly exits the method
+}
+```
+
+### Test Improvements
+
+Enhanced test infrastructure with better error handling and logging:
+- Added try-catch in `parseResponseToMap()` to handle JSON parsing failures gracefully
+- Added logging for agent execution responses to aid debugging
+
+## Limitations
+
+None.
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#477](https://github.com/opensearch-project/skills/pull/477) | Fix github ci linux build and RAG tool missing return | [#445](https://github.com/opensearch-project/skills/issues/445) |
+
+### Related Issues
+| Issue | Description |
+|-------|-------------|
+| [#445](https://github.com/opensearch-project/skills/issues/445) | Flaky test in RAGToolIT |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -68,6 +68,7 @@
 
 ### skills
 - CVE Fixes
+- CI Fixes
 
 ### observability
 - Observability SOP


### PR DESCRIPTION
## Summary

Investigation of GitHub Issue #2013: [bugfix] Skills CI

### Changes
- Created release report: `docs/releases/v2.19.0/features/skills/ci-fixes.md`
- Updated feature report: `docs/features/skills/skills-tools.md` (added v2.19.0 to Change History and References)
- Updated release index: `docs/releases/v2.19.0/index.md`

### Key Findings

This PR documents the following bug fixes in Skills plugin v2.19.0:

1. **GitHub Actions CI Fix**: Fixed Linux build failures due to GLIBC version incompatibilities with Node.js 20 by using the shared CI image workflow from opensearch-build repository

2. **RAGTool Missing Return Fix**: Fixed a bug where a missing `return` statement after `listener.onResponse(r)` when `enableContentGeneration` is `false` could cause unexpected behavior

### Source PR
- [opensearch-project/skills#477](https://github.com/opensearch-project/skills/pull/477)