### PR TITLE
docs: add OUI Bump report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-oui.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-oui.md
@@ -90,6 +90,7 @@ function MyComponent() {
 
 - **v3.2.0** (2025-07-29): Updated to OUI 1.21 with `preserveTabContent` prop for `EuiTabbedContent` component
 - **v2.18.0** (2024-11-05): Updated to OUI 1.15 with new `$euiSideNavBackgroundColor` variable, font changes from Fira Code to Source Code Pro
+- **v2.16.0** (2024-07-22): Updated to OUI 1.8 with Split Button component, faster animations, compressed form components, and accessibility improvements
 
 
 ## References
@@ -106,3 +107,4 @@ function MyComponent() {
 | v2.18.0 | [#8246](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8246) | Update OUI to 1.13 |   |
 | v2.18.0 | [#8372](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8372) | Update OUI to 1.14 |   |
 | v2.18.0 | [#8480](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8480) | Update OUI to 1.15 |   |
+| v2.16.0 | [#7363](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7363) | Update OUI to 1.8 |   |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/oui-bump.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/oui-bump.md
@@ -1,0 +1,68 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# OUI Bump
+
+## Summary
+
+OpenSearch Dashboards v2.16.0 updates the OpenSearch UI (OUI) component library from version 1.7.0 to 1.8.0. This update brings UI improvements including a new Split Button component, enhanced accessibility, faster animations, and various bug fixes.
+
+## Details
+
+### What's New in v2.16.0
+
+The OUI 1.8.0 update includes:
+
+| Category | Changes |
+|----------|---------|
+| New Components | Split Button component for combined action/dropdown buttons |
+| Accessibility | Improved screenreader support for data grid copy/paste |
+| UI Polish | Faster animations for modals, popovers, and tooltips |
+| Typography | Base font size set to 18px in Next Theme |
+| Buttons | Consistent font sizes, reverted font-weight to normal |
+| Forms | Compressed form components, color-picker, and combobox |
+| Bug Fixes | Breadcrumb alignment, data grid lines, resizable panel collapse button |
+
+### Technical Changes
+
+The update modifies the `@opensearch-project/oui` dependency across multiple packages:
+
+| Package | Change |
+|---------|--------|
+| `package.json` | `1.7.0` → `1.8.0` |
+| `packages/osd-ui-framework/package.json` | `1.7.0` → `1.8.0` |
+| `packages/osd-ui-shared-deps/package.json` | `1.7.0` → `1.8.0` |
+| Test plugin packages | `1.7.0` → `1.8.0` |
+
+### Key OUI 1.8.0 Features
+
+**Split Button Component**
+A new component combining a primary action button with a dropdown for additional options.
+
+**Accessibility Improvements**
+- Eliminated screenreader content when copying/pasting data grid tables
+- Fixed info tooltip display on icon-only buttons
+
+**Animation Performance**
+Faster animations for modals, popovers, and tooltips improve perceived responsiveness.
+
+**Form Component Updates**
+- Compressed variants for form components
+- Updated color-picker and combobox components
+- Filter button improvements
+
+## Limitations
+
+- This is a dependency update; no new APIs are exposed directly to plugins
+- The PR was labeled "Skip-Changelog" indicating minimal user-facing impact
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#7363](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7363) | Bump OUI to 1.8.0 | - |
+
+### OUI Release
+- [OUI 1.8.0 Release Notes](https://github.com/opensearch-project/oui/releases/tag/1.8.0)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -19,6 +19,7 @@
 - MDS Version Decoupling
 - Navigation Next
 - OpenAPI Specification
+- OUI Bump
 - Query Editor Extensions Fix
 - Quick Range Selection Fix
 - Sample Data Import


### PR DESCRIPTION
## Summary

Adds release report for OUI Bump in OpenSearch Dashboards v2.16.0.

## Changes

- Created release report: `docs/releases/v2.16.0/features/opensearch-dashboards/oui-bump.md`
- Updated feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-oui.md`
- Updated release index: `docs/releases/v2.16.0/index.md`

## Key Findings

OUI 1.8.0 update (from 1.7.0) includes:
- New Split Button component
- Faster animations for modals, popovers, tooltips
- Compressed form components
- Accessibility improvements for data grid
- Various bug fixes

Closes #2310