### PR TITLE
docs: add Security Dashboards CVE & Build Fixes report for v2.16.0

### DIFF
--- a/docs/features/security-dashboards/security-dashboards-plugin.md
+++ b/docs/features/security-dashboards/security-dashboards-plugin.md
@@ -113,6 +113,7 @@ export function validateNextUrl(url: string, basePath: string): string | undefin
 
 - **v2.19.0** (2025-01-21): Fixed OpenID login redirect to preserve query parameters and URL fragments; Fixed tenant defaulting incorrectly based on preferred tenants order instead of default tenant setting
 - **v2.17.0** (2024-09-17): UI/UX enhancements including smaller/compressed components, updated page headers, avatar relocation to left nav, consistency and density improvements; Fixed tenancy app registration, basepath URL validation, page header UX, and navigation titles/descriptions
+- **v2.16.0** (2024-08-06): Security fix for CVE-2024-4068 (braces package ReDoS vulnerability); CI/CD build fixes for Node.js 20 compatibility
 
 
 ## References
@@ -134,6 +135,8 @@ export function validateNextUrl(url: string, basePath: string): string | undefin
 | v2.17.0 | [#2096](https://github.com/opensearch-project/security-dashboards-plugin/pull/2096) | Fix basepath nextUrl validation |   |
 | v2.17.0 | [#2108](https://github.com/opensearch-project/security-dashboards-plugin/pull/2108) | UX fixes for page header |   |
 | v2.17.0 | [#2084](https://github.com/opensearch-project/security-dashboards-plugin/pull/2084) | Update titles and descriptions |   |
+| v2.16.0 | [#2039](https://github.com/opensearch-project/security-dashboards-plugin/pull/2039) | Addresses CVE-2024-4068 and updates yarn.lock |   |
+| v2.16.0 | [#2060](https://github.com/opensearch-project/security-dashboards-plugin/pull/2060) | Format package.json and update CI workflows |   |
 
 ### Issues (Design / RFC)
 - [Issue #2056](https://github.com/opensearch-project/security-dashboards-plugin/issues/2056): Tenant link visibility bug

--- a/docs/releases/v2.16.0/features/security-dashboards/cve-build-fixes.md
+++ b/docs/releases/v2.16.0/features/security-dashboards/cve-build-fixes.md
@@ -1,0 +1,57 @@
+---
+tags:
+  - security-dashboards
+---
+# Security Dashboards CVE & Build Fixes
+
+## Summary
+
+This release addresses a security vulnerability (CVE-2024-4068) in the `braces` package and fixes CI/CD build issues related to Node.js 20 compatibility in the Security Dashboards Plugin.
+
+## Details
+
+### What's New in v2.16.0
+
+#### CVE-2024-4068 Fix
+
+The `braces` package was updated from v3.0.2 to v3.0.3 to address CVE-2024-4068, a Regular Expression Denial of Service (ReDoS) vulnerability. This vulnerability could allow attackers to cause excessive CPU consumption through specially crafted input strings.
+
+**Changes:**
+- Updated `braces` dependency to v3.0.3
+- Updated `fill-range` dependency to v7.1.1
+- Regenerated `yarn.lock` to ensure consistent dependency resolution
+
+#### Build CI Fixes
+
+GitHub Actions workflows were updated to use newer versions of the `setup-opensearch-dashboards` action to ensure compatibility with Node.js 20 runtime environment.
+
+**Changes:**
+- Updated `derek-ho/setup-opensearch-dashboards` from v1 to v3 in:
+  - `.github/workflows/integration-test.yml`
+  - `.github/workflows/unit-test.yml`
+- Formatted `opensearch_dashboards.json` for consistency
+
+### Technical Changes
+
+| File | Change |
+|------|--------|
+| `package.json` | Added `braces: ^3.0.3` to resolutions |
+| `yarn.lock` | Updated dependency tree for security fixes |
+| `.github/workflows/integration-test.yml` | Updated action version |
+| `.github/workflows/unit-test.yml` | Updated action version |
+
+## Limitations
+
+- These are maintenance fixes with no functional changes to the plugin
+- The CVE fix requires a full `yarn install` to update the dependency tree
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#2039](https://github.com/opensearch-project/security-dashboards-plugin/pull/2039) | Addresses CVE-2024-4068 and updates yarn.lock | - |
+| [#2060](https://github.com/opensearch-project/security-dashboards-plugin/pull/2060) | Format package.json and update CI workflows | - |
+
+### Security Advisory
+- [CVE-2024-4068](https://nvd.nist.gov/vuln/detail/CVE-2024-4068): ReDoS vulnerability in braces package

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -111,6 +111,9 @@
 ### reporting
 - System Index Descriptors Registration
 
+### security-dashboards
+- CVE & Build Fixes
+
 ### sql
 - SQL Async Query Core Refactoring
 - SparkParameterComposerCollection


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security Dashboards CVE & Build Fixes in OpenSearch v2.16.0.

### Changes
- Created release report: `docs/releases/v2.16.0/features/security-dashboards/cve-build-fixes.md`
- Updated feature report: `docs/features/security-dashboards/security-dashboards-plugin.md` (added v2.16.0 change history and PR references)
- Updated release index: `docs/releases/v2.16.0/index.md`

### Key Findings
- **CVE-2024-4068 Fix**: Updated `braces` package from v3.0.2 to v3.0.3 to address ReDoS vulnerability
- **Build CI Fixes**: Updated GitHub Actions workflows to use `derek-ho/setup-opensearch-dashboards@v3` for Node.js 20 compatibility

### Related PRs
- [#2039](https://github.com/opensearch-project/security-dashboards-plugin/pull/2039): Addresses CVE-2024-4068 and updates yarn.lock
- [#2060](https://github.com/opensearch-project/security-dashboards-plugin/pull/2060): Format package.json and update CI workflows

Closes #2230