### PR TITLE
docs: add data-enhancements-cleanup report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-query-enhancements.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-query-enhancements.md
@@ -97,6 +97,12 @@ flowchart TB
 | `query:enhancements:enabled` | Enable query enhancements feature | false |
 | `data.search.polling.interval` | Polling interval for async queries (ms) | 5000 |
 
+**Deprecated Settings (removed in v2.16.0):**
+| Setting | Description | Status |
+|---------|-------------|--------|
+| `data.enhancements.enabled` | Config file toggle for enhancements | Removed - use `query:enhancements:enabled` UI setting |
+| `query:dataSource:readOnly` | Read-only data source in query editor | Removed - no replacement |
+
 ### Usage Example
 
 ```
@@ -121,7 +127,7 @@ source = logs-* | where status >= 400 | head 100
 
 - **v3.0.0** (2025-03-11): PPL query bugfixes - grammar parsing in auto-suggest, timezone handling for time columns, millisecond precision in date fields, error message display in query editors, time range handling for non-search queries
 - **v2.18.0** (2024-11-05): Bug fixes for async polling, error handling, language compatibility, saved query persistence; Added extensibility for custom search strategies via `defineSearchStrategyRoute`; Added keyboard shortcut (Cmd/Ctrl+Enter) for query execution; Exposed datasets and data_frames modules for external plugin imports
-- **v2.16.0** (2024-07-30): Initial Language Selector support - plugins can register custom query languages via UI Service; Dynamic search interceptor switching at runtime; Data Frame structure for non-DSL query results; Configuration via `data.enhancements.enabled`
+- **v2.16.0** (2024-07-30): Initial Language Selector support - plugins can register custom query languages via UI Service; Dynamic search interceptor switching at runtime; Data Frame structure for non-DSL query results; **Deprecated**: Removed `data.enhancements.enabled` config toggle and `query:dataSource:readOnly` UI setting - feature now controlled solely via `query:enhancements:enabled` UI setting
 
 
 ## References
@@ -149,4 +155,5 @@ source = logs-* | where status >= 400 | head 100
 | v2.18.0 | [#8743](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8743) | Fix error handling in query enhancement facet | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
 | v2.18.0 | [#8749](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8749) | Updates query and language if language is not supported by query data |   |
 | v2.18.0 | [#8771](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8771) | Fix error handling for ppl jobs API | [#1234](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/1234) |
+| v2.16.0 | [#7291](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7291) | Remove data enhancements config and readonly flag | [#7212](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7212) |
 | v2.16.0 | [#6613](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6613) | Support language selector from the data plugin | [#6639](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6639) |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/data-enhancements-cleanup.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/data-enhancements-cleanup.md
@@ -1,0 +1,54 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Data Enhancements Cleanup
+
+## Summary
+
+This deprecation removes the `data.enhancements.enabled` configuration toggle and the `query:dataSource:readOnly` UI setting from OpenSearch Dashboards. The query enhancements feature now relies solely on the `query:enhancements:enabled` UI setting for enablement, simplifying the configuration model.
+
+## Details
+
+### What's Deprecated in v2.16.0
+
+The following configuration options have been removed:
+
+| Removed Setting | Type | Previous Default | Replacement |
+|-----------------|------|------------------|-------------|
+| `data.enhancements.enabled` | opensearch_dashboards.yml | `false` | Use `query:enhancements:enabled` UI setting |
+| `query:dataSource:readOnly` | UI Setting | `true` | Removed (no replacement needed) |
+
+### Technical Changes
+
+1. **Configuration File Changes**
+   - Removed `data.enhancements.enabled` from `opensearch_dashboards.yml`
+   - The `start:enhancements` npm script no longer requires the `--data.enhancements.enabled=true` flag
+
+2. **UI Settings Cleanup**
+   - Removed `QUERY_DATA_SOURCE_READONLY` constant from UI settings
+   - Removed the "Read-only data source in query editor" advanced setting
+   - Query editor no longer checks `isDataSourceReadOnly` flag
+
+3. **Code Simplification**
+   - Settings class now initializes `isEnabled` to `false` instead of reading from config
+   - Removed dead URL link reference in template.tsx
+
+### Migration
+
+Users who previously enabled data enhancements via `data.enhancements.enabled: true` in `opensearch_dashboards.yml` should:
+
+1. Remove the `data.enhancements.enabled` line from configuration
+2. Enable query enhancements via Advanced Settings: `query:enhancements:enabled = true`
+
+## Limitations
+
+- The `query:dataSource:readOnly` setting is removed without replacement as it was experimental and caused confusion
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#7291](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7291) | Remove data enhancements config and readonly flag | Followup to [#7212](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7212) |
+| [#7212](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7212) | Add query enhancements plugin as a core plugin | [#6072](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6072) |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -3,6 +3,7 @@
 ## Features
 
 ### opensearch-dashboards
+- Data Enhancements Cleanup
 - Data Explorer
 - Field Name Search
 - Language Selector


### PR DESCRIPTION
## Summary

Documents the deprecation of `data.enhancements.enabled` config toggle and `query:dataSource:readOnly` UI setting in OpenSearch Dashboards v2.16.0.

## Changes
- Created release report: `docs/releases/v2.16.0/features/opensearch-dashboards/data-enhancements-cleanup.md`
- Updated feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-query-enhancements.md`
  - Added deprecated settings table
  - Updated change history
  - Added PR #7291 to references
- Updated release index

## Related
- Closes #2284
- PR: [#7291](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7291)