### PR TITLE
docs: add sidecar-z-index-fix report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-ai-chat.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-ai-chat.md
@@ -264,6 +264,7 @@ npm run start:ag-ui
 
 - **v3.4.0** (2025-11): Global search integration, suggestion system, state persistence, session storage, Explore integration, UI improvements
 - **v3.3.0** (2025-10): Initial implementation with Chat plugin, Context Provider plugin, and osd-agents ReAct agent
+- **v2.16.0** (2024-06): Fixed Sidecar z-index to render above mask overlays (z-index 1000 → 1001)
 
 
 ## References
@@ -288,6 +289,7 @@ npm run start:ag-ui
 | v3.3.0 | [#10600](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10600) | Add experimental AI Chat and Context Provider plugins | [#10571](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10571) |
 | v3.3.0 | [#10612](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10612) | AG-UI compliant LangGraph ReAct agent implementation |   |
 | v3.3.0 | [#10624](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10624) | Mark context provider and chat as experimental |   |
+| v2.16.0 | [#6964](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6964) | Fix Sidecar z-index to render above mask overlays |   |
 
 ### Issues (Design / RFC)
 - [RFC #10585](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10585): AI Assistant Framework for OpenSearch Dashboards

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/sidecar-z-index-fix.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/sidecar-z-index-fix.md
@@ -1,0 +1,51 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Sidecar Z-Index Fix
+
+## Summary
+
+Fixed a z-index issue where the Sidecar panel was being covered by UI mask overlays. The Sidecar container's z-index was increased from 1000 to 1001 to ensure it renders above modal masks.
+
+## Details
+
+### What's New in v2.16.0
+
+The Sidecar component is a fixed-position panel used by features like the AI Chat assistant. When flyout dialogs or modals with masks were opened, the mask overlay (z-index 1000) would cover the Sidecar panel, making it inaccessible.
+
+### Technical Changes
+
+The fix updates the Sidecar's z-index to be one level above the EUI mask:
+
+```scss
+// Before
+.osdSidecarFlyout {
+  z-index: 1000;
+}
+
+// After
+.osdSidecarFlyout {
+  // Sidecar z-index should more than mask. Actually will be 1001.
+  z-index: $euiZMaskBelowHeader + 1;
+}
+```
+
+The change uses the EUI variable `$euiZMaskBelowHeader` (value: 1000) plus 1, ensuring the Sidecar always renders above mask overlays while maintaining proper layering with other UI elements.
+
+### Changed Files
+
+| File | Change |
+|------|--------|
+| `src/core/public/overlays/sidecar/components/sidecar.scss` | Updated z-index from 1000 to `$euiZMaskBelowHeader + 1` |
+
+## Limitations
+
+- The Sidecar will now render above all mask overlays, which is the intended behavior for an independent container
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#6964](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6964) | Update sidecar z-index style | - |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -14,6 +14,7 @@
 - Navigation Next
 - OpenAPI Specification
 - Query Editor Extensions Fix
+- Sidecar Z-Index Fix
 - Timeline Visualization Fixes
 - Visualization Color Fix
 - Workspace


### PR DESCRIPTION
## Summary

Adds release report for the Sidecar Z-Index Fix in OpenSearch Dashboards v2.16.0.

## Changes

- Created release report: `docs/releases/v2.16.0/features/opensearch-dashboards/sidecar-z-index-fix.md`
- Updated release index: `docs/releases/v2.16.0/index.md`
- Updated feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-ai-chat.md` (added to Change History and References)

## Investigation Summary

Fixed a z-index issue where the Sidecar panel was being covered by UI mask overlays. The Sidecar container's z-index was increased from 1000 to 1001 (`$euiZMaskBelowHeader + 1`) to ensure it renders above modal masks.

## Related

- Closes #2324
- PR: opensearch-project/OpenSearch-Dashboards#6964