### PR TITLE
docs: add security integration tests report for v2.19.0

### DIFF
--- a/docs/features/learning/learning-to-rank.md
+++ b/docs/features/learning/learning-to-rank.md
@@ -149,6 +149,7 @@ POST my_index/_search
 ## Change History
 
 - **v3.4.0** (2026-02-18): Bug fixes - legacy version ID computation update for OpenSearch compatibility, integration test stability improvements (ML index warning fix, implicit refresh), rescore-only SLTR logging fix; Test infrastructure enhancements - narrowed index cleanup scope to LTR indexes only, improved test isolation for parallel execution
+- **v2.19.0** (2025-02-18): Infrastructure - Added support for running integration tests against external clusters with security plugin enabled; added Spotless code formatting plugin
 - **v3.3.0** (2026-01-14): Build infrastructure fixes - log4j exclusion from JAR, Gradle 9 compatibility, hybrid float comparison for tests, code coverage reporting, spotless plugin upgrade
 - **v3.2.0** (2025-09-16): Added XGBoost missing values support for correct NaN handling; Build infrastructure upgrade (Gradle 8.14, JDK 24 support); fixed flaky test with ULP tolerance adjustment
 - **v3.0.0** (2025-05-13): Added XGBoost raw JSON parser for proper `save_model` format support; fixed ApproximateScoreQuery test
@@ -185,3 +186,4 @@ POST my_index/_search
 | v3.2.0 | [#205](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/205) | Fix flaky test with ULP tolerance adjustment |   |
 | v3.0.0 | [#151](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/151) | Add XGBoost model parser for correct serialization format | [#497](https://github.com/o19s/elasticsearch-learning-to-rank/issues/497) |
 | v3.0.0 | [#158](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/158) | Fix test for ApproximateScoreQuery |   |
+| v2.19.0 | [#122](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/122) | Support integration tests against external cluster with security plugin | [#120](https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/120) |

--- a/docs/releases/v2.19.0/features/opensearch-learning-to-rank-base/security-integration-tests.md
+++ b/docs/releases/v2.19.0/features/opensearch-learning-to-rank-base/security-integration-tests.md
@@ -1,0 +1,83 @@
+---
+tags:
+  - opensearch-learning-to-rank-base
+---
+# Security Integration Tests
+
+## Summary
+
+Added support for running integration tests against an external OpenSearch cluster with the security plugin enabled. This infrastructure improvement enables testing the Learning to Rank plugin in secured environments, ensuring compatibility with authentication and authorization features.
+
+## Details
+
+### What's New in v2.19.0
+
+This PR adds the ability to run integration tests against external OpenSearch clusters that have the security plugin enabled. Previously, integration tests could only run against local test clusters without security.
+
+### Technical Changes
+
+#### New Gradle Task
+
+A new `integTestRemote` task was added to `build.gradle` for running tests against external clusters:
+
+```groovy
+task integTestRemote(type: RestIntegTestTask) {
+    description = "Run integration tests from src/javaRestTest"
+    testClassesDirs = sourceSets.javaRestTest.output.classesDirs
+    classpath = sourceSets.javaRestTest.runtimeClasspath
+
+    systemProperty 'tests.security.manager', 'false'
+    systemProperty "https", System.getProperty("https")
+    systemProperty "user", System.getProperty("user")
+    systemProperty "password", System.getProperty("password")
+}
+```
+
+#### System Properties
+
+The following system properties are now supported for secure cluster testing:
+
+| Property | Description |
+|----------|-------------|
+| `https` | Enable HTTPS connection to the cluster |
+| `user` | Username for authentication |
+| `password` | Password for authentication |
+
+#### Spotless Integration
+
+The PR also adds the Spotless code formatting plugin to the build:
+
+```groovy
+plugins {
+    id 'com.diffplug.spotless' version '6.23.0'
+}
+
+spotless {
+    java {
+        removeUnusedImports()
+        importOrder 'java', 'javax', 'org', 'com'
+        eclipse().configFile rootProject.file('.eclipseformat.xml')
+    }
+}
+```
+
+### Usage
+
+To run integration tests against a secured external cluster:
+
+```bash
+./gradlew integTestRemote -Dhttps=true -Duser=admin -Dpassword=<password>
+```
+
+## Limitations
+
+- Requires manual setup of the external cluster with security plugin
+- Test credentials must be provided via system properties
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#122](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/122) | [Backport to 2.x] Support Integration Tests against an external test cluster with security plugin enabled | [#120](https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/120) |
+| [#121](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/121) | Support Integration Tests against an external test cluster with security plugin enabled (main) | [#120](https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/120) |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -75,3 +75,6 @@
 
 ### observability
 - Observability SOP
+
+### opensearch-learning-to-rank-base
+- Security Integration Tests


### PR DESCRIPTION
## Summary

Adds release report for the Learning to Rank security integration tests feature in v2.19.0.

### Changes
- Created release report: `docs/releases/v2.19.0/features/opensearch-learning-to-rank-base/security-integration-tests.md`
- Updated feature report: `docs/features/learning/learning-to-rank.md` (added v2.19.0 to Change History and References)
- Updated release index: `docs/releases/v2.19.0/index.md`

### Related
- PR: opensearch-project/opensearch-learning-to-rank-base#122
- Issue: #2011