### PR TITLE
docs: add logging-improvements report for v2.16.0

### DIFF
--- a/docs/features/opensearch/index.md
+++ b/docs/features/opensearch/index.md
@@ -105,6 +105,7 @@
 | [opensearch-lucene-similarity](opensearch-lucene-similarity.md) | Lucene Similarity |
 | [opensearch-lucene-upgrade](opensearch-lucene-upgrade.md) | Lucene Upgrade |
 | [opensearch-mapping-transformer](opensearch-mapping-transformer.md) | Mapping Transformer |
+| [opensearch-masterservice-logging](opensearch-masterservice-logging.md) | MasterService Logging Optimization |
 | [opensearch-match-only-text](opensearch-match-only-text.md) | Match Only Text Field |
 | [opensearch-maven-snapshots-publishing](opensearch-maven-snapshots-publishing.md) | Maven Snapshots Publishing |
 | [opensearch-merge-segment-settings](opensearch-merge-segment-settings.md) | Merge & Segment Settings |

--- a/docs/features/opensearch/opensearch-masterservice-logging.md
+++ b/docs/features/opensearch/opensearch-masterservice-logging.md
@@ -1,0 +1,117 @@
+---
+tags:
+  - opensearch
+---
+# MasterService Logging Optimization
+
+## Summary
+
+OpenSearch provides optimized logging mechanisms in the MasterService and TaskBatcher components to balance debugging capabilities with cluster performance. The logging system uses lazy evaluation to defer expensive summary computation, ensuring that detailed task information is only generated when explicitly needed.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph TaskBatcher
+        TB[TaskBatcher.runIfNotProcessed]
+        TSG[taskSummaryGenerator]
+        SS[Short Summary]
+        LS[Long Summary]
+    end
+    
+    subgraph MasterService
+        MS[MasterService.runTasks]
+        DEBUG[DEBUG Logging]
+        TRACE[TRACE Logging]
+    end
+    
+    TB --> TSG
+    TSG -->|false| SS
+    TSG -->|true| LS
+    MS --> DEBUG
+    MS --> TRACE
+    SS --> DEBUG
+    LS --> TRACE
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `TaskBatcher` | Batches cluster state update tasks and manages task execution |
+| `MasterService` | Coordinates cluster state updates on the cluster manager node |
+| `taskSummaryGenerator` | Function that lazily generates short or long task summaries |
+
+### Configuration
+
+Logging levels are configured via Log4j settings:
+
+| Log Level | Summary Type | Use Case |
+|-----------|--------------|----------|
+| DEBUG | Short summary | Production debugging with minimal overhead |
+| TRACE | Long summary | Detailed debugging during development/troubleshooting |
+
+### Log Output Examples
+
+**DEBUG Level (Short Summary)**:
+```
+executing cluster state update for [Tasks batched with key: org.opensearch.cluster.routing.allocation.AllocationService and count: 1500]
+```
+
+**TRACE Level (Long Summary)**:
+```
+executing cluster state update for [shard-started[ShardRouting{...}], shard-started[ShardRouting{...}], ...]
+```
+
+### Implementation Details
+
+The optimization uses a `Function<Boolean, String>` to defer summary computation:
+
+```java
+Function<Boolean, String> taskSummaryGenerator = (longSummaryRequired) -> {
+    if (longSummaryRequired == null || !longSummaryRequired) {
+        return buildShortSummary(updateTask.batchingKey, toExecute.size());
+    }
+    // Expensive computation only when needed
+    final Map<String, List<BatchedTask>> processTasksBySource = new HashMap<>();
+    for (final BatchedTask task : toExecute) {
+        processTasksBySource.computeIfAbsent(task.source, s -> new ArrayList<>()).add(task);
+    }
+    return processTasksBySource.entrySet().stream()
+        .map(entry -> {
+            String tasks = updateTask.describeTasks(entry.getValue());
+            return tasks.isEmpty() ? entry.getKey() : entry.getKey() + "[" + tasks + "]";
+        })
+        .reduce((s1, s2) -> s1 + ", " + s2).orElse("");
+};
+```
+
+## Limitations
+
+- Short summary provides less detail for debugging cluster state issues
+- TRACE level logging may still cause performance impact in high-throughput scenarios
+- Summary format change may affect log parsing tools that depend on previous format
+
+## Change History
+
+- **v2.16.0** (2024-07-22): Introduced short/long summary separation to reduce DEBUG logging overhead ([#14795](https://github.com/opensearch-project/OpenSearch/pull/14795))
+
+## References
+
+### Documentation
+
+- OpenSearch Logging Configuration: https://opensearch.org/docs/latest/install-and-configure/configuring-opensearch/logs/
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#14795](https://github.com/opensearch-project/OpenSearch/pull/14795) | Reduce logging in DEBUG for MasterService:run |
+
+### Related Issues
+
+| Issue | Description |
+|-------|-------------|
+| [#12249](https://github.com/opensearch-project/OpenSearch/issues/12249) | [BUG] Reduce TaskBatcher excessive logging in DEBUG mode |

--- a/docs/releases/v2.16.0/features/opensearch/logging-improvements.md
+++ b/docs/releases/v2.16.0/features/opensearch/logging-improvements.md
@@ -1,0 +1,70 @@
+---
+tags:
+  - opensearch
+---
+# Logging Improvements
+
+## Summary
+
+OpenSearch v2.16.0 introduces optimized logging in the MasterService and TaskBatcher components to reduce performance overhead during cluster state updates. The change introduces short and long task summaries, deferring expensive summary computation to TRACE level logging only.
+
+## Details
+
+### What's New in v2.16.0
+
+This release addresses a critical performance issue where computing task summaries for DEBUG logging could take up to 10 minutes in clusters with large numbers of pending tasks (e.g., 200K shards during recovery).
+
+### Problem Addressed
+
+When executing pending tasks in `TaskBatcher.runIfNotProcessed()`, the system previously computed a detailed task summary for all batched tasks regardless of log level. For scenarios with 200K tasks in a batching key's linked list, this summary computation blocked task execution for approximately 10 minutes.
+
+### Technical Changes
+
+#### TaskBatcher Changes
+
+- Introduced a `Function<Boolean, String> taskSummaryGenerator` that lazily generates summaries
+- Short summary (for DEBUG): `"Tasks batched with key: {batchingKey} and count: {taskCount}"`
+- Long summary (for TRACE): Full task details with source and description
+
+```java
+// New short summary format
+private String buildShortSummary(final Object batchingKey, final int taskCount) {
+    return "Tasks batched with key: " + batchingKey.toString().split("\\$")[0] + " and count: " + taskCount;
+}
+```
+
+#### MasterService Changes
+
+- Modified `runTasks()` to use short summary for DEBUG logging
+- Long summary only computed when TRACE logging is enabled
+- `ClusterChangedEvent` now uses short summary as source field
+
+```java
+final String longSummary = logger.isTraceEnabled() ? taskInputs.taskSummaryGenerator.apply(true) : "";
+final String shortSummary = taskInputs.taskSummaryGenerator.apply(false);
+```
+
+### Performance Impact
+
+- Saves ~10 minutes during recovery phase for clusters with 200K shards
+- Long summary computation only occurs when TRACE level logging is explicitly enabled
+- No impact on cluster state update functionality
+
+## Limitations
+
+- Detailed task information requires TRACE level logging, which may not be practical in production
+- Short summary provides less debugging information than previous DEBUG output
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14795](https://github.com/opensearch-project/OpenSearch/pull/14795) | Reduce logging in DEBUG for MasterService:run | [#12249](https://github.com/opensearch-project/OpenSearch/issues/12249) |
+
+### Related Issues
+
+| Issue | Description |
+|-------|-------------|
+| [#12249](https://github.com/opensearch-project/OpenSearch/issues/12249) | [BUG] Reduce TaskBatcher excessive logging in DEBUG mode |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -4,6 +4,7 @@
 
 ### opensearch
 - ClusterManager Optimizations
+- Logging Improvements
 - @InternalApi Annotation
 - Cluster Stats Optimization
 - Search Thread Resource Usage


### PR DESCRIPTION
## Summary

Adds documentation for the Logging Improvements feature in OpenSearch v2.16.0.

### Changes
- Release report: `docs/releases/v2.16.0/features/opensearch/logging-improvements.md`
- Feature report: `docs/features/opensearch/opensearch-masterservice-logging.md`
- Updated release index and features index

### Key Points
- Optimized logging in MasterService and TaskBatcher to reduce performance overhead
- Introduced short/long task summary separation (short for DEBUG, long for TRACE)
- Saves ~10 minutes during recovery phase for clusters with 200K shards

### References
- PR: [opensearch-project/OpenSearch#14795](https://github.com/opensearch-project/OpenSearch/pull/14795)
- Issue: [opensearch-project/OpenSearch#12249](https://github.com/opensearch-project/OpenSearch/issues/12249)