### PR TITLE
docs: add query-fixes report for v2.16.0

### DIFF
--- a/docs/features/opensearch/index.md
+++ b/docs/features/opensearch/index.md
@@ -132,6 +132,7 @@
 | [opensearch-query-builders](opensearch-query-builders.md) | Query Builders |
 | [opensearch-query-cache](opensearch-query-cache.md) | Query Cache |
 | [opensearch-query-coordinator-context](opensearch-query-coordinator-context.md) | Query Coordinator Context |
+| [opensearch-query-dsl](opensearch-query-dsl.md) | Query DSL |
 | [opensearch-query-optimization](opensearch-query-optimization.md) | Query Optimization |
 | [opensearch-query-performance-optimizations](opensearch-query-performance-optimizations.md) | Query Performance Optimizations |
 | [opensearch-query-phase-plugin-extension](opensearch-query-phase-plugin-extension.md) | Query Phase Plugin Extension |

--- a/docs/features/opensearch/opensearch-query-dsl.md
+++ b/docs/features/opensearch/opensearch-query-dsl.md
@@ -1,0 +1,96 @@
+---
+tags:
+  - opensearch
+---
+# OpenSearch Query DSL
+
+## Summary
+
+OpenSearch Query DSL (Domain Specific Language) provides a full-featured query language for defining searches. It supports full-text queries, term-level queries, compound queries, and specialized queries for various use cases including fuzzy matching, phrase matching, and autocomplete functionality.
+
+## Details
+
+### Query Types
+
+#### Full-Text Queries
+| Query | Description |
+|-------|-------------|
+| `match` | Standard full-text query with fuzzy matching support |
+| `match_phrase` | Matches exact phrases in order |
+| `match_phrase_prefix` | Matches phrases with prefix matching on the last term |
+| `multi_match` | Matches across multiple fields |
+| `query_string` | Supports Lucene query syntax |
+
+#### Term-Level Queries
+| Query | Description |
+|-------|-------------|
+| `term` | Exact term matching |
+| `terms` | Multiple exact term matching |
+| `fuzzy` | Matches terms within edit distance |
+| `prefix` | Prefix matching |
+| `wildcard` | Wildcard pattern matching |
+| `regexp` | Regular expression matching |
+
+### Index Prefixes
+
+The `index_prefixes` mapping parameter enables efficient prefix searches on text fields by creating a hidden sub-field (`{field}._index_prefix`) that indexes edge n-grams.
+
+```json
+{
+  "mappings": {
+    "properties": {
+      "title": {
+        "type": "text",
+        "index_prefixes": {
+          "min_chars": 2,
+          "max_chars": 5
+        }
+      }
+    }
+  }
+}
+```
+
+### Position Increment Gap
+
+When indexing arrays of text values, `position_increment_gap` (default: 100) creates artificial gaps between values to prevent phrase queries from matching across array boundaries.
+
+```json
+{
+  "mappings": {
+    "properties": {
+      "tags": {
+        "type": "text",
+        "position_increment_gap": 100
+      }
+    }
+  }
+}
+```
+
+### IndexOrDocValuesQuery Optimization
+
+For keyword fields with both `index: true` and `doc_values: true`, OpenSearch can use `IndexOrDocValuesQuery` to choose the most efficient execution path based on the query characteristics.
+
+## Limitations
+
+- Fuzzy queries can be resource-intensive for large edit distances
+- `match_phrase_prefix` with `index_prefixes` requires proper `position_increment_gap` handling for multi-value fields
+- Expensive queries (fuzzy, prefix, wildcard, regexp) can be disabled via `search.allow_expensive_queries` setting
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Fixed `match_phrase_prefix` query not working on text fields with multiple values and `index_prefixes` enabled; Fixed `FuzzyQuery` on keyword fields to use `IndexOrDocValuesQuery` when both index and doc_values are true
+
+## References
+
+### Documentation
+- [Query DSL](https://docs.opensearch.org/latest/query-dsl/)
+- [Fuzzy Query](https://docs.opensearch.org/latest/query-dsl/term/fuzzy/)
+- [Match Phrase Prefix Query](https://docs.opensearch.org/latest/query-dsl/full-text/match-phrase-prefix/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#10959](https://github.com/opensearch-project/OpenSearch/pull/10959) | Fix match_phrase_prefix_query not working on text field with multiple values and index_prefixes |
+| v2.16.0 | [#14378](https://github.com/opensearch-project/OpenSearch/pull/14378) | Fix FuzzyQuery in keyword field will use IndexOrDocValuesQuery when both of index and doc_value are true |

--- a/docs/releases/v2.16.0/features/opensearch/query-fixes.md
+++ b/docs/releases/v2.16.0/features/opensearch/query-fixes.md
@@ -1,0 +1,53 @@
+---
+tags:
+  - opensearch
+---
+# Query Fixes
+
+## Summary
+
+OpenSearch v2.16.0 includes two important bug fixes for query functionality: a fix for `match_phrase_prefix` query not working correctly on text fields with multiple values and `index_prefixes`, and a fix for `FuzzyQuery` on keyword fields to properly use `IndexOrDocValuesQuery` when both index and doc_values are enabled.
+
+## Details
+
+### match_phrase_prefix Query Fix
+
+**Issue**: When executing a `match_phrase_prefix` query on a text field with multiple values and `index_prefixes` enabled, the query would fail to return expected results. This occurred because the sub-field `{text_field}._index_prefix` was not using the `position_increment_gap` parameter (which defaults to 100), causing the `spanNearQuery` to not work correctly.
+
+**Root Cause**: The `PrefixFieldType` was not properly inheriting the `position_increment_gap` from the parent text field's analyzer. When multiple values are indexed in an array field, OpenSearch uses `position_increment_gap` to create a fake gap between values to prevent phrase queries from matching across array boundaries.
+
+**Fix**: The `PrefixWrappedAnalyzer` class was updated to accept and use the `position_increment_gap` from the parent analyzer. The `PrefixFieldType` now properly sets the analyzer with the correct position increment gap.
+
+**Changed Files**:
+- `TextFieldMapper.java`: Updated `PrefixWrappedAnalyzer` to include `positionIncrementGap` parameter and override `getPositionIncrementGap()` method
+- `TextFieldTypeTests.java`: Added test for position increment gap on index prefix field
+
+### FuzzyQuery on Keyword Field Fix
+
+**Issue**: `FuzzyQuery` on keyword fields was not using `IndexOrDocValuesQuery` when both `index` and `doc_values` were set to `true`, missing potential query optimization.
+
+**Root Cause**: In `FuzzyQueryBuilder.doToQuery()`, the call to `fieldType.fuzzyQuery()` was going to `StringFieldType.fuzzyQuery()` instead of `KeywordFieldMapper.fuzzyQuery()` because the method signature didn't include the `RewriteMethod` parameter.
+
+**Fix**: Added a new overloaded `fuzzyQuery()` method in `StringFieldType` that accepts the `RewriteMethod` parameter, and updated `FuzzyQueryBuilder` to call this new method. This allows `KeywordFieldMapper` to properly construct an `IndexOrDocValuesQuery` that can leverage both the inverted index and doc values for better query performance.
+
+**Changed Files**:
+- `StringFieldType.java`: Added new `fuzzyQuery()` method with `RewriteMethod` parameter
+- `KeywordFieldMapper.java`: Fixed call to `super.fuzzyQuery()` to include `method` parameter
+- `FuzzyQueryBuilder.java`: Updated to call the new method signature
+
+## Limitations
+
+- The `match_phrase_prefix` fix requires reindexing documents to take effect for existing indices
+- The `FuzzyQuery` optimization only applies when both `index: true` and `doc_values: true` are set on keyword fields
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#10959](https://github.com/opensearch-project/OpenSearch/pull/10959) | Fix match_phrase_prefix_query not working on text field with multiple values and index_prefixes | [#9203](https://github.com/opensearch-project/OpenSearch/issues/9203) |
+| [#14378](https://github.com/opensearch-project/OpenSearch/pull/14378) | Fix FuzzyQuery in keyword field will use IndexOrDocValuesQuery when both of index and doc_value are true | [#14377](https://github.com/opensearch-project/OpenSearch/issues/14377) |
+
+### Documentation
+- [Fuzzy Query](https://docs.opensearch.org/2.16/query-dsl/term/fuzzy/)
+- [Match Phrase Prefix Query](https://docs.opensearch.org/2.16/query-dsl/full-text/match-phrase-prefix/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -14,6 +14,7 @@
 - Multi-Part Upload Fix
 - Nested Aggregations Fix
 - PIT (Point In Time) API
+- Query Fixes
 - REST High-Level Client Fixes
 - Searchable Snapshots
 - System Index Warning


### PR DESCRIPTION
## Summary

Investigation of GitHub Issue #2268 - Query Fixes for OpenSearch v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch/query-fixes.md`
- Feature report: `docs/features/opensearch/opensearch-query-dsl.md` (created)

### Key Changes in v2.16.0
- Fixed `match_phrase_prefix` query not working on text fields with multiple values and `index_prefixes` enabled
- Fixed `FuzzyQuery` on keyword fields to use `IndexOrDocValuesQuery` when both index and doc_values are true

### PRs Investigated
- [#10959](https://github.com/opensearch-project/OpenSearch/pull/10959) - Fix match_phrase_prefix_query
- [#14378](https://github.com/opensearch-project/OpenSearch/pull/14378) - Fix FuzzyQuery IndexOrDocValuesQuery

Closes #2268