### PR TITLE
docs: add osd-availability report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/index.md
+++ b/docs/features/opensearch-dashboards/index.md
@@ -43,6 +43,7 @@
 | [opensearch-dashboards-navigation](opensearch-dashboards-navigation.md) | Navigation |
 | [opensearch-dashboards-numeric-precision](opensearch-dashboards-numeric-precision.md) | Numeric Precision Setting |
 | [opensearch-dashboards-osd-optimizer-cache](opensearch-dashboards-osd-optimizer-cache.md) | OSD Optimizer Cache |
+| [opensearch-dashboards-osd-availability](opensearch-dashboards-osd-availability.md) | OSD Availability |
 | [opensearch-dashboards-openapi-specification](opensearch-dashboards-openapi-specification.md) | OpenAPI Specification |
 | [opensearch-dashboards-oui](opensearch-dashboards-oui.md) | OpenSearch UI (OUI) |
 | [opensearch-dashboards-plugin-compatibility](opensearch-dashboards-plugin-compatibility.md) | Plugin Compatibility |

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-osd-availability.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-osd-availability.md
@@ -1,0 +1,84 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# OSD Availability
+
+## Summary
+
+OSD Availability features improve the resilience and stability of OpenSearch Dashboards by handling edge cases that could cause process crashes or service disruptions.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Logging Pipeline"
+        A[Log Event] --> B[LogInterceptor]
+        B --> C[Squeeze Filter]
+        C --> D[Log Format]
+        D --> E{Destination}
+        E -->|stdout| F[Process stdout]
+        E -->|file| G[File Stream]
+    end
+    
+    subgraph "Error Handling"
+        G -->|ENOSPC| H{ignoreEnospcError?}
+        H -->|true| I[Log to Console]
+        H -->|false| J[Process Crash]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `log_reporter.js` | Manages logging stream pipeline and error handling |
+| `configuration.js` | Passes logging configuration to the reporter |
+| `schema.js` | Defines configuration schema including `ignoreEnospcError` |
+
+### Configuration
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `logging.ignoreEnospcError` | boolean | `false` | When enabled, ENOSPC errors in the logging pipeline are caught and logged to console instead of crashing the process |
+
+### Usage Example
+
+```yaml
+# opensearch_dashboards.yml
+
+# Enable graceful handling of disk-full errors
+logging.ignoreEnospcError: true
+
+# Recommended: Also configure log rotation to prevent disk issues
+logging.dest: /var/log/opensearch-dashboards/opensearch_dashboards.log
+logging.rotate.enabled: true
+logging.rotate.everyBytes: 10485760
+logging.rotate.keepFiles: 7
+```
+
+## Limitations
+
+- `logging.ignoreEnospcError` only affects file-based logging destinations
+- When enabled, log entries may be lost during disk-full conditions
+- The setting is disabled by default to maintain backward compatibility and ensure administrators are aware of disk space issues
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Added `logging.ignoreEnospcError` configuration to prevent process crashes when disk is full
+
+## References
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#6733](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6733) | Prevent OSD process crashes when disk is full |
+
+### Issues
+
+| Issue | Description |
+|-------|-------------|
+| [#6607](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6607) | Feature request: Allow admin to customize OSD logging exception handling behavior |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/osd-availability.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/osd-availability.md
@@ -1,0 +1,60 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# OSD Availability
+
+## Summary
+
+This bugfix prevents OpenSearch Dashboards from crashing when the disk is full by introducing a new configuration option `logging.ignoreEnospcError` that handles ENOSPC (no space left on device) errors gracefully in the logging pipeline.
+
+## Details
+
+### What's New in v2.16.0
+
+Prior to this fix, when the disk became full, the OSD process would crash due to unhandled ENOSPC errors in the logging stream. This was particularly problematic in production environments where disk space issues could cause unexpected service outages.
+
+### Technical Changes
+
+The fix introduces a new feature flag `logging.ignoreEnospcError` that controls how ENOSPC errors are handled:
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `logging.ignoreEnospcError` | boolean | `false` | When `true`, ENOSPC errors in the logging pipeline are caught and logged to console instead of crashing the process |
+
+### Implementation
+
+The changes modify the logging pipeline in `log_reporter.js`:
+
+1. When `ignoreEnospcError` is enabled and logging to a file, the pipeline uses Node.js `pipeline()` with an error callback
+2. ENOSPC errors are caught and logged to console instead of propagating and crashing the process
+3. Other errors continue to throw as before to maintain existing behavior
+
+### Configuration Example
+
+```yaml
+# opensearch_dashboards.yml
+logging.ignoreEnospcError: true
+```
+
+For Docker deployments, the setting can be passed as an environment variable.
+
+## Limitations
+
+- This setting only affects file-based logging (not stdout)
+- When enabled, log entries may be lost during disk-full conditions
+- The setting is disabled by default to maintain backward compatibility
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#6733](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6733) | Prevent OSD process crashes when disk is full | [#6607](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6607) |
+
+### Issues
+
+| Issue | Description |
+|-------|-------------|
+| [#6607](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6607) | Feature request: Allow admin to customize OSD logging exception handling behavior |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch-dashboards
 - Breadcrumb & Router Fixes
+- OSD Availability
 - Build & Compilation Fixes
 - CI/CD Improvements
 - Dashboard Flyout Fix


### PR DESCRIPTION
## Summary

Adds documentation for the OSD Availability bugfix in OpenSearch Dashboards v2.16.0.

### Changes
- **Release report**: `docs/releases/v2.16.0/features/opensearch-dashboards/osd-availability.md`
- **Feature report**: `docs/features/opensearch-dashboards/opensearch-dashboards-osd-availability.md`
- Updated index files

### Key Feature
Introduces `logging.ignoreEnospcError` configuration option to prevent OSD process crashes when disk is full.

### References
- PR: opensearch-project/OpenSearch-Dashboards#6733
- Issue: opensearch-project/OpenSearch-Dashboards#6607

Closes #2315