### PR TITLE
docs: add dashboards-maps WMS CRS fix report for v2.19.0

### DIFF
--- a/docs/features/dashboards-maps/dashboards-maps-maps-geospatial.md
+++ b/docs/features/dashboards-maps/dashboards-maps-maps-geospatial.md
@@ -160,6 +160,7 @@ flowchart TB
 ## Change History
 
 - **v3.0.0** (2025-05-06): Added Cluster Layer with geohash/geotile/geohex aggregations, legend support, and multi-data source support. Fixed layer config panel styling and data label overlap issues.
+- **v2.19.0** (2025-02-18): Fixed WMS BBOX calculation bug by locking custom WMS CRS input to EPSG:3857 (the only CRS supported by MapLibre GL).
 - **v2.17.0** (2024-09-17): Deprecated multi-data source display in Maps UI (Trineo UX alignment). Migrated integration tests to opensearch-dashboards-functional-test repository.
 
 
@@ -180,6 +181,7 @@ flowchart TB
 | v3.0.0 | [#703](https://github.com/opensearch-project/dashboards-maps/pull/703) | Introduce cluster layer | [#250](https://github.com/opensearch-project/dashboards-maps/issues/250) |
 | v3.0.0 | [#704](https://github.com/opensearch-project/dashboards-maps/pull/704) | Fix layer config panel background |   |
 | v3.0.0 | [#718](https://github.com/opensearch-project/dashboards-maps/pull/718) | Fix data label overlap |   |
+| v2.19.0 | [#632](https://github.com/opensearch-project/dashboards-maps/pull/632) | Lock WMS CRS input to EPSG:3857 | [#600](https://github.com/opensearch-project/dashboards-maps/issues/600) |
 | v2.17.0 | [#651](https://github.com/opensearch-project/dashboards-maps/pull/651) | Deprecate maps multi data source display | [#649](https://github.com/opensearch-project/dashboards-maps/issues/649) |
 | v2.17.0 | [#664](https://github.com/opensearch-project/dashboards-maps/pull/664) | Migrate integration tests to FTR repository | [#592](https://github.com/opensearch-project/dashboards-maps/issues/592) |
 

--- a/docs/releases/v2.19.0/features/dashboards-maps/wms-crs-fix.md
+++ b/docs/releases/v2.19.0/features/dashboards-maps/wms-crs-fix.md
@@ -1,0 +1,58 @@
+---
+tags:
+  - dashboards-maps
+---
+# WMS CRS Fix
+
+## Summary
+
+Fixed a bug where custom WMS layers would generate incorrect bounding box (BBOX) parameters when using coordinate reference systems other than EPSG:3857. The fix locks the WMS CRS input to EPSG:3857, which is the only coordinate system supported by MapLibre GL.
+
+## Details
+
+### What's New in v2.19.0
+
+The custom WMS layer configuration now enforces EPSG:3857 as the coordinate reference system:
+
+- The CRS input field is disabled and locked to `EPSG:3857`
+- If no CRS is specified in the layer source, it defaults to `EPSG:3857`
+- This prevents incorrect BBOX calculations that previously occurred when users specified other CRS values like EPSG:4326
+
+### Technical Changes
+
+The fix modifies two components:
+
+1. **UI Component** (`custom_map_source.tsx`): Disables the CRS input field and sets a constant value of `EPSG:3857`
+
+2. **Layer Functions** (`customLayerFunctions.ts`): Adds a fallback to ensure `EPSG:3857` is used when building WMS URLs
+
+```typescript
+// Ensures CRS defaults to EPSG:3857 for WMS layers
+if (!layerSource.crs) {
+  layerSource.crs = "EPSG:3857"
+}
+```
+
+### Root Cause
+
+MapLibre GL only supports the Web Mercator projection (EPSG:3857). When users specified other coordinate systems like EPSG:4326 (WGS 84), the BBOX parameter values were calculated in EPSG:3857 coordinates but labeled with the user-specified CRS. This resulted in BBOX values that were approximately 100,000 times larger than expected, making WMS layers unusable.
+
+For example, a request for Iowa would generate:
+- **Before fix**: `bbox=-10644926.307106785,5009377.085697312,-10331840.239250705,5322463.153553393` (EPSG:3857 values with EPSG:4326 label)
+- **After fix**: `bbox=-10644926.307106785,5009377.085697312,-10331840.239250705,5322463.153553393&srs=EPSG:3857` (correct CRS label)
+
+## Limitations
+
+- Custom WMS layers are now restricted to EPSG:3857 coordinate system only
+- WMS servers that do not support EPSG:3857 cannot be used as custom map sources
+- This is a workaround rather than a full fix; true multi-CRS support would require MapLibre to support coordinate transformations
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#632](https://github.com/opensearch-project/dashboards-maps/pull/632) | Lock WMS CRS input to EPSG:3857 | [#600](https://github.com/opensearch-project/dashboards-maps/issues/600) |
+
+### Issues
+- [#600](https://github.com/opensearch-project/dashboards-maps/issues/600): Maps miscalculates WMS BBOX

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -78,6 +78,9 @@
 ### security-dashboards
 - Security Dashboards Bug Fixes
 
+### dashboards-maps
+- WMS CRS Fix
+
 ### dashboards-reporting
 - Reporting Bug Fixes
 


### PR DESCRIPTION
## Summary

Adds documentation for the WMS CRS bug fix in dashboards-maps v2.19.0.

### Changes
- Created release report: `docs/releases/v2.19.0/features/dashboards-maps/wms-crs-fix.md`
- Updated feature report: `docs/features/dashboards-maps/dashboards-maps-maps-geospatial.md` (Change History + References)
- Updated release index: `docs/releases/v2.19.0/index.md`

### Bug Fix Details
- **Issue**: Custom WMS layers generated incorrect BBOX parameters when using CRS other than EPSG:3857
- **Fix**: Locked WMS CRS input to EPSG:3857 (the only CRS supported by MapLibre GL)
- **PR**: opensearch-project/dashboards-maps#632
- **Related Issue**: opensearch-project/dashboards-maps#600

Closes #2003