### PR TITLE
docs: add rest-high-level-client-fixes report for v2.16.0

### DIFF
--- a/docs/features/opensearch/index.md
+++ b/docs/features/opensearch/index.md
@@ -153,6 +153,7 @@
 | [opensearch-request-cache](opensearch-request-cache.md) | Request Cache |
 | [opensearch-rescore-named-queries](opensearch-rescore-named-queries.md) | Rescore Named Queries |
 | [opensearch-resthandler-wrapper](opensearch-resthandler-wrapper.md) | RestHandler.Wrapper |
+| [opensearch-rest-high-level-client](opensearch-rest-high-level-client.md) | REST High-Level Client |
 | [opensearch-rule-based-auto-tagging](opensearch-rule-based-auto-tagging.md) | Rule-Based Auto-Tagging |
 | [opensearch-s3-repository](opensearch-s3-repository.md) | S3 Repository |
 | [opensearch-scaled-float-field](opensearch-scaled-float-field.md) | Scaled Float Field |

--- a/docs/features/opensearch/opensearch-rest-high-level-client.md
+++ b/docs/features/opensearch/opensearch-rest-high-level-client.md
@@ -1,0 +1,94 @@
+---
+tags:
+  - opensearch
+---
+# REST High-Level Client
+
+## Summary
+
+The OpenSearch Java REST High-Level Client (RHLC) provides a high-level Java API for interacting with OpenSearch clusters. It offers strongly-typed requests and responses, making it easier to work with OpenSearch from Java applications compared to raw HTTP requests.
+
+**Note:** This client is deprecated and will be removed in OpenSearch 3.0.0. Users should migrate to the [Java client](https://opensearch.org/docs/latest/clients/java/).
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Java Application"
+        RHLC[REST High-Level Client]
+        RC[REST Client]
+    end
+    subgraph "Network"
+        Proxy[Proxy/Load Balancer]
+    end
+    subgraph "OpenSearch"
+        OS[OpenSearch Cluster]
+    end
+    RHLC --> RC
+    RC --> Proxy
+    Proxy --> OS
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `RestHighLevelClient` | Main client class providing high-level API methods |
+| `RequestConverters` | Converts high-level requests to low-level HTTP requests |
+| `RestClient` | Low-level HTTP client for actual network communication |
+
+### Configuration
+
+Maven dependency:
+```xml
+<dependency>
+  <groupId>org.opensearch.client</groupId>
+  <artifactId>opensearch-rest-high-level-client</artifactId>
+  <version>2.16.0</version>
+</dependency>
+```
+
+### Usage Example
+
+```java
+// Create client
+RestHighLevelClient client = new RestHighLevelClient(
+    RestClient.builder(new HttpHost("localhost", 9200, "https"))
+);
+
+// Search template (uses /_render/template endpoint)
+SearchTemplateRequest request = new SearchTemplateRequest();
+request.setSimulate(true);
+request.setScript("{ \"query\": { \"match\": { \"{{field}}\": \"{{value}}\" } } }");
+SearchTemplateResponse response = client.searchTemplate(request, RequestOptions.DEFAULT);
+
+// Multi term vectors (uses /_mtermvectors endpoint)
+MultiTermVectorsRequest mtvRequest = new MultiTermVectorsRequest();
+mtvRequest.add(new TermVectorsRequest("index", "1"));
+MultiTermVectorsResponse mtvResponse = client.mtermVectors(mtvRequest, RequestOptions.DEFAULT);
+
+client.close();
+```
+
+## Limitations
+
+- Deprecated: Will be removed in OpenSearch 3.0.0
+- Users should migrate to the Java client
+- Some endpoint paths historically lacked leading slashes, causing issues with strict HTTP intermediaries
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Fixed `searchTemplate` and `mtermVectors` endpoints to include leading slashes for HTTP compliance
+
+## References
+
+### Documentation
+- [Java high-level REST client](https://docs.opensearch.org/latest/clients/java-rest-high-level/)
+- [Java client (recommended)](https://docs.opensearch.org/latest/clients/java/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#14465](https://github.com/opensearch-project/OpenSearch/pull/14465) | Fixed searchTemplate & mtermVectors endpoint paths |

--- a/docs/releases/v2.16.0/features/opensearch/rest-high-level-client-fixes.md
+++ b/docs/releases/v2.16.0/features/opensearch/rest-high-level-client-fixes.md
@@ -1,0 +1,66 @@
+---
+tags:
+  - opensearch
+---
+# REST High-Level Client Fixes
+
+## Summary
+
+Fixed endpoint path formatting in the deprecated Java REST High-Level Client (RHLC) for `searchTemplate` and `mtermVectors` operations. The endpoints were missing leading slashes, causing HTTP 400 errors when using strict intermediaries like proxies or load balancers.
+
+## Details
+
+### What's New in v2.16.0
+
+The REST High-Level Client had two endpoints that constructed HTTP requests with non-absolute paths (missing leading `/`):
+
+| Endpoint | Before | After |
+|----------|--------|-------|
+| `_render/template` | `GET _render/template HTTP/1.1` | `GET /_render/template HTTP/1.1` |
+| `_mtermvectors` | `GET _mtermvectors HTTP/1.1` | `GET /_mtermvectors HTTP/1.1` |
+
+### Technical Changes
+
+The fix modifies `RequestConverters.java` in the `client/rest-high-level` module:
+
+**searchTemplate endpoint:**
+```java
+// Before
+request = new Request(HttpGet.METHOD_NAME, "_render/template");
+
+// After
+request = new Request(HttpGet.METHOD_NAME, "/_render/template");
+```
+
+**mtermVectors endpoint:**
+```java
+// Before
+String endpoint = "_mtermvectors";
+Request request = new Request(HttpGet.METHOD_NAME, endpoint);
+
+// After
+Request request = new Request(HttpGet.METHOD_NAME, "/_mtermvectors");
+```
+
+### Impact
+
+- OpenSearch itself is lenient and accepts requests without leading slashes
+- Strict HTTP intermediaries (proxies, load balancers) may reject these requests with HTTP 400 Bad Request
+- Amazon OpenSearch Service users were particularly affected due to stricter request validation
+
+## Limitations
+
+- The REST High-Level Client is deprecated and will be removed in OpenSearch 3.0.0
+- Users should migrate to the [Java client](https://opensearch.org/docs/latest/clients/java/) instead
+- A more comprehensive fix in `RestClient` (PR #14423) remains open as a draft
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14465](https://github.com/opensearch-project/OpenSearch/pull/14465) | Correct RHLC searchTemplate & mtermVectors endpoints to have leading slash | Relates to #14423 |
+| [#14423](https://github.com/opensearch-project/OpenSearch/pull/14423) | Normalize URI paths in RestClient (draft) | - |
+
+### Documentation
+- [Java high-level REST client](https://docs.opensearch.org/2.16/clients/java-rest-high-level/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -13,6 +13,7 @@
 - Multi-Part Upload Fix
 - Nested Aggregations Fix
 - PIT (Point In Time) API
+- REST High-Level Client Fixes
 - Searchable Snapshots
 - System Index Warning
 


### PR DESCRIPTION
## Summary

Adds documentation for REST High-Level Client endpoint path fixes in OpenSearch v2.16.0.

## Changes

- **Release Report**: `docs/releases/v2.16.0/features/opensearch/rest-high-level-client-fixes.md`
- **Feature Report**: `docs/features/opensearch/opensearch-rest-high-level-client.md`
- Updated release and feature indexes

## Key Findings

PR #14465 fixed endpoint paths in the deprecated Java REST High-Level Client:
- `searchTemplate`: `_render/template` → `/_render/template`
- `mtermVectors`: `_mtermvectors` → `/_mtermvectors`

The missing leading slashes caused HTTP 400 errors with strict intermediaries like proxies and load balancers (including Amazon OpenSearch Service).

## References

- PR: https://github.com/opensearch-project/OpenSearch/pull/14465
- Related: https://github.com/opensearch-project/OpenSearch/pull/14423 (draft for global fix)

Closes #2270