### PR TITLE
docs: add k-NN Faiss Updates report for v2.16.0

### DIFF
--- a/docs/features/k-nn/k-nn-byte-vector-support.md
+++ b/docs/features/k-nn/k-nn-byte-vector-support.md
@@ -231,6 +231,7 @@ Based on OpenSearch Benchmark tests:
 ## Change History
 
 - **v2.17.0** (2024-09-17): Initial implementation with HNSW and IVF support for Faiss byte vectors
+- **v2.16.0** (2024-08-06): Bumped Faiss submodule to 33c0ba5 with SQ8_direct_signed support (prerequisite for byte vectors)
 
 
 ## References
@@ -248,6 +249,7 @@ Based on OpenSearch Benchmark tests:
 |---------|-----|-------------|---------------|
 | v2.17.0 | [#1823](https://github.com/opensearch-project/k-NN/pull/1823) | Add HNSW support for Faiss byte vector | [#1659](https://github.com/opensearch-project/k-NN/issues/1659) |
 | v2.17.0 | [#2002](https://github.com/opensearch-project/k-NN/pull/2002) | Add IVF support for Faiss byte vector | [#1659](https://github.com/opensearch-project/k-NN/issues/1659) |
+| v2.16.0 | [#1796](https://github.com/opensearch-project/k-NN/pull/1796) | Bump Faiss to 33c0ba5 (SQ8_direct_signed) | [#1659](https://github.com/opensearch-project/k-NN/issues/1659) |
 
 ### Issues (Design / RFC)
 - [Issue #1659](https://github.com/opensearch-project/k-NN/issues/1659): Original feature request

--- a/docs/releases/v2.16.0/features/k-nn/faiss-updates.md
+++ b/docs/releases/v2.16.0/features/k-nn/faiss-updates.md
@@ -1,0 +1,49 @@
+---
+tags:
+  - k-nn
+---
+# k-NN Faiss Updates
+
+## Summary
+
+This release bumps the Faiss submodule to commit 33c0ba5 and updates the CMake minimum required version to 3.24.0. This update is a prerequisite for enabling Faiss byte vector support, which provides significant memory savings for large-scale vector search applications.
+
+## Details
+
+### What's New in v2.16.0
+
+The Faiss library dependency was updated to include support for the `SQ8_direct_signed` scalar quantizer, which enables direct encoding of signed byte vectors without training. This update:
+
+1. **Faiss Submodule Bump**: Updated to commit [33c0ba5](https://github.com/facebookresearch/faiss/commit/33c0ba5d002a7cd9761513f06ecc9822079d4a2f)
+2. **CMake Version Update**: Bumped minimum required CMake version to 3.24.0 to match Faiss requirements
+3. **Patch Updates**: Updated patches to be compatible with the new Faiss version
+
+### Technical Changes
+
+The Faiss update introduces the `QT_8bit_direct_signed` quantizer type, which:
+
+- Accepts signed byte vectors in the range [-128, 127]
+- Does not require training (unlike other quantizers)
+- Quantizes float vector values directly into byte-sized vectors
+- Reduces memory footprint by a factor of 4 compared to float vectors
+
+This change is foundational for the byte vector support feature that was fully implemented in v2.17.0.
+
+## Limitations
+
+- This is a dependency update only; the byte vector feature requires additional implementation (completed in v2.17.0)
+- CMake 3.24.0 or higher is now required for building the k-NN plugin
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#1796](https://github.com/opensearch-project/k-NN/pull/1796) | Bump faiss commit to 33c0ba5 | [#1659](https://github.com/opensearch-project/k-NN/issues/1659) |
+
+### Issues
+- [#1659](https://github.com/opensearch-project/k-NN/issues/1659): Support for Faiss byte vector
+
+### External References
+- [Faiss ScalarQuantizer Documentation](https://faiss.ai/cpp_api/struct/structfaiss_1_1ScalarQuantizer.html)
+- [Faiss Issue #3488](https://github.com/facebookresearch/faiss/issues/3488): QT_8bit_direct_signed support

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -2,6 +2,9 @@
 
 ## Features
 
+### k-nn
+- Faiss Updates
+
 ### opensearch
 - Fingerprint Ingest Processor
 - Aggregation Optimizations


### PR DESCRIPTION
## Summary
Investigation of GitHub Issue #2231: k-NN Faiss Updates for v2.16.0

### Reports Created
- Release report: `docs/releases/v2.16.0/features/k-nn/faiss-updates.md`
- Feature report: `docs/features/k-nn/k-nn-byte-vector-support.md` (updated)

### Key Changes in v2.16.0
- Bumped Faiss submodule to commit 33c0ba5
- Updated CMake minimum required version to 3.24.0
- Added SQ8_direct_signed scalar quantizer support (prerequisite for byte vectors)

### Resources Used
- PR: opensearch-project/k-NN#1796
- Issue: opensearch-project/k-NN#1659
- Docs: https://docs.opensearch.org/2.16/search-plugins/knn/knn-vector-quantization/