### PR TITLE
docs: add cat-api-help report for v2.16.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -13,6 +13,7 @@ Cumulative feature documentation across all versions.
 ## opensearch
 
 - Append Only Indices
+- CAT API
 - Date Field Sorting
 - GetStats API
 - Painless Script Hashing Methods

--- a/docs/features/opensearch/cat-api.md
+++ b/docs/features/opensearch/cat-api.md
@@ -1,0 +1,76 @@
+---
+tags:
+  - opensearch
+---
+# CAT API
+
+## Summary
+
+The CAT (Compact and Aligned Text) API provides a human-readable format for cluster information. It returns data in a tabular format that is easy to read in terminals and command-line interfaces.
+
+## Details
+
+### Overview
+
+CAT APIs are designed for human consumption using the command line or Kibana console. They return plain text output by default, making them ideal for quick cluster diagnostics.
+
+### Available Endpoints
+
+| Endpoint | Description |
+|----------|-------------|
+| `_cat/nodes` | Node information including version, build, and resource usage |
+| `_cat/indices` | Index information |
+| `_cat/shards` | Shard allocation information |
+| `_cat/health` | Cluster health status |
+| `_cat/allocation` | Shard allocation per node |
+
+### Help Parameter
+
+Each CAT endpoint supports a `?help` parameter that displays available columns and their descriptions:
+
+```bash
+GET _cat/nodes?help
+```
+
+### Common Parameters
+
+| Parameter | Description |
+|-----------|-------------|
+| `v` | Include column headers |
+| `help` | Show available columns |
+| `h` | Select specific columns |
+| `format` | Output format (text, json, yaml) |
+| `s` | Sort by column |
+
+### Usage Example
+
+```bash
+# Get node information with headers
+GET _cat/nodes?v
+
+# Get specific columns
+GET _cat/nodes?v&h=name,ip,heap.percent,ram.percent
+
+# Get help for available columns
+GET _cat/nodes?help
+```
+
+## Limitations
+
+- CAT APIs are intended for human consumption; use JSON APIs for programmatic access
+- Output format may change between versions
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Updated help output to replace legacy "es" references with "os" (OpenSearch) terminology in `_cat/nodes` endpoint
+
+## References
+
+### Documentation
+- [CAT API](https://docs.opensearch.org/latest/api-reference/cat/index/)
+- [CAT nodes](https://docs.opensearch.org/latest/api-reference/cat/cat-nodes/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#14722](https://github.com/opensearch-project/OpenSearch/pull/14722) | Update help output for _cat |

--- a/docs/releases/v2.16.0/features/opensearch/cat-api-help.md
+++ b/docs/releases/v2.16.0/features/opensearch/cat-api-help.md
@@ -1,0 +1,61 @@
+---
+tags:
+  - opensearch
+---
+# CAT API Help
+
+## Summary
+
+Updated the CAT API help output to replace legacy Elasticsearch references with OpenSearch terminology. This change affects the `_cat/nodes` endpoint help text.
+
+## Details
+
+### What's New in v2.16.0
+
+The `_cat/nodes?help` endpoint previously displayed outdated terminology from the Elasticsearch fork:
+
+| Field | Before | After |
+|-------|--------|-------|
+| version | es version | os version |
+| type | es distribution type | os distribution type |
+| build | es build hash | os build hash |
+
+### Technical Changes
+
+Modified `RestNodesAction.java` to update the description strings in the table cell definitions:
+
+```java
+// Before
+table.addCell("version", "default:false;alias:v;desc:es version");
+table.addCell("type", "default:false;alias:t;desc:es distribution type");
+table.addCell("build", "default:false;alias:b;desc:es build hash");
+
+// After
+table.addCell("version", "default:false;alias:v;desc:os version");
+table.addCell("type", "default:false;alias:t;desc:os distribution type");
+table.addCell("build", "default:false;alias:b;desc:os build hash");
+```
+
+### Usage
+
+```bash
+GET _cat/nodes?help
+```
+
+Response now shows OpenSearch-specific terminology in the description column.
+
+## Limitations
+
+- Only the `_cat/nodes` endpoint was updated in this PR
+- Other CAT API endpoints may still contain legacy references (see Issue #14653 for full scope)
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14722](https://github.com/opensearch-project/OpenSearch/pull/14722) | Fix: update help output for _cat | [#14653](https://github.com/opensearch-project/OpenSearch/issues/14653) |
+
+### Documentation
+- [CAT nodes API](https://docs.opensearch.org/2.16/api-reference/cat/cat-nodes/)
+- [CAT API](https://docs.opensearch.org/2.16/api-reference/cat/index/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -3,6 +3,7 @@
 ## Features
 
 ### opensearch
+- CAT API Help
 - Circuit Breaker Improvements
 - FS Info Reporting Fix
 - Multi-Part Upload Fix


### PR DESCRIPTION
## Summary

Investigation report for CAT API Help deprecation item in OpenSearch v2.16.0.

### Changes
- Release report: `docs/releases/v2.16.0/features/opensearch/cat-api-help.md`
- Feature report: `docs/features/opensearch/cat-api.md` (new)
- Updated release index and features index

### Key Findings
- PR #14722 updated the `_cat/nodes` help output to replace legacy Elasticsearch references ("es") with OpenSearch terminology ("os")
- Affected fields: version, type, build descriptions
- This was a documentation/deprecation cleanup after the fork

Closes #2278