### PR TITLE
docs: add pit-point-in-time-api report for v2.16.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -17,6 +17,7 @@ Cumulative feature documentation across all versions.
 - Date Field Sorting
 - GetStats API
 - Painless Script Hashing Methods
+- Point in Time (PIT) API
 - Snapshot Repository
 - Synonym Analyzer Configuration
 

--- a/docs/features/opensearch/point-in-time-api.md
+++ b/docs/features/opensearch/point-in-time-api.md
@@ -1,0 +1,158 @@
+---
+tags:
+  - opensearch
+---
+# Point in Time (PIT) API
+
+## Summary
+
+Point in Time (PIT) is a lightweight view into the state of data as it existed at a specific point in time. PIT enables consistent search results across multiple queries by preserving a snapshot of the index state, even when the underlying data changes. This is essential for pagination, deep scrolling, and scenarios requiring repeatable search results.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Client"
+        APP[Application]
+    end
+    
+    subgraph "OpenSearch Cluster"
+        subgraph "PIT Management"
+            CREATE[Create PIT]
+            LIST[List PITs]
+            DELETE[Delete PIT]
+        end
+        
+        subgraph "Search"
+            SEARCH[Search API]
+            AFTER[search_after]
+        end
+        
+        subgraph "Index"
+            SEGMENTS[Index Segments]
+            SNAPSHOT[Segment Snapshot]
+        end
+    end
+    
+    APP -->|POST /_search/point_in_time| CREATE
+    APP -->|GET /_search/point_in_time/_all| LIST
+    APP -->|DELETE /_search/point_in_time| DELETE
+    APP -->|POST /_search with pit.id| SEARCH
+    
+    CREATE --> SNAPSHOT
+    SNAPSHOT --> SEGMENTS
+    SEARCH --> SNAPSHOT
+    SEARCH --> AFTER
+    LIST -->|ListPitInfo| APP
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ListPitInfo` | Data class containing PIT metadata: `pitId`, `creationTime`, `keepAlive` |
+| `CreatePitAction` | Action for creating new PIT contexts |
+| `GetAllPitNodesResponse` | Response containing list of all PITs across nodes |
+| `DeletePitAction` | Action for deleting PIT contexts |
+
+### API Endpoints
+
+| Operation | Endpoint | Description |
+|-----------|----------|-------------|
+| Create PIT | `POST /<index>/_search/point_in_time?keep_alive=1h` | Creates a PIT for specified indexes |
+| List PITs | `GET /_search/point_in_time/_all` | Lists all active PITs |
+| Delete PIT | `DELETE /_search/point_in_time` | Deletes specified PITs |
+| Search with PIT | `POST /_search` with `pit.id` in body | Searches using a PIT context |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `point_in_time.max_keep_alive` | Maximum allowed keep-alive for PITs | `24h` |
+| `search.max_open_pit_context` | Maximum number of open PIT contexts | `300` |
+
+### Usage Example
+
+```bash
+# Create a PIT
+POST /my-index/_search/point_in_time?keep_alive=1h
+
+# Response
+{
+  "pit_id": "46ToAwMDaWR5BXV1aWQy...",
+  "creation_time": 1718990725000
+}
+
+# Search with PIT
+POST /_search
+{
+  "pit": {
+    "id": "46ToAwMDaWR5BXV1aWQy...",
+    "keep_alive": "1h"
+  },
+  "sort": [{"@timestamp": "asc"}],
+  "search_after": [1718990725000]
+}
+
+# List all PITs
+GET /_search/point_in_time/_all
+
+# Response
+{
+  "pits": [
+    {
+      "pit_id": "46ToAwMDaWR5BXV1aWQy...",
+      "creation_time": 1718990725000,
+      "keep_alive": 3600000
+    }
+  ]
+}
+
+# Delete PIT
+DELETE /_search/point_in_time
+{
+  "pit_id": ["46ToAwMDaWR5BXV1aWQy..."]
+}
+```
+
+### Java Client Usage
+
+```java
+// Create PIT
+CreatePitRequest request = new CreatePitRequest(TimeValue.timeValueHours(1), true, "my-index");
+CreatePitResponse response = client.execute(CreatePitAction.INSTANCE, request).get();
+String pitId = response.getId();
+
+// List all PITs
+GetAllPitNodesResponse pitsResponse = client.execute(GetAllPitsAction.INSTANCE, new GetAllPitNodesRequest()).get();
+for (ListPitInfo pitInfo : pitsResponse.getPitInfos()) {
+    String id = pitInfo.getPitId();
+    long creationTime = pitInfo.getCreationTime();
+    long keepAlive = pitInfo.getKeepAlive();  // Available since v2.16.0
+}
+```
+
+## Limitations
+
+- PIT contexts consume cluster resources (memory and disk for retained segments)
+- PIT data is lost on cluster or node failure
+- Maximum keep-alive is limited by `point_in_time.max_keep_alive` setting
+- PITs cannot be used with the Scroll API simultaneously
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Added `ListPitInfo.getKeepAlive()` getter for programmatic access to keep-alive duration
+- **v2.4.0**: Initial PIT API implementation
+
+## References
+
+### Documentation
+- [Point in Time](https://docs.opensearch.org/latest/search-plugins/searching-data/point-in-time/): Conceptual overview
+- [Point in Time API](https://docs.opensearch.org/latest/search-plugins/searching-data/point-in-time-api/): API reference
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#14495](https://github.com/opensearch-project/OpenSearch/pull/14495) | Add ListPitInfo::getKeepAlive() getter |

--- a/docs/releases/v2.16.0/features/opensearch/pit-point-in-time-api.md
+++ b/docs/releases/v2.16.0/features/opensearch/pit-point-in-time-api.md
@@ -1,0 +1,58 @@
+---
+tags:
+  - opensearch
+---
+# PIT (Point In Time) API
+
+## Summary
+
+Added `getKeepAlive()` getter method to the `ListPitInfo` class, enabling programmatic access to the keep-alive duration of Point in Time (PIT) contexts. This was a missing API that prevented client libraries from retrieving the keep-alive value when listing PITs.
+
+## Details
+
+### What's New in v2.16.0
+
+The `ListPitInfo` class now exposes the `keepAlive` property through a public getter method:
+
+```java
+public long getKeepAlive() {
+    return keepAlive;
+}
+```
+
+This allows client applications and integrations (such as Spring Data OpenSearch) to access the keep-alive duration when listing PIT contexts via the List All PITs API.
+
+### Technical Changes
+
+| Component | Change |
+|-----------|--------|
+| `ListPitInfo.java` | Added `getKeepAlive()` method returning the keep-alive value in milliseconds |
+| Test utilities | Updated `PitTestsUtil.assertUsingGetAllPits()` to verify keep-alive values |
+
+### API Response
+
+The List All PITs API response includes the `keep_alive` field:
+
+```json
+{
+  "pits": [
+    {
+      "pit_id": "...",
+      "creation_time": 1718990725000,
+      "keep_alive": 86400000
+    }
+  ]
+}
+```
+
+## Limitations
+
+- The `keepAlive` value is returned in milliseconds
+- PIT contexts are lost on cluster or node failure
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14495](https://github.com/opensearch-project/OpenSearch/pull/14495) | Add ListPitInfo::getKeepAlive() getter | [spring-data-opensearch#218](https://github.com/opensearch-project/spring-data-opensearch/pull/218) |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -11,6 +11,7 @@
 - GetResult NPE Fix
 - Index Creation NPE Fix
 - Multi-Part Upload Fix
+- PIT (Point In Time) API
 - System Index Warning
 
 ### opensearch-dashboards


### PR DESCRIPTION
## Summary

Added documentation for the PIT (Point In Time) API enhancement in v2.16.0.

### Changes
- **Release report**: `docs/releases/v2.16.0/features/opensearch/pit-point-in-time-api.md`
- **Feature report**: `docs/features/opensearch/point-in-time-api.md` (new)
- Updated release and features indexes

### Key Changes in v2.16.0
- Added `ListPitInfo.getKeepAlive()` getter method for programmatic access to PIT keep-alive duration
- Enables client libraries (e.g., Spring Data OpenSearch) to retrieve keep-alive values when listing PITs

### References
- PR: [opensearch-project/OpenSearch#14495](https://github.com/opensearch-project/OpenSearch/pull/14495)
- Related: [spring-data-opensearch#218](https://github.com/opensearch-project/spring-data-opensearch/pull/218)

Closes #2273