### PR TITLE
docs: add searchable-snapshots report for v2.16.0

### DIFF
--- a/docs/features/opensearch/opensearch-searchable-snapshot.md
+++ b/docs/features/opensearch/opensearch-searchable-snapshot.md
@@ -87,6 +87,7 @@ Response shows `"store": { "type": "remote_snapshot" }` for searchable snapshot 
 
 - **v2.19.0** (2025-01-14): Bug fixes for alias rollover, scripted query permissions, and shallow copy snapshots on closed indexes
 - **v2.18.0**: Added k-NN index support for NMSLIB and Faiss engines
+- **v2.16.0** (2024-08-06): Fixed shard-level metadata blob creation for snapshotting searchable snapshot indexes; Fixed scripted field query failures due to cache eviction permissions
 - **v2.7.0**: Initial searchable snapshots feature
 
 ## References
@@ -101,3 +102,5 @@ Response shows `"store": { "type": "remote_snapshot" }` for searchable snapshot 
 | v2.19.0 | [#16483](https://github.com/opensearch-project/OpenSearch/pull/16483) | Rollover alias supports restored searchable snapshot index |
 | v2.19.0 | [#16544](https://github.com/opensearch-project/OpenSearch/pull/16544) | Fix scripted query permissions for remote snapshots |
 | v2.19.0 | [#16868](https://github.com/opensearch-project/OpenSearch/pull/16868) | Fix shallow copy snapshot failures on closed index |
+| v2.16.0 | [#13190](https://github.com/opensearch-project/OpenSearch/pull/13190) | Write shard level metadata blob when snapshotting searchable snapshot indexes |
+| v2.16.0 | [#14411](https://github.com/opensearch-project/OpenSearch/pull/14411) | Fix scripted field query failures with cache eviction |

--- a/docs/releases/v2.16.0/features/opensearch/searchable-snapshots.md
+++ b/docs/releases/v2.16.0/features/opensearch/searchable-snapshots.md
@@ -1,0 +1,58 @@
+---
+tags:
+  - opensearch
+---
+# Searchable Snapshots
+
+## Summary
+
+OpenSearch 2.16.0 includes two bug fixes for searchable snapshots: proper shard-level metadata blob creation when snapshotting searchable snapshot indexes, and a fix for scripted field queries on remote snapshot indexes.
+
+## Details
+
+### What's New in v2.16.0
+
+#### Shard-Level Metadata Blob Fix
+
+Previously, when taking a snapshot of a searchable snapshot index, OpenSearch only captured index metadata without creating shard-level snapshot metadata (`snap-{uuid}.dat` blob). This caused failures when:
+- Calling the snapshot status API
+- Cloning snapshots containing searchable snapshot indexes
+
+The fix ensures shard-level metadata blobs are written even for searchable snapshot indexes, enabling proper snapshot status reporting and cloning operations.
+
+#### Scripted Field Query Fix
+
+Queries using scripted fields on searchable snapshot indexes failed with `AccessControlException` when the file cache needed to evict entries. The error occurred because:
+1. Scripted queries run with restricted permissions
+2. Cache eviction requires file deletion permissions
+3. The `AccessController.doPrivileged` call was not positioned correctly in the call stack
+
+The fix moves the privileged action wrapper to encompass the entire `fileCache.compute()` operation, ensuring proper permissions for both cache reads and evictions during scripted queries.
+
+### Technical Changes
+
+#### BlobStoreRepository.java
+- Added check for `store.indexSettings().isRemoteSnapshot()` before determining files to upload
+- Searchable snapshot indexes now create empty `indexCommitPointFiles` list instead of skipping shard snapshot entirely
+
+#### TransferManager.java
+- Moved `AccessController.doPrivileged` wrapper from `createIndexInput()` to `fetchBlob()`
+- Ensures file cache operations (including evictions) have proper permissions when triggered by plugins
+
+## Limitations
+
+- Searchable snapshot indexes remain read-only
+- Snapshot status for searchable snapshot shards shows 0 total file count (expected behavior since no files are uploaded)
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#13190](https://github.com/opensearch-project/OpenSearch/pull/13190) | Write shard level metadata blob when snapshotting searchable snapshot indexes | - |
+| [#14411](https://github.com/opensearch-project/OpenSearch/pull/14411) | Add perms for remote snapshot cache eviction on scripted query | [#14268](https://github.com/opensearch-project/OpenSearch/issues/14268) |
+
+### Documentation
+
+- [Searchable Snapshots](https://docs.opensearch.org/2.16/tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -13,6 +13,7 @@
 - Multi-Part Upload Fix
 - Nested Aggregations Fix
 - PIT (Point In Time) API
+- Searchable Snapshots
 - System Index Warning
 
 ### opensearch-dashboards


### PR DESCRIPTION
## Summary

Adds documentation for Searchable Snapshots bug fixes in OpenSearch v2.16.0.

### Changes in v2.16.0

1. **Shard-Level Metadata Blob Fix** (PR #13190)
   - Fixed issue where snapshotting searchable snapshot indexes didn't create shard-level metadata blobs
   - Enables snapshot status API and snapshot cloning for searchable snapshot indexes

2. **Scripted Field Query Fix** (PR #14411)
   - Fixed `AccessControlException` when querying searchable snapshots with scripted fields
   - Moved privileged action wrapper to cover file cache eviction operations

### Files Changed

- Created: `docs/releases/v2.16.0/features/opensearch/searchable-snapshots.md`
- Updated: `docs/features/opensearch/opensearch-searchable-snapshot.md`
- Updated: `docs/releases/v2.16.0/index.md`

Closes #2271