### PR TITLE
docs: add alias-api-validation report for v2.16.0

### DIFF
--- a/docs/features/opensearch/alias-api-validation.md
+++ b/docs/features/opensearch/alias-api-validation.md
@@ -1,0 +1,115 @@
+---
+tags:
+  - opensearch
+---
+# Alias API Validation
+
+## Summary
+
+The Create or Update Alias API provides strict validation of request body parameters, ensuring that only recognized fields are accepted and throwing exceptions for unknown parameters.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph "Create or Update Alias API"
+        Request[HTTP Request] --> Parser[Request Parser]
+        Parser --> Validator{Field Validation}
+        Validator -->|Known Field| Process[Process Field]
+        Validator -->|Unknown Field| Error[IllegalArgumentException]
+        Process --> AliasAction[IndicesAliasesRequest]
+        AliasAction --> Execute[Execute Alias Operation]
+    end
+```
+
+### Supported Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `index` | String | Index name (can override URL path parameter) |
+| `alias` | String | Alias name (can override URL path parameter) |
+| `filter` | Object | Query filter for the alias |
+| `routing` | String | Custom routing value for both index and search |
+| `index_routing` | String | Custom routing for index operations only |
+| `search_routing` | String | Custom routing for search operations only |
+| `is_write_index` | Boolean | Designates this index as the write index for the alias |
+| `is_hidden` | Boolean | Makes the alias hidden from most APIs |
+
+### API Endpoints
+
+The Create or Update Alias API supports multiple URL patterns:
+
+```
+PUT /{index}/_alias/{name}
+POST /{index}/_alias/{name}
+PUT /{index}/_aliases/{name}
+PUT /_alias/{name}
+POST /_alias/{name}
+PUT /_aliases/{name}
+PUT /{index}/_alias
+PUT /{index}/_aliases
+PUT /_alias
+```
+
+### Usage Example
+
+```json
+PUT /my-index/_alias/my-alias
+{
+  "filter": {
+    "term": {
+      "status": "published"
+    }
+  },
+  "routing": "1",
+  "is_write_index": true,
+  "is_hidden": false
+}
+```
+
+### Error Handling
+
+When an unknown field is provided, the API returns an error:
+
+```json
+PUT /my-index/_alias/my-alias
+{
+  "unknown_field": "value"
+}
+```
+
+Response:
+```json
+{
+  "error": {
+    "type": "illegal_argument_exception",
+    "reason": "unknown field [unknown_field]"
+  },
+  "status": 400
+}
+```
+
+## Limitations
+
+- The `is_hidden` parameter behavior may vary between versions
+- Request body parameters override URL path parameters when both are specified
+
+## Change History
+
+- **v2.16.0** (2024-07-15): Added validation for unknown fields, added `is_hidden` parameter support
+
+## References
+
+### Documentation
+- [Create or Update Alias API](https://docs.opensearch.org/latest/api-reference/index-apis/update-alias/)
+- [Index Aliases](https://docs.opensearch.org/latest/im-plugin/index-alias/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#14719](https://github.com/opensearch-project/OpenSearch/pull/14719) | Fix create or update alias API doesn't throw exception for unsupported parameters |
+
+### Related Issues
+- [#14384](https://github.com/opensearch-project/OpenSearch/issues/14384) - Validation issue while adding/removing backing indices in aliases

--- a/docs/features/opensearch/index.md
+++ b/docs/features/opensearch/index.md
@@ -2,6 +2,7 @@
 
 | Document | Description |
 |----------|-------------|
+| [alias-api-validation](alias-api-validation.md) | Alias API Validation |
 | [append-only-indices](append-only-indices.md) | Append Only Indices |
 | [auto-date-histogram](auto-date-histogram.md) | Auto Date Histogram Aggregation |
 | [dependency-updates](dependency-updates.md) | Dependency Updates |

--- a/docs/releases/v2.16.0/features/opensearch/alias-api-validation.md
+++ b/docs/releases/v2.16.0/features/opensearch/alias-api-validation.md
@@ -1,0 +1,65 @@
+---
+tags:
+  - opensearch
+---
+# Alias API Validation
+
+## Summary
+
+This release fixes a bug in the Create or Update Alias API (`PUT _alias/{alias}`) where unsupported parameters in the request body were silently ignored instead of throwing an exception. Additionally, the `is_hidden` parameter was not being parsed correctly.
+
+## Details
+
+### What's New in v2.16.0
+
+The Create or Update Alias API now properly validates request body parameters and throws an `IllegalArgumentException` when unknown fields are encountered.
+
+### Technical Changes
+
+The fix was implemented in `RestIndexPutAliasAction.java`:
+
+1. **Unknown field validation**: Added exception throwing for unrecognized fields in the request body
+2. **`is_hidden` parameter support**: Added parsing logic for the `is_hidden` parameter that was previously omitted
+
+```java
+// Now throws exception for unknown fields
+} else {
+    throw new IllegalArgumentException("unknown field [" + currentFieldName + "]");
+}
+```
+
+### Supported Request Body Parameters
+
+| Parameter | Type | Description |
+|-----------|------|-------------|
+| `index` | String | Index name (overrides URL path) |
+| `alias` | String | Alias name (overrides URL path) |
+| `filter` | Object | Filter for the alias |
+| `routing` | String | Custom routing value |
+| `index_routing` | String | Custom routing for index operations |
+| `search_routing` | String | Custom routing for search operations |
+| `is_write_index` | Boolean | Whether this is the write index |
+| `is_hidden` | Boolean | Whether the alias is hidden (newly supported) |
+
+### API Endpoints
+
+The fix applies to all Create or Update Alias API endpoints:
+- `PUT /{index}/_alias/{name}`
+- `POST /{index}/_alias/{name}`
+- `PUT /{index}/_aliases/{name}`
+- `PUT /_alias/{name}`
+- `PUT /_aliases/{name}`
+
+## Limitations
+
+- The `is_hidden` parameter test is skipped for versions prior to 3.0.0 in the REST API spec tests
+
+## References
+
+### Documentation
+- [Create or Update Alias API](https://docs.opensearch.org/2.16/api-reference/index-apis/update-alias/)
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14719](https://github.com/opensearch-project/OpenSearch/pull/14719) | Fix create or update alias API doesn't throw exception for unsupported parameters | [#14384](https://github.com/opensearch-project/OpenSearch/issues/14384) |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -3,6 +3,7 @@
 ## Features
 
 ### opensearch
+- Alias API Validation
 - CAT API Help
 - Circuit Breaker Improvements
 - FS Info Reporting Fix


### PR DESCRIPTION
## Summary

This PR adds documentation for the Alias API Validation fix in OpenSearch v2.16.0.

### Changes
- Release report: `docs/releases/v2.16.0/features/opensearch/alias-api-validation.md`
- Feature report: `docs/features/opensearch/alias-api-validation.md`
- Updated release index and features index

### Key Changes in v2.16.0
- Create or Update Alias API now validates request body parameters
- Throws `IllegalArgumentException` for unknown fields
- Added support for `is_hidden` parameter

### Related
- Closes #2276
- PR: opensearch-project/OpenSearch#14719
- Issue: opensearch-project/OpenSearch#14384