### PR TITLE
docs: add VisBuilder GA report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-visbuilder.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-visbuilder.md
@@ -111,7 +111,7 @@ graph TB
 
 ## Change History
 
-- **v2.16.0** (2024-08-06): Enhanced drag-and-drop with cross-axis movement, field replacement, and reordering; Added experimental Vega specification generation; Bug fixes for Metric/Table rendering, configuration pane scrolling, legend toggle, and data source compatibility
+- **v2.16.0** (2024-08-06): Promoted from experimental to production (GA); Removed experimental banner and beaker icon; No longer requires lab mode; Enhanced drag-and-drop with cross-axis movement, field replacement, and reordering; Added experimental Vega specification generation; Bug fixes for Metric/Table rendering, configuration pane scrolling, legend toggle, and data source compatibility
 
 ## References
 
@@ -121,6 +121,7 @@ graph TB
 ### Pull Requests
 | Version | PR | Description |
 |---------|-----|-------------|
+| v2.16.0 | [#6436](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6436) | Change VisBuilder from experimental to production (GA) |
 | v2.16.0 | [#7107](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7107) | Enhance Drag & Drop functionality in Vis Builder |
 | v2.16.0 | [#7288](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7288) | Add capability to generate dynamic Vega |
 | v2.16.0 | [#6674](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6674) | Fix flat render structure in Metric and Table Vis |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/visbuilder-ga.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/visbuilder-ga.md
@@ -1,0 +1,58 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# VisBuilder GA
+
+## Summary
+
+VisBuilder has been promoted from experimental to production status in OpenSearch Dashboards v2.16.0. This change removes the experimental banner, beaker icon, and lab mode dependency, making VisBuilder a fully supported visualization tool available to all users by default.
+
+## Details
+
+### What's New in v2.16.0
+
+VisBuilder is now generally available (GA) as a production-ready visualization tool. Key changes include:
+
+| Change | Description |
+|--------|-------------|
+| Experimental banner removed | No longer displays "This editor is experimental" warning |
+| Beaker icon removed | Saved VisBuilder visualizations no longer show experimental icon |
+| Lab mode dependency removed | VisBuilder loads regardless of `visualize:enableLabs` setting |
+| Stage property updated | Changed from `experimental` to `production` |
+
+### Technical Changes
+
+The following components were removed or modified:
+
+| File | Change |
+|------|--------|
+| `experimental_info.tsx` | Removed - experimental banner component |
+| `disabled_embeddable.tsx` | Removed - disabled state for lab mode |
+| `disabled_visualization.tsx` | Removed - disabled visualization message |
+| `workspace.tsx` | Removed ExperimentalInfo component |
+| `plugin.ts` | Removed `stage: 'experimental'` property |
+| `vis_builder_embeddable_factory.tsx` | Removed lab mode check and DisabledEmbeddable |
+| `types.ts` | Updated stage type to only allow `'production'` |
+
+### User Impact
+
+- VisBuilder is now available without enabling experimental features
+- Existing VisBuilder visualizations continue to work without changes
+- No migration required for saved visualizations
+- VisBuilder visualizations can be embedded in dashboards without lab mode
+
+## Limitations
+
+None specific to this change. VisBuilder retains all existing functionality.
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#6436](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6436) | Change VisBuilder from experimental to production | [#6435](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6435) |
+| [#6971](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6971) | Backport to 2.x branch | - |
+
+### Documentation
+- [VisBuilder Documentation](https://docs.opensearch.org/2.16/dashboards/visualize/visbuilder/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -42,5 +42,6 @@
 - Vega Visualization Fixes
 - VisBuilder Enhancements
 - VisBuilder Fixes
+- VisBuilder GA
 - Visualization Color Fix
 - Workspace


### PR DESCRIPTION
## Summary

This PR adds documentation for VisBuilder's promotion from experimental to production (GA) status in OpenSearch Dashboards v2.16.0.

## Changes

### Release Report
- Created `docs/releases/v2.16.0/features/opensearch-dashboards/visbuilder-ga.md`
- Documents the removal of experimental banner, beaker icon, and lab mode dependency

### Feature Report
- Updated `docs/features/opensearch-dashboards/opensearch-dashboards-visbuilder.md`
- Added GA status to Change History
- Added PR #6436 to References

### Release Index
- Updated `docs/releases/v2.16.0/index.md` with VisBuilder GA entry

## Related
- Investigation Issue: #2289
- Source PR: [opensearch-project/OpenSearch-Dashboards#6436](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6436)