### PR TITLE
docs: add derived-fields report for v2.16.0

### DIFF
--- a/docs/features/opensearch/opensearch-derived-fields.md
+++ b/docs/features/opensearch/opensearch-derived-fields.md
@@ -152,6 +152,7 @@ PUT /logs/_mapping
 
 - **v3.3.0**: Fixed query rewrite for range queries on derived fields by implementing selective rewrite based on query type
 - **v2.17.0**: Added support for most aggregation types on derived fields
+- **v2.16.0**: Fixed race condition in derived field parsing when defined in search requests
 - **v2.15.0**: Initial implementation of derived fields feature
 
 
@@ -165,6 +166,7 @@ PUT /logs/_mapping
 |---------|-----|-------------|---------------|
 | v3.3.0 | [#19496](https://github.com/opensearch-project/OpenSearch/pull/19496) | Fix derived field rewrite to handle range queries | [#19337](https://github.com/opensearch-project/OpenSearch/issues/19337) |
 | v2.17.0 | - | Added aggregation support for derived fields |   |
+| v2.16.0 | [#14445](https://github.com/opensearch-project/OpenSearch/pull/14445) | Fix race condition in derived field parsing from search requests | [#14444](https://github.com/opensearch-project/OpenSearch/issues/14444) |
 | v2.15.0 | - | Initial implementation of derived fields |   |
 
 ### Issues (Design / RFC)

--- a/docs/releases/v2.16.0/features/opensearch/derived-fields.md
+++ b/docs/releases/v2.16.0/features/opensearch/derived-fields.md
@@ -1,0 +1,50 @@
+---
+tags:
+  - opensearch
+---
+# Derived Fields
+
+## Summary
+
+Fixed a race condition in derived field parsing when derived fields are defined within search requests. The issue caused `ConcurrentModificationException` errors during concurrent search operations.
+
+## Details
+
+### What's New in v2.16.0
+
+This release fixes a critical race condition that occurred when derived fields were defined in search requests rather than index mappings.
+
+### Technical Changes
+
+The bug occurred because:
+1. Derived fields are created per `QueryShardContext`
+2. Multiple `QueryShardContext` instances can be created for a single search request
+3. The `DocumentMapperParser.parse()` method modifies the map passed to it by removing parsed keys
+4. When multiple contexts tried to parse the same derived field definition concurrently, a `ConcurrentModificationException` was thrown
+
+The fix implements a `deepCopy()` method in `DefaultDerivedFieldResolver` that creates a complete copy of the derived field object map before passing it to the parser. This ensures each parsing operation works on its own copy of the data.
+
+```java
+// Before (race condition)
+.parse(DerivedFieldMapper.CONTENT_TYPE, derivedFieldObject);
+
+// After (thread-safe)
+.parse(DerivedFieldMapper.CONTENT_TYPE, (Map) deepCopy(derivedFieldObject));
+```
+
+The `deepCopy()` method recursively copies:
+- Maps (creating new HashMap instances)
+- Lists (creating new ArrayList instances)
+- Byte arrays (using Arrays.copyOf)
+- Primitive values (passed through unchanged)
+
+## Limitations
+
+No new limitations introduced. See the Derived Fields feature documentation for existing limitations.
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14445](https://github.com/opensearch-project/OpenSearch/pull/14445) | Fix race condition while parsing derived fields from search definition | [#14444](https://github.com/opensearch-project/OpenSearch/issues/14444) |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -3,6 +3,7 @@
 ## Features
 
 ### opensearch
+- Derived Fields
 - Dynamic Mapping
 - Processor Allowlist
 - Application Configuration Templates


### PR DESCRIPTION
## Summary

Documents the derived fields race condition fix in OpenSearch v2.16.0.

### Changes
- Created release report: `docs/releases/v2.16.0/features/opensearch/derived-fields.md`
- Updated feature report: `docs/features/opensearch/opensearch-derived-fields.md` (added v2.16.0 to Change History and References)
- Updated release index: `docs/releases/v2.16.0/index.md`

### Key Fix
Fixed `ConcurrentModificationException` when derived fields are defined in search requests by implementing deep copy of the derived field object map before parsing.

### Related
- Closes #2239
- OpenSearch PR: [#14445](https://github.com/opensearch-project/OpenSearch/pull/14445)
- OpenSearch Issue: [#14444](https://github.com/opensearch-project/OpenSearch/issues/14444)