### PR TITLE
docs: add opensearch-dashboards-cve-fixes report for v2.16.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dependency-updates.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dependency-updates.md
@@ -77,7 +77,7 @@ yarn upgrade json11@^2.0.0
 
 - **v3.0.0** (2025-05-13): Security updates for vega (5.32.0), dompurify (3.2.4), markdown-it (13.0.2) addressing CVE-2025-25304 and CVE-2025-26791
 - **v2.18.0** (2024-10-22): JSON11 upgrade to 2.0.0 for UTF-8 safety, chokidar bump to 3.6.0
-- **v2.16.0** (2024-08-06): Babel dependency fix - updated @babel/traverse to ^7.25.0 and @babel/plugin-transform-class-static-block to ^7.24.7 to resolve bootstrapping errors on 2.x branch
+- **v2.16.0** (2024-08-06): Multiple CVE fixes - tar (CVE-2024-28863), ejs (CVE-2024-33883), braces (CVE-2024-4067/4068), jimp/phin (GHSA-x565-32qp-m3vf), axios (SNYK-JS-AXIOS-6144788), ws (CVE-2024-37890); Babel dependency fix
 
 
 ## References
@@ -95,6 +95,12 @@ yarn upgrade json11@^2.0.0
 | v2.18.0 | [#8603](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8603) | Upgrade JSON11 from 1.1.2 to 2.0.0 | [#7367](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7367) |
 | v2.18.0 | [#8490](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/8490) | Bump chokidar from 3.5.3 to 3.6.0 |   |
 | v2.16.0 | [#7541](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7541) | Fix babel error (update @babel/traverse and @babel/plugin-transform-class-static-block) |   |
+| v2.16.0 | [#6492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6492) | [CVE-2024-28863] Bump tar from 6.1.13 to 6.2.1 | [#6488](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6488) |
+| v2.16.0 | [#6770](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6770) | [CVE-2024-33883] Bump ejs from 3.1.7 to 3.1.10 | [#6769](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6769) |
+| v2.16.0 | [#6911](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6911) | [CVE-2024-4067/4068] Bump braces-dependent packages | [#6791](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6791), [#6792](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6792) |
+| v2.16.0 | [#6977](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6977) | [GHSA-x565-32qp-m3vf] Bump jimp to remove phin |   |
+| v2.16.0 | [#7149](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7149) | [SNYK-JS-AXIOS-6144788] Bump axios to 1.7.2 |   |
+| v2.16.0 | [#7153](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7153) | [CVE-2024-37890] Bump ws to 8.17.1/7.5.10 |   |
 
 ### Issues (Design / RFC)
 - [Issue #9400](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9400): CVE-2025-25304 in vega-selections

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/cve-fixes.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/cve-fixes.md
@@ -1,0 +1,76 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# OpenSearch Dashboards CVE Fixes
+
+## Summary
+
+OpenSearch Dashboards v2.16.0 addresses multiple security vulnerabilities (CVEs) by updating vulnerable npm dependencies. These updates fix denial-of-service, prototype pollution, and other security issues in third-party packages.
+
+## Details
+
+### What's New in v2.16.0
+
+Six security-related dependency updates were merged to address known CVEs:
+
+| CVE/Advisory | Package | Previous Version | Updated Version | Severity |
+|--------------|---------|------------------|-----------------|----------|
+| CVE-2024-28863 | tar | 6.1.13 | 6.2.1 | High |
+| CVE-2024-33883 | ejs | 3.1.7 | 3.1.10 | High |
+| CVE-2024-4067, CVE-2024-4068 | braces (via micromatch, webpack) | < 3.0.3 | 3.0.3+ | High |
+| GHSA-x565-32qp-m3vf | jimp (phin dependency) | < 0.22.0 | 0.22.0 | Medium |
+| SNYK-JS-AXIOS-6144788 | axios | < 1.7.2 | 1.7.2 | Medium |
+| CVE-2024-37890 | ws | 8.5.0, 7.5.7 | 8.17.1, 7.5.10 | High |
+
+### Technical Changes
+
+#### tar (CVE-2024-28863)
+Denial of service vulnerability in the tar package. The update to 6.2.1 fixes the issue where specially crafted tar files could cause excessive CPU consumption.
+
+#### ejs (CVE-2024-33883)
+Template injection vulnerability in the EJS templating engine. The update to 3.1.10 addresses prototype pollution issues.
+
+#### braces (CVE-2024-4067, CVE-2024-4068)
+Regular expression denial of service (ReDoS) vulnerability in the braces package. Multiple packages were updated:
+- `@amoo-miki/webpack` to `4.46.0-xxhash.1`
+- `micromatch` to `4.0.7`
+- `@types/watchpack` to `2.4.4`
+- `watchpack` to `2.4.1`
+
+#### jimp (GHSA-x565-32qp-m3vf)
+The `phin` HTTP client dependency had a vulnerability. The update to `jimp@0.22.0` removes the vulnerable code path, and an arbitrary bump of `phin` avoids including the offending version in dev dependencies.
+
+#### axios (SNYK-JS-AXIOS-6144788)
+Cross-Site Request Forgery (CSRF) vulnerability in axios. The update to 1.7.2 fixes the issue.
+
+#### ws (CVE-2024-37890)
+Denial of service vulnerability in the WebSocket library. Both major version lines were updated:
+- ws 8.x: 8.5.0 → 8.17.1
+- ws 7.x: 7.5.7 → 7.5.10
+
+## Limitations
+
+- These are dependency updates only; no functional changes to OpenSearch Dashboards
+- Users running older versions should upgrade to receive these security fixes
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#6492](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6492) | Bump tar from 6.1.13 to 6.2.1 | [#6488](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6488) |
+| [#6770](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6770) | Bump ejs from 3.1.7 to 3.1.10 | [#6769](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6769) |
+| [#6911](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6911) | Bump packages dependent on braces | [#6791](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6791), [#6792](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6792) |
+| [#6977](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/6977) | Bump jimp to remove phin dependency | - |
+| [#7149](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7149) | Bump axios to 1.7.2 | - |
+| [#7153](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7153) | Bump ws from 8.5.0 to 8.17.1 and 7.5.7 to 7.5.10 | - |
+
+### Security Advisories
+- [CVE-2024-28863](https://nvd.nist.gov/vuln/detail/CVE-2024-28863) - tar denial of service
+- [CVE-2024-33883](https://nvd.nist.gov/vuln/detail/CVE-2024-33883) - ejs prototype pollution
+- [CVE-2024-4067](https://nvd.nist.gov/vuln/detail/CVE-2024-4067) - braces ReDoS
+- [CVE-2024-4068](https://nvd.nist.gov/vuln/detail/CVE-2024-4068) - braces ReDoS
+- [GHSA-x565-32qp-m3vf](https://github.com/advisories/GHSA-x565-32qp-m3vf) - phin vulnerability
+- [SNYK-JS-AXIOS-6144788](https://security.snyk.io/vuln/SNYK-JS-AXIOS-6144788) - axios CSRF
+- [CVE-2024-37890](https://nvd.nist.gov/vuln/detail/CVE-2024-37890) - ws denial of service

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -49,3 +49,4 @@
 - Workspace
 - Workspace Admin and Sample Data
 - Theme & Dark Mode Settings
+- CVE Fixes


### PR DESCRIPTION
## Summary

Adds documentation for OpenSearch Dashboards CVE fixes in v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch-dashboards/cve-fixes.md`
- Feature report: Updated `docs/features/opensearch-dashboards/opensearch-dashboards-dependency-updates.md`

### CVEs Addressed
| CVE/Advisory | Package | Updated Version |
|--------------|---------|-----------------|
| CVE-2024-28863 | tar | 6.2.1 |
| CVE-2024-33883 | ejs | 3.1.10 |
| CVE-2024-4067, CVE-2024-4068 | braces | 3.0.3+ |
| GHSA-x565-32qp-m3vf | jimp/phin | 0.22.0 |
| SNYK-JS-AXIOS-6144788 | axios | 1.7.2 |
| CVE-2024-37890 | ws | 8.17.1, 7.5.10 |

Closes #2283"