### PR TITLE
docs: add @InternalApi annotation report for v2.16.0

### DIFF
--- a/docs/features/opensearch/index.md
+++ b/docs/features/opensearch/index.md
@@ -91,6 +91,7 @@
 | [opensearch-ingest-pipeline-script-processor](opensearch-ingest-pipeline-script-processor.md) | Ingest Pipeline Script Processor |
 | [opensearch-ingest-pipeline-update](opensearch-ingest-pipeline-update.md) | Ingest Pipeline Update Operation Behavior |
 | [opensearch-inner-hits](opensearch-inner-hits.md) | Inner Hits |
+| [opensearch-internalapi-annotation](opensearch-internalapi-annotation.md) | @InternalApi Annotation |
 | [opensearch-jackson--query-limits](opensearch-jackson--query-limits.md) | Jackson & Query Limits |
 | [opensearch-java-17-modernization](opensearch-java-17-modernization.md) | Java 17 Modernization |
 | [opensearch-java-agent-accesscontroller](opensearch-java-agent-accesscontroller.md) | Java Agent AccessController |

--- a/docs/features/opensearch/opensearch-internalapi-annotation.md
+++ b/docs/features/opensearch/opensearch-internalapi-annotation.md
@@ -1,0 +1,144 @@
+---
+tags:
+  - opensearch
+---
+# @InternalApi Annotation
+
+## Summary
+
+The `@InternalApi` annotation marks APIs that have no compatibility guarantees and should not be used outside of OpenSearch core components. It is part of OpenSearch's API annotation system that helps maintain clear boundaries between public and internal APIs.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "API Annotation System"
+        PA["@PublicApi"]
+        DA["@DeprecatedApi"]
+        EA["@ExperimentalApi"]
+        IA["@InternalApi"]
+    end
+    
+    subgraph "Build Tooling"
+        AAP["ApiAnnotationProcessor"]
+        JC["japicmp Task"]
+    end
+    
+    PA --> AAP
+    DA --> AAP
+    EA --> AAP
+    IA --> AAP
+    
+    PA --> JC
+    DA --> JC
+    IA -.->|excluded| JC
+```
+
+### Annotation Definition
+
+The `@InternalApi` annotation can be applied to various Java elements:
+
+```java
+@Documented
+@Target({
+    ElementType.TYPE,
+    ElementType.PACKAGE,
+    ElementType.METHOD,
+    ElementType.CONSTRUCTOR,
+    ElementType.PARAMETER,
+    ElementType.FIELD,
+    ElementType.ANNOTATION_TYPE,
+    ElementType.MODULE
+})
+@PublicApi(since = "2.10.0")
+public @interface InternalApi {
+}
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `@InternalApi` | Annotation marking internal APIs with no compatibility guarantees |
+| `ApiAnnotationProcessor` | Compile-time processor that validates API annotation usage |
+| japicmp task | Build task that detects breaking changes, excludes `@InternalApi` classes |
+
+### Usage
+
+#### Marking Internal Classes
+
+```java
+@InternalApi
+public class InternalImplementation {
+    // This class should not be used outside OpenSearch core
+}
+```
+
+#### Internal Constructors on Public Classes
+
+For classes that are part of the public API but should not be instantiated externally:
+
+```java
+@PublicApi(since = "1.0.0")
+public class PublicButNotInstantiable {
+    @InternalApi
+    public PublicButNotInstantiable(InternalDependency dep) {
+        // Constructor is internal - don't instantiate outside core
+    }
+    
+    public void publicMethod() {
+        // This method is part of the public API
+    }
+}
+```
+
+### API Annotation Processor Rules
+
+The `ApiAnnotationProcessor` enforces the following rules:
+
+1. Public APIs (`@PublicApi`, `@DeprecatedApi`, `@ExperimentalApi`) should only expose other public APIs
+2. `@InternalApi` elements should not be part of public API signatures (with exceptions)
+3. Constructor arguments have relaxed semantics - can be not annotated or `@InternalApi`
+
+### Build Integration
+
+The japicmp task configuration:
+
+```groovy
+tasks.register("japicmp", me.champeau.gradle.japicmp.JapicmpTask) {
+    failOnModification = true
+    ignoreMissingClasses = true
+    annotationIncludes = ['@org.opensearch.common.annotation.PublicApi', '@org.opensearch.common.annotation.DeprecatedApi']
+    annotationExcludes = ['@org.opensearch.common.annotation.InternalApi']
+}
+```
+
+## Limitations
+
+- Runtime enforcement is not provided - the annotation is for documentation and build-time checks only
+- External code can still access and instantiate `@InternalApi` classes at runtime
+- Breaking changes to `@InternalApi` classes are not reported but may still affect plugins
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Enhanced to allow `@InternalApi` on constructors of public classes; added to japicmp exclusions
+- **v2.10.0**: Initial introduction of `@InternalApi` annotation
+
+## References
+
+### Documentation
+
+- [OpenSearch API Annotations](https://github.com/opensearch-project/OpenSearch/tree/main/libs/common/src/main/java/org/opensearch/common/annotation)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#14575](https://github.com/opensearch-project/OpenSearch/pull/14575) | Allow @InternalApi annotation on classes not meant to be constructed outside of the OpenSearch core |
+| v2.16.0 | [#14597](https://github.com/opensearch-project/OpenSearch/pull/14597) | Add @InternalApi annotation to japicmp exclusions |
+
+### Related Issues
+
+- [#13308](https://github.com/opensearch-project/OpenSearch/issues/13308) - Feature Request: Allow annotation of InternalApi on classes not meant to be consumed outside of OpenSearch

--- a/docs/releases/v2.16.0/features/opensearch/internalapi-annotation.md
+++ b/docs/releases/v2.16.0/features/opensearch/internalapi-annotation.md
@@ -1,0 +1,78 @@
+---
+tags:
+  - opensearch
+---
+# @InternalApi Annotation
+
+## Summary
+
+OpenSearch v2.16.0 enhances the `@InternalApi` annotation to allow marking classes that should not be constructed outside of OpenSearch core, even when they are referenced by public APIs. This change also adds `@InternalApi` to japicmp exclusions, preventing false-positive breaking change reports for internal classes.
+
+## Details
+
+### What's New in v2.16.0
+
+#### Relaxed Constructor Semantics
+
+The `ApiAnnotationProcessor` now allows `@InternalApi` annotation on constructors of `@PublicApi` classes. This enables marking classes as internal when:
+
+- The class is referenced by public APIs (e.g., as a method parameter or return type)
+- The class instances should only be created within OpenSearch core
+- External consumers should use the class but not instantiate it
+
+Example use case: `IndexShard` has a verbose constructor but instances should not be created outside of core.
+
+```java
+@PublicApi(since = "1.0.0")
+public class PublicApiConstructorAnnotatedInternalApi {
+    @InternalApi
+    public PublicApiConstructorAnnotatedInternalApi(NotAnnotated arg) {}
+}
+```
+
+#### japicmp Exclusions
+
+The `@InternalApi` annotation is now added to japicmp exclusions in the build configuration:
+
+```groovy
+tasks.register("japicmp", me.champeau.gradle.japicmp.JapicmpTask) {
+    annotationIncludes = ['@org.opensearch.common.annotation.PublicApi', '@org.opensearch.common.annotation.DeprecatedApi']
+    annotationExcludes = ['@org.opensearch.common.annotation.InternalApi']
+}
+```
+
+This prevents the "detect breaking changes" workflow from flagging changes to `@InternalApi` annotated classes as breaking changes.
+
+### Technical Changes
+
+| Component | Change |
+|-----------|--------|
+| `ApiAnnotationProcessor` | Constructor arguments now have relaxed semantics - can be not annotated or annotated as `@InternalApi` |
+| `server/build.gradle` | Added `annotationExcludes` for `@InternalApi` in japicmp task |
+
+### Problem Solved
+
+Previously, classes like `RemoteStorePathStrategy` that were internal but referenced by public APIs had to be marked as `@PublicApi`, causing:
+
+1. False-positive breaking change reports when modifying these classes
+2. Incorrect API surface exposure to external consumers
+
+## Limitations
+
+- The `@InternalApi` annotation only affects compile-time checks and build tooling
+- Runtime behavior is not enforced - external code can still instantiate these classes
+- Developers must rely on documentation and annotation to understand usage restrictions
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14575](https://github.com/opensearch-project/OpenSearch/pull/14575) | Allow @InternalApi annotation on classes not meant to be constructed outside of the OpenSearch core | [#13308](https://github.com/opensearch-project/OpenSearch/issues/13308) |
+| [#14597](https://github.com/opensearch-project/OpenSearch/pull/14597) | Add @InternalApi annotation to japicmp exclusions | [#13308](https://github.com/opensearch-project/OpenSearch/issues/13308) |
+
+### Related Issues
+
+- [#13308](https://github.com/opensearch-project/OpenSearch/issues/13308) - Feature Request: Allow annotation of InternalApi on classes not meant to be consumed outside of OpenSearch
+- [#13275](https://github.com/opensearch-project/OpenSearch/issues/13275) - Original discussion about RemoteStorePathStrategy annotation issues

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -3,6 +3,7 @@
 ## Features
 
 ### opensearch
+- @InternalApi Annotation
 - Bulk API Deprecation
 - SBP (Search Backpressure) Bug Fix
 - Alias API Validation


### PR DESCRIPTION
## Summary

This PR adds documentation for the `@InternalApi` annotation enhancements introduced in OpenSearch v2.16.0.

## Changes

### Release Report
- `docs/releases/v2.16.0/features/opensearch/internalapi-annotation.md`

### Feature Report
- `docs/features/opensearch/opensearch-internalapi-annotation.md`

## Key Changes in v2.16.0

- **Relaxed constructor semantics**: `@InternalApi` can now be used on constructors of `@PublicApi` classes, allowing classes to be consumed but not instantiated by external code
- **japicmp exclusions**: `@InternalApi` annotated classes are now excluded from breaking change detection

## Related PRs

- [opensearch-project/OpenSearch#14575](https://github.com/opensearch-project/OpenSearch/pull/14575) - Allow @InternalApi annotation on classes not meant to be constructed outside of the OpenSearch core
- [opensearch-project/OpenSearch#14597](https://github.com/opensearch-project/OpenSearch/pull/14597) - Add @InternalApi annotation to japicmp exclusions

## Related Issue

Closes #2261