### PR TITLE
docs: add ML Commons Blueprints & Tutorials report for v2.16.0

### DIFF
--- a/docs/features/ml-commons/ml-commons-blueprints.md
+++ b/docs/features/ml-commons/ml-commons-blueprints.md
@@ -69,9 +69,13 @@ OpenSearch provides two types of connector blueprints:
 - Claude 4 Sonnet and Opus (standard and extended thinking modes)
 - Converse API (Claude 3 Sonnet and other chat models)
 
+#### Amazon Textract
+- Document text extraction
+
 #### OpenAI
 - text-embedding-ada-002
 - GPT-4o (chat completions)
+- Batch API (offline inference)
 
 #### Cohere
 - embed-english-v3.0/v2.0
@@ -79,6 +83,10 @@ OpenSearch provides two types of connector blueprints:
 
 #### Azure OpenAI
 - text-embedding-ada-002
+
+#### Amazon SageMaker
+- Cross-encoder reranking models
+- Batch transform jobs (offline inference)
 
 ### Configuration
 
@@ -144,6 +152,7 @@ POST /_plugins/_ml/connectors/_create
 - **v3.1.0** (2026-01-10): Added Claude 4 Sonnet and Opus blueprint with extended thinking mode support
 - **v3.0.0** (2025-05-06): Added standard blueprints for vector search, Claude 3.7 blueprint, Azure OpenAI blueprint, RAG tutorials
 - **v2.18.0** (2024-11-12): Added Bedrock Converse blueprint, cross-account model invocation tutorial, role temporary credential support, Titan Embedding V2 blueprint
+- **v2.16.0** (2024-08-06): Added Amazon Textract blueprint, Cohere embedding on Bedrock, offline batch inference connectors (SageMaker/OpenAI), cross-encoder reranking tutorial, secrets caching for non-AWS models, standardized Bedrock blueprint format
 - **v2.14.0** (2024-05-14): Introduced ML inference processor support for standard blueprints
 - **v2.9.0** (2023-07-24): Initial connector blueprints feature
 
@@ -171,6 +180,13 @@ POST /_plugins/_ml/connectors/_create
 | v2.18.0 | [#3058](https://github.com/opensearch-project/ml-commons/pull/3058) | Support role temporary credential in connector tutorial |   |
 | v2.18.0 | [#3064](https://github.com/opensearch-project/ml-commons/pull/3064) | Add tutorial for cross-account model invocation |   |
 | v2.18.0 | [#3094](https://github.com/opensearch-project/ml-commons/pull/3094) | Tune Titan embedding model blueprint for V2 | [#3081](https://github.com/opensearch-project/ml-commons/issues/3081) |
+| v2.16.0 | [#2562](https://github.com/opensearch-project/ml-commons/pull/2562) | Add Amazon Textract blueprint |   |
+| v2.16.0 | [#2607](https://github.com/opensearch-project/ml-commons/pull/2607) | Add tutorial for cross-encoder model on SageMaker |   |
+| v2.16.0 | [#2637](https://github.com/opensearch-project/ml-commons/pull/2637) | Update tutorials for caching secrets for non-AWS models |   |
+| v2.16.0 | [#2642](https://github.com/opensearch-project/ml-commons/pull/2642) | Make all Bedrock model blueprints in a tidier format |   |
+| v2.16.0 | [#2667](https://github.com/opensearch-project/ml-commons/pull/2667) | Add connector blueprint for Cohere embedding models in Bedrock |   |
+| v2.16.0 | [#2692](https://github.com/opensearch-project/ml-commons/pull/2692) | Make all Amazon managed LLM blueprints in a tidier format |   |
+| v2.16.0 | [#2768](https://github.com/opensearch-project/ml-commons/pull/2768) | Add offline batch inference connector blueprints | [#2488](https://github.com/opensearch-project/ml-commons/issues/2488) |
 
 ### Issues (Design / RFC)
 - [Issue #3619](https://github.com/opensearch-project/ml-commons/issues/3619): Standard blueprints feature request

--- a/docs/releases/v2.16.0/features/ml-commons/ml-commons-blueprints-tutorials.md
+++ b/docs/releases/v2.16.0/features/ml-commons/ml-commons-blueprints-tutorials.md
@@ -1,0 +1,66 @@
+---
+tags:
+  - ml-commons
+---
+# ML Commons Blueprints & Tutorials
+
+## Summary
+
+OpenSearch v2.16.0 adds new connector blueprints and tutorials for ML Commons, including Amazon Textract integration, Cohere embedding models on Bedrock, offline batch inference connectors, cross-encoder reranking on SageMaker, and improved documentation for secrets caching with non-AWS models.
+
+## Details
+
+### What's New in v2.16.0
+
+#### New Connector Blueprints
+
+| Blueprint | Description |
+|-----------|-------------|
+| Amazon Textract | Connector blueprint for document text extraction using Amazon Textract |
+| Cohere Embedding on Bedrock | Blueprints for Cohere embedding models (embed-english-v3, embed-multilingual-v3) via Amazon Bedrock |
+| Offline Batch Inference | Connector blueprints for batch inference against SageMaker and OpenAI |
+
+#### New Tutorials
+
+| Tutorial | Description |
+|----------|-------------|
+| Cross-Encoder Reranking on SageMaker | Guide for deploying and using cross-encoder models on SageMaker for reranking |
+| Secrets Caching for Non-AWS Models | Updated tutorials for caching secrets from client side to reduce API calls to secret manager |
+
+#### Blueprint Format Improvements
+
+- Standardized format for all Bedrock model blueprints to enable automated model interface creation
+- Tidier format for Amazon managed LLM blueprints to support automated model interface
+
+### Technical Changes
+
+#### Secrets Caching Updates
+New IAM permissions required for caching secrets from client side:
+- Reduces API calls to secret manager in Amazon OpenSearch Service
+- Validated with OpenAI and Cohere integrations
+
+#### Offline Batch Inference
+Connector blueprints support batch inference workflows:
+- SageMaker batch transform jobs
+- OpenAI batch API integration
+
+## Limitations
+
+- Secrets caching requires additional IAM permissions for secret manager access
+- Offline batch inference connectors are designed for asynchronous processing, not real-time inference
+
+## References
+
+### Pull Requests
+| PR | Description |
+|----|-------------|
+| [#2562](https://github.com/opensearch-project/ml-commons/pull/2562) | Add Amazon Textract blueprint |
+| [#2607](https://github.com/opensearch-project/ml-commons/pull/2607) | Add tutorial for cross-encoder model on SageMaker |
+| [#2637](https://github.com/opensearch-project/ml-commons/pull/2637) | Update tutorials for caching secrets for non-AWS models |
+| [#2642](https://github.com/opensearch-project/ml-commons/pull/2642) | Make all Bedrock model blueprints in a tidier format |
+| [#2667](https://github.com/opensearch-project/ml-commons/pull/2667) | Add connector blueprint for Cohere embedding models in Bedrock |
+| [#2692](https://github.com/opensearch-project/ml-commons/pull/2692) | Make all Amazon managed LLM blueprints in a tidier format |
+| [#2768](https://github.com/opensearch-project/ml-commons/pull/2768) | Add offline batch inference connector blueprints |
+
+### Related Issues
+- [#2488](https://github.com/opensearch-project/ml-commons/issues/2488) - Offline batch inference feature request

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -18,6 +18,7 @@
 ### ml-commons
 - Model & Connector Enhancements
 - System Index & Dependencies
+- ML Commons Blueprints & Tutorials
 
 ### multi-plugin
 - MDS Version Decoupling (Plugins)


### PR DESCRIPTION
## Summary

Adds release report and updates feature report for ML Commons Blueprints & Tutorials in v2.16.0.

### Changes in v2.16.0
- Amazon Textract connector blueprint
- Cohere embedding models on Bedrock blueprints
- Offline batch inference connectors (SageMaker/OpenAI)
- Cross-encoder reranking tutorial for SageMaker
- Secrets caching tutorial for non-AWS models
- Standardized Bedrock blueprint format

### Files Changed
- `docs/releases/v2.16.0/features/ml-commons/ml-commons-blueprints-tutorials.md` (new)
- `docs/features/ml-commons/ml-commons-blueprints.md` (updated)
- `docs/releases/v2.16.0/index.md` (updated)

Closes #2219