### PR TITLE
docs: add circuit-breaker-improvements report for v2.16.0

### DIFF
--- a/docs/features/opensearch/index.md
+++ b/docs/features/opensearch/index.md
@@ -22,6 +22,7 @@
 | [opensearch-cardinality-aggregation](opensearch-cardinality-aggregation.md) | Cardinality Aggregation |
 | [opensearch-cat-indices-api](opensearch-cat-indices-api.md) | Cat Indices API |
 | [opensearch-ci-infrastructure](opensearch-ci-infrastructure.md) | CI Infrastructure |
+| [opensearch-circuit-breaker](opensearch-circuit-breaker.md) | Circuit Breaker |
 | [opensearch-client-api-enhancements](opensearch-client-api-enhancements.md) | Client API Enhancements |
 | [opensearch-cluster-info-resource-stats](opensearch-cluster-info-resource-stats.md) | Cluster Info & Resource Stats |
 | [opensearch-cluster-management](opensearch-cluster-management.md) | Cluster Management |

--- a/docs/features/opensearch/opensearch-circuit-breaker.md
+++ b/docs/features/opensearch/opensearch-circuit-breaker.md
@@ -1,0 +1,98 @@
+---
+tags:
+  - opensearch
+---
+# Circuit Breaker
+
+## Summary
+
+Circuit breakers are a memory protection mechanism in OpenSearch that prevent OutOfMemoryError by monitoring and limiting memory usage across various operations. When memory consumption approaches configured thresholds, circuit breakers "trip" and reject requests with a `CircuitBreakingException`, allowing the cluster to remain stable.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Circuit Breaker Hierarchy"
+        Parent[Parent Circuit Breaker]
+        Parent --> Request[Request Circuit Breaker]
+        Parent --> FieldData[Field Data Circuit Breaker]
+        Parent --> InFlight[In-Flight Request Circuit Breaker]
+    end
+    
+    subgraph "Protected Operations"
+        Request --> Agg[Aggregations]
+        Request --> Search[Search Reduce Phase]
+        FieldData --> FDCache[Field Data Cache]
+        InFlight --> Transport[Transport/HTTP Requests]
+    end
+```
+
+### Circuit Breaker Types
+
+| Circuit Breaker | Purpose | Default Limit |
+|-----------------|---------|---------------|
+| Parent | Total memory limit for all child breakers | 95% JVM heap (real memory) or 70% (reserved) |
+| Request | Memory for request data structures (aggregations, etc.) | 60% JVM heap |
+| Field Data | Memory for loading field data into cache | 40% JVM heap |
+| In-Flight Request | Memory for incoming transport/HTTP requests | 100% JVM heap |
+
+### Configuration
+
+| Setting | Type | Description | Default |
+|---------|------|-------------|---------|
+| `indices.breaker.total.use_real_memory` | Static | Use actual vs reserved memory | `true` |
+| `indices.breaker.total.limit` | Dynamic | Parent breaker limit | 95% or 70% |
+| `indices.breaker.request.limit` | Dynamic | Request breaker limit | 60% |
+| `indices.breaker.request.overhead` | Dynamic | Estimation multiplier | 1.0 |
+| `indices.breaker.fielddata.limit` | Dynamic | Field data breaker limit | 40% |
+| `indices.breaker.fielddata.overhead` | Dynamic | Estimation multiplier | 1.03 |
+| `network.breaker.inflight_requests.limit` | Dynamic | In-flight request limit | 100% |
+| `network.breaker.inflight_requests.overhead` | Dynamic | Estimation multiplier | 2.0 |
+
+### Error Response
+
+When a circuit breaker trips, clients receive HTTP 429 with details:
+
+```json
+{
+  "error": {
+    "type": "circuit_breaking_exception",
+    "reason": "[parent] Data too large, data for [<operation>] would be [X bytes], which is larger than the limit of [Y bytes]",
+    "bytes_wanted": 512967080,
+    "bytes_limit": 510027366,
+    "durability": "TRANSIENT"
+  },
+  "status": 429
+}
+```
+
+### Monitoring
+
+Circuit breaker statistics are available via the Nodes Stats API:
+
+```
+GET /_nodes/stats/breaker
+```
+
+## Limitations
+
+- Circuit breakers use estimations; actual memory usage may differ
+- Some operations may not be fully covered by circuit breaker checks
+- Overhead multipliers add safety margin but may cause premature tripping
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Added circuit breaker protection to histogram aggregation empty bucket generation ([#14754](https://github.com/opensearch-project/OpenSearch/pull/14754))
+
+## References
+
+### Documentation
+- [Circuit breaker settings](https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/circuit-breaker/)
+- [Nodes Stats API - breakers](https://docs.opensearch.org/latest/api-reference/nodes-apis/nodes-stats/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#14754](https://github.com/opensearch-project/OpenSearch/pull/14754) | Use circuit breaker in InternalHistogram when adding empty buckets |

--- a/docs/releases/v2.16.0/features/opensearch/circuit-breaker-improvements.md
+++ b/docs/releases/v2.16.0/features/opensearch/circuit-breaker-improvements.md
@@ -1,0 +1,78 @@
+---
+tags:
+  - opensearch
+---
+# Circuit Breaker Improvements
+
+## Summary
+
+OpenSearch v2.16.0 adds circuit breaker protection to the histogram aggregation's empty bucket generation process. Previously, histogram aggregations with small intervals and large data ranges could cause OutOfMemoryError and crash the node. Now, the request circuit breaker monitors memory usage during empty bucket creation and trips before memory is exhausted.
+
+## Details
+
+### What's New in v2.16.0
+
+The `InternalHistogram.addEmptyBuckets()` method now calls `reduceContext.consumeBucketsAndMaybeBreak(0)` each time an empty bucket is created. This integrates with the existing request circuit breaker to track memory allocation during the reduce phase.
+
+### Problem Addressed
+
+When a histogram aggregation spans a large value range with a small interval, OpenSearch generates empty buckets to fill gaps between actual data points. For example, with values at 1 and 1,234,567,890 using interval=100, OpenSearch would attempt to create over 12 million empty buckets.
+
+Before this fix:
+- The empty bucket generation bypassed circuit breaker checks
+- Memory allocation continued until JVM heap was exhausted
+- Node crashed with `OutOfMemoryError`
+
+After this fix:
+- Each empty bucket allocation is tracked by the circuit breaker
+- When memory limit is reached, a `CircuitBreakingException` is thrown
+- The request fails gracefully with HTTP 429 status
+
+### Technical Changes
+
+Modified `InternalHistogram.java` to add circuit breaker checks in four locations within `addEmptyBuckets()`:
+1. When filling empty buckets for the entire range (no data)
+2. When filling empty buckets before the first data point
+3. When filling empty buckets between data points
+4. When filling empty buckets after the last data point
+
+### Error Response
+
+When the circuit breaker trips, clients receive a structured error response:
+
+```json
+{
+  "error": {
+    "type": "search_phase_execution_exception",
+    "caused_by": {
+      "type": "circuit_breaking_exception",
+      "reason": "[parent] Data too large, data for [allocated_buckets] would be...",
+      "durability": "TRANSIENT"
+    }
+  },
+  "status": 429
+}
+```
+
+### Workarounds (Pre-v2.16.0)
+
+For users on earlier versions:
+- Use `"min_doc_count": 1` to skip empty bucket generation
+- Increase JVM heap size (temporary mitigation only)
+- Use larger interval values
+
+## Limitations
+
+- The circuit breaker check adds minimal overhead per bucket
+- Existing `search.max_buckets` limit (default: 65,535) may trip before the circuit breaker for moderately large ranges
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14754](https://github.com/opensearch-project/OpenSearch/pull/14754) | Use circuit breaker in InternalHistogram when adding empty buckets | [#14558](https://github.com/opensearch-project/OpenSearch/issues/14558) |
+
+### Documentation
+- [Circuit breaker settings](https://docs.opensearch.org/2.16/install-and-configure/configuring-opensearch/circuit-breaker/)
+- [Histogram aggregation](https://docs.opensearch.org/2.16/aggregations/bucket/histogram/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -3,6 +3,7 @@
 ## Features
 
 ### opensearch
+- Circuit Breaker Improvements
 - FS Info Reporting Fix
 - Multi-Part Upload Fix
 - System Index Warning


### PR DESCRIPTION
## Summary

Investigation of Circuit Breaker Improvements for OpenSearch v2.16.0.

### Changes
- Added circuit breaker protection to histogram aggregation empty bucket generation
- Prevents OutOfMemoryError when histogram aggregations span large value ranges with small intervals

### Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch/circuit-breaker-improvements.md`
- Feature report: `docs/features/opensearch/opensearch-circuit-breaker.md` (new)

### Source
- PR: [opensearch-project/OpenSearch#14754](https://github.com/opensearch-project/OpenSearch/pull/14754)
- Issue: [opensearch-project/OpenSearch#14558](https://github.com/opensearch-project/OpenSearch/issues/14558)

Closes #2279