### PR TITLE
docs: add security-netty report for v2.19.0

### DIFF
--- a/docs/features/security/security-plugin.md
+++ b/docs/features/security/security-plugin.md
@@ -176,6 +176,7 @@ config:
 
 - **v3.2.0** (2025-09-16): Enhancements - nested JWT claim support for subject extraction, stream transport security integration, plugin permission declaration mechanism via plugin-permissions.yml; Bugfixes - JWT clock skew tolerance now properly applied, demo certificate installation in Helm/K8s environments, mixed cluster config update handling, cluster permission detection, SecureHttpTransportParameters provider, tenancy access serialization; Refactoring - JWT Vendor with flexible claims builder
 - **v3.0.0** (2025-05-06): Breaking changes - Blake2b hash fix, OpenSSL removal, whitelist→allowlist; Enhancements - optimized privilege evaluation, CIDR support in ignore_hosts, password validation improvements
+- **v2.19.0** (2025-02-11): Bugfixes - Netty4HttpRequestHeaderVerifier now handles HTTP upgrade requests by accepting HttpRequest instead of DefaultHttpRequest; Infrastructure - JaCoCo report generation for integTestRemote task, RestHelper TLS configuration updated to use DefaultClientTlsStrategy
 - **v2.18.0** (2024-11-05): Enhancements - datastream support for audit logs, auto-convert V6 to V7 configuration, circuit breaker override for security APIs, improved certificate error messages, JWT in MultipleAuthentication, remote index permissions for AD; Bugfixes - header serialization for rolling upgrades, PBKDF2 password hashing, SSL exception handler; Maintenance - cache endpoint deprecation warning, undeprecate securityadmin script, ASN1 refactoring for FIPS compatibility, CVE-2024-47554 fix
 - **v2.17.0** (2024-09-17): Bugfixes - demo certificate validation, auth token endpoint, audit config null handling, certificate SAN ordering, TermsAggregationEvaluator permissions; Refactoring - security provider instantiation for FIPS support, Log4j utility removal
 
@@ -231,6 +232,8 @@ config:
 | v3.0.0 | [#1467](https://github.com/opensearch-project/security/pull/1467) | Refactored flaky test |   |
 | v3.0.0 | [#1498](https://github.com/opensearch-project/security/pull/1498) | Remove overrides of preserveIndicesUponCompletion |   |
 | v3.0.0 | [#1503](https://github.com/opensearch-project/security/pull/1503) | Remove usage of deprecated batchSize() method |   |
+| v2.19.0 | [#5045](https://github.com/opensearch-project/security/pull/5045) | Fix Netty4 header verifier for HTTP upgrade requests | Follow-up to [#5035](https://github.com/opensearch-project/security/pull/5035) |
+| v2.19.0 | [#5050](https://github.com/opensearch-project/security/pull/5050) | Generate JaCoCo report for integTestRemote task |   |
 | v2.18.0 | [#4756](https://github.com/opensearch-project/security/pull/4756) | Support datastreams as an AuditLog Sink |   |
 | v2.18.0 | [#4753](https://github.com/opensearch-project/security/pull/4753) | Auto-convert V6 configuration to V7 (2.x only) |   |
 | v2.18.0 | [#4779](https://github.com/opensearch-project/security/pull/4779) | Add circuit breaker override for security APIs |   |

--- a/docs/releases/v2.19.0/features/security/security-netty.md
+++ b/docs/releases/v2.19.0/features/security/security-netty.md
@@ -1,0 +1,55 @@
+---
+tags:
+  - security
+---
+# Security Netty
+
+## Summary
+
+Bug fixes for the Security plugin's Netty4 HTTP request handling and test infrastructure improvements in v2.19.0.
+
+## Details
+
+### What's New in v2.19.0
+
+#### Netty4 Header Verifier Fix
+
+The `Netty4HttpRequestHeaderVerifier` class was updated to handle HTTP upgrade requests properly. The handler now extends `SimpleChannelInboundHandler<HttpRequest>` instead of `SimpleChannelInboundHandler<DefaultHttpRequest>`, allowing it to process all HTTP request types including upgrade requests.
+
+**Technical Change:**
+```java
+// Before (v2.18.x)
+public class Netty4HttpRequestHeaderVerifier extends SimpleChannelInboundHandler<DefaultHttpRequest>
+
+// After (v2.19.0)
+public class Netty4HttpRequestHeaderVerifier extends SimpleChannelInboundHandler<HttpRequest>
+```
+
+This fix is a follow-up to PR #5035 which addressed Apache HttpClient5/HttpCore5 compatibility issues after the library update in OpenSearch core.
+
+#### Test Infrastructure Improvements
+
+- Updated `RestHelper` test class to use `DefaultClientTlsStrategy` instead of the deprecated `ClientTlsStrategyBuilder`
+- Simplified TLS configuration in tests by removing custom `TlsDetailsFactory`
+- Added JaCoCo code coverage report generation for the `integTestRemote` task
+
+### Technical Changes
+
+| Component | Change |
+|-----------|--------|
+| `Netty4HttpRequestHeaderVerifier` | Changed generic type from `DefaultHttpRequest` to `HttpRequest` |
+| `RestHelper` | Migrated from `ClientTlsStrategyBuilder` to `DefaultClientTlsStrategy` |
+| `build.gradle` | Added `jacocoTestReport` finalization for `integTestRemote` task |
+
+## Limitations
+
+- These are internal implementation changes with no user-facing configuration changes
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#5045](https://github.com/opensearch-project/security/pull/5045) | Fix Netty4 header verifier inbound handler to deal with upgrade requests | Follow-up to [#5035](https://github.com/opensearch-project/security/pull/5035) |
+| [#5050](https://github.com/opensearch-project/security/pull/5050) | Generate jacoco report for integTestRemote task | Backport of [#5049](https://github.com/opensearch-project/security/pull/5049) |
+| [#5035](https://github.com/opensearch-project/security/pull/5035) | Fix tests after Apache HttpClient5/HttpCore5 update | Related to [OpenSearch#16757](https://github.com/opensearch-project/OpenSearch/pull/16757) |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -68,6 +68,7 @@
 
 ### security
 - CVE Fixes
+- Security Netty
 
 ### security-analytics
 - Security Analytics Bug Fixes


### PR DESCRIPTION
## Summary

Investigation of GitHub Issue #2007 - Security Netty bugfixes for v2.19.0.

## Reports Created
- Release report: `docs/releases/v2.19.0/features/security/security-netty.md`
- Feature report: `docs/features/security/security-plugin.md` (updated)

## Key Changes in v2.19.0
- **Netty4HttpRequestHeaderVerifier fix**: Changed handler to accept `HttpRequest` instead of `DefaultHttpRequest` to properly handle HTTP upgrade requests
- **Test infrastructure**: Added JaCoCo report generation for `integTestRemote` task, updated `RestHelper` TLS configuration

## PRs Investigated
- [security#5045](https://github.com/opensearch-project/security/pull/5045): Fix Netty4 header verifier inbound handler
- [security#5050](https://github.com/opensearch-project/security/pull/5050): Generate jacoco report for integTestRemote task

Closes #2007