### PR TITLE
docs: add Security Plugin Maintenance report for v2.16.0

### DIFF
--- a/docs/features/security/security-plugin.md
+++ b/docs/features/security/security-plugin.md
@@ -179,6 +179,7 @@ config:
 - **v2.19.0** (2025-02-11): Bugfixes - Netty4HttpRequestHeaderVerifier now handles HTTP upgrade requests by accepting HttpRequest instead of DefaultHttpRequest; Infrastructure - JaCoCo report generation for integTestRemote task, RestHelper TLS configuration updated to use DefaultClientTlsStrategy
 - **v2.18.0** (2024-11-05): Enhancements - datastream support for audit logs, auto-convert V6 to V7 configuration, circuit breaker override for security APIs, improved certificate error messages, JWT in MultipleAuthentication, remote index permissions for AD; Bugfixes - header serialization for rolling upgrades, PBKDF2 password hashing, SSL exception handler; Maintenance - cache endpoint deprecation warning, undeprecate securityadmin script, ASN1 refactoring for FIPS compatibility, CVE-2024-47554 fix
 - **v2.17.0** (2024-09-17): Bugfixes - demo certificate validation, auth token endpoint, audit config null handling, certificate SAN ordering, TermsAggregationEvaluator permissions; Refactoring - security provider instantiation for FIPS support, Log4j utility removal
+- **v2.16.0** (2024-08-06): Maintenance - removed unused Apache CXF dependency, Gradle 8.8→8.9 updates, code cleanup (unnecessary return statements), test framework modernization (Hamcrest matchers), ML roles refactoring, Security Analytics threat intel action support
 
 
 ## References
@@ -259,6 +260,13 @@ config:
 | v2.17.0 | [#4611](https://github.com/opensearch-project/security/pull/4611) | Refactor security provider instantiation |   |
 | v2.17.0 | [#4653](https://github.com/opensearch-project/security/pull/4653) | Remove Log4j Strings utility usage |   |
 | v2.17.0 | [#4694](https://github.com/opensearch-project/security/pull/4694) | PluginSubject build fix |   |
+| v2.16.0 | [#4580](https://github.com/opensearch-project/security/pull/4580) | Remove unused Apache CXF dependency |   |
+| v2.16.0 | [#4558](https://github.com/opensearch-project/security/pull/4558) | Remove unnecessary return statements |   |
+| v2.16.0 | [#4553](https://github.com/opensearch-project/security/pull/4553) | Update Gradle to 8.9 |   |
+| v2.16.0 | [#4544](https://github.com/opensearch-project/security/pull/4544) | Replace JUnit assertEquals() with Hamcrest assertThat() | [#1832](https://github.com/opensearch-project/security/issues/1832), [#3680](https://github.com/opensearch-project/security/issues/3680) |
+| v2.16.0 | [#4498](https://github.com/opensearch-project/security/pull/4498) | Add security analytics threat intel action | [security-analytics#1117](https://github.com/opensearch-project/security-analytics/issues/1117) |
+| v2.16.0 | [#4459](https://github.com/opensearch-project/security/pull/4459) | Update to Gradle 8.8 |   |
+| v2.16.0 | [#4151](https://github.com/opensearch-project/security/pull/4151) | Refactor and update existing ML roles |   |
 
 ### Issues (Design / RFC)
 - [Issue #5430](https://github.com/opensearch-project/security/issues/5430): Nested JWT claims feature request (v3.2.0)

--- a/docs/releases/v2.16.0/features/security/security-plugin-maintenance.md
+++ b/docs/releases/v2.16.0/features/security/security-plugin-maintenance.md
@@ -1,0 +1,64 @@
+---
+tags:
+  - security
+---
+# Security Plugin Maintenance
+
+## Summary
+
+OpenSearch v2.16.0 includes several maintenance updates to the Security plugin, including dependency cleanup, code quality improvements, Gradle updates, test framework modernization, and new permissions for Security Analytics threat intelligence.
+
+## Details
+
+### What's New in v2.16.0
+
+#### Dependency Cleanup
+- Removed unused Apache CXF dependency that was previously used for JWT implementation in the SAML flow
+- Since v2.12, the JWT implementation changed from Apache CXF to Nimbus ([#3421](https://github.com/opensearch-project/security/pull/3421))
+- This cleanup reduces the plugin's dependency footprint and potential security surface
+
+#### Code Quality Improvements
+- Removed unnecessary return statements throughout the codebase for cleaner code
+- Replaced JUnit `assertEquals()` with Hamcrest `assertThat()` matchers for more expressive test assertions
+- Resolves long-standing issues [#1832](https://github.com/opensearch-project/security/issues/1832) and [#3680](https://github.com/opensearch-project/security/issues/3680)
+
+#### Build System Updates
+- Updated Gradle from 8.7 to 8.8, then to 8.9
+- Keeps the build system current with latest Gradle features and security patches
+
+#### ML Roles Refactoring
+- Refactored and updated existing ML (Machine Learning) roles
+- Improves role definitions for ML-related operations
+
+#### Security Analytics Integration
+- Added new API action names for Security Analytics threat intelligence project
+- Supports the threat intelligence feature in Security Analytics ([security-analytics#1117](https://github.com/opensearch-project/security-analytics/issues/1117))
+
+### Technical Changes
+
+| Change | Description | Impact |
+|--------|-------------|--------|
+| Apache CXF removal | Removed unused JWT library | Reduced dependencies |
+| Return statement cleanup | Code style improvement | No functional change |
+| Hamcrest matchers | Test framework modernization | Better test assertions |
+| Gradle 8.8 → 8.9 | Build system update | Build improvements |
+| ML roles update | Role definition changes | ML permission handling |
+| Threat intel actions | New API permissions | Security Analytics support |
+
+## Limitations
+
+- These are maintenance changes with no user-facing feature changes
+- ML role changes may affect existing ML-related permission configurations
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#4580](https://github.com/opensearch-project/security/pull/4580) | Remove unused dependency Apache CXF | - |
+| [#4558](https://github.com/opensearch-project/security/pull/4558) | Remove unnecessary return statements | - |
+| [#4544](https://github.com/opensearch-project/security/pull/4544) | Replace JUnit assertEquals() with Hamcrest assertThat() | [#1832](https://github.com/opensearch-project/security/issues/1832), [#3680](https://github.com/opensearch-project/security/issues/3680) |
+| [#4553](https://github.com/opensearch-project/security/pull/4553) | Update Gradle to 8.9 | - |
+| [#4459](https://github.com/opensearch-project/security/pull/4459) | Update to Gradle 8.8 | - |
+| [#4151](https://github.com/opensearch-project/security/pull/4151) | Refactor and update existing ML roles | - |
+| [#4498](https://github.com/opensearch-project/security/pull/4498) | Add security analytics threat intel action | [security-analytics#1117](https://github.com/opensearch-project/security-analytics/issues/1117) |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -122,6 +122,7 @@
 
 ### security
 - Dependency Bumps
+- Security Plugin Maintenance
 
 ### sql
 - SQL Async Query Core Refactoring


### PR DESCRIPTION
## Summary

Adds release report for Security Plugin Maintenance in v2.16.0 and updates the Security Plugin feature report.

### Changes in v2.16.0
- Removed unused Apache CXF dependency (cleanup from JWT implementation change in v2.12)
- Updated Gradle from 8.7 to 8.9
- Code quality improvements (removed unnecessary return statements)
- Test framework modernization (JUnit assertEquals → Hamcrest assertThat)
- ML roles refactoring
- Added Security Analytics threat intel action support

### Files Changed
- Created: `docs/releases/v2.16.0/features/security/security-plugin-maintenance.md`
- Updated: `docs/features/security/security-plugin.md` (Change History + References)
- Updated: `docs/releases/v2.16.0/index.md`

Closes #2228