### PR TITLE
docs: add system index handling report for v2.19.0

### DIFF
--- a/docs/features/learning/learning-to-rank.md
+++ b/docs/features/learning/learning-to-rank.md
@@ -149,7 +149,7 @@ POST my_index/_search
 ## Change History
 
 - **v3.4.0** (2026-02-18): Bug fixes - legacy version ID computation update for OpenSearch compatibility, integration test stability improvements (ML index warning fix, implicit refresh), rescore-only SLTR logging fix; Test infrastructure enhancements - narrowed index cleanup scope to LTR indexes only, improved test isolation for parallel execution
-- **v2.19.0** (2025-02-18): Infrastructure - Added support for running integration tests against external clusters with security plugin enabled; added Spotless code formatting plugin
+- **v2.19.0** (2025-02-18): System index handling - REST handlers now stash thread context before accessing `.ltrstore*` system indices (RestAddFeatureToSet, RestCreateModelFromSet, RestFeatureManager, RestStoreManager); Integration test fixes for system index warnings; Build infrastructure improvements (Java 11/17 builds, LTR onboarding scripts)
 - **v3.3.0** (2026-01-14): Build infrastructure fixes - log4j exclusion from JAR, Gradle 9 compatibility, hybrid float comparison for tests, code coverage reporting, spotless plugin upgrade
 - **v3.2.0** (2025-09-16): Added XGBoost missing values support for correct NaN handling; Build infrastructure upgrade (Gradle 8.14, JDK 24 support); fixed flaky test with ULP tolerance adjustment
 - **v3.0.0** (2025-05-13): Added XGBoost raw JSON parser for proper `save_model` format support; fixed ApproximateScoreQuery test
@@ -186,4 +186,8 @@ POST my_index/_search
 | v3.2.0 | [#205](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/205) | Fix flaky test with ULP tolerance adjustment |   |
 | v3.0.0 | [#151](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/151) | Add XGBoost model parser for correct serialization format | [#497](https://github.com/o19s/elasticsearch-learning-to-rank/issues/497) |
 | v3.0.0 | [#158](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/158) | Fix test for ApproximateScoreQuery |   |
+| v2.19.0 | [#126](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/126) | Modified Rest Handlers to stash context before modifying system indices | [#120](https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/120) |
+| v2.19.0 | [#129](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/129) | Stashed context for GET calls |  |
+| v2.19.0 | [#132](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/132) | Modify ITs to ignore transient warning |  |
+| v2.19.0 | [#135](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/135) | Refactor index refresh logic in ITs |  |
 | v2.19.0 | [#122](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/122) | Support integration tests against external cluster with security plugin | [#120](https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/120) |

--- a/docs/releases/v2.19.0/features/learning/system-index-handling.md
+++ b/docs/releases/v2.19.0/features/learning/system-index-handling.md
@@ -1,0 +1,77 @@
+---
+tags:
+  - learning
+---
+# System Index Handling
+
+## Summary
+
+Bug fixes for the Learning to Rank (LTR) plugin to properly handle system index access in OpenSearch 2.19.0. The `.ltrstore*` indices are system indices, and accessing them without proper thread context stashing caused integration test failures and warnings.
+
+## Details
+
+### What's New in v2.19.0
+
+The LTR plugin's REST handlers now properly stash the thread context before accessing system indices (`.ltrstore*`). This prevents warnings about direct system index access and ensures compatibility with OpenSearch's system index protection mechanisms.
+
+### Technical Changes
+
+#### Thread Context Stashing
+
+Modified REST handlers to stash thread context before system index operations:
+
+- `RestAddFeatureToSet` - Feature set modifications
+- `RestCreateModelFromSet` - Model creation from feature sets
+- `RestFeatureManager` - Feature CRUD operations (get, delete, add/update)
+- `RestStoreManager` - LTR store deletion
+
+**Pattern applied:**
+```java
+return (channel) -> {
+    try (ThreadContext.StoredContext threadContext = 
+            client.threadPool().getThreadContext().stashContext()) {
+        ActionListener<Response> wrappedListener = ActionListener
+            .runBefore(originalListener, () -> threadContext.restore());
+        builder.execute(wrappedListener);
+    } catch (Exception e) {
+        channel.sendResponse(new BytesRestResponse(
+            RestStatus.INTERNAL_SERVER_ERROR, e.getMessage()));
+    }
+};
+```
+
+#### Integration Test Fixes
+
+- Added `allowed_warnings` directives in YAML tests to handle system index access warnings
+- Refactored index refresh logic to target specific indices instead of all indices
+- Fixed test cases to use proper LTR store deletion API instead of direct index deletion
+
+### Build Infrastructure
+
+- Added builds against Java 11 and 17
+- Modified build scripts to onboard LTR to OpenSearch
+- Backported commits from main to 2.x branch
+
+## Limitations
+
+- System index access warnings may still appear in logs but do not affect functionality
+- The `.ltrstore*` indices remain system indices with restricted direct access
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#126](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/126) | Modified Rest Handlers to stash context before modifying system indices | [#120](https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/120) |
+| [#129](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/129) | Stashed context for GET calls |  |
+| [#132](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/132) | Modify ITs to ignore transient warning |  |
+| [#135](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/135) | Refactor index refresh logic in ITs |  |
+| [#124](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/124) | Added builds against Java 11 and 17 |  |
+| [#116](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/116) | Backporting commits from main to 2.x |  |
+| [#98](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/98) | Modified build scripts to onboard LTR to OpenSearch |  |
+| [#91](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/91) | Merge main into 2.x |  |
+
+### Related Issues
+| Issue | Description |
+|-------|-------------|
+| [#120](https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/120) | Integration Test Failed for opensearch-learning-to-rank-base-2.19.0 |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -78,3 +78,4 @@
 
 ### opensearch-learning-to-rank-base
 - Security Integration Tests
+- System Index Handling


### PR DESCRIPTION
## Summary
Bug fixes for the Learning to Rank (LTR) plugin to properly handle system index access in OpenSearch 2.19.0.

### Changes
- Created release report: `docs/releases/v2.19.0/features/learning/system-index-handling.md`
- Updated feature report: `docs/features/learning/learning-to-rank.md` (Change History and References)
- Updated release index: `docs/releases/v2.19.0/index.md`

### Key Fixes in v2.19.0
- REST handlers now stash thread context before accessing `.ltrstore*` system indices
- Integration test fixes for system index access warnings
- Build infrastructure improvements (Java 11/17 builds)

### Related Issue
Closes #2010