### PR TITLE
docs: add home-page-enhancements report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/index.md
+++ b/docs/features/opensearch-dashboards/index.md
@@ -36,6 +36,7 @@
 | [opensearch-dashboards-explore-traces](opensearch-dashboards-explore-traces.md) | Explore Traces |
 | [opensearch-dashboards-explore](opensearch-dashboards-explore.md) | Explore Plugin |
 | [opensearch-dashboards-global-search](opensearch-dashboards-global-search.md) | Global Search |
+| [opensearch-dashboards-home-page](opensearch-dashboards-home-page.md) | Home Page |
 | [opensearch-dashboards-i18n-localization](opensearch-dashboards-i18n-localization.md) | i18n & Localization |
 | [opensearch-dashboards-input-control-visualization](opensearch-dashboards-input-control-visualization.md) | Input Control Visualization |
 | [opensearch-dashboards-keyboard-shortcuts](opensearch-dashboards-keyboard-shortcuts.md) | Keyboard Shortcuts |

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-home-page.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-home-page.md
@@ -1,0 +1,98 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Home Page
+
+## Summary
+
+The OpenSearch Dashboards Home Page provides a customizable landing experience with dynamic content areas, static information cards, and workspace integration. It serves as the central hub for users to access documentation, recent items, and getting started resources.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Home Page System"
+        A[Home Plugin] --> B[Content Management Plugin]
+        B --> C[Page Registry]
+        C --> D[HOME_PAGE_ID]
+        D --> E[Content Areas]
+    end
+    subgraph "Content Areas"
+        E --> F[SERVICE_CARDS]
+        F --> G[What's New Card]
+        F --> H[Learn OpenSearch Card]
+        F --> I[Workspace Cards]
+    end
+    subgraph "Settings"
+        J[Advanced Settings] --> K[home:useNewHomePage]
+        K --> L[Enable/Disable New UI]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `HomeListCard` | Renders static content cards with title, description list, and optional "View all" link |
+| `SectionTypeService` | Manages home page sections and content providers |
+| Content Management | Plugin that handles dynamic content registration and rendering |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `home:useNewHomePage` | Enable the new home page UI | `false` |
+
+### Static List Cards
+
+The home page includes pre-configured static cards:
+
+#### What's New Card
+Displays latest updates and announcements with links to documentation.
+
+#### Learn OpenSearch Card
+Provides quick access to:
+- Quickstart guide
+- Building data visualizations
+- Creating dashboards
+
+### Content Provider Registration
+
+Plugins can register content providers to add cards to the home page:
+
+```typescript
+contentManagement.registerContentProvider({
+  id: 'my_card',
+  getContent: () => ({
+    id: 'my_content',
+    kind: 'custom',
+    order: 5,
+    render: () => React.createElement(MyComponent),
+  }),
+  getTargetArea: () => HOME_CONTENT_AREAS.SERVICE_CARDS,
+});
+```
+
+## Limitations
+
+- Static card content is hardcoded and not configurable via UI
+- New home page requires explicit opt-in via advanced settings
+- Some features require additional permissions when workspace is enabled
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Added static list cards (What's New, Learn OpenSearch); fixed crash for users without write permissions
+
+## References
+
+### Documentation
+- [OpenSearch Dashboards Quickstart](https://opensearch.org/docs/latest/dashboards/quickstart/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#7351](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7351) | Add home page static list card |
+| v2.16.0 | [#7054](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7054) | Fix crash for anonymous users without write permission |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/home-page-enhancements.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/home-page-enhancements.md
@@ -1,0 +1,76 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Home Page Enhancements
+
+## Summary
+
+OpenSearch Dashboards v2.16.0 introduces static list cards to the new home page and fixes a critical bug that caused the home page to crash for users without write permissions.
+
+## Details
+
+### What's New in v2.16.0
+
+#### Static List Cards
+
+A new `HomeListCard` component provides configurable static content cards for the home page. Two pre-configured cards are registered:
+
+| Card | Purpose |
+|------|---------|
+| What's New | Displays latest updates and announcements |
+| Learn OpenSearch | Links to quickstart guide, visualization docs, and dashboard creation guides |
+
+The cards are rendered in the `SERVICE_CARDS` content area with configurable order (3 and 4 respectively).
+
+#### Bug Fix: Anonymous User Support
+
+Fixed a critical issue where the new home page crashed for users without index write permissions. The fix removes the error handling that blocked page rendering when the `homepage.save({})` call failed.
+
+### Technical Changes
+
+```mermaid
+graph TB
+    subgraph "Home Page Architecture"
+        A[Home Plugin] --> B[Content Management]
+        B --> C[SERVICE_CARDS Area]
+        C --> D[What's New Card]
+        C --> E[Learn OpenSearch Card]
+    end
+    subgraph "Bug Fix"
+        F[SectionTypeService] --> G[homepage.save]
+        G -.->|No longer blocks| H[Page Render]
+    end
+```
+
+#### New Component: HomeListCard
+
+```typescript
+interface Config {
+  title: string;
+  list: Array<{
+    label: string;
+    href: string;
+    description: string;
+  }>;
+  allLink?: string;
+}
+```
+
+The component renders:
+- A title header
+- A description list with external links
+- Optional "View all" link
+
+## Limitations
+
+- Static list card content is hardcoded and not configurable via settings
+- The bug fix is a temporary solution; a more robust permission-aware approach may be needed
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#7351](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7351) | Add home page static list card | - |
+| [#7054](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7054) | Fix crash for users without write permission | [#6320](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6320) |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch-dashboards
 - Aggregated View Fixes
+- Home Page Enhancements
 - Breadcrumb & Router Fixes
 - OSD Availability
 - Build & Compilation Fixes


### PR DESCRIPTION
## Summary

Adds investigation report for Home Page Enhancements in OpenSearch Dashboards v2.16.0.

### Changes in v2.16.0
- Added static list cards (What's New, Learn OpenSearch) to the new home page
- Fixed critical bug where home page crashed for users without write permissions

### Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch-dashboards/home-page-enhancements.md`
- Feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-home-page.md`

### Related PRs
- [#7351](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7351) - Add home page static list card
- [#7054](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7054) - Fix crash for anonymous users

Closes #2309