### PR TITLE
docs: add Data Set Navigator report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-discover.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-discover.md
@@ -150,7 +150,7 @@ Requires ML agent configuration:
 - **v3.0.0** (2025-05-13): Added CSV export functionality, reorganized results display with ResultsActionBar, customizable summary panel title, experimental Data plugin `__enhance` API with resultsActionBar, and 6 bug fixes for saved search handling and workspace integration
 - **v2.19.0** (2025-01-14): Added indexed views framework to dataset selector, results canvas banner framework, data2summary agent validation, default query string framework, custom time filter logic per dataset type, query editor bottom panel extension, and Cypress test data attributes
 - **v2.18.0** (2024-11-05): Added AI-powered data summary panel, updated visual appearance, cache management in dataset selector, and 14 bug fixes for stability and usability
-- **v2.16.0** (2024-08-06): Fixed discover options location, legacy URL global state migration, duplicate timestamp column, anchor row highlighting in surrounding docs view, wide table last column rendering, Discover Next styling issues, and database loading display for external data sources
+- **v2.16.0** (2024-08-06): Added Data Set Navigator component with DataSetManager service for dataset state management and URL state synchronization; fixed discover options location, legacy URL global state migration, duplicate timestamp column, anchor row highlighting in surrounding docs view, wide table last column rendering, Discover Next styling issues, and database loading display for external data sources
 
 
 ## References
@@ -204,6 +204,7 @@ Requires ML agent configuration:
 ### v2.16.0 Pull Requests
 | PR | Description |
 |----|-------------|
+| [#7492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7492) | Add back data set navigator to control state |
 | [#7581](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7581) | Fix discover options' location |
 | [#6780](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6780) | Migrate global state from legacy URL |
 | [#6983](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6983) | Check if timestamp is already included to remove duplicate column |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/data-set-navigator.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/data-set-navigator.md
@@ -1,0 +1,86 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Data Set Navigator
+
+## Summary
+
+This release re-adds the Data Set Navigator component to the control state in OpenSearch Dashboards. The Data Set Navigator is part of the "discover-next" feature that enables users to select and manage datasets when the query enhancements toggle is enabled. This change introduces a new `DataSetManager` service for managing dataset state and integrates it with the query state synchronization system.
+
+## Details
+
+### What's New in v2.16.0
+
+The PR adds back the Data Set Navigator component that was temporarily removed during other changes. Key additions include:
+
+1. **DataSetManager Service**: A new service (`DataSetManager`) that manages the current dataset state with reactive updates via RxJS observables
+2. **Dataset State Synchronization**: Integration with the query state sync system to persist dataset selection in URL state
+3. **UI Component Export**: The `DataSetNavigator` component is now exported from the data plugin's public API
+4. **Data Types**: New TypeScript types for `SimpleDataSet`, `SimpleDataSource`, and related enums
+
+### Technical Changes
+
+#### New DataSetManager Service
+
+```typescript
+// src/plugins/data/public/query/dataset_manager/dataset_manager.ts
+export class DataSetManager {
+  private dataSet$: BehaviorSubject<SimpleDataSet | undefined>;
+  
+  public init = async (indexPatterns: IndexPatternsContract) => {...};
+  public getUpdates$ = () => this.dataSet$.asObservable().pipe(skip(1));
+  public getDataSet = () => this.dataSet$.getValue();
+  public setDataSet = (dataSet: SimpleDataSet | undefined) => {...};
+  public getDefaultDataSet = () => this.defaultDataSet;
+}
+```
+
+#### New Data Types
+
+| Type | Description |
+|------|-------------|
+| `SIMPLE_DATA_SOURCE_TYPES` | Enum for data source types (`data-source`, `external-source`) |
+| `SIMPLE_DATA_SET_TYPES` | Enum for dataset types (`index-pattern`, `temporary`, `temporary-async`) |
+| `SimpleDataSet` | Interface for dataset with id, title, fields, timeFieldName |
+| `SimpleDataSource` | Interface for data source with id, name, indices, tables |
+| `DataFrameQueryConfig` | Configuration for dataframe queries |
+
+#### Query State Integration
+
+The dataset state is now synchronized with URL state through `connectStorageToQueryState` and `connectToQueryState` functions, allowing dataset selection to persist across page navigation.
+
+#### Exported APIs
+
+New exports from `@opensearch-project/opensearch-dashboards/data`:
+- `DataSetNavigator` - UI component for dataset selection
+- `DataSetManager` - Service for managing dataset state
+- `DataSetContract` - Type definition for the service contract
+- `setAsyncSessionId`, `getAsyncSessionId`, `setAsyncSessionIdByObj` - Session management utilities
+
+### Configuration
+
+The Data Set Navigator is enabled when the query enhancements setting is turned on:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `query:enhancements:enabled` | Enable query enhancements including Data Set Navigator | `false` |
+| `home:useNewHomePage` | Enable new home page (used with enhancements) | `false` |
+
+## Limitations
+
+- The Data Set Navigator only appears when `query:enhancements:enabled` is set to `true`
+- Dataset state synchronization requires the query enhancements feature flag
+- Some dashboard listing tests were skipped due to state management changes
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#7492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7492) | Add back data set navigator to control state | N/A |
+| [#7532](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7532) | Backport to 2.x branch | N/A |
+| [#7542](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7542) | Update fetch functions to include local cluster | N/A |
+| [#7546](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7546) | Fixes Discover next styling | N/A |
+| [#7552](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7552) | Fix query assist after data set navigator changes | N/A |
+| [#7566](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7566) | Fixes dataset navigator menu styling & search error toast | N/A |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -9,6 +9,7 @@
 - Build & Compilation Fixes
 - CI/CD Improvements
 - Dashboard Flyout Fix
+- Data Set Navigator
 - Data Source Client Fixes
 - Data Source Form Tests
 - Data Source Management Bug Fixes


### PR DESCRIPTION
## Summary
Add documentation for the Data Set Navigator feature in OpenSearch Dashboards v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch-dashboards/data-set-navigator.md`
- Feature report: Updated `docs/features/opensearch-dashboards/opensearch-dashboards-discover.md`

### Key Changes in v2.16.0
- Added Data Set Navigator component with DataSetManager service
- Dataset state management with URL state synchronization
- New TypeScript types for SimpleDataSet, SimpleDataSource
- Integration with query state sync system

### Resources Used
- PR: [#7492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7492)
- Related PRs: #7532, #7542, #7546, #7552, #7566