### PR TITLE
docs: add VisBuilder Fixes report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/index.md
+++ b/docs/features/opensearch-dashboards/index.md
@@ -56,6 +56,7 @@
 | [opensearch-dashboards-timeline-visualization](opensearch-dashboards-timeline-visualization.md) | Timeline Visualization |
 | [opensearch-dashboards-ui-settings](opensearch-dashboards-ui-settings.md) | UI Settings |
 | [opensearch-dashboards-vended-dashboard-progress](opensearch-dashboards-vended-dashboard-progress.md) | Vended Dashboard Progress |
+| [opensearch-dashboards-visbuilder](opensearch-dashboards-visbuilder.md) | VisBuilder |
 | [opensearch-dashboards-visualization-color-mapping](opensearch-dashboards-visualization-color-mapping.md) | Visualization Color Mapping |
 | [opensearch-dashboards-webpack-and-build-performance](opensearch-dashboards-webpack-and-build-performance.md) | Webpack & Build Performance |
 | [opensearch-dashboards-workspace](opensearch-dashboards-workspace.md) | Workspace |

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-visbuilder.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-visbuilder.md
@@ -1,0 +1,112 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# VisBuilder
+
+## Summary
+
+VisBuilder is a drag-and-drop visualization tool in OpenSearch Dashboards that allows users to create data visualizations without preselecting the visualization output type. It provides an immediate view of data with intuitive field-based configuration.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "VisBuilder Plugin"
+        subgraph "UI Components"
+            DND[Drag & Drop Interface]
+            CONFIG[Configuration Pane]
+            PREVIEW[Visualization Preview]
+        end
+        
+        subgraph "Visualization Types"
+            METRIC[Metric Vis]
+            TABLE[Table Vis]
+            BAR[Bar Chart]
+            LINE[Line Chart]
+            AREA[Area Chart]
+        end
+        
+        subgraph "Expression Renderer"
+            EXPR[ReactExpressionRenderer]
+            CONTAINER[VisualizationContainer]
+        end
+    end
+    
+    subgraph "Data Layer"
+        INDEX[Index Pattern]
+        DS[Data Source]
+    end
+    
+    DND --> CONFIG
+    CONFIG --> PREVIEW
+    PREVIEW --> EXPR
+    EXPR --> METRIC
+    EXPR --> TABLE
+    EXPR --> BAR
+    EXPR --> LINE
+    EXPR --> AREA
+    INDEX --> EXPR
+    DS --> INDEX
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Drag & Drop Interface | Field selector with drag-and-drop to axis wells |
+| Configuration Pane | Side panel for configuring visualization options |
+| Visualization Preview | Real-time preview of the visualization |
+| ReactExpressionRenderer | Expression-based rendering engine |
+| VisualizationContainer | Wrapper component for loading states and error handling |
+
+### Supported Visualization Types
+
+| Type | Description |
+|------|-------------|
+| Metric | Single value display with optional comparison |
+| Table | Tabular data display with sorting |
+| Bar Chart | Vertical/horizontal bar visualizations |
+| Line Chart | Time-series line visualizations |
+| Area Chart | Stacked or overlapping area visualizations |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| Index Pattern | Data source for visualization | Required |
+| Metrics | Aggregation fields (Y-axis) | Count |
+| Buckets | Grouping fields (X-axis) | None |
+| Legend | Show/hide legend | Visible |
+
+### Usage Example
+
+1. Navigate to Visualize → Create visualization → VisBuilder
+2. Select an index pattern
+3. Drag fields from the field list to Metrics or Buckets wells
+4. Configure aggregation options in the configuration pane
+5. Save the visualization
+
+## Limitations
+
+- Some visualization types may have rendering issues with specific data configurations
+- Legend toggle may require page refresh in certain scenarios (fixed in v2.16.0)
+- Data source compatibility requires proper index pattern ID handling
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Bug fixes for Metric/Table rendering, configuration pane scrolling, legend toggle, and data source compatibility
+
+## References
+
+### Documentation
+- [VisBuilder Documentation](https://docs.opensearch.org/latest/dashboards/visualize/visbuilder/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#6674](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6674) | Fix flat render structure in Metric and Table Vis |
+| v2.16.0 | [#6811](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6811) | Bug fixes for config pane scroll and legend toggle |
+| v2.16.0 | [#6948](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6948) | Fix vis-builder not rendering with data source |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/visbuilder-fixes.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/visbuilder-fixes.md
@@ -1,0 +1,55 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# VisBuilder Fixes
+
+## Summary
+
+Bug fixes for VisBuilder visualization tool in OpenSearch Dashboards v2.16.0, addressing rendering issues with Metric and Table visualizations, configuration pane scrolling problems, legend toggle functionality, and data source compatibility.
+
+## Details
+
+### What's New in v2.16.0
+
+Three PRs addressed critical VisBuilder bugs:
+
+1. **Flat Render Structure Fix** (PR #6674): Fixed rendering issues in Metric and Table visualizations caused by callback behavior in `ReactExpressionRenderer`. The `VisualizationContainer` wrapper was preventing proper `isLoading` state updates.
+
+2. **Configuration Pane and Legend Toggle Fixes** (PR #6811): Fixed two UI issues:
+   - Configuration pane scrolling horizontally when dragging fields (caused by secondary edit pane being added to DOM even when not in use)
+   - Legend toggle affordance not working after initial toggle
+
+3. **Data Source Compatibility Fix** (PR #6948): Fixed VisBuilder visualizations not rendering when using multiple data sources. Added handling for `visbuilder` type to support data source by updating references with proper index pattern ID prefixes.
+
+### Technical Changes
+
+| Issue | Root Cause | Fix |
+|-------|------------|-----|
+| Metric/Table not rendering | `VisualizationContainer` wrapper breaking `isLoading` callback | Moved `VisualizationContainer` directly into `MetricVisComponent` |
+| Config pane horizontal scroll | Secondary edit pane in DOM when not visible | Hide secondary pane properly when not in use |
+| Legend toggle broken | State not updating correctly after first toggle | Fixed toggle state management |
+| Data source rendering failure | Index pattern ID missing data source prefix | Added `visbuilder` type handling in sample data reference updates |
+
+### Affected Components
+
+| Component | File Path |
+|-----------|-----------|
+| MetricVisComponent | `src/plugins/vis_builder/public/visualizations/metric/` |
+| TableVisComponent | `src/plugins/vis_builder/public/visualizations/table/` |
+| Configuration Pane | `src/plugins/vis_builder/public/application/components/` |
+| Sample Data Util | `src/plugins/home/server/services/sample_data/data_sets/util.ts` |
+
+## Limitations
+
+- These fixes are specific to VisBuilder; similar issues in other visualization types may require separate fixes
+- Data source compatibility fix only addresses sample data scenarios
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#6674](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6674) | Flat render structure in Metric and Table Vis | [#6671](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6671) |
+| [#6811](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6811) | Bug Fixes for Vis Builder | [#6679](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6679), [#6680](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6680) |
+| [#6948](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6948) | Fix web log sample visualization & vis-builder not rendering with data source | [#6857](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6857), [#6938](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6938) |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -25,5 +25,6 @@
 - Sidecar Z-Index Fix
 - Timeline Visualization Fixes
 - Vega Visualization Fixes
+- VisBuilder Fixes
 - Visualization Color Fix
 - Workspace


### PR DESCRIPTION
## Summary

Investigation of VisBuilder bug fixes in OpenSearch Dashboards v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch-dashboards/visbuilder-fixes.md`
- Feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-visbuilder.md` (created)

### Key Changes in v2.16.0
- Fixed Metric and Table visualization rendering issues (PR #6674)
- Fixed configuration pane horizontal scrolling when dragging fields (PR #6811)
- Fixed legend toggle not working after initial toggle (PR #6811)
- Fixed VisBuilder not rendering with data source (PR #6948)

### PRs Investigated
- [#6674](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6674) - Flat render structure in Metric and Table Vis
- [#6811](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6811) - Bug Fixes for Vis Builder
- [#6948](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6948) - Fix web log sample visualization & vis-builder not rendering with data source

Closes #2313