### PR TITLE
docs: add index-management-build-fixes report for v2.16.0

### DIFF
--- a/docs/features/index-management/index-management.md
+++ b/docs/features/index-management/index-management.md
@@ -305,6 +305,7 @@ PUT _plugins/_rollup/jobs/sample_rollup
 - **v3.0.0** (2025-05-06): Added ISM unfollow action for CCR, rollup target index settings, CVE fixes, Java Agent migration
 - **v2.18.0** (2024-11-05): Added `plugins.rollup.search.search_source_indices` setting to allow searching non-rollup and rollup indices together, UX improvements (refresh buttons, section header styling), transform API input validation, fixed snapshot status detection, fixed snapshot policy button reload, fixed data source initialization
 - **v2.17.0** (2024-09-17): Performance optimization for skip execution check using cluster service instead of NodesInfoRequest, security integration test fixes
+- **v2.16.0** (2024-08-06): Build fixes - added SPI Maven publishing support, updated GitHub Actions to Java 21, fixed CVE-2024-4068 (braces package) in dashboards plugin
 
 
 ## References
@@ -344,6 +345,9 @@ PUT _plugins/_rollup/jobs/sample_rollup
 | v2.18.0 | [#1189](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1189) | Data source initialization fix |   |
 | v2.17.0 | [#1219](https://github.com/opensearch-project/index-management/pull/1219) | Skip execution optimization using cluster service | [#1075](https://github.com/opensearch-project/index-management/issues/1075) |
 | v2.17.0 | [#1222](https://github.com/opensearch-project/index-management/pull/1222) | Security integration test fixes |   |
+| v2.16.0 | [#1207](https://github.com/opensearch-project/index-management/pull/1207) | Add publish in spi build.gradle |   |
+| v2.16.0 | [#1208](https://github.com/opensearch-project/index-management/pull/1208) | Fix github action |   |
+| v2.16.0 | [#1091](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1091) | Bumped up braces package version to address CVE-2024-4068 |   |
 
 ### Issues (Design / RFC)
 - [Issue #375](https://github.com/opensearch-project/index-management/issues/375): Feature request for ISM template exclusion patterns

--- a/docs/releases/v2.16.0/features/index-management/index-management-build-fixes.md
+++ b/docs/releases/v2.16.0/features/index-management/index-management-build-fixes.md
@@ -1,0 +1,68 @@
+---
+tags:
+  - index-management
+---
+# Index Management Build Fixes
+
+## Summary
+
+Build and CI/CD fixes for the Index Management plugin in v2.16.0, including SPI Maven publishing support, GitHub Actions updates for Java 21, and a security vulnerability fix for the braces package (CVE-2024-4068) in the dashboards plugin.
+
+## Details
+
+### What's New in v2.16.0
+
+#### SPI Maven Publishing (Backend)
+
+Added Maven publishing support for the Index Management SPI module, enabling other plugins to consume the SPI as a dependency:
+
+```groovy
+compileOnly "org.opensearch:opensearch-index-management-spi:${opensearch_version}"
+```
+
+This allows plugins like Cross-Cluster Replication to extend ISM functionality by depending on the published SPI artifact.
+
+**Changes:**
+- Added `maven-publish` plugin to `spi/build.gradle`
+- Configured shadow publication with sources and javadoc JARs
+- Added `publishShadowPublicationToSnapshotsRepository` task to maven-publish workflow
+- Fixed build dependency ordering for POM file generation
+
+#### GitHub Actions Java 21 Update (Backend)
+
+Updated GitHub Actions workflows to use Java 21 (from Java 17) to align with OpenSearch's JDK requirements:
+
+- `bwc-test-workflow.yml`: Java 17 → 21
+- `docker-security-test-workflow.yml`: Java 17 → 21
+- `security-test-workflow.yml`: Java 17 → 21
+- Added `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true` environment variable to workflows using older Node.js versions
+
+#### CVE-2024-4068 Fix (Dashboards)
+
+Updated the `braces` package in the Index Management Dashboards Plugin to address [CVE-2024-4068](https://github.com/advisories/GHSA-grv7-fg5c-xmjg), a high-severity vulnerability in the braces package that could cause uncontrolled resource consumption via crafted input.
+
+**Fix:** Updated `yarn.lock` to use braces v3.0.3 which patches the vulnerability.
+
+## Limitations
+
+- The SPI publishing change only affects the build/release process; no runtime behavior changes
+- GitHub Actions changes are CI-only and do not affect plugin functionality
+
+## References
+
+### Pull Requests
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#1207](https://github.com/opensearch-project/index-management/pull/1207) | index-management | Add publish in spi build.gradle |
+| [#1208](https://github.com/opensearch-project/index-management/pull/1208) | index-management | Fix github action |
+| [#1091](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1091) | index-management-dashboards-plugin | Bumped up braces package version to address CVE-2024-4068 |
+
+### Related PRs
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#1562](https://github.com/opensearch-project/alerting/pull/1562) | alerting | Reference for SPI publishing pattern |
+| [#1604](https://github.com/opensearch-project/alerting/pull/1604) | alerting | Reference for SPI publishing pattern |
+| [#1795](https://github.com/opensearch-project/k-NN/pull/1795) | k-NN | Reference for GitHub Actions fix |
+
+### Security Advisory
+- [GHSA-grv7-fg5c-xmjg](https://github.com/advisories/GHSA-grv7-fg5c-xmjg): CVE-2024-4068 - Uncontrolled resource consumption in braces

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -5,6 +5,9 @@
 ### dashboards-observability
 - Observability Getting Started & Dashboards
 
+### index-management
+- Index Management Build Fixes
+
 ### k-nn
 - Faiss Updates
 


### PR DESCRIPTION
## Summary

Adds release report for Index Management Build Fixes in v2.16.0.

### Changes
- **Release report**: `docs/releases/v2.16.0/features/index-management/index-management-build-fixes.md`
- **Feature report update**: Added v2.16.0 entry to `docs/features/index-management/index-management.md` Change History and References

### PRs Investigated
| PR | Repository | Description |
|----|------------|-------------|
| [#1207](https://github.com/opensearch-project/index-management/pull/1207) | index-management | Add publish in spi build.gradle |
| [#1208](https://github.com/opensearch-project/index-management/pull/1208) | index-management | Fix github action |
| [#1091](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1091) | index-management-dashboards-plugin | Bumped up braces package version to address CVE-2024-4068 |

### Key Changes in v2.16.0
- Added SPI Maven publishing support for other plugins to consume
- Updated GitHub Actions workflows to Java 21
- Fixed CVE-2024-4068 (braces package vulnerability) in dashboards plugin

Closes #2225