### PR TITLE
docs: add wkt-parser-refactoring report for v2.16.0

### DIFF
--- a/docs/features/opensearch/index.md
+++ b/docs/features/opensearch/index.md
@@ -144,6 +144,7 @@
 | [opensearch-reactor-netty-transport](opensearch-reactor-netty-transport.md) | Reactor Netty Transport |
 | [opensearch-refresh-task-scheduling](opensearch-refresh-task-scheduling.md) | Refresh Task Scheduling |
 | [opensearch-reindex-api](opensearch-reindex-api.md) | Reindex API |
+| [opensearch-recursive-parser-refactoring](opensearch-recursive-parser-refactoring.md) | Recursive Parser Refactoring |
 | [opensearch-remote-repository-validation](opensearch-remote-repository-validation.md) | Remote Repository Validation |
 | [opensearch-remote-store-metadata-api](opensearch-remote-store-metadata-api.md) | Remote Store Metadata API |
 | [opensearch-remote-store-metrics](opensearch-remote-store-metrics.md) | Remote Store Metrics |

--- a/docs/features/opensearch/opensearch-recursive-parser-refactoring.md
+++ b/docs/features/opensearch/opensearch-recursive-parser-refactoring.md
@@ -1,0 +1,94 @@
+---
+tags:
+  - opensearch
+---
+# Recursive Parser Refactoring
+
+## Summary
+
+OpenSearch refactored several recursive parsing methods to use iterative approaches, preventing stack overflow errors and improving stability when processing deeply nested structures such as WKT geometry collections, filter paths, and Grok patterns.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Before (Recursive)"
+        R1[parse] --> R2[parse]
+        R2 --> R3[parse]
+        R3 --> R4[...]
+        R4 --> R5[StackOverflow]
+    end
+    subgraph "After (Iterative)"
+        I1[parse] --> I2[Deque/Stack]
+        I2 --> I3[Loop]
+        I3 --> I4[Depth Check]
+        I4 --> I5[Result]
+    end
+```
+
+### Components
+
+| Component | Class | Method | Depth Limit |
+|-----------|-------|--------|-------------|
+| WKT Parser | `WellKnownText` | `parseGeometryCollection` | 1000 |
+| FilterPath Parser | `FilterPath` | `parse` | N/A |
+| Grok Validator | `Grok` | `validatePatternBank` | 500 |
+
+### WKT GeometryCollection Parser
+
+Parses Well-Known Text (WKT) format for geometry collections. The iterative implementation uses a `Deque<List<Geometry>>` to track nested collections.
+
+Key changes:
+- `MAX_DEPTH_OF_GEO_COLLECTION = 1000` constant added
+- Uses `ArrayDeque` for stack-based iteration
+- Separates `parseSimpleGeometry` from `parseGeometryCollection`
+
+### FilterPath Parser
+
+Parses filter paths used in response filtering (e.g., `_source` filtering). The refactored implementation uses regex-based splitting.
+
+Key changes:
+- Uses `String.split("(?<!\\\\)\\\\.")` to split by unescaped dots
+- Builds `FilterPath` chain from end to start
+- Handles empty strings and null values
+
+### Grok Pattern Validator
+
+Validates Grok pattern banks for circular references. The iterative implementation uses a custom `Frame` class.
+
+Key changes:
+- `MAX_PATTERN_DEPTH_SIZE = 500` constant added
+- Uses `Frame` class with `patternName`, `path`, and `startIndex`
+- Tracks visited patterns with `HashSet`
+- Uses `pathMap` for circular reference detection
+
+## Limitations
+
+- Depth limits are hardcoded and not configurable
+- GeometryCollection depth: 1000 levels maximum
+- Grok pattern depth: 500 levels maximum
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Refactored WKT parser, FilterPath parser, and Grok validator to iterative approaches
+
+## References
+
+### Documentation
+
+- [Geo-shape field type](https://opensearch.org/docs/latest/field-types/supported-field-types/geo-shape/)
+- [Grok processor](https://opensearch.org/docs/latest/ingest-pipelines/processors/grok/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#14086](https://github.com/opensearch-project/OpenSearch/pull/14086) | Switch to iterative version of WKT format parser |
+| v2.16.0 | [#14200](https://github.com/opensearch-project/OpenSearch/pull/14200) | Refactoring FilterPath.parse by using an iterative approach |
+| v2.16.0 | [#14206](https://github.com/opensearch-project/OpenSearch/pull/14206) | Refactoring Grok.validatePatternBank by using an iterative approach |
+
+### Related Issues
+| Issue | Description |
+|-------|-------------|
+| [#12067](https://github.com/opensearch-project/OpenSearch/issues/12067) | Replace recursive FilterPath.parse with iterative approach |

--- a/docs/releases/v2.16.0/features/opensearch/wkt-parser-refactoring.md
+++ b/docs/releases/v2.16.0/features/opensearch/wkt-parser-refactoring.md
@@ -1,0 +1,62 @@
+---
+tags:
+  - opensearch
+---
+# WKT Parser Refactoring
+
+## Summary
+
+OpenSearch v2.16.0 refactors several recursive parsing methods to use iterative approaches, preventing stack overflow errors and improving stability when processing deeply nested structures.
+
+## Details
+
+### What's New in v2.16.0
+
+Three parsing components were refactored from recursive to iterative implementations:
+
+| Component | File | Change |
+|-----------|------|--------|
+| WKT Parser | `WellKnownText.java` | GeometryCollection parsing now uses iterative approach with depth limit |
+| FilterPath Parser | `FilterPath.java` | Path segment parsing uses regex-based splitting instead of recursion |
+| Grok Pattern Validator | `Grok.java` | Pattern bank validation uses stack-based iteration |
+
+### Technical Changes
+
+#### WKT GeometryCollection Parser
+
+The `parseGeometryCollection` method was refactored to use a `Deque` for managing nested geometry collections:
+
+- Uses `ArrayDeque` instead of recursive calls
+- Introduces `MAX_DEPTH_OF_GEO_COLLECTION = 1000` limit
+- Throws `IllegalArgumentException` when depth exceeds limit
+
+#### FilterPath Parser
+
+The `FilterPath.parse` method was simplified:
+
+- Uses regex `(?<!\\)\\.` to split filter paths by unescaped dots
+- Builds `FilterPath` chain iteratively from end to start
+- Handles empty strings and null values gracefully
+
+#### Grok Pattern Validator
+
+The `validatePatternBank` method was refactored:
+
+- Uses `Frame` class to track pattern name, path, and start index
+- Implements `MAX_PATTERN_DEPTH_SIZE = 500` limit
+- Detects circular references using `pathMap` for visited patterns
+
+## Limitations
+
+- GeometryCollection depth limited to 1000 levels
+- Grok pattern reference depth limited to 500 levels
+- These limits are hardcoded and not configurable
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14086](https://github.com/opensearch-project/OpenSearch/pull/14086) | Switch to iterative version of WKT format parser | - |
+| [#14200](https://github.com/opensearch-project/OpenSearch/pull/14200) | Refactoring FilterPath.parse by using an iterative approach | [#12067](https://github.com/opensearch-project/OpenSearch/issues/12067) |
+| [#14206](https://github.com/opensearch-project/OpenSearch/pull/14206) | Refactoring Grok.validatePatternBank by using an iterative approach | - |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch
 - Alias API Validation
+- WKT Parser Refactoring
 - Cluster Shard Limits
 - CAT API Help
 - Circuit Breaker Improvements


### PR DESCRIPTION
## Summary

Documents the WKT Parser Refactoring changes in OpenSearch v2.16.0.

### Changes
- Refactored WKT GeometryCollection parser to iterative approach (PR #14086)
- Refactored FilterPath.parse to iterative approach (PR #14200)
- Refactored Grok.validatePatternBank to iterative approach (PR #14206)

### Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch/wkt-parser-refactoring.md`
- Feature report: `docs/features/opensearch/opensearch-recursive-parser-refactoring.md`

Closes #2267