### PR TITLE
docs: add bulk-api-deprecation report for v2.16.0

### DIFF
--- a/docs/features/opensearch/opensearch-bulk-api.md
+++ b/docs/features/opensearch/opensearch-bulk-api.md
@@ -132,6 +132,8 @@ POST _bulk
 - **v3.4.0** (2026-01-14): Added proper `error_trace` parameter support for stack traces in bulk error responses
 - **v3.4.0** (2026-01-14): Fixed `indices` property not being initialized during deserialization
 - **v3.0.0** (2025-05-13): Removed deprecated `batch_size` parameter; batch processing is now automatic
+- **v2.16.0** (2024-08-06): Deprecated `batch_size` parameter; default changed to `Integer.MAX_VALUE` for automatic batch processing
+- **v2.16.0** (2024-08-06): Fixed bulk upsert to honor `default_pipeline` and `final_pipeline` from index templates during auto-index creation
 - **v2.14.0** (2024-04-30): Added `batch_size` parameter for ingest pipeline batch processing (deprecated)
 - **v2.9.0** (2023-07-18): Enforced 512 byte document ID limit in bulk updates
 - **v1.0.0** (2021-07-12): Initial implementation
@@ -149,8 +151,10 @@ POST _bulk
 | v3.4.0 | [#19985](https://github.com/opensearch-project/OpenSearch/pull/19985) | Implement error_trace parameter for bulk requests | [#19945](https://github.com/opensearch-project/OpenSearch/issues/19945) |
 | v3.4.0 | [#20132](https://github.com/opensearch-project/OpenSearch/pull/20132) | Fix `indices` property initialization during deserialization |   |
 | v3.0.0 | [#17801](https://github.com/opensearch-project/OpenSearch/pull/17801) | Remove deprecated `batch_size` parameter | [#14283](https://github.com/opensearch-project/OpenSearch/issues/14283) |
-| v2.9.0 | [#8039](https://github.com/opensearch-project/OpenSearch/pull/8039) | Enforce 512 byte document ID limit | [#6595](https://github.com/opensearch-project/OpenSearch/issues/6595) |
+| v2.16.0 | [#14725](https://github.com/opensearch-project/OpenSearch/pull/14725) | Deprecate `batch_size` parameter, change default to MAX_VALUE | [#14283](https://github.com/opensearch-project/OpenSearch/issues/14283) |
+| v2.16.0 | [#12891](https://github.com/opensearch-project/OpenSearch/pull/12891) | Fix bulk upsert pipeline resolution for auto-created indexes | [#12888](https://github.com/opensearch-project/OpenSearch/issues/12888) |
 | v2.14.0 | [#12457](https://github.com/opensearch-project/OpenSearch/pull/12457) | Add batch processing for ingest processors |   |
+| v2.9.0 | [#8039](https://github.com/opensearch-project/OpenSearch/pull/8039) | Enforce 512 byte document ID limit | [#6595](https://github.com/opensearch-project/OpenSearch/issues/6595) |
 
 ### Issues (Design / RFC)
 - [Issue #19945](https://github.com/opensearch-project/OpenSearch/issues/19945): Bug report - Bulk API ignores error_trace query parameter

--- a/docs/releases/v2.16.0/features/opensearch/bulk-api-deprecation.md
+++ b/docs/releases/v2.16.0/features/opensearch/bulk-api-deprecation.md
@@ -1,0 +1,48 @@
+---
+tags:
+  - opensearch
+---
+# Bulk API Deprecation
+
+## Summary
+
+In v2.16.0, the `batch_size` parameter on the Bulk API was deprecated and its default value changed to `Integer.MAX_VALUE`. This change makes batch processing automatic for ingest pipelines, eliminating the need for users to manually configure batch sizes. Additionally, a bug fix ensures that `default_pipeline` and `final_pipeline` settings from index templates are correctly applied during bulk upsert operations when auto-creating indexes.
+
+## Details
+
+### batch_size Parameter Deprecation
+
+The `batch_size` parameter was introduced in v2.14.0 to control how many documents are batched together when processed by ingest pipelines. However, requiring users to manually set this parameter created unnecessary complexity.
+
+**Changes in v2.16.0:**
+- Default value changed from `1` to `Integer.MAX_VALUE`
+- Using the `batch_size` parameter now emits a deprecation warning
+- All documents in a bulk request are now processed together by default
+
+This change allows ingest processor developers to optimize batch processing internally, providing performance benefits without requiring changes to client ingestion tooling.
+
+### Pipeline Resolution Bug Fix
+
+A bug was fixed where bulk upsert operations would not honor `default_pipeline` and `final_pipeline` settings defined in index templates when the target index didn't exist and was auto-created.
+
+**Root Cause:**
+When executing an update action with upsert in the Bulk API, if the specified index doesn't exist but matches an index template, the `index` field was `null` in the `IndexRequest`. This caused the pipeline resolution code path to be skipped.
+
+**Fix:**
+The pipeline resolution logic now correctly resolves pipelines from index templates even when the index is being auto-created during the bulk operation.
+
+## Limitations
+
+- The `batch_size` parameter is deprecated and will be removed in a future version (removed in v3.0.0)
+- Users should update their tooling to remove explicit `batch_size` settings
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14725](https://github.com/opensearch-project/OpenSearch/pull/14725) | Change default batch size to Integer.MAX_VALUE and add deprecation warning | [#14283](https://github.com/opensearch-project/OpenSearch/issues/14283) |
+| [#12891](https://github.com/opensearch-project/OpenSearch/pull/12891) | Fix bulk upsert ignores default_pipeline and final_pipeline | [#12888](https://github.com/opensearch-project/OpenSearch/issues/12888) |
+
+### Documentation
+- [Bulk API Documentation](https://docs.opensearch.org/2.16/api-reference/document-apis/bulk/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -3,6 +3,7 @@
 ## Features
 
 ### opensearch
+- Bulk API Deprecation
 - SBP (Search Backpressure) Bug Fix
 - Alias API Validation
 - Ingest Pipeline Fixes


### PR DESCRIPTION
## Summary
Add documentation for Bulk API Deprecation changes in OpenSearch v2.16.0.

### Changes
- **Release report**: `docs/releases/v2.16.0/features/opensearch/bulk-api-deprecation.md`
- **Feature report update**: `docs/features/opensearch/opensearch-bulk-api.md`

### Key Changes in v2.16.0
1. **batch_size parameter deprecation**: Default changed from `1` to `Integer.MAX_VALUE`, making batch processing automatic
2. **Pipeline resolution bug fix**: Fixed bulk upsert to honor `default_pipeline` and `final_pipeline` from index templates during auto-index creation

### Related PRs
- [#14725](https://github.com/opensearch-project/OpenSearch/pull/14725) - Deprecate batch_size parameter
- [#12891](https://github.com/opensearch-project/OpenSearch/pull/12891) - Fix bulk upsert pipeline resolution

Closes #2263