### PR TITLE
docs: add CI/CD Improvements report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-ci-cd-documentation.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-ci-cd-documentation.md
@@ -99,6 +99,7 @@ For Cypress testing, an alternative Docker development environment is available:
 ## Change History
 
 - **v3.0.0** (2025-05-06): CI/CD hardening, Discover 2.0 documentation, Docker development environment, pre-commit hooks for developer docs
+- **v2.16.0** (2024-08-06): Skip running tests for CODEOWNERS file changes
 
 
 ## References
@@ -118,3 +119,4 @@ For Cypress testing, an alternative Docker development environment is available:
 | v3.0.0 | [#9467](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9467) | Add Joey Liu as maintainer | [#295](https://github.com/opensearch-project/.github/issues/295) |
 | v3.0.0 | [#9525](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9525) | Getting started with Discover 2.0 |   |
 | v3.0.0 | [#6585](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6585) | Pre-commit hook for developer docs | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
+| v2.16.0 | [#7197](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7197) | Skip running tests for CODEOWNERS changes |   |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/ci-cd-improvements.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/ci-cd-improvements.md
@@ -1,0 +1,54 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# CI/CD Improvements
+
+## Summary
+
+This release improves CI/CD efficiency by skipping test runs when only the CODEOWNERS file is modified. This optimization reduces unnecessary CI resource usage for administrative changes that don't affect code functionality.
+
+## Details
+
+### What's New in v2.16.0
+
+The `build_and_test_workflow.yml` GitHub Actions workflow now includes `CODEOWNERS` in the `paths-ignore` list for both `push` and `pull_request` triggers. This means:
+
+- Pushes that only modify CODEOWNERS will not trigger the full test suite
+- Pull requests that only modify CODEOWNERS will not trigger the full test suite
+
+### Technical Changes
+
+The workflow file was updated to add `CODEOWNERS` to the existing `paths-ignore` patterns:
+
+```yaml
+on:
+  push:
+    branches: ['**']
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.lycheeignore'
+      - 'CODEOWNERS'  # Added in v2.16.0
+      - 'changelogs/fragments/**'
+  pull_request:
+    branches: ['**']
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - '.lycheeignore'
+      - 'CODEOWNERS'  # Added in v2.16.0
+      - 'changelogs/fragments/**'
+```
+
+## Limitations
+
+- This optimization only applies to commits that exclusively modify CODEOWNERS
+- If CODEOWNERS is modified alongside other files, the full test suite will still run
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#7197](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7197) | Skip running tests for updates in CODEOWNERS | N/A |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -1,0 +1,6 @@
+# OpenSearch v2.16.0 Release
+
+## Features
+
+### opensearch-dashboards
+- CI/CD Improvements


### PR DESCRIPTION
## Summary

Adds release report for CI/CD Improvements in OpenSearch Dashboards v2.16.0.

### Changes
- Created release report: `docs/releases/v2.16.0/features/opensearch-dashboards/ci-cd-improvements.md`
- Updated feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-ci-cd-documentation.md`
- Created release index: `docs/releases/v2.16.0/index.md`

### Key Change in v2.16.0
- Skip running tests when only CODEOWNERS file is modified (PR #7197)

Closes #2338