### PR TITLE
docs: add custom-codecs QAT security fix report for v2.19.0

### DIFF
--- a/docs/features/custom-codecs/custom-codecs.md
+++ b/docs/features/custom-codecs/custom-codecs.md
@@ -205,6 +205,7 @@ Benchmark results comparing codecs against the default LZ4 codec (using `nyc_tax
 - **v3.1.0** (2025-09-16): Added QAT-accelerated ZSTD codec (`qat_zstd`), upgraded qat-java to 2.3.2
 - **v3.1.0** (2025-09-16): Fixed BWC test dependency version and added java-agent plugin to BWC tests
 - **v3.0.0** (2025-05-06): Upgraded to Lucene 10.1.0 with new codec implementations (Lucene101*), bumped zstd-jni to 1.5.6-1, migrated to Java Agent from SecurityManager
+- **v2.19.0** (2025-02-18): Fixed Java security permission issue for QAT codecs by wrapping `QatZipper` instantiation with `AccessController.doPrivileged`
 - **v2.15.0** (2024-06-25): Added QAT hardware-accelerated codecs (`qat_lz4`, `qat_deflate`)
 - **v2.9.0** (2023-07-24): Initial implementation of ZSTD codecs (`zstd`, `zstd_no_dict`)
 
@@ -231,3 +232,4 @@ Benchmark results comparing codecs against the default LZ4 codec (using `nyc_tax
 | v3.0.0 | [#232](https://github.com/opensearch-project/custom-codecs/pull/232) | Bump ZSTD lib version to 1.5.6-1 |   |
 | v3.0.0 | [#235](https://github.com/opensearch-project/custom-codecs/pull/235) | Fix build due to phasing off SecurityManager in favor of Java Agent |   |
 | v3.0.0 | [#237](https://github.com/opensearch-project/custom-codecs/pull/237) | Add java agent plugin |   |
+| v2.19.0 | [#211](https://github.com/opensearch-project/custom-codecs/pull/211) | Wrap QatZipper with AccessController.doPrivileged | Customer-reported issue |

--- a/docs/releases/v2.19.0/features/custom-codecs/qat-security-fix.md
+++ b/docs/releases/v2.19.0/features/custom-codecs/qat-security-fix.md
@@ -1,0 +1,55 @@
+---
+tags:
+  - custom-codecs
+---
+# QAT Security Permission Fix
+
+## Summary
+
+Fixed a Java security permission issue that prevented `qat_deflate` and `qat_lz4` codecs from working correctly. The `isQATAvailable()` method was returning `false` due to a `java.security` permission failure when checking QAT hardware availability.
+
+## Details
+
+### Problem
+
+Users reported that `qat_deflate` and `qat_lz4` hardware-accelerated codecs were not functioning. Investigation revealed that `isQATAvailable()` in `QatZipperFactory` was returning `false` because the call to `QatZipper` constructor triggered a Java security permission check that failed.
+
+### Solution
+
+The fix wraps the `QatZipper` instantiation with `AccessController.doPrivileged()` to grant the necessary permissions for QAT hardware detection and initialization.
+
+### Code Change
+
+```java
+// Before
+public static QatZipper createInstance(...) {
+    return new QatZipper(algorithm, level, mode, retryCount, pmode);
+}
+
+// After
+public static QatZipper createInstance(...) {
+    return java.security.AccessController.doPrivileged(
+        (java.security.PrivilegedAction<QatZipper>) () -> 
+            new QatZipper(algorithm, level, mode, retryCount, pmode)
+    );
+}
+```
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `QatZipperFactory.java` | Wrapped `QatZipper` constructor call with `AccessController.doPrivileged` |
+| `.github/workflows/check.yml` | Updated CI workflow configuration |
+
+## Limitations
+
+- This fix addresses the security permission issue but does not change the underlying QAT hardware requirements
+- QAT hardware acceleration still requires Intel 4th/5th Gen Xeon processors with Linux kernel 3.10+
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#211](https://github.com/opensearch-project/custom-codecs/pull/211) | Wrap a call to QatZipper with AccessController.doPrivileged | Customer-reported issue |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -2,6 +2,9 @@
 
 ## Features
 
+### custom-codecs
+- QAT Security Permission Fix
+
 ### ml-commons
 - ML Commons Tutorials
 


### PR DESCRIPTION
## Summary

Adds documentation for the Custom Codecs QAT security permission fix in v2.19.0.

### Changes
- Created release report: `docs/releases/v2.19.0/features/custom-codecs/qat-security-fix.md`
- Updated feature report: `docs/features/custom-codecs/custom-codecs.md` (Change History and References)
- Updated release index: `docs/releases/v2.19.0/index.md`

### Bug Fix Details
Fixed a Java security permission issue that prevented `qat_deflate` and `qat_lz4` codecs from working. The fix wraps `QatZipper` instantiation with `AccessController.doPrivileged()`.

### Related
- PR: opensearch-project/custom-codecs#211
- Issue: #2002