### PR TITLE
docs: add index-creation-npe-fix report for v2.16.0

### DIFF
--- a/docs/features/opensearch/opensearch-index-settings.md
+++ b/docs/features/opensearch/opensearch-index-settings.md
@@ -165,6 +165,7 @@ PUT my-index/_settings
 - **v3.4.0** (2025-01-15): Added custom creation_date setting and tier-aware shard limit validation
 - **v2.19.0** (2024-12-10): Fixed Get Index Settings API to show `number_of_routing_shards` when explicitly set at index creation
 - **v2.18.0** (2024-11-05): Fixed default value handling when `index.number_of_replicas` and `index.number_of_routing_shards` are set to `null`
+- **v2.16.0** (2024-08-06): Fixed NPE when creating index with `index.number_of_replicas` set to `null`
 
 
 ## References
@@ -180,9 +181,11 @@ PUT my-index/_settings
 | v2.19.0 | [#16294](https://github.com/opensearch-project/OpenSearch/pull/16294) | Fix get index settings API doesn't show `number_of_routing_shards` when explicitly set | [#14199](https://github.com/opensearch-project/OpenSearch/issues/14199) |
 | v2.18.0 | [#14948](https://github.com/opensearch-project/OpenSearch/pull/14948) | Fix update settings with null replica not honoring cluster setting |   |
 | v2.18.0 | [#16331](https://github.com/opensearch-project/OpenSearch/pull/16331) | Fix wrong default value when setting routing shards to null | [#16327](https://github.com/opensearch-project/OpenSearch/issues/16327) |
+| v2.16.0 | [#14812](https://github.com/opensearch-project/OpenSearch/pull/14812) | Fix NPE when creating index with `index.number_of_replicas` set to null | [#14783](https://github.com/opensearch-project/OpenSearch/issues/14783) |
 
 ### Issues (Design / RFC)
 - [Issue #19610](https://github.com/opensearch-project/OpenSearch/issues/19610): Feature request for tier-agnostic shard limit validation
 - [Issue #14810](https://github.com/opensearch-project/OpenSearch/issues/14810): Bug report for replica count default
+- [Issue #14783](https://github.com/opensearch-project/OpenSearch/issues/14783): NPE when SETTING_NUMBER_OF_REPLICAS is null
 - [Issue #16327](https://github.com/opensearch-project/OpenSearch/issues/16327): Bug report for routing shards default
 - [Issue #14199](https://github.com/opensearch-project/OpenSearch/issues/14199): Bug report for missing `number_of_routing_shards` in Get Index Settings API

--- a/docs/releases/v2.16.0/features/opensearch/index-creation-npe-fix.md
+++ b/docs/releases/v2.16.0/features/opensearch/index-creation-npe-fix.md
@@ -1,0 +1,67 @@
+---
+tags:
+  - opensearch
+---
+# Index Creation NPE Fix
+
+## Summary
+
+Fixed a NullPointerException (NPE) that occurred when creating an index with `index.number_of_replicas` explicitly set to `null`. The fix ensures that when the replica count is null, OpenSearch falls back to the cluster default value (`cluster.default_number_of_replicas`) instead of throwing an exception.
+
+## Details
+
+### What's New in v2.16.0
+
+This release fixes a bug where creating an index with `index.number_of_replicas` set to `null` caused a NullPointerException in `IndexSettings.getNumberOfReplicas()`.
+
+### Root Cause
+
+The `IndexSettings.getNumberOfReplicas()` method returned an `int` primitive type but called `settings.getAsInt()` with a `null` default value. When the setting was explicitly set to `null`, the auto-unboxing from `Integer` to `int` caused an NPE.
+
+```java
+// Before fix - caused NPE when setting was null
+public int getNumberOfReplicas() {
+    return settings.getAsInt(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, null);
+}
+```
+
+### Technical Changes
+
+The fix was applied in `MetadataCreateIndexService.aggregateIndexSettings()`:
+
+```java
+// Before
+if (INDEX_NUMBER_OF_REPLICAS_SETTING.exists(indexSettingsBuilder) == false) {
+    indexSettingsBuilder.put(SETTING_NUMBER_OF_REPLICAS, DEFAULT_REPLICA_COUNT_SETTING.get(currentState.metadata().settings()));
+}
+
+// After
+if (INDEX_NUMBER_OF_REPLICAS_SETTING.exists(indexSettingsBuilder) == false
+    || indexSettingsBuilder.get(SETTING_NUMBER_OF_REPLICAS) == null) {
+    indexSettingsBuilder.put(SETTING_NUMBER_OF_REPLICAS, DEFAULT_REPLICA_COUNT_SETTING.get(currentState.metadata().settings()));
+}
+```
+
+The additional null check ensures that even when the setting key exists but has a null value, the cluster default is applied.
+
+### Behavior After Fix
+
+When creating an index with `index.number_of_replicas` set to `null`:
+1. OpenSearch detects the null value
+2. Falls back to `cluster.default_number_of_replicas` setting
+3. If cluster default is not set, uses the hardcoded default of `1`
+
+## Limitations
+
+- This fix only addresses the NPE during index creation
+- The underlying `IndexSettings.getNumberOfReplicas()` method signature remains unchanged
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14812](https://github.com/opensearch-project/OpenSearch/pull/14812) | Use default value when index.number_of_replicas is null | [#14783](https://github.com/opensearch-project/OpenSearch/issues/14783) |
+
+### Issues
+- [#14783](https://github.com/opensearch-project/OpenSearch/issues/14783): NPE when SETTING_NUMBER_OF_REPLICAS is null

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -6,6 +6,7 @@
 - CAT API Help
 - Circuit Breaker Improvements
 - FS Info Reporting Fix
+- Index Creation NPE Fix
 - Multi-Part Upload Fix
 - System Index Warning
 


### PR DESCRIPTION
## Summary

Adds documentation for the Index Creation NPE Fix in OpenSearch v2.16.0.

### Changes
- Created release report: `docs/releases/v2.16.0/features/opensearch/index-creation-npe-fix.md`
- Updated feature report: `docs/features/opensearch/opensearch-index-settings.md` (added v2.16.0 entry to Change History and References)
- Updated release index: `docs/releases/v2.16.0/index.md`

### Bug Fix Details
Fixed a NullPointerException that occurred when creating an index with `index.number_of_replicas` explicitly set to `null`. The fix ensures OpenSearch falls back to the cluster default value instead of throwing an exception.

### Related
- PR: [opensearch-project/OpenSearch#14812](https://github.com/opensearch-project/OpenSearch/pull/14812)
- Issue: [opensearch-project/OpenSearch#14783](https://github.com/opensearch-project/OpenSearch/issues/14783)
- Investigation Issue: #2277