### PR TITLE
docs: add ingest-pipeline-fixes report for v2.16.0

### DIFF
--- a/docs/features/opensearch/index.md
+++ b/docs/features/opensearch/index.md
@@ -88,6 +88,7 @@
 | [opensearch-index-output](opensearch-index-output.md) | Index Output Optimization |
 | [opensearch-index-refresh](opensearch-index-refresh.md) | Index Refresh |
 | [opensearch-index-settings](opensearch-index-settings.md) | Index Settings |
+| [opensearch-ingest-pipeline-script-processor](opensearch-ingest-pipeline-script-processor.md) | Ingest Pipeline Script Processor |
 | [opensearch-ingest-pipeline-update](opensearch-ingest-pipeline-update.md) | Ingest Pipeline Update Operation Behavior |
 | [opensearch-inner-hits](opensearch-inner-hits.md) | Inner Hits |
 | [opensearch-jackson--query-limits](opensearch-jackson--query-limits.md) | Jackson & Query Limits |

--- a/docs/features/opensearch/opensearch-ingest-pipeline-script-processor.md
+++ b/docs/features/opensearch/opensearch-ingest-pipeline-script-processor.md
@@ -1,0 +1,134 @@
+---
+tags:
+  - opensearch
+---
+# Ingest Pipeline Script Processor
+
+## Summary
+
+The Script Processor is an ingest pipeline processor that executes Painless scripts to modify or transform documents during ingestion. It supports inline and stored scripts with script caching for improved performance.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Script Processor Flow"
+        A[Incoming Document] --> B[IngestDocument]
+        B --> C[Script Processor]
+        C --> D[Execute Painless Script]
+        D --> E[Deep Copy Document]
+        E --> F[Next Processor]
+    end
+```
+
+### Configuration
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `source` | Optional* | Inline Painless script to execute |
+| `id` | Optional* | ID of a stored script |
+| `lang` | Optional | Script language (default: `painless`) |
+| `params` | Optional | Parameters passed to the script |
+| `description` | Optional | Description of the processor |
+| `if` | Optional | Conditional execution |
+| `ignore_failure` | Optional | Ignore processor failures |
+| `on_failure` | Optional | Processors to run on failure |
+
+*Either `source` or `id` must be specified, but not both.
+
+### Supported Data Types
+
+The script processor supports the following data types in document fields:
+
+| Data Type | Support | Notes |
+|-----------|---------|-------|
+| `String` | ✅ Full | |
+| `Integer` | ✅ Full | |
+| `Long` | ✅ Full | |
+| `Float` | ✅ Full | |
+| `Double` | ✅ Full | |
+| `Boolean` | ✅ Full | |
+| `Short` | ✅ Full | Fixed in v2.16.0 |
+| `Byte` | ✅ Full | Fixed in v2.16.0 |
+| `Character` | ❌ Broken | See Limitations |
+| `List` | ✅ Full | |
+| `Map` | ✅ Full | |
+
+### Usage Example
+
+#### Basic Script Processor
+
+```json
+PUT _ingest/pipeline/my-script-pipeline
+{
+  "description": "Convert message to uppercase",
+  "processors": [
+    {
+      "script": {
+        "source": "ctx.message = ctx.message.toUpperCase()",
+        "lang": "painless"
+      }
+    }
+  ]
+}
+```
+
+#### Using Parameters
+
+```json
+PUT _ingest/pipeline/parameterized-pipeline
+{
+  "processors": [
+    {
+      "script": {
+        "source": "ctx.multiplied = ctx.value * params.factor",
+        "params": {
+          "factor": 2
+        }
+      }
+    }
+  ]
+}
+```
+
+#### Using Numeric Types (Fixed in v2.16.0)
+
+```json
+PUT _ingest/pipeline/numeric-types-pipeline
+{
+  "processors": [
+    {
+      "script": {
+        "source": "ctx.byte_field = (byte)127; ctx.short_field = (short)32767"
+      }
+    }
+  ]
+}
+```
+
+## Limitations
+
+- `Character` data type is not supported in script processors and will cause failures
+- Scripts are compiled per unique source, so dynamic scripts should use parameters instead of string concatenation
+- The `lang` parameter only supports `painless`
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Fixed handling of Short and Byte data types in ScriptProcessor deep copy
+- **v2.8.0**: Added deep copy in ScriptProcessor flow (introduced regression for Short/Byte types)
+- **v1.0.0**: Initial implementation
+
+## References
+
+### Documentation
+- [Script Processor](https://docs.opensearch.org/latest/ingest-pipelines/processors/script/): Official documentation
+- [Ingest Pipelines](https://docs.opensearch.org/latest/ingest-pipelines/): Ingest pipeline overview
+- [Script APIs](https://docs.opensearch.org/latest/api-reference/script-apis/index/): Stored script management
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#14380](https://github.com/opensearch-project/OpenSearch/pull/14380) | Add missing data types to IngestDocument deep copy |
+| v2.8.0 | [#11725](https://github.com/opensearch-project/OpenSearch/pull/11725) | Added deep copy in ScriptProcessor flow |

--- a/docs/releases/v2.16.0/features/opensearch/ingest-pipeline-fixes.md
+++ b/docs/releases/v2.16.0/features/opensearch/ingest-pipeline-fixes.md
@@ -1,0 +1,70 @@
+---
+tags:
+  - opensearch
+---
+# Ingest Pipeline Fixes
+
+## Summary
+
+This release fixes a regression in the ScriptProcessor where Short and Byte data types caused failures during ingest pipeline execution. The bug was introduced in v2.8.0 when a new deep copy operation was added to the ScriptProcessor flow.
+
+## Details
+
+### What's New in v2.16.0
+
+The fix adds missing data type handlers for `Short` and `Byte` in the `IngestDocument.deepCopy()` method. Previously, when a Painless script assigned Short or Byte values to document fields, subsequent processors in the pipeline would fail because these types were not properly handled during the deep copy operation.
+
+### Technical Changes
+
+The `IngestDocument.deepCopyMap()` method was updated to handle additional primitive wrapper types:
+
+| Data Type | Status Before | Status After |
+|-----------|---------------|--------------|
+| `Short` | ❌ Not handled | ✅ Handled |
+| `Byte` | ❌ Not handled | ✅ Handled |
+| `Character` | ❌ Not handled | ❌ Still broken (tracked separately) |
+
+### Affected Scenario
+
+The following pipeline configuration would fail before this fix:
+
+```json
+{
+  "description": "Pipeline with Short/Byte types",
+  "processors": [
+    {
+      "script": {
+        "source": "ctx.byte = (byte)127; ctx.short = (short)32767"
+      }
+    },
+    {
+      "script": {
+        "source": "ctx.other_field = 'other_field'"
+      }
+    }
+  ]
+}
+```
+
+The first script processor would succeed, but the second processor would fail because the deep copy of the document (containing Byte and Short values) was not handled correctly.
+
+### Root Cause
+
+PR #11725 (v2.8.0) added a new invocation of `deepCopyMap()` in the ScriptProcessor flow. The `deepCopyMap()` method did not have handlers for `Short` and `Byte` types, causing the copy operation to fail when these types were present in the document.
+
+## Limitations
+
+- The `Character` data type still fails in script processors (tracked in Issue #14382)
+- This fix only addresses the deep copy regression; other data type handling issues may exist
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14380](https://github.com/opensearch-project/OpenSearch/pull/14380) | Add missing data types to IngestDocument deep copy | [#14379](https://github.com/opensearch-project/OpenSearch/issues/14379) |
+
+### Issues
+- [#14379](https://github.com/opensearch-project/OpenSearch/issues/14379): BUG - ScriptProcessor fails with Byte and Short data types
+- [#14382](https://github.com/opensearch-project/OpenSearch/issues/14382): Character data type failure (separate issue)
+- [#11725](https://github.com/opensearch-project/OpenSearch/pull/11725): Original PR that introduced the deep copy invocation

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch
 - Alias API Validation
+- Ingest Pipeline Fixes
 - WKT Parser Refactoring
 - Cluster Shard Limits
 - CAT API Help


### PR DESCRIPTION
## Summary

Adds documentation for the Ingest Pipeline Fixes in OpenSearch v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch/ingest-pipeline-fixes.md`
- Feature report: `docs/features/opensearch/opensearch-ingest-pipeline-script-processor.md`

### Key Changes in v2.16.0
- Fixed handling of Short and Byte data types in ScriptProcessor deep copy
- The bug was introduced in v2.8.0 when a new deep copy operation was added to the ScriptProcessor flow

### Resources Used
- PR: [#14380](https://github.com/opensearch-project/OpenSearch/pull/14380)
- Issue: [#14379](https://github.com/opensearch-project/OpenSearch/issues/14379)
- Docs: https://docs.opensearch.org/2.16/ingest-pipelines/processors/script/

Closes #2266