### PR TITLE
docs: add navigation-next report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-navigation.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-navigation.md
@@ -127,7 +127,7 @@ The navigation automatically adapts to screen size:
 
 - **v3.4.0** (2025-10-08): Fixed disabled prop propagation for navigation links - `isDisabled` state now correctly passed to `EuiSideNavItem` components
 - **v2.18.0** (2024-10-22): Flattened navigation in Analytics(all) use case, persistent expand/collapse state, small screen compatibility, border style updates, sample data menu restored
-- **v2.16.0** (2024-08-06): Fixed breadcrumb navigation for 4 migrated applications (Assets, Index Pattern Management, Data Sources Management, Application Settings) when new navigation enabled; added `getScopedBreadcrumbs` utility for BrowserRouter compatibility; workspace overview visible in all use cases
+- **v2.16.0** (2024-08-06): Fixed breadcrumb navigation for 4 migrated applications (Assets, Index Pattern Management, Data Sources Management, Application Settings) when new navigation enabled; added `getScopedBreadcrumbs` utility for BrowserRouter compatibility; workspace overview visible in all use cases; fixed Dev Tools tab CSS for new left navigation; fixed navigation-next integration issues (auto-collapse on home, typo fixes, workspace visibility); redirect users to home in global when workspace enabled
 
 
 ## References
@@ -144,4 +144,7 @@ The navigation automatically adapts to screen size:
 | v2.18.0 | [#8489](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8489) | Update border style when new left nav expanded | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v2.18.0 | [#8076](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8076) | Add sample data menu back | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v2.18.0 | [#7962](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7962) | Make left nav compatible with small screen | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
+| v2.16.0 | [#7551](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7551) | Redirect user to home in global when workspace enabled | - |
 | v2.16.0 | [#7401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7401) | Fix breadcrumb for migrated apps with BrowserRouter | - |
+| v2.16.0 | [#7356](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7356) | Fix navigation-next integration issues | - |
+| v2.16.0 | [#7328](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7328) | Update dev tools tab css for new left navigation | - |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/navigation-next.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/navigation-next.md
@@ -1,0 +1,52 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Navigation Next
+
+## Summary
+
+Bug fixes for the new left navigation system in OpenSearch Dashboards v2.16.0. These changes address CSS styling issues in Dev Tools, workspace integration problems, and navigation behavior when workspaces are enabled.
+
+## Details
+
+### What's New in v2.16.0
+
+#### Dev Tools Tab CSS Fix
+Updated CSS for Dev Tools tabs to work correctly with the new left navigation. Removed `justify-content: space-between` styling that caused incorrect tab spacing when Workbench was moved to Dev Tools.
+
+#### Navigation-Next Integration Fixes
+Multiple fixes for the navigation-next feature branch integration:
+- Always collapse the new left navigation on home page when workspace is enabled
+- Fixed typos in use case descriptions
+- Declared `advanced_settings`, `dev_tools`, `data_administration_landing`, `settings_and_setup_landing` pages as features not visible within workspace
+- Removed unnecessary `flushLeft` styling in workspace picker
+- Show overview page in workspace of type "all" and hide home
+
+#### Global Navigation Redirect
+When workspace is enabled, users are redirected to home in global context to prevent creating objects in global scope:
+- Changed "back" button to "home" when user is in Settings and Setup / Data Administration nav groups
+- Changed navGroup to dataAdministration when navigating to devTools
+
+### Technical Changes
+
+| Change | Description |
+|--------|-------------|
+| Dev Tools CSS | Removed `justify-content: space-between` from dev tools tab styling |
+| Workspace visibility | Marked admin pages as not visible within workspace |
+| Navigation collapse | Auto-collapse left nav on home when workspace enabled |
+| Global redirect | Redirect users to home in global context with workspace enabled |
+
+## Limitations
+
+- These fixes are specific to the new navigation system (feature flag required)
+- Workspace feature must be enabled for some fixes to take effect
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#7328](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7328) | Update dev tools tab css for new left navigation | - |
+| [#7356](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7356) | Fix navigation-next integration issues | - |
+| [#7551](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7551) | Redirect user to home in global when workspace is enabled | - |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -10,4 +10,5 @@
 - Look & Feel UI Improvements
 - Maintainer Updates
 - MDS Version Decoupling
+- Navigation Next
 - OpenAPI Specification


### PR DESCRIPTION
## Summary

Investigation report for Navigation Next bugfixes in OpenSearch Dashboards v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch-dashboards/navigation-next.md`
- Feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-navigation.md` (updated)

### Key Changes in v2.16.0
- Fixed Dev Tools tab CSS for new left navigation
- Fixed navigation-next integration issues (auto-collapse on home, typo fixes, workspace visibility)
- Redirect users to home in global when workspace enabled

### PRs Investigated
- #7328: Update dev tools tab css for new left navigation
- #7356: Fix navigation-next integration issues
- #7551: Redirect user to home in global when workspace is enabled

Closes #2330