### PR TITLE
docs: add Security Dashboards bug fixes report for v2.19.0

### DIFF
--- a/docs/features/security-dashboards/security-dashboards-plugin.md
+++ b/docs/features/security-dashboards/security-dashboards-plugin.md
@@ -111,6 +111,7 @@ export function validateNextUrl(url: string, basePath: string): string | undefin
 
 ## Change History
 
+- **v2.19.0** (2025-01-21): Fixed OpenID login redirect to preserve query parameters and URL fragments; Fixed tenant defaulting incorrectly based on preferred tenants order instead of default tenant setting
 - **v2.17.0** (2024-09-17): UI/UX enhancements including smaller/compressed components, updated page headers, avatar relocation to left nav, consistency and density improvements; Fixed tenancy app registration, basepath URL validation, page header UX, and navigation titles/descriptions
 
 
@@ -123,6 +124,8 @@ export function validateNextUrl(url: string, basePath: string): string | undefin
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v2.19.0 | [#2140](https://github.com/opensearch-project/security-dashboards-plugin/pull/2140) | Preserve Query in nextUrl during openid login redirect | [#1823](https://github.com/opensearch-project/security-dashboards-plugin/issues/1823) |
+| v2.19.0 | [#2163](https://github.com/opensearch-project/security-dashboards-plugin/pull/2163) | Fix tenant defaulting incorrectly | [#2019](https://github.com/opensearch-project/security-dashboards-plugin/issues/2019) |
 | v2.17.0 | [#2079](https://github.com/opensearch-project/security-dashboards-plugin/pull/2079) | Use smaller and compressed variants of buttons and form components |   |
 | v2.17.0 | [#2082](https://github.com/opensearch-project/security-dashboards-plugin/pull/2082) | Conditionally change where avatar shows up |   |
 | v2.17.0 | [#2083](https://github.com/opensearch-project/security-dashboards-plugin/pull/2083) | Adds page headers for updated UX |   |
@@ -135,3 +138,5 @@ export function validateNextUrl(url: string, basePath: string): string | undefin
 ### Issues (Design / RFC)
 - [Issue #2056](https://github.com/opensearch-project/security-dashboards-plugin/issues/2056): Tenant link visibility bug
 - [Issue #2097](https://github.com/opensearch-project/security-dashboards-plugin/issues/2097): Basepath nextUrl validation bug
+- [Issue #1823](https://github.com/opensearch-project/security-dashboards-plugin/issues/1823): Auth redirect resets query
+- [Issue #2019](https://github.com/opensearch-project/security-dashboards-plugin/issues/2019): Tenant defaulting incorrectly based on preferred tenants order

--- a/docs/releases/v2.19.0/features/security-dashboards/security-dashboards-bugfixes.md
+++ b/docs/releases/v2.19.0/features/security-dashboards/security-dashboards-bugfixes.md
@@ -1,0 +1,79 @@
+---
+tags:
+  - security-dashboards
+---
+# Security Dashboards Bug Fixes
+
+## Summary
+
+OpenSearch v2.19.0 includes two bug fixes for the Security Dashboards Plugin addressing issues with OpenID Connect login redirects and multi-tenancy default tenant selection.
+
+## Details
+
+### What's New in v2.19.0
+
+#### OpenID Login Redirect URL Preservation
+
+Fixed an issue where query parameters and URL fragments were lost during OpenID Connect authentication redirects.
+
+**Problem**: When users accessed a shared dashboard link while not logged in, after successful OpenID authentication they were redirected to the default dashboards page instead of the original URL they requested.
+
+**Solution**: The `generateNextUrl` method in `openid_auth.ts` now preserves the query string from the original request:
+
+```typescript
+private generateNextUrl(request: OpenSearchDashboardsRequest): string {
+  let path = getRedirectUrl({
+    request,
+    basePath: this.coreSetup.http.basePath.serverBasePath,
+    nextUrl: request.url.pathname || '/app/opensearch-dashboards',
+  });
+  if (request.url.search) {
+    path += request.url.search;
+  }
+  return escape(path);
+}
+```
+
+This also preserves the `security_tenant` parameter when multi-tenancy is enabled, ensuring users are redirected to the correct tenant after login.
+
+#### Tenant Default Selection Fix
+
+Fixed an issue where the default tenant was incorrectly determined based on the order of `opensearch_security.multitenancy.tenants.preferred` instead of the configured default tenant.
+
+**Problem**: If `opensearch_security.multitenancy.tenants.preferred: ["Global", "Private"]` and the default tenant was set to `Private`, users would be logged into `Global` tenant instead.
+
+**Solution**: Added case-insensitive matching for the `Private` tenant in `tenant_resolver.ts`:
+
+```typescript
+export const PRIVATE_TENANTS: string[] = [PRIVATE_TENANT_SYMBOL, 'private', 'Private'];
+```
+
+This ensures the tenant resolver correctly identifies the requested tenant regardless of case, allowing the default tenant setting to take precedence over the preferred tenants order.
+
+### Technical Changes
+
+| File | Change |
+|------|--------|
+| `server/auth/types/openid/openid_auth.ts` | Preserve query string in nextUrl during redirect |
+| `server/auth/types/openid/routes.ts` | Change `redirectHash` schema from boolean to string |
+| `server/multitenancy/tenant_resolver.ts` | Add `'Private'` to PRIVATE_TENANTS array |
+
+## Limitations
+
+- The OpenID redirect fix only applies to OpenID Connect authentication; SAML already had this functionality
+- Tenant resolution fix is case-sensitive for custom tenant names (only affects built-in Private/Global tenants)
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#2140](https://github.com/opensearch-project/security-dashboards-plugin/pull/2140) | Preserve Query in nextUrl during openid login redirect | [#1823](https://github.com/opensearch-project/security-dashboards-plugin/issues/1823), [#2119](https://github.com/opensearch-project/security-dashboards-plugin/issues/2119) |
+| [#2163](https://github.com/opensearch-project/security-dashboards-plugin/pull/2163) | Fix tenant defaulting incorrectly | [#2019](https://github.com/opensearch-project/security-dashboards-plugin/issues/2019) |
+
+### Issues
+| Issue | Description |
+|-------|-------------|
+| [#1823](https://github.com/opensearch-project/security-dashboards-plugin/issues/1823) | Auth redirect resets query in v2.12+ |
+| [#2019](https://github.com/opensearch-project/security-dashboards-plugin/issues/2019) | Tenant defaulting incorrectly based on preferred tenants order |
+| [#2119](https://github.com/opensearch-project/security-dashboards-plugin/issues/2119) | Related OpenID redirect issue |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -69,6 +69,9 @@
 ### security
 - CVE Fixes
 
+### security-dashboards
+- Security Dashboards Bug Fixes
+
 ### skills
 - CVE Fixes
 - CI Fixes


### PR DESCRIPTION
## Summary

This PR adds documentation for Security Dashboards Plugin bug fixes in OpenSearch v2.19.0.

### Reports Created
- Release report: `docs/releases/v2.19.0/features/security-dashboards/security-dashboards-bugfixes.md`
- Feature report updated: `docs/features/security-dashboards/security-dashboards-plugin.md`

### Key Changes in v2.19.0

1. **OpenID Login Redirect URL Preservation** (PR #2140)
   - Fixed issue where query parameters and URL fragments were lost during OpenID Connect authentication redirects
   - Users are now correctly redirected to their original URL after login
   - Preserves `security_tenant` parameter for multi-tenancy

2. **Tenant Default Selection Fix** (PR #2163)
   - Fixed issue where default tenant was incorrectly determined based on `opensearch_security.multitenancy.tenants.preferred` order
   - Default tenant setting now takes precedence over preferred tenants order

### Related Issues
- #1823: Auth redirect resets query
- #2019: Tenant defaulting incorrectly based on preferred tenants order

Closes #2009