### PR TITLE
docs: add processor-allowlist report for v2.16.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -21,6 +21,7 @@ Cumulative feature documentation across all versions.
 - GetStats API
 - Painless Script Hashing Methods
 - Point in Time (PIT) API
+- Processor Allowlist
 - Search Backpressure
 - Snapshot Repository
 - Synonym Analyzer Configuration

--- a/docs/features/opensearch/processor-allowlist.md
+++ b/docs/features/opensearch/processor-allowlist.md
@@ -1,0 +1,116 @@
+---
+tags:
+  - opensearch
+---
+# Processor Allowlist
+
+## Summary
+
+Processor Allowlist is a security and operational feature that allows cluster operators to selectively enable specific ingest and search pipeline processors. This provides fine-grained control over which processors are available, useful for limiting CPU-bound work on coordinator nodes or restricting functionality in security-conscious environments.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "opensearch.yml"
+        A[Allowlist Settings]
+    end
+    subgraph "Node Startup"
+        B[IngestCommonModulePlugin]
+        C[SearchPipelineCommonModulePlugin]
+    end
+    subgraph "Available Processors"
+        D[Filtered Ingest Processors]
+        E[Filtered Search Request Processors]
+        F[Filtered Search Response Processors]
+        G[Filtered Search Phase Results Processors]
+    end
+    A --> B
+    A --> C
+    B --> D
+    C --> E
+    C --> F
+    C --> G
+```
+
+### Configuration
+
+| Setting | Scope | Description |
+|---------|-------|-------------|
+| `ingest.common.processors.allowed` | Node | Allowlist for ingest-common processors |
+| `search.pipeline.common.request.processors.allowed` | Node | Allowlist for search request processors |
+| `search.pipeline.common.response.processors.allowed` | Node | Allowlist for search response processors |
+| `search.pipeline.common.search.phase.results.processors.allowed` | Node | Allowlist for search phase results processors |
+
+### Behavior Rules
+
+| Configuration | Result |
+|---------------|--------|
+| Setting not defined | All processors enabled (default behavior) |
+| Empty list `[]` | All processors disabled |
+| `["processor1", "processor2"]` | Only listed processors enabled |
+| Unknown processor in list | Node fails to start with `IllegalArgumentException` |
+
+### Usage Example
+
+```yaml
+# opensearch.yml - Restrict to minimal processors
+ingest.common.processors.allowed:
+  - date
+  - set
+  - remove
+
+search.pipeline.common.request.processors.allowed:
+  - filter_query
+
+search.pipeline.common.response.processors.allowed:
+  - rename_field
+```
+
+### Available Ingest Processors
+
+The following processors can be controlled via `ingest.common.processors.allowed`:
+
+`append`, `bytes`, `community_id`, `convert`, `copy`, `csv`, `date`, `date_index_name`, `dissect`, `dot_expander`, `drop`, `fail`, `fingerprint`, `foreach`, `grok`, `gsub`, `html_strip`, `join`, `json`, `kv`, `lowercase`, `pipeline`, `remove`, `remove_by_pattern`, `rename`, `script`, `set`, `sort`, `split`, `trim`, `uppercase`, `urldecode`
+
+### Available Search Pipeline Processors
+
+**Request Processors** (`search.pipeline.common.request.processors.allowed`):
+- `filter_query`
+- `script`
+- `oversample`
+
+**Response Processors** (`search.pipeline.common.response.processors.allowed`):
+- `rename_field`
+- `truncate_hits`
+- `collapse`
+
+## Limitations
+
+- Static settings require node restart to take effect
+- Changing allowlist between restarts causes pipelines using disabled processors to fail
+- Cannot selectively enable processors from plugins (only module processors)
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Initial implementation for ingest-common and search-pipeline-common processors
+
+## References
+
+### Documentation
+
+- [Ingest Processors](https://docs.opensearch.org/latest/ingest-pipelines/processors/index-processors/)
+- [Search Processors](https://docs.opensearch.org/latest/search-plugins/search-pipelines/search-processors/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#14479](https://github.com/opensearch-project/OpenSearch/pull/14479) | Add allowlist setting for ingest-common processors |
+| v2.16.0 | [#14562](https://github.com/opensearch-project/OpenSearch/pull/14562) | Add allowlist setting for search-pipeline-common processors |
+
+### Issues
+
+- [#14439](https://github.com/opensearch-project/OpenSearch/issues/14439) - Feature request for fine-grained control of processors

--- a/docs/releases/v2.16.0/features/opensearch/processor-allowlist.md
+++ b/docs/releases/v2.16.0/features/opensearch/processor-allowlist.md
@@ -1,0 +1,88 @@
+---
+tags:
+  - opensearch
+---
+# Processor Allowlist
+
+## Summary
+
+OpenSearch v2.16.0 introduces allowlist settings for ingest-common and search-pipeline-common processors. This feature enables operators to selectively enable specific processors by name, providing fine-grained control over which processors are available in a cluster.
+
+## Details
+
+### What's New in v2.16.0
+
+This release adds static settings that allow operators to control which processors are enabled:
+
+**Ingest Processors:**
+- Setting: `ingest.common.processors.allowed`
+
+**Search Pipeline Processors:**
+- Setting: `search.pipeline.common.request.processors.allowed`
+- Setting: `search.pipeline.common.response.processors.allowed`
+- Setting: `search.pipeline.common.search.phase.results.processors.allowed`
+
+### Behavior
+
+| Scenario | Behavior |
+|----------|----------|
+| Setting not defined | All installed processors are enabled (default) |
+| Empty list `[]` | All processors are disabled |
+| List of processor names | Only specified processors are enabled |
+| Unknown processor in list | Server fails to start with `IllegalArgumentException` |
+
+### Configuration Example
+
+```yaml
+# opensearch.yml
+
+# Enable only specific ingest processors
+ingest.common.processors.allowed:
+  - date
+  - set
+  - grok
+
+# Enable only specific search pipeline request processors
+search.pipeline.common.request.processors.allowed:
+  - filter_query
+  - script
+
+# Enable only specific search pipeline response processors
+search.pipeline.common.response.processors.allowed:
+  - rename_field
+  - truncate_hits
+```
+
+### Technical Changes
+
+The implementation adds filtering logic to the processor registration in both modules:
+
+1. **IngestCommonModulePlugin**: Added `PROCESSORS_ALLOWLIST_SETTING` and `filterForAllowlistSetting()` method
+2. **SearchPipelineCommonModulePlugin**: Added three separate allowlist settings for request, response, and search phase results processors
+
+### Use Case
+
+This feature is particularly useful for:
+- Dedicated coordinator nodes where CPU-bound work needs to be strictly controlled
+- Security-conscious deployments that want to limit available functionality
+- Environments where only specific pipeline processors are needed
+
+## Limitations
+
+- Settings are static (node-level) and require a node restart to take effect
+- If the allowlist is changed between restarts, any pipeline using a now-disabled processor will fail
+- The behavior is similar to uninstalling a plugin that provided a processor
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14479](https://github.com/opensearch-project/OpenSearch/pull/14479) | Add allowlist setting for ingest-common processors | [#14439](https://github.com/opensearch-project/OpenSearch/issues/14439) |
+| [#14562](https://github.com/opensearch-project/OpenSearch/pull/14562) | Add allowlist setting for search-pipeline-common processors | [#14439](https://github.com/opensearch-project/OpenSearch/issues/14439) |
+
+### Documentation
+
+- [Ingest Processors](https://docs.opensearch.org/2.16/ingest-pipelines/processors/index-processors/)
+- [Search Processors](https://docs.opensearch.org/2.16/search-plugins/search-pipelines/search-processors/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -3,6 +3,7 @@
 ## Features
 
 ### opensearch
+- Processor Allowlist
 - Application Configuration Templates
 - ClusterManager Optimizations
 - Logging Improvements


### PR DESCRIPTION
## Summary

Adds documentation for the Processor Allowlist feature introduced in OpenSearch v2.16.0.

## Reports Created

- Release report: `docs/releases/v2.16.0/features/opensearch/processor-allowlist.md`
- Feature report: `docs/features/opensearch/processor-allowlist.md`

## Feature Overview

This feature introduces allowlist settings for ingest-common and search-pipeline-common processors, enabling operators to selectively enable specific processors by name.

### Settings Added

- `ingest.common.processors.allowed` - Allowlist for ingest processors
- `search.pipeline.common.request.processors.allowed` - Allowlist for search request processors
- `search.pipeline.common.response.processors.allowed` - Allowlist for search response processors
- `search.pipeline.common.search.phase.results.processors.allowed` - Allowlist for search phase results processors

## Related PRs

- opensearch-project/OpenSearch#14479 - Add allowlist setting for ingest-common processors
- opensearch-project/OpenSearch#14562 - Add allowlist setting for search-pipeline-common processors

Closes #2241