### PR TITLE
docs: add workspace bugfix report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-workspace.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-workspace.md
@@ -174,6 +174,7 @@ opensearch_security.multitenancy.enabled: false
 - **v3.0.0** (2025-05-06): Bug fixes for saved object isolation, recent items error filtering, and stale workspace error handling
 - **v2.19.0** (2025-01-09): Added dismissible get started section for overview pages; optimized recent items with workspace deletion filtering; refactored bulk_get permission handler for better error responses; added privacy levels for workspace access control; enabled category-based search for Dev Tools; added two-step loading for data source association modal
 - **v2.18.0** (2024-11-05): Major feature additions including workspace-level UI settings, collaborator management system (WorkspaceCollaboratorTypesService, AddCollaboratorsModal, Collaborators Page), data connection integration, global search bar in left nav, ACL auditor for permission bypass detection; 14 bug fixes for UI/UX improvements
+- **v2.16.0** (2024-08-06): Bug fixes for data source preservation on workspace deletion, navigation to detail page for all use case workspaces, permission validation on detail page, and added workspaces/permissions fields to _bulk_get response
 
 
 ## References
@@ -224,3 +225,7 @@ opensearch_security.multitenancy.enabled: false
 | v2.18.0 | [#8675](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8675) | Fix non-workspace admin defaultIndex update | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v2.18.0 | [#8718](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8718) | Fix index pattern issues |   |
 | v2.18.0 | [#8719](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8719) | Generate short URL with workspace info | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
+| v2.16.0 | [#7279](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7279) | Unassign data source before deleteByWorkspace |   |
+| v2.16.0 | [#7405](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7405) | Navigate to detail page when clicking all use case workspace |   |
+| v2.16.0 | [#7435](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7435) | Add permission validation at workspace detail page |   |
+| v2.16.0 | [#7565](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7565) | Add workspaces and permissions fields into saved objects _bulk_get response | [#7564](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7564) |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/workspace.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/workspace.md
@@ -1,0 +1,57 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Workspace
+
+## Summary
+
+Bug fixes for the Workspace feature in OpenSearch Dashboards v2.16.0, addressing data source deletion, navigation, permission validation, and saved objects API issues.
+
+## Details
+
+### What's New in v2.16.0
+
+This release includes 4 bug fixes for the Workspace feature:
+
+| Fix | Description |
+|-----|-------------|
+| Data source preservation | Data sources are now unassigned before workspace deletion, preventing accidental data source removal |
+| Navigation fix | Clicking workspaces with "all use case" now correctly navigates to the workspace detail page |
+| Permission validation | Added permission validation on workspace detail page to prevent duplicate user ID entries |
+| Bulk get API fix | Added `workspaces` and `permissions` fields to saved objects `_bulk_get` response |
+
+### Technical Changes
+
+#### Data Source Unassignment on Workspace Deletion
+
+Previously, calling `deleteByWorkspace` would delete data sources that were only assigned to the workspace being deleted. The fix unassigns data sources before deletion to preserve them.
+
+```typescript
+// Before deletion, unassign data sources
+await unassignDataSourcesFromWorkspace(workspaceId);
+await deleteByWorkspace(workspaceId);
+```
+
+#### Permission Validation on Detail Page
+
+The `WorkspaceDetailForm` component now receives `permissionEnabled` prop, enabling `useWorkspaceForm` to validate input data such as duplicate user IDs in "Manage Access and Permissions".
+
+#### Saved Objects Bulk Get Response
+
+The `_bulk_get` API response now includes `workspaces` and `permissions` fields for saved objects, enabling proper workspace context handling.
+
+## Limitations
+
+- Data source unassignment only applies to data sources exclusively assigned to the deleted workspace
+- Permission validation requires the security plugin to be properly configured
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#7279](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7279) | Unassign data source before deleteByWorkspace |   |
+| [#7405](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7405) | Navigate to detail page when clicking all use case workspace |   |
+| [#7435](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7435) | Add permission validation at workspace detail page |   |
+| [#7565](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7565) | Add workspaces and permissions fields into saved objects _bulk_get response | [#7564](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7564) |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -13,3 +13,4 @@
 - MDS Version Decoupling
 - Navigation Next
 - OpenAPI Specification
+- Workspace


### PR DESCRIPTION
## Summary

Investigation of GitHub Issue #2328 - Workspace bug fixes for v2.16.0.

## Changes

### Release Report Created
- `docs/releases/v2.16.0/features/opensearch-dashboards/workspace.md`

### Feature Report Updated
- `docs/features/opensearch-dashboards/opensearch-dashboards-workspace.md`
  - Added v2.16.0 to Change History
  - Added 4 PRs to References

## Bug Fixes Documented

| PR | Description |
|----|-------------|
| #7279 | Unassign data source before deleteByWorkspace |
| #7405 | Navigate to detail page when clicking all use case workspace |
| #7435 | Add permission validation at workspace detail page |
| #7565 | Add workspaces and permissions fields into saved objects _bulk_get response |

Closes #2328