### PR TITLE
docs: add Use Cases & Landing Pages report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-navigation.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-navigation.md
@@ -82,8 +82,29 @@ flowchart TB
 | Setting | Description | Default |
 |---------|-------------|---------|
 | `navGroupEnabled` | Enable the new navigation group system | `false` |
-| `showInAllNavGroup` | Show link in Analytics(all) nav group | `false` |
+| `showInAllNavGroup` | Show link in All use case nav group | `false` |
 | Navigation dock state | Docked or undocked navigation | Docked |
+
+### Navigation Groups
+
+| Navigation Group | ID | Type | Order | Description |
+|------------------|-----|------|-------|-------------|
+| Data Administration | `dataAdministration` | System | 1000 | Data management features |
+| Settings and Setup | `settingsAndSetup` | System | 2000 | Configuration and settings |
+| All | `all` | System | 3000 | Unified view of all features |
+| Observability | `observability` | - | 4000 | Monitoring and analysis |
+| Security Analytics | `security-analytics` | - | 5000 | Security threat detection |
+| Analytics | `analytics` | - | 6000 | Data analysis and insights |
+| Search | `search` | - | 7000 | Search functionality |
+
+### Landing Pages
+
+System navigation groups have dedicated landing pages that display feature cards:
+
+| Landing Page | App ID | Navigation Group |
+|--------------|--------|------------------|
+| Settings and Setup | `settings_landing` | Settings and Setup |
+| Data Administration | `data_administration_landing` | Data Administration |
 
 ### Usage Example
 
@@ -127,7 +148,7 @@ The navigation automatically adapts to screen size:
 
 - **v3.4.0** (2025-10-08): Fixed disabled prop propagation for navigation links - `isDisabled` state now correctly passed to `EuiSideNavItem` components
 - **v2.18.0** (2024-10-22): Flattened navigation in Analytics(all) use case, persistent expand/collapse state, small screen compatibility, border style updates, sample data menu restored
-- **v2.16.0** (2024-08-06): Renamed "Detect" category to "Configure" with adjusted ordering (Configure: 2000, Visualize and Report: 3000); fixed breadcrumb navigation for 4 migrated applications (Assets, Index Pattern Management, Data Sources Management, Application Settings) when new navigation enabled; added `getScopedBreadcrumbs` utility for BrowserRouter compatibility; workspace overview visible in all use cases; fixed Dev Tools tab CSS for new left navigation; fixed navigation-next integration issues (auto-collapse on home, typo fixes, workspace visibility); redirect users to home in global when workspace enabled
+- **v2.16.0** (2024-08-06): Added "All use case" navigation group with `showInAllNavGroup` plugin property; introduced landing pages for Settings and Setup (`settings_landing`) and Data Administration (`data_administration_landing`) navigation groups; renamed "Detect" category to "Configure" with adjusted ordering; fixed breadcrumb navigation for migrated applications; added `getScopedBreadcrumbs` utility; workspace overview visible in all use cases; fixed Dev Tools tab CSS; fixed navigation-next integration issues; redirect users to home in global when workspace enabled
 
 
 ## References
@@ -144,6 +165,8 @@ The navigation automatically adapts to screen size:
 | v2.18.0 | [#8489](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8489) | Update border style when new left nav expanded | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v2.18.0 | [#8076](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8076) | Add sample data menu back | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v2.18.0 | [#7962](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7962) | Make left nav compatible with small screen | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
+| v2.16.0 | [#7235](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7235) | Add all use case | - |
+| v2.16.0 | [#7282](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7282) | Enable landing page for settings and data administration | [#7283](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7283) |
 | v2.16.0 | [#7339](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7339) | Update category: rename Detect to Configure | - |
 | v2.16.0 | [#7551](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7551) | Redirect user to home in global when workspace enabled | - |
 | v2.16.0 | [#7401](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7401) | Fix breadcrumb for migrated apps with BrowserRouter | - |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/use-cases-landing-pages.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/use-cases-landing-pages.md
@@ -1,0 +1,125 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Use Cases & Landing Pages
+
+## Summary
+
+OpenSearch Dashboards v2.16.0 introduces the "All use case" navigation group and landing pages for system navigation groups. The "All use case" provides a unified view containing all features across different use cases, while landing pages offer organized entry points for "Settings and Setup" and "Data Administration" navigation groups.
+
+## Details
+
+### What's New in v2.16.0
+
+#### All Use Case Navigation Group
+A new "All use case" navigation group aggregates features from all other use cases into a single unified view. Plugins can declare visibility in this group using the `showInAllNavGroup` property.
+
+| Property | Description |
+|----------|-------------|
+| `ALL_USE_CASE_ID` | Constant identifier: `'all'` |
+| `showInAllNavGroup` | Boolean flag for plugins to declare visibility in All use case |
+| Order | 3000 (after Settings and Setup) |
+| Type | `NavGroupType.SYSTEM` |
+
+#### Landing Pages for System Navigation Groups
+Two new landing pages provide organized entry points for system navigation groups:
+
+| Landing Page | App ID | Description |
+|--------------|--------|-------------|
+| Settings and Setup | `settings_landing` | Landing page for settings and configuration features |
+| Data Administration | `data_administration_landing` | Landing page for data management features |
+
+#### Landing Page Architecture
+
+```mermaid
+graph TB
+    subgraph "Landing Page System"
+        SettingsLanding[Settings Landing Page]
+        DataAdminLanding[Data Administration Landing Page]
+        FeatureCards[Feature Cards Component]
+    end
+    
+    subgraph "Navigation Groups"
+        SettingsGroup[Settings and Setup Group]
+        DataAdminGroup[Data Administration Group]
+    end
+    
+    subgraph "Core Services"
+        NavGroupService[Nav Group Service]
+        ChromeNavLinks[Chrome Nav Links]
+        Application[Application Service]
+    end
+    
+    SettingsLanding --> FeatureCards
+    DataAdminLanding --> FeatureCards
+    
+    SettingsLanding --> SettingsGroup
+    DataAdminLanding --> DataAdminGroup
+    
+    SettingsGroup --> NavGroupService
+    DataAdminGroup --> NavGroupService
+    NavGroupService --> ChromeNavLinks
+    FeatureCards --> Application
+```
+
+#### Feature Cards Component
+A new `FeatureCards` component renders navigation links as clickable cards organized in a grid layout:
+
+- Displays 4 cards per row
+- Groups cards by category with section headers
+- Supports "Get Started" cards section
+- Shows link title and description
+- Navigates to app on card click
+
+### Technical Changes
+
+| Change | Description |
+|--------|-------------|
+| `ChromeRegistrationNavLink.showInAllNavGroup` | New property for plugins to declare visibility in All use case |
+| `ChromeNavLink.description` | New property for nav link descriptions (displayed on landing pages) |
+| `ALL_USE_CASE_ID` constant | Exported from `core/utils` for plugin use |
+| `fulfillRegistrationLinksToChromeNavLinks` | Utility function exported from core for converting registration links |
+| `FeatureCards` component | New React component for rendering landing page cards |
+| `renderApp` function | Landing page application renderer in management plugin |
+
+### Plugin Integration
+
+Plugins can declare visibility in the All use case:
+
+```typescript
+core.chrome.navGroup.addNavLinksToGroup(DEFAULT_NAV_GROUPS.observability, [
+  {
+    id: 'myPlugin',
+    title: 'My Plugin',
+    showInAllNavGroup: true,  // Show in All use case
+    order: 100
+  }
+]);
+```
+
+### Navigation Group Order Updates
+
+| Navigation Group | Old Order | New Order |
+|------------------|-----------|-----------|
+| Data Administration | 1000 | 1000 |
+| Settings and Setup | 2000 | 2000 |
+| All | - | 3000 (new) |
+| Observability | 3000 | 4000 |
+| Security Analytics | 4000 | 5000 |
+| Analytics | 5000 | 6000 |
+| Search | 6000 | 7000 |
+
+## Limitations
+
+- Landing pages are only visible when the new navigation group system is enabled (`navGroupEnabled`)
+- The All use case requires plugins to explicitly opt-in via `showInAllNavGroup`
+- Landing pages filter out hidden nav links and the landing page itself from display
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#7235](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7235) | Add all use case | - |
+| [#7282](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7282) | Enable landing page for settings and data administration | [#7283](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7283) |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -31,6 +31,7 @@
 - Sidecar Z-Index Fix
 - Timeline Visualization Fixes
 - UI Improvements
+- Use Cases & Landing Pages
 - Vega Visualization Fixes
 - VisBuilder Fixes
 - Visualization Color Fix


### PR DESCRIPTION
## Summary
Add documentation for Use Cases & Landing Pages feature introduced in OpenSearch Dashboards v2.16.0.

### Changes
- Created release report: `docs/releases/v2.16.0/features/opensearch-dashboards/use-cases-landing-pages.md`
- Updated feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-navigation.md`
- Updated release index: `docs/releases/v2.16.0/index.md`

### Key Features Documented
- **All Use Case**: New navigation group aggregating features from all use cases with `showInAllNavGroup` plugin property
- **Landing Pages**: New landing pages for Settings and Setup (`settings_landing`) and Data Administration (`data_administration_landing`) navigation groups
- **Feature Cards Component**: New React component for rendering landing page cards

### Related PRs
- [#7235](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7235) - Add all use case
- [#7282](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7282) - Enable landing page for settings and data administration

Closes #2301