### PR TITLE
docs: add security-roles report for v2.19.0

### DIFF
--- a/docs/features/security/security-permissions.md
+++ b/docs/features/security/security-permissions.md
@@ -136,12 +136,60 @@ forecast_read_access:
 ## Limitations
 
 - Forecast roles are separate from Anomaly Detection roles (`anomaly_read_access`, `anomaly_full_access`)
+- LTR roles require the Learning to Rank plugin to be installed
 - Cross-cluster forecasting requires `cluster_monitor` permission and proper cluster connectivity
 - Reserved roles cannot be modified through the API; changes require editing `roles.yml` directly
+
+### Learning to Rank (LTR) Roles Configuration
+
+#### ltr_read_access
+
+Provides read-only access to LTR resources:
+
+```yaml
+ltr_read_access:
+  reserved: true
+  cluster_permissions:
+    - cluster:admin/ltr/caches/stats
+    - cluster:admin/ltr/featurestore/list
+    - cluster:admin/ltr/stats
+```
+
+#### ltr_full_access
+
+Provides full access to all LTR functionality:
+
+```yaml
+ltr_full_access:
+  reserved: true
+  cluster_permissions:
+    - cluster:admin/ltr/*
+```
+
+### Anomaly Detection Role Enhancements
+
+The `anomaly_full_access` role includes permissions for ingest pipeline management:
+
+```yaml
+anomaly_full_access:
+  reserved: true
+  cluster_permissions:
+    - cluster:admin/ingest/pipeline/delete
+    - cluster:admin/ingest/pipeline/put
+    - cluster_monitor
+    - cluster:admin/opendistro/ad/*
+  index_permissions:
+    - index_patterns:
+        - '*'
+      allowed_actions:
+        - indices:admin/setting/put
+        # ... other permissions
+```
 
 ## Change History
 
 - **v3.1.0** (2025-06): Added `forecast_read_access` and `forecast_full_access` roles with complete permissions for forecasting feature including `cluster_monitor` and `indices:admin/mappings/get`
+- **v2.19.0** (2025-01): Added `ltr_read_access` and `ltr_full_access` roles for Learning to Rank; Enhanced `anomaly_full_access` with ingest pipeline permissions
 
 
 ## References
@@ -157,3 +205,5 @@ forecast_read_access:
 | v3.1.0 | [#5386](https://github.com/opensearch-project/security/pull/5386) | Add forecast roles and permissions |   |
 | v3.1.0 | [#5405](https://github.com/opensearch-project/security/pull/5405) | Add missing cluster:monitor permission |   |
 | v3.1.0 | [#5412](https://github.com/opensearch-project/security/pull/5412) | Add missing mapping get permission |   |
+| v2.19.0 | [#5069](https://github.com/opensearch-project/security/pull/5069) | Add ingest pipeline and indices permissions for anomaly_full_access |   |
+| v2.19.0 | [#5070](https://github.com/opensearch-project/security/pull/5070) | Add LTR read and full access roles |   |

--- a/docs/releases/v2.19.0/features/security/security-roles.md
+++ b/docs/releases/v2.19.0/features/security/security-roles.md
@@ -1,0 +1,79 @@
+---
+tags:
+  - security
+---
+# Security Roles
+
+## Summary
+
+OpenSearch v2.19.0 adds new predefined security roles for Learning to Rank (LTR) and enhances the Anomaly Detection role with additional permissions for ingest pipelines and index settings.
+
+## Details
+
+### What's New in v2.19.0
+
+#### Learning to Rank (LTR) Roles
+
+Two new predefined roles for the Learning to Rank plugin:
+
+| Role | Description | Permissions |
+|------|-------------|-------------|
+| `ltr_read_access` | Read-only access to LTR resources | Cache stats, feature store list, LTR stats |
+| `ltr_full_access` | Full access to all LTR operations | All LTR cluster admin actions |
+
+**ltr_read_access configuration:**
+```yaml
+ltr_read_access:
+  reserved: true
+  cluster_permissions:
+    - cluster:admin/ltr/caches/stats
+    - cluster:admin/ltr/featurestore/list
+    - cluster:admin/ltr/stats
+```
+
+**ltr_full_access configuration:**
+```yaml
+ltr_full_access:
+  reserved: true
+  cluster_permissions:
+    - cluster:admin/ltr/*
+```
+
+#### Anomaly Detection Role Enhancements
+
+The `anomaly_full_access` role now includes additional permissions for ingest pipeline management and index settings:
+
+| Permission | Type | Purpose |
+|------------|------|---------|
+| `cluster:admin/ingest/pipeline/delete` | Cluster | Delete ingest pipelines |
+| `cluster:admin/ingest/pipeline/put` | Cluster | Create/update ingest pipelines |
+| `indices:admin/setting/put` | Index | Update index settings |
+
+These permissions enable anomaly detection workflows that require creating ingest pipelines for data preprocessing.
+
+### Technical Changes
+
+The changes are implemented in `config/roles.yml`:
+
+1. **LTR roles** - Added at the end of the roles configuration file
+2. **Anomaly detection enhancements** - Added to existing `anomaly_full_access` role
+
+## Limitations
+
+- LTR roles require the Learning to Rank plugin to be installed
+- The new anomaly detection permissions apply only to `anomaly_full_access`, not `anomaly_read_access`
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#5069](https://github.com/opensearch-project/security/pull/5069) | Add ingest pipeline and indices permissions for anomaly_full_access | Backport of #5065 |
+| [#5070](https://github.com/opensearch-project/security/pull/5070) | Add LTR read and full access roles | Backport of #5067 |
+
+### Documentation
+
+- [Predefined Roles](https://docs.opensearch.org/2.19/security/access-control/users-roles/#predefined-roles)
+- [Learning to Rank](https://docs.opensearch.org/2.19/search-plugins/ltr/index/)
+- [Anomaly Detection Security](https://docs.opensearch.org/2.19/observing-your-data/ad/security/)

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -86,6 +86,7 @@
 - JWT Authentication Bug Fixes
 - Security Audit Logging
 - Security Netty
+- Security Roles
 
 ### security-analytics
 - Security Analytics Bug Fixes


### PR DESCRIPTION
## Summary

Adds documentation for Security Roles enhancements in OpenSearch v2.19.0.

### Changes
- **Release Report**: `docs/releases/v2.19.0/features/security/security-roles.md`
- **Feature Report Update**: `docs/features/security/security-permissions.md`
- **Release Index Update**: `docs/releases/v2.19.0/index.md`

### Key Changes in v2.19.0

1. **New LTR Roles**:
   - `ltr_read_access`: Read-only access to Learning to Rank resources
   - `ltr_full_access`: Full access to all LTR operations

2. **Anomaly Detection Enhancements**:
   - Added ingest pipeline permissions (`cluster:admin/ingest/pipeline/delete`, `cluster:admin/ingest/pipeline/put`)
   - Added index settings permission (`indices:admin/setting/put`)

### Related PRs
- [security#5069](https://github.com/opensearch-project/security/pull/5069): Add ingest pipeline permissions for anomaly_full_access
- [security#5070](https://github.com/opensearch-project/security/pull/5070): Add LTR read and full access roles

Closes #1992