### PR TITLE
docs: add vega-visualization-fixes report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-features.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-features.md
@@ -110,6 +110,7 @@ source=logs | where status =
 ## Change History
 
 - **v3.0.0** (2025-02): Added autocomplete value suggestions, Vega PPL time field support, dependency license validation, and Discover scrolling improvements
+- **v2.16.0** (2024-08): Fixed Vega URL parser error message formatting for unsupported query types
 
 
 ## References
@@ -127,6 +128,7 @@ source=logs | where status =
 | v3.0.0 | [#9064](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9064) | Dependency license validation |   |
 | v3.0.0 | [#9152](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9152) | Vega PPL time field support | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v3.0.0 | [#9298](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9298) | Discover scrolling improvements |   |
+| v2.16.0 | [#6777](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6777) | Fix Vega URL parser error message formatting |   |
 
 ### Issues (Design / RFC)
 - [Issue #9169](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9169): Vega PPL %timefield% feature request

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/vega-visualization-fixes.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/vega-visualization-fixes.md
@@ -1,0 +1,54 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Vega Visualization Fixes
+
+## Summary
+
+This release fixes an error message formatting issue in the Vega visualization URL parser. When users specified an unsupported query type (such as `ppl`), the error message displayed template placeholders instead of the actual type value.
+
+## Details
+
+### What's New in v2.16.0
+
+The fix corrects string interpolation in the error message generation for unsupported URL types in Vega visualizations.
+
+### Technical Changes
+
+**Before (broken):**
+```
+url: {"%type%": "${type}"} is not supported
+```
+
+**After (fixed):**
+```
+url: {"%type%": "ppl"} is not supported
+```
+
+The issue was caused by using single quotes instead of template literals (backticks) for string interpolation in the `vega_parser.ts` file:
+
+```typescript
+// Before (incorrect - no interpolation)
+urlObject: 'url: {"%type%": "${type}"}'
+
+// After (correct - template literal with interpolation)
+urlObject: `url: {"%type%": "${type}"}`
+```
+
+### Affected Component
+
+| Component | File | Change |
+|-----------|------|--------|
+| vis_type_vega | `src/plugins/vis_type_vega/public/data_model/vega_parser.ts` | Fixed string interpolation |
+
+## Limitations
+
+None.
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#6777](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6777) | Fix vega visualization error message not been formatted | - |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -20,5 +20,6 @@
 - Sample Data Import
 - Sidecar Z-Index Fix
 - Timeline Visualization Fixes
+- Vega Visualization Fixes
 - Visualization Color Fix
 - Workspace


### PR DESCRIPTION
## Summary

Adds documentation for Vega visualization error message fix in OpenSearch Dashboards v2.16.0.

## Changes

- Created release report: `docs/releases/v2.16.0/features/opensearch-dashboards/vega-visualization-fixes.md`
- Updated feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-dashboards-features.md`
- Updated release index: `docs/releases/v2.16.0/index.md`

## Related

- Closes #2318
- PR: opensearch-project/OpenSearch-Dashboards#6777