### PR TITLE
docs: add saved-objects-management report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-workspace.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-workspace.md
@@ -174,7 +174,7 @@ opensearch_security.multitenancy.enabled: false
 - **v3.0.0** (2025-05-06): Bug fixes for saved object isolation, recent items error filtering, and stale workspace error handling
 - **v2.19.0** (2025-01-09): Added dismissible get started section for overview pages; optimized recent items with workspace deletion filtering; refactored bulk_get permission handler for better error responses; added privacy levels for workspace access control; enabled category-based search for Dev Tools; added two-step loading for data source association modal
 - **v2.18.0** (2024-11-05): Major feature additions including workspace-level UI settings, collaborator management system (WorkspaceCollaboratorTypesService, AddCollaboratorsModal, Collaborators Page), data connection integration, global search bar in left nav, ACL auditor for permission bypass detection; 14 bug fixes for UI/UX improvements
-- **v2.16.0** (2024-08-06): Bug fixes for data source preservation on workspace deletion, navigation to detail page for all use case workspaces, permission validation on detail page, and added workspaces/permissions fields to _bulk_get response
+- **v2.16.0** (2024-08-06): Bug fixes for data source preservation on workspace deletion, navigation to detail page for all use case workspaces, permission validation on detail page, added workspaces/permissions fields to _bulk_get response, and fixed saved objects management page to show error toast when workspace read-only users fail to delete saved objects
 
 
 ## References
@@ -229,3 +229,4 @@ opensearch_security.multitenancy.enabled: false
 | v2.16.0 | [#7405](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7405) | Navigate to detail page when clicking all use case workspace |   |
 | v2.16.0 | [#7435](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7435) | Add permission validation at workspace detail page |   |
 | v2.16.0 | [#7565](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7565) | Add workspaces and permissions fields into saved objects _bulk_get response | [#7564](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7564) |
+| v2.16.0 | [#6756](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6756) | Show error toast when workspace read-only user fails to delete saved objects |   |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/saved-objects-management.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/saved-objects-management.md
@@ -1,0 +1,80 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Saved Objects Management
+
+## Summary
+
+Fixed error handling in the Saved Objects Management page when workspace read-only users attempt to delete saved objects. Previously, the UI would display an infinite loading spinner; now it shows a proper error toast notification and allows users to continue with other operations.
+
+## Details
+
+### What's New in v2.16.0
+
+This release fixes a UX issue in the Saved Objects Management page where workspace read-only users experienced a broken UI state when attempting to delete saved objects they don't have permission to delete.
+
+### Problem
+
+When a workspace read-only user attempted to delete a saved object:
+1. A loading spinner would appear and never stop
+2. The user could not interact with the table or perform other operations
+3. No error message was displayed to explain the failure
+
+### Solution
+
+The `delete` method in `SavedObjectsTable` component was refactored to:
+1. Wrap the delete operation in a try-catch block
+2. Display an error toast notification when deletion fails
+3. Keep the delete confirmation modal open on failure so users can cancel
+4. Reset the `isDeleting` state to allow further interactions
+
+### Technical Changes
+
+The fix modifies `src/plugins/saved_objects_management/public/management_section/objects_table/saved_objects_table.tsx`:
+
+```typescript
+delete = async () => {
+  const { savedObjectsClient, notifications } = this.props;
+  // ... existing code ...
+  
+  try {
+    // Delete operations
+    await Promise.all(deletes);
+    this.setState({ selectedSavedObjects: [] });
+    await this.fetchSavedObjects();
+    await this.fetchCounts();
+    this.setState({ isShowingDeleteConfirmModal: false });
+  } catch (error) {
+    notifications.toasts.addDanger({
+      title: i18n.translate(
+        'savedObjectsManagement.objectsTable.unableDeleteSavedObjectsNotificationMessage',
+        { defaultMessage: 'Unable to delete saved objects' }
+      ),
+      text: `${error}`,
+    });
+  }
+  
+  this.setState({ isDeleting: false });
+};
+```
+
+### User Experience
+
+| Before | After |
+|--------|-------|
+| Infinite loading spinner | Error toast notification |
+| UI becomes unresponsive | Modal stays open, user can cancel |
+| No feedback on failure | Clear error message displayed |
+
+## Limitations
+
+- The error toast displays a generic message; specific permission errors are not detailed
+- Users must have appropriate workspace permissions to delete saved objects
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#6756](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6756) | Show error toast when fail to delete saved objects |   |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -18,6 +18,7 @@
 - Query Editor Extensions Fix
 - Quick Range Selection Fix
 - Sample Data Import
+- Saved Objects Management
 - Sidecar Z-Index Fix
 - Timeline Visualization Fixes
 - Vega Visualization Fixes


### PR DESCRIPTION
## Summary
Add release report for Saved Objects Management bugfix in v2.16.0.

### Changes
- Created release report: `docs/releases/v2.16.0/features/opensearch-dashboards/saved-objects-management.md`
- Updated Workspace feature report with bug fix in Change History and References
- Updated release index

### Bug Fix Details
Fixed error handling in the Saved Objects Management page when workspace read-only users attempt to delete saved objects. Previously, the UI would display an infinite loading spinner; now it shows a proper error toast notification.

### Related
- PR: opensearch-project/OpenSearch-Dashboards#6756
- Issue: #2317