### PR TITLE
docs: add tiered-caching report for v2.16.0

### DIFF
--- a/docs/features/opensearch/opensearch-tiered-caching.md
+++ b/docs/features/opensearch/opensearch-tiered-caching.md
@@ -114,7 +114,8 @@ GET /_nodes/stats/caches/request_cache?level=tier
 - **v3.3.0** (2025-11-18): Fixed query execution exception handling; ensures proper cleanup of concurrent request tracking map when exceptions occur
 - **v3.0.0** (2025-05-06): Single cache manager for disk caches reduces CPU overhead; took-time policy extended to guard heap tier
 - **v2.19.0** (2025-02-25): Fixed cache stats API accuracy when shards are closed; Fixed max size settings not working with pluggable caching; Deprecated `indices.requests.cache.size` setting
-- **v2.18.0** (2024-11-05): Segmented cache architecture with configurable segments; query recomputation moved outside write lock; new settings for segment count and per-tier sizes
+- **v2.18.0** (2024-11-05): Segmented cache architecture with configurable segments; new settings for segment count and per-tier sizes
+- **v2.16.0** (2024-08-06): Query recomputation moved outside write lock using CompletableFuture-based concurrency; reduces thread contention during cache misses
 - **v2.14.0** (2024-05-14): Initial experimental tiered caching support for request cache
 - **v2.13.0** (2024-04-02): cache-ehcache plugin introduced for disk cache implementation
 
@@ -137,6 +138,7 @@ GET /_nodes/stats/caches/request_cache?level=tier
 | v2.19.0 | [#16560](https://github.com/opensearch-project/OpenSearch/pull/16560) | Fix TieredSpilloverCache stats when shards are closed | [#16559](https://github.com/opensearch-project/OpenSearch/issues/16559) |
 | v2.19.0 | [#16636](https://github.com/opensearch-project/OpenSearch/pull/16636) | Fix max size settings with pluggable caching | [#16631](https://github.com/opensearch-project/OpenSearch/issues/16631) |
 | v2.18.0 | [#16047](https://github.com/opensearch-project/OpenSearch/pull/16047) | Segmented cache changes for improved concurrency | [#13989](https://github.com/opensearch-project/OpenSearch/issues/13989) |
+| v2.16.0 | [#14187](https://github.com/opensearch-project/OpenSearch/pull/14187) | Move query recomputation logic outside write lock | [#13989](https://github.com/opensearch-project/OpenSearch/issues/13989) |
 | v2.14.0 | - | Initial tiered caching support (experimental) |   |
 | v2.13.0 | - | cache-ehcache plugin introduced |   |
 

--- a/docs/releases/v2.16.0/features/opensearch/tiered-caching.md
+++ b/docs/releases/v2.16.0/features/opensearch/tiered-caching.md
@@ -1,0 +1,68 @@
+---
+tags:
+  - opensearch
+---
+# Tiered Caching Performance Improvement
+
+## Summary
+
+OpenSearch v2.16.0 improves tiered caching performance by moving query recomputation logic outside the write lock. This change significantly reduces thread contention during cache misses, allowing multiple threads to compute queries concurrently rather than waiting for a single global write lock.
+
+## Details
+
+### What's New in v2.16.0
+
+The key change in this release addresses a performance bottleneck in the `TieredSpilloverCache.computeIfAbsent()` method. Previously, when a cache miss occurred, the query recomputation was performed while holding a write lock, causing all other threads to wait.
+
+### Technical Changes
+
+The implementation introduces a `CompletableFuture`-based approach to handle concurrent requests for the same key:
+
+```mermaid
+sequenceDiagram
+    participant T1 as Thread 1
+    participant T2 as Thread 2
+    participant Map as CompletableFuture Map
+    participant Cache as On-Heap Cache
+    
+    T1->>Map: putIfAbsent(key, future)
+    Note over T1: Succeeds (first thread)
+    T2->>Map: putIfAbsent(key, future)
+    Note over T2: Gets existing future
+    T1->>T1: Load query (outside lock)
+    T2->>Map: future.get() - waits
+    T1->>Cache: put(key, value) with write lock
+    T1->>Map: Complete future
+    T2->>T2: Returns cached value
+```
+
+Key implementation details:
+- A `ConcurrentHashMap<ICacheKey<K>, CompletableFuture<Tuple<ICacheKey<K>, V>>>` tracks in-flight computations
+- Only the first thread for a given key performs the actual query computation
+- Other threads wait on the `CompletableFuture` and receive the computed value
+- The write lock is only held during the final `put()` operation, not during query computation
+- Proper exception handling ensures the future map is cleaned up even when errors occur
+
+### Performance Impact
+
+This change provides significant performance improvements in high-concurrency scenarios:
+- Eliminates thread blocking during query recomputation
+- Reduces lock contention on the global write lock
+- Ensures each unique key is loaded only once, even with concurrent requests
+- Maintains thread safety while improving throughput
+
+## Limitations
+
+- This is part of the experimental tiered caching feature
+- The improvement specifically targets the `computeIfAbsent()` path during cache misses
+- A follow-up change to make TieredCache segmented was planned for further improvements (delivered in v2.18.0)
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14187](https://github.com/opensearch-project/OpenSearch/pull/14187) | Move query recomputation logic outside write lock | [#13989](https://github.com/opensearch-project/OpenSearch/issues/13989) |
+
+### Issues
+- [#13989](https://github.com/opensearch-project/OpenSearch/issues/13989): Performance improvement for TieredCaching

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -11,6 +11,7 @@
 - Ingest Pipeline Fixes
 - Ingest Processor Improvements
 - Query Categorization Removal
+- Tiered Caching Performance Improvement
 - WKT Parser Refactoring
 - Cluster Shard Limits
 - CAT API Help


### PR DESCRIPTION
## Summary

Adds release report for Tiered Caching performance improvement in OpenSearch v2.16.0.

## Changes

- Created release report: `docs/releases/v2.16.0/features/opensearch/tiered-caching.md`
- Updated feature report: `docs/features/opensearch/opensearch-tiered-caching.md` (added v2.16.0 to Change History and PR references)
- Updated release index: `docs/releases/v2.16.0/index.md`

## Key Findings

PR #14187 improves tiered caching performance by moving query recomputation logic outside the write lock:
- Uses `CompletableFuture`-based approach to handle concurrent requests for the same key
- Only the first thread computes the query; others wait on the future
- Write lock is only held during the final `put()` operation
- Significantly reduces thread contention during cache misses

Closes #2254