### PR TITLE
docs: add Application Configuration Templates report for v2.16.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -12,6 +12,7 @@ Cumulative feature documentation across all versions.
 
 ## opensearch
 
+- Application-Based Configuration (ABC) Templates
 - Append Only Indices
 - CAT API
 - Cluster Shard Limits

--- a/docs/features/opensearch/application-configuration-templates.md
+++ b/docs/features/opensearch/application-configuration-templates.md
@@ -1,0 +1,166 @@
+---
+tags:
+  - opensearch
+---
+# Application-Based Configuration (ABC) Templates
+
+## Summary
+
+Application-Based Configuration (ABC) templates are predefined system templates in OpenSearch that simplify index configuration by providing optimized settings and mappings for specific use cases. Instead of manually configuring numerous settings, users can specify a `context` when creating an index or index template, and OpenSearch automatically applies the appropriate configuration for that use case.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Template Repository"
+        TR[Template Repository Plugin]
+        TM[Template Metadata]
+        TC[Template Content]
+    end
+    subgraph "SystemTemplatesService"
+        STS[Service]
+        STL[Loader]
+    end
+    subgraph "Cluster State"
+        CT[Component Templates]
+        STL_MAP[System Templates Lookup]
+    end
+    subgraph "Index Creation"
+        IT[Index Template]
+        CTX[Context Field]
+        IDX[Index]
+    end
+    TR --> STS
+    TM --> STS
+    TC --> STS
+    STS --> STL
+    STL --> CT
+    CT --> STL_MAP
+    IT --> CTX
+    CTX --> STL_MAP
+    STL_MAP --> IDX
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SystemTemplatesPlugin` | Plugin interface for providing template repositories |
+| `SystemTemplateRepository` | Repository interface for listing and fetching templates |
+| `SystemTemplatesService` | Service that orchestrates template loading on cluster manager election |
+| `SystemTemplateLoader` | Interface for loading templates into the cluster |
+| `ClusterStateSystemTemplateLoader` | Default loader that stores templates as component templates |
+| `SystemTemplateMetadata` | Metadata about a template (name, version, type) |
+| `SystemTemplate` | Container for template content and metadata |
+| `TemplateRepositoryMetadata` | Metadata about a template repository |
+| `Context` | Field in `ComposableIndexTemplate` for referencing ABC templates |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.application_templates.enabled` | Enable/disable ABC templates at cluster level | `false` |
+| `opensearch.experimental.feature.application_templates.enabled` | Feature flag (node-level) | `false` |
+
+### Context Field Structure
+
+The `context` field in index templates supports the following properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `name` | String | Name of the ABC template to use |
+| `version` | String | Template version (`_latest` for latest, or specific version number) |
+| `params` | Object | Optional parameters for template customization |
+
+### Usage Example
+
+```json
+PUT _index_template/my-logs
+{
+  "index_patterns": ["my-logs-*"],
+  "template": {
+    "settings": {
+      "number_of_shards": 1
+    }
+  },
+  "context": {
+    "name": "logs",
+    "version": "_latest",
+    "params": {}
+  }
+}
+```
+
+### Template Naming Convention
+
+System templates follow a specific naming pattern:
+- Format: `@abc_template@{name}@{version}`
+- Example: `@abc_template@logs@1`
+
+### Precedence Order
+
+When resolving settings, mappings, and aliases for an index:
+1. Component templates from `composed_of` (lowest priority)
+2. Index template's declared settings/mappings/aliases
+3. Context-referenced ABC template (highest priority)
+
+### Plugin Interface
+
+Plugins can provide ABC templates by implementing `SystemTemplatesPlugin`:
+
+```java
+public interface SystemTemplatesPlugin {
+    SystemTemplateRepository loadRepository() throws IOException;
+    SystemTemplateLoader loaderFor(SystemTemplateMetadata templateInfo);
+}
+```
+
+### Available Templates (as of v2.17)
+
+| Template Name | Use Case |
+|---------------|----------|
+| `logs` | General log data |
+| `metrics` | Time-series metrics |
+| `nginx-logs` | NGINX access/error logs |
+| `amazon-cloudtrail-logs` | AWS CloudTrail logs |
+| `amazon-elb-logs` | AWS ELB access logs |
+| `amazon-s3-logs` | AWS S3 access logs |
+| `apache-web-logs` | Apache HTTP server logs |
+| `k8s-logs` | Kubernetes logs |
+
+### Performance Benefits
+
+Using ABC templates provides:
+- ~20% storage improvement (with `zstd_no_dict` compression)
+- ~6% improvement in indexing p99 latency
+- Optimized merge policy (`log_byte_size`) for time-range queries
+
+## Limitations
+
+- Experimental feature requiring feature flag enablement
+- System templates can only be managed through repository plugins, not APIs
+- Context cannot be removed once configured for an index
+- Settings from ABC templates cannot be overridden during index creation
+- Template updates apply only to newly created indexes
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Initial implementation with plugin SPI and context field support
+
+## References
+
+### Documentation
+- [Index Context Documentation](https://opensearch.org/docs/latest/im-plugin/index-context/)
+- [ABC Templates Blog Post](https://opensearch.org/blog/opensearch-simplified-the-power-of-application-based-templates/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#14659](https://github.com/opensearch-project/OpenSearch/pull/14659) | Add Plugin interface for loading ABC templates |
+| v2.16.0 | [#14811](https://github.com/opensearch-project/OpenSearch/pull/14811) | Add logic to create index templates using context field |
+
+### Related Issues
+- [RFC: Application Based Configuration Templates](https://github.com/opensearch-project/OpenSearch/issues/12683)
+- [ABC Templates Implementation Details](https://github.com/opensearch-project/OpenSearch/issues/14649)

--- a/docs/releases/v2.16.0/features/opensearch/application-configuration-templates.md
+++ b/docs/releases/v2.16.0/features/opensearch/application-configuration-templates.md
@@ -1,0 +1,121 @@
+---
+tags:
+  - opensearch
+---
+# Application Configuration Templates
+
+## Summary
+
+OpenSearch 2.16.0 introduces Application-Based Configuration (ABC) templates as an experimental feature. ABC templates are predefined system templates that simplify index configuration by providing optimized settings and mappings for specific use cases such as logs, metrics, and events. This feature reduces the complexity of manual configuration and enables automatic application of best practices.
+
+## Details
+
+### What's New in v2.16.0
+
+ABC templates provide a plugin-based SPI (Service Provider Interface) for loading application-based configuration templates into OpenSearch. The feature introduces:
+
+1. **SystemTemplatesPlugin Interface**: A new plugin interface that allows loading templates from external repositories
+2. **Context Field for Index Templates**: A new `context` field in composable index templates that references ABC templates
+3. **System Template Repository**: Infrastructure for storing and managing versioned system templates
+4. **Automatic Template Loading**: Templates are loaded when a node becomes cluster manager
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Plugin Layer"
+        STP[SystemTemplatesPlugin]
+        STR[SystemTemplateRepository]
+    end
+    subgraph "Core Services"
+        STS[SystemTemplatesService]
+        STL[SystemTemplateLoader]
+        CSSTL[ClusterStateSystemTemplateLoader]
+    end
+    subgraph "Cluster State"
+        CT[Component Templates]
+        IT[Index Templates]
+    end
+    STP --> STR
+    STR --> STS
+    STS --> STL
+    STL --> CSSTL
+    CSSTL --> CT
+    IT -->|context| CT
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SystemTemplatesPlugin` | Plugin interface for providing template repositories |
+| `SystemTemplateRepository` | Repository interface for listing and fetching templates |
+| `SystemTemplatesService` | Service that orchestrates template loading on cluster manager election |
+| `SystemTemplateLoader` | Interface for loading templates into the cluster |
+| `ClusterStateSystemTemplateLoader` | Default loader that stores templates as component templates |
+| `SystemTemplateMetadata` | Metadata about a template (name, version, type) |
+| `Context` | New field in `ComposableIndexTemplate` for referencing ABC templates |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `cluster.application_templates.enabled` | Enable/disable ABC templates | `false` |
+| `opensearch.experimental.feature.application_templates.enabled` | Feature flag to enable the experimental feature | `false` |
+
+### Usage Example
+
+```json
+PUT _index_template/my-logs
+{
+  "index_patterns": ["my-logs-*"],
+  "template": {
+    "settings": {
+      "refresh_interval": "60s"
+    }
+  },
+  "context": {
+    "name": "logs",
+    "version": "_latest",
+    "params": {}
+  }
+}
+```
+
+### Technical Changes
+
+- New package `org.opensearch.cluster.applicationtemplates` containing all ABC template classes
+- `ComposableIndexTemplate` extended with optional `Context` field
+- `Metadata` class extended with `systemTemplatesLookup` for efficient template resolution
+- `MetadataIndexTemplateService` updated with validation logic for context-based templates
+- System templates are stored as component templates with special metadata marker (`_type: @abc_template`)
+
+### Precedence Order
+
+When resolving settings for an index:
+1. Component templates (lowest priority)
+2. Index template's declared settings
+3. Context-referenced ABC template settings (highest priority)
+
+## Limitations
+
+- Feature is experimental and requires enabling the feature flag
+- System templates can only be created/updated/deleted through the repository mechanism, not via APIs
+- Once a context is configured for an index, it cannot be removed
+- Settings defined in the ABC template cannot be overridden during index creation
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14659](https://github.com/opensearch-project/OpenSearch/pull/14659) | Add Plugin interface for loading application based configuration templates | [#14649](https://github.com/opensearch-project/OpenSearch/issues/14649) |
+| [#14811](https://github.com/opensearch-project/OpenSearch/pull/14811) | Add logic to create index templates (v2) using context field | [#12683](https://github.com/opensearch-project/OpenSearch/issues/12683) |
+
+### Documentation
+- [Index Context Documentation](https://opensearch.org/docs/latest/im-plugin/index-context/)
+- [ABC Templates Blog Post](https://opensearch.org/blog/opensearch-simplified-the-power-of-application-based-templates/)
+
+### Related Issues
+- [RFC: Application Based Configuration Templates](https://github.com/opensearch-project/OpenSearch/issues/12683)
+- [ABC Templates Implementation Details](https://github.com/opensearch-project/OpenSearch/issues/14649)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -3,6 +3,7 @@
 ## Features
 
 ### opensearch
+- Application Configuration Templates
 - ClusterManager Optimizations
 - Logging Improvements
 - @InternalApi Annotation


### PR DESCRIPTION
## Summary

This PR adds documentation for the Application Configuration Templates feature introduced in OpenSearch v2.16.0.

## Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch/application-configuration-templates.md`
- Feature report: `docs/features/opensearch/application-configuration-templates.md`

## Key Changes in v2.16.0
- New `SystemTemplatesPlugin` interface for loading ABC templates from repositories
- New `context` field in composable index templates for referencing ABC templates
- System templates stored as component templates with special metadata marker
- Templates automatically loaded when node becomes cluster manager

## PRs Investigated
- [#14659](https://github.com/opensearch-project/OpenSearch/pull/14659) - Plugin interface for loading ABC templates
- [#14811](https://github.com/opensearch-project/OpenSearch/pull/14811) - Context field support in index templates

## Related Issue
Closes #2244