### PR TITLE
docs: add quick-range-selection-fix report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-discover.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-discover.md
@@ -150,7 +150,7 @@ Requires ML agent configuration:
 - **v3.0.0** (2025-05-13): Added CSV export functionality, reorganized results display with ResultsActionBar, customizable summary panel title, experimental Data plugin `__enhance` API with resultsActionBar, and 6 bug fixes for saved search handling and workspace integration
 - **v2.19.0** (2025-01-14): Added indexed views framework to dataset selector, results canvas banner framework, data2summary agent validation, default query string framework, custom time filter logic per dataset type, query editor bottom panel extension, and Cypress test data attributes
 - **v2.18.0** (2024-11-05): Added AI-powered data summary panel, updated visual appearance, cache management in dataset selector, and 14 bug fixes for stability and usability
-- **v2.16.0** (2024-08-06): Fixed Discover Next styling issues (query bar, dataset navigator, language selector, field search) and database loading display for external data sources
+- **v2.16.0** (2024-08-06): Fixed Discover Next styling issues (query bar, dataset navigator, language selector, field search), database loading display for external data sources, and quick range time picker date math parsing
 
 
 ## References
@@ -204,5 +204,6 @@ Requires ML agent configuration:
 ### v2.16.0 Pull Requests
 | PR | Description |
 |----|-------------|
+| [#6782](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6782) | Fixes quick range time picker to use datemath for parsing |
 | [#7546](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7546) | Fixes Discover next styling |
 | [#7567](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7567) | Fixes databases not being displayed upon success |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/quick-range-selection-fix.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/quick-range-selection-fix.md
@@ -1,0 +1,67 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Quick Range Selection Fix
+
+## Summary
+
+Fixed the quick range time picker to properly parse date math expressions like `now-15m` by using the `datemath` package. This ensures that relative time expressions in the time filter are correctly converted to absolute datetime values.
+
+## Details
+
+### What's New in v2.16.0
+
+The quick range selection in the time picker was not correctly parsing date math expressions. This fix introduces a `formatTimePickerDate` utility function that uses the `datemath` package to properly parse relative time expressions.
+
+### Technical Changes
+
+A new utility function was added to `src/plugins/data/common/data_frames/utils.ts`:
+
+```typescript
+/**
+ * Parses timepicker datetimes using datemath package.
+ * Will attempt to parse strings such as "now - 15m"
+ *
+ * @param dateRange - of type TimeRange
+ * @param dateFormat - formatting string (should work with Moment)
+ * @returns object with `fromDate` and `toDate` strings in UTC
+ */
+export const formatTimePickerDate = (dateRange: TimeRange, dateFormat: string) => {
+  const dateMathParse = (date: string) => {
+    const parsedDate = datemath.parse(date);
+    return parsedDate ? parsedDate.utc().format(dateFormat) : '';
+  };
+
+  const fromDate = dateMathParse(dateRange.from);
+  const toDate = dateMathParse(dateRange.to);
+
+  return { fromDate, toDate };
+};
+```
+
+### Changed Files
+
+| File | Change |
+|------|--------|
+| `src/plugins/data/common/data_frames/utils.ts` | Added `formatTimePickerDate` utility function |
+| `src/plugins/data/common/data_frames/data_frame_utils.test.ts` | Added unit tests for the new function |
+
+### Behavior
+
+| Input | Output |
+|-------|--------|
+| `{ from: 'now-15m', to: 'now' }` | `{ fromDate: '2024-05-04 12:15:00.000', toDate: '2024-05-04 12:30:00.000' }` |
+| `{ from: 'fake', to: 'date' }` | `{ fromDate: 'Invalid date', toDate: 'Invalid date' }` |
+
+## Limitations
+
+- Invalid date strings return `'Invalid date'` rather than throwing an error
+- Output is always in UTC timezone
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#6782](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6782) | Fix for quickrange to use datemath to parse datetime strings | - |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -16,6 +16,7 @@
 - Navigation Next
 - OpenAPI Specification
 - Query Editor Extensions Fix
+- Quick Range Selection Fix
 - Sample Data Import
 - Sidecar Z-Index Fix
 - Timeline Visualization Fixes


### PR DESCRIPTION
## Summary
Investigation of GitHub Issue #2319 - Quick Range Selection Fix for OpenSearch Dashboards v2.16.0.

## Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch-dashboards/quick-range-selection-fix.md`
- Feature report: Updated `docs/features/opensearch-dashboards/opensearch-dashboards-discover.md`

## Key Changes
- Added `formatTimePickerDate` utility function that uses `datemath` package to properly parse relative time expressions like `now-15m`
- The fix ensures quick range selections in the time picker are correctly converted to absolute datetime values

## PR Investigated
- [#6782](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6782)