### PR TITLE
docs: add fs-info-reporting-fix report for v2.16.0

### DIFF
--- a/docs/features/opensearch/opensearch-file-cache.md
+++ b/docs/features/opensearch/opensearch-file-cache.md
@@ -239,6 +239,7 @@ PUT _cluster/settings
 
 - **v3.3.0** (2025-10-06): Added file cache active usage threshold monitoring with automatic index blocking
 - **v3.1.0** (2025-05-28): Added file pinning support and granular statistics (full file, block file, pinned file stats)
+- **v2.16.0** (2024-08-06): Fixed fs info reporting negative available size when file cache space is occupied by other files
 - **v2.7.0**: Initial implementation for Searchable Snapshots
 
 
@@ -255,6 +256,7 @@ PUT _cluster/settings
 | v3.3.0 | [#19071](https://github.com/opensearch-project/OpenSearch/pull/19071) | Added file cache active usage guard rails to DiskThresholdMonitor |   |
 | v3.1.0 | [#17617](https://github.com/opensearch-project/OpenSearch/pull/17617) | Added File Cache Pinning | [#13648](https://github.com/opensearch-project/OpenSearch/issues/13648) |
 | v3.1.0 | [#17538](https://github.com/opensearch-project/OpenSearch/pull/17538) | Added File Cache Stats (block and full file level) | [#17479](https://github.com/opensearch-project/OpenSearch/issues/17479) |
+| v2.16.0 | [#11573](https://github.com/opensearch-project/OpenSearch/pull/11573) | Fixed fs info reporting negative available size |   |
 | v2.7.0 | Initial | File Cache introduced for Searchable Snapshots |   |
 
 ### Issues (Design / RFC)

--- a/docs/releases/v2.16.0/features/opensearch/fs-info-reporting-fix.md
+++ b/docs/releases/v2.16.0/features/opensearch/fs-info-reporting-fix.md
@@ -1,0 +1,62 @@
+---
+tags:
+  - opensearch
+---
+# FS Info Reporting Fix
+
+## Summary
+
+Fixed an issue where filesystem info could report negative available size values on nodes with both `data` and `search` roles when file cache space was occupied by other files (primarily local index files).
+
+## Details
+
+### What's New in v2.16.0
+
+This release fixes a bug in the `FsProbe` class that caused `IllegalArgumentException` when calculating available disk space on nodes using file cache.
+
+### Problem
+
+On nodes with both `data` and `search` roles, the available disk space calculation could produce negative values when:
+
+1. Space is reserved for file cache (`node.search.cache.size`)
+2. The reserved file cache space is being used by other files (e.g., local index files)
+3. The calculation `available -= (fileCacheReserved - fileCacheUtilized)` results in a negative value
+
+This caused exceptions like:
+```
+java.lang.IllegalArgumentException: Values less than -1 bytes are not supported: -1781760b
+    at org.opensearch.core.common.unit.ByteSizeValue.<init>(ByteSizeValue.java:78)
+    at org.opensearch.monitor.fs.FsInfo$Path.getAvailable(FsInfo.java:141)
+    at org.opensearch.cluster.InternalClusterInfoService.fillDiskUsagePerNode(...)
+```
+
+### Solution
+
+The fix adds a bounds check in `FsProbe.stats()` to ensure available space is never reported as negative:
+
+```java
+paths[i].available -= (paths[i].fileCacheReserved - paths[i].fileCacheUtilized);
+// occurs if reserved file cache space is occupied by other files, like local indices
+if (paths[i].available < 0) {
+    paths[i].available = 0;
+}
+```
+
+### Technical Changes
+
+| File | Change |
+|------|--------|
+| `FsProbe.java` | Added bounds check to prevent negative available size |
+| `FsProbeTests.java` | Added test case `testFsInfoWhenFileCacheOccupied` |
+
+## Limitations
+
+- When file cache space is fully occupied by other files, available space will be reported as 0 rather than the actual negative value
+- This may affect disk allocation decisions in edge cases where the reserved space is heavily contested
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#11573](https://github.com/opensearch-project/OpenSearch/pull/11573) | Fix fs info reporting negative available size | - |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -2,6 +2,9 @@
 
 ## Features
 
+### opensearch
+- FS Info Reporting Fix
+
 ### opensearch-dashboards
 - Data Enhancements Cleanup
 - Data Explorer


### PR DESCRIPTION
## Summary

Adds documentation for the FS Info Reporting Fix in OpenSearch v2.16.0.

### Changes
- Created release report: `docs/releases/v2.16.0/features/opensearch/fs-info-reporting-fix.md`
- Updated feature report: `docs/features/opensearch/opensearch-file-cache.md` (added v2.16.0 to Change History and References)
- Updated release index: `docs/releases/v2.16.0/index.md`

### Issue
Closes #2282

### PR Investigated
- [opensearch-project/OpenSearch#11573](https://github.com/opensearch-project/OpenSearch/pull/11573) - Fix fs info reporting negative available size