### PR TITLE
docs: add dashboard-flyout-fix report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-ui-updates.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-ui-updates.md
@@ -105,7 +105,7 @@ import { EuiTitle, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 ## Change History
 
 - **v2.17.0** (2024-09-17): OUI upgrades from 1.9.0 to 1.12.0, header spacing improvements, recent items button refactoring
-- **v2.16.0** (2024-08-06): Look & Feel initiative - semantic headers for page/modal/flyout, consistent plus icons, OUI tooltips replacing browser tooltips, small popover padding, small tab sizing, Discover/query bar density improvements, VisBuilder guidance, recent items icon fixes for dark mode
+- **v2.16.0** (2024-08-06): Look & Feel initiative - semantic headers for page/modal/flyout, consistent plus icons, OUI tooltips replacing browser tooltips, small popover padding, small tab sizing, Discover/query bar density improvements, VisBuilder guidance, recent items icon fixes for dark mode, added `closeFlyout()` API to close active flyouts when switching dashboard view modes
 
 
 ## References
@@ -133,3 +133,4 @@ import { EuiTitle, EuiButtonIcon, EuiToolTip } from '@elastic/eui';
 | v2.16.0 | [#7508](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7508) | Update icon of recent items from OUI library to enable dark mode |   |
 | v2.16.0 | [#7523](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7523) | Apply small popover padding and add OUI tooltips |   |
 | v2.16.0 | [#7530](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7530) | Discover and Query Management fix |   |
+| v2.16.0 | [#6923](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6923) | Close any open flyouts when changing dashboard view mode |   |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/dashboard-flyout-fix.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/dashboard-flyout-fix.md
@@ -1,0 +1,88 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Dashboard Flyout Fix
+
+## Summary
+
+Fixes an issue where system flyouts (such as the add panel flyout) remained open when switching dashboard view modes. The fix adds a `closeFlyout()` method to the overlay service and calls it when transitioning between edit and view modes.
+
+## Details
+
+### What's New in v2.16.0
+
+A new `close()` method was added to the `FlyoutService` that allows programmatic closing of any active flyout. This method is now called when:
+
+1. Switching from edit mode to view mode without changes
+2. Discarding changes and switching to view mode
+
+### Technical Changes
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant Dashboard
+    participant OverlayService
+    participant FlyoutService
+    
+    User->>Dashboard: Click "Cancel" or switch mode
+    Dashboard->>OverlayService: closeFlyout()
+    OverlayService->>FlyoutService: close()
+    FlyoutService->>FlyoutService: activeFlyout.close()
+    FlyoutService->>FlyoutService: cleanupDom()
+```
+
+#### API Changes
+
+New method added to `OverlayFlyoutStart` interface:
+
+```typescript
+interface OverlayFlyoutStart {
+  open(mount: MountPoint, options?: OverlayFlyoutOpenOptions): OverlayRef;
+  close(): void;  // New in v2.16.0
+}
+```
+
+New method exposed on `OverlayStart`:
+
+```typescript
+interface OverlayStart {
+  openFlyout: OverlayFlyoutStart['open'];
+  closeFlyout: OverlayFlyoutStart['close'];  // New in v2.16.0
+  // ... other methods
+}
+```
+
+#### Implementation
+
+The `close()` method in `FlyoutService`:
+
+```typescript
+close: () => {
+  if (this.activeFlyout) {
+    this.activeFlyout.close();
+    this.cleanupDom();
+  }
+}
+```
+
+#### Files Changed
+
+| File | Change |
+|------|--------|
+| `src/core/public/overlays/flyout/flyout_service.tsx` | Added `close()` method to `FlyoutService` |
+| `src/core/public/overlays/overlay_service.ts` | Exposed `closeFlyout` on `OverlayStart` |
+| `src/plugins/dashboard/public/application/utils/get_nav_actions.tsx` | Call `closeFlyout()` on mode change |
+
+## Limitations
+
+- The `close()` method only closes the currently active flyout
+- Multiple calls to `close()` are safe (no-op if no active flyout)
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#6923](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6923) | Close any open flyouts when changing view mode of the dashboard | |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -6,6 +6,7 @@
 - Breadcrumb & Router Fixes
 - Build & Compilation Fixes
 - CI/CD Improvements
+- Dashboard Flyout Fix
 - Data Source Management Bug Fixes
 - Discover Fixes
 - Look & Feel UI Improvements


### PR DESCRIPTION
## Summary

Adds documentation for the Dashboard Flyout Fix in OpenSearch Dashboards v2.16.0.

### Changes
- Created release report: `docs/releases/v2.16.0/features/opensearch-dashboards/dashboard-flyout-fix.md`
- Updated feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-ui-updates.md`
- Updated release index: `docs/releases/v2.16.0/index.md`

### Key Changes in v2.16.0
- Added `closeFlyout()` method to `OverlayService` to programmatically close active flyouts
- Dashboard now closes any open flyouts when switching between edit and view modes
- Fixes issue where add panel flyout remained open after mode change

### Source PR
- [opensearch-project/OpenSearch-Dashboards#6923](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6923)