### PR TITLE
docs: add k-NN Build & Patches report for v2.16.0

### DIFF
--- a/docs/features/k-nn/k-nn-build.md
+++ b/docs/features/k-nn/k-nn-build.md
@@ -128,7 +128,7 @@ permission java.lang.RuntimePermission "loadLibrary.opensearchknn_faiss_avx512_s
 ## Change History
 
 - **v3.4.0** (2026-01-11): Added SIMD library to build configurations; migrated to S3 snapshots repository
-
+- **v2.16.0** (2024-08-06): Fixed custom patch application to apply only once by comparing patch-id; updated developer guide for ARM (M-series) build instructions
 
 ## References
 
@@ -137,6 +137,8 @@ permission java.lang.RuntimePermission "loadLibrary.opensearchknn_faiss_avx512_s
 |---------|-----|-------------|---------------|
 | v3.4.0 | [#3025](https://github.com/opensearch-project/k-NN/pull/3025) | Include opensearchknn_simd in build configurations |   |
 | v3.4.0 | [#2943](https://github.com/opensearch-project/k-NN/pull/2943) | Onboard to S3 snapshots | [#5360](https://github.com/opensearch-project/opensearch-build/issues/5360) |
+| v2.16.0 | [#1833](https://github.com/opensearch-project/k-NN/pull/1833) | Apply custom patch only once by comparing patch-id | - |
+| v2.16.0 | [#1746](https://github.com/opensearch-project/k-NN/pull/1746) | Update dev guide to fix clang linking issue on ARM | - |
 
 ### Issues (Design / RFC)
 - [Issue #5360](https://github.com/opensearch-project/opensearch-build/issues/5360): Migration from Sonatype snapshots repo to ci.opensearch.org snapshots repo

--- a/docs/releases/v2.16.0/features/k-nn/k-nn-build-patches.md
+++ b/docs/releases/v2.16.0/features/k-nn/k-nn-build-patches.md
@@ -1,0 +1,49 @@
+---
+tags:
+  - k-nn
+---
+# k-NN Build & Patches
+
+## Summary
+
+Bug fixes for the k-NN plugin build infrastructure in v2.16.0, addressing custom patch application issues and developer guide improvements for ARM-based development environments.
+
+## Details
+
+### What's New in v2.16.0
+
+#### Custom Patch Application Fix
+
+The build system now applies custom patches only once by comparing the patch-id of the last commit. Previously, when multiple custom patches touched the same file, re-applying patches would fail, causing consistent build failures when building the JNI library more than once.
+
+The fix modifies the CMake configuration to:
+1. Check the patch-id of the last commit before applying patches
+2. Skip patch application if the patch has already been applied
+3. Eliminate the need to manually remove `git rebase-apply` and `external/faiss` folders
+
+This improvement reduces development time by avoiding the workaround of rebuilding from scratch.
+
+#### Developer Guide Update for ARM
+
+Updated the `DEVELOPER_GUIDE.md` with corrected instructions for building on Apple M-series chips. The previous instructions had clang linking issues on ARM architecture. The updated guide uses gcc/g++ instead of clang to build and link the external k-NN libraries.
+
+### Technical Changes
+
+| Change | Description |
+|--------|-------------|
+| CMake patch logic | Compare patch-id before applying to prevent duplicate application |
+| CI configuration | Removed `submodule: true` option (no longer needed after Linux image upgrade) |
+| Developer guide | Updated M-series build instructions to use gcc/g++ |
+
+## Limitations
+
+- The patch-id comparison requires git to be available in the build environment
+- ARM build instructions are specific to Apple M-series chips (M2, M3)
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#1833](https://github.com/opensearch-project/k-NN/pull/1833) | Apply custom patch only once by comparing the patch-id of the last commit | - |
+| [#1746](https://github.com/opensearch-project/k-NN/pull/1746) | Update dev guide to fix clang linking issue on ARM | - |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -13,6 +13,7 @@
 
 ### k-nn
 - Faiss Updates
+- k-NN Build & Patches
 
 ### ml-commons
 - Model & Connector Enhancements


### PR DESCRIPTION
## Summary

Adds release report for k-NN Build & Patches in v2.16.0.

### Changes in v2.16.0
- Fixed custom patch application to apply only once by comparing patch-id (prevents build failures when rebuilding JNI library)
- Updated developer guide for ARM (M-series) build instructions using gcc/g++ instead of clang

### Reports
- Release report: `docs/releases/v2.16.0/features/k-nn/k-nn-build-patches.md`
- Feature report: `docs/features/k-nn/k-nn-build.md` (updated)

### Pull Requests
- [#1833](https://github.com/opensearch-project/k-NN/pull/1833) - Apply custom patch only once by comparing patch-id
- [#1746](https://github.com/opensearch-project/k-NN/pull/1746) - Update dev guide to fix clang linking issue on ARM

Closes #2221