### PR TITLE
docs: add search-thread-resource-usage report for v2.16.0

### DIFF
--- a/docs/features/opensearch/index.md
+++ b/docs/features/opensearch/index.md
@@ -175,6 +175,7 @@
 | [opensearch-search-scoring](opensearch-search-scoring.md) | Search Scoring |
 | [opensearch-search-settings](opensearch-search-settings.md) | Search Settings |
 | [opensearch-search-shard-routing](opensearch-search-shard-routing.md) | Search Shard Routing |
+| [opensearch-search-thread-resource-usage](opensearch-search-thread-resource-usage.md) | Search Thread Resource Usage |
 | [opensearch-search-tie-breaking](opensearch-search-tie-breaking.md) | Search Tie-breaking (_shard_doc) |
 | [opensearch-searchable-snapshot](opensearch-searchable-snapshot.md) | Searchable Snapshots |
 | [opensearch-searchable-snapshots](opensearch-searchable-snapshots.md) | Searchable Snapshots |

--- a/docs/features/opensearch/opensearch-search-thread-resource-usage.md
+++ b/docs/features/opensearch/opensearch-search-thread-resource-usage.md
@@ -1,0 +1,111 @@
+---
+tags:
+  - opensearch
+---
+# Search Thread Resource Usage
+
+## Summary
+
+Search Thread Resource Usage is a feature that provides accurate resource tracking for search tasks in OpenSearch. It enables plugins and internal components to access CPU and memory usage statistics for search operations at the coordinator node level, supporting features like Query Insights and Search Backpressure.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Search Request Processing"
+        Client[Client] --> |Search Request| Coord[Coordinator Node]
+        Coord --> |Execute| ST[Search Task]
+        ST --> |Phases| SP[Search Phases]
+    end
+    
+    subgraph "Resource Tracking"
+        SP --> |onRequestEnd| STROL[SearchTaskRequestOperationsListener]
+        STROL --> TRTS[TaskResourceTrackingService]
+        TRTS --> |Track| CPU[CPU Usage]
+        TRTS --> |Track| Heap[Heap Usage]
+    end
+    
+    subgraph "Consumers"
+        CPU --> QI[Query Insights Plugin]
+        Heap --> QI
+        CPU --> SBP[Search Backpressure]
+        Heap --> SBP
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SearchTaskRequestOperationsListener` | Listener that subscribes to search task operations and refreshes resource stats on completion |
+| `TaskResourceTrackingService` | Core service that tracks and manages resource statistics for tasks |
+| `SearchRequestOperationsListener` | Base interface for listeners that respond to search request lifecycle events |
+| `SearchRequestOperationsCompositeListenerFactory` | Factory that manages registration of multiple search request listeners |
+
+### How It Works
+
+1. When a search request is received, OpenSearch creates a `SearchTask` to track the operation
+2. The `SearchTaskRequestOperationsListener` is registered as part of the composite listener factory
+3. During search execution, the `TaskResourceTrackingService` tracks resource consumption
+4. On request completion (`onRequestEnd`), the listener:
+   - Calls `refreshResourceStats()` to capture final resource usage
+   - Calls `removeTaskResourceUsage()` to clean up thread context
+5. On request failure (`onRequestFailure`), only cleanup is performed
+
+### Configuration
+
+This feature is enabled by default and requires no additional configuration. It works in conjunction with task resource tracking settings:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `task_resource_tracking.enabled` | Enable/disable task resource tracking | `true` |
+
+### Usage Example
+
+Plugins can implement `SearchRequestOperationsListener` to access resource statistics:
+
+```java
+public class MyResourceListener extends SearchRequestOperationsListener {
+    private final TaskResourceTrackingService trackingService;
+    
+    @Override
+    public void onRequestEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        Task task = context.getTask();
+        // Access resource stats after refresh
+        TaskResourceInfo resourceInfo = task.getResourceStats();
+        long cpuTimeNanos = resourceInfo.getCpuTimeInNanos();
+        long memoryInBytes = resourceInfo.getMemoryInBytes();
+        // Process resource information
+    }
+}
+```
+
+## Limitations
+
+- Resource tracking adds minimal overhead to search request processing
+- Statistics are captured at request completion, not during individual execution phases
+- Accuracy depends on the underlying JVM's ability to report thread CPU time
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Initial implementation of `SearchTaskRequestOperationsListener` for accurate search task resource tracking
+
+## References
+
+### Documentation
+
+- [Query Insights](https://docs.opensearch.org/latest/observing-your-data/query-insights/index/)
+- [Search Backpressure](https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/search-backpressure/)
+- [Tasks API](https://docs.opensearch.org/latest/api-reference/tasks/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#14832](https://github.com/opensearch-project/OpenSearch/pull/14832) | Create listener to refresh search thread resource usage |
+
+### Related Projects
+
+- [Query Insights Plugin](https://github.com/opensearch-project/query-insights)

--- a/docs/releases/v2.16.0/features/opensearch/search-thread-resource-usage.md
+++ b/docs/releases/v2.16.0/features/opensearch/search-thread-resource-usage.md
@@ -1,0 +1,100 @@
+---
+tags:
+  - opensearch
+---
+# Search Thread Resource Usage
+
+## Summary
+
+OpenSearch 2.16.0 introduces a new listener mechanism (`SearchTaskRequestOperationsListener`) that refreshes search thread resource usage statistics upon request completion. This enables plugins like Query Insights to access accurate task resource usage data for search operations.
+
+## Details
+
+### What's New in v2.16.0
+
+A new `SearchTaskRequestOperationsListener` class has been added to the OpenSearch core. This listener subscribes to search task operations and ensures resource statistics are refreshed when search requests complete.
+
+### Technical Changes
+
+The implementation adds:
+
+1. **SearchTaskRequestOperationsListener**: A new listener class that extends `SearchRequestOperationsListener`
+2. **Integration with TaskResourceTrackingService**: The listener calls `refreshResourceStats()` on request completion to capture accurate resource usage
+3. **Node initialization changes**: The `TaskResourceTrackingService` is now initialized earlier in the node startup sequence to support the new listener
+
+```java
+public final class SearchTaskRequestOperationsListener extends SearchRequestOperationsListener {
+    private final TaskResourceTrackingService taskResourceTrackingService;
+
+    public SearchTaskRequestOperationsListener(TaskResourceTrackingService taskResourceTrackingService) {
+        this.taskResourceTrackingService = taskResourceTrackingService;
+    }
+
+    @Override
+    public void onRequestEnd(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        taskResourceTrackingService.refreshResourceStats(context.getTask());
+        taskResourceTrackingService.removeTaskResourceUsage();
+    }
+
+    @Override
+    public void onRequestFailure(SearchPhaseContext context, SearchRequestContext searchRequestContext) {
+        taskResourceTrackingService.removeTaskResourceUsage();
+    }
+}
+```
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Search Request Flow"
+        SR[Search Request] --> ST[Search Task]
+        ST --> STROL[SearchTaskRequestOperationsListener]
+    end
+    
+    subgraph "Resource Tracking"
+        STROL --> TRTS[TaskResourceTrackingService]
+        TRTS --> |refreshResourceStats| RS[Resource Stats]
+        TRTS --> |removeTaskResourceUsage| TC[Thread Context Cleanup]
+    end
+    
+    subgraph "Consumers"
+        RS --> QI[Query Insights Plugin]
+        RS --> SBP[Search Backpressure]
+    end
+```
+
+### Key Components
+
+| Component | Description |
+|-----------|-------------|
+| `SearchTaskRequestOperationsListener` | Listener that captures search task resource usage on request completion |
+| `TaskResourceTrackingService` | Service that tracks and refreshes resource statistics for tasks |
+| `SearchRequestOperationsCompositeListenerFactory` | Factory that registers the new listener alongside existing listeners |
+
+### Use Cases
+
+This feature primarily benefits:
+
+- **Query Insights Plugin**: Can now access accurate CPU and memory usage for search tasks at the coordinator node level
+- **Search Backpressure**: Enhanced resource tracking for better backpressure decisions
+- **Custom Plugins**: Any plugin implementing `SearchRequestOperationsListener` can leverage accurate resource stats
+
+## Limitations
+
+- Resource tracking adds minimal overhead to search request processing
+- Statistics are captured at request completion, not during execution phases
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14832](https://github.com/opensearch-project/OpenSearch/pull/14832) | Create listener to refresh search thread resource usage | Related to Query Insights plugin |
+
+### Related Resources
+
+- [Query Insights Plugin](https://github.com/opensearch-project/query-insights)
+- [Search Backpressure Documentation](https://docs.opensearch.org/2.16/tuning-your-cluster/availability-and-recovery/search-backpressure/)
+- [Query Insights Documentation](https://docs.opensearch.org/2.16/observing-your-data/query-insights/index/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch
 - @InternalApi Annotation
+- Search Thread Resource Usage
 - Dependency Bumps (Core)
 - Bulk API Deprecation
 - SBP (Search Backpressure) Bug Fix


### PR DESCRIPTION
## Summary
Add documentation for Search Thread Resource Usage feature introduced in OpenSearch v2.16.0.

## Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch/search-thread-resource-usage.md`
- Feature report: `docs/features/opensearch/opensearch-search-thread-resource-usage.md`

## Key Changes in v2.16.0
- New `SearchTaskRequestOperationsListener` class for capturing search task resource usage
- Integration with `TaskResourceTrackingService` for accurate CPU and memory tracking
- Enables Query Insights plugin to access task resource statistics

## Source
- PR: [#14832](https://github.com/opensearch-project/OpenSearch/pull/14832)