### PR TITLE
docs: add breadcrumb-router-fixes report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-navigation.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-navigation.md
@@ -127,6 +127,7 @@ The navigation automatically adapts to screen size:
 
 - **v3.4.0** (2025-10-08): Fixed disabled prop propagation for navigation links - `isDisabled` state now correctly passed to `EuiSideNavItem` components
 - **v2.18.0** (2024-10-22): Flattened navigation in Analytics(all) use case, persistent expand/collapse state, small screen compatibility, border style updates, sample data menu restored
+- **v2.16.0** (2024-08-06): Fixed breadcrumb navigation for 4 migrated applications (Assets, Index Pattern Management, Data Sources Management, Application Settings) when new navigation enabled; added `getScopedBreadcrumbs` utility for BrowserRouter compatibility; workspace overview visible in all use cases
 
 
 ## References
@@ -143,3 +144,4 @@ The navigation automatically adapts to screen size:
 | v2.18.0 | [#8489](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8489) | Update border style when new left nav expanded | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v2.18.0 | [#8076](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8076) | Add sample data menu back | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v2.18.0 | [#7962](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7962) | Make left nav compatible with small screen | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
+| v2.16.0 | [#7401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7401) | Fix breadcrumb for migrated apps with BrowserRouter | - |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/breadcrumb-router-fixes.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/breadcrumb-router-fixes.md
@@ -1,0 +1,72 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Breadcrumb & Router Fixes
+
+## Summary
+
+Fixed breadcrumb navigation issues for four applications (Assets, Index Pattern Management, Data Sources Management, Application Settings) when the new navigation feature flag is enabled. These applications were migrated from sub-applications within Dashboard Management to standalone applications in the left navigation, which broke their breadcrumb functionality with BrowserRouter.
+
+## Details
+
+### What's New in v2.16.0
+
+This fix addresses breadcrumb navigation issues that occurred when the `navGroupEnabled` feature flag is turned on. The changes ensure breadcrumbs work correctly with BrowserRouter for migrated applications.
+
+### Technical Changes
+
+#### Problem
+When new navigation is enabled, four applications were added to the left navigation as standalone apps:
+- Assets (Saved Objects Management)
+- Index Pattern Management
+- Data Sources Management
+- Application Settings (Advanced Settings)
+
+Previously, these worked as sub-applications within Dashboard Management, which intercepted `setBreadCrumbs` calls to make breadcrumbs compatible with BrowserRouter and inherit the parent history from OSD core.
+
+After migration to standalone applications, they used `core.chrome.setBreadCrumbs` directly, which doesn't support BrowserRouter.
+
+#### Solution
+A new utility function `getScopedBreadcrumbs` was introduced to wrap breadcrumb items with proper router navigation:
+
+```typescript
+export const getScopedBreadcrumbs = (
+  crumbs: ChromeBreadcrumb[] = [],
+  appHistory: ScopedHistory
+) => {
+  const wrapBreadcrumb = (item: ChromeBreadcrumb, scopedHistory: ScopedHistory) => ({
+    ...item,
+    ...(item.href ? reactRouterNavigate(scopedHistory, item.href) : {}),
+  });
+  return crumbs.map((item) => wrapBreadcrumb(item, appHistory));
+};
+```
+
+#### Updated Plugins
+Each affected plugin now wraps breadcrumbs using `getScopedBreadcrumbs`:
+
+| Plugin | File |
+|--------|------|
+| Advanced Settings | `src/plugins/advanced_settings/public/plugin.ts` |
+| Data Source Management | `src/plugins/data_source_management/public/plugin.ts` |
+| Index Pattern Management | `src/plugins/index_pattern_management/public/plugin.ts` |
+| Saved Objects Management | `src/plugins/saved_objects_management/public/plugin.ts` |
+
+#### Additional Fixes
+- Left navigation now shows expandable menu on home page when workspace is enabled
+- Workspace overview is now visible in all use cases
+- Fixed navigation group display when current nav group is "all"
+- Hidden nav links no longer show in navigation groups
+
+## Limitations
+
+- Changes only take effect when the `navGroupEnabled` feature flag is enabled
+- No impact on existing application behavior when feature flag is disabled
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#7401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7401) | Fix breadcrumb issue for 4 new added applications with BrowserRouter | - |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -3,6 +3,7 @@
 ## Features
 
 ### opensearch-dashboards
+- Breadcrumb & Router Fixes
 - Build & Compilation Fixes
 - CI/CD Improvements
 - Discover Fixes


### PR DESCRIPTION
## Summary

Added documentation for breadcrumb & router fixes in OpenSearch Dashboards v2.16.0.

### Changes
- Created release report: `docs/releases/v2.16.0/features/opensearch-dashboards/breadcrumb-router-fixes.md`
- Updated feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-navigation.md` (added v2.16.0 to Change History and References)
- Updated release index: `docs/releases/v2.16.0/index.md`

### Key Findings
- Fixed breadcrumb navigation for 4 migrated applications (Assets, Index Pattern Management, Data Sources Management, Application Settings)
- Introduced `getScopedBreadcrumbs` utility for BrowserRouter compatibility
- Workspace overview now visible in all use cases

### Related
- Closes #2333
- PR: opensearch-project/OpenSearch-Dashboards#7401