### PR TITLE
docs: add sql-build-fixes report for v2.16.0

### DIFF
--- a/docs/features/sql/sql-ci-tests.md
+++ b/docs/features/sql/sql-ci-tests.md
@@ -121,6 +121,7 @@ googleJavaFormat {
 ## Change History
 
 - **v3.4.0** (2026-01-11): Major CI/CD improvements including Gradle 9.2.0, JDK 25, BWC test splitting, query timeouts, and maven snapshots publishing
+- **v2.16.0** (2024-08-06): Fixed checkout action failures with Node16 compatibility; restored MacOS workflows using macos-13 runner
 
 
 ## References
@@ -139,6 +140,8 @@ googleJavaFormat {
 | v3.4.0 | [#4598](https://github.com/opensearch-project/sql/pull/4598) | Onboard async query core to maven snapshots | [#5360](https://github.com/opensearch-project/opensearch-build/issues/5360) |
 | v3.4.0 | [#4588](https://github.com/opensearch-project/sql/pull/4588) | Onboard maven snapshots publishing to S3 | [#5360](https://github.com/opensearch-project/opensearch-build/issues/5360) |
 | v3.4.0 | [#4484](https://github.com/opensearch-project/sql/pull/4484) | Publish internal modules for downstream reuse |   |
+| v2.16.0 | [#2819](https://github.com/opensearch-project/sql/pull/2819) | Fix checkout action failure | [#2807](https://github.com/opensearch-project/sql/pull/2807) |
+| v2.16.0 | [#2831](https://github.com/opensearch-project/sql/pull/2831) | Add MacOS workflows back and fix artifact not found | [#2662](https://github.com/opensearch-project/sql/pull/2662) |
 
 ### Issues (Design / RFC)
 - [Issue #4722](https://github.com/opensearch-project/sql/issues/4722): Gradle upgrade tracking

--- a/docs/releases/v2.16.0/features/sql/sql-build-fixes.md
+++ b/docs/releases/v2.16.0/features/sql/sql-build-fixes.md
@@ -1,0 +1,69 @@
+---
+tags:
+  - sql
+---
+# SQL Build Fixes
+
+## Summary
+
+Fixed GitHub Actions workflow failures in the SQL plugin by addressing checkout action compatibility issues and restoring MacOS build workflows with proper runner configuration.
+
+## Details
+
+### What's New in v2.16.0
+
+Two build infrastructure fixes were implemented:
+
+1. **Checkout Action Fix (PR #2819)**: Added `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION` environment variable to allow Node16 actions in GitHub Actions workflows, resolving checkout action failures.
+
+2. **MacOS Workflow Restoration (PR #2831)**: Re-enabled MacOS build workflows that were previously removed due to M-series artifact issues. The fix uses `macos-13` runner instead of `macos-latest` to ensure Intel-based artifacts are available.
+
+### Technical Changes
+
+#### Checkout Action Fix
+
+Modified workflow files to allow Node16 actions:
+
+```yaml
+# .github/workflows/integ-tests-with-security.yml
+# .github/workflows/sql-test-and-build-workflow.yml
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+```
+
+#### MacOS Workflow Restoration
+
+Updated OS matrix to include MacOS:
+
+```yaml
+# integ-tests-with-security.yml
+matrix:
+  os: [ windows-latest, macos-13 ]  # Added macos-13
+
+# sql-test-and-build-workflow.yml
+matrix:
+  entry:
+    - { os: windows-latest, java: 21, os_build_args: -x doctest -PbuildPlatform=windows }
+    - { os: macos-13, java: 21 }  # Added MacOS entry
+```
+
+### Files Changed
+
+| File | Changes |
+|------|---------|
+| `.github/workflows/integ-tests-with-security.yml` | Added Node16 env var, added macos-13 to OS matrix |
+| `.github/workflows/sql-test-and-build-workflow.yml` | Added Node16 env var, added macos-13 build entry |
+
+## Limitations
+
+- MacOS builds use `macos-13` (Intel) instead of `macos-latest` (M-series) due to artifact availability
+- Node16 action compatibility workaround may need updates when actions are upgraded
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#2819](https://github.com/opensearch-project/sql/pull/2819) | Fix checkout action failure (backport from #2807) | - |
+| [#2831](https://github.com/opensearch-project/sql/pull/2831) | Add MacOS workflows back and fix artifact not found issue | [#2662](https://github.com/opensearch-project/sql/pull/2662) |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -137,3 +137,4 @@
 ### sql
 - SQL Async Query Core Refactoring
 - SparkParameterComposerCollection
+- SQL Build Fixes


### PR DESCRIPTION
## Summary

Added release report for SQL Build Fixes in v2.16.0.

### Changes
- Created release report: `docs/releases/v2.16.0/features/sql/sql-build-fixes.md`
- Updated feature report: `docs/features/sql/sql-ci-tests.md` (added v2.16.0 to Change History and References)
- Updated release index: `docs/releases/v2.16.0/index.md`

### PRs Investigated
- [#2819](https://github.com/opensearch-project/sql/pull/2819): Fix checkout action failure
- [#2831](https://github.com/opensearch-project/sql/pull/2831): Add MacOS workflows back and fix artifact not found issue

Closes #2222