### PR TITLE
docs: update workspace report for v2.16.0 with additional PRs

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-workspace.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-workspace.md
@@ -174,7 +174,7 @@ opensearch_security.multitenancy.enabled: false
 - **v3.0.0** (2025-05-06): Bug fixes for saved object isolation, recent items error filtering, and stale workspace error handling
 - **v2.19.0** (2025-01-09): Added dismissible get started section for overview pages; optimized recent items with workspace deletion filtering; refactored bulk_get permission handler for better error responses; added privacy levels for workspace access control; enabled category-based search for Dev Tools; added two-step loading for data source association modal
 - **v2.18.0** (2024-11-05): Major feature additions including workspace-level UI settings, collaborator management system (WorkspaceCollaboratorTypesService, AddCollaboratorsModal, Collaborators Page), data connection integration, global search bar in left nav, ACL auditor for permission bypass detection; 14 bug fixes for UI/UX improvements
-- **v2.16.0** (2024-08-06): Bug fixes for data source preservation on workspace deletion, navigation to detail page for all use case workspaces, permission validation on detail page, added workspaces/permissions fields to _bulk_get response, and fixed saved objects management page to show error toast when workspace read-only users fail to delete saved objects
+- **v2.16.0** (2024-08-06): Added get started cards on home page, admin-only workspace creation controls, enriched breadcrumbs with workspace/use case context; restricted saved objects access for non-admin users; fixed workspace name duplication check to use exact match; bug fixes for data source preservation on workspace deletion, navigation to detail page for all use case workspaces, permission validation on detail page, added workspaces/permissions fields to _bulk_get response
 
 
 ## References
@@ -225,6 +225,11 @@ opensearch_security.multitenancy.enabled: false
 | v2.18.0 | [#8675](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8675) | Fix non-workspace admin defaultIndex update | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v2.18.0 | [#8718](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8718) | Fix index pattern issues |   |
 | v2.18.0 | [#8719](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8719) | Generate short URL with workspace info | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
+| v2.16.0 | [#7333](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7333) | Register four get started cards in home page | [#7332](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7332) |
+| v2.16.0 | [#7357](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7357) | Hide create workspace button for non dashboard admin | [#7358](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7358) |
+| v2.16.0 | [#7360](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7360) | Enrich breadcrumbs by workspace and use case | [#7359](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7359) |
+| v2.16.0 | [#7125](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7125) | Restrict saved objects finding when workspace enabled | [#7127](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7127) |
+| v2.16.0 | [#6776](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6776) | Fix workspace name duplication check | [#6480](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6480) |
 | v2.16.0 | [#7279](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7279) | Unassign data source before deleteByWorkspace |   |
 | v2.16.0 | [#7405](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7405) | Navigate to detail page when clicking all use case workspace |   |
 | v2.16.0 | [#7435](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7435) | Add permission validation at workspace detail page |   |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/workspace.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/workspace.md
@@ -6,51 +6,102 @@ tags:
 
 ## Summary
 
-Bug fixes for the Workspace feature in OpenSearch Dashboards v2.16.0, addressing data source deletion, navigation, permission validation, and saved objects API issues.
+Workspace feature enhancements and bug fixes in OpenSearch Dashboards v2.16.0, including new home page get started cards, admin-only workspace creation controls, enriched breadcrumbs with workspace context, and fixes for saved objects access control and name duplication validation.
 
 ## Details
 
 ### What's New in v2.16.0
 
-This release includes 4 bug fixes for the Workspace feature:
+This release includes 3 feature enhancements and 6 bug fixes for the Workspace feature:
+
+#### Feature Enhancements
+
+| Feature | Description |
+|---------|-------------|
+| Get started cards | Four new get started cards registered on the home page when workspace is enabled |
+| Admin-only workspace creation | Create workspace button hidden for non-dashboard admin users in workspace menu and list |
+| Enriched breadcrumbs | Breadcrumbs now include workspace name and use case context for better navigation |
+
+#### Bug Fixes
 
 | Fix | Description |
 |-----|-------------|
-| Data source preservation | Data sources are now unassigned before workspace deletion, preventing accidental data source removal |
+| Saved objects access restriction | Non-dashboard admin users can only access saved objects within their permitted workspaces |
+| Name duplication check | Workspace name duplication check now uses exact match instead of partial match |
+| Data source preservation | Data sources are now unassigned before workspace deletion, preventing accidental removal |
 | Navigation fix | Clicking workspaces with "all use case" now correctly navigates to the workspace detail page |
 | Permission validation | Added permission validation on workspace detail page to prevent duplicate user ID entries |
 | Bulk get API fix | Added `workspaces` and `permissions` fields to saved objects `_bulk_get` response |
 
 ### Technical Changes
 
-#### Data Source Unassignment on Workspace Deletion
+#### Get Started Cards on Home Page
 
-Previously, calling `deleteByWorkspace` would delete data sources that were only assigned to the workspace being deleted. The fix unassigns data sources before deletion to preserve them.
+When workspace is enabled with the new home page, four get started cards are registered to help users onboard:
 
-```typescript
-// Before deletion, unassign data sources
-await unassignDataSourcesFromWorkspace(workspaceId);
-await deleteByWorkspace(workspaceId);
+```yaml
+# Enable in opensearch_dashboards.yml
+workspace.enabled: true
+uiSettings:
+  overrides:
+    "home:useNewHomePage": true
 ```
 
-#### Permission Validation on Detail Page
+#### Admin-Only Workspace Creation
 
-The `WorkspaceDetailForm` component now receives `permissionEnabled` prop, enabling `useWorkspaceForm` to validate input data such as duplicate user IDs in "Manage Access and Permissions".
+Only dashboard admin users can create workspaces. The create workspace button is hidden in both the workspace picker menu and workspace list page for non-admin users.
 
-#### Saved Objects Bulk Get Response
+```yaml
+# Configure dashboard admin users
+opensearchDashboards.dashboardAdmin.users: ['admin_user']
+```
 
-The `_bulk_get` API response now includes `workspaces` and `permissions` fields for saved objects, enabling proper workspace context handling.
+#### Enriched Breadcrumbs
+
+Breadcrumbs are now enriched with workspace and use case context:
+- When workspace is enabled: breadcrumbs show workspace name and its use case
+- When workspace is disabled: breadcrumbs show current nav group
+
+#### Saved Objects Access Restriction
+
+Non-dashboard admin users are restricted to accessing saved objects only within their permitted workspaces:
+- `options.workspaces`: Non-permitted workspaces are filtered out
+- `options.ACLSearchParams`: Principals are replaced with the requesting user
+- Default ACLSearchParams are used if no workspace or ACL params provided
+
+#### Workspace Name Duplication Check
+
+The name duplication check now uses exact match by enclosing the workspace name in double quotes:
+
+```json
+{
+  "query": {
+    "simple_query_string": {
+      "query": "\"demo workspace\"",
+      "fields": ["workspace.name"]
+    }
+  }
+}
+```
+
+This converts to a `TermQuery` for exact matching on the `keyword` field type.
 
 ## Limitations
 
-- Data source unassignment only applies to data sources exclusively assigned to the deleted workspace
-- Permission validation requires the security plugin to be properly configured
+- Dashboard admin configuration requires the security plugin to be properly configured
+- Saved objects access restriction only applies when workspace is enabled
+- Get started cards only appear with the new home page enabled
 
 ## References
 
 ### Pull Requests
 | PR | Description | Related Issue |
 |----|-------------|---------------|
+| [#7333](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7333) | Register four get started cards in home page | [#7332](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7332) |
+| [#7357](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7357) | Hide create workspace button for non dashboard admin | [#7358](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7358) |
+| [#7360](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7360) | Enrich breadcrumbs by workspace and use case | [#7359](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7359) |
+| [#7125](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7125) | Restrict saved objects finding when workspace enabled | [#7127](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7127) |
+| [#6776](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6776) | Fix workspace name duplication check | [#6480](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6480) |
 | [#7279](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7279) | Unassign data source before deleteByWorkspace |   |
 | [#7405](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7405) | Navigate to detail page when clicking all use case workspace |   |
 | [#7435](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7435) | Add permission validation at workspace detail page |   |


### PR DESCRIPTION
## Summary

Updates the Workspace documentation for v2.16.0 with additional PRs from Issue #2306.

### Changes

**Release Report** (`docs/releases/v2.16.0/features/opensearch-dashboards/workspace.md`):
- Added 3 feature enhancements: get started cards, admin-only workspace creation, enriched breadcrumbs
- Added 2 bug fixes: saved objects access restriction, name duplication check fix
- Merged with existing bug fixes from previous investigation

**Feature Report** (`docs/features/opensearch-dashboards/opensearch-dashboards-workspace.md`):
- Updated v2.16.0 change history entry
- Added 5 new PRs to references section

### PRs Added
| PR | Description | Category |
|----|-------------|----------|
| #7333 | Register four get started cards in home page | feature |
| #7357 | Hide create workspace button for non dashboard admin | feature |
| #7360 | Enrich breadcrumbs by workspace and use case | feature |
| #7125 | Restrict saved objects finding when workspace enabled | bugfix |
| #6776 | Fix workspace name duplication check | bugfix |

Closes #2306