### PR TITLE
docs: add getresult-npe-fix report for v2.16.0

### DIFF
--- a/docs/features/opensearch/getresult-parsing.md
+++ b/docs/features/opensearch/getresult-parsing.md
@@ -1,0 +1,63 @@
+---
+tags:
+  - opensearch
+---
+# GetResult Parsing
+
+## Summary
+
+The `GetResult` class handles parsing of document retrieval responses in OpenSearch. It provides methods to parse JSON responses from Get API operations and construct result objects containing document data, metadata, and status information.
+
+## Details
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `GetResult` | Core class for parsing and representing Get API responses |
+| `fromXContentEmbedded()` | Static method to parse embedded GetResult from XContent |
+| `fromXContent()` | Static method to parse standalone GetResult from XContent |
+
+### Required Fields
+
+The `found` field is required when parsing a GetResult. If missing, a `ParsingException` is thrown with the message "Missing required field [found]".
+
+### Usage Example
+
+```java
+// Parsing a GetResult from JSON
+try (XContentParser parser = JsonXContent.jsonXContent.createParser(
+    NamedXContentRegistry.EMPTY,
+    LoggingDeprecationHandler.INSTANCE,
+    jsonString
+)) {
+    GetResult result = GetResult.fromXContent(parser);
+    if (result.isExists()) {
+        // Document found - process source
+        Map<String, Object> source = result.getSourceAsMap();
+    }
+}
+```
+
+## Limitations
+
+- The `found` field must be present in the JSON response; omitting it results in a `ParsingException`
+- Cannot assume a default value for `found` as it would mask potential data issues
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Fixed NPE when `found` field is missing - now throws descriptive `ParsingException`
+
+## References
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#14552](https://github.com/opensearch-project/OpenSearch/pull/14552) | Handle NPE in GetResult if "found" field is missing |
+
+### Issues
+
+| Issue | Description |
+|-------|-------------|
+| [#14519](https://github.com/opensearch-project/OpenSearch/issues/14519) | Parsing a GetResult returns NPE if "found" field is missing |

--- a/docs/features/opensearch/index.md
+++ b/docs/features/opensearch/index.md
@@ -74,6 +74,7 @@
 | [opensearch-filter-rewrite-optimization](opensearch-filter-rewrite-optimization.md) | Filter Rewrite Optimization |
 | [opensearch-fips-compliance](opensearch-fips-compliance.md) | FIPS Compliance |
 | [opensearch-flat-object-field](opensearch-flat-object-field.md) | Flat Object Field Type |
+| [getresult-parsing](getresult-parsing.md) | GetResult Parsing |
 | [opensearch-getstats-api](opensearch-getstats-api.md) | GetStats API |
 | [opensearch-gradle-build-system](opensearch-gradle-build-system.md) | Gradle Build System |
 | [opensearch-grok-processor](opensearch-grok-processor.md) | Grok Processor |

--- a/docs/releases/v2.16.0/features/opensearch/getresult-npe-fix.md
+++ b/docs/releases/v2.16.0/features/opensearch/getresult-npe-fix.md
@@ -1,0 +1,51 @@
+---
+tags:
+  - opensearch
+---
+# GetResult NPE Fix
+
+## Summary
+
+Fixed a NullPointerException (NPE) in `GetResult.fromXContentEmbedded()` that occurred when parsing a GetResult response with a missing `found` field. The fix adds proper null checking and throws a descriptive `ParsingException` instead of an unexpected NPE.
+
+## Details
+
+### What's New in v2.16.0
+
+The `GetResult.fromXContentEmbedded()` method now validates that the required `found` field is present before constructing the GetResult object. If the field is missing, a `ParsingException` with the message "Missing required field [found]" is thrown.
+
+### Technical Changes
+
+The bug occurred because:
+1. The `found` variable was initialized to `null` (as a `Boolean` wrapper type)
+2. The field was only conditionally set when parsing the JSON
+3. When `found` remained `null`, unboxing it to a primitive `boolean` for the constructor caused an NPE
+
+The fix adds a null check after parsing completes:
+
+```java
+if (found == null) {
+    throw new ParsingException(
+        parser.getTokenLocation(),
+        String.format(Locale.ROOT, "Missing required field [%s]", GetResult.FOUND)
+    );
+}
+```
+
+### Affected Component
+
+| Component | File |
+|-----------|------|
+| GetResult | `server/src/main/java/org/opensearch/index/get/GetResult.java` |
+
+## Limitations
+
+None. This is a straightforward bug fix that improves error handling consistency.
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14552](https://github.com/opensearch-project/OpenSearch/pull/14552) | Handle NPE in GetResult if "found" field is missing | [#14519](https://github.com/opensearch-project/OpenSearch/issues/14519) |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -7,6 +7,7 @@
 - CAT API Help
 - Circuit Breaker Improvements
 - FS Info Reporting Fix
+- GetResult NPE Fix
 - Index Creation NPE Fix
 - Multi-Part Upload Fix
 - System Index Warning


### PR DESCRIPTION
## Summary

Documents the GetResult NPE fix introduced in OpenSearch v2.16.0.

### Changes
- Release report: `docs/releases/v2.16.0/features/opensearch/getresult-npe-fix.md`
- Feature report: `docs/features/opensearch/getresult-parsing.md`
- Updated release index and features index

### Related
- Closes #2275
- OpenSearch PR: [#14552](https://github.com/opensearch-project/OpenSearch/pull/14552)
- OpenSearch Issue: [#14519](https://github.com/opensearch-project/OpenSearch/issues/14519)