### PR TITLE
docs: add Discover Fixes report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-discover.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-discover.md
@@ -150,7 +150,7 @@ Requires ML agent configuration:
 - **v3.0.0** (2025-05-13): Added CSV export functionality, reorganized results display with ResultsActionBar, customizable summary panel title, experimental Data plugin `__enhance` API with resultsActionBar, and 6 bug fixes for saved search handling and workspace integration
 - **v2.19.0** (2025-01-14): Added indexed views framework to dataset selector, results canvas banner framework, data2summary agent validation, default query string framework, custom time filter logic per dataset type, query editor bottom panel extension, and Cypress test data attributes
 - **v2.18.0** (2024-11-05): Added AI-powered data summary panel, updated visual appearance, cache management in dataset selector, and 14 bug fixes for stability and usability
-- **v2.16.0** (2024-08-06): Fixed Discover Next styling issues (query bar, dataset navigator, language selector, field search), database loading display for external data sources, and quick range time picker date math parsing
+- **v2.16.0** (2024-08-06): Fixed discover options location, legacy URL global state migration, duplicate timestamp column, anchor row highlighting in surrounding docs view, wide table last column rendering, Discover Next styling issues, and database loading display for external data sources
 
 
 ## References
@@ -204,6 +204,10 @@ Requires ML agent configuration:
 ### v2.16.0 Pull Requests
 | PR | Description |
 |----|-------------|
-| [#6782](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6782) | Fixes quick range time picker to use datemath for parsing |
+| [#7581](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7581) | Fix discover options' location |
+| [#6780](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6780) | Migrate global state from legacy URL |
+| [#6983](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6983) | Check if timestamp is already included to remove duplicate column |
+| [#7025](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7025) | Highlight the anchor row in surrounding doc view |
+| [#7058](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7058) | Allow last column of wide table to show properly |
 | [#7546](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7546) | Fixes Discover next styling |
 | [#7567](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7567) | Fixes databases not being displayed upon success |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/discover-fixes.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/discover-fixes.md
@@ -6,50 +6,82 @@ tags:
 
 ## Summary
 
-Bug fixes for the Discover Next (Discover 2.0) feature in OpenSearch Dashboards v2.16.0, addressing styling issues and database loading display problems when query enhancements are enabled.
+Bug fixes and improvements for the Discover application in OpenSearch Dashboards v2.16.0, addressing UI layout issues, URL state migration, duplicate column handling, surrounding document view highlighting, and table column rendering.
 
 ## Details
 
 ### What's New in v2.16.0
 
-Two bug fixes were introduced to improve the Discover Next experience:
+Seven fixes were introduced to improve the Discover experience:
 
-1. **Styling Fixes** - Corrected styling issues in the Discover 2.0 page when the query enhancements toggle is enabled, including:
-   - Query bar styling improvements
-   - Dataset navigator styling updates with database icon and tooltip
-   - Language selector with arrow down icon
-   - Query editor layout restructuring with collapsible sections
-   - Sidebar field search styling improvements
-   - Histogram chart wrapper styling
+1. **Discover Options Location Fix** (PR #7581) - Repositioned the discover options (document table settings) to appear inline with the hits counter instead of below the time chart header, improving UI layout when query enhancements toggle is off.
 
-2. **Database Loading Fix** - Fixed an issue where databases were not being displayed in the dataset navigator after successful loading from external data sources.
+2. **Legacy URL Global State Migration** (PR #6780) - Fixed migration of global state (`_g` parameter) from legacy Discover URLs. Previously, time range, filters, and refresh interval settings were lost when navigating from legacy URLs.
+
+3. **Duplicate Timestamp Column Fix** (PR #6983) - Fixed duplicate timestamp column appearing in the document table when the time field was already included in the selected columns.
+
+4. **Anchor Row Highlighting** (PR #7025) - Added visual highlighting for the anchor row in the surrounding documents view, making it easier to identify the context document.
+
+5. **Wide Table Last Column Fix** (PR #7058) - Fixed the last column of tables wider than the viewport being crushed. Now all columns including the last one have fixed widths set.
+
+6. **Styling Fixes** (PR #7546) - Corrected styling issues in the Discover 2.0 page when query enhancements toggle is enabled.
+
+7. **Database Loading Fix** (PR #7567) - Fixed databases not being displayed in the dataset navigator after successful loading from external data sources.
 
 ### Technical Changes
 
-#### Styling Changes (PR #7546)
+#### Discover Options Location (PR #7581)
 
 | Component | Change |
 |-----------|--------|
-| Dataset Navigator | Added database icon, tooltip, and updated CSS class naming |
-| Query Editor | Restructured layout with collapsible top bar and body sections |
-| Language Selector | Added arrow down icon, sorted language options alphabetically |
-| Field Search | Updated styling for query enhancements mode |
-| Chart Wrapper | Added border and padding styling for histogram |
-| App Container | Added height calculations for `dsc--next` class |
+| Chart Header | Moved `discoverOptions` from separate row to inline with `hitsCounter` |
+| Toggle Button | Renamed from `queryEditorCollapseBtn` to `histogramCollapseBtn` |
+| i18n Labels | Updated toggle label from `queryEditor.collapse` to `histogram.collapse` |
 
-#### Database Loading Fix (PR #7567)
+#### Legacy URL Migration (PR #6780)
 
-Added `useEffect` hook in `DataSetNavigator` component to properly handle the `SUCCESS` status from `databasesLoadStatus`, ensuring databases are displayed after successful loading from external data sources.
+Added global state (`_g`) extraction and migration in `migrateUrlState()` function:
+- Extracts `_g` state containing time range, filters, and refresh interval
+- Preserves global state when migrating from legacy `#/` or `#/view/{id}` URLs
+- Added comprehensive unit tests for migration scenarios
+
+#### Duplicate Column Prevention (PR #6983)
+
+Modified `getLegacyDisplayedColumns()` in `helper.tsx`:
+- Added check `!columns.includes(indexPattern.timeFieldName)` before prepending time column
+- Prevents duplicate timestamp column when user explicitly adds time field to columns
+- Added unit tests covering various column configuration scenarios
+
+#### Anchor Row Highlighting (PR #7025)
+
+| Change | Description |
+|--------|-------------|
+| Type Extension | Added `isAnchor?: boolean` property to `OpenSearchSearchHit` type |
+| Row Styling | Added conditional `osdDocTable__row--highlight` class to anchor rows |
+| Visual Effect | Anchor document now visually distinguished in surrounding docs view |
+
+#### Wide Table Column Fix (PR #7058)
+
+Changed column width calculation in `DefaultDiscoverTable`:
+- Previously: Last column excluded from fixed width calculation to allow growth
+- Now: All columns (except first) get fixed widths based on `getBoundingClientRect()`
+- Prevents last column from being crushed when table exceeds viewport width
 
 ## Limitations
 
 - Styling changes only apply when the query enhancements toggle is enabled
-- Database loading fix specifically addresses external data source types (`SIMPLE_DATA_SOURCE_TYPES.EXTERNAL`)
+- Database loading fix specifically addresses external data source types
+- Anchor row highlighting requires the `isAnchor` property to be set on the document
 
 ## References
 
 ### Pull Requests
 | PR | Description | Related Issue |
 |----|-------------|---------------|
-| [#7546](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7546) | Fixes Discover next styling |  |
-| [#7567](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7567) | Fixes databases not being displayed upon success |  |
+| [#7581](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7581) | Fix discover options' location | |
+| [#6780](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6780) | Migrate global state from legacy URL | [#6766](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6766) |
+| [#6983](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6983) | Check if timestamp is already included to remove duplicate column | [#6982](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6982) |
+| [#7025](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7025) | Highlight the anchor row in surrounding doc view | [#6457](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6457) |
+| [#7058](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7058) | Allow last column of wide table to show properly | [#7056](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7056) |
+| [#7546](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7546) | Fixes Discover next styling | |
+| [#7567](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7567) | Fixes databases not being displayed upon success | |


### PR DESCRIPTION
## Summary

Updates the Discover Fixes release report for v2.16.0 with additional PRs from Issue #2312.

### Changes

**Release Report** (`docs/releases/v2.16.0/features/opensearch-dashboards/discover-fixes.md`):
- Added 5 additional PRs to the existing report:
  - PR #7581: Fix discover options' location
  - PR #6780: Migrate global state from legacy URL
  - PR #6983: Check if timestamp is already included to remove duplicate column
  - PR #7025: Highlight the anchor row in surrounding doc view
  - PR #7058: Allow last column of wide table to show properly
- Updated summary and technical details sections

**Feature Report** (`docs/features/opensearch-dashboards/opensearch-dashboards-discover.md`):
- Updated v2.16.0 Change History entry
- Added new PRs to v2.16.0 Pull Requests reference section

### Related Issue
Closes #2312