### PR TITLE
docs: add MDS Version Decoupling report for v2.16.0

### DIFF
--- a/docs/features/multi-plugin/multi-plugin-multi-data-source-support.md
+++ b/docs/features/multi-plugin/multi-plugin-multi-data-source-support.md
@@ -150,6 +150,7 @@ POST /_plugins/_query/_datasources
 - **v3.0.0** (2025-05-13): Added MDS support for batch concurrent search (`_msearch`); fixed dataset selector column header; added URL trimming for data source creation
 - **v2.18.0** (2024-11-05): Added MDS support to Integrations plugin; users can install and manage integrations across multiple connected clusters
 - **v2.17.0** (2024-09-17): Reporting plugin de-registers when MDS enabled; Notifications persists dataSourceId in URL for new navigation
+- **v2.16.0** (2024-08-06): Added `datasourceversion` and `installedplugins` fields to `DataSourceView` returns for version decoupling support; fixed filter logic to apply after fetching data source details
 - **v2.15.0** (2024-06-25): Added MDS support to Security Analytics and Alerting plugins
 - **v2.14.0** (2024-05-02): Initial MDS support added to multiple plugins including Notifications, Index Management, Anomaly Detection, Security, Maps, Machine Learning, and Search Relevance
 
@@ -169,6 +170,7 @@ POST /_plugins/_query/_datasources
 | v2.18.0 | [#2051](https://github.com/opensearch-project/dashboards-observability/pull/2051) | dashboards-observability | MDS support in Integrations for observability plugin |   |
 | v2.17.0 | [#411](https://github.com/opensearch-project/dashboards-reporting/pull/411) | dashboards-reporting | De-register reporting when MDS is enabled |   |
 | v2.17.0 | [#249](https://github.com/opensearch-project/dashboards-notifications/pull/249) | dashboards-notifications | Persist dataSourceId across applications |   |
+| v2.16.0 | [#7420](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7420) | OpenSearch-Dashboards | Add data source version and installed plugins in DataSourceView | [#7099](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7099) |
 | v2.14.0 | [#186](https://github.com/opensearch-project/dashboards-notifications/pull/186) | dashboards-notifications | Initial MDS support in Notifications |   |
 
 ### Issues (Design / RFC)

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/mds-version-decoupling.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/mds-version-decoupling.md
@@ -1,0 +1,80 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# MDS Version Decoupling
+
+## Summary
+
+This bugfix adds data source version and installed plugins information to the `DataSourceView` component returns, enabling version decoupling support for the Multiple Data Source (MDS) feature. It also fixes the filter logic to ensure filters are applied correctly after fetching data source details.
+
+## Details
+
+### What's New in v2.16.0
+
+The `DataSourceView` component now returns additional metadata about connected data sources:
+
+- `datasourceversion`: The OpenSearch version of the connected data source
+- `installedplugins`: List of plugins installed on the connected data source
+
+This enables plugins to make version-aware decisions when working with different data sources, supporting the broader version decoupling initiative.
+
+### Technical Changes
+
+#### DataSourceView Component Fix
+
+The filter logic in `DataSourceView` was corrected to apply filters after fetching the full data source details, rather than before:
+
+```typescript
+// Before: Filter applied before fetching details (incorrect)
+if (optionId === '' && this.props.hideLocalCluster ||
+    (this.props.dataSourceFilter &&
+     this.props.selectedOption.filter(this.props.dataSourceFilter).length === 0)) {
+  // Clear selection
+}
+
+// After: Filter applied after fetching details (correct)
+if (optionId === '' && this.props.hideLocalCluster) {
+  // Clear selection for local cluster
+}
+// Then fetch details and apply filter
+const selectedDataSource = await getDataSourceById(...);
+if (this.props.dataSourceFilter &&
+    [selectedDataSource].filter(this.props.dataSourceFilter).length === 0) {
+  // Clear selection if filter doesn't match
+}
+```
+
+#### Utils Enhancement
+
+The `getDataSourceById` utility function now includes version and plugin information in its return value:
+
+| Field | Description |
+|-------|-------------|
+| `datasourceversion` | OpenSearch version from `dataSourceVersion` attribute |
+| `installedplugins` | Plugin list from `installedPlugins` attribute |
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `src/plugins/data_source_management/public/components/data_source_view/data_source_view.tsx` | Fixed filter logic timing |
+| `src/plugins/data_source_management/public/components/utils.ts` | Added version and plugins to return object |
+
+## Limitations
+
+- Version information is only available for data sources that have been properly configured with version metadata
+- Plugin list availability depends on the connected cluster's configuration
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#7420](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7420) | Add data source version and installed plugins in data source viewer returns | [#7099](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7099) |
+
+### Issues
+| Issue | Description |
+|-------|-------------|
+| [#7099](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7099) | Support Version Decoupling in Index Patterns Dashboards Plugin |
+| [#5877](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5877) | RFC: Plugins Version Decoupling |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -9,4 +9,5 @@
 - Discover Fixes
 - Look & Feel UI Improvements
 - Maintainer Updates
+- MDS Version Decoupling
 - OpenAPI Specification


### PR DESCRIPTION
## Summary

Adds documentation for the MDS Version Decoupling bugfix in OpenSearch Dashboards v2.16.0.

## Changes

### Release Report
- Created `docs/releases/v2.16.0/features/opensearch-dashboards/mds-version-decoupling.md`
- Documents the addition of `datasourceversion` and `installedplugins` fields to DataSourceView returns
- Documents the filter logic fix in DataSourceView component

### Feature Report Update
- Updated `docs/features/multi-plugin/multi-plugin-multi-data-source-support.md`
- Added v2.16.0 entry to Change History
- Added PR #7420 to References

### Release Index
- Updated `docs/releases/v2.16.0/index.md` to include MDS Version Decoupling

## Related Issue
Closes #2331

## References
- PR: [opensearch-project/OpenSearch-Dashboards#7420](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7420)
- Issue: [opensearch-project/OpenSearch-Dashboards#7099](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7099)