### PR TITLE
docs: add System Index Registry report for v2.16.0

### DIFF
--- a/docs/features/opensearch/index.md
+++ b/docs/features/opensearch/index.md
@@ -202,6 +202,7 @@
 | [opensearch-subject-interface](opensearch-subject-interface.md) | Subject Interface |
 | [opensearch-system-indices](opensearch-system-indices.md) | System Indices |
 | [opensearch-system-index-warning](opensearch-system-index-warning.md) | System Index Warning Handling |
+| [opensearch-system-index-registry](opensearch-system-index-registry.md) | System Index Registry |
 | [opensearch-system-ingest-pipeline](opensearch-system-ingest-pipeline.md) | System Ingest Pipeline |
 | [opensearch-systemd-security-configurations](opensearch-systemd-security-configurations.md) | Systemd Security Configurations |
 | [opensearch-task-cancellation-monitoring](opensearch-task-cancellation-monitoring.md) | Task Cancellation Monitoring |

--- a/docs/features/opensearch/opensearch-system-index-registry.md
+++ b/docs/features/opensearch/opensearch-system-index-registry.md
@@ -1,0 +1,121 @@
+---
+tags:
+  - opensearch
+---
+# System Index Registry
+
+## Summary
+
+The System Index Registry is a centralized mechanism in OpenSearch for managing and querying system index descriptors registered by plugins. It provides static helper methods to determine if index expressions match system index patterns, enabling plugin-aware system index protection and access control.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Node Startup"
+        Node[Node.java] --> |collect descriptors| Plugins[SystemIndexPlugin instances]
+        Plugins --> |getSystemIndexDescriptors| SIM[SystemIndexDescriptorMap]
+        SIM --> |register| SIR[SystemIndexRegistry]
+    end
+    
+    subgraph "SystemIndexRegistry"
+        SIR --> SMAP[Descriptor Map<br/>pluginClassName → Collection&lt;Descriptor&gt;]
+        SIR --> SPAT[Pattern Array<br/>String[]]
+        SIR --> TASK[Task Index Descriptor<br/>.tasks*]
+    end
+    
+    subgraph "Runtime Queries"
+        SEC[Security Plugin] --> |matchesSystemIndexPattern| SIR
+        SEC --> |matchesPluginSystemIndexPattern| SIR
+        SI[SystemIndices] --> |getAllDescriptors| SIR
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `SystemIndexRegistry` | Central registry holding all system index descriptors and providing query methods |
+| `SystemIndexDescriptor` | Describes a system index with pattern and description |
+| `SystemIndices` | Facade class that delegates to SystemIndexRegistry for index matching |
+
+### Key Methods
+
+| Method | Description |
+|--------|-------------|
+| `matchesSystemIndexPattern(Set<String>)` | Returns indices matching any registered system index pattern |
+| `matchesPluginSystemIndexPattern(String, Set<String>)` | Returns indices matching a specific plugin's system index patterns |
+| `getAllDescriptors()` | Returns all registered system index descriptors |
+
+### Configuration
+
+Plugins register system indices by implementing `SystemIndexPlugin`:
+
+```java
+public class MyPlugin extends Plugin implements SystemIndexPlugin {
+    @Override
+    public Collection<SystemIndexDescriptor> getSystemIndexDescriptors(Settings settings) {
+        return Collections.singletonList(
+            new SystemIndexDescriptor(".my-plugin-index*", "My Plugin System Index")
+        );
+    }
+}
+```
+
+### Usage Example
+
+```java
+// Check if indices are system indices
+Set<String> indices = Set.of(".opendistro_security", "my-data-index");
+Set<String> systemIndices = SystemIndexRegistry.matchesSystemIndexPattern(indices);
+// Returns: {".opendistro_security"}
+
+// Check if indices belong to a specific plugin
+Set<String> pluginIndices = SystemIndexRegistry.matchesPluginSystemIndexPattern(
+    "org.opensearch.security.OpenSearchSecurityPlugin",
+    indices
+);
+// Returns: {".opendistro_security"}
+```
+
+### Built-in System Indices
+
+The registry automatically includes the Task Result Index:
+
+| Pattern | Description |
+|---------|-------------|
+| `.tasks*` | Task Result Index for storing async task results |
+
+## Limitations
+
+- The `SystemIndexRegistry` is marked as `@ExperimentalApi` and may change in future versions
+- Pattern overlap between plugins is detected at registration time and throws `IllegalStateException`
+- Plugin class names must be unique; duplicate source names cause `IllegalArgumentException`
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Initial implementation
+  - Created `SystemIndexRegistry` class with `matchesSystemIndexPattern` method
+  - Added `matchesPluginSystemIndexPattern` for plugin-specific matching
+  - Changed method signatures from `List` to `Set` for better performance
+  - Promoted `SystemIndexDescriptor` to `@PublicApi`
+  - Changed plugin key from `getSimpleName()` to `getCanonicalName()` for uniqueness
+
+## References
+
+### Documentation
+
+- [System indexes](https://docs.opensearch.org/2.16/security/configuration/system-indices/) - OpenSearch documentation on system index configuration
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#14415](https://github.com/opensearch-project/OpenSearch/pull/14415) | Create SystemIndexRegistry with helper method matchesSystemIndex |
+| v2.16.0 | [#14750](https://github.com/opensearch-project/OpenSearch/pull/14750) | Add matchesPluginSystemIndexPattern to SystemIndexRegistry |
+
+### Related Issues
+
+- [security#4439](https://github.com/opensearch-project/security/issues/4439) - RFC: Strengthen System Index Protection in the Plugin Ecosystem

--- a/docs/releases/v2.16.0/features/opensearch/system-index-registry.md
+++ b/docs/releases/v2.16.0/features/opensearch/system-index-registry.md
@@ -1,0 +1,98 @@
+---
+tags:
+  - opensearch
+---
+# System Index Registry
+
+## Summary
+
+OpenSearch v2.16.0 introduces the `SystemIndexRegistry` class, a centralized registry for managing system index descriptors. This feature provides static helper methods to determine if index expressions match system index patterns registered by plugins, enabling better system index protection and plugin-aware access control.
+
+## Details
+
+### What's New in v2.16.0
+
+The `SystemIndexRegistry` class was created to centralize system index management that was previously scattered across `SystemIndices`. This refactoring enables:
+
+1. **Centralized Pattern Matching**: Static methods to check if index expressions match registered system index patterns
+2. **Plugin-Specific Matching**: New `matchesPluginSystemIndexPattern` method to identify system indices owned by specific plugins
+3. **Overlap Detection**: Built-in validation to prevent overlapping system index patterns between plugins
+
+### Technical Changes
+
+#### New SystemIndexRegistry Class
+
+```java
+@ExperimentalApi
+public class SystemIndexRegistry {
+    // Check if indices match any system index pattern
+    public static Set<String> matchesSystemIndexPattern(Set<String> indexExpressions);
+    
+    // Check if indices match a specific plugin's system index patterns
+    public static Set<String> matchesPluginSystemIndexPattern(
+        String pluginClassName, 
+        Set<String> indexExpressions
+    );
+    
+    // Get all registered system index descriptors
+    static List<SystemIndexDescriptor> getAllDescriptors();
+}
+```
+
+#### Key Implementation Details
+
+- System index descriptors are stored in a map keyed by plugin canonical class name
+- The Task Result Index (`.tasks*`) is automatically registered as a built-in system index
+- Pattern overlap checking uses Lucene automaton operations for accurate detection
+- Method signatures changed from `List` to `Set` for better performance in security use cases
+
+#### SystemIndexDescriptor API Change
+
+The `SystemIndexDescriptor` class was promoted from `@opensearch.internal` to `@PublicApi(since = "2.16.0")`, making it part of the stable public API.
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Plugin Registration"
+        P1[Plugin 1] --> |getSystemIndexDescriptors| SIR[SystemIndexRegistry]
+        P2[Plugin 2] --> |getSystemIndexDescriptors| SIR
+        P3[Plugin N] --> |getSystemIndexDescriptors| SIR
+    end
+    
+    subgraph "SystemIndexRegistry"
+        SIR --> MAP[Descriptor Map<br/>pluginClass → descriptors]
+        SIR --> PAT[Pattern Array]
+    end
+    
+    subgraph "Query Methods"
+        Q1[matchesSystemIndexPattern] --> PAT
+        Q2[matchesPluginSystemIndexPattern] --> MAP
+    end
+```
+
+### Motivation
+
+This change supports the broader initiative to strengthen system index protection in the plugin ecosystem (see [security#4439](https://github.com/opensearch-project/security/issues/4439)). Previously, the security plugin maintained a hardcoded list of system indices. With this registry:
+
+- Plugins properly register system indices via `SystemIndexPlugin.getSystemIndexDescriptors()`
+- The security plugin can dynamically discover all registered system indices
+- Plugin-specific access control becomes possible (a plugin can only access its own system indices)
+
+## Limitations
+
+- The `SystemIndexRegistry` is marked as `@ExperimentalApi` and may change in future versions
+- Pattern matching is performed at registration time; dynamic pattern changes require re-registration
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14415](https://github.com/opensearch-project/OpenSearch/pull/14415) | Create SystemIndexRegistry with helper method matchesSystemIndex | [security#4439](https://github.com/opensearch-project/security/issues/4439) |
+| [#14750](https://github.com/opensearch-project/OpenSearch/pull/14750) | Add matchesPluginSystemIndexPattern to SystemIndexRegistry | [#14733](https://github.com/opensearch-project/OpenSearch/issues/14733) |
+
+### Related Issues
+
+- [security#4439](https://github.com/opensearch-project/security/issues/4439) - RFC: Strengthen System Index Protection in the Plugin Ecosystem

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -39,6 +39,7 @@
 - Searchable Snapshots
 - Shard Allocation Improvements
 - System Index Warning
+- System Index Registry
 
 ### opensearch-dashboards
 - Data Enhancements Cleanup


### PR DESCRIPTION
## Summary

Adds documentation for the System Index Registry feature introduced in OpenSearch v2.16.0.

## Changes

- **Release Report**: `docs/releases/v2.16.0/features/opensearch/system-index-registry.md`
- **Feature Report**: `docs/features/opensearch/opensearch-system-index-registry.md`
- Updated release index and features index

## Feature Overview

The System Index Registry is a centralized mechanism for managing system index descriptors registered by plugins. Key capabilities:

- `matchesSystemIndexPattern()` - Check if indices match any system index pattern
- `matchesPluginSystemIndexPattern()` - Check if indices match a specific plugin's patterns
- Automatic overlap detection between plugin patterns

## Related PRs

- [opensearch-project/OpenSearch#14415](https://github.com/opensearch-project/OpenSearch/pull/14415) - Create SystemIndexRegistry
- [opensearch-project/OpenSearch#14750](https://github.com/opensearch-project/OpenSearch/pull/14750) - Add matchesPluginSystemIndexPattern

## Investigation Issue

Closes #2242