### PR TITLE
docs: add Fingerprint Ingest Processor report for v2.16.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -18,6 +18,7 @@ Cumulative feature documentation across all versions.
 - Cluster Shard Limits
 - Date Field Sorting
 - Dependency Management
+- Fingerprint Ingest Processor
 - GetStats API
 - Painless Script Hashing Methods
 - Point in Time (PIT) API

--- a/docs/features/opensearch/opensearch-fingerprint-ingest-processor.md
+++ b/docs/features/opensearch/opensearch-fingerprint-ingest-processor.md
@@ -1,0 +1,151 @@
+---
+tags:
+  - opensearch
+---
+# Fingerprint Ingest Processor
+
+## Summary
+
+The fingerprint ingest processor generates a cryptographic hash value for document fields during ingestion. This hash can be used to deduplicate documents within an index and collapse search results based on content similarity.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph Ingest Pipeline
+        A[Document] --> B[Fingerprint Processor]
+        B --> C{Field Selection}
+        C -->|fields| D[Include Listed Fields]
+        C -->|exclude_fields| E[Exclude Listed Fields]
+        C -->|empty| F[Include All Fields]
+        D --> G[Sort & Deduplicate]
+        E --> G
+        F --> G
+        G --> H[Concatenate Fields]
+        H --> I[Apply Hash Algorithm]
+        I --> J[Store in target_field]
+    end
+    J --> K[Indexed Document]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `FingerprintProcessor` | Main processor class that generates hash values |
+| `FingerprintProcessor.Factory` | Factory for creating processor instances from configuration |
+| `HashMethod` | Enum defining supported hash algorithms |
+
+### Configuration
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `fields` | Optional | - | List of fields to include in hash calculation |
+| `exclude_fields` | Optional | - | Fields to exclude (mutually exclusive with `fields`) |
+| `hash_method` | Optional | `SHA-1@2.16.0` | Hash algorithm to use |
+| `target_field` | Optional | `fingerprint` | Field to store the hash value |
+| `ignore_missing` | Optional | `false` | Exit quietly if required field is missing |
+
+### Supported Hash Methods
+
+| Method | Description |
+|--------|-------------|
+| `MD5@2.16.0` | MD5 hash (128-bit) |
+| `SHA-1@2.16.0` | SHA-1 hash (160-bit, default) |
+| `SHA-256@2.16.0` | SHA-256 hash (256-bit) |
+| `SHA3-256@2.16.0` | SHA3-256 hash (256-bit) |
+
+### Hash Generation Process
+
+1. **Field Selection**: Select fields based on `fields` or `exclude_fields` configuration
+2. **Deduplication & Sorting**: Remove duplicate field names and sort alphabetically
+3. **Metadata Exclusion**: Automatically exclude metadata fields (`_index`, `_id`, `_routing`)
+4. **Concatenation**: Build string in format `|field1|length:value1|field2|length:value2|`
+5. **Hashing**: Apply selected hash algorithm
+6. **Output**: Store Base64-encoded hash with method prefix in target field
+
+### Usage Examples
+
+**Basic usage with specific fields:**
+```json
+PUT /_ingest/pipeline/fingerprint_pipeline
+{
+  "description": "Generate fingerprint for documents",
+  "processors": [
+    {
+      "fingerprint": {
+        "fields": ["title", "content"],
+        "target_field": "content_hash"
+      }
+    }
+  ]
+}
+```
+
+**Using SHA-256 with all fields:**
+```json
+{
+  "processors": [
+    {
+      "fingerprint": {
+        "hash_method": "SHA-256@2.16.0"
+      }
+    }
+  ]
+}
+```
+
+**Deduplication query using fingerprint:**
+```json
+GET my_index/_search
+{
+  "size": 0,
+  "aggs": {
+    "duplicates": {
+      "terms": {
+        "field": "fingerprint",
+        "min_doc_count": 2
+      }
+    }
+  }
+}
+```
+
+**Collapsing search results:**
+```json
+GET my_index/_search
+{
+  "collapse": {
+    "field": "fingerprint"
+  }
+}
+```
+
+## Limitations
+
+- `fields` and `exclude_fields` are mutually exclusive
+- Field names cannot be null or empty
+- Metadata fields are always excluded from hash calculation
+- Hash method version is fixed to ensure consistent hashing across cluster nodes
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Initial implementation of fingerprint ingest processor
+
+## References
+
+### Documentation
+
+- [Fingerprint Processor](https://docs.opensearch.org/latest/ingest-pipelines/processors/fingerprint/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#13724](https://github.com/opensearch-project/OpenSearch/pull/13724) | Add fingerprint ingest processor |
+
+### Related Issues
+
+- [#13612](https://github.com/opensearch-project/OpenSearch/issues/13612) - Feature request for fingerprint ingest processor

--- a/docs/releases/v2.16.0/features/opensearch/fingerprint-ingest-processor.md
+++ b/docs/releases/v2.16.0/features/opensearch/fingerprint-ingest-processor.md
@@ -1,0 +1,117 @@
+---
+tags:
+  - opensearch
+---
+# Fingerprint Ingest Processor
+
+## Summary
+
+OpenSearch v2.16.0 introduces the `fingerprint` ingest processor, which generates a hash value for specified fields or all fields in a document. The hash value can be used to deduplicate documents within an index and collapse search results.
+
+## Details
+
+### What's New in v2.16.0
+
+The fingerprint processor is a new ingest processor that computes a cryptographic hash from document fields during ingestion. This enables:
+
+- **Document deduplication**: Identify and remove duplicate documents based on content
+- **Search result collapsing**: Group search results by fingerprint to show unique content
+
+### How It Works
+
+For each field, the processor concatenates:
+- Field name
+- Length of field value
+- Field value itself
+
+These are separated by the pipe character `|`. For example: `|field1|3:value1|field2|10:value2|`
+
+For nested object fields, the field name is flattened using dot notation (e.g., `root_field.sub_field1`).
+
+### Configuration Parameters
+
+| Parameter | Required | Default | Description |
+|-----------|----------|---------|-------------|
+| `fields` | Optional | - | List of fields to include in hash calculation |
+| `exclude_fields` | Optional | - | Fields to exclude from hash calculation (mutually exclusive with `fields`) |
+| `hash_method` | Optional | `SHA-1@2.16.0` | Hash algorithm: `MD5@2.16.0`, `SHA-1@2.16.0`, `SHA-256@2.16.0`, or `SHA3-256@2.16.0` |
+| `target_field` | Optional | `fingerprint` | Field to store the generated hash value |
+| `ignore_missing` | Optional | `false` | Exit quietly if a required field is missing |
+| `description` | Optional | - | Description of the processor |
+| `if` | Optional | - | Condition for running the processor |
+| `ignore_failure` | Optional | `false` | Ignore failures |
+| `on_failure` | Optional | - | Processors to run on failure |
+| `tag` | Optional | - | Identifier tag for debugging |
+
+### Usage Examples
+
+**Include specific fields:**
+```json
+{
+  "processors": [
+    {
+      "fingerprint": {
+        "fields": ["foo", "bar"],
+        "target_field": "fingerprint",
+        "hash_method": "SHA-256@2.16.0"
+      }
+    }
+  ]
+}
+```
+
+**Exclude specific fields:**
+```json
+{
+  "processors": [
+    {
+      "fingerprint": {
+        "exclude_fields": ["timestamp", "metadata"],
+        "target_field": "fingerprint"
+      }
+    }
+  ]
+}
+```
+
+**Include all fields (default when both `fields` and `exclude_fields` are empty):**
+```json
+{
+  "processors": [
+    {
+      "fingerprint": {}
+    }
+  ]
+}
+```
+
+### Hash Method Versioning
+
+The version number is appended to hash method names (e.g., `SHA-1@2.16.0`) to ensure consistent hashing across OpenSearch versions. If the processing logic changes in future versions, new hash methods with updated version numbers will be introduced.
+
+### Technical Implementation
+
+The processor is implemented in `FingerprintProcessor.java` within the `ingest-common` module. Key implementation details:
+
+- Fields are deduplicated and sorted alphabetically for consistent hash generation
+- Metadata fields (`_index`, `_id`, `_routing`) are automatically excluded
+- Nested objects are flattened with dot notation
+- Hash output is Base64-encoded with the method prefix (e.g., `SHA-1@2.16.0:YqpBTuHXCPV04j/7lGfWeUl8Tyo=`)
+
+## Limitations
+
+- Either `fields` or `exclude_fields` can be set, not both
+- Field names in `fields` and `exclude_fields` cannot be null or empty
+- Metadata fields are always excluded from hash calculation
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#13724](https://github.com/opensearch-project/OpenSearch/pull/13724) | Add fingerprint ingest processor | [#13612](https://github.com/opensearch-project/OpenSearch/issues/13612) |
+
+### Documentation
+
+- [Fingerprint Processor Documentation](https://docs.opensearch.org/2.16/ingest-pipelines/processors/fingerprint/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -3,6 +3,7 @@
 ## Features
 
 ### opensearch
+- Fingerprint Ingest Processor
 - Aggregation Optimizations
 - Workload Management
 - Writable Warm


### PR DESCRIPTION
## Summary

This PR adds documentation for the Fingerprint Ingest Processor feature introduced in OpenSearch v2.16.0.

## Changes

- **Release Report**: `docs/releases/v2.16.0/features/opensearch/fingerprint-ingest-processor.md`
- **Feature Report**: `docs/features/opensearch/opensearch-fingerprint-ingest-processor.md`
- Updated release index and features index

## Feature Overview

The fingerprint processor generates a cryptographic hash value for document fields during ingestion, enabling:
- Document deduplication within an index
- Search result collapsing based on content similarity

### Key Capabilities
- Supports multiple hash algorithms: MD5, SHA-1, SHA-256, SHA3-256
- Flexible field selection (include or exclude specific fields)
- Versioned hash methods for consistent hashing across OpenSearch versions

## References

- PR: [opensearch-project/OpenSearch#13724](https://github.com/opensearch-project/OpenSearch/pull/13724)
- Issue: [opensearch-project/OpenSearch#13612](https://github.com/opensearch-project/OpenSearch/issues/13612)
- Docs: [Fingerprint Processor](https://docs.opensearch.org/2.16/ingest-pipelines/processors/fingerprint/)

Closes #2233