### PR TITLE
docs: add reporting bugfixes report for v2.19.0

### DIFF
--- a/docs/features/dashboards-reporting/dashboards-reporting.md
+++ b/docs/features/dashboards-reporting/dashboards-reporting.md
@@ -120,6 +120,7 @@ opensearch-reporting-cli \
 
 - **v3.4.0** (2026-01-14): Security fix for CVE-2025-57810 (jspdf bump), fixed null/undefined datetime handling in CSV reports
 - **v3.0.0** (2025-05-20): Fixed date range handling in report generation, made time parameters optional, fixed popover UI positioning
+- **v2.19.0** (2025-02-18): Sanitize markdown in header/footer preview, fixed CSV nested fields parsing, hide reporting button when MDS enabled in notebooks
 - **v2.18.0** (2024-11-12): Fixed missing EUI component imports in report_settings component
 
 
@@ -138,6 +139,9 @@ opensearch-reporting-cli \
 | v3.0.0 | [#524](https://github.com/opensearch-project/dashboards-reporting/pull/524) | Support for date range in report generation | [#414](https://github.com/opensearch-project/dashboards-reporting/issues/414) |
 | v3.0.0 | [#554](https://github.com/opensearch-project/dashboards-reporting/pull/554) | Updated optional parameters for timeFrom and timeTo |   |
 | v3.0.0 | [#570](https://github.com/opensearch-project/dashboards-reporting/pull/570) | Reporting Popover UI fix | [#401](https://github.com/opensearch-project/dashboards-reporting/issues/401) |
+| v2.19.0 | [#476](https://github.com/opensearch-project/dashboards-reporting/pull/476) | Sanitize markdown when previewing report header/footer |   |
+| v2.19.0 | [#502](https://github.com/opensearch-project/dashboards-reporting/pull/502) | CSV report generation had missing nested fields | [#375](https://github.com/opensearch-project/dashboards-reporting/issues/375) |
+| v2.19.0 | [dashboards-observability#2278](https://github.com/opensearch-project/dashboards-observability/pull/2278) | Updated notebooks reporting button render |   |
 | v2.18.0 | [#464](https://github.com/opensearch-project/dashboards-reporting/pull/464) | Fix missing imports in report_settings |   |
 
 ### Issues (Design / RFC)

--- a/docs/releases/v2.19.0/features/dashboards-reporting/reporting-bugfixes.md
+++ b/docs/releases/v2.19.0/features/dashboards-reporting/reporting-bugfixes.md
@@ -1,0 +1,57 @@
+---
+tags:
+  - dashboards-reporting
+---
+# Reporting Bug Fixes
+
+## Summary
+
+OpenSearch v2.19.0 includes bug fixes for the Dashboards Reporting plugin addressing markdown sanitization in report headers/footers, CSV report generation with nested fields, and notebooks reporting button rendering with Multi-Data Source (MDS) enabled.
+
+## Details
+
+### What's New in v2.19.0
+
+#### Markdown Sanitization for Report Headers/Footers
+
+The report header and footer markdown preview now sanitizes HTML content using DOMPurify. Previously, sanitization was only applied during report generation, but not during the create/edit preview. This ensures consistent security behavior across the UI.
+
+**Technical Changes:**
+- Added `createDOMPurify` import from `dompurify` package
+- Applied `DOMPurify.sanitize()` to markdown preview in `generateMarkdownPreview` callback
+- Affects both header and footer markdown editors in `report_settings.tsx`
+
+#### CSV Report Generation with Nested Fields
+
+Fixed an issue where CSV reports from saved searches were missing nested field values. The previous implementation only checked for fields with a dot (`.`) in their key names, ignoring fields containing arrays of objects.
+
+**Root Cause:**
+The `dataReportHelpers.ts` code handling nested fields only checked if fields had a key with a `.` in them, ignoring fields which had an array of objects.
+
+**Technical Changes:**
+- Updated `flattenHits()` function to properly handle nested objects
+- Enhanced `traverse()` function to extract values from arrays of objects
+- Added logic to flatten nested array objects into dot-notation keys (e.g., `products.price`, `customer.address.city`)
+
+#### Notebooks Reporting Button with MDS
+
+Fixed the notebooks reporting button to hide when Multi-Data Source (MDS) is enabled. The reporting actions button was incorrectly displayed even when MDS was active, which is not supported.
+
+**Technical Changes:**
+- Added `dataSourceMDSEnabled` state check to `showReportingContextMenu` condition
+- Added `data-test-subj="reporting-actions-button"` for testing
+- Added unit tests for both MDS enabled and disabled scenarios
+
+## Limitations
+
+- Nested field flattening in CSV reports may produce large column counts for deeply nested data structures
+- Reporting functionality remains unavailable when MDS is enabled in notebooks
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [dashboards-reporting#476](https://github.com/opensearch-project/dashboards-reporting/pull/476) | Sanitize markdown when previewing report header/footer | |
+| [dashboards-reporting#502](https://github.com/opensearch-project/dashboards-reporting/pull/502) | CSV report generation had missing nested fields | [#375](https://github.com/opensearch-project/dashboards-reporting/issues/375) |
+| [dashboards-observability#2278](https://github.com/opensearch-project/dashboards-observability/pull/2278) | Updated notebooks reporting button render | |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -78,6 +78,9 @@
 ### security-dashboards
 - Security Dashboards Bug Fixes
 
+### dashboards-reporting
+- Reporting Bug Fixes
+
 ### skills
 - CVE Fixes
 - CI Fixes


### PR DESCRIPTION
## Summary

This PR adds documentation for the Reporting bug fixes in OpenSearch v2.19.0.

### Changes
- Created release report: `docs/releases/v2.19.0/features/dashboards-reporting/reporting-bugfixes.md`
- Updated feature report: `docs/features/dashboards-reporting/dashboards-reporting.md`
- Updated release index: `docs/releases/v2.19.0/index.md`

### Bug Fixes Documented
1. **Markdown Sanitization** (dashboards-reporting#476): Sanitize markdown when previewing report header/footer using DOMPurify
2. **CSV Nested Fields** (dashboards-reporting#502): Fixed CSV report generation missing nested field values
3. **Notebooks MDS Button** (dashboards-observability#2278): Hide reporting button when Multi-Data Source is enabled in notebooks

Closes #2004