### PR TITLE
docs: add system-index-warning report for v2.16.0

### DIFF
--- a/docs/features/opensearch/index.md
+++ b/docs/features/opensearch/index.md
@@ -189,6 +189,7 @@
 | [opensearch-streaming-transport-aggregation](opensearch-streaming-transport-aggregation.md) | Streaming Transport & Aggregation |
 | [opensearch-subject-interface](opensearch-subject-interface.md) | Subject Interface |
 | [opensearch-system-indices](opensearch-system-indices.md) | System Indices |
+| [opensearch-system-index-warning](opensearch-system-index-warning.md) | System Index Warning Handling |
 | [opensearch-system-ingest-pipeline](opensearch-system-ingest-pipeline.md) | System Ingest Pipeline |
 | [opensearch-systemd-security-configurations](opensearch-systemd-security-configurations.md) | Systemd Security Configurations |
 | [opensearch-task-cancellation-monitoring](opensearch-task-cancellation-monitoring.md) | Task Cancellation Monitoring |

--- a/docs/features/opensearch/opensearch-system-index-warning.md
+++ b/docs/features/opensearch/opensearch-system-index-warning.md
@@ -1,0 +1,68 @@
+---
+tags:
+  - opensearch
+---
+# System Index Warning Handling
+
+## Summary
+
+OpenSearch provides mechanisms to handle system index access warnings in the test framework. System indices are protected indexes used internally by OpenSearch and its plugins to store configuration and operational data. When tests access these indices, warnings are generated to indicate that direct access to system indices will be restricted in future versions.
+
+## Details
+
+### Overview
+
+System indices in OpenSearch (prefixed with `.`) are protected and used by various plugins:
+- `.opendistro_security` - Security plugin configuration
+- `.opendistro-alerting-*` - Alerting plugin data
+- `.opensearch-notifications-*` - Notifications configuration
+- `.opendistro-anomaly-*` - Anomaly detection data
+
+When REST API operations like `/_refresh` access these indices, OpenSearch generates warnings to inform users that direct access to system indices will be prevented by default in future major versions.
+
+### Test Framework Support
+
+The `OpenSearchRestTestCase` class provides a `refreshAllIndices()` method that refreshes all indices including hidden system indices. This method includes a custom warning handler to suppress system index access warnings during testing.
+
+### Warning Handler Behavior
+
+The warning handler in `refreshAllIndices()`:
+1. Returns `false` (no failure) if there are no warnings
+2. Iterates through all warnings to check if they are system index warnings
+3. Returns `false` (no failure) only if ALL warnings are system index access warnings
+4. Returns `true` (failure) if any non-system-index warning is present
+
+### Configuration
+
+System indices can be configured in `opensearch.yml`:
+
+```yaml
+plugins.security.system_indices.enabled: true
+plugins.security.system_indices.indices:
+  - ".opendistro-alerting-config"
+  - ".opendistro-alerting-alert*"
+  - ".opendistro-anomaly-results*"
+  - ".opensearch-notifications-*"
+```
+
+## Limitations
+
+- System index warnings are informational and do not affect functionality in current versions
+- Direct access to system indices may be restricted in future major versions
+- The warning suppression only applies to the test framework, not production code
+
+## Change History
+
+- **v2.16.0** (2024-07-05): Fixed handling of multiple system index warnings in `OpenSearchRestTestCase.refreshAllIndices()` ([#14635](https://github.com/opensearch-project/OpenSearch/pull/14635))
+
+## References
+
+### Documentation
+
+- [System Indexes](https://docs.opensearch.org/latest/security/configuration/system-indices/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#14635](https://github.com/opensearch-project/OpenSearch/pull/14635) | Allow system index warning in OpenSearchRestTestCase.refreshAllIndices |

--- a/docs/releases/v2.16.0/features/opensearch/system-index-warning.md
+++ b/docs/releases/v2.16.0/features/opensearch/system-index-warning.md
@@ -1,0 +1,76 @@
+---
+tags:
+  - opensearch
+---
+# System Index Warning
+
+## Summary
+
+This change improves the handling of system index access warnings in the OpenSearch test framework. The `refreshAllIndices` method in `OpenSearchRestTestCase` now correctly ignores multiple system index warnings instead of only handling a single warning.
+
+## Details
+
+### What's New in v2.16.0
+
+The `OpenSearchRestTestCase.refreshAllIndices()` method was updated to properly handle multiple system index access warnings. Previously, the warning handler only checked if there was exactly one warning and if it started with "this request accesses system indices:". This caused test failures when multiple system indices were accessed in a single refresh operation.
+
+### Technical Changes
+
+The warning handler logic was refactored from:
+
+```java
+if (warnings.isEmpty()) {
+    return false;
+} else if (warnings.size() > 1) {
+    return true;
+} else {
+    return warnings.get(0).startsWith("this request accesses system indices:") == false;
+}
+```
+
+To:
+
+```java
+if (warnings.isEmpty()) {
+    return false;
+}
+boolean allSystemIndexWarnings = true;
+for (String warning : warnings) {
+    if (!warning.startsWith("this request accesses system indices:")) {
+        allSystemIndexWarnings = false;
+        break;
+    }
+}
+return !allSystemIndexWarnings;
+```
+
+This change allows the test framework to ignore any number of system index warnings as long as all warnings are related to system index access.
+
+### Affected Components
+
+| Component | Description |
+|-----------|-------------|
+| `OpenSearchRestTestCase` | Base class for REST integration tests |
+| `refreshAllIndices()` | Method that refreshes all indices including hidden ones |
+
+### Use Case
+
+This fix is particularly important for plugins that create multiple system indices, such as:
+- Alerting plugin (`.opendistro-alerting-*`)
+- Notifications plugin (`.opensearch-notifications-*`)
+- Security plugin (`.opendistro_security`)
+
+When running integration tests that refresh all indices, the previous implementation would fail if multiple system indices existed.
+
+## Limitations
+
+- This change only affects the test framework and does not modify production behavior
+- System index warnings are still generated; they are just properly ignored in tests
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14635](https://github.com/opensearch-project/OpenSearch/pull/14635) | Allow system index warning in OpenSearchRestTestCase.refreshAllIndices | Related to [alerting#1584](https://github.com/opensearch-project/alerting/pull/1584) |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch
 - FS Info Reporting Fix
+- System Index Warning
 
 ### opensearch-dashboards
 - Data Enhancements Cleanup


### PR DESCRIPTION
## Summary

Add documentation for System Index Warning feature in v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch/system-index-warning.md`
- Feature report: `docs/features/opensearch/opensearch-system-index-warning.md`

### Key Changes in v2.16.0
- Fixed handling of multiple system index warnings in `OpenSearchRestTestCase.refreshAllIndices()`
- The warning handler now correctly ignores all system index access warnings instead of only handling a single warning

### Source
- PR: [opensearch-project/OpenSearch#14635](https://github.com/opensearch-project/OpenSearch/pull/14635)