### PR TITLE
docs: add Data Source API report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-data-source-selector.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-data-source-selector.md
@@ -140,7 +140,7 @@ Using the aggregated view:
 ## Change History
 
 - **v3.2.0** (2026-01-10): Added workspace-aware scope support for default data source retrieval
-- **v2.16.0** (2024-08-06): Multiple bug fixes including unified getDefaultDataSourceId API, improved error handling with DataSourceError, fixed hideLocalCluster configuration, fixed Dev Tools selector position, and moved manageableBy flag to DSM plugin; added comprehensive unit tests for edit data source form, multi-selectable component, data source item, toast buttons, and validation form
+- **v2.16.0** (2024-08-06): Removed endpoint validation for create data source saved object API to enable data source import; multiple bug fixes including unified getDefaultDataSourceId API, improved error handling with DataSourceError, fixed hideLocalCluster configuration, fixed Dev Tools selector position, and moved manageableBy flag to DSM plugin; added comprehensive unit tests for edit data source form, multi-selectable component, data source item, toast buttons, and validation form
 
 ## References
 
@@ -153,6 +153,7 @@ Using the aggregated view:
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
 | v3.2.0 | [#9832](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9832) | Support scope in data source selector |   |
+| v2.16.0 | [#6899](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6899) | Remove endpoint validation for create data source saved object API | [#6893](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6893) |
 | v2.16.0 | [#6843](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6843) | Unify getDefaultDataSourceId and export | - |
 | v2.16.0 | [#6903](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6903) | Use DataSourceError for error handling | [#6738](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6738) |
 | v2.16.0 | [#7314](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7314) | Remove data sources as required plugin | - |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/data-source-api.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/data-source-api.md
@@ -1,0 +1,61 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Data Source API
+
+## Summary
+
+In v2.16.0, the endpoint validation for the create data source saved object API was removed. This change enables users to import data sources without being blocked by the previously added endpoint validation, which was conflicting with the import functionality.
+
+## Details
+
+### What's New in v2.16.0
+
+The data source plugin previously performed endpoint validation when creating a data source saved object through the API. This validation checked whether the endpoint was a valid OpenSearch endpoint by attempting to connect to it. However, this validation conflicted with the ability to import data sources, as imported data sources might not be immediately accessible during the import process.
+
+### Technical Changes
+
+The following changes were made to the `data_source` plugin:
+
+| Component | Change |
+|-----------|--------|
+| `DataSourceSavedObjectsClientWrapper` | Removed `DataSourceServiceSetup` and `CustomApiSchemaRegistry` dependencies |
+| `validateEndpoint` method | Simplified to only check URL validity using `isValidURL()`, removed connection validation |
+| `validateAttributes` method | Removed `request` parameter, simplified validation flow |
+| Plugin initialization | Reordered service initialization, moved `dataSourceService.setup()` after auditor registration |
+
+### Before vs After
+
+**Before (v2.15.0 and earlier):**
+- Creating a data source saved object triggered endpoint validation
+- The system attempted to connect to the endpoint to verify it was a valid OpenSearch cluster
+- Import operations could fail if the endpoint was not immediately reachable
+
+**After (v2.16.0):**
+- Endpoint validation only checks URL format and blocked IP addresses
+- No connection attempt is made during saved object creation
+- Import operations succeed regardless of endpoint reachability
+- Connection validation still occurs through the "Test connection" feature in the UI
+
+### Impact
+
+This change improves the user experience for:
+- Importing data sources from exported NDJSON files
+- Creating data sources programmatically via the API
+- Bulk data source provisioning scenarios
+
+## Limitations
+
+- Endpoint validation is no longer performed at creation time; users should use "Test connection" to verify connectivity
+- Invalid endpoints will only be detected when attempting to use the data source
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#6899](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6899) | Remove endpoint validation for create data source saved object API | [#6893](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6893) |
+
+### Documentation
+- [Configuring and using multiple data sources](https://docs.opensearch.org/2.16/dashboards/management/multi-data-sources/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -11,6 +11,7 @@
 - CI/CD Improvements
 - Dashboard Flyout Fix
 - Data Set Navigator
+- Data Source API
 - Data Source Client Fixes
 - Data Source Form Tests
 - Data Source Management Bug Fixes


### PR DESCRIPTION
## Summary

This PR adds documentation for the Data Source API enhancement in OpenSearch Dashboards v2.16.0.

### Changes
- **Release report**: `docs/releases/v2.16.0/features/opensearch-dashboards/data-source-api.md`
- **Feature report update**: Updated `docs/features/opensearch-dashboards/opensearch-dashboards-data-source-selector.md` with v2.16.0 changes
- **Release index**: Added Data Source API to the v2.16.0 release index

### Key Changes in v2.16.0
- Removed endpoint validation for create data source saved object API
- Enables data source import without connection validation blocking
- Simplifies programmatic data source creation via API

### Related
- Closes #2304
- PR: [opensearch-project/OpenSearch-Dashboards#6899](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6899)
- Issue: [opensearch-project/OpenSearch-Dashboards#6893](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6893)