### PR TITLE
docs: add saved-objects-migration report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/index.md
+++ b/docs/features/opensearch-dashboards/index.md
@@ -55,6 +55,7 @@
 | [opensearch-dashboards-query-enhancements](opensearch-dashboards-query-enhancements.md) | Query Enhancements |
 | [opensearch-dashboards-sample-data](opensearch-dashboards-sample-data.md) | Sample Data |
 | [opensearch-dashboards-saved-query-ux](opensearch-dashboards-saved-query-ux.md) | Saved Query UX |
+| [opensearch-dashboards-saved-objects-migration](opensearch-dashboards-saved-objects-migration.md) | Saved Objects Migration |
 | [opensearch-dashboards-tsvb-visualization](opensearch-dashboards-tsvb-visualization.md) | TSVB Visualization |
 | [opensearch-dashboards-timeline-visualization](opensearch-dashboards-timeline-visualization.md) | Timeline Visualization |
 | [opensearch-dashboards-ui-metric-collector](opensearch-dashboards-ui-metric-collector.md) | UI Metric Collector |

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-saved-objects-migration.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-saved-objects-migration.md
@@ -1,0 +1,110 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Saved Objects Migration
+
+## Summary
+
+OpenSearch Dashboards provides a saved objects migration system that automatically migrates saved objects (dashboards, visualizations, index patterns, etc.) when upgrading between versions. The migration process handles schema changes and ensures data compatibility across versions.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph Migration Process
+        A[Start Migration] --> B[Check Source Index]
+        B --> C{Index Exists?}
+        C -->|No| D[Create New Index]
+        C -->|Yes| E[Delete Index Templates]
+        E --> F{Delete Types Enabled?}
+        F -->|Yes| G[Delete Saved Objects by Type]
+        F -->|No| H[Create Destination Index]
+        G --> H
+        H --> I[Migrate Documents]
+        I --> J[Update Alias]
+        J --> K[Migration Complete]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `IndexMigrator` | Core migration orchestrator that handles index creation and document migration |
+| `MigrationContext` | Holds migration state including source/destination index info and configuration |
+| `MigrationOpenSearchClient` | Specialized OpenSearch client for migration operations |
+| `SavedObjectsSerializer` | Handles serialization/deserialization of saved objects |
+
+### Configuration
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `migrations.batchSize` | number | `1000` | Number of documents to migrate per batch |
+| `migrations.scrollDuration` | string | `15m` | Scroll context duration for reading documents |
+| `migrations.pollInterval` | number | `1500` | Interval (ms) to poll for migration status |
+| `migrations.skip` | boolean | `false` | Skip migrations entirely (use with caution) |
+| `migrations.delete.enabled` | boolean | `false` | Enable deletion of saved objects by type during migration |
+| `migrations.delete.types` | string[] | `[]` | List of saved object types to delete during migration |
+
+### Delete Types Feature
+
+The `migrations.delete` configuration allows administrators to specify saved object types that should be deleted during migration. This is useful when:
+
+- Migrating from legacy systems (Kibana OSS) with incompatible saved object types
+- Removing deprecated plugin data that prevents migration
+- Cleaning up orphaned saved objects from disabled plugins
+
+```yaml
+# opensearch_dashboards.yml
+migrations:
+  delete:
+    enabled: true
+    types:
+      - ui-metric
+      - telemetry
+      - legacy-plugin-type
+```
+
+**Warning**: This feature permanently deletes saved objects. Ensure you have backups before enabling.
+
+### Usage Example
+
+Standard migration happens automatically on startup. To configure delete types:
+
+```yaml
+# opensearch_dashboards.yml
+
+# Enable deletion of specific saved object types during migration
+migrations:
+  delete:
+    enabled: true
+    types:
+      - ui-metric  # Legacy telemetry data
+```
+
+## Limitations
+
+- Migration is a one-way process; rollback requires restoring from backup
+- Large indices may take significant time to migrate
+- Delete types feature permanently removes data without recovery option
+- `migrations.delete.types` must not be empty when `migrations.delete.enabled` is `true`
+
+## Change History
+
+- **v2.16.0** (2024-07-23): Added `migrations.delete` configuration to delete saved objects by type during migration ([#6443](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6443))
+
+## References
+
+### Documentation
+- [Migrating from Kibana OSS to OpenSearch Dashboards](https://docs.opensearch.org/latest/upgrade-to/dashboards-upgrade-to/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#6443](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6443) | Enable deletion of saved objects by type if configured |
+
+### Related Issues
+- [#1040](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1040) - Telemetry docs migration issue

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/saved-objects-migration.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/saved-objects-migration.md
@@ -1,0 +1,77 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Saved Objects Migration
+
+## Summary
+
+OpenSearch Dashboards v2.16.0 introduces a new configuration option to delete saved objects by type during migration. This feature helps resolve compatibility issues when migrating from legacy systems (like Kibana OSS) where incompatible saved object types may prevent successful migration.
+
+## Details
+
+### What's New in v2.16.0
+
+Two new configuration settings enable administrators to specify saved object types that should be deleted during the migration process:
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `migrations.delete.enabled` | boolean | `false` | Enable deletion of saved objects by type during migration |
+| `migrations.delete.types` | string[] | `[]` | List of saved object types to delete |
+
+### Technical Changes
+
+The implementation adds a `deleteSavedObjectsByType` function to the migration process that:
+
+1. Checks if `migrations.delete.enabled` is `true`
+2. Retrieves the list of types from `migrations.delete.types`
+3. Executes a `deleteByQuery` operation on the source index before migration
+4. Removes corresponding type mappings from the target index
+
+```mermaid
+flowchart TB
+    A[Migration Start] --> B{delete.enabled?}
+    B -->|No| D[Continue Migration]
+    B -->|Yes| C[Delete Saved Objects by Type]
+    C --> E[Remove Type Mappings]
+    E --> D
+```
+
+### Configuration Example
+
+```yaml
+# opensearch_dashboards.yml
+migrations:
+  delete:
+    enabled: true
+    types:
+      - ui-metric
+      - telemetry
+```
+
+### Use Case
+
+This feature addresses a common migration issue where:
+
+1. Users migrate from Kibana OSS to OpenSearch Dashboards
+2. Legacy saved objects (e.g., telemetry, ui-metric) exist in the `.kibana` index
+3. These types are not defined by any enabled plugin in OpenSearch Dashboards
+4. Migration fails because OpenSearch Dashboards cannot process unknown types
+
+With this feature, administrators can configure OpenSearch Dashboards to automatically delete these incompatible types during migration.
+
+## Limitations
+
+- **Data Loss Risk**: Deleted saved objects cannot be recovered. Use with caution and ensure you have backups.
+- **Validation**: If `migrations.delete.enabled` is `true`, `migrations.delete.types` must not be empty (validation enforced).
+- **One-time Operation**: Deletion occurs during migration; it does not affect saved objects created after migration.
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#6443](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6443) | Enable deletion of saved objects by type if configured | [#1040](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1040) |
+
+### Related Issues
+- [#1040](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1040) - Telemetry docs migration issue

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -34,6 +34,7 @@
 - Quick Range Selection Fix
 - Sample Data Import
 - Saved Objects Management
+- Saved Objects Migration
 - Sidecar Z-Index Fix
 - Timeline Visualization Fixes
 - UI Improvements


### PR DESCRIPTION
## Summary

Adds documentation for the Saved Objects Migration feature introduced in OpenSearch Dashboards v2.16.0.

## Changes

- **Release Report**: `docs/releases/v2.16.0/features/opensearch-dashboards/saved-objects-migration.md`
- **Feature Report**: `docs/features/opensearch-dashboards/opensearch-dashboards-saved-objects-migration.md`
- Updated release and feature indexes

## Feature Overview

This feature adds `migrations.delete` configuration to delete saved objects by type during migration, helping resolve compatibility issues when migrating from legacy systems (Kibana OSS).

### Key Configuration
- `migrations.delete.enabled`: Enable deletion of saved objects by type
- `migrations.delete.types`: List of saved object types to delete

## References
- PR: opensearch-project/OpenSearch-Dashboards#6443
- Issue: opensearch-project/OpenSearch-Dashboards#1040

Closes #2290