### PR TITLE
docs: add System Index Descriptors Registration report for v2.16.0

### DIFF
--- a/docs/features/reporting/reporting-plugin.md
+++ b/docs/features/reporting/reporting-plugin.md
@@ -113,6 +113,7 @@ The Reporting plugin integrates with OpenSearch Security:
 - **v3.3.0** (2026-01-11): Security fix for CVE-2025-7783
 - **v3.2.0** (2026-01-11): Fixed system index creation permissions and tenant URL parsing
 - **v3.1.0** (2025-06-13): Version increment and release notes maintenance
+- **v2.16.0** (2024-08-06): Registered system indices through `SystemIndexPlugin.getSystemIndexDescriptors` for formal system index protection
 
 
 ## References
@@ -132,6 +133,7 @@ The Reporting plugin integrates with OpenSearch Security:
 | v3.3.0 | [#640](https://github.com/opensearch-project/reporting/pull/640) | Fixing CVE-2025-7783 |   |
 | v3.2.0 | [#1108](https://github.com/opensearch-project/reporting/pull/1108) | Create report indices in system context to avoid permission issues | [#998](https://github.com/opensearch-project/reporting/issues/998) |
 | v3.2.0 | [#599](https://github.com/opensearch-project/dashboards-reporting/pull/599) | Fix tenant URL parsing when generating reports from Discover | [#535](https://github.com/opensearch-project/dashboards-reporting/issues/535) |
+| v2.16.0 | [#1009](https://github.com/opensearch-project/reporting/pull/1009) | Register system index descriptors through SystemIndexPlugin | [security#4439](https://github.com/opensearch-project/security/issues/4439) |
 
 ### Issues (Design / RFC)
 - [Issue #998](https://github.com/opensearch-project/reporting/issues/998): Permission issue when creating reporting indices

--- a/docs/features/sql/sql-ppl-engine.md
+++ b/docs/features/sql/sql-ppl-engine.md
@@ -103,6 +103,7 @@ POST /_plugins/_ppl
 - **v3.0.0**: Apache Calcite integration (V3 engine)
 - **v2.19.0**: PPL metadata fields support (`_id`, `_index`, etc.); grammar validation for PPL; async query state management improvements; bug fixes for datetime parsing, CSV output, and FilterOperator
 - **v2.17.0**: Increased default query size limit (200 → 10000)
+- **v2.16.0**: Registered system indices (`.ql-datasources`, `.spark-request-buffer*`) through `SystemIndexPlugin.getSystemIndexDescriptors` for formal system index protection
 
 
 ## References
@@ -111,3 +112,9 @@ POST /_plugins/_ppl
 - [SQL and PPL Documentation](https://docs.opensearch.org/3.0/search-plugins/sql/index/)
 - [SQL Settings](https://docs.opensearch.org/3.0/search-plugins/sql/settings/)
 - [SQL Plugin Repository](https://github.com/opensearch-project/sql)
+
+### Pull Requests
+| Version | PR | Description | Related Issue |
+|---------|-----|-------------|---------------|
+| v2.16.0 | [#2772](https://github.com/opensearch-project/sql/pull/2772) | Register system index descriptors through SystemIndexPlugin | [security#4439](https://github.com/opensearch-project/security/issues/4439) |
+| v2.16.0 | [#2817](https://github.com/opensearch-project/sql/pull/2817) | Backport: Register system index descriptors through SystemIndexPlugin | [security#4439](https://github.com/opensearch-project/security/issues/4439) |

--- a/docs/releases/v2.16.0/features/reporting/system-index-descriptors-registration.md
+++ b/docs/releases/v2.16.0/features/reporting/system-index-descriptors-registration.md
@@ -1,0 +1,91 @@
+---
+tags:
+  - reporting
+---
+# System Index Descriptors Registration
+
+## Summary
+
+In v2.16.0, the reporting and sql plugins now formally register their system indices through the `SystemIndexPlugin.getSystemIndexDescriptors` extension point in OpenSearch core. This change is part of a broader initiative to strengthen system index protection across the plugin ecosystem.
+
+## Details
+
+### What's New in v2.16.0
+
+Previously, plugins managed their system indices informally without registering them through the core extension point. This change introduces formal registration of system indices, enabling better security controls and protection mechanisms.
+
+### Technical Changes
+
+#### Reporting Plugin
+
+The `ReportsSchedulerPlugin` class now implements `SystemIndexPlugin` and registers two system indices:
+
+| Index Name | Description |
+|------------|-------------|
+| `.opendistro-reports-definitions` | Reports Scheduler Plugin Definitions index |
+| `.opendistro-reports-instances` | Reports Scheduler Plugin Instances index |
+
+```kotlin
+class ReportsSchedulerPlugin : Plugin(), ActionPlugin, SystemIndexPlugin, JobSchedulerExtension {
+    override fun getSystemIndexDescriptors(settings: Settings): Collection<SystemIndexDescriptor> {
+        return listOf(
+            SystemIndexDescriptor(REPORT_DEFINITIONS_INDEX_NAME, "Reports Scheduler Plugin Definitions index"),
+            SystemIndexDescriptor(REPORT_INSTANCES_INDEX_NAME, "Reports Scheduler Plugin Instances index")
+        )
+    }
+}
+```
+
+#### SQL Plugin
+
+The `SQLPlugin` class now implements `SystemIndexPlugin` and registers:
+
+| Index Pattern | Description |
+|---------------|-------------|
+| `.ql-datasources` | SQL DataSources index |
+| `.spark-request-buffer*` | SQL Spark Request Buffer index pattern |
+
+```java
+public class SQLPlugin extends Plugin implements ActionPlugin, ScriptPlugin, SystemIndexPlugin {
+    @Override
+    public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
+        List<SystemIndexDescriptor> systemIndexDescriptors = new ArrayList<>();
+        systemIndexDescriptors.add(
+            new SystemIndexDescriptor(
+                OpenSearchDataSourceMetadataStorage.DATASOURCE_INDEX_NAME, "SQL DataSources index"));
+        systemIndexDescriptors.add(
+            new SystemIndexDescriptor(
+                SPARK_REQUEST_BUFFER_INDEX_NAME + "*", "SQL Spark Request Buffer index pattern"));
+        return systemIndexDescriptors;
+    }
+}
+```
+
+### Background
+
+This change is related to a broader security initiative ([security#4439](https://github.com/opensearch-project/security/issues/4439)) to strengthen system index protection. The goal is to:
+
+1. Formally register all plugin system indices through the `SystemIndexPlugin` extension point
+2. Enable the security plugin to enforce access controls based on registered system indices
+3. Prevent unauthorized access to plugin system indices when the ThreadContext is stashed
+
+## Limitations
+
+- The indices are functionally unchanged; this is purely a formal registration
+- Full system index protection requires additional security plugin changes (ongoing work)
+
+## References
+
+### Pull Requests
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#1009](https://github.com/opensearch-project/reporting/pull/1009) | reporting | Register system index descriptors through SystemIndexPlugin |
+| [#2817](https://github.com/opensearch-project/sql/pull/2817) | sql | Backport: Register system index descriptors through SystemIndexPlugin |
+| [#2772](https://github.com/opensearch-project/sql/pull/2772) | sql | Original: Register system index descriptors through SystemIndexPlugin |
+
+### Related Issues
+
+| Issue | Repository | Description |
+|-------|------------|-------------|
+| [#4439](https://github.com/opensearch-project/security/issues/4439) | security | RFC: Strengthen System Index Protection in the Plugin Ecosystem |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -78,5 +78,8 @@
 ### notifications
 - Version Bumps & Release Notes
 
+### reporting
+- System Index Descriptors Registration
+
 ### sql
 - SQL Async Query Core Refactoring


### PR DESCRIPTION
## Summary

This PR adds documentation for the System Index Descriptors Registration bugfix in OpenSearch v2.16.0.

## Changes

### Release Report
- Created `docs/releases/v2.16.0/features/reporting/system-index-descriptors-registration.md`

### Feature Reports Updated
- Updated `docs/features/reporting/reporting-plugin.md` - Added v2.16.0 change history and PR reference
- Updated `docs/features/sql/sql-ppl-engine.md` - Added v2.16.0 change history and PR references

### Release Index
- Updated `docs/releases/v2.16.0/index.md` - Added reporting section with System Index Descriptors Registration

## Key Changes in v2.16.0

The reporting and sql plugins now formally register their system indices through the `SystemIndexPlugin.getSystemIndexDescriptors` extension point:

- **Reporting Plugin**: Registers `.opendistro-reports-definitions` and `.opendistro-reports-instances`
- **SQL Plugin**: Registers `.ql-datasources` and `.spark-request-buffer*`

This is part of a broader security initiative (security#4439) to strengthen system index protection across the plugin ecosystem.

## Related PRs
- [reporting#1009](https://github.com/opensearch-project/reporting/pull/1009)
- [sql#2772](https://github.com/opensearch-project/sql/pull/2772)
- [sql#2817](https://github.com/opensearch-project/sql/pull/2817)

Closes #2258