### PR TITLE
docs: add security dependency bumps report for v2.16.0

### DIFF
--- a/docs/features/security/security-plugin-dependencies.md
+++ b/docs/features/security/security-plugin-dependencies.md
@@ -88,6 +88,7 @@ Dependency updates in the Security plugin follow this process:
 - **v3.0.0** (2025-02-25): 13 dependency updates including Spring 6.2.5, Bouncy Castle 1.80, OpenSAML 5.1.4/9.1.4, ASM 9.8, Commons IO 2.19.0, JUnit Jupiter 5.12.2
 - **v2.19.0** (2024-12-10): Security fixes for Cypress and cross-spawn dependencies
 - **v2.18.0** (2024-10-22): Updated snappy-java, gradle.test-retry, commons-io, scala-library, checker-qual, and logback-classic
+- **v2.16.0** (2024-07-23): 7 dependency updates including Spring 5.3.37, JJWT 0.12.6 (memory leak fix), Kafka 3.7.1, JUnit Jupiter 5.10.3, woodstox-core 6.7.0, checker-qual 3.45.0, eclipse.core.runtime 3.31.100
 
 
 ## References
@@ -151,3 +152,10 @@ Dependency updates in the Security plugin follow this process:
 | v2.18.0 | [#4750](https://github.com/opensearch-project/security/pull/4750) | Bump commons-io 2.16.1 → 2.17.0 |   |
 | v2.18.0 | [#4749](https://github.com/opensearch-project/security/pull/4749) | Bump scala-library 2.13.14 → 2.13.15 |   |
 | v2.18.0 | [#4717](https://github.com/opensearch-project/security/pull/4717) | Bump checker-qual and logback-classic |   |
+| v2.16.0 | [#4531](https://github.com/opensearch-project/security/pull/4531) | Bump checker-qual 3.44.0 → 3.45.0 |   |
+| v2.16.0 | [#4501](https://github.com/opensearch-project/security/pull/4501) | Bump kafka 3.7.0 → 3.7.1 |   |
+| v2.16.0 | [#4503](https://github.com/opensearch-project/security/pull/4503) | Bump junit-jupiter 5.10.2 → 5.10.3 |   |
+| v2.16.0 | [#4483](https://github.com/opensearch-project/security/pull/4483) | Bump woodstox-core 6.6.2 → 6.7.0 |   |
+| v2.16.0 | [#4484](https://github.com/opensearch-project/security/pull/4484) | Bump jjwt 0.12.5 → 0.12.6 |   |
+| v2.16.0 | [#4467](https://github.com/opensearch-project/security/pull/4467) | Bump eclipse.core.runtime 3.31.0 → 3.31.100 |   |
+| v2.16.0 | [#4466](https://github.com/opensearch-project/security/pull/4466) | Bump spring 5.3.36 → 5.3.37 |   |

--- a/docs/releases/v2.16.0/features/security/dependency-bumps.md
+++ b/docs/releases/v2.16.0/features/security/dependency-bumps.md
@@ -1,0 +1,69 @@
+---
+tags:
+  - security
+---
+# Security Dependency Bumps
+
+## Summary
+
+OpenSearch Security plugin v2.16.0 includes 7 dependency updates covering runtime, test, and build dependencies. These updates improve stability, fix bugs, and address potential security vulnerabilities.
+
+## Details
+
+### What's New in v2.16.0
+
+| Dependency | Previous | New | Category |
+|------------|----------|-----|----------|
+| checker-qual | 3.44.0 | 3.45.0 | Build |
+| kafka | 3.7.0 | 3.7.1 | Runtime |
+| junit-jupiter | 5.10.2 | 5.10.3 | Test |
+| woodstox-core | 6.6.2 | 6.7.0 | Runtime |
+| jjwt | 0.12.5 | 0.12.6 | Runtime |
+| eclipse.core.runtime | 3.31.0 | 3.31.100 | Build |
+| spring | 5.3.36 | 5.3.37 | Runtime |
+
+### Key Improvements
+
+#### JJWT 0.12.6
+- Fixes decompression memory leak in concurrent environments when using GZIP compression
+- Ensures application-configured Base64Url decoder is used after JWS signature verification
+- Upgrades internal BouncyCastle dependency to 1.78
+
+#### Spring Framework 5.3.37
+- Fixes AspectJ CTW aspects executed twice issue
+- Fixes SpEL compilation failures when indexing into Map with primitives
+- Fixes SpEL compilation failures when indexing into arrays/lists with Integer
+- Improves AnnotationUtils performance with deep stacks
+
+#### JUnit Jupiter 5.10.3
+- Fixes NPE when deserializing TestIdentifier
+- Fixes class-level execution conditions on GraalVM
+- Uses same default seed for method and class ordering
+
+#### Kafka 3.7.1
+- Patch release with bug fixes and stability improvements
+
+#### Woodstox 6.7.0
+- Ensures events' immutable non-null location in WstxEventFactory
+
+#### Checker Framework 3.45.0
+- Adds Non-Empty Checker
+- Replaces JavaParser with javac for improved performance
+
+## Limitations
+
+- These are routine dependency updates with no breaking changes
+- All updates are backward compatible within the 2.x release line
+
+## References
+
+### Pull Requests
+| PR | Description |
+|----|-------------|
+| [#4531](https://github.com/opensearch-project/security/pull/4531) | Bump checker-qual 3.44.0 → 3.45.0 |
+| [#4501](https://github.com/opensearch-project/security/pull/4501) | Bump kafka 3.7.0 → 3.7.1 |
+| [#4503](https://github.com/opensearch-project/security/pull/4503) | Bump junit-jupiter 5.10.2 → 5.10.3 |
+| [#4483](https://github.com/opensearch-project/security/pull/4483) | Bump woodstox-core 6.6.2 → 6.7.0 |
+| [#4484](https://github.com/opensearch-project/security/pull/4484) | Bump jjwt 0.12.5 → 0.12.6 |
+| [#4467](https://github.com/opensearch-project/security/pull/4467) | Bump eclipse.core.runtime 3.31.0 → 3.31.100 |
+| [#4466](https://github.com/opensearch-project/security/pull/4466) | Bump spring 5.3.36 → 5.3.37 |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -114,6 +114,9 @@
 ### security-dashboards
 - CVE & Build Fixes
 
+### security
+- Dependency Bumps
+
 ### sql
 - SQL Async Query Core Refactoring
 - SparkParameterComposerCollection


### PR DESCRIPTION
## Summary

Adds documentation for Security plugin dependency bumps in OpenSearch v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/security/dependency-bumps.md`
- Feature report: `docs/features/security/security-plugin-dependencies.md` (updated)

### Key Changes in v2.16.0
- 7 dependency updates covering runtime, test, and build dependencies
- JJWT 0.12.6: Fixes memory leak in concurrent environments
- Spring 5.3.37: Fixes AspectJ and SpEL compilation issues
- JUnit Jupiter 5.10.3: Fixes NPE and GraalVM issues
- Kafka 3.7.1, woodstox-core 6.7.0, checker-qual 3.45.0, eclipse.core.runtime 3.31.100

### Related Issue
Closes #2229