### PR TITLE
docs: add visualization-color-fix report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/index.md
+++ b/docs/features/opensearch-dashboards/index.md
@@ -54,5 +54,6 @@
 | [opensearch-dashboards-tsvb-visualization](opensearch-dashboards-tsvb-visualization.md) | TSVB Visualization |
 | [opensearch-dashboards-ui-settings](opensearch-dashboards-ui-settings.md) | UI Settings |
 | [opensearch-dashboards-vended-dashboard-progress](opensearch-dashboards-vended-dashboard-progress.md) | Vended Dashboard Progress |
+| [opensearch-dashboards-visualization-color-mapping](opensearch-dashboards-visualization-color-mapping.md) | Visualization Color Mapping |
 | [opensearch-dashboards-webpack-and-build-performance](opensearch-dashboards-webpack-and-build-performance.md) | Webpack & Build Performance |
 | [opensearch-dashboards-workspace](opensearch-dashboards-workspace.md) | Workspace |

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-visualization-color-mapping.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-visualization-color-mapping.md
@@ -1,0 +1,90 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Visualization Color Mapping
+
+## Summary
+
+The Visualization Color Mapping system in OpenSearch Dashboards manages color assignment for data series across all visualizations. It uses the `MappedColors` class to maintain consistent color assignments and leverages the EUI color blind palette for accessibility.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Charts Plugin"
+        MC[MappedColors Class]
+        CP[Color Palette<br/>euiPaletteColorBlind]
+        CM[Config Mapping<br/>visualization:colorMapping]
+    end
+    
+    subgraph "Visualizations"
+        V1[Pie Chart]
+        V2[Bar Chart]
+        V3[Line Chart]
+        V4[Area Chart]
+    end
+    
+    CM --> MC
+    CP --> MC
+    MC --> V1
+    MC --> V2
+    MC --> V3
+    MC --> V4
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `MappedColors` | Core class managing color-to-key mappings |
+| `euiPaletteColorBlind` | EUI function providing accessible color palette |
+| `COLOR_MAPPING_SETTING` | UI setting for custom color overrides |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `visualization:colorMapping` | Custom key-to-color mappings | `{}` |
+
+### Color Palette Behavior
+
+The color palette uses `euiPaletteColorBlind` with dynamic configuration based on the number of data items:
+
+| Items | Rotations | Direction | Order |
+|-------|-----------|-----------|-------|
+| 1-10 | 1 | `both` | `append` |
+| 11-20 | 2 | `lighter` | `append` |
+| 21+ | 3+ | `both` | `middle-out` |
+
+### Usage Example
+
+```typescript
+// Color mapping is handled automatically by visualizations
+// Custom mappings can be set via Advanced Settings:
+// visualization:colorMapping: { "error": "#ff0000", "success": "#00ff00" }
+```
+
+## Limitations
+
+- Maximum of ~50 distinct colors before palette repetition
+- Custom color mappings override automatic assignments
+- Color consistency depends on data key stability
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Fixed color ordering for visualizations with more than 10 items by adjusting palette rotation parameters
+
+## References
+
+### Documentation
+
+- [EUI Color Palette](https://oui.opensearch.org/#/utilities/color-palettes): OUI color palette documentation
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#7051](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7051) | Fix colors of visualizations with more than 10 items |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/visualization-color-fix.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/visualization-color-fix.md
@@ -1,0 +1,60 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Visualization Color Fix
+
+## Summary
+
+Fixed an issue where visualizations with more than 10 items displayed incorrect colors. The color palette rotation logic was updated to ensure consistent color ordering regardless of the number of data items.
+
+## Details
+
+### What's New in v2.16.0
+
+This bug fix addresses a color display issue in OpenSearch Dashboards visualizations that occurred when displaying more than 10 data items.
+
+### Problem
+
+When a visualization contained more than 10 items, the `euiPaletteColorBlind` function would rotate through colors in an inconsistent manner, causing:
+- Colors to appear in unexpected order
+- Visual inconsistency between visualizations with different item counts
+- Difficulty distinguishing data series in charts
+
+### Technical Changes
+
+The fix modifies the `MappedColors` class in `src/plugins/charts/public/services/colors/mapped_colors.ts`:
+
+| Parameter | Before | After |
+|-----------|--------|-------|
+| `rotations` | Calculated inline | Extracted to variable for reuse |
+| `direction` | `'both'` (always) | `'lighter'` when rotations=2, `'both'` otherwise |
+| `order` | Not specified | `'middle-out'` when rotations>2, `'append'` otherwise |
+
+```typescript
+// Updated color palette configuration
+const rotations = Math.ceil(keys.length / 10);
+const colorPalette = euiPaletteColorBlind({
+  rotations,
+  direction: rotations === 2 ? 'lighter' : 'both',
+  order: rotations > 2 ? 'middle-out' : 'append',
+})
+```
+
+This ensures that:
+1. Original colors are always used first
+2. Color rotation maintains visual consistency
+3. The palette expands predictably as more items are added
+
+## Limitations
+
+- This fix applies only to visualizations using the default color palette
+- Custom color mappings configured via `visualization:colorMapping` setting are not affected
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#7051](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7051) | Fix colors of visualizations with more than 10 items | [#5422](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5422) |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -14,4 +14,5 @@
 - Navigation Next
 - OpenAPI Specification
 - Query Editor Extensions Fix
+- Visualization Color Fix
 - Workspace


### PR DESCRIPTION
## Summary

Investigation report for GitHub Issue #2326 - Visualization Color Fix (v2.16.0)

## Reports Created

- Release report: `docs/releases/v2.16.0/features/opensearch-dashboards/visualization-color-fix.md`
- Feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-visualization-color-mapping.md`

## Key Changes in v2.16.0

- Fixed color ordering for visualizations with more than 10 items
- Updated `euiPaletteColorBlind` parameters to ensure consistent color rotation
- Colors now use original palette first before rotating to lighter/darker variants

## Resources Used

- PR: opensearch-project/OpenSearch-Dashboards#7051
- Issue: opensearch-project/OpenSearch-Dashboards#5422