### PR TITLE
docs: add index-management report for v2.19.0

### DIFF
--- a/docs/features/index-management-dashboards/index-management-dashboards.md
+++ b/docs/features/index-management-dashboards/index-management-dashboards.md
@@ -116,6 +116,7 @@ graph TB
 
 ## Change History
 
+- **v2.19.0** (2025-02-18): Performance improvement using Cat Snapshot API for repository page, bug fixes for snapshot restore alias handling, snapshot policy schedule editing, and index expression display
 - **v2.17.0** (2024-09-17): Comprehensive UI/UX improvements implementing "Look and Feel" and "Fit and Finish" design guidelines across all pages, navigation redesign, notification modal, MDS support for Shrink page, history navigation bug fixes
 
 
@@ -130,6 +131,10 @@ graph TB
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v2.19.0 | [#1242](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1242) | Use Cat Snapshot API for repository snapshot count | Performance |
+| v2.19.0 | [#1193](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1193) | Fix snapshot restore alias handling | Bug fix |
+| v2.19.0 | [#1213](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1213) | Fix snapshot restore default alias value | Bug fix |
+| v2.19.0 | [#1207](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1207) | Fix snapshot policy schedule editing and index expression display | [#947](https://github.com/opensearch-project/index-management-dashboards-plugin/issues/947) |
 | v2.17.0 | [#1106](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1106) | Navigation redesign |   |
 | v2.17.0 | [#1123](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1123) | ISM pages look and feel |   |
 | v2.17.0 | [#1132](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1132) | Snapshots, datastreams, rollups styling |   |

--- a/docs/releases/v2.19.0/features/index-management-dashboards/index-management.md
+++ b/docs/releases/v2.19.0/features/index-management-dashboards/index-management.md
@@ -1,0 +1,68 @@
+---
+tags:
+  - index-management-dashboards
+---
+# Index Management
+
+## Summary
+
+OpenSearch v2.19.0 includes bug fixes and performance improvements for the Index Management Dashboards plugin, focusing on snapshot management functionality. Key changes include using the Cat Snapshot API for improved repository page performance and fixes for snapshot restore and policy editing issues.
+
+## Details
+
+### What's New in v2.19.0
+
+#### Performance Improvements
+
+**Cat Snapshot API for Repository Page**
+- Replaced Get Snapshot API with Cat Snapshot API for retrieving snapshot counts
+- Cat Snapshot API uses minimal information from backend storage calls
+- Significantly reduces load time when loading repository information with many snapshots
+
+#### Bug Fixes
+
+**Snapshot Restore Alias Handling**
+- Fixed issue where snapshot restore always restored index aliases regardless of user selection
+- The "Restore aliases" checkbox now correctly controls whether aliases are restored
+- Default value for `include_aliases` parameter set to `true` per API documentation
+
+**Snapshot Policy Schedule Editing**
+- Fixed issue where users could not modify snapshot schedule time during policy editing
+- Schedule times can now be successfully updated and saved
+
+**Index Expression Display**
+- Fixed problem where index expressions displayed as `[Object][Object]` instead of actual values
+- Snapshot details page now properly shows index expressions as strings
+- Snapshots now correctly include the specified indices
+
+#### Maintenance
+
+**Integration Test Improvements**
+- Updated integration tests to use `adminClient` when searching system indexes
+- Addresses test failures when running with Security plugin enabled
+- Aligns with security changes in v2.18.0 that protect system indices
+
+**Build Fixes**
+- Fixed 2.x build issues related to update settings requests on read-only indices
+- Addresses compatibility with OpenSearch core bug fix in PR #16568
+
+**Dependency Updates**
+- Updated Cypress version
+- Fixed CVE-2024-21538 security vulnerability
+
+## Limitations
+
+- Cat Snapshot API performance improvement is most noticeable with repositories containing many snapshots
+- Snapshot restore alias behavior change may affect existing automation scripts that relied on previous behavior
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#1242](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1242) | Use Cat Snapshot API for repository snapshot count | Performance |
+| [#1193](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1193) | Fix snapshot restore alias handling | Bug fix |
+| [#1213](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1213) | Fix snapshot restore default alias value | Bug fix |
+| [#1207](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1207) | Fix snapshot policy schedule editing and index expression display | [#947](https://github.com/opensearch-project/index-management-dashboards-plugin/issues/947) |
+| [#1286](https://github.com/opensearch-project/index-management/pull/1286) | Use adminClient for system index searches in tests | [#1269](https://github.com/opensearch-project/index-management/issues/1269) |
+| [#1315](https://github.com/opensearch-project/index-management/pull/1315) | Fix 2.x build for read-only index settings | [#1304](https://github.com/opensearch-project/index-management/issues/1304), [#1305](https://github.com/opensearch-project/index-management/issues/1305) |

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -106,6 +106,9 @@
 ### dashboards-reporting
 - Reporting Bug Fixes
 
+### index-management-dashboards
+- Index Management
+
 ### skills
 - CVE Fixes
 - CI Fixes


### PR DESCRIPTION
## Summary

Add documentation for Index Management Dashboards plugin changes in OpenSearch v2.19.0.

### Reports Created
- Release report: `docs/releases/v2.19.0/features/index-management-dashboards/index-management.md`
- Feature report: `docs/features/index-management-dashboards/index-management-dashboards.md` (updated)

### Key Changes in v2.19.0
- Performance improvement using Cat Snapshot API for repository page loading
- Bug fix for snapshot restore alias handling
- Bug fix for snapshot policy schedule editing
- Bug fix for index expression display in snapshot details
- Integration test improvements for Security plugin compatibility
- Build fixes for read-only index settings
- CVE-2024-21538 security fix

### Resources Used
- Issue: #1988
- PRs: #1242, #1193, #1213, #1207, #1286, #1315 (index-management-dashboards-plugin and index-management)