### PR TITLE
docs: add maintainer-updates report for v2.16.0

### DIFF
--- a/docs/releases/v2.16.0/features/opensearch-dashboards/maintainer-updates.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/maintainer-updates.md
@@ -1,0 +1,45 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Maintainer Updates
+
+## Summary
+
+OpenSearch Dashboards v2.16.0 includes several updates to the project's maintainer roster. Six new maintainers were added and one maintainer transitioned to emeritus status, reflecting the project's growing community and evolving leadership.
+
+## Details
+
+### What's New in v2.16.0
+
+The following maintainer changes were made to the OpenSearch Dashboards repository:
+
+| Change Type | Maintainer | GitHub Handle | PR |
+|-------------|------------|---------------|-----|
+| Added | Yuanqi Zhang | @zhyuanqi | [#6788](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6788) |
+| Emeritus | Matt Provost | @BSFishy | [#6790](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6790) |
+| Added | Eric Meng | @mengweieric | [#6798](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6798) |
+| Added | Suchit Sahoo | @LDrago27 | [#6980](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6980) |
+| Added | Viraj Sanghvi | @virajsanghvi | [#7196](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7196) |
+| Added | Sean Li | @sejli | [#7458](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7458) |
+| Added | Joshua Li | @joshuali925 | [#7553](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7553) |
+
+### Files Changed
+
+These PRs updated the following files:
+- `MAINTAINERS.md` - Project maintainer list
+- `.github/CODEOWNERS` - Code ownership assignments
+
+## References
+
+### Pull Requests
+
+| PR | Description |
+|----|-------------|
+| [#6788](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6788) | Add zhyuanqi as maintainer |
+| [#6790](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6790) | Move @BSFishy to emeritus maintainer |
+| [#6798](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6798) | Add mengweieric as maintainer |
+| [#6980](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6980) | Add Suchit as maintainer |
+| [#7196](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7196) | Add Viraj as maintainer |
+| [#7458](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7458) | Add Sean as maintainer |
+| [#7553](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7553) | Add Joshua as maintainer |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -4,4 +4,5 @@
 
 ### opensearch-dashboards
 - CI/CD Improvements
+- Maintainer Updates
 - OpenAPI Specification


### PR DESCRIPTION
## Summary

Documents maintainer roster changes in OpenSearch Dashboards v2.16.0.

### Changes
- 6 new maintainers added: @zhyuanqi, @mengweieric, @LDrago27, @virajsanghvi, @sejli, @joshuali925
- 1 maintainer moved to emeritus: @BSFishy

### Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch-dashboards/maintainer-updates.md`

### Related PRs
- opensearch-project/OpenSearch-Dashboards#6788
- opensearch-project/OpenSearch-Dashboards#6790
- opensearch-project/OpenSearch-Dashboards#6798
- opensearch-project/OpenSearch-Dashboards#6980
- opensearch-project/OpenSearch-Dashboards#7196
- opensearch-project/OpenSearch-Dashboards#7458
- opensearch-project/OpenSearch-Dashboards#7553

Closes #2336