### PR TITLE
docs: add security-audit-logging report for v2.19.0

### DIFF
--- a/docs/features/security/security-features.md
+++ b/docs/features/security/security-features.md
@@ -127,6 +127,7 @@ PUT _plugins/_security/api/roles/search_relevance_reader
 - **v3.4.0** (2026-01): Added webhook Basic Auth support, fixed REST header propagation, deprecated system_indices.indices setting, allowed static/custom config overlap, updated search relevance permissions; Bug fixes for multi-tenancy `.kibana` index updates, WildcardMatcher empty string handling, array validator blank string checks, audit log sensitive parameter filtering, deprecated SSL settings, BCFIPS provider bootstrap timing, AccessController migration, PrivilegesEvaluator modularization
 - **v3.3.0** (2026-01): Bug fixes for system index access when protection disabled, JWT log spam with empty roles_key
 - **v3.1.0** (2025-06-10): Bug fixes for stale cache post snapshot restore, compliance audit log diff computation, DLS/FLS filter reader corrections, authentication header logging improvements
+- **v2.19.0** (2024-12-10): Bug fixes for compliance audit log `log_request_body` setting, OpenSSL availability warning log noise reduction, OBO authenticator log level correction
 - **v2.18.0** (2024-10-29): Bug fixes for system index protection, SAML audit logging, demo config detection, SSL dual mode propagation, stored field handling, and closed index mappings
 
 
@@ -160,6 +161,9 @@ PUT _plugins/_security/api/roles/search_relevance_reader
 | v3.1.0 | [#5279](https://github.com/opensearch-project/security/pull/5279) | Fix: Compliance audit log diff computation | [#5280](https://github.com/opensearch-project/security/issues/5280) |
 | v3.1.0 | [#5303](https://github.com/opensearch-project/security/pull/5303) | Fix: DlsFlsFilterLeafReader PointValues handling |   |
 | v3.1.0 | [#5377](https://github.com/opensearch-project/security/pull/5377) | Fix: Conditional invalid auth header logging |   |
+| v2.19.0 | [#4918](https://github.com/opensearch-project/security/pull/4918) | Fix: Honor log_request_body setting in compliance audit log | [#4534](https://github.com/opensearch-project/security/issues/4534) |
+| v2.19.0 | [#4906](https://github.com/opensearch-project/security/pull/4906) | Fix: Log OpenSSL warning only when explicitly enabled | [#4881](https://github.com/opensearch-project/security/issues/4881) |
+| v2.19.0 | [#4956](https://github.com/opensearch-project/security/pull/4956) | Fix: Change OBO disabled log level to DEBUG |   |
 | v2.18.0 | [#4775](https://github.com/opensearch-project/security/pull/4775) | Fix: Admin system index read |   |
 | v2.18.0 | [#4770](https://github.com/opensearch-project/security/pull/4770) | Fix: Remove SAML failed login audit |   |
 | v2.18.0 | [#4798](https://github.com/opensearch-project/security/pull/4798) | Fix: Handle non-flat YAML settings |   |

--- a/docs/releases/v2.19.0/features/security/security-audit-logging.md
+++ b/docs/releases/v2.19.0/features/security/security-audit-logging.md
@@ -1,0 +1,70 @@
+---
+tags:
+  - security
+---
+# Security Audit Logging
+
+## Summary
+
+OpenSearch v2.19.0 includes three bug fixes related to security logging: improved compliance audit log behavior for the `log_request_body` setting, reduced log noise for OpenSSL availability warnings, and corrected log levels for On-Behalf-Of (OBO) authentication messages.
+
+## Details
+
+### What's New in v2.19.0
+
+#### Compliance Audit Log `log_request_body` Setting Fix
+
+The compliance audit logging now properly honors the `log_request_body` setting. Previously, when `write_log_diffs` was enabled, the request body was logged regardless of the `log_request_body` setting. This fix ensures:
+
+- When `log_request_body` is disabled and `write_log_diffs` is enabled, only the diff content is logged without the full request body
+- Document creation events now properly compute diffs from an empty source (`{}`) when no original document exists
+- The `audit_request_body` field is correctly omitted when `log_request_body` is set to `false`
+
+**Configuration Example**:
+```yaml
+plugins.security.audit.config.log_request_body: false
+plugins.security.compliance.write_log_diffs: true
+plugins.security.compliance.write_metadata_only: false
+```
+
+#### OpenSSL Availability Warning Reduction
+
+The OpenSSL availability warning is now only logged when OpenSSL is explicitly enabled but not available. Previously, the warning was always logged when OpenSSL was unavailable, even when not explicitly configured. The warning now only appears when:
+
+- `plugins.security.ssl.http.enable_openssl_if_available` is set to `true`, OR
+- `plugins.security.ssl.transport.enable_openssl_if_available` is set to `true`
+
+This reduces unnecessary log noise in environments using the default JDK SSL implementation.
+
+#### OBO Authenticator Log Level Fix
+
+The On-Behalf-Of (OBO) authenticator log message "On-behalf-of authentication is disabled" has been changed from `ERROR` to `DEBUG` level. This message is not indicative of an application error—it simply indicates that OBO authentication is not enabled, which is a normal configuration state.
+
+### Technical Changes
+
+| Component | Change | Impact |
+|-----------|--------|--------|
+| `AbstractAuditLog.java` | Modified `logDocumentWritten()` to respect `log_request_body` setting when `write_log_diffs` is enabled | Compliance audit logs now correctly omit request body when configured |
+| `SslSettingsManager.java` | Added conditional check for OpenSSL settings before logging warning | Reduced log noise for default SSL configurations |
+| `OnBehalfOfAuthenticator.java` | Changed log level from `ERROR` to `DEBUG` for disabled OBO message | Cleaner logs when OBO is intentionally disabled |
+
+## Limitations
+
+- The compliance audit log fix only affects write operations with `write_log_diffs` enabled
+- OpenSSL warning suppression requires explicit configuration of the OpenSSL settings
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#4918](https://github.com/opensearch-project/security/pull/4918) | Honor log_request_body setting in compliance audit log (backport) | [#4534](https://github.com/opensearch-project/security/issues/4534) |
+| [#4832](https://github.com/opensearch-project/security/pull/4832) | Honor log_request_body setting in compliance audit log (main) | [#4534](https://github.com/opensearch-project/security/issues/4534) |
+| [#4906](https://github.com/opensearch-project/security/pull/4906) | Log OpenSSL warning only when explicitly enabled (backport) | [#4881](https://github.com/opensearch-project/security/issues/4881) |
+| [#4901](https://github.com/opensearch-project/security/pull/4901) | Log OpenSSL warning only when explicitly enabled (main) | [#4881](https://github.com/opensearch-project/security/issues/4881) |
+| [#4956](https://github.com/opensearch-project/security/pull/4956) | Change OBO disabled log level to DEBUG (backport) | |
+| [#4952](https://github.com/opensearch-project/security/pull/4952) | Change OBO disabled log level to DEBUG (main) | |
+
+### Documentation
+- [Audit Logs Documentation](https://docs.opensearch.org/2.19/security/audit-logs/index/)
+- [Audit Log Field Reference](https://docs.opensearch.org/2.19/security/audit-logs/field-reference/)

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -68,6 +68,7 @@
 
 ### security
 - CVE Fixes
+- Security Audit Logging
 - Security Netty
 
 ### security-analytics


### PR DESCRIPTION
## Summary

Adds release report for Security Audit Logging bug fixes in OpenSearch v2.19.0.

## Changes

### Release Report Created
- `docs/releases/v2.19.0/features/security/security-audit-logging.md`

### Feature Report Updated
- `docs/features/security/security-features.md` - Added v2.19.0 entry to Change History and PR references

### Release Index Updated
- `docs/releases/v2.19.0/index.md` - Added Security Audit Logging entry

## Bug Fixes Covered

1. **Compliance Audit Log `log_request_body` Setting** ([#4918](https://github.com/opensearch-project/security/pull/4918))
   - Honors `log_request_body` setting when `write_log_diffs` is enabled
   - Properly computes diffs from empty source for new documents

2. **OpenSSL Availability Warning** ([#4906](https://github.com/opensearch-project/security/pull/4906))
   - Warning only logged when OpenSSL is explicitly enabled but unavailable
   - Reduces log noise for default JDK SSL configurations

3. **OBO Authenticator Log Level** ([#4956](https://github.com/opensearch-project/security/pull/4956))
   - Changed "On-behalf-of authentication is disabled" from ERROR to DEBUG level

Closes #2006