### PR TITLE
docs: add security-certificates report for v2.19.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -17,4 +17,5 @@ Cumulative feature documentation across all versions.
 
 ## security
 
+- Security Certificate Management
 - Security Identity Plugin

--- a/docs/features/security/security-certificate-management.md
+++ b/docs/features/security/security-certificate-management.md
@@ -1,0 +1,143 @@
+---
+tags:
+  - security
+---
+# Security Certificate Management
+
+## Summary
+
+The OpenSearch Security plugin provides comprehensive SSL/TLS certificate management capabilities for securing both transport layer (node-to-node) and REST layer (client-to-node) communication. This includes support for PEM certificates, PKCS#8 keys, JKS/PKCS12 keystores, certificate hot reloading, and configurable validation options.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph "Certificate Sources"
+        PEM[PEM Files]
+        KS[Keystore/Truststore]
+    end
+    
+    subgraph "SSL Configuration"
+        HTTP[HTTP Layer SSL]
+        Transport[Transport Layer SSL]
+    end
+    
+    subgraph "Certificate Management"
+        HotReload[Hot Reload]
+        API[Reload API]
+        Validation[Certificate Validation]
+    end
+    
+    PEM --> HTTP
+    PEM --> Transport
+    KS --> HTTP
+    KS --> Transport
+    
+    HTTP --> HotReload
+    Transport --> HotReload
+    HTTP --> API
+    Transport --> API
+    
+    HotReload --> Validation
+    API --> Validation
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Transport Layer TLS | Secures node-to-node communication within the cluster |
+| REST Layer TLS | Secures client-to-node communication via HTTPS |
+| Certificate Hot Reload | Automatic certificate refresh without cluster restart |
+| Reload Certificates API | Manual certificate reload via REST endpoint |
+| DN Verification | Validates certificate Distinguished Names during reload |
+| CA Validation | Validates authority certificates before SSL context reload |
+
+### Configuration
+
+#### PEM Certificate Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.ssl.http.enabled` | Enable TLS on REST layer | `false` |
+| `plugins.security.ssl.http.pemcert_filepath` | Path to node certificate (PEM) | Required |
+| `plugins.security.ssl.http.pemkey_filepath` | Path to private key (PKCS#8) | Required |
+| `plugins.security.ssl.http.pemtrustedcas_filepath` | Path to root CA (PEM) | Required |
+| `plugins.security.ssl.transport.pemcert_filepath` | Path to transport certificate | Required |
+| `plugins.security.ssl.transport.pemkey_filepath` | Path to transport private key | Required |
+| `plugins.security.ssl.transport.pemtrustedcas_filepath` | Path to transport root CA | Required |
+
+#### Hot Reload Settings
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.ssl.certificates_hot_reload.enabled` | Enable automatic certificate hot reload | `false` |
+| `plugins.security.ssl_cert_reload_enabled` | Enable Reload Certificates API | `false` |
+| `plugins.security.ssl.http.enforce_cert_reload_dn_verification` | Enforce DN verification for HTTP reload | `true` |
+| `plugins.security.ssl.transport.enforce_cert_reload_dn_verification` | Enforce DN verification for transport reload | `true` |
+
+### Usage Example
+
+```yaml
+# opensearch.yml - Certificate configuration with hot reload
+
+# REST layer TLS
+plugins.security.ssl.http.enabled: true
+plugins.security.ssl.http.pemcert_filepath: node.pem
+plugins.security.ssl.http.pemkey_filepath: node-key.pem
+plugins.security.ssl.http.pemtrustedcas_filepath: root-ca.pem
+
+# Transport layer TLS
+plugins.security.ssl.transport.pemcert_filepath: node.pem
+plugins.security.ssl.transport.pemkey_filepath: node-key.pem
+plugins.security.ssl.transport.pemtrustedcas_filepath: root-ca.pem
+
+# Enable automatic hot reload
+plugins.security.ssl.certificates_hot_reload.enabled: true
+
+# Or enable manual reload API
+plugins.security.ssl_cert_reload_enabled: true
+
+# Optional: Disable DN verification for Let's Encrypt rotation
+plugins.security.ssl.http.enforce_cert_reload_dn_verification: false
+plugins.security.ssl.transport.enforce_cert_reload_dn_verification: false
+```
+
+### Reload Certificates API
+
+```bash
+# Reload HTTP layer certificates
+curl --cacert ca.pem --cert admin.pem --key admin.key \
+  -XPUT https://localhost:9200/_plugins/_security/api/ssl/http/reloadcerts
+
+# Reload transport layer certificates
+curl --cacert ca.pem --cert admin.pem --key admin.key \
+  -XPUT https://localhost:9200/_plugins/_security/api/ssl/transport/reloadcerts
+```
+
+## Limitations
+
+- Hot reload monitoring interval is fixed at 5 seconds
+- Certificates must be stored in the OpenSearch config directory
+- Only superadmin users can use the Reload Certificates API
+- When DN verification is disabled, additional security controls should be in place
+
+## Change History
+
+- **v2.19.0** (2025-02-18): Added file system hot reload, configurable DN verification, CA validation, JDK PKCS fixes
+
+## References
+
+### Documentation
+- [Configuring TLS Certificates](https://docs.opensearch.org/latest/security/configuration/tls/): Official TLS configuration guide
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.19.0 | [#4880](https://github.com/opensearch-project/security/pull/4880) | Add support for certificates hot reload |
+| v2.19.0 | [#4752](https://github.com/opensearch-project/security/pull/4752) | Allow skipping hot reload DN validation |
+| v2.19.0 | [#4835](https://github.com/opensearch-project/security/pull/4835) | Add validation of authority certificates |
+| v2.19.0 | [#5000](https://github.com/opensearch-project/security/pull/5000) | Set default value for key/trust store type for JDK PKCS |
+| v2.19.0 | [#4999](https://github.com/opensearch-project/security/pull/4999) | Fix SSL config for JDK PKCS setup |

--- a/docs/releases/v2.19.0/features/security/security-certificates.md
+++ b/docs/releases/v2.19.0/features/security/security-certificates.md
@@ -1,0 +1,93 @@
+---
+tags:
+  - security
+---
+# Security Certificates
+
+## Summary
+
+OpenSearch v2.19.0 introduces significant enhancements to SSL/TLS certificate management in the Security plugin. The key improvements include automatic hot reloading of certificates from the file system, validation of authority certificates before SSL context reload, configurable DN verification during certificate hot reload, and bug fixes for JDK PKCS keystore/truststore configurations.
+
+## Details
+
+### What's New in v2.19.0
+
+#### Certificate Hot Reload from File System
+
+A new feature enables automatic hot reloading of TLS certificates by monitoring the file system. When enabled, OpenSearch monitors keystore resources every 5 seconds and automatically reloads certificates when changes are detected.
+
+```yaml
+# Enable automatic certificate hot reload
+plugins.security.ssl.certificates_hot_reload.enabled: true
+```
+
+This addresses a limitation where the existing `PUT /_plugins/_security/api/ssl/{type}/reloadcerts` endpoint only reloaded certificates on the coordinator node, not across the entire cluster.
+
+#### Configurable DN Verification for Hot Reload
+
+Two new settings allow skipping Distinguished Name (DN) validation during certificate hot reload:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.security.ssl.http.enforce_cert_reload_dn_verification` | Enforce DN verification for HTTP layer certificate reload | `true` |
+| `plugins.security.ssl.transport.enforce_cert_reload_dn_verification` | Enforce DN verification for transport layer certificate reload | `true` |
+
+When set to `false`, the DN validation (IssuerDN, SubjectDN, and SAN) is skipped during hot reload. This is useful for scenarios like Let's Encrypt certificate rotation where intermediate CAs may change.
+
+```yaml
+# Disable DN verification for certificate hot reload
+plugins.security.ssl.http.enforce_cert_reload_dn_verification: false
+plugins.security.ssl.transport.enforce_cert_reload_dn_verification: false
+```
+
+#### Authority Certificate Validation
+
+Added validation of authority certificates prior to reloading the SSL context. This ensures that invalid or corrupted CA certificates are detected before they can cause SSL/TLS failures.
+
+### Technical Changes
+
+#### JDK PKCS Keystore/Truststore Fixes
+
+- Set default value for key/trust store type as a constant for JDK PKCS setup
+- Fixed SSL configuration issues for JDK PKCS setup that could cause initialization failures
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph "Certificate Hot Reload"
+        FS[File System Monitor] -->|"every 5s"| Check{Certificate Changed?}
+        Check -->|Yes| Validate[Validate Certificates]
+        Check -->|No| FS
+        Validate --> CA[Validate CA Certificates]
+        CA --> DN{DN Verification Enabled?}
+        DN -->|Yes| VerifyDN[Verify DN Match]
+        DN -->|No| Reload
+        VerifyDN --> Reload[Reload SSL Context]
+        Reload --> FS
+    end
+    
+    subgraph "Manual Reload API"
+        API[PUT /_plugins/_security/api/ssl/.../reloadcerts] --> Validate
+    end
+```
+
+## Limitations
+
+- Hot reload monitoring interval is fixed at 5 seconds
+- When DN verification is disabled, ensure proper security controls are in place as certificates from different CAs can be loaded
+- The file system hot reload feature requires certificates to be stored in the OpenSearch config directory
+
+## References
+
+### Documentation
+- [Configuring TLS Certificates](https://docs.opensearch.org/2.19/security/configuration/tls/): Official TLS configuration guide including hot reload settings
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#4880](https://github.com/opensearch-project/security/pull/4880) | Add support for certificates hot reload | [#4427](https://github.com/opensearch-project/security/issues/4427) |
+| [#4839](https://github.com/opensearch-project/security/pull/4839) | Allow skipping hot reload DN validation (backport) | [#4509](https://github.com/opensearch-project/security/issues/4509) |
+| [#4862](https://github.com/opensearch-project/security/pull/4862) | Add validation of authority certificates (backport) | - |
+| [#5003](https://github.com/opensearch-project/security/pull/5003) | Set default value for key/trust store type for JDK PKCS (backport) | - |
+| [#5033](https://github.com/opensearch-project/security/pull/5033) | Fix SSL config for JDK PKCS setup (backport) | - |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -85,6 +85,7 @@
 - CVE Fixes
 - JWT Authentication Bug Fixes
 - Security Audit Logging
+- Security Certificates
 - Security Identity Plugin
 - Security Netty
 - Security Privilege Evaluation


### PR DESCRIPTION
## Summary

Adds documentation for Security Certificates enhancements in OpenSearch v2.19.0.

### Key Changes in v2.19.0
- **Certificate Hot Reload**: Automatic hot reloading of TLS certificates from file system (monitors every 5 seconds)
- **Configurable DN Verification**: New settings to skip DN validation during certificate hot reload
- **CA Validation**: Added validation of authority certificates before SSL context reload
- **JDK PKCS Fixes**: Bug fixes for JDK PKCS keystore/truststore configurations

### Reports Created
- Release report: `docs/releases/v2.19.0/features/security/security-certificates.md`
- Feature report: `docs/features/security/security-certificate-management.md`

### PRs Investigated
- #4880 - Add support for certificates hot reload
- #4839 - Allow skipping hot reload DN validation
- #4862 - Add validation of authority certificates
- #5003 - Set default value for key/trust store type for JDK PKCS
- #5033 - Fix SSL config for JDK PKCS setup

Closes #1989