### PR TITLE
docs: add Theme & Dark Mode Settings report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/index.md
+++ b/docs/features/opensearch-dashboards/index.md
@@ -57,6 +57,7 @@
 | [opensearch-dashboards-sample-data](opensearch-dashboards-sample-data.md) | Sample Data |
 | [opensearch-dashboards-saved-query-ux](opensearch-dashboards-saved-query-ux.md) | Saved Query UX |
 | [opensearch-dashboards-saved-objects-migration](opensearch-dashboards-saved-objects-migration.md) | Saved Objects Migration |
+| [opensearch-dashboards-theme-dark-mode-settings](opensearch-dashboards-theme-dark-mode-settings.md) | Theme & Dark Mode Settings |
 | [opensearch-dashboards-tsvb-visualization](opensearch-dashboards-tsvb-visualization.md) | TSVB Visualization |
 | [opensearch-dashboards-timeline-visualization](opensearch-dashboards-timeline-visualization.md) | Timeline Visualization |
 | [opensearch-dashboards-ui-metric-collector](opensearch-dashboards-ui-metric-collector.md) | UI Metric Collector |

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-theme-dark-mode-settings.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-theme-dark-mode-settings.md
@@ -1,0 +1,113 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Theme & Dark Mode Settings
+
+## Summary
+
+OpenSearch Dashboards provides user-specific theme and dark mode settings, allowing individual users to customize their appearance preferences independently. Users can choose between light mode, dark mode, or automatic browser-based detection, with settings stored locally per device.
+
+## Details
+
+### Architecture
+
+The theme system in OpenSearch Dashboards separates server-side defaults from client-side user preferences:
+
+```mermaid
+graph TB
+    subgraph Server
+        Config[opensearch_dashboards.yml]
+        SavedObjects[(Saved Objects)]
+        StartupJS[startup.js Generator]
+    end
+    
+    subgraph Browser
+        LocalStorage[(Local Storage)]
+        ThemeLoader[Theme Loader]
+        AppearanceMenu[Appearance Menu]
+    end
+    
+    Config --> StartupJS
+    SavedObjects --> StartupJS
+    StartupJS --> ThemeLoader
+    LocalStorage --> ThemeLoader
+    ThemeLoader --> AppearanceMenu
+    AppearanceMenu --> LocalStorage
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `startup.js` | Render-blocking script that applies theme before page content loads |
+| `HeaderUserThemeMenu` | React component for the appearance menu in global navigation |
+| `ui_settings_client.ts` | Client-side settings manager with local storage support |
+| `preferBrowserSetting` | UI setting property indicating browser-stored values |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `theme:enableUserControl` | Enable user control of theme settings | `true` |
+| `theme:darkMode` | Dark mode preference | `false` |
+| `theme:version` | Theme version (`v7` or `Next (preview)`) | `v7` |
+
+### Theme Options
+
+**Screen Mode:**
+- Light mode - Always use light theme
+- Dark mode - Always use dark theme  
+- Use browser settings - Match OS/browser preference
+
+**Theme Version:**
+- v7 - Classic OpenSearch Dashboards theme
+- Next (preview) - Modern theme preview
+
+### Usage Example
+
+Users access theme settings via the Appearance menu in the top navigation bar:
+
+1. Click the color palette icon in the header
+2. Select theme version (v7 or Next)
+3. Select screen mode (Light, Dark, or Browser settings)
+4. Click "Apply" to save and reload
+
+### Storage Mechanism
+
+When user control is enabled, theme preferences are stored in browser local storage:
+
+```json
+{
+  "theme:darkMode": { "userValue": true },
+  "theme:version": { "userValue": "Next (preview)" }
+}
+```
+
+The `useBrowserColorScheme` flag indicates automatic mode detection.
+
+## Limitations
+
+- Theme settings are per-device, not synced across browsers/devices
+- Server-side rendering cannot access user theme preferences
+- Page reload required for theme changes to take effect
+- "Use browser settings" only checks at page load, not dynamically
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Initial implementation - user-specific theme settings with appearance menu and browser settings support
+
+## References
+
+### Documentation
+- [OpenSearch Dashboards Quickstart - Appearance Theme](https://docs.opensearch.org/latest/dashboards/quickstart/#customizing-the-appearance-theme)
+- [Advanced Settings](https://docs.opensearch.org/latest/dashboards/management/advanced-settings/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#5652](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5652) | Make theme settings user-specific and user-configurable |
+
+### Issues
+- [#4462](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4462) - Add dark mode option that respects browser settings
+- [#4454](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4454) - User-specific settings (related)

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/theme-dark-mode-settings.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/theme-dark-mode-settings.md
@@ -1,0 +1,89 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Theme & Dark Mode Settings
+
+## Summary
+
+OpenSearch Dashboards v2.16.0 introduces user-specific theme and dark mode settings, allowing individual users to customize their appearance preferences independently of cluster-wide settings. Theme settings are now stored in browser local storage rather than as cluster-wide saved objects, enabling different users on the same instance to use different themes.
+
+## Details
+
+### What's New in v2.16.0
+
+This release fundamentally changes how theme settings work in OpenSearch Dashboards:
+
+1. **User-Specific Settings**: Theme version and dark mode are now stored per-device in browser local storage
+2. **Appearance Menu**: New global navigation control for quick theme switching
+3. **Browser Settings Support**: Option to automatically match browser/OS dark mode preferences
+4. **Admin Opt-Out**: Administrators can disable user control via Advanced Settings
+
+### Architecture
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant LocalStorage
+    participant Server
+    participant SavedObjects
+    
+    Note over Browser,SavedObjects: Page Load Flow
+    Browser->>LocalStorage: Read uiSettings
+    Browser->>Server: Request startup.js
+    Server->>SavedObjects: Get default settings
+    Server->>Browser: Return startup.js with defaults
+    Browser->>Browser: Apply theme from localStorage or defaults
+    
+    Note over Browser,SavedObjects: User Changes Theme
+    Browser->>LocalStorage: Save theme preference
+    Browser->>Browser: Reload page with new theme
+```
+
+### Key Components
+
+| Component | Description |
+|-----------|-------------|
+| `startup.js` | New script that applies theme settings before page render |
+| `HeaderUserThemeMenu` | New appearance menu in global navigation |
+| `ui_settings_client.ts` | Updated to read/write browser-stored settings |
+| `theme:enableUserControl` | New setting to enable/disable user control |
+| `preferBrowserSetting` | New UI setting property for browser-stored values |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `theme:enableUserControl` | Enable user control of theme settings | `true` |
+| `theme:darkMode` | Dark mode preference (now per-user) | `false` |
+| `theme:version` | Theme version (v7 or Next preview) | `v7` |
+
+### Usage
+
+When `theme:enableUserControl` is enabled:
+- Users see an "Appearance" button in the top navigation
+- Theme changes are stored in browser local storage
+- Users can choose "Use browser settings" to auto-match OS preferences
+- Advanced Settings shows theme options as disabled with explanatory message
+
+When disabled:
+- Theme settings work as before (cluster-wide)
+- No appearance menu in navigation
+- Administrators control theme via Advanced Settings
+
+## Limitations
+
+- Server-side components cannot know the user's theme preference (stored client-side)
+- Theme changes require page reload to take effect
+- Browser settings option only checks preference at page load, not dynamically
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#5652](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5652) | Make theme settings user-specific and user-configurable | [#4462](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4462) |
+
+### Documentation
+- [OpenSearch Dashboards Quickstart - Appearance Theme](https://docs.opensearch.org/2.16/dashboards/quickstart/#customizing-the-appearance-theme)
+- [Advanced Settings](https://docs.opensearch.org/2.16/dashboards/management/advanced-settings/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -47,3 +47,4 @@
 - Visualization Color Fix
 - Workspace
 - Workspace Admin and Sample Data
+- Theme & Dark Mode Settings


### PR DESCRIPTION
## Summary

This PR adds documentation for the Theme & Dark Mode Settings feature introduced in OpenSearch Dashboards v2.16.0.

## Changes

### Release Report
- `docs/releases/v2.16.0/features/opensearch-dashboards/theme-dark-mode-settings.md`

### Feature Report
- `docs/features/opensearch-dashboards/opensearch-dashboards-theme-dark-mode-settings.md`

## Feature Overview

OpenSearch Dashboards v2.16.0 introduces user-specific theme and dark mode settings:

- Theme settings stored per-device in browser local storage
- New "Appearance" menu in global navigation for quick theme switching
- Support for automatic browser/OS dark mode detection
- Admin opt-out capability via `theme:enableUserControl` setting

## Related Issue
Closes #2285

## References
- PR: [opensearch-project/OpenSearch-Dashboards#5652](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/5652)
- Issue: [opensearch-project/OpenSearch-Dashboards#4462](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/4462)