### PR TITLE
docs: add UI Metric Collector report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/index.md
+++ b/docs/features/opensearch-dashboards/index.md
@@ -57,6 +57,7 @@
 | [opensearch-dashboards-saved-query-ux](opensearch-dashboards-saved-query-ux.md) | Saved Query UX |
 | [opensearch-dashboards-tsvb-visualization](opensearch-dashboards-tsvb-visualization.md) | TSVB Visualization |
 | [opensearch-dashboards-timeline-visualization](opensearch-dashboards-timeline-visualization.md) | Timeline Visualization |
+| [opensearch-dashboards-ui-metric-collector](opensearch-dashboards-ui-metric-collector.md) | UI Metric Collector |
 | [opensearch-dashboards-ui-settings](opensearch-dashboards-ui-settings.md) | UI Settings |
 | [opensearch-dashboards-vended-dashboard-progress](opensearch-dashboards-vended-dashboard-progress.md) | Vended Dashboard Progress |
 | [opensearch-dashboards-visbuilder](opensearch-dashboards-visbuilder.md) | VisBuilder |

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-ui-metric-collector.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-ui-metric-collector.md
@@ -1,0 +1,151 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# UI Metric Collector
+
+## Summary
+
+The UI Metric Collector is a telemetry feature in OpenSearch Dashboards that tracks user interactions with UI elements and application usage. It collects metrics such as button clicks, page views, and time spent on different applications, storing them in saved objects for analysis. The feature is disabled by default and must be explicitly enabled via configuration.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Client (Browser)"
+        UI[UI Components]
+        Reporter[UI Metric Reporter]
+    end
+    
+    subgraph "OSD Server"
+        API["/api/ui_metric/report"]
+        Batch[Batch Buffer]
+        Store[Store Report]
+    end
+    
+    subgraph "OpenSearch"
+        SO[Saved Objects<br/>ui-metric type]
+    end
+    
+    UI -->|Track events| Reporter
+    Reporter -->|POST report| API
+    API --> Batch
+    Batch -->|After interval| Store
+    Store -->|incrementCounter| SO
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| UI Metric Reporter | Client-side component that tracks UI interactions and sends reports |
+| Report API | Server endpoint (`/api/ui_metric/report`) that receives metric reports |
+| Batch Buffer | Server-side buffer that accumulates reports before persisting |
+| Store Report | Logic to persist metrics to saved objects |
+| Stats API | Endpoint (`/api/stats`) to retrieve collected metrics |
+
+### Configuration
+
+| Setting | Description | Default | Since |
+|---------|-------------|---------|-------|
+| `usageCollection.uiMetric.enabled` | Enable/disable UI Metric Collector | `false` | v2.14.0 |
+| `usageCollection.uiMetric.debug` | Enable debug logging | `false` (dev mode) | v2.14.0 |
+| `usageCollection.uiMetric.batchingIntervalInS` | Server-side batching interval in seconds | `60` | v2.16.0 |
+
+### Usage Example
+
+#### Enable UI Metric Collector
+
+Add to `opensearch_dashboards.yml`:
+
+```yaml
+usageCollection:
+  uiMetric:
+    enabled: true
+    batchingIntervalInS: 60
+```
+
+#### Report Format
+
+The client sends reports in the following format:
+
+```json
+{
+  "report": {
+    "reportVersion": 1,
+    "uiStatsMetrics": {
+      "console-count-GET_cat.indices": {
+        "key": "console-count-GET_cat.indices",
+        "appName": "console",
+        "eventName": "GET_cat.indices",
+        "type": "count",
+        "stats": {
+          "min": 0,
+          "max": 1,
+          "avg": 0.5,
+          "sum": 21
+        }
+      }
+    }
+  }
+}
+```
+
+#### Retrieve Metrics
+
+```bash
+GET /api/stats?extended=true&legacy=true&exclude_usage=false
+```
+
+Response includes `ui_metric` and `application_usage` fields with collected data.
+
+### Data Model
+
+#### UI Stats Metrics
+
+| Field | Description |
+|-------|-------------|
+| `key` | Unique identifier (`{appName}-{type}-{eventName}`) |
+| `appName` | Application name (e.g., `console`, `discover`) |
+| `eventName` | Event being tracked |
+| `type` | Metric type (e.g., `count`) |
+| `stats.sum` | Total count of events |
+
+#### Application Usage
+
+| Field | Description |
+|-------|-------------|
+| `appId` | Application identifier |
+| `numberOfClicks` | Total clicks in the application |
+| `minutesOnScreen` | Time spent in the application |
+
+## Limitations
+
+- Feature is disabled by default; requires explicit configuration to enable
+- Server-side batching may lose uncommitted metrics if the server restarts
+- Metrics are only persisted when a new report arrives after the batching interval (no background timer)
+- No built-in visualization dashboard for collected metrics
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Added server-side batching to reduce write operations when multiple concurrent users report metrics
+- **v2.14.0** (2024-05-01): Initial implementation - enabled UI Metric Collector with feature flag
+
+## References
+
+### Documentation
+
+- OpenSearch Dashboards Usage Collection Plugin
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#6721](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6721) | Add Server Side Batching for UI Metric Collectors |
+| v2.14.0 | [#6203](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6203) | Enable UI Metric Collector |
+
+### Related Issues
+
+- [#6375](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6375) - Server Side batching for saving UI metrics

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/ui-metric-collector.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/ui-metric-collector.md
@@ -1,0 +1,90 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# UI Metric Collector Server-Side Batching
+
+## Summary
+
+OpenSearch Dashboards v2.16.0 introduces server-side batching for the UI Metric Collector, reducing the number of write operations to OpenSearch when multiple concurrent users report UI metrics. This optimization addresses performance concerns when many users interact with the dashboard simultaneously.
+
+## Details
+
+### What's New in v2.16.0
+
+The UI Metric Collector now batches incoming metric reports on the server side before persisting them to saved objects. Instead of writing each metric report immediately, the server accumulates reports over a configurable interval and writes them in a single batch operation.
+
+### Technical Changes
+
+#### Batching Mechanism
+
+```mermaid
+sequenceDiagram
+    participant Client1 as Client 1
+    participant Client2 as Client 2
+    participant Server as OSD Server
+    participant SO as Saved Objects
+
+    Client1->>Server: POST /api/ui_metric/report
+    Note over Server: Add to batch, check interval
+    Server-->>Client1: {status: "ok"}
+    
+    Client2->>Server: POST /api/ui_metric/report
+    Note over Server: Add to batch, interval not elapsed
+    Server-->>Client2: {status: "ok"}
+    
+    Note over Server: Batching interval elapsed
+    Client1->>Server: POST /api/ui_metric/report
+    Note over Server: Write previous batch
+    Server->>SO: incrementCounter (batched sum)
+    Server-->>Client1: {status: "ok"}
+```
+
+#### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `usageCollection.uiMetric.enabled` | Enable UI Metric Collector | `false` |
+| `usageCollection.uiMetric.debug` | Enable debug mode | `false` (dev mode) |
+| `usageCollection.uiMetric.batchingIntervalInS` | Batching interval in seconds | `60` |
+
+#### Key Implementation Details
+
+- **Batch Report Structure**: Reports are combined using a `combineReports()` function that merges:
+  - User agent information
+  - UI stats metrics (summing the `stats.sum` values)
+  - Application usage (summing `numberOfClicks` and `minutesOnScreen`)
+
+- **Increment Counter Enhancement**: The `SavedObjectsRepository.incrementCounter()` method now accepts an optional `incrementValue` parameter (default: 1), allowing batch writes with accumulated sums.
+
+- **Report Endpoint**: `/api/ui_metric/report` now buffers reports and only writes to saved objects when the batching interval has elapsed.
+
+### Files Changed
+
+| File | Change |
+|------|--------|
+| `src/plugins/usage_collection/server/routes/report_metrics.ts` | Added batching logic and `combineReports()` function |
+| `src/plugins/usage_collection/server/config.ts` | Added `batchingIntervalInS` configuration |
+| `src/plugins/usage_collection/common/constants.ts` | Added `DEFAULT_BATCHING_INTERVAL_FOR_UI_METRIC_IN_S` constant |
+| `src/core/server/saved_objects/service/lib/repository.ts` | Added `incrementValue` parameter to `incrementCounter()` |
+| `src/plugins/usage_collection/server/report/store_report.ts` | Updated to use `stats.sum` for increment value |
+| `src/plugins/usage_collection/server/types.ts` | Added `BatchReport` interface |
+
+## Limitations
+
+- Batching is performed in-memory on the server; if the server restarts during a batching interval, uncommitted metrics may be lost
+- The batching interval applies globally to all metric reports, not per-metric type
+- Metrics are only persisted when a new report arrives after the interval has elapsed (no background timer)
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#6721](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6721) | Add Server Side Batching for UI Metric Collectors | [#6375](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6375) |
+| [#6203](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6203) | Enable UI Metric Collector (v2.14.0) | - |
+
+### Related Issues
+
+- [#6375](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6375) - Server Side batching for saving UI metrics

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch-dashboards
 - Field Name Search
+- UI Metric Collector Server-Side Batching
 - PPL Support in Vega Visualization
 - Content Management Plugin
 - JSON11 Long Numerals


### PR DESCRIPTION
## Summary

Adds documentation for the UI Metric Collector Server-Side Batching feature introduced in OpenSearch Dashboards v2.16.0.

## Changes

- **Release Report**: `docs/releases/v2.16.0/features/opensearch-dashboards/ui-metric-collector.md`
- **Feature Report**: `docs/features/opensearch-dashboards/opensearch-dashboards-ui-metric-collector.md`
- Updated release index and features index

## Key Points

- Server-side batching reduces write operations when multiple concurrent users report UI metrics
- Configurable batching interval (default: 60 seconds)
- Builds on the UI Metric Collector feature introduced in v2.14.0

## References

- PR: opensearch-project/OpenSearch-Dashboards#6721
- Issue: opensearch-project/OpenSearch-Dashboards#6375

Closes #2292