### PR TITLE
docs: add Observability CVE Fixes report for v2.16.0

### DIFF
--- a/docs/features/observability/index.md
+++ b/docs/features/observability/index.md
@@ -6,3 +6,4 @@
 | [observability-infrastructure](observability-infrastructure.md) | Observability Infrastructure |
 | [observability-integrations](observability-integrations.md) | Observability Integrations |
 | [observability-release-maintenance](observability-release-maintenance.md) | Observability Release Maintenance |
+| [observability-security-maintenance](observability-security-maintenance.md) | Observability Security Maintenance |

--- a/docs/features/observability/observability-security-maintenance.md
+++ b/docs/features/observability/observability-security-maintenance.md
@@ -1,0 +1,49 @@
+---
+tags:
+  - observability
+---
+# Observability Security Maintenance
+
+## Summary
+
+This document tracks security-related maintenance activities for the OpenSearch Dashboards Observability plugin, including CVE remediation, dependency updates, and security patches.
+
+## Details
+
+### Security Practices
+
+The Observability plugin follows OpenSearch security practices for dependency management:
+
+- Regular dependency audits for known vulnerabilities
+- Prompt remediation of critical and high-severity CVEs
+- Compatibility testing before dependency upgrades
+- Fallback strategies when upgrades cause breaking changes
+
+### Dependency Management
+
+Key frontend dependencies requiring security monitoring:
+
+| Category | Packages |
+|----------|----------|
+| Data Grid | ag-grid (removed in v2.16.0) |
+| WebSocket | ws |
+| Utilities | braces, micromatch |
+
+## Limitations
+
+- Some CVE fixes may require removing functionality when upgrades are incompatible
+- Build system constraints may limit upgrade options
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Addressed CVE-2024-38996, CVE-2024-39001, CVE-2024-37890 by removing ag-grid and upgrading ws/braces packages
+
+## References
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#1987](https://github.com/opensearch-project/dashboards-observability/pull/1987) | Fix CVEs for ag-grid, ws and braces packages |
+| v2.16.0 | [#1989](https://github.com/opensearch-project/dashboards-observability/pull/1989) | CVE fix for ag (rollback) |
+| v2.16.0 | [#2001](https://github.com/opensearch-project/dashboards-observability/pull/2001) | Remove ag grid package |

--- a/docs/releases/v2.16.0/features/observability/observability-cve-fixes.md
+++ b/docs/releases/v2.16.0/features/observability/observability-cve-fixes.md
@@ -1,0 +1,68 @@
+---
+tags:
+  - observability
+---
+# Observability CVE Fixes
+
+## Summary
+
+OpenSearch Dashboards Observability plugin v2.16.0 addresses critical security vulnerabilities (CVEs) in frontend dependencies, specifically in the ag-grid, ws, and braces packages. Due to compatibility issues with the upgraded ag-grid v32, the data table component was removed from the Logs Explorer view.
+
+## Details
+
+### What's New in v2.16.0
+
+#### CVE Remediation
+
+The following CVEs were addressed:
+
+| CVE ID | Package | Severity | Resolution |
+|--------|---------|----------|------------|
+| CVE-2024-38996 | ag-grid | Critical | Package removed |
+| CVE-2024-39001 | ag-grid | High | Package removed |
+| CVE-2024-37890 | ws | High | Upgraded to ^8.18.0 |
+| N/A | braces | Medium | Upgraded to ^3.0.3 |
+
+#### Dependency Changes
+
+Initial attempt (PR #1987):
+- Upgraded `@ag-grid-community/styles` from ^31.2.0 to ^32.0.2
+- Upgraded `ag-grid-react` from ^31.2.0 to ^32.0.2
+- Added resolutions for `braces` (^3.0.3) and `ws` (^8.18.0)
+
+Rollback (PR #1989):
+- Downgraded `@ag-grid-community/styles` to ^31.3.4 due to ES2020 compilation failures with v32
+
+Final resolution (PR #2001):
+- Completely removed ag-grid package due to critical CVE-2024-38996
+- Disabled data table functionality in Logs Explorer
+
+### Technical Changes
+
+The ag-grid v32 upgrade caused webpack compilation failures due to ES2020 syntax:
+
+```
+ERROR in ./node_modules/ag-grid-react/dist/package/index.cjs.js 284:49
+Module parse failed: Unexpected token (284:49)
+```
+
+The spread operator syntax used in v32 was incompatible with the existing webpack configuration. Rather than modifying the build configuration, the team chose to remove the ag-grid dependency entirely.
+
+### UI Impact
+
+The data table view in Logs Explorer was removed. Users can access the same data through the Events view.
+
+## Limitations
+
+- Data table visualization in Logs Explorer is no longer available
+- Users must use the Events view for tabular log data
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#1987](https://github.com/opensearch-project/dashboards-observability/pull/1987) | Fix CVEs for ag-grid, ws and braces packages | CVE-2024-39001, CVE-2024-37890 |
+| [#1989](https://github.com/opensearch-project/dashboards-observability/pull/1989) | CVE fix for ag (rollback to v31.3.4) | CVE-2024-39001 |
+| [#2001](https://github.com/opensearch-project/dashboards-observability/pull/2001) | Remove ag grid package | [#1910](https://github.com/opensearch-project/dashboards-observability/issues/1910) |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -131,6 +131,9 @@
 - Dependency Bumps
 - Security Plugin Maintenance
 
+### observability
+- Observability CVE Fixes
+
 ### sql
 - SQL Async Query Core Refactoring
 - SparkParameterComposerCollection


### PR DESCRIPTION
## Summary

Adds documentation for Observability CVE Fixes in v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/observability/observability-cve-fixes.md`
- Feature report: `docs/features/observability/observability-security-maintenance.md`

### Key Changes in v2.16.0
- Addressed CVE-2024-38996, CVE-2024-39001 (ag-grid) by removing the package
- Fixed CVE-2024-37890 by upgrading ws to ^8.18.0
- Added resolution for braces (^3.0.3)
- Data table view in Logs Explorer was removed due to ag-grid removal

### PRs Investigated
- #1987: Fix CVEs for ag-grid, ws and braces packages
- #1989: CVE fix for ag (rollback to v31.3.4)
- #2001: Remove ag grid package

Closes #2223