### PR TITLE
docs: add language-selector report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-query-enhancements.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-query-enhancements.md
@@ -121,6 +121,7 @@ source = logs-* | where status >= 400 | head 100
 
 - **v3.0.0** (2025-03-11): PPL query bugfixes - grammar parsing in auto-suggest, timezone handling for time columns, millisecond precision in date fields, error message display in query editors, time range handling for non-search queries
 - **v2.18.0** (2024-11-05): Bug fixes for async polling, error handling, language compatibility, saved query persistence; Added extensibility for custom search strategies via `defineSearchStrategyRoute`; Added keyboard shortcut (Cmd/Ctrl+Enter) for query execution; Exposed datasets and data_frames modules for external plugin imports
+- **v2.16.0** (2024-07-30): Initial Language Selector support - plugins can register custom query languages via UI Service; Dynamic search interceptor switching at runtime; Data Frame structure for non-DSL query results; Configuration via `data.enhancements.enabled`
 
 
 ## References
@@ -148,3 +149,4 @@ source = logs-* | where status >= 400 | head 100
 | v2.18.0 | [#8743](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8743) | Fix error handling in query enhancement facet | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v2.18.0 | [#8749](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8749) | Updates query and language if language is not supported by query data |   |
 | v2.18.0 | [#8771](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8771) | Fix error handling for ppl jobs API | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
+| v2.16.0 | [#6613](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6613) | Support language selector from the data plugin | [#6639](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6639) |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/language-selector.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/language-selector.md
@@ -1,0 +1,132 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Language Selector
+
+## Summary
+
+OpenSearch Dashboards v2.16.0 introduces the Language Selector feature, enabling plugins to register custom query languages and dynamically switch the search interceptor at runtime. This foundational change allows the Data plugin to support multiple query languages (SQL, PPL) alongside DQL and Lucene, with configurable UI components per language.
+
+## Details
+
+### What's New in v2.16.0
+
+The Language Selector feature introduces an extensible architecture for multiple query language support:
+
+1. **UI Service Enhancement**: Plugins can register query language enhancements that modify the search bar behavior
+2. **Dynamic Search Interceptor**: The search service can switch interceptors at runtime based on selected language
+3. **Data Frame Support**: New data structure for handling query results from non-DSL query languages
+4. **Configuration Flag**: Enable via `data.enhancements.enabled: true` in `opensearch_dashboards.yml`
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Plugin Registration"
+        P[Plugin] -->|__enhance| UI[UI Service]
+    end
+    subgraph "Data Plugin"
+        UI --> LS[Language Selector]
+        UI --> SB[Search Bar Config]
+        LS --> SI[Search Interceptor]
+    end
+    subgraph "Search Layer"
+        SI --> SS[Search Strategy]
+        SS --> DF[Data Frame]
+    end
+    subgraph "Data Sources"
+        SS --> OS[OpenSearch]
+        SS --> SQL[SQL Plugin]
+    end
+```
+
+### Query Enhancement Interface
+
+Plugins register language support using the `QueryEnhancement` interface:
+
+```typescript
+interface QueryEnhancement {
+  language: string;
+  search: SearchInterceptor;
+  searchBar?: {
+    showQueryInput?: boolean;
+    showFilterBar?: boolean;
+    showDatePicker?: boolean;
+    showAutoRefreshOnly?: boolean;
+    queryStringInput?: {
+      initialValue?: string;  // '<data_source>' placeholder supported
+    };
+    dateRange?: {
+      initialFrom?: string;
+      initialTo?: string;
+    };
+  };
+  fields?: {
+    filterable?: boolean;
+    visualizable?: boolean;
+  };
+  showDocLinks?: boolean;
+}
+```
+
+### Registration Example
+
+```typescript
+data.__enhance({
+  ui: {
+    query: {
+      language: 'SQL',
+      search: sqlSearchInterceptor,
+      searchBar: {
+        showDatePicker: false,
+        showFilterBar: false,
+        queryStringInput: {
+          initialValue: 'SELECT * FROM <data_source>'
+        },
+      },
+    },
+  },
+});
+```
+
+### Data Frame Structure
+
+New `IDataFrame` interface for standardized result handling:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `DATA_FRAME_TYPES` | Frame type (default or polling) |
+| `name` | `string` | Data source name |
+| `schema` | `IFieldType[]` | Available fields from data source |
+| `fields` | `IFieldType[]` | Fields in result set |
+| `size` | `number` | Number of rows |
+| `meta` | `Record<string, any>` | Aggregation config and metadata |
+
+### Technical Changes
+
+- Added `data.enhancements.enabled` configuration option
+- New `@opensearch/datemath` package dependency for date handling
+- Extended `opensearch-datemath` with `isDateTime()` function
+- Added `DataSourceService` and `DataSourceFactory` for data source management
+- New UI settings: `query:dataSourceReadOnly`, `dataframe:hydrationStrategy`
+- Search request extended with `language` property
+- Build query returns `unsupported` type for non-native languages
+
+## Limitations
+
+- Feature is experimental and disabled by default
+- Requires `data.enhancements.enabled: true` to activate
+- Time range handling may have issues when switching between languages with different time formats
+- Index patterns created with unique IDs require existing pattern for visualization compatibility
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#6613](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6613) | Support language selector from the data plugin | [#6639](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6639), [#5504](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5504) |
+
+### Related Issues
+- [#6639](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6639): Multiple Query Languages Support Proposal
+- [#5504](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5504): Multiple query language support tracking

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch-dashboards
 - Field Name Search
+- Language Selector
 - UI Metric Collector Server-Side Batching
 - PPL Support in Vega Visualization
 - Content Management Plugin


### PR DESCRIPTION
## Summary

Adds documentation for the Language Selector feature introduced in OpenSearch Dashboards v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch-dashboards/language-selector.md`
- Feature report: Updated `docs/features/opensearch-dashboards/opensearch-dashboards-query-enhancements.md`

### Key Changes in v2.16.0
- Plugins can register custom query languages via UI Service
- Dynamic search interceptor switching at runtime
- Data Frame structure for non-DSL query results
- Configuration via `data.enhancements.enabled`

### Resources Used
- PR: [#6613](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6613)
- Issue: [#6639](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6639)

Closes #2291