### PR TITLE
docs: add workload-management report for v2.16.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -25,6 +25,7 @@ Cumulative feature documentation across all versions.
 - Search Backpressure
 - Snapshot Repository
 - Synonym Analyzer Configuration
+- Workload Management
 
 ## security
 

--- a/docs/features/opensearch/workload-management.md
+++ b/docs/features/opensearch/workload-management.md
@@ -1,0 +1,106 @@
+---
+tags:
+  - opensearch
+---
+# Workload Management
+
+## Summary
+
+Workload Management is a feature for organizing search requests into Query Groups with configurable resource limits, enabling node-level resiliency and fair resource allocation across tenants. It allows administrators to define resource thresholds and enforcement policies for different workload categories.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Coordinator Node"
+        REQ[Search Request] --> RES[Sandbox Resolution]
+        RES --> QG[Query Group Assignment]
+    end
+    
+    subgraph "Cluster State"
+        QGM[QueryGroupMetadata]
+    end
+    
+    subgraph "Data Nodes"
+        PROP[Header Propagator]
+        TRACK[Resource Tracker]
+        CANCEL[Task Cancellation]
+    end
+    
+    QG --> PROP
+    QGM --> RES
+    PROP --> TRACK
+    TRACK --> CANCEL
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `QueryGroup` | Schema defining resource limits and resiliency mode |
+| `QueryGroupMetadata` | Cluster metadata storing all Query Groups |
+| `QueryGroupThreadContextStatePropagator` | Propagates queryGroupId across requests and nodes |
+| `ResourceType` | Enum for resource types (CPU, MEMORY) |
+
+### QueryGroup Schema
+
+```json
+{
+    "_id": "<uuid>",
+    "name": "<name>",
+    "resiliency_mode": "<soft|enforced|monitor>",
+    "resourceLimits": {
+        "cpu": 0.3,
+        "memory": 0.4
+    },
+    "updatedAt": 1720047207
+}
+```
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `name` | Query group name | Required |
+| `resiliency_mode` | Enforcement mode | Required |
+| `resourceLimits` | Resource thresholds (0.0-1.0) | At least one required |
+
+### Resiliency Modes
+
+| Mode | Description |
+|------|-------------|
+| `soft` | Can exceed limits when node is not under duress |
+| `enforced` | Strictly enforces limits; cancels tasks immediately |
+| `monitor` | Logs violations without cancellation |
+
+### Resource Types
+
+| Type | Description |
+|------|-------------|
+| `cpu` | CPU usage threshold |
+| `memory` | Heap memory usage threshold |
+
+## Limitations
+
+- Experimental feature (`@ExperimentalApi`)
+- Query Group CRUD APIs not yet available (v2.16.0)
+- Resource monitoring framework in development
+
+## Change History
+
+- **v2.16.0** (2024-07-23): Initial implementation with QueryGroup schema and header propagation
+
+## References
+
+### Documentation
+
+- [RFC: Search Query Sandboxing](https://github.com/opensearch-project/OpenSearch/issues/12342)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#13669](https://github.com/opensearch-project/OpenSearch/pull/13669) | Add QueryGroup schema |
+| v2.16.0 | [#14614](https://github.com/opensearch-project/OpenSearch/pull/14614) | Add queryGroupId header propagator |

--- a/docs/releases/v2.16.0/features/opensearch/workload-management.md
+++ b/docs/releases/v2.16.0/features/opensearch/workload-management.md
@@ -1,0 +1,85 @@
+---
+tags:
+  - opensearch
+---
+# Workload Management
+
+## Summary
+
+OpenSearch v2.16.0 introduces the foundational components for Workload Management, a new feature designed to provide node-level resiliency by organizing search requests into Query Groups with configurable resource limits. This release adds the QueryGroup schema and header propagation mechanism.
+
+## Details
+
+### What's New in v2.16.0
+
+This release establishes the core infrastructure for Workload Management:
+
+1. **QueryGroup Schema** - A new cluster metadata construct for defining resource-limited query groups
+2. **Header Propagation** - Mechanism to propagate queryGroupId across child requests and nodes
+
+### QueryGroup Schema
+
+The QueryGroup is a logical construct for running search requests within virtual resource limits. Each QueryGroup includes:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `_id` | String | Unique identifier (UUID) |
+| `name` | String | Human-readable name (max 50 chars) |
+| `resiliency_mode` | Enum | `soft`, `enforced`, or `monitor` |
+| `resourceLimits` | Map | Resource type to threshold mapping |
+| `updatedAt` | Long | Epoch timestamp in milliseconds |
+
+Example schema:
+```json
+{
+    "_id": "fafjafjkaf9ag8a9ga9g7ag0aagaga",
+    "resourceLimits": {
+        "memory": 0.4
+    },
+    "resiliency_mode": "enforced",
+    "name": "analytics",
+    "updatedAt": 4513232415
+}
+```
+
+### Resiliency Modes
+
+| Mode | Behavior |
+|------|----------|
+| `soft` | Can exceed limits if node is not in duress |
+| `enforced` | Never breaches limits; cancels tasks immediately when exceeded |
+| `monitor` | No cancellation; logs eligible task cancellations only |
+
+### Resource Types
+
+| Resource | Description |
+|----------|-------------|
+| `cpu` | CPU usage threshold |
+| `memory` | Memory/heap usage threshold |
+
+### Header Propagation
+
+The `QueryGroupThreadContextStatePropagator` class propagates the `queryGroupId` header:
+- Across child requests within the same node
+- Across nodes in the cluster
+
+This enables resource tracking and usage-based cancellation for Query Groups.
+
+## Limitations
+
+- This is foundational work; full Query Group management APIs are not yet available
+- Resource monitoring and cancellation framework will be added in subsequent releases
+- Marked as `@ExperimentalApi`
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#13669](https://github.com/opensearch-project/OpenSearch/pull/13669) | Add QueryGroup schema | [#12342](https://github.com/opensearch-project/OpenSearch/issues/12342) |
+| [#14614](https://github.com/opensearch-project/OpenSearch/pull/14614) | Add queryGroupId header propagator | [#12342](https://github.com/opensearch-project/OpenSearch/issues/12342) |
+
+### Related Issues
+
+- [RFC: Search Query Sandboxing](https://github.com/opensearch-project/OpenSearch/issues/12342)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -3,6 +3,7 @@
 ## Features
 
 ### opensearch
+- Workload Management
 - Batching Processor
 - Derived Fields
 - Dynamic Mapping


### PR DESCRIPTION
## Summary

Adds documentation for Workload Management feature introduced in OpenSearch v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch/workload-management.md`
- Feature report: `docs/features/opensearch/workload-management.md`

### Key Changes in v2.16.0
- QueryGroup schema for defining resource-limited query groups
- Header propagation mechanism for queryGroupId across requests and nodes
- Support for resiliency modes: soft, enforced, monitor
- Resource types: CPU and memory

### PRs Investigated
- [#13669](https://github.com/opensearch-project/OpenSearch/pull/13669) - Add QueryGroup schema
- [#14614](https://github.com/opensearch-project/OpenSearch/pull/14614) - Add queryGroupId header propagator

Closes #2237