### PR TITLE
docs: add Data Explorer report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/index.md
+++ b/docs/features/opensearch-dashboards/index.md
@@ -22,6 +22,7 @@
 | [opensearch-dashboards-dashboards-maintenance](opensearch-dashboards-dashboards-maintenance.md) | Dashboards Maintenance |
 | [opensearch-dashboards-dashboards-ui-updates](opensearch-dashboards-dashboards-ui-updates.md) | Dashboards UI Updates (OUI) |
 | [opensearch-dashboards-data-connections](opensearch-dashboards-data-connections.md) | Data Connections |
+| [opensearch-dashboards-data-explorer](opensearch-dashboards-data-explorer.md) | Data Explorer |
 | [opensearch-dashboards-data-importer](opensearch-dashboards-data-importer.md) | Data Importer |
 | [opensearch-dashboards-data-source-permissions](opensearch-dashboards-data-source-permissions.md) | Data Source Permissions |
 | [opensearch-dashboards-data-source-selector](opensearch-dashboards-data-source-selector.md) | Data Source Selector |

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-data-explorer.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-data-explorer.md
@@ -1,0 +1,88 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Data Explorer
+
+## Summary
+
+Data Explorer is the container application framework in OpenSearch Dashboards that hosts the Discover plugin and provides the infrastructure for data exploration experiences. It manages the application shell, routing, state management, and coordination between various data exploration components including the sidebar, canvas, and panel areas.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Dashboards"
+        subgraph "Data Explorer Plugin"
+            App[DataExplorerApp]
+            AC[AppContainer]
+            View[View Component]
+            Sidebar[Sidebar]
+            Canvas[Canvas]
+            Panel[Panel]
+        end
+        subgraph "Data Services"
+            QS[Query Service]
+            FM[Filter Manager]
+            TF[Time Filter]
+        end
+        subgraph "Discover Plugin"
+            DV[Discover View]
+            DT[Document Table]
+            FS[Field Selector]
+        end
+    end
+    
+    App --> AC
+    AC --> View
+    View --> Sidebar
+    View --> Canvas
+    View --> Panel
+    DV --> View
+    QS --> Canvas
+    FM --> Canvas
+    TF --> Canvas
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| DataExplorerApp | Main application entry point that initializes the explorer |
+| AppContainer | Container component managing layout and routing |
+| View | Pluggable view component that hosts specific exploration experiences |
+| Sidebar | Left panel for field selection and navigation |
+| Canvas | Main content area for displaying data and visualizations |
+| Panel | Bottom or side panel for additional information |
+
+### State Management
+
+Data Explorer uses Redux for state management with the following slices:
+- `metadata` - Index pattern and view metadata
+- `preload` - Preloaded data and default configurations
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `data_explorer.enabled` | Enable Data Explorer plugin | true |
+
+## Limitations
+
+- Data Explorer is tightly coupled with the Discover plugin
+- Custom views require implementing the View interface
+- State synchronization with URL can cause performance issues if not optimized
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Performance optimization - View components now render directly based on data service updates instead of history object changes, reducing unnecessary AppContainer re-renders
+- **v2.15.0** (2024-06-04): Initial stable release with Discover integration
+
+## References
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#6167](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6167) | Allow render from View directly, not from Data Explorer |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/data-explorer.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/data-explorer.md
@@ -1,0 +1,78 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Data Explorer
+
+## Summary
+
+Data Explorer is the container application in OpenSearch Dashboards that hosts the Discover plugin and manages the overall data exploration experience. In v2.16.0, a performance optimization was introduced to allow View components to render directly without going through the Data Explorer's AppContainer, reducing unnecessary re-renders when data services update.
+
+## Details
+
+### What's New in v2.16.0
+
+The main change in this release addresses a performance issue where the entire AppContainer would re-render whenever data services (query, filter, or time range) were updated. This happened because the history object changes triggered re-renders at the top level.
+
+### Technical Changes
+
+**Before (v2.15.0 and earlier):**
+- Data Explorer's AppContainer subscribed to history changes
+- Query, filter, or time range updates modified the history object
+- History changes triggered full AppContainer re-renders
+- Child components (Canvas, Panel) re-rendered as a consequence
+
+**After (v2.16.0):**
+- View components (Canvas, Panel) render directly based on data updates
+- Components subscribe to data service changes independently
+- History object changes no longer trigger AppContainer re-renders
+- Only affected components re-render when data updates occur
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Before v2.16.0"
+        DE1[Data Explorer] --> AC1[AppContainer]
+        AC1 --> |history changes| V1[View]
+        V1 --> C1[Canvas]
+        V1 --> P1[Panel]
+        DS1[Data Services] --> |updates| H1[History]
+        H1 --> |triggers| AC1
+    end
+    
+    subgraph "After v2.16.0"
+        DE2[Data Explorer] --> AC2[AppContainer]
+        AC2 --> V2[View]
+        V2 --> C2[Canvas]
+        V2 --> P2[Panel]
+        DS2[Data Services] --> |direct updates| C2
+        DS2 --> |direct updates| P2
+    end
+```
+
+### Code Changes
+
+The changes were made in `src/plugins/data_explorer/public/components/`:
+
+| File | Changes |
+|------|---------|
+| `app.tsx` | Removed history subscription and URL sync logic; simplified to render View directly |
+| `app_container.tsx` | Removed re-render triggers based on history changes |
+
+Key modifications:
+- Removed `useLocation` hook from `DataExplorerApp`
+- Removed `syncQueryStateWithUrl` call that caused re-renders
+- Simplified component to pass params directly to View
+
+## Limitations
+
+- This optimization is specific to the Data Explorer plugin architecture
+- Other plugins using similar patterns may need separate optimization
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#6167](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6167) | Allow render from View directly, not from Data Explorer | - |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -3,6 +3,7 @@
 ## Features
 
 ### opensearch-dashboards
+- Data Explorer
 - Field Name Search
 - Language Selector
 - UI Metric Collector Server-Side Batching


### PR DESCRIPTION
## Summary

This PR adds documentation for the Data Explorer feature in OpenSearch Dashboards v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch-dashboards/data-explorer.md`
- Feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-data-explorer.md` (new)

### Key Changes in v2.16.0
- Performance optimization: View components now render directly based on data service updates instead of history object changes
- Reduces unnecessary AppContainer re-renders when query, filter, or time range updates occur

### Resources Used
- PR: [#6167](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6167)

Closes #2287