### PR TITLE
docs: add lucene-upgrade report for v2.16.0

### DIFF
--- a/docs/features/opensearch/opensearch-lucene-upgrade.md
+++ b/docs/features/opensearch/opensearch-lucene-upgrade.md
@@ -77,6 +77,12 @@ GET /_nodes?filter_path=nodes.*.version
 - **v3.1.0**: Upgrade to Apache Lucene 10.2.1 with SeededKnnVectorQuery, binary quantized vector codecs, TopDocs#rrf, and API changes (DisiPriorityQueue, TopScoreDocCollectorManager). Plugin updates: neural-search hybrid query refactoring, learning-to-rank RankerQuery fix.
 - **v3.0.0**: Upgrade to Apache Lucene 10
 - **v2.18.0**: Upgrade to Apache Lucene 9.12.0 with new Lucene912PostingsFormat, JDK 23 Panama Vectorization support, dynamic range facets, and various performance optimizations
+- **v2.16.0**: Upgrade to Apache Lucene 9.11.0 (stable release from snapshot). Includes posix_madvise support for MMapDirectory, 4-bit HNSW vectors with compression, intra-merge parallelism, RWLock for LRUQueryCache, MemorySegment Vector scorer (~2x latency improvement for byte vectors), and ICU4J 74.2 upgrade.
+- **v3.3.0**: Upgrade to Apache Lucene 10.3.0. New KNN1030Codec for k-NN plugin, Lucene103 codecs for custom-codecs plugin. API changes include new `AcceptDocs` interface replacing `Bits` in vector search, and `IOContext` hints for optimized file access.
+- **v3.3.0**: Migrate deprecated `Operations#union(Automaton, Automaton)` usages to `Operations#union(Collection<Automaton>)` in AutomatonQueries, XContentMapValues, and SystemIndices classes.
+- **v3.1.0**: Upgrade to Apache Lucene 10.2.1 with SeededKnnVectorQuery, binary quantized vector codecs, TopDocs#rrf, and API changes (DisiPriorityQueue, TopScoreDocCollectorManager). Plugin updates: neural-search hybrid query refactoring, learning-to-rank RankerQuery fix.
+- **v3.0.0**: Upgrade to Apache Lucene 10
+- **v2.18.0**: Upgrade to Apache Lucene 9.12.0 with new Lucene912PostingsFormat, JDK 23 Panama Vectorization support, dynamic range facets, and various performance optimizations
 
 
 ## References
@@ -104,6 +110,7 @@ GET /_nodes?filter_path=nodes.*.version
 | v3.1.0 | [learning-to-rank-base#186](https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/186) | Lucene 10.2 upgrade changes for RankerQuery | [#184](https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/184) |
 | v3.0.0 | [#16366](https://github.com/opensearch-project/OpenSearch/pull/16366) | Apache Lucene 10 update | [#11415](https://github.com/opensearch-project/OpenSearch/issues/11415) |
 | v2.18.0 | [#15333](https://github.com/opensearch-project/OpenSearch/pull/15333) | Update Apache Lucene to 9.12.0 |   |
+| v2.16.0 | [#14042](https://github.com/opensearch-project/OpenSearch/pull/14042) | Update to Apache Lucene 9.11.0 |   |
 
 ### Issues (Design / RFC)
 - [Issue #1334](https://github.com/opensearch-project/neural-search/issues/1334): Neural-search build failure due to Lucene API changes

--- a/docs/releases/v2.16.0/features/opensearch/lucene-upgrade.md
+++ b/docs/releases/v2.16.0/features/opensearch/lucene-upgrade.md
@@ -1,0 +1,61 @@
+---
+tags:
+  - opensearch
+---
+# Lucene Upgrade
+
+## Summary
+
+OpenSearch v2.16.0 upgrades Apache Lucene from 9.11.0-snapshot to the stable 9.11.0 release. This upgrade brings production-ready stability and includes all features and optimizations from the Lucene 9.11.0 release.
+
+## Details
+
+### What's New in v2.16.0
+
+This release updates the Lucene dependency from a snapshot version (9.11.0-snapshot-4be6531) to the official stable release (9.11.0).
+
+### Lucene 9.11.0 Highlights
+
+| Feature | Description |
+|---------|-------------|
+| posix_madvise support | MMapDirectory uses IOContext to pass MADV flags to the kernel on Linux/macOS with Java 21+, improving paging logic for large indexes under memory pressure |
+| 4-bit HNSW vectors | Support for 4-bit vectors with optional 50% memory reduction through compression |
+| Intra-merge parallelism | MergeScheduler can provide an executor for parallel merging via ConcurrentMergeScheduler |
+| RWLock for LRUQueryCache | Reduced contention using read-write locks instead of synchronized access |
+| MemorySegment Vector scorer | Scoring without copying on-heap, improving search latency by ~2x for byte vectors |
+| Primitive collections | Optimized primitive collections for better performance and heap utilization |
+| Recursive graph bisection | Now supported on indexes with blocks |
+| ICU4J upgrade | Updated to version 74.2 |
+
+### Technical Changes
+
+The PR updates the following Lucene modules:
+- lucene-core
+- lucene-analysis-common
+- lucene-analysis-icu
+- lucene-analysis-kuromoji
+- lucene-analysis-nori
+- lucene-analysis-phonetic
+- lucene-analysis-smartcn
+- lucene-analysis-stempel
+- lucene-analysis-morfologik
+- lucene-backward-codecs
+- lucene-expressions
+- lucene-grouping
+- lucene-highlighter
+
+## Limitations
+
+- No breaking changes from the snapshot version
+- Index format remains compatible within the 9.x series
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14042](https://github.com/opensearch-project/OpenSearch/pull/14042) | Update to Apache Lucene 9.11.0 | N/A |
+
+### Documentation
+- [Lucene 9.11.0 Release Notes](https://lucene.apache.org/core/9_11_0/changes/Changes.html)
+- [Lucene 9.11.1 Release Notes](https://cwiki.apache.org/confluence/display/LUCENE/ReleaseNote9_11_1) (patch release)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -10,6 +10,7 @@
 - Alias API Validation
 - Ingest Pipeline Fixes
 - Ingest Processor Improvements
+- Lucene Upgrade
 - Query Categorization Removal
 - Tiered Caching Performance Improvement
 - WKT Parser Refactoring


### PR DESCRIPTION
## Summary
Add release report for Lucene Upgrade in OpenSearch v2.16.0.

### Changes
- Created release report: `docs/releases/v2.16.0/features/opensearch/lucene-upgrade.md`
- Updated feature report: `docs/features/opensearch/opensearch-lucene-upgrade.md` (added v2.16.0 to Change History and References)
- Updated release index: `docs/releases/v2.16.0/index.md`

### Key Findings
OpenSearch v2.16.0 upgrades Apache Lucene from 9.11.0-snapshot to the stable 9.11.0 release, which includes:
- posix_madvise support for MMapDirectory (Linux/macOS with Java 21+)
- 4-bit HNSW vectors with optional 50% memory reduction
- Intra-merge parallelism via ConcurrentMergeScheduler
- RWLock for LRUQueryCache (reduced contention)
- MemorySegment Vector scorer (~2x latency improvement for byte vectors)
- ICU4J upgrade to 74.2

### Related Issue
Closes #2253