### PR TITLE
docs: add query-editor-extensions-fix report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-query-editor.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-query-editor.md
@@ -133,6 +133,7 @@ The footer bar displays:
 - **v3.3.0**: Added PPL Formatter (`Shift+Option+F`), updated PPL grammar to latest version, removed redundant error popover, fixed Enter key behavior when switching query languages
 - **v3.2.0**: Fixed autocomplete stale query issue, improved Tab/Enter key handling for suggestions, made generated query scrollable, refined "Replace query" button placement
 - **v2.18.0** (2024-11-05): Added footer bar to single-line editor, fixed query editor extension ordering, improved PPL autocomplete
+- **v2.16.0** (2024-08-06): Fixed object empty check and render order issues in query editor extensions
 
 
 ## References
@@ -155,3 +156,5 @@ The footer bar displays:
 | v2.18.0 | [#8565](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8565) | Adds editor footer to single line editor on focus | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v2.18.0 | [#8045](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8045) | Fix order of query editor extensions not working | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v2.18.0 | [#8087](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8087) | PPL Autocomplete functions, fields, & table suggestion | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
+| v2.16.0 | [#7077](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7077) | Fix object empty check and render order in query editor extensions | #7034 |
+| v2.16.0 | [#7034](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7034) | Add query editor extensions | #6077 |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/query-editor-extensions-fix.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/query-editor-extensions-fix.md
@@ -1,0 +1,67 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Query Editor Extensions Fix
+
+## Summary
+
+This release fixes object empty check logic and render order issues in the Query Editor Extensions component, improving reliability and performance of the search bar extension system.
+
+## Details
+
+### What's New in v2.16.0
+
+This bugfix addresses issues introduced in PR #7034 which added query editor extensions:
+
+1. **Fixed Object Empty Check**: Corrected the logic for checking if `configMap` is empty. The previous implementation `!Object.keys(configMap)` always returned `false` because `Object.keys()` returns an array (truthy). Changed to `Object.keys(configMap).length === 0`.
+
+2. **Fixed Render Order**: QueryEditorExtensions requires container divs to be mounted before extensions can render. The previous implementation mounted extensions first and relied on re-rendering of `queryEditorTopRow`. Moving the extension rendering into the QueryEditor component ensures refs are properly set before use.
+
+3. **Improved Component Architecture**: Moved `QueryEditorExtensions` from `QueryEditorTopRow` into `QueryEditor` component, simplifying the ref management and ensuring proper render lifecycle.
+
+### Technical Changes
+
+#### Before (Problematic)
+```typescript
+// In query_editor_extensions.tsx - incorrect empty check
+if (!configMap || !Object.keys(configMap)) return [];
+// Object.keys() returns [], which is truthy, so this never short-circuits
+
+// In query_editor_top_row.tsx - refs passed down
+<QueryEditor
+  queryEditorHeaderRef={queryEditorHeaderRef}
+  queryEditorBannerRef={queryEditorBannerRef}
+/>
+```
+
+#### After (Fixed)
+```typescript
+// In query_editor_extensions.tsx - correct empty check
+if (!configMap || Object.keys(configMap).length === 0) return [];
+
+// In query_editor.tsx - refs managed internally
+private headerRef: RefObject<HTMLDivElement> = createRef();
+private bannerRef: RefObject<HTMLDivElement> = createRef();
+```
+
+### Files Changed
+
+| File | Changes |
+|------|---------|
+| `query_editor.tsx` | Moved extension rendering logic, internalized refs |
+| `query_editor_extensions.tsx` | Fixed empty object check |
+| `query_editor_top_row.tsx` | Removed extension rendering, simplified props |
+
+## Limitations
+
+- No behavior changes for end users; this is an internal fix
+- Extensions still require proper registration through the UI Enhancements API
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#7077](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7077) | Fix object empty check and minor perf issue in query editor extensions | Follow-up to #7034 |
+| [#7034](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7034) | [Discover-next] Add query editor extensions | #6077 |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -13,4 +13,5 @@
 - MDS Version Decoupling
 - Navigation Next
 - OpenAPI Specification
+- Query Editor Extensions Fix
 - Workspace


### PR DESCRIPTION
## Summary

Investigation of GitHub Issue #2327 - Query Editor Extensions Fix for v2.16.0.

## Changes

- Created release report: `docs/releases/v2.16.0/features/opensearch-dashboards/query-editor-extensions-fix.md`
- Updated feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-query-editor.md` (Change History + References)
- Updated release index: `docs/releases/v2.16.0/index.md`

## Key Findings

PR #7077 fixes issues introduced in PR #7034 (query editor extensions):
1. Fixed incorrect object empty check (`!Object.keys(configMap)` → `Object.keys(configMap).length === 0`)
2. Fixed render order by moving QueryEditorExtensions into QueryEditor component
3. Simplified ref management by internalizing refs

Closes #2327