### PR TITLE
docs: add batching-processor report for v2.16.0

### DIFF
--- a/docs/features/opensearch/index.md
+++ b/docs/features/opensearch/index.md
@@ -18,6 +18,7 @@
 | [opensearch-async-shard-fetch-metrics](opensearch-async-shard-fetch-metrics.md) | Async Shard Fetch Metrics |
 | [opensearch-automata-regex-optimization](opensearch-automata-regex-optimization.md) | Automata & Regex Optimization |
 | [opensearch-azure-repository](opensearch-azure-repository.md) | Azure Repository Plugin |
+| [opensearch-batching-processor](opensearch-batching-processor.md) | Batching Processor |
 | [opensearch-booleanquery-rewrite-optimizations](opensearch-booleanquery-rewrite-optimizations.md) | BooleanQuery Rewrite Optimizations |
 | [opensearch-bulk-api](opensearch-bulk-api.md) | Bulk API |
 | [opensearch-cardinality-aggregation](opensearch-cardinality-aggregation.md) | Cardinality Aggregation |

--- a/docs/features/opensearch/opensearch-batching-processor.md
+++ b/docs/features/opensearch/opensearch-batching-processor.md
@@ -1,0 +1,167 @@
+---
+tags:
+  - opensearch
+---
+# Batching Processor
+
+## Summary
+
+The Batching Processor framework provides an abstract base class (`AbstractBatchingProcessor`) for building ingest processors that can efficiently process multiple documents in batches. This enables significant performance improvements for bulk ingestion workloads, particularly for processors that benefit from batch operations such as ML inference processors.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Ingest Pipeline"
+        A[Bulk Request] --> B[IngestService]
+        B --> C[AbstractBatchingProcessor]
+        C --> D{batch_size >= docs?}
+        D -->|Yes| E[subBatchExecute - single batch]
+        D -->|No| F[cutBatches]
+        F --> G[subBatchExecute - batch 1]
+        F --> H[subBatchExecute - batch 2]
+        F --> I[subBatchExecute - batch N]
+        E --> J[Handler callback]
+        G --> J
+        H --> J
+        I --> J
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `AbstractBatchingProcessor` | Abstract base class extending `AbstractProcessor` |
+| `AbstractBatchingProcessor.Factory` | Factory class for creating batch processor instances |
+| `IngestDocumentWrapper` | Wrapper for documents being processed in batches |
+
+### Class Hierarchy
+
+```mermaid
+classDiagram
+    AbstractProcessor <|-- AbstractBatchingProcessor
+    AbstractBatchingProcessor <|-- TextEmbeddingProcessor
+    AbstractBatchingProcessor <|-- SparseEncodingProcessor
+    
+    class AbstractProcessor {
+        +String tag
+        +String description
+        +execute(IngestDocument)
+    }
+    
+    class AbstractBatchingProcessor {
+        +int batchSize
+        +batchExecute(List~IngestDocumentWrapper~, Consumer)
+        #subBatchExecute(List~IngestDocumentWrapper~, Consumer)*
+        -cutBatches(List~IngestDocumentWrapper~)
+    }
+```
+
+### Configuration
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `batch_size` | Integer | 1 | Number of documents to process in each batch. Must be a positive integer. |
+
+### How It Works
+
+1. **Document Collection**: When documents arrive via the Bulk API, they are wrapped in `IngestDocumentWrapper` objects
+2. **Batch Evaluation**: The `batchExecute()` method checks if the batch size is larger than or equal to the document count
+3. **Batch Splitting**: If documents exceed batch size, `cutBatches()` splits them into appropriately sized sub-batches
+4. **Parallel Processing**: Each sub-batch is processed via `subBatchExecute()` with results collected asynchronously
+5. **Result Aggregation**: An `AtomicInteger` counter tracks completion, triggering the handler when all batches complete
+
+### Usage Example
+
+#### Creating a Custom Batch Processor
+
+```java
+public class MyBatchProcessor extends AbstractBatchingProcessor {
+    
+    public MyBatchProcessor(String tag, String description, int batchSize) {
+        super(tag, description, batchSize);
+    }
+    
+    @Override
+    protected void subBatchExecute(
+            List<IngestDocumentWrapper> ingestDocumentWrappers,
+            Consumer<List<IngestDocumentWrapper>> handler) {
+        // Process documents in batch
+        // Call handler.accept() with results when complete
+    }
+    
+    @Override
+    public IngestDocument execute(IngestDocument ingestDocument) {
+        // Single document processing (fallback)
+        return ingestDocument;
+    }
+    
+    @Override
+    public String getType() {
+        return "my_batch_processor";
+    }
+}
+```
+
+#### Pipeline Configuration
+
+```json
+PUT _ingest/pipeline/batch-processing-pipeline
+{
+  "description": "Pipeline with batch-enabled processor",
+  "processors": [
+    {
+      "text_embedding": {
+        "model_id": "my-model-id",
+        "batch_size": 10,
+        "field_map": {
+          "text_field": "embedding_field"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Batch-Enabled Processors
+
+The following processors extend `AbstractBatchingProcessor`:
+
+| Processor | Description |
+|-----------|-------------|
+| `text_embedding` | Generates vector embeddings from text fields |
+| `sparse_encoding` | Generates sparse vectors for neural sparse search |
+
+## Limitations
+
+- Default batch size is 1, requiring explicit configuration for batch processing
+- Batch processing benefits are most significant when using the Bulk API
+- Concrete processors must implement thread-safe `subBatchExecute()` methods
+- Results may be returned in different order than input documents
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Initial implementation of `AbstractBatchingProcessor` base class
+
+## References
+
+### Documentation
+
+- [Ingest Processors](https://docs.opensearch.org/latest/ingest-pipelines/processors/index-processors/)
+- [Bulk API](https://docs.opensearch.org/latest/api-reference/document-apis/bulk/)
+- [Text Embedding Processor](https://docs.opensearch.org/latest/ingest-pipelines/processors/text-embedding/)
+- [Sparse Encoding Processor](https://docs.opensearch.org/latest/ingest-pipelines/processors/sparse-encoding/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#14554](https://github.com/opensearch-project/OpenSearch/pull/14554) | Add batching processor base type AbstractBatchingProcessor |
+| v2.16.0 | [#14595](https://github.com/opensearch-project/OpenSearch/pull/14595) | Backport to 2.x branch |
+
+### Related Issues
+
+- [#14283](https://github.com/opensearch-project/OpenSearch/issues/14283) - Feature request: Make batch ingestion automatic

--- a/docs/releases/v2.16.0/features/opensearch/batching-processor.md
+++ b/docs/releases/v2.16.0/features/opensearch/batching-processor.md
@@ -1,0 +1,97 @@
+---
+tags:
+  - opensearch
+---
+# Batching Processor
+
+## Summary
+
+OpenSearch v2.16.0 introduces `AbstractBatchingProcessor`, a new base class for ingest processors that enables efficient batch processing of documents. This allows processors to handle multiple documents simultaneously rather than one at a time, improving performance for bulk ingestion workloads.
+
+## Details
+
+### What's New in v2.16.0
+
+The `AbstractBatchingProcessor` abstract class provides a foundation for building ingest processors that can process documents in batches. It offers two key functionalities:
+
+1. **Batch size configuration**: Parses the `batch_size` parameter from processor configuration
+2. **Automatic batch splitting**: Splits incoming documents into batches based on the configured batch size
+
+### Technical Changes
+
+#### New Class: AbstractBatchingProcessor
+
+Located at `org.opensearch.ingest.AbstractBatchingProcessor`, this class extends `AbstractProcessor` and provides:
+
+| Component | Description |
+|-----------|-------------|
+| `BATCH_SIZE_FIELD` | Configuration field name (`batch_size`) |
+| `DEFAULT_BATCH_SIZE` | Default value of 1 (single document processing) |
+| `batchSize` | Protected field storing the configured batch size |
+
+#### Key Methods
+
+| Method | Description |
+|--------|-------------|
+| `batchExecute()` | Overrides the default batch execution to split documents into sub-batches |
+| `subBatchExecute()` | Abstract method that concrete processors must implement for actual batch processing |
+| `cutBatches()` | Internal method that splits documents into batches of the configured size |
+
+#### Factory Class
+
+The `AbstractBatchingProcessor.Factory` abstract class handles:
+- Reading `batch_size` from processor configuration
+- Validating that batch size is a positive integer
+- Delegating to `newProcessor()` for concrete processor instantiation
+
+### Configuration
+
+Processors extending `AbstractBatchingProcessor` accept the following configuration:
+
+| Setting | Type | Default | Description |
+|---------|------|---------|-------------|
+| `batch_size` | Integer | 1 | Number of documents to process in each batch |
+
+### Usage Example
+
+Processors that extend `AbstractBatchingProcessor` can be configured in an ingest pipeline:
+
+```json
+PUT _ingest/pipeline/my-batch-pipeline
+{
+  "processors": [
+    {
+      "my_batch_processor": {
+        "batch_size": 10,
+        "field_map": {
+          "input_field": "output_field"
+        }
+      }
+    }
+  ]
+}
+```
+
+## Limitations
+
+- The default batch size is 1, meaning batch processing is opt-in
+- Concrete processors must implement `subBatchExecute()` to leverage batch processing
+- Batch processing is most beneficial when used with the Bulk API
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14554](https://github.com/opensearch-project/OpenSearch/pull/14554) | Add batching processor base type AbstractBatchingProcessor | [#14283](https://github.com/opensearch-project/OpenSearch/issues/14283) |
+| [#14595](https://github.com/opensearch-project/OpenSearch/pull/14595) | Backport to 2.x branch | - |
+
+### Related Issues
+
+- [#14283](https://github.com/opensearch-project/OpenSearch/issues/14283) - Feature request for automatic batch ingestion
+
+### Documentation
+
+- [Ingest Processors](https://docs.opensearch.org/2.16/ingest-pipelines/processors/index-processors/)
+- [Bulk API](https://docs.opensearch.org/2.16/api-reference/document-apis/bulk/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -3,6 +3,7 @@
 ## Features
 
 ### opensearch
+- Batching Processor
 - Derived Fields
 - Dynamic Mapping
 - Processor Allowlist


### PR DESCRIPTION
## Summary

Add documentation for the Batching Processor feature introduced in OpenSearch v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch/batching-processor.md`
- Feature report: `docs/features/opensearch/opensearch-batching-processor.md`

### Key Changes in v2.16.0
- New `AbstractBatchingProcessor` base class for building batch-enabled ingest processors
- Configurable `batch_size` parameter for controlling document batch sizes
- Automatic batch splitting for efficient bulk ingestion

### Resources Used
- PR: [#14554](https://github.com/opensearch-project/OpenSearch/pull/14554)
- Issue: [#14283](https://github.com/opensearch-project/OpenSearch/issues/14283)
- Docs: [Ingest Processors](https://docs.opensearch.org/2.16/ingest-pipelines/processors/index-processors/)

Closes #2238