### PR TITLE
docs: add common-utils bugfixes report for v2.19.0

### DIFF
--- a/docs/features/common-utils/common-utils.md
+++ b/docs/features/common-utils/common-utils.md
@@ -131,6 +131,7 @@ ReplicationPluginInterface.stopReplication(client, request, listener)
 ## Change History
 
 - **v3.3.0** (2025-10-16): Updated user attributes XContent parsing to use `key=value` format in `custom_attribute_names`, updated delete_backport_branch workflow to include release-chores branches
+- **v2.19.0** (2025-02-04): Fixed bucket selector aggregation writeable name, added fanoutEnabled field to DocLevelMonitorInput for duplicate alert prevention
 - **v3.3.0** (2025-10-16): Added release notes for version 2.13.0.0 (backported to main branch)
 - **v3.2.0** (2025-07-17): Security fix for CVE-2025-48734, reverted batch findings API, upgraded to Gradle 8.14 and JDK 24
 - **v3.0.0** (2025-03-19): Added replication plugin interface, fixed transport package imports, added pipe character escaping in user info
@@ -154,6 +155,9 @@ ReplicationPluginInterface.stopReplication(client, request, listener)
 | v3.0.0 | [#667](https://github.com/opensearch-project/common-utils/pull/667) | Adding replication (CCR) plugin interface | [#726](https://github.com/opensearch-project/index-management/issues/726) |
 | v3.0.0 | [#790](https://github.com/opensearch-project/common-utils/pull/790) | Fix imports for split transport package |   |
 | v3.0.0 | [#801](https://github.com/opensearch-project/common-utils/pull/801) | Escape/Unescape pipe in UserInfo | [#2756](https://github.com/opensearch-project/security/issues/2756) |
+| v2.19.0 | [#773](https://github.com/opensearch-project/common-utils/pull/773) | Fix bucket selector aggregation writeable name |   |
+| v2.19.0 | [#758](https://github.com/opensearch-project/common-utils/pull/758) | Monitor model changed to add optional fanoutEnabled field |   |
+| v2.19.0 | [#780](https://github.com/opensearch-project/common-utils/pull/780) | Added 2.19.0.0 release notes | [#751](https://github.com/opensearch-project/common-utils/issues/751) |
 
 ### Issues (Design / RFC)
 - [Issue #2756](https://github.com/opensearch-project/security/issues/2756): Username pipe character issue

--- a/docs/releases/v2.19.0/features/common-utils/common-utils-bugfixes.md
+++ b/docs/releases/v2.19.0/features/common-utils/common-utils-bugfixes.md
@@ -1,0 +1,52 @@
+---
+tags:
+  - common-utils
+---
+# Common Utils Bug Fixes
+
+## Summary
+
+Bug fixes and maintenance updates for the Common Utils library in v2.19.0, including fixes for bucket selector aggregation writeable name, monitor model enhancements for fanout control, and release notes.
+
+## Details
+
+### What's New in v2.19.0
+
+#### Bucket Selector Aggregation Fix
+
+Fixed the `getWriteableName()` method in `BucketSelectorIndices` class to return the correct aggregation name instead of the instance name. This fix ensures proper serialization and deserialization of bucket selector aggregations used by the Alerting plugin.
+
+**Key Changes:**
+- Changed `getWriteableName()` to return `BucketSelectorExtAggregationBuilder.NAME.preferredName` instead of `name`
+- Added `StreamInput` constructor for proper deserialization
+- Added comprehensive unit tests for bucket selector aggregation
+
+#### Monitor Model Fanout Control
+
+Added an optional `fanoutEnabled` field to `DocLevelMonitorInput` to control fanout behavior in document-level monitors. This addresses duplicate alert generation when aggregate sigma rules are matched.
+
+**Key Changes:**
+- Added `fanoutEnabled` field (optional, defaults to `true`)
+- When set to `false`, disables fanout approach for chained findings doc level monitors
+- Prevents duplicate alerts in detectors configured with aggregation sigma rules
+
+### Technical Changes
+
+| Component | Change |
+|-----------|--------|
+| `BucketSelectorIndices` | Fixed writeable name, added StreamInput constructor |
+| `DocLevelMonitorInput` | Added `fan_out_enabled` field for fanout control |
+
+## Limitations
+
+- The `fanoutEnabled` field is optional and defaults to `true` for backward compatibility
+- Bucket selector fix requires coordinated updates with the Alerting plugin
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#773](https://github.com/opensearch-project/common-utils/pull/773) | Fix bucket selector aggregation writeable name | - |
+| [#758](https://github.com/opensearch-project/common-utils/pull/758) | Monitor model changed to add optional fanoutEnabled field | - |
+| [#780](https://github.com/opensearch-project/common-utils/pull/780) | Added 2.19.0.0 release notes | [#751](https://github.com/opensearch-project/common-utils/issues/751) |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -2,6 +2,9 @@
 
 ## Features
 
+### common-utils
+- Common Utils Bug Fixes
+
 ### custom-codecs
 - QAT Security Permission Fix
 


### PR DESCRIPTION
## Summary

Investigation of GitHub Issue #2001 - Common Utils bug fixes for v2.19.0.

### Reports Created
- Release report: `docs/releases/v2.19.0/features/common-utils/common-utils-bugfixes.md`
- Feature report: `docs/features/common-utils/common-utils.md` (updated)

### Key Changes in v2.19.0
- Fixed bucket selector aggregation writeable name (PR #773)
- Added fanoutEnabled field to DocLevelMonitorInput for duplicate alert prevention (PR #758)
- Added 2.19.0.0 release notes (PR #780)

### PRs Investigated
- [#773](https://github.com/opensearch-project/common-utils/pull/773) - Fix bucket selector aggregation writeable name
- [#758](https://github.com/opensearch-project/common-utils/pull/758) - Monitor model changed to add optional fanoutEnabled field
- [#780](https://github.com/opensearch-project/common-utils/pull/780) - Added 2.19.0.0 release notes