### PR TITLE
docs: add field-name-search report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-discover.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-discover.md
@@ -150,7 +150,7 @@ Requires ML agent configuration:
 - **v3.0.0** (2025-05-13): Added CSV export functionality, reorganized results display with ResultsActionBar, customizable summary panel title, experimental Data plugin `__enhance` API with resultsActionBar, and 6 bug fixes for saved search handling and workspace integration
 - **v2.19.0** (2025-01-14): Added indexed views framework to dataset selector, results canvas banner framework, data2summary agent validation, default query string framework, custom time filter logic per dataset type, query editor bottom panel extension, and Cypress test data attributes
 - **v2.18.0** (2024-11-05): Added AI-powered data summary panel, updated visual appearance, cache management in dataset selector, and 14 bug fixes for stability and usability
-- **v2.16.0** (2024-08-06): Added Data Set Navigator component with DataSetManager service for dataset state management and URL state synchronization; fixed discover options location, legacy URL global state migration, duplicate timestamp column, anchor row highlighting in surrounding docs view, wide table last column rendering, Discover Next styling issues, and database loading display for external data sources
+- **v2.16.0** (2024-08-06): Added Data Set Navigator component with DataSetManager service for dataset state management and URL state synchronization; made field name search filter case insensitive; fixed discover options location, legacy URL global state migration, duplicate timestamp column, anchor row highlighting in surrounding docs view, wide table last column rendering, Discover Next styling issues, and database loading display for external data sources
 
 
 ## References
@@ -204,6 +204,7 @@ Requires ML agent configuration:
 ### v2.16.0 Pull Requests
 | PR | Description |
 |----|-------------|
+| [#6759](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6759) | Make field name search filter case insensitive |
 | [#7492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7492) | Add back data set navigator to control state |
 | [#7581](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7581) | Fix discover options' location |
 | [#6780](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6780) | Migrate global state from legacy URL |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/field-name-search.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/field-name-search.md
@@ -1,0 +1,52 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Field Name Search
+
+## Summary
+
+The field name search filter in Discover's sidebar is now case insensitive, improving usability when searching for fields in the field selector.
+
+## Details
+
+### What's New in v2.16.0
+
+Prior to this change, the "Search field names" filter in Discover's sidebar required exact case matching. Users had to type field names with the correct capitalization to find them.
+
+With this enhancement, the field name search now performs case-insensitive matching. For example, searching for "timestamp", "TIMESTAMP", or "TimeStamp" will all find a field named `@timestamp`.
+
+### Technical Changes
+
+The change modifies the `isFieldFiltered` function in the Discover plugin's field filter logic:
+
+```typescript
+// Before: Case-sensitive matching
+const matchName = !filterState.name || field.name.indexOf(filterState.name) !== -1;
+
+// After: Case-insensitive matching
+const matchName = !filterState.name || 
+  field.name.toLowerCase().indexOf(filterState.name.toLowerCase()) !== -1;
+```
+
+**Changed File:**
+- `src/plugins/discover/public/application/components/sidebar/lib/field_filter.ts`
+
+### Usage
+
+1. Navigate to Discover
+2. In the left sidebar, use the "Search field names" input
+3. Type any field name (case doesn't matter)
+4. Fields matching the search term will be displayed regardless of case
+
+## Limitations
+
+- This change only affects the field name search in Discover's sidebar
+- Other search/filter functionality in OpenSearch Dashboards is not affected
+
+## References
+
+### Pull Requests
+| PR | Description |
+|----|-------------|
+| [#6759](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6759) | Make Field Name Search Filter Case Insensitive |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -3,6 +3,7 @@
 ## Features
 
 ### opensearch-dashboards
+- Field Name Search
 - PPL Support in Vega Visualization
 - Content Management Plugin
 - JSON11 Long Numerals


### PR DESCRIPTION
## Summary

Adds documentation for the Field Name Search case-insensitive filter feature in OpenSearch Dashboards v2.16.0.

## Changes
- Created release report: `docs/releases/v2.16.0/features/opensearch-dashboards/field-name-search.md`
- Updated feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-discover.md`
- Updated release index: `docs/releases/v2.16.0/index.md`

## Related
- Closes #2293
- PR: opensearch-project/OpenSearch-Dashboards#6759