### PR TITLE
docs: add openapi-specification report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/index.md
+++ b/docs/features/opensearch-dashboards/index.md
@@ -1,0 +1,58 @@
+# Opensearch Dashboards
+
+| Document | Description |
+|----------|-------------|
+| [dashboards-health-checks](dashboards-health-checks.md) | Dashboards Health Checks |
+| [opensearch-dashboards-ai-chat](opensearch-dashboards-ai-chat.md) | OpenSearch Dashboards AI Chat |
+| [opensearch-dashboards-async-query](opensearch-dashboards-async-query.md) | Async Query |
+| [opensearch-dashboards-banner-plugin](opensearch-dashboards-banner-plugin.md) | Banner Plugin |
+| [opensearch-dashboards-bar-chart-enhancements](opensearch-dashboards-bar-chart-enhancements.md) | Bar Chart Enhancements |
+| [opensearch-dashboards-content-management](opensearch-dashboards-content-management.md) | Content Management |
+| [opensearch-dashboards-cross-cluster-search](opensearch-dashboards-cross-cluster-search.md) | Cross-Cluster Search in OpenSearch Dashboards |
+| [opensearch-dashboards-dashboards-ai-insights](opensearch-dashboards-dashboards-ai-insights.md) | Dashboards AI Insights |
+| [opensearch-dashboards-dashboards-ci-cd-documentation](opensearch-dashboards-dashboards-ci-cd-documentation.md) | Dashboards CI/CD & Documentation |
+| [opensearch-dashboards-dashboards-ci-tests](opensearch-dashboards-dashboards-ci-tests.md) | Dashboards CI/Tests |
+| [opensearch-dashboards-dashboards-code-quality-testing](opensearch-dashboards-dashboards-code-quality-testing.md) | Dashboards Code Quality & Testing |
+| [opensearch-dashboards-dashboards-console](opensearch-dashboards-dashboards-console.md) | Dashboards Console (Dev Tools) |
+| [opensearch-dashboards-dashboards-csp](opensearch-dashboards-dashboards-csp.md) | Dashboards Content Security Policy (CSP) |
+| [opensearch-dashboards-dashboards-cypress-testing](opensearch-dashboards-dashboards-cypress-testing.md) | Dashboards Cypress Testing |
+| [opensearch-dashboards-dashboards-features](opensearch-dashboards-dashboards-features.md) | Dashboards Features |
+| [opensearch-dashboards-dashboards-frontend-cleanup](opensearch-dashboards-dashboards-frontend-cleanup.md) | Dashboards Frontend Cleanup |
+| [opensearch-dashboards-dashboards-improvements](opensearch-dashboards-dashboards-improvements.md) | Dashboards Improvements |
+| [opensearch-dashboards-dashboards-maintenance](opensearch-dashboards-dashboards-maintenance.md) | Dashboards Maintenance |
+| [opensearch-dashboards-dashboards-ui-updates](opensearch-dashboards-dashboards-ui-updates.md) | Dashboards UI Updates (OUI) |
+| [opensearch-dashboards-data-connections](opensearch-dashboards-data-connections.md) | Data Connections |
+| [opensearch-dashboards-data-importer](opensearch-dashboards-data-importer.md) | Data Importer |
+| [opensearch-dashboards-data-source-permissions](opensearch-dashboards-data-source-permissions.md) | Data Source Permissions |
+| [opensearch-dashboards-data-source-selector](opensearch-dashboards-data-source-selector.md) | Data Source Selector |
+| [opensearch-dashboards-dataset-explorer](opensearch-dashboards-dataset-explorer.md) | Dataset Explorer |
+| [opensearch-dashboards-dataset-management](opensearch-dashboards-dataset-management.md) | Dataset Management |
+| [opensearch-dashboards-dependency-updates](opensearch-dashboards-dependency-updates.md) | Dependency Updates (OpenSearch Dashboards) |
+| [opensearch-dashboards-dev-tools](opensearch-dashboards-dev-tools.md) | Dev Tools |
+| [opensearch-dashboards-discover](opensearch-dashboards-discover.md) | Discover |
+| [opensearch-dashboards-dompurify-sanitization](opensearch-dashboards-dompurify-sanitization.md) | DOMPurify Sanitization |
+| [opensearch-dashboards-dynamic-config](opensearch-dashboards-dynamic-config.md) | Dynamic Config |
+| [opensearch-dashboards-experimental-features](opensearch-dashboards-experimental-features.md) | Experimental Features - User Personal Settings |
+| [opensearch-dashboards-explore-traces](opensearch-dashboards-explore-traces.md) | Explore Traces |
+| [opensearch-dashboards-explore](opensearch-dashboards-explore.md) | Explore Plugin |
+| [opensearch-dashboards-global-search](opensearch-dashboards-global-search.md) | Global Search |
+| [opensearch-dashboards-i18n-localization](opensearch-dashboards-i18n-localization.md) | i18n & Localization |
+| [opensearch-dashboards-input-control-visualization](opensearch-dashboards-input-control-visualization.md) | Input Control Visualization |
+| [opensearch-dashboards-keyboard-shortcuts](opensearch-dashboards-keyboard-shortcuts.md) | Keyboard Shortcuts |
+| [opensearch-dashboards-monaco-editor](opensearch-dashboards-monaco-editor.md) | Monaco Editor |
+| [opensearch-dashboards-navigation](opensearch-dashboards-navigation.md) | Navigation |
+| [opensearch-dashboards-numeric-precision](opensearch-dashboards-numeric-precision.md) | Numeric Precision Setting |
+| [opensearch-dashboards-osd-optimizer-cache](opensearch-dashboards-osd-optimizer-cache.md) | OSD Optimizer Cache |
+| [opensearch-dashboards-openapi-specification](opensearch-dashboards-openapi-specification.md) | OpenAPI Specification |
+| [opensearch-dashboards-oui](opensearch-dashboards-oui.md) | OpenSearch UI (OUI) |
+| [opensearch-dashboards-plugin-compatibility](opensearch-dashboards-plugin-compatibility.md) | Plugin Compatibility |
+| [opensearch-dashboards-query-assistant](opensearch-dashboards-query-assistant.md) | Query Assistant |
+| [opensearch-dashboards-query-editor](opensearch-dashboards-query-editor.md) | Query Editor |
+| [opensearch-dashboards-query-enhancements](opensearch-dashboards-query-enhancements.md) | Query Enhancements |
+| [opensearch-dashboards-sample-data](opensearch-dashboards-sample-data.md) | Sample Data |
+| [opensearch-dashboards-saved-query-ux](opensearch-dashboards-saved-query-ux.md) | Saved Query UX |
+| [opensearch-dashboards-tsvb-visualization](opensearch-dashboards-tsvb-visualization.md) | TSVB Visualization |
+| [opensearch-dashboards-ui-settings](opensearch-dashboards-ui-settings.md) | UI Settings |
+| [opensearch-dashboards-vended-dashboard-progress](opensearch-dashboards-vended-dashboard-progress.md) | Vended Dashboard Progress |
+| [opensearch-dashboards-webpack-and-build-performance](opensearch-dashboards-webpack-and-build-performance.md) | Webpack & Build Performance |
+| [opensearch-dashboards-workspace](opensearch-dashboards-workspace.md) | Workspace |

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-openapi-specification.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-openapi-specification.md
@@ -1,0 +1,118 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# OpenAPI Specification
+
+## Summary
+
+OpenSearch Dashboards provides OpenAPI specifications for its REST APIs, enabling developers to understand, explore, and integrate with Dashboards APIs using standard tooling like Swagger UI and code generators.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenAPI Specifications"
+        YAML[YAML Spec Files]
+    end
+    subgraph "Tooling"
+        Swagger[Swagger UI]
+        CodeGen[Code Generators]
+        Linter[API Linters]
+    end
+    subgraph "Consumers"
+        Dev[Developers]
+        SDK[Client SDKs]
+        Docs[Documentation]
+    end
+    YAML --> Swagger
+    YAML --> CodeGen
+    YAML --> Linter
+    Swagger --> Dev
+    CodeGen --> SDK
+    Swagger --> Docs
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Saved Objects API Spec | OpenAPI specification for saved objects CRUD operations |
+| Index Patterns API Spec | OpenAPI specification for index pattern field retrieval |
+
+### Covered APIs
+
+#### Saved Objects APIs
+
+| Operation | Method | Endpoint |
+|-----------|--------|----------|
+| Get | GET | `/api/saved_objects/{type}/{id}` |
+| Create | POST | `/api/saved_objects/{type}/{id}` |
+| Find | GET | `/api/saved_objects/_find` |
+| Bulk Get | POST | `/api/saved_objects/_bulk_get` |
+| Bulk Create | POST | `/api/saved_objects/_bulk_create` |
+| Bulk Update | PUT | `/api/saved_objects/_bulk_update` |
+| Update | PUT | `/api/saved_objects/{type}/{id}` |
+| Delete | DELETE | `/api/saved_objects/{type}/{id}` |
+| Migrate | POST | `/api/saved_objects/_migrate` |
+| Import | POST | `/api/saved_objects/_import` |
+| Export | POST | `/api/saved_objects/_export` |
+| Resolve Import Errors | POST | `/api/saved_objects/_resolve_import_errors` |
+
+#### Index Patterns APIs
+
+| Operation | Method | Endpoint |
+|-----------|--------|----------|
+| Get Fields | GET | `/api/index_patterns/_fields_for_wildcard` |
+
+### Usage Example
+
+To view the API documentation locally using Swagger UI:
+
+```bash
+# Navigate to the OpenAPI spec directory
+cd docs/openapi/saved_objects
+
+# Start a local server
+npx serve
+
+# Open http://localhost:3000 in your browser
+```
+
+## Limitations
+
+- Only Saved Objects and Index Patterns APIs are currently documented
+- Bundling tool for combining specifications is not yet available
+- Linting and validation tooling is planned but not implemented
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Added OpenAPI specification for index pattern fields API
+- **v2.15.0** (2024-06-04): Initial OpenAPI specifications for Saved Objects APIs (get, create, find, bulk operations, import/export)
+
+## References
+
+### Documentation
+
+- [OpenAPI Specification](https://swagger.io/specification/)
+- [Swagger UI](https://swagger.io/tools/swagger-ui/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#7270](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7270) | Add OpenAPI specification for index pattern fields API |
+| v2.15.0 | [#6799](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6799) | Add OpenAPI specification for GET and CREATE saved object APIs |
+| v2.15.0 | [#6855](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6855) | Add examples for saved object creation |
+| v2.15.0 | [#6856](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6856) | Add OpenAPI doc for saved_object find API |
+| v2.15.0 | [#6859](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6859) | Add OpenAPI specification for bulk create and bulk update APIs |
+| v2.15.0 | [#6860](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6860) | Add OpenAPI specification for bulk_get API |
+| v2.15.0 | [#6864](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6864) | Add OpenAPI specification for update, delete and migrate APIs |
+| v2.15.0 | [#6872](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6872) | Add OpenAPI specification for import and export APIs |
+| v2.15.0 | [#6885](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6885) | Add OpenAPI specifications for resolve import errors API |
+
+### Issues
+
+- [#6719](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6719) - [Proposal] OpenAPI specifications for dashboards APIs

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/openapi-specification.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/openapi-specification.md
@@ -1,0 +1,92 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# OpenAPI Specification
+
+## Summary
+
+OpenSearch Dashboards v2.16.0 adds comprehensive OpenAPI specifications for the Saved Objects APIs and Index Patterns API. These specifications enable developers to understand and interact with Dashboards APIs using standard OpenAPI tooling like Swagger UI.
+
+## Details
+
+### What's New in v2.16.0
+
+This release adds OpenAPI specification files (YAML format) documenting the following APIs:
+
+#### Saved Objects APIs
+
+| API | Method | Endpoint | Description |
+|-----|--------|----------|-------------|
+| Get | GET | `/api/saved_objects/{type}/{id}` | Retrieve a single saved object |
+| Create | POST | `/api/saved_objects/{type}/{id}` | Create a new saved object |
+| Find | GET | `/api/saved_objects/_find` | Search for saved objects |
+| Bulk Get | POST | `/api/saved_objects/_bulk_get` | Retrieve multiple saved objects |
+| Bulk Create | POST | `/api/saved_objects/_bulk_create` | Create multiple saved objects |
+| Bulk Update | PUT | `/api/saved_objects/_bulk_update` | Update multiple saved objects |
+| Update | PUT | `/api/saved_objects/{type}/{id}` | Update a saved object |
+| Delete | DELETE | `/api/saved_objects/{type}/{id}` | Delete a saved object |
+| Migrate | POST | `/api/saved_objects/_migrate` | Migrate saved objects |
+| Import | POST | `/api/saved_objects/_import` | Import saved objects from file |
+| Export | POST | `/api/saved_objects/_export` | Export saved objects to file |
+| Resolve Import Errors | POST | `/api/saved_objects/_resolve_import_errors` | Resolve conflicts from import |
+
+#### Index Patterns API
+
+| API | Method | Endpoint | Description |
+|-----|--------|----------|-------------|
+| Get Fields | GET | `/api/index_patterns/_fields_for_wildcard` | Retrieve fields for index pattern |
+
+### Technical Changes
+
+The OpenAPI specifications are stored in the `docs/openapi/` directory within the OpenSearch Dashboards repository:
+- `docs/openapi/saved_objects/` - Saved Objects API specifications
+- `docs/openapi/index_patterns/` - Index Patterns API specifications
+
+Each specification includes:
+- Request/response schemas with detailed field descriptions
+- Example payloads for common operations (index patterns, visualizations, dashboards)
+- Error response definitions
+- Query parameter documentation
+
+### Usage
+
+To view the API documentation locally:
+
+```bash
+cd docs/openapi/saved_objects
+npx serve
+# Open http://localhost:3000 in browser
+```
+
+The specifications can be used with:
+- Swagger UI for interactive API exploration
+- Code generation tools for client SDKs
+- API testing tools
+- Documentation generators
+
+## Limitations
+
+- Specifications cover Saved Objects and Index Patterns APIs only; other Dashboards APIs are not yet documented
+- Tooling for bundling specifications is not yet available
+- Linting and validation for specifications is planned but not implemented
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#6799](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6799) | Add OpenAPI specification for GET and CREATE saved object APIs | [#6719](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6719) |
+| [#6855](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6855) | Add examples for saved object creation (index pattern, vega, dashboards) | [#6719](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6719) |
+| [#6856](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6856) | Add OpenAPI doc for saved_object find API | [#6719](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6719) |
+| [#6859](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6859) | Add OpenAPI specification for bulk create and bulk update APIs | [#6719](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6719) |
+| [#6860](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6860) | Add OpenAPI specification for bulk_get API | [#6719](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6719) |
+| [#6864](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6864) | Add OpenAPI specification for update, delete and migrate APIs | [#6719](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6719) |
+| [#6872](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6872) | Add OpenAPI specification for import and export APIs | [#6719](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6719) |
+| [#6885](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6885) | Add OpenAPI specifications for resolve import errors API | [#6719](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6719) |
+| [#7270](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7270) | Add OpenAPI specification for index pattern fields API | - |
+
+### Issues
+
+- [#6719](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6719) - [Proposal] OpenAPI specifications for dashboards APIs

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -4,3 +4,4 @@
 
 ### opensearch-dashboards
 - CI/CD Improvements
+- OpenAPI Specification


### PR DESCRIPTION
## Summary

Add documentation for OpenAPI Specification feature in OpenSearch Dashboards v2.16.0.

## Changes

- Created release report: `docs/releases/v2.16.0/features/opensearch-dashboards/openapi-specification.md`
- Created feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-openapi-specification.md`
- Updated release index: `docs/releases/v2.16.0/index.md`
- Updated features index: `docs/features/opensearch-dashboards/index.md`

## Related Issue

Closes #2337