### PR TITLE
docs: add cluster-shard-limits report for v2.16.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -14,6 +14,7 @@ Cumulative feature documentation across all versions.
 
 - Append Only Indices
 - CAT API
+- Cluster Shard Limits
 - Date Field Sorting
 - GetStats API
 - Painless Script Hashing Methods

--- a/docs/features/opensearch/opensearch-cluster-shard-limits.md
+++ b/docs/features/opensearch/opensearch-cluster-shard-limits.md
@@ -1,0 +1,88 @@
+---
+tags:
+  - opensearch
+---
+# Cluster Shard Limits
+
+## Summary
+
+OpenSearch enforces cluster-wide shard limits to prevent resource exhaustion. The `ShardLimitValidator` class validates that creating new indices or opening closed indices won't exceed the configured maximum number of shards.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Shard Limit Validation"
+        A[Index Creation Request] --> B[ShardLimitValidator]
+        C[Open Index Request] --> B
+        B --> D{Check Limits}
+        D -->|Within Limit| E[Allow Operation]
+        D -->|Exceeds Limit| F[Reject with Error]
+    end
+    
+    subgraph "Limit Calculation"
+        G[cluster.max_shards_per_node] --> H[Compute Max Shards]
+        I[Node Count] --> H
+        J[cluster.routing.allocation.total_shards_limit] --> H
+        H --> K[Effective Cluster Limit]
+    end
+```
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.max_shards_per_node` | Maximum shards per data node | 1000 |
+| `cluster.routing.allocation.total_shards_limit` | Hard limit for total cluster shards (-1 = disabled) | -1 |
+| `cluster.ignore_dot_indexes` | Skip validation for dot-prefixed indexes | false |
+
+### Limit Calculation
+
+The effective cluster shard limit is calculated as:
+
+```
+computedMaxShards = min(Integer.MAX_VALUE, maxShardsPerNode × nodeCount)
+effectiveLimit = min(totalShardsLimit, computedMaxShards)
+```
+
+If `total_shards_limit` is -1 (disabled), only the computed limit applies.
+
+### Validation Behavior
+
+- System indices are excluded from validation
+- When `cluster.ignore_dot_indexes` is true, dot-prefixed indices (except data streams) are excluded
+- Closed indices don't count toward the limit
+- Validation occurs at index creation and when opening closed indices
+
+### Usage Example
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "cluster.max_shards_per_node": 2000
+  }
+}
+```
+
+## Limitations
+
+- The computed maximum is capped at `Integer.MAX_VALUE` to prevent overflow
+- Very high values of `cluster.max_shards_per_node` may not be practical due to memory constraints
+- System indices bypass the limit, which could theoretically allow exceeding the configured maximum
+
+## Change History
+
+- **v2.16.0** (2024-06-20): Fixed integer overflow bug in max shards calculation ([#14155](https://github.com/opensearch-project/OpenSearch/pull/14155))
+
+## References
+
+### Documentation
+- [Cluster Settings](https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/cluster-settings/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#14155](https://github.com/opensearch-project/OpenSearch/pull/14155) | Fix the computed max shards of cluster to avoid int overflow |

--- a/docs/releases/v2.16.0/features/opensearch/cluster-shard-limits.md
+++ b/docs/releases/v2.16.0/features/opensearch/cluster-shard-limits.md
@@ -1,0 +1,58 @@
+---
+tags:
+  - opensearch
+---
+# Cluster Shard Limits
+
+## Summary
+
+Fixed an integer overflow bug in the cluster shard limit calculation that could cause shard allocation failures when `cluster.max_shards_per_node` was set to a high value and the cluster was scaled up.
+
+## Details
+
+### What's New in v2.16.0
+
+The `ShardLimitValidator` class was updated to prevent integer overflow when computing the maximum number of shards allowed in a cluster.
+
+### Technical Changes
+
+The bug occurred when calculating `maxShardsInCluster` by multiplying `maxShardsPerNodeSetting * nodeCount`. With high values of `cluster.max_shards_per_node` (e.g., 500,000,000) and multiple nodes, this multiplication could overflow the 32-bit integer limit, resulting in negative values.
+
+**Before (buggy):**
+```java
+maxShardsInCluster = maxShardsPerNodeSetting * nodeCount;
+```
+
+**After (fixed):**
+```java
+int computedMaxShards = (int) Math.min(Integer.MAX_VALUE, (long) maxShardsPerNodeSetting * nodeCount);
+```
+
+The fix:
+1. Casts `maxShardsPerNodeSetting` to `long` before multiplication to prevent overflow
+2. Uses `Math.min()` to cap the result at `Integer.MAX_VALUE`
+3. Changed `currentOpenShards` from `int` to `long` for consistency
+
+### Error Message Before Fix
+
+When the overflow occurred, users would see confusing error messages like:
+```
+Validation Failed: 1: this action would add [2] total shards, but this cluster currently has [30101]/[-1089934592] maximum shards open
+```
+
+The negative number (`-1089934592`) was the result of integer overflow.
+
+## Limitations
+
+- The `cluster.max_shards_per_node` setting still accepts very high values, but the computed cluster maximum is now capped at `Integer.MAX_VALUE` (2,147,483,647)
+- This is a breaking change for clusters that relied on the previous (buggy) behavior
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14155](https://github.com/opensearch-project/OpenSearch/pull/14155) | Fix the computed max shards of cluster to avoid int overflow | [#13907](https://github.com/opensearch-project/OpenSearch/issues/13907) |
+
+### Documentation
+- [Cluster Settings](https://docs.opensearch.org/2.16/install-and-configure/configuring-opensearch/cluster-settings/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch
 - Alias API Validation
+- Cluster Shard Limits
 - CAT API Help
 - Circuit Breaker Improvements
 - File Cache Initialization Fix


### PR DESCRIPTION
## Summary

Added documentation for the Cluster Shard Limits fix in OpenSearch v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch/cluster-shard-limits.md`
- Feature report: `docs/features/opensearch/opensearch-cluster-shard-limits.md`

### Key Changes in v2.16.0
- Fixed integer overflow bug in `ShardLimitValidator.checkShardLimit()` when computing maximum cluster shards
- The multiplication of `maxShardsPerNodeSetting * nodeCount` now uses long arithmetic and caps at `Integer.MAX_VALUE`

### Related
- Resolves investigation Issue #2269
- OpenSearch PR: [#14155](https://github.com/opensearch-project/OpenSearch/pull/14155)
- OpenSearch Issue: [#13907](https://github.com/opensearch-project/OpenSearch/issues/13907)