### PR TITLE
docs: add task-cancellation report for v2.16.0

### DIFF
--- a/docs/features/opensearch/opensearch-task-management.md
+++ b/docs/features/opensearch/opensearch-task-management.md
@@ -155,6 +155,7 @@ The `resource_stats` object tracks resource usage for tasks that support resourc
 ## Change History
 
 - **v2.18.0** (2024-11-05): Fixed missing `cancellation_time_millis` and `resource_stats` fields in task index mapping
+- **v2.16.0** (2024-07-10): Enhanced task cancellation error messages to include the reason why parent task was cancelled
 
 
 ## References
@@ -167,6 +168,8 @@ The `resource_stats` object tracks resource usage for tasks that support resourc
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
 | v2.18.0 | [#16201](https://github.com/opensearch-project/OpenSearch/pull/16201) | Fix missing fields in task index mapping | [#16060](https://github.com/opensearch-project/OpenSearch/issues/16060) |
+| v2.16.0 | [#14604](https://github.com/opensearch-project/OpenSearch/pull/14604) | Print reason why parent task was cancelled | [#11830](https://github.com/opensearch-project/OpenSearch/issues/11830) |
 
 ### Issues (Design / RFC)
 - [Issue #16060](https://github.com/opensearch-project/OpenSearch/issues/16060): Bug report for missing mapping fields
+- [Issue #11830](https://github.com/opensearch-project/OpenSearch/issues/11830): Feature request to print detail reason why the parent task cancelled

--- a/docs/releases/v2.16.0/features/opensearch/task-cancellation.md
+++ b/docs/releases/v2.16.0/features/opensearch/task-cancellation.md
@@ -1,0 +1,67 @@
+---
+tags:
+  - opensearch
+---
+# Task Cancellation
+
+## Summary
+
+Enhanced task cancellation error messages to include the reason why a parent task was cancelled. Previously, when a parent task was cancelled, child tasks would fail with a generic message. Now the cancellation reason is propagated to provide better debugging information.
+
+## Details
+
+### What's New in v2.16.0
+
+When a parent task is cancelled in OpenSearch, any attempt to start child tasks will now include the cancellation reason in the error message. This helps operators understand why tasks failed.
+
+**Before:**
+```
+TaskCancelledException: The parent task was cancelled, shouldn't start any child tasks
+```
+
+**After:**
+```
+TaskCancelledException: The parent task was cancelled, shouldn't start any child tasks, by user request
+```
+
+### Technical Changes
+
+The implementation adds a `banReason` field to `CancellableTaskHolder` in `TaskManager.java`:
+
+| Component | Change |
+|-----------|--------|
+| `TaskManager.CancellableTaskHolder` | Added `banReason` field to store cancellation reason |
+| `TaskManager.startBanOnChildrenNodes()` | New overload accepting `reason` parameter |
+| `TaskCancellationService` | Passes cancellation reason to `startBanOnChildrenNodes()` |
+
+### Code Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant TCS as TaskCancellationService
+    participant TM as TaskManager
+    participant CTH as CancellableTaskHolder
+
+    User->>TCS: Cancel task (with reason)
+    TCS->>TM: startBanOnChildrenNodes(taskId, callback, reason)
+    TM->>CTH: startBan(callback, reason)
+    CTH->>CTH: Store banReason
+    Note over CTH: Child task attempts to start
+    CTH-->>User: TaskCancelledException with reason
+```
+
+## Limitations
+
+- The reason is only included when child tasks attempt to start after the parent is cancelled
+- Existing running child tasks are not affected by this change
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14604](https://github.com/opensearch-project/OpenSearch/pull/14604) | Print reason why parent task was cancelled | [#11830](https://github.com/opensearch-project/OpenSearch/issues/11830) |
+
+### Issues
+- [#11830](https://github.com/opensearch-project/OpenSearch/issues/11830): Feature request to print detail reason why the parent task cancelled

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -9,6 +9,7 @@
 - @InternalApi Annotation
 - Cluster Stats Optimization
 - Search Thread Resource Usage
+- Task Cancellation
 - Transport Optimization
 - Dependency Bumps (Core)
 - Bulk API Deprecation


### PR DESCRIPTION
## Summary
Add documentation for Task Cancellation enhancement in OpenSearch v2.16.0.

### Changes
- Created release report: `docs/releases/v2.16.0/features/opensearch/task-cancellation.md`
- Updated feature report: `docs/features/opensearch/opensearch-task-management.md` (added v2.16.0 to Change History and References)
- Updated release index: `docs/releases/v2.16.0/index.md`

### Feature Details
PR [#14604](https://github.com/opensearch-project/OpenSearch/pull/14604) enhanced task cancellation error messages to include the reason why a parent task was cancelled, improving debugging experience.

Closes #2243