### PR TITLE
docs: add Remote Store report for v2.16.0

### DIFF
--- a/docs/features/opensearch/opensearch-remote-store.md
+++ b/docs/features/opensearch/opensearch-remote-store.md
@@ -130,7 +130,7 @@ PUT /_cluster/settings
 - **v3.1.0** (2026-01-10): Added close index request rejection during migration; Fixed cluster state diff download failures during alias operations
 - **v3.0.0** (2024-12-16): Added `cluster.remote_state.download.serve_read_api.enabled` setting to control full cluster state download on term mismatch
 - **v2.19.0** (2025-02-18): Fixed stale cluster state custom file deletion bug in `RemoteClusterStateCleanupManager`; Reverted minimum codec version upload logic for remote state manifest; Added OpenSearch version-aware deserialization for custom metadata to fix cluster upgrade failures
-- **v2.16.0** (2024-08-06): Fixed S3 multipart upload failures for remote cluster state objects by creating new `ByteArrayIndexInput` instances per upload part
+- **v2.16.0** (2024-08-06): Added rate limiter for low priority uploads; Refactored remote routing table service to align with remote state interfaces; Added shard-diff path to diff manifest to reduce remote store read calls; Fixed S3 multipart upload failures for remote cluster state objects
 
 
 ## References
@@ -148,6 +148,9 @@ PUT /_cluster/settings
 | v3.0.0 | [#16798](https://github.com/opensearch-project/OpenSearch/pull/16798) | Setting to disable full cluster state download from remote on term mismatch | [#8957](https://github.com/opensearch-project/documentation-website/issues/8957) |
 | v2.19.0 | [#16670](https://github.com/opensearch-project/OpenSearch/pull/16670) | Fix stale cluster state custom file deletion | - |
 | v2.19.0 | [#16403](https://github.com/opensearch-project/OpenSearch/pull/16403) | Revert uploading of remote cluster state manifest using min codec version | - |
+| v2.16.0 | [#14374](https://github.com/opensearch-project/OpenSearch/pull/14374) | Rate limiter for remote store low priority uploads | [#14373](https://github.com/opensearch-project/OpenSearch/issues/14373) |
+| v2.16.0 | [#14668](https://github.com/opensearch-project/OpenSearch/pull/14668) | Refactor remote-routing-table service inline with remote state interfaces | [#14067](https://github.com/opensearch-project/OpenSearch/issues/14067) |
+| v2.16.0 | [#14684](https://github.com/opensearch-project/OpenSearch/pull/14684) | Add shard-diff path to diff manifest to reduce remote store read calls | [#15125](https://github.com/opensearch-project/OpenSearch/issues/15125) |
 | v2.19.0 | [#16494](https://github.com/opensearch-project/OpenSearch/pull/16494) | Add opensearch version info while deserialization | - |
 | v2.16.0 | [#14888](https://github.com/opensearch-project/OpenSearch/pull/14888) | Create new IndexInput for multi part upload | [#14808](https://github.com/opensearch-project/OpenSearch/issues/14808) |
 

--- a/docs/releases/v2.16.0/features/opensearch/remote-store.md
+++ b/docs/releases/v2.16.0/features/opensearch/remote-store.md
@@ -1,0 +1,63 @@
+---
+tags:
+  - opensearch
+---
+# Remote Store
+
+## Summary
+
+OpenSearch v2.16.0 introduces three enhancements to Remote Store: a rate limiter for low priority uploads, refactored remote routing table service aligned with remote state interfaces, and shard-diff path support in diff manifests to reduce remote store read calls.
+
+## Details
+
+### What's New in v2.16.0
+
+#### Rate Limiter for Low Priority Uploads
+
+A new rate limiter has been added specifically for low priority remote store uploads. Previously, the existing rate limiter applied to both high and low priority uploads without distinction. This enhancement allows operators to control low priority upload bandwidth separately, preventing low priority operations from consuming resources needed for critical uploads.
+
+**Configuration**:
+```yaml
+# Repository settings
+max_remote_low_priority_upload_bytes_per_sec: <value>
+```
+
+The rate limiter applies to operations like clone index uploads that are marked as low priority. When content length exceeds 15GB, uploads are automatically treated as low priority.
+
+#### Remote Routing Table Service Refactoring
+
+The `RemoteRoutingTableService` has been refactored to implement remote table entities, aligning with the remote state interfaces pattern. Key changes include:
+
+- Introduction of `RemoteRoutingTableBlobStore` for managing routing table blob storage
+- New `RemoteIndexRoutingTable` class extending `AbstractRemoteWritableBlobEntity`
+- Simplified API with `getAsyncIndexRoutingWriteAction` and `getAsyncIndexRoutingReadAction` methods
+- Settings moved to `RemoteRoutingTableBlobStore`:
+  - `cluster.remote_store.routing_table.path_type` (default: `HASHED_PREFIX`)
+  - `cluster.remote_store.routing_table.path_hash_algo` (default: `FNV_1A_BASE64`)
+
+#### Shard-Diff Path in Diff Manifest
+
+A new shard-diff path has been added to the diff manifest to reduce the number of read calls to remote store. This optimization stores incremental routing table differences rather than full routing tables when only shard-level changes occur.
+
+Key components:
+- `RoutingTableIncrementalDiff`: Represents differences between routing tables
+- `RemoteRoutingTableDiff`: Remote store entity for routing table diffs
+- New manifest codec version `CODEC_V3` with `indicesRoutingDiffPath` field
+
+## Limitations
+
+- Rate limiter for low priority uploads requires repository reconfiguration to take effect
+- Remote routing table feature requires experimental feature flag `REMOTE_PUBLICATION_EXPERIMENTAL` to be enabled
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#14374](https://github.com/opensearch-project/OpenSearch/pull/14374) | Rate limiter for remote store low priority uploads | [#14373](https://github.com/opensearch-project/OpenSearch/issues/14373) |
+| [#14668](https://github.com/opensearch-project/OpenSearch/pull/14668) | Refactor remote-routing-table service inline with remote state interfaces | [#14067](https://github.com/opensearch-project/OpenSearch/issues/14067) |
+| [#14684](https://github.com/opensearch-project/OpenSearch/pull/14684) | Add shard-diff path to diff manifest to reduce number of read calls remote store | [#15125](https://github.com/opensearch-project/OpenSearch/issues/15125) |
+
+### Documentation
+- [Remote-backed storage](https://docs.opensearch.org/2.16/tuning-your-cluster/availability-and-recovery/remote-store/index/)
+- [Remote cluster state](https://docs.opensearch.org/2.16/tuning-your-cluster/availability-and-recovery/remote-store/remote-cluster-state/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -26,6 +26,7 @@
 - Ingest Processor Improvements
 - Lucene Upgrade
 - Query Categorization Removal
+- Remote Store
 - Repository Verification
 - Search Pipelines
 - Tiered Caching Performance Improvement


### PR DESCRIPTION
## Summary

This PR adds documentation for Remote Store enhancements in OpenSearch v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/opensearch/remote-store.md`
- Feature report: `docs/features/opensearch/opensearch-remote-store.md` (updated)

### Key Changes in v2.16.0
- Rate limiter for low priority uploads (`max_remote_low_priority_upload_bytes_per_sec`)
- Refactored remote routing table service to align with remote state interfaces
- Added shard-diff path to diff manifest to reduce remote store read calls

### PRs Investigated
- [#14374](https://github.com/opensearch-project/OpenSearch/pull/14374) - Rate limiter for remote store low priority uploads
- [#14668](https://github.com/opensearch-project/OpenSearch/pull/14668) - Refactor remote-routing-table service
- [#14684](https://github.com/opensearch-project/OpenSearch/pull/14684) - Add shard-diff path to diff manifest

Closes #2234