### PR TITLE
docs: add navigation-next category update report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-navigation.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-navigation.md
@@ -127,7 +127,7 @@ The navigation automatically adapts to screen size:
 
 - **v3.4.0** (2025-10-08): Fixed disabled prop propagation for navigation links - `isDisabled` state now correctly passed to `EuiSideNavItem` components
 - **v2.18.0** (2024-10-22): Flattened navigation in Analytics(all) use case, persistent expand/collapse state, small screen compatibility, border style updates, sample data menu restored
-- **v2.16.0** (2024-08-06): Fixed breadcrumb navigation for 4 migrated applications (Assets, Index Pattern Management, Data Sources Management, Application Settings) when new navigation enabled; added `getScopedBreadcrumbs` utility for BrowserRouter compatibility; workspace overview visible in all use cases; fixed Dev Tools tab CSS for new left navigation; fixed navigation-next integration issues (auto-collapse on home, typo fixes, workspace visibility); redirect users to home in global when workspace enabled
+- **v2.16.0** (2024-08-06): Renamed "Detect" category to "Configure" with adjusted ordering (Configure: 2000, Visualize and Report: 3000); fixed breadcrumb navigation for 4 migrated applications (Assets, Index Pattern Management, Data Sources Management, Application Settings) when new navigation enabled; added `getScopedBreadcrumbs` utility for BrowserRouter compatibility; workspace overview visible in all use cases; fixed Dev Tools tab CSS for new left navigation; fixed navigation-next integration issues (auto-collapse on home, typo fixes, workspace visibility); redirect users to home in global when workspace enabled
 
 
 ## References
@@ -144,6 +144,7 @@ The navigation automatically adapts to screen size:
 | v2.18.0 | [#8489](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8489) | Update border style when new left nav expanded | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v2.18.0 | [#8076](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8076) | Add sample data menu back | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v2.18.0 | [#7962](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7962) | Make left nav compatible with small screen | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
+| v2.16.0 | [#7339](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7339) | Update category: rename Detect to Configure | - |
 | v2.16.0 | [#7551](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7551) | Redirect user to home in global when workspace enabled | - |
 | v2.16.0 | [#7401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7401) | Fix breadcrumb for migrated apps with BrowserRouter | - |
 | v2.16.0 | [#7356](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7356) | Fix navigation-next integration issues | - |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/navigation-next.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/navigation-next.md
@@ -6,11 +6,23 @@ tags:
 
 ## Summary
 
-Bug fixes for the new left navigation system in OpenSearch Dashboards v2.16.0. These changes address CSS styling issues in Dev Tools, workspace integration problems, and navigation behavior when workspaces are enabled.
+Updates and bug fixes for the new left navigation system in OpenSearch Dashboards v2.16.0. Key changes include renaming the "Detect" category to "Configure" with adjusted ordering, CSS styling fixes in Dev Tools, workspace integration improvements, and navigation behavior enhancements when workspaces are enabled.
 
 ## Details
 
 ### What's New in v2.16.0
+
+#### Category Updates
+Updated navigation categories in `default_app_categories.ts`:
+- Renamed "Detect" category to "Configure" for better clarity
+- Adjusted category ordering: Configure now has order 2000 (previously Detect was 3000)
+- Visualize and Report category order changed to 3000 (previously 2000)
+- Added deprecation markers for legacy category names (`dashboardAndReport`, `detect`)
+
+| Category | Old Order | New Order |
+|----------|-----------|-----------|
+| Configure (was Detect) | 3000 | 2000 |
+| Visualize and Report | 2000 | 3000 |
 
 #### Dev Tools Tab CSS Fix
 Updated CSS for Dev Tools tabs to work correctly with the new left navigation. Removed `justify-content: space-between` styling that caused incorrect tab spacing when Workbench was moved to Dev Tools.
@@ -32,6 +44,8 @@ When workspace is enabled, users are redirected to home in global context to pre
 
 | Change | Description |
 |--------|-------------|
+| Category rename | "Detect" → "Configure" in default_app_categories.ts |
+| Category ordering | Configure: 2000, Visualize and Report: 3000 |
 | Dev Tools CSS | Removed `justify-content: space-between` from dev tools tab styling |
 | Workspace visibility | Marked admin pages as not visible within workspace |
 | Navigation collapse | Auto-collapse left nav on home when workspace enabled |
@@ -41,12 +55,14 @@ When workspace is enabled, users are redirected to home in global context to pre
 
 - These fixes are specific to the new navigation system (feature flag required)
 - Workspace feature must be enabled for some fixes to take effect
+- Legacy category names (`dashboardAndReport`, `detect`) are deprecated but still available for backward compatibility
 
 ## References
 
 ### Pull Requests
 | PR | Description | Related Issue |
 |----|-------------|---------------|
+| [#7339](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7339) | Update category: rename Detect to Configure, adjust ordering | - |
 | [#7328](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7328) | Update dev tools tab css for new left navigation | - |
 | [#7356](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7356) | Fix navigation-next integration issues | - |
 | [#7551](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7551) | Redirect user to home in global when workspace is enabled | - |


### PR DESCRIPTION
## Summary
Updates documentation for Navigation Next feature in v2.16.0 to include PR #7339 which renamed the "Detect" category to "Configure" and adjusted category ordering.

### Reports Updated
- Release report: `docs/releases/v2.16.0/features/opensearch-dashboards/navigation-next.md`
- Feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-navigation.md`

### Key Changes in v2.16.0
- Renamed "Detect" category to "Configure" for better clarity
- Adjusted category ordering: Configure (2000), Visualize and Report (3000)
- Added deprecation markers for legacy category names

### Resources Used
- PR: [#7339](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7339)