### PR TITLE
docs: add PPL Support report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/index.md
+++ b/docs/features/opensearch-dashboards/index.md
@@ -49,6 +49,7 @@
 | [opensearch-dashboards-openapi-specification](opensearch-dashboards-openapi-specification.md) | OpenAPI Specification |
 | [opensearch-dashboards-oui](opensearch-dashboards-oui.md) | OpenSearch UI (OUI) |
 | [opensearch-dashboards-plugin-compatibility](opensearch-dashboards-plugin-compatibility.md) | Plugin Compatibility |
+| [opensearch-dashboards-ppl-vega](opensearch-dashboards-ppl-vega.md) | PPL Support in Vega Visualization |
 | [opensearch-dashboards-query-assistant](opensearch-dashboards-query-assistant.md) | Query Assistant |
 | [opensearch-dashboards-query-editor](opensearch-dashboards-query-editor.md) | Query Editor |
 | [opensearch-dashboards-query-enhancements](opensearch-dashboards-query-enhancements.md) | Query Enhancements |

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-ppl-vega.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-ppl-vega.md
@@ -1,0 +1,105 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# PPL Support in Vega Visualization
+
+## Summary
+
+PPL (Piped Processing Language) support in Vega visualizations enables users to query OpenSearch data using PPL syntax directly within Vega specifications. This provides an alternative to the traditional OpenSearch Query DSL, offering a more intuitive pipe-based query language for data exploration and visualization.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Vega Visualization"
+        VP[VegaParser]
+        PPL[PPLQueryParser]
+        SA[SearchAPI]
+    end
+    subgraph "Query Enhancements Plugin"
+        PPLRS[PPL Raw Search Strategy]
+    end
+    subgraph "OpenSearch"
+        PPLAPI[PPL API]
+    end
+    VP --> PPL
+    PPL --> SA
+    SA --> PPLRS
+    PPLRS --> PPLAPI
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `PPLQueryParser` | Parses PPL queries from Vega specifications and handles time filter injection |
+| `pplraw` search strategy | Executes PPL queries and returns raw JSON data for Vega consumption |
+| `SearchAPI` | Extended to support PPL strategy option and response inspection |
+
+### Configuration
+
+PPL queries in Vega use the `ppl` data source type with the following structure:
+
+| Setting | Description | Required |
+|---------|-------------|----------|
+| `body.query` | PPL query string | Yes |
+| `%timefield%` | Field name for time filter injection | No |
+| `%context%` | Enable dashboard context (time range, filters) | No |
+| `data_source_name` | Target data source for multi-data-source setups | No |
+
+### Usage Example
+
+```hjson
+{
+  $schema: https://vega.github.io/schema/vega-lite/v5.json
+  data: {
+    url: {
+      %context%: true
+      %timefield%: @timestamp
+      body: {
+        query: "source=my_index | stats avg(bytes) by host"
+      }
+    }
+  }
+  mark: bar
+  encoding: {
+    x: { field: host, type: nominal }
+    y: { field: avg(bytes), type: quantitative }
+  }
+}
+```
+
+### Time Filter Injection
+
+When `%timefield%` is specified, the PPL parser automatically injects a time filter based on the dashboard's time range:
+
+```
+source=my_index | where `@timestamp` >= '2024-01-01 00:00:00.000' and `@timestamp` <= '2024-01-31 23:59:59.999' | stats count() by response
+```
+
+## Limitations
+
+- Requires the query enhancements plugin to be enabled
+- PPL syntax must be valid; errors are reported in the Vega inspector
+- Time filter injection requires explicit `%timefield%` configuration
+- Multi-data-source support requires `data_source_name` to be specified
+
+## Change History
+
+- **v2.16.0** (2024-07-23): Initial implementation of PPL support in Vega visualization
+
+## References
+
+### Documentation
+
+- [Vega Visualization](https://docs.opensearch.org/latest/dashboards/visualize/vega/)
+- [PPL Documentation](https://docs.opensearch.org/latest/search-plugins/sql/ppl/index/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#7285](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7285) | Support PPL in vega visualization |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/ppl-support.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/ppl-support.md
@@ -1,0 +1,90 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# PPL Support in Vega Visualization
+
+## Summary
+
+OpenSearch Dashboards v2.16.0 introduces PPL (Piped Processing Language) support in Vega visualizations. This feature enables users to query OpenSearch data using PPL syntax directly within Vega specifications, providing an alternative to the traditional OpenSearch Query DSL.
+
+## Details
+
+### What's New in v2.16.0
+
+This release adds a new `ppl` data source type to Vega visualizations, allowing users to write PPL queries instead of OpenSearch DSL queries.
+
+### Technical Changes
+
+#### New PPL Query Parser
+
+A new `PPLQueryParser` class was added to handle PPL queries in Vega specifications:
+
+- Parses PPL query syntax from Vega `data.url.body.query`
+- Validates that the query is a non-empty string
+- Integrates with the existing Vega data model
+
+#### PPL Raw Search Strategy
+
+A new `pplraw` search strategy was registered in the query enhancements plugin:
+
+- Executes PPL queries against OpenSearch
+- Returns raw JSON data suitable for Vega consumption
+- Supports multi-data-source configurations via `dataSourceId`
+
+#### Search API Updates
+
+The search API was enhanced to:
+
+- Pass raw request context to search strategies
+- Support the `pplraw` strategy option
+- Handle PPL response inspection in the Vega inspector
+
+### Usage Example
+
+```hjson
+{
+  $schema: https://vega.github.io/schema/vega-lite/v5.json
+  data: {
+    url: {
+      %context%: true
+      %timefield%: @timestamp
+      body: {
+        query: "source=opensearch_dashboards_sample_data_logs | stats count() by response"
+      }
+    }
+  }
+  mark: bar
+  encoding: {
+    x: { field: response, type: nominal }
+    y: { field: count(), type: quantitative }
+  }
+}
+```
+
+### Components Modified
+
+| Component | Changes |
+|-----------|---------|
+| `vis_type_vega` | Added `PPLQueryParser`, integrated with `VegaParser` |
+| `query_enhancements` | Added `pplraw` search strategy |
+| `data` plugin | Updated search routes to pass raw request |
+
+## Limitations
+
+- PPL support in Vega requires the query enhancements plugin to be enabled
+- UI changes for PPL in Vega are not included in this release (planned for future commits)
+- Time filter injection for PPL queries requires explicit `%timefield%` configuration
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#7285](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7285) | Support PPL in vega visualization | - |
+
+### Documentation
+
+- [Vega Visualization](https://docs.opensearch.org/2.16/dashboards/visualize/vega/)
+- [PPL Documentation](https://docs.opensearch.org/2.16/search-plugins/sql/ppl/index/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -3,6 +3,7 @@
 ## Features
 
 ### opensearch-dashboards
+- PPL Support in Vega Visualization
 - Content Management Plugin
 - JSON11 Long Numerals
 - Aggregated View Fixes


### PR DESCRIPTION
## Summary

This PR adds documentation for PPL Support in Vega Visualization feature introduced in OpenSearch Dashboards v2.16.0.

## Reports Created

- Release report: `docs/releases/v2.16.0/features/opensearch-dashboards/ppl-support.md`
- Feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-ppl-vega.md`

## Key Changes in v2.16.0

- Added `PPLQueryParser` class to handle PPL queries in Vega specifications
- Registered new `pplraw` search strategy in query enhancements plugin
- Extended SearchAPI to support PPL strategy option

## Resources Used

- PR: [#7285](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7285)
- Docs: https://docs.opensearch.org/2.16/dashboards/visualize/vega/

Closes #2299