### PR TITLE
docs: add cluster-stats-optimization report for v2.16.0

### DIFF
--- a/docs/features/opensearch/opensearch-cluster-stats-api.md
+++ b/docs/features/opensearch/opensearch-cluster-stats-api.md
@@ -154,6 +154,7 @@ GET /_cluster/stats/os,indices/shards,docs/nodes/_all
 ## Change History
 
 - **v2.18.0** (2024-10-22): Added URI path filtering support for selective metric retrieval
+- **v2.16.0** (2024-08-06): Optimized cluster stats by pre-computing shard statistics at node level, reducing coordinator overhead by up to 74%
 - **v1.0.0**: Initial cluster stats API implementation
 
 
@@ -167,3 +168,4 @@ GET /_cluster/stats/os,indices/shards,docs/nodes/_all
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
 | v2.18.0 | [#15938](https://github.com/opensearch-project/OpenSearch/pull/15938) | URI path filtering support in cluster stats API |   |
+| v2.16.0 | [#14426](https://github.com/opensearch-project/OpenSearch/pull/14426) | Optimize Cluster Stats Indices to precompute node level stats | [#14714](https://github.com/opensearch-project/OpenSearch/issues/14714) |

--- a/docs/releases/v2.16.0/features/opensearch/cluster-stats-optimization.md
+++ b/docs/releases/v2.16.0/features/opensearch/cluster-stats-optimization.md
@@ -1,0 +1,91 @@
+---
+tags:
+  - opensearch
+---
+# Cluster Stats Optimization
+
+## Summary
+
+OpenSearch v2.16.0 introduces a significant performance optimization for the Cluster Stats API (`_cluster/stats`). The optimization pre-computes shard-level statistics at each data node before sending responses to the coordinator node, reducing the computational overhead on the coordinator and improving response times by up to 74% in large clusters.
+
+## Details
+
+### What's New in v2.16.0
+
+The previous implementation of cluster stats had a performance bottleneck in large clusters with many shards:
+
+1. Each node sent individual shard-level statistics to the coordinator
+2. The coordinator node accumulated all shard stats from all nodes
+3. Creating hash-maps from StreamInput and iterating through them was computationally expensive
+
+The new optimization introduces node-level pre-aggregation:
+
+```mermaid
+graph TB
+    subgraph "Before v2.16.0"
+        A1[Node 1] -->|Shard Stats Array| C1[Coordinator]
+        A2[Node 2] -->|Shard Stats Array| C1
+        A3[Node N] -->|Shard Stats Array| C1
+        C1 -->|Iterate All Shards| D1[Aggregate]
+    end
+```
+
+```mermaid
+graph TB
+    subgraph "After v2.16.0"
+        B1[Node 1] -->|Pre-aggregated Stats| C2[Coordinator]
+        B2[Node 2] -->|Pre-aggregated Stats| C2
+        B3[Node N] -->|Pre-aggregated Stats| C2
+        C2 -->|Node-level Merge| D2[Aggregate]
+    end
+```
+
+### Technical Changes
+
+| Component | Change |
+|-----------|--------|
+| `ClusterStatsRequest` | Added `useAggregatedNodeLevelResponses` flag |
+| `ClusterStatsNodeResponse` | Added `AggregatedNodeLevelStats` inner class for pre-computed stats |
+| `ClusterStatsIndices` | Updated to handle both legacy shard-level and new node-level aggregated responses |
+| `TransportClusterStatsAction` | Modified to pass aggregation flag to node responses |
+| `RestClusterStatsAction` | Enabled aggregated responses by default for REST API calls |
+
+### New Classes
+
+| Class | Description |
+|-------|-------------|
+| `AggregatedNodeLevelStats` | Contains pre-computed `CommonStats` and per-index `AggregatedIndexStats` |
+| `AggregatedIndexStats` | Holds aggregated shard counts (total, primaries) per index |
+
+### Performance Improvement
+
+Tested on a 20,000 shard (empty) cluster with 500 attempts and parallelization of 5:
+
+| Metric | Before Optimization | After Optimization | Improvement |
+|--------|--------------------|--------------------|-------------|
+| Average | 0.77s | 0.20s | 74% faster |
+| P90 | 1.04s | 0.33s | 68% faster |
+| Max | 1.51s | 0.63s | 58% faster |
+| Min | 0.27s | 0.09s | 67% faster |
+
+### Backward Compatibility
+
+The optimization is transparent to API consumers - the response format remains unchanged. The implementation includes version checks to maintain compatibility during rolling upgrades between v2.x and v3.0.0.
+
+## Limitations
+
+- The optimization is enabled by default only for REST API calls
+- Internal transport calls can opt-in via the `useAggregatedNodeLevelResponses` flag
+- During mixed-version clusters, nodes may fall back to legacy behavior
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14426](https://github.com/opensearch-project/OpenSearch/pull/14426) | Optimize Cluster Stats Indices to precompute node level stats | [#14714](https://github.com/opensearch-project/OpenSearch/issues/14714) |
+
+### Related Issues
+| Issue | Description |
+|-------|-------------|
+| [#14714](https://github.com/opensearch-project/OpenSearch/issues/14714) | Cluster Stats Request performs shard level aggregations on coordinator node instead of individual data nodes |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch
 - @InternalApi Annotation
+- Cluster Stats Optimization
 - Search Thread Resource Usage
 - Dependency Bumps (Core)
 - Bulk API Deprecation


### PR DESCRIPTION
## Summary

Adds documentation for the Cluster Stats Optimization feature introduced in OpenSearch v2.16.0.

### Changes
- Created release report: `docs/releases/v2.16.0/features/opensearch/cluster-stats-optimization.md`
- Updated feature report: `docs/features/opensearch/opensearch-cluster-stats-api.md` (added v2.16.0 to Change History)
- Updated release index: `docs/releases/v2.16.0/index.md`

### Key Points
- Pre-computes shard statistics at node level before sending to coordinator
- Reduces coordinator overhead by up to 74% in large clusters
- Transparent to API consumers - response format unchanged

### Related
- Closes #2251
- PR: opensearch-project/OpenSearch#14426
- Issue: opensearch-project/OpenSearch#14714