### PR TITLE
docs: add build-compilation-fixes report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-maintenance.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-maintenance.md
@@ -69,7 +69,7 @@ Enhanced error handling for edge cases:
 ## Change History
 
 - **v2.18.0** (2024-10-22): Version bump to 2.18.0, enhanced search API cleanup (removed ConnectionsService, deprecated routes, improved error handling)
-
+- **v2.16.0** (2024-08-06): Build and compilation fixes - lint checker fix, removed unused imports causing compilation errors, Angular legacy code cleanup
 
 ## References
 
@@ -82,3 +82,6 @@ Enhanced error handling for edge cases:
 |---------|-----|-------------|---------------|
 | v2.18.0 | [#8225](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8225) | Post 2.17 version bump |   |
 | v2.18.0 | [#8226](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8226) | Clean up enhanced search API |   |
+| v2.16.0 | [#6771](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6771) | Lint checker failure fix |   |
+| v2.16.0 | [#6879](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6879) | Remove unused import and property which broke compilation | [#6878](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6878) |
+| v2.16.0 | [#7087](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7087) | Remove angular related comment and code |   |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/build-compilation-fixes.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/build-compilation-fixes.md
@@ -6,40 +6,41 @@ tags:
 
 ## Summary
 
-This release fixes a bootstrapping error caused by Babel dependency incompatibilities in the 2.x branch. The fix updates `@babel/traverse` and `@babel/plugin-transform-class-static-block` to compatible versions.
+This release includes several build and compilation fixes for OpenSearch Dashboards, addressing lint checker failures, removing unused code that broke compilation, and cleaning up legacy Angular-related code.
 
 ## Details
 
 ### What's New in v2.16.0
 
-A Babel error was preventing successful bootstrapping of OpenSearch Dashboards on the 2.x branch. The issue was caused by version incompatibilities between Babel packages.
+Multiple fixes were applied to improve build stability and code quality:
+
+1. **Lint Checker Fix**: Added `site.com` to `.lycheeignore` to resolve lint checker failures caused by example URLs in documentation.
+
+2. **Compilation Fix**: Removed unused import (`DataSourceSelectionService`) and property from the data source view example component that was causing compilation errors.
+
+3. **Angular Code Cleanup**: Removed legacy Angular-related comments and code from the codebase, including:
+   - Removed Angular coupling comment from SCSS mixins
+   - Removed `ng-bind-html` attribute from tooltip formatter JSX
 
 ### Technical Changes
 
-The fix updates the following dependencies in `package.json`:
-
-| Dependency | Previous Version | New Version |
-|------------|-----------------|-------------|
-| `@babel/traverse` (resolution) | ^7.23.2 | ^7.25.0 |
-| `@babel/plugin-transform-class-static-block` | ^7.24.4 | ^7.24.7 |
-
-These updates resolve compatibility issues specific to the 2.x branch. The main branch already had compatible versions.
-
-### Files Changed
-
-| File | Changes |
-|------|---------|
-| `package.json` | Updated Babel dependency versions |
-| `yarn.lock` | Updated lockfile with new dependency tree |
+| Fix | File | Change |
+|-----|------|--------|
+| Lint checker | `.lycheeignore` | Added `site.com` to ignore list |
+| Unused import | `examples/multiple_data_source_examples/public/components/data_source_view_example.tsx` | Removed `DataSourceSelectionService` import and `dataSourceSelection` prop |
+| Angular cleanup | `packages/osd-ui-framework/src/global_styling/mixins/_global_mixins.scss` | Removed Angular coupling comment |
+| Angular cleanup | `src/plugins/vis_type_vislib/public/vislib/components/tooltip/_hierarchical_tooltip_formatter.js` | Removed `ng-bind-html` attribute |
 
 ## Limitations
 
-- This fix is specific to the 2.x branch
-- The main branch does not require these changes
+- These are maintenance fixes with no user-facing impact
+- The Angular cleanup is part of ongoing legacy code removal
 
 ## References
 
 ### Pull Requests
 | PR | Description | Related Issue |
 |----|-------------|---------------|
-| [#7541](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7541) | Fix babel error | - |
+| [#6771](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6771) | Lint checker failure fix | - |
+| [#6879](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6879) | Remove unused import and property which broke compilation | [#6878](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6878) |
+| [#7087](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7087) | Remove angular related comment and code | - |


### PR DESCRIPTION
## Summary

Updates documentation for Build & Compilation Fixes in OpenSearch Dashboards v2.16.0.

### Changes
- Updated release report: `docs/releases/v2.16.0/features/opensearch-dashboards/build-compilation-fixes.md`
- Updated feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-maintenance.md`

### PRs Documented
| PR | Description |
|----|-------------|
| #6771 | Lint checker failure fix |
| #6879 | Remove unused import and property which broke compilation |
| #7087 | Remove angular related comment and code |

Closes #2322