### PR TITLE
docs: add k-NN Vector Search report for v2.19.0

### DIFF
--- a/docs/features/k-nn/k-nn-vector-search-k-nn.md
+++ b/docs/features/k-nn/k-nn-vector-search-k-nn.md
@@ -222,9 +222,12 @@ PUT /_cluster/settings
 - Graph indexes consume significant memory
 - Remote Index Build is experimental (v3.0.0)
 - Maximum vector dimension depends on engine and available memory
+- NMSLIB engine is deprecated as of v2.19.0; migrate to FAISS or Lucene
+- Derived source feature is experimental (v2.19.0)
 
 ## Change History
 
+- **v2.19.0** (2025-02-18): Cosine similarity support for FAISS engine; AVX-512 SPR build mode for Intel Sapphire Rapids; binary vector support for Lucene engine; derived source for vector fields (experimental); multi-value innerHit for nested k-NN fields; concurrent graph creation for Lucene engine; expand_nested_docs parameter for NMSLIB; NMSLIB engine deprecation; numerous bug fixes including C++17 upgrade, byte vector filter fix, mapping validation, query vector memory release, filter rewrite logic fix
 - **v3.4.0** (2026-01-11): Bug fixes for memory optimized search on old indices (NPE), totalHits inconsistency, race condition in KNNQueryBuilder with cosine similarity, Faiss inner product score-to-distance calculation, disk-based vector search BWC for segment merge
 - **v3.3.0** (2026-01-11): Bug fixes for MDC check NPE with byte vectors, derived source deserialization on invalid documents, cosine score range in LuceneOnFaiss, filter k nullable, integer overflow in distance computation, AVX2 detection on non-Linux/Mac/Windows platforms, radial search for byte vectors with FAISS, MMR doc ID issue, JNI local reference leak, nested exact search rescoring
 - **v3.2.0** (2025-10-01): GPU indexing support for FP16, Byte, and Binary vectors via Cagra2; Asymmetric Distance Computation (ADC) for improved recall on binary quantized indices; random rotation feature for binary encoder; gRPC support for k-NN queries; nested search support for IndexBinaryHNSWCagra; dynamic index thread quantity defaults (4 threads for 32+ core machines); NativeMemoryCacheKeyHelper @ collision fix
@@ -289,6 +292,14 @@ PUT /_cluster/settings
 | v3.1.0 | [#2739](https://github.com/opensearch-project/k-NN/pull/2739) | Fix: LuceneOnFaiss to use sliced IndexInput |   |
 | v3.1.0 | [#2641](https://github.com/opensearch-project/k-NN/pull/2641) | Fix: Nested vector query with efficient filter |   |
 | v3.0.0 | [#2564](https://github.com/opensearch-project/k-NN/pull/2564) | Breaking changes - remove deprecated settings |   |
+| v2.19.0 | [#2376](https://github.com/opensearch-project/k-NN/pull/2376) | Add cosine similarity support for faiss engine | [#2242](https://github.com/opensearch-project/k-NN/issues/2242) |
+| v2.19.0 | [#2404](https://github.com/opensearch-project/k-NN/pull/2404) | Add FAISS_OPT_LEVEL=avx512_spr build mode |   |
+| v2.19.0 | [#2283](https://github.com/opensearch-project/k-NN/pull/2283) | Add multi-value innerHit support for nested k-NN fields | [#2249](https://github.com/opensearch-project/k-NN/issues/2249) |
+| v2.19.0 | [#2292](https://github.com/opensearch-project/k-NN/pull/2292) | Add binary index support for Lucene engine | [#1857](https://github.com/opensearch-project/k-NN/issues/1857) |
+| v2.19.0 | [#2449](https://github.com/opensearch-project/k-NN/pull/2449) | Introduce derived vector source via stored fields | [#2377](https://github.com/opensearch-project/k-NN/issues/2377) |
+| v2.19.0 | [#2331](https://github.com/opensearch-project/k-NN/pull/2331) | Add expand_nested_docs parameter support to NMSLIB engine |   |
+| v2.19.0 | [#2480](https://github.com/opensearch-project/k-NN/pull/2480) | Enable concurrent graph creation for Lucene engine | [#1581](https://github.com/opensearch-project/k-NN/issues/1581) |
+| v2.19.0 | [#2427](https://github.com/opensearch-project/k-NN/pull/2427) | Deprecate nmslib engine |   |
 | v2.18.0 | [#2195](https://github.com/opensearch-project/k-NN/pull/2195) | Fix lucene codec after lucene version bumped to 9.12 | [#2193](https://github.com/opensearch-project/k-NN/issues/2193) |
 | v2.18.0 | [#2133](https://github.com/opensearch-project/k-NN/pull/2133) | Optimize KNNVectorValues creation for non-quantization cases | [#2134](https://github.com/opensearch-project/k-NN/issues/2134) |
 | v2.18.0 | [#2127](https://github.com/opensearch-project/k-NN/pull/2127) | Remove benchmarks folder from k-NN repo | [#1954](https://github.com/opensearch-project/k-NN/issues/1954) |
@@ -324,3 +335,8 @@ PUT /_cluster/settings
 - [Issue #2796](https://github.com/opensearch-project/k-NN/issues/2796): GPU indexing RFC
 - [Issue #2714](https://github.com/opensearch-project/k-NN/issues/2714): ADC and Random Rotation RFC
 - [Issue #2816](https://github.com/opensearch-project/k-NN/issues/2816): gRPC k-NN support
+- [Issue #2242](https://github.com/opensearch-project/k-NN/issues/2242): Cosine similarity for FAISS engine
+- [Issue #2249](https://github.com/opensearch-project/k-NN/issues/2249): Multi-value innerHit for nested k-NN fields
+- [Issue #1857](https://github.com/opensearch-project/k-NN/issues/1857): Binary index support for Lucene engine
+- [Issue #2377](https://github.com/opensearch-project/k-NN/issues/2377): Derived vector source design
+- [Issue #1581](https://github.com/opensearch-project/k-NN/issues/1581): Concurrent graph creation for Lucene

--- a/docs/releases/v2.19.0/features/k-nn/k-nn-vector-search.md
+++ b/docs/releases/v2.19.0/features/k-nn/k-nn-vector-search.md
@@ -1,0 +1,164 @@
+---
+tags:
+  - k-nn
+---
+# k-NN Vector Search
+
+## Summary
+
+OpenSearch v2.19.0 brings significant enhancements to the k-NN plugin including cosine similarity support for FAISS engine, AVX-512 SPR optimizations for Intel Sapphire Rapids processors, binary vector support for Lucene engine, derived source for vector fields, multi-value innerHit support for nested k-NN fields, concurrent graph creation for Lucene, and NMSLIB engine deprecation. The release also includes numerous bug fixes and performance improvements.
+
+## Details
+
+### What's New in v2.19.0
+
+#### Cosine Similarity for FAISS Engine
+FAISS engine now natively supports cosine similarity by normalizing vectors before ingestion and using inner product for search. This eliminates the need for manual vector normalization while maintaining competitive search and force merge performance.
+
+```json
+PUT /my-index
+{
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 128,
+        "method": {
+          "name": "hnsw",
+          "space_type": "cosinesimil",
+          "engine": "faiss"
+        }
+      }
+    }
+  }
+}
+```
+
+#### AVX-512 SPR Build Mode
+New `FAISS_OPT_LEVEL=avx512_spr` build mode enables advanced AVX-512 instructions available on Intel Sapphire Rapids and newer processors, including `avx512_fp16`, `avx512_bf16`, and `avx512_vpopcntdq`. This accelerates Hamming distance evaluation for binary vectors.
+
+#### Binary Vector Support for Lucene Engine
+Lucene engine now supports binary vectors, providing an alternative to FAISS for binary vector workloads without native library dependencies.
+
+```json
+PUT /binary-index
+{
+  "mappings": {
+    "properties": {
+      "binary_vector": {
+        "type": "knn_vector",
+        "dimension": 64,
+        "data_type": "binary",
+        "method": {
+          "name": "hnsw",
+          "engine": "lucene"
+        }
+      }
+    }
+  }
+}
+```
+
+#### Derived Source for Vector Fields (Experimental)
+Vectors can now be excluded from `_source` field on disk and reconstructed on read, reducing storage overhead. This feature uses a custom StoredFieldsFormat that removes vectors during write and injects them back during read.
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index.knn.derived_source.enabled": true
+  }
+}
+```
+
+#### Multi-Value innerHit for Nested k-NN Fields
+Support for returning all nested fields with their scores inside innerHit for nested k-NN fields, applicable to both Lucene and FAISS engines.
+
+#### Concurrent Graph Creation for Lucene
+Lucene engine now supports concurrent graph creation using the `index_thread_qty` setting, improving indexing performance on multi-core systems.
+
+#### NMSLIB Engine Deprecation
+The NMSLIB engine is now deprecated. Users should migrate to FAISS or Lucene engines for new indices.
+
+### Technical Changes
+
+| Change | Description | PR |
+|--------|-------------|-----|
+| Cosine similarity for FAISS | Normalize vectors before ingestion, use inner product for search | [#2376](https://github.com/opensearch-project/k-NN/pull/2376) |
+| AVX-512 SPR support | New build mode for Intel Sapphire Rapids processors | [#2404](https://github.com/opensearch-project/k-NN/pull/2404) |
+| Binary vectors for Lucene | Binary vector support in Lucene engine | [#2292](https://github.com/opensearch-project/k-NN/pull/2292) |
+| Derived source | Remove vectors from _source, reconstruct on read | [#2449](https://github.com/opensearch-project/k-NN/pull/2449) |
+| Multi-value innerHit | Return all nested fields with scores | [#2283](https://github.com/opensearch-project/k-NN/pull/2283) |
+| expand_nested_docs for NMSLIB | Support expand_nested_docs parameter | [#2331](https://github.com/opensearch-project/k-NN/pull/2331) |
+| Concurrent Lucene graph creation | Enable concurrent graph creation with index_thread_qty | [#2480](https://github.com/opensearch-project/k-NN/pull/2480) |
+| NMSLIB deprecation | Deprecate NMSLIB engine | [#2427](https://github.com/opensearch-project/k-NN/pull/2427) |
+
+### Enhancements
+
+| Enhancement | Description | PR |
+|-------------|-------------|-----|
+| expand_nested query parameter | New knn query parameter for nested documents | [#1013](https://github.com/opensearch-project/k-NN/pull/1013) |
+| Writing layer for native engines | Introduced writing layer relying on FieldWriter | [#2241](https://github.com/opensearch-project/k-NN/pull/2241) |
+| Method parameter override | Allow method parameter override for training-based indices | [#2290](https://github.com/opensearch-project/k-NN/pull/2290) |
+| Lucene query optimization | Prevent unnecessary rewrites in Lucene query execution | [#2305](https://github.com/opensearch-project/k-NN/pull/2305) |
+| Detailed training error messages | More detailed error messages for KNN model training | [#2378](https://github.com/opensearch-project/k-NN/pull/2378) |
+| ANN search optimization | Direct ANN search when filters match all documents | [#2320](https://github.com/opensearch-project/k-NN/pull/2320) |
+| Cosine similarity formula | Use single formula for cosine similarity calculation | [#2357](https://github.com/opensearch-project/k-NN/pull/2357) |
+| M-series MacOS build | Build works for M-series MacOS without manual changes | [#2397](https://github.com/opensearch-project/k-NN/pull/2397) |
+| Memory optimization | Remove DocsWithFieldSet reference from NativeEngineFieldVectorsWriter | [#2408](https://github.com/opensearch-project/k-NN/pull/2408) |
+| Quantization graph build | Remove skip building graph check for quantization use case | [#2430](https://github.com/opensearch-project/k-NN/pull/2430) |
+| Script scoring optimization | Remove redundant type conversions for binary vectors | [#2351](https://github.com/opensearch-project/k-NN/pull/2351) |
+| Default graph build behavior | Update default to 0 to always build graph | [#2452](https://github.com/opensearch-project/k-NN/pull/2452) |
+
+### Bug Fixes
+
+| Bug Fix | Description | PR |
+|---------|-------------|-----|
+| C++17 upgrade | Updated C++ version in JNI from c++11 to c++17 | [#2259](https://github.com/opensearch-project/k-NN/pull/2259) |
+| Dependency upgrade | Upgrade bytebuddy and objenesis to match OpenSearch | [#2279](https://github.com/opensearch-project/k-NN/pull/2279) |
+| Byte vector filter bug | Fix Faiss byte vector efficient filter bug | [#2448](https://github.com/opensearch-project/k-NN/pull/2448) |
+| Mapping validation | Fix bug where mapping accepts both dimension and model-id | [#2410](https://github.com/opensearch-project/k-NN/pull/2410) |
+| Field name validation | Add version check for full field name validation | [#2477](https://github.com/opensearch-project/k-NN/pull/2477) |
+| Engine version update | Update engine for version 2.19 or above | [#2501](https://github.com/opensearch-project/k-NN/pull/2501) |
+| Missing vector field | Fix bug when segment has no vector field for native engines | [#2282](https://github.com/opensearch-project/k-NN/pull/2282) |
+| Fields parameter search | Fix search failure with fields parameter | [#2314](https://github.com/opensearch-project/k-NN/pull/2314) |
+| NPE on segment merge | Fix NPE while merging segments after vector field deletion | [#2365](https://github.com/opensearch-project/k-NN/pull/2365) |
+| Non-knn index validation | Allow validation for non-knn index only after 2.17.0 | [#2315](https://github.com/opensearch-project/k-NN/pull/2315) |
+| index.knn setting update | Prevent updating index.knn setting after index creation | [#2348](https://github.com/opensearch-project/k-NN/pull/2348) |
+| Query vector memory | Release query vector memory after execution | [#2346](https://github.com/opensearch-project/k-NN/pull/2346) |
+| Shard-level rescoring | Fix shard level rescoring disabled setting flag | [#2352](https://github.com/opensearch-project/k-NN/pull/2352) |
+| Filter rewrite logic | Fix filter rewrite logic causing incorrect results | [#2359](https://github.com/opensearch-project/k-NN/pull/2359) |
+| space_type retrieval | Retrieve space_type from index setting when both sources available | [#2374](https://github.com/opensearch-project/k-NN/pull/2374) |
+| on_disk rescore setting | Fix rescore=false for on_disk knn indices | [#2399](https://github.com/opensearch-project/k-NN/pull/2399) |
+| index.knn modification | Prevent index.knn setting modification after creation | [#2445](https://github.com/opensearch-project/k-NN/pull/2445) |
+| Cluster version settings | Select index settings based on cluster version | [#2236](https://github.com/opensearch-project/k-NN/pull/2236) |
+| Quantization cache maintenance | Added periodic cache maintenance for QuantizationStateCache | [#2308](https://github.com/opensearch-project/k-NN/pull/2308) |
+| ExactSearcher NPE | Added null checks for fieldInfo in ExactSearcher | [#2278](https://github.com/opensearch-project/k-NN/pull/2278) |
+| Lucene BWC tests | Added Lucene backward compatibility tests | [#2313](https://github.com/opensearch-project/k-NN/pull/2313) |
+| jsonpath upgrade | Upgrade jsonpath from 2.8.0 to 2.9.0 | [#2325](https://github.com/opensearch-project/k-NN/pull/2325) |
+| Faiss Hamming acceleration | Bump Faiss commit to accelerate Hamming distance | [#2381](https://github.com/opensearch-project/k-NN/pull/2381) |
+| Spotless mirror repo | Add spotless mirror repo for fixing builds | [#2453](https://github.com/opensearch-project/k-NN/pull/2453) |
+
+## Limitations
+
+- Derived source feature is experimental
+- NMSLIB engine is deprecated; migrate to FAISS or Lucene
+- AVX-512 SPR optimizations require Intel Sapphire Rapids or newer processors
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#2376](https://github.com/opensearch-project/k-NN/pull/2376) | Add cosine similarity support for faiss engine | [#2242](https://github.com/opensearch-project/k-NN/issues/2242) |
+| [#2404](https://github.com/opensearch-project/k-NN/pull/2404) | Add FAISS_OPT_LEVEL=avx512_spr build mode | - |
+| [#2283](https://github.com/opensearch-project/k-NN/pull/2283) | Add multi-value innerHit support for nested k-NN fields | [#2249](https://github.com/opensearch-project/k-NN/issues/2249) |
+| [#2292](https://github.com/opensearch-project/k-NN/pull/2292) | Add binary index support for Lucene engine | [#1857](https://github.com/opensearch-project/k-NN/issues/1857) |
+| [#2449](https://github.com/opensearch-project/k-NN/pull/2449) | Introduce derived vector source via stored fields | [#2377](https://github.com/opensearch-project/k-NN/issues/2377) |
+| [#2331](https://github.com/opensearch-project/k-NN/pull/2331) | Add expand_nested_docs parameter support to NMSLIB engine | - |
+| [#2480](https://github.com/opensearch-project/k-NN/pull/2480) | Enable concurrent graph creation for Lucene engine | [#1581](https://github.com/opensearch-project/k-NN/issues/1581) |
+| [#2427](https://github.com/opensearch-project/k-NN/pull/2427) | Deprecate nmslib engine | - |
+
+### Documentation
+- [k-NN Plugin Documentation](https://docs.opensearch.org/2.19/vector-search/)
+- [k-NN API Reference](https://docs.opensearch.org/2.19/vector-search/api/knn/)

--- a/docs/releases/v2.19.0/index.md
+++ b/docs/releases/v2.19.0/index.md
@@ -124,5 +124,8 @@
 - Security Integration Tests
 - System Index Handling
 
+### k-nn
+- k-NN Vector Search
+
 ### learning
 - Learning to Rank


### PR DESCRIPTION
## Summary

This PR adds the k-NN Vector Search release report for OpenSearch v2.19.0 and updates the cumulative feature report.

### Reports Created
- Release report: `docs/releases/v2.19.0/features/k-nn/k-nn-vector-search.md`
- Feature report: `docs/features/k-nn/k-nn-vector-search-k-nn.md` (updated)

### Key Changes in v2.19.0
- Cosine similarity support for FAISS engine
- AVX-512 SPR build mode for Intel Sapphire Rapids processors
- Binary vector support for Lucene engine
- Derived source for vector fields (experimental)
- Multi-value innerHit for nested k-NN fields
- Concurrent graph creation for Lucene engine
- expand_nested_docs parameter for NMSLIB
- NMSLIB engine deprecation
- Numerous bug fixes and enhancements

### Resources Used
- GitHub Issue: #1986
- PRs: #2376, #2404, #2283, #2292, #2449, #2331, #2480, #2427, and 37 more
- Docs: https://docs.opensearch.org/2.19/vector-search/