### PR TITLE
docs: add query-improvements report for v2.16.0

### DIFF
--- a/docs/features/opensearch/index.md
+++ b/docs/features/opensearch/index.md
@@ -143,6 +143,7 @@
 | [opensearch-query-rewriting](opensearch-query-rewriting.md) | Query Rewriting |
 | [opensearch-query-string-monitoring](opensearch-query-string-monitoring.md) | Query String Monitoring |
 | [opensearch-query-string-regex](opensearch-query-string-regex.md) | Query String & Regex Queries |
+| [opensearch-query-settings](opensearch-query-settings.md) | Query Settings |
 | [opensearch-randomness](opensearch-randomness.md) | Randomness |
 | [opensearch-reactor-netty-transport](opensearch-reactor-netty-transport.md) | Reactor Netty Transport |
 | [opensearch-refresh-task-scheduling](opensearch-refresh-task-scheduling.md) | Refresh Task Scheduling |

--- a/docs/features/opensearch/opensearch-query-settings.md
+++ b/docs/features/opensearch/opensearch-query-settings.md
@@ -1,0 +1,127 @@
+---
+tags:
+  - opensearch
+---
+# Query Settings
+
+## Summary
+
+OpenSearch provides cluster-level settings to control query behavior, including limits on boolean query complexity. The `indices.query.bool.max_clause_count` setting defines the maximum number of clauses allowed in boolean queries and affects wildcard/prefix query expansion.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Query Processing"
+        A[Query Request] --> B[QueryShardContext]
+        B --> C[Query Parser]
+        C --> D{Clause Count Check}
+        D -->|Within Limit| E[Execute Query]
+        D -->|Exceeds Limit| F[TooManyClauses Exception]
+    end
+    
+    subgraph "Setting Management"
+        G[Cluster Settings API] --> H[ClusterSettings]
+        H --> I[SearchService]
+        I --> J[IndexSearcher.setMaxClauseCount]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SearchService.INDICES_MAX_CLAUSE_COUNT_SETTING` | Dynamic cluster setting for max clause count |
+| `IndexSearcher.setMaxClauseCount()` | Lucene method to enforce clause limit |
+| `QueryParserHelper.checkForTooManyFields()` | Validates field expansion against limit |
+
+### Configuration
+
+| Setting | Description | Default | Dynamic |
+|---------|-------------|---------|---------|
+| `indices.query.bool.max_clause_count` | Maximum clauses in boolean queries | 1024 | Yes (v2.16.0+) |
+
+### Usage Example
+
+#### Check Current Setting
+
+```json
+GET _cluster/settings?include_defaults=true&filter_path=*.indices.query.bool.max_clause_count
+```
+
+#### Update Setting Dynamically
+
+```json
+PUT _cluster/settings
+{
+  "transient": {
+    "indices.query.bool.max_clause_count": 2048
+  }
+}
+```
+
+#### Persistent Update
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "indices.query.bool.max_clause_count": 4096
+  }
+}
+```
+
+### Affected Query Types
+
+The max clause count affects:
+- Boolean queries with many clauses
+- Wildcard queries that expand to many terms
+- Prefix queries that expand to many terms
+- Query string queries with field expansion
+- Multi-match queries across many fields
+
+### Error Handling
+
+When the clause limit is exceeded:
+
+```json
+{
+  "error": {
+    "root_cause": [
+      {
+        "type": "too_many_clauses",
+        "reason": "maxClauseCount is set to 1024"
+      }
+    ]
+  }
+}
+```
+
+## Limitations
+
+- Very high values can cause memory issues with complex queries
+- Setting changes take effect immediately but don't affect in-flight queries
+- The limit is enforced at the `IndexSearcher` level (Lucene)
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Changed `indices.query.bool.max_clause_count` from static to dynamic setting. Moved setting from `SearchModule` to `SearchService`.
+- **v1.0.0**: Initial implementation inherited from Elasticsearch 7.10 with static setting.
+
+## References
+
+### Documentation
+- [Index Settings](https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/index-settings/): Configuration reference
+- [Query String](https://docs.opensearch.org/latest/query-dsl/full-text/query-string/): Query string query documentation
+- [Simple Query String](https://docs.opensearch.org/latest/query-dsl/full-text/simple-query-string/): Simple query string documentation
+
+### Pull Requests
+| Version | PR | Description | Related Issue |
+|---------|-----|-------------|---------------|
+| v2.16.0 | [#13568](https://github.com/opensearch-project/OpenSearch/pull/13568) | Set INDICES_MAX_CLAUSE_COUNT dynamically | [#12549](https://github.com/opensearch-project/OpenSearch/issues/12549), [#1526](https://github.com/opensearch-project/OpenSearch/issues/1526) |
+
+### Issues (Design / RFC)
+- [Issue #12549](https://github.com/opensearch-project/OpenSearch/issues/12549): Feature request for dynamic maxClauseCount update
+- [Issue #1526](https://github.com/opensearch-project/OpenSearch/issues/1526): Original request to make setting dynamic

--- a/docs/features/opensearch/opensearch-unsigned-long.md
+++ b/docs/features/opensearch/opensearch-unsigned-long.md
@@ -164,6 +164,7 @@ POST my_index/_search
 
 - **v3.0.0** (2025-03-05): Fixed bug where terms queries on unsigned_long fields with values > Long.MAX_VALUE caused assertion errors. Introduced `UnsignedLongHashSet` class with proper unsigned comparison.
 - **v2.19.0** (2025-02-18): Added support for retrieving doc values using `docvalue_fields` parameter. Fixed multi-value sort for unsigned long fields by introducing `SortedNumericUnsignedLongValues` and extending `MultiValueMode` with unsigned long support.
+- **v2.16.0** (2024-08-06): Optimized range queries to return `MatchNoDocsQuery` when lower bound exceeds upper bound.
 - **v2.8.0**: Initial implementation of unsigned_long field type.
 
 
@@ -179,6 +180,7 @@ POST my_index/_search
 | v3.0.0 | [#17207](https://github.com/opensearch-project/OpenSearch/pull/17207) | Fix unsigned long sorting assertion in LongHashSet | [#17206](https://github.com/opensearch-project/OpenSearch/issues/17206) |
 | v2.19.0 | [#16543](https://github.com/opensearch-project/OpenSearch/pull/16543) | Support retrieving doc values of unsigned long field | - |
 | v2.19.0 | [#16732](https://github.com/opensearch-project/OpenSearch/pull/16732) | Fix multi-value sort for unsigned long | [#16698](https://github.com/opensearch-project/OpenSearch/issues/16698) |
+| v2.16.0 | [#14416](https://github.com/opensearch-project/OpenSearch/pull/14416) | Optimize range queries to return MatchNoDocsQuery when lower > upper | [#14404](https://github.com/opensearch-project/OpenSearch/issues/14404) |
 | v2.8.0 | - | Initial implementation of unsigned_long field type |   |
 
 ### Issues (Design / RFC)

--- a/docs/releases/v2.16.0/features/opensearch/query-improvements.md
+++ b/docs/releases/v2.16.0/features/opensearch/query-improvements.md
@@ -1,0 +1,78 @@
+---
+tags:
+  - opensearch
+---
+# Query Improvements
+
+## Summary
+
+OpenSearch v2.16.0 introduces two query-related improvements: the `indices.query.bool.max_clause_count` setting is now dynamically updateable without requiring a cluster restart, and `unsignedLongRangeQuery` now returns `MatchNoDocsQuery` when lower bounds exceed upper bounds for better query optimization.
+
+## Details
+
+### Dynamic Max Clause Count Setting
+
+The `indices.query.bool.max_clause_count` setting controls the maximum number of clauses allowed in boolean queries and affects wildcard/prefix query expansion. Previously, this was a static setting requiring a cluster restart to change.
+
+#### Before v2.16.0
+- Setting was static (`Setting.Property.NodeScope` only)
+- Required cluster restart to modify
+- Defined in `SearchModule` class
+
+#### After v2.16.0
+- Setting is now dynamic (`Setting.Property.Dynamic`)
+- Can be updated at runtime via cluster settings API
+- Moved to `SearchService` class
+- Uses `IndexSearcher.setMaxClauseCount()` for runtime updates
+
+#### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `indices.query.bool.max_clause_count` | Maximum clauses in boolean queries | 1024 |
+
+#### Usage Example
+
+Update the setting dynamically:
+
+```json
+PUT _cluster/settings
+{
+  "transient": {
+    "indices.query.bool.max_clause_count": 2048
+  }
+}
+```
+
+### UnsignedLong Range Query Optimization
+
+Range queries on `unsigned_long` fields now return `MatchNoDocsQuery` immediately when the lower bound exceeds the upper bound, avoiding unnecessary query execution.
+
+#### Technical Change
+
+In `NumberFieldMapper.unsignedLongRangeQuery()`:
+
+```java
+if (l.compareTo(u) > 0) {
+    return new MatchNoDocsQuery();
+}
+```
+
+This optimization aligns with similar behavior in Lucene for other numeric types (see [LUCENE-8811](https://issues.apache.org/jira/browse/LUCENE-8811)).
+
+## Limitations
+
+- The `max_clause_count` setting change takes effect immediately but does not affect queries already in progress
+- Setting very high values for `max_clause_count` can lead to memory issues with complex queries
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#13568](https://github.com/opensearch-project/OpenSearch/pull/13568) | Set INDICES_MAX_CLAUSE_COUNT dynamically | [#12549](https://github.com/opensearch-project/OpenSearch/issues/12549), [#1526](https://github.com/opensearch-project/OpenSearch/issues/1526) |
+| [#14416](https://github.com/opensearch-project/OpenSearch/pull/14416) | Optimize UnsignedLong range queries to convert to MatchNoDocsQuery when lower > upper bounds | [#14404](https://github.com/opensearch-project/OpenSearch/issues/14404) |
+
+### Documentation
+- [Index Settings](https://docs.opensearch.org/2.16/install-and-configure/configuring-opensearch/index-settings/): Configuration reference
+- [Query String](https://docs.opensearch.org/2.16/query-dsl/full-text/query-string/): Query string query documentation

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -23,6 +23,7 @@
 - Nested Aggregations Fix
 - PIT (Point In Time) API
 - Query Fixes
+- Query Improvements
 - REST High-Level Client Fixes
 - Searchable Snapshots
 - Shard Allocation Improvements


### PR DESCRIPTION
## Summary

Adds release report and feature documentation for Query Improvements in OpenSearch v2.16.0.

### Changes in v2.16.0

1. **Dynamic Max Clause Count Setting**: The `indices.query.bool.max_clause_count` setting is now dynamically updateable without requiring a cluster restart.

2. **UnsignedLong Range Query Optimization**: Range queries on `unsigned_long` fields now return `MatchNoDocsQuery` immediately when lower bound exceeds upper bound.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch/query-improvements.md`
- Feature report: `docs/features/opensearch/opensearch-query-settings.md` (new)
- Updated: `docs/features/opensearch/opensearch-unsigned-long.md` (added v2.16.0 change)

### Pull Requests Investigated
- [#13568](https://github.com/opensearch-project/OpenSearch/pull/13568): Set INDICES_MAX_CLAUSE_COUNT dynamically
- [#14416](https://github.com/opensearch-project/OpenSearch/pull/14416): Optimize UnsignedLong range queries

Closes #2255