### PR TITLE
docs: add multi-part-upload-fix report for v2.16.0

### DIFF
--- a/docs/features/opensearch/opensearch-remote-store.md
+++ b/docs/features/opensearch/opensearch-remote-store.md
@@ -130,6 +130,7 @@ PUT /_cluster/settings
 - **v3.1.0** (2026-01-10): Added close index request rejection during migration; Fixed cluster state diff download failures during alias operations
 - **v3.0.0** (2024-12-16): Added `cluster.remote_state.download.serve_read_api.enabled` setting to control full cluster state download on term mismatch
 - **v2.19.0** (2025-02-18): Fixed stale cluster state custom file deletion bug in `RemoteClusterStateCleanupManager`; Reverted minimum codec version upload logic for remote state manifest; Added OpenSearch version-aware deserialization for custom metadata to fix cluster upgrade failures
+- **v2.16.0** (2024-08-06): Fixed S3 multipart upload failures for remote cluster state objects by creating new `ByteArrayIndexInput` instances per upload part
 
 
 ## References
@@ -148,6 +149,7 @@ PUT /_cluster/settings
 | v2.19.0 | [#16670](https://github.com/opensearch-project/OpenSearch/pull/16670) | Fix stale cluster state custom file deletion | - |
 | v2.19.0 | [#16403](https://github.com/opensearch-project/OpenSearch/pull/16403) | Revert uploading of remote cluster state manifest using min codec version | - |
 | v2.19.0 | [#16494](https://github.com/opensearch-project/OpenSearch/pull/16494) | Add opensearch version info while deserialization | - |
+| v2.16.0 | [#14888](https://github.com/opensearch-project/OpenSearch/pull/14888) | Create new IndexInput for multi part upload | [#14808](https://github.com/opensearch-project/OpenSearch/issues/14808) |
 
 ### Issues (Design / RFC)
 - [Issue #18328](https://github.com/opensearch-project/OpenSearch/issues/18328): Reject close index requests during DocRep to SegRep migration

--- a/docs/releases/v2.16.0/features/opensearch/multi-part-upload-fix.md
+++ b/docs/releases/v2.16.0/features/opensearch/multi-part-upload-fix.md
@@ -1,0 +1,78 @@
+---
+tags:
+  - opensearch
+---
+# Multi-Part Upload Fix
+
+## Summary
+
+Fixed S3 multipart upload failures for remote cluster state objects. When remote state files exceeded 5 MB, the S3 plugin attempted multipart upload but failed due to all upload parts sharing the same `IndexInput` instance, causing file pointer conflicts and content-length mismatches.
+
+## Details
+
+### What's New in v2.16.0
+
+This release fixes a critical bug where S3 multipart uploads failed for remote cluster state objects when the payload exceeded 5 MB (the threshold for multipart upload).
+
+### Technical Changes
+
+The root cause was that when initializing parts for multipart upload, all parts shared the same `IndexInput` instance. Each part set the file pointer to its starting position, but since they shared the same backing `IndexInput`, the file pointer was overwritten by the last part. This caused:
+
+1. Only one part could read data correctly
+2. Other parts encountered content-length mismatches
+3. Upload failures with errors like "Request content was only X bytes, but the specified content-length was Y bytes"
+
+The fix ensures a new `ByteArrayIndexInput` instance is created for each part in the stream supplier function, rather than reusing a single instance.
+
+**Affected Components:**
+
+| Component | Change |
+|-----------|--------|
+| `BlobStoreTransferService` | Create new `ByteArrayIndexInput` per part in `OffsetRangeInputStreamSupplier` |
+| `ChecksumBlobStoreFormat` | Create new `ByteArrayIndexInput` per part for async upload |
+| `ConfigBlobStoreFormat` | Create new `ByteArrayIndexInput` per part for urgent priority uploads |
+
+**Code Change Pattern:**
+
+Before (broken):
+```java
+try (IndexInput input = new ByteArrayIndexInput(resourceDescription, bytes)) {
+    uploadBlobAsyncInternal(
+        ...,
+        (size, position) -> new OffsetRangeIndexInputStream(input, size, position),
+        ...
+    );
+}
+```
+
+After (fixed):
+```java
+uploadBlobAsyncInternal(
+    ...,
+    (size, position) -> new OffsetRangeIndexInputStream(
+        new ByteArrayIndexInput(resourceDescription, bytes), size, position),
+    ...
+);
+```
+
+### Reproduction Scenario
+
+1. Create a remote state publication enabled cluster with S3 as backing store
+2. Add nodes until `DiscoveryNodes` in cluster state exceeds 5 MB
+3. S3 plugin triggers multipart upload
+4. Upload fails with content-length mismatch exception
+
+## Limitations
+
+- This fix only addresses the multipart upload issue for remote cluster state
+- The 5 MB threshold for multipart upload is determined by the S3 plugin configuration
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14888](https://github.com/opensearch-project/OpenSearch/pull/14888) | Create new IndexInput for multi part upload | [#14808](https://github.com/opensearch-project/OpenSearch/issues/14808) |
+
+### Issues
+- [#14808](https://github.com/opensearch-project/OpenSearch/issues/14808): S3 Multi-part upload fails for remote cluster state

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch
 - FS Info Reporting Fix
+- Multi-Part Upload Fix
 - System Index Warning
 
 ### opensearch-dashboards


### PR DESCRIPTION
## Summary

Adds documentation for the S3 multipart upload fix in OpenSearch v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch/multi-part-upload-fix.md`
- Feature report: Updated `docs/features/opensearch/opensearch-remote-store.md` (Change History + References)

### Key Changes in v2.16.0
- Fixed S3 multipart upload failures for remote cluster state objects
- Root cause: All upload parts shared the same `IndexInput` instance, causing file pointer conflicts
- Fix: Create new `ByteArrayIndexInput` instance per upload part in the stream supplier function

### Resources Used
- PR: [#14888](https://github.com/opensearch-project/OpenSearch/pull/14888)
- Issue: [#14808](https://github.com/opensearch-project/OpenSearch/issues/14808)

Closes #2280