### PR TITLE
docs: add ML Commons Model & Connector Enhancements report for v2.16.0

### DIFF
--- a/docs/features/ml-commons/ml-commons-model-inference.md
+++ b/docs/features/ml-commons/ml-commons-model-inference.md
@@ -259,6 +259,7 @@ PUT /_search/pipeline/summarize_pipeline
 ## Change History
 
 - **v2.18.0** (2024-11-12): Added remote model auto-redeployment filtering, optional llmQuestion for RAG, search extension output support, query string in input_map, MLToolSpec config field, AWS Textract/Comprehend trusted endpoints
+- **v2.16.0** (2024-08-06): Added automated model interface generation for AWS LLMs (Bedrock, Comprehend, Textract), increased execute thread pool size for agents, multi-modal default preprocess function (`connector.pre_process.multimodal.embedding`), configurable disk circuit breaker via `plugins.ml_commons.disk_free_space_threshold`
 
 
 ## References
@@ -277,6 +278,10 @@ PUT /_search/pipeline/summarize_pipeline
 | v2.18.0 | [#2899](https://github.com/opensearch-project/ml-commons/pull/2899) | Enable pass query string to input_map in ml inference search response processor | [#2897](https://github.com/opensearch-project/ml-commons/issues/2897) |
 | v2.18.0 | [#2977](https://github.com/opensearch-project/ml-commons/pull/2977) | Add config field in MLToolSpec for static parameters | [#2836](https://github.com/opensearch-project/ml-commons/issues/2836) |
 | v2.18.0 | [#3154](https://github.com/opensearch-project/ml-commons/pull/3154) | Add textract and comprehend url to trusted endpoints |   |
+| v2.16.0 | [#2689](https://github.com/opensearch-project/ml-commons/pull/2689) | Automated model interface generation on AWS LLMs |   |
+| v2.16.0 | [#2691](https://github.com/opensearch-project/ml-commons/pull/2691) | Increase execute thread pool size |   |
+| v2.16.0 | [#2500](https://github.com/opensearch-project/ml-commons/pull/2500) | Add multi-modal default preprocess function | [#2364](https://github.com/opensearch-project/ml-commons/issues/2364) |
+| v2.16.0 | [#2634](https://github.com/opensearch-project/ml-commons/pull/2634) | Change disk circuit breaker to cluster settings | [#2639](https://github.com/opensearch-project/ml-commons/issues/2639) |
 
 ### Issues (Design / RFC)
 - [Issue #2897](https://github.com/opensearch-project/ml-commons/issues/2897): Query text in input_map feature request

--- a/docs/releases/v2.16.0/features/ml-commons/model-connector-enhancements.md
+++ b/docs/releases/v2.16.0/features/ml-commons/model-connector-enhancements.md
@@ -1,0 +1,115 @@
+---
+tags:
+  - ml-commons
+---
+# ML Commons Model & Connector Enhancements
+
+## Summary
+
+OpenSearch v2.16.0 introduces several enhancements to ML Commons model and connector functionality, including automated model interface generation for AWS LLMs, increased execute thread pool size for better agent performance, multi-modal default preprocess function support, and configurable disk circuit breaker settings.
+
+## Details
+
+### What's New in v2.16.0
+
+#### Automated Model Interface Generation for AWS LLMs
+
+When registering a remote model connected to AWS services (Bedrock, Comprehend, Textract), ML Commons now automatically generates the model interface based on the connector configuration. This eliminates the need to manually specify input/output schemas for supported models.
+
+Supported models include:
+- Amazon Bedrock: AI21 Labs Jurassic-2, Anthropic Claude v2/v3, Cohere Embed, Titan Embed Text/Multi-Modal
+- Amazon Comprehend: DetectDominantLanguage API
+- Amazon Textract: DetectDocumentText API
+
+The interface is automatically set during model registration if:
+1. The connector specifies `service_name` parameter (e.g., `bedrock`, `comprehend`, `textract`)
+2. The connector specifies the model name or API name
+3. No custom interface is already provided
+
+#### Execute Thread Pool Size Increase
+
+The execute thread pool size has been increased to improve agent execution performance:
+
+| Setting | Before | After |
+|---------|--------|-------|
+| Pool Size | `max(1, allocatedProcessors - 1)` | `allocatedProcessors * 4` |
+| Queue Size | `10` | `10000` |
+
+This change addresses bottlenecks when running ML agents that use the execute thread pool.
+
+#### Multi-Modal Default Preprocess Function
+
+A new built-in preprocess function `connector.pre_process.multimodal.embedding` simplifies multi-modal embedding workflows. Previously, users needed to write custom painless scripts to handle text and image inputs.
+
+The function:
+- Accepts `TextDocsInputDataSet` with text in the first position and optional image (base64) in the second
+- Automatically maps to `inputText` and `inputImage` parameters
+- Returns `RemoteInferenceInputDataSet` directly if already in that format
+
+#### Disk Circuit Breaker Cluster Settings
+
+The disk circuit breaker threshold is now configurable via cluster settings instead of being hardcoded.
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ml_commons.disk_free_space_threshold` | Minimum free disk space before circuit breaker opens | `5gb` |
+
+### Technical Changes
+
+#### ModelInterfaceUtils
+
+New utility class that provides preset model interfaces for AWS services:
+
+```java
+// Automatically applied during model registration
+ModelInterfaceUtils.updateRegisterModelInputModelInterfaceFieldsByConnector(
+    registerModelInput, 
+    connector
+);
+```
+
+#### MultiModalConnectorPreProcessFunction
+
+```java
+// Usage in connector configuration
+{
+  "pre_process_function": "connector.pre_process.multimodal.embedding"
+}
+```
+
+Input format:
+```json
+{
+  "text_docs": ["input text", "base64_encoded_image"]
+}
+```
+
+Output format:
+```json
+{
+  "parameters": {
+    "inputText": "input text",
+    "inputImage": "base64_encoded_image"
+  }
+}
+```
+
+## Limitations
+
+- Automated model interface generation only supports specific AWS models listed above
+- Multi-modal preprocess function requires text in the first position; image-only input is not supported
+- Disk circuit breaker setting requires cluster restart to take effect initially (dynamic updates work after)
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#2689](https://github.com/opensearch-project/ml-commons/pull/2689) | Automated model interface generation on AWS LLMs | - |
+| [#2691](https://github.com/opensearch-project/ml-commons/pull/2691) | Increase execute thread pool size | - |
+| [#2500](https://github.com/opensearch-project/ml-commons/pull/2500) | Add multi-modal default preprocess function | [#2364](https://github.com/opensearch-project/ml-commons/issues/2364) |
+| [#2634](https://github.com/opensearch-project/ml-commons/pull/2634) | Change disk circuit breaker to cluster settings | [#2639](https://github.com/opensearch-project/ml-commons/issues/2639) |
+
+### Issues
+- [#2364](https://github.com/opensearch-project/ml-commons/issues/2364): Add default multi-modal process function in ml-commons
+- [#2639](https://github.com/opensearch-project/ml-commons/issues/2639): Tests failing due to disk circuit breaker open

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -5,6 +5,9 @@
 ### k-nn
 - Faiss Updates
 
+### ml-commons
+- Model & Connector Enhancements
+
 ### opensearch
 - Fingerprint Ingest Processor
 - Aggregation Optimizations


### PR DESCRIPTION
## Summary

This PR adds documentation for ML Commons Model & Connector Enhancements in OpenSearch v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/ml-commons/model-connector-enhancements.md`
- Feature report updated: `docs/features/ml-commons/ml-commons-model-inference.md`

### Key Changes in v2.16.0
- **Automated model interface generation**: AWS LLMs (Bedrock, Comprehend, Textract) now auto-generate model interfaces during registration
- **Execute thread pool size increase**: Pool size increased from `max(1, processors-1)` to `processors*4` with queue size from 10 to 10000
- **Multi-modal preprocess function**: New `connector.pre_process.multimodal.embedding` for text+image inputs
- **Configurable disk circuit breaker**: New `plugins.ml_commons.disk_free_space_threshold` cluster setting

### PRs Investigated
- [#2689](https://github.com/opensearch-project/ml-commons/pull/2689) - Automated model interface generation on AWS LLMs
- [#2691](https://github.com/opensearch-project/ml-commons/pull/2691) - Increase execute thread pool size
- [#2500](https://github.com/opensearch-project/ml-commons/pull/2500) - Add multi-modal default preprocess function
- [#2634](https://github.com/opensearch-project/ml-commons/pull/2634) - Change disk circuit breaker to cluster settings

Closes #2188