### PR TITLE
docs: add performance-analyzer-dependencies report for v2.16.0

### DIFF
--- a/docs/features/performance-analyzer/performance-analyzer.md
+++ b/docs/features/performance-analyzer/performance-analyzer.md
@@ -121,6 +121,7 @@ GET localhost:9600/_plugins/_performanceanalyzer/rca?name=HighHeapUsageClusterRC
 - **v3.3.0** (2026-01-11): Transport channel wrapper improvements - delegate getProfileName(), getChannelType(), getVersion(), and get() to wrapped channel; removed getInnerChannel() method for better security plugin compatibility
 - **v3.2.0** (2025-07-18): Build infrastructure update - SpotBugs 6.2.2, Checkstyle 10.26.1; Removed CVE-2025-27820 workaround
 - **v2.17.0** (2024-09-17): Added RTFCacheConfigMetricsCollector for cache configuration telemetry; Updated PA Commons dependency to 1.6.0
+- **v2.16.0** (2024-08-06): Security dependency updates - BouncyCastle 1.74 → 1.78.1 (CVE fixes); PA Commons 1.4.0 → 1.5.0
 
 
 ## References
@@ -140,3 +141,5 @@ GET localhost:9600/_plugins/_performanceanalyzer/rca?name=HighHeapUsageClusterRC
 | v3.2.0 | [#826](https://github.com/opensearch-project/performance-analyzer/pull/826) | Bump SpotBugs to 6.2.2 and Checkstyle to 10.26.1 |   |
 | v2.17.0 | [#690](https://github.com/opensearch-project/performance-analyzer/pull/690) | Added CacheConfig Telemetry collectors |   |
 | v2.17.0 | [#712](https://github.com/opensearch-project/performance-analyzer/pull/712) | Bump PA to use 1.6.0 PA commons lib |   |
+| v2.16.0 | [#656](https://github.com/opensearch-project/performance-analyzer/pull/656) | Bump bouncycastle from 1.74 to 1.78.1 | Security advisories |
+| v2.16.0 | [#698](https://github.com/opensearch-project/performance-analyzer/pull/698) | Bump PA to use 1.5.0 PA commons lib |   |

--- a/docs/releases/v2.16.0/features/performance-analyzer/performance-analyzer-dependencies.md
+++ b/docs/releases/v2.16.0/features/performance-analyzer/performance-analyzer-dependencies.md
@@ -1,0 +1,54 @@
+---
+tags:
+  - performance-analyzer
+---
+# Performance Analyzer Dependencies
+
+## Summary
+
+Security and compatibility updates for Performance Analyzer dependencies in v2.16.0, including BouncyCastle cryptographic library upgrade and PA Commons library version bump.
+
+## Details
+
+### What's New in v2.16.0
+
+This release includes two dependency updates addressing security vulnerabilities and compatibility:
+
+1. **BouncyCastle Upgrade (1.74 → 1.78.1)**: Addresses multiple security advisories
+2. **PA Commons Library Update (1.4.0 → 1.5.0)**: Compatibility update for v2.16.0 release
+
+### Technical Changes
+
+#### BouncyCastle Security Update
+
+Updated BouncyCastle cryptographic libraries to address security vulnerabilities:
+
+| Library | Old Version | New Version |
+|---------|-------------|-------------|
+| `bcprov-jdk15to18` | 1.74 | 1.78.1 |
+| `bcpkix-jdk18on` | 1.74 | 1.78.1 |
+
+Security advisories resolved:
+- [GHSA-m44j-cfrm-g8qc](https://github.com/advisories/GHSA-m44j-cfrm-g8qc)
+- [GHSA-v435-xc8x-wvr9](https://github.com/advisories/GHSA-v435-xc8x-wvr9)
+- [GHSA-8xfc-gm6g-vgpv](https://github.com/advisories/GHSA-8xfc-gm6g-vgpv)
+
+#### PA Commons Library Update
+
+Updated Performance Analyzer Commons library version:
+
+| Setting | Old Value | New Value |
+|---------|-----------|-----------|
+| `paCommonsVersion` | 1.4.0 | 1.5.0 |
+
+## Limitations
+
+No functional changes or new limitations introduced. These are dependency-only updates.
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#656](https://github.com/opensearch-project/performance-analyzer/pull/656) | Bump bouncycastle from 1.74 to 1.78.1 | Security advisories |
+| [#698](https://github.com/opensearch-project/performance-analyzer/pull/698) | Bump PA to use 1.5.0 PA commons lib | Release 2.16 compatibility |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -124,6 +124,9 @@
 ### notifications
 - Version Bumps & Release Notes
 
+### performance-analyzer
+- Performance Analyzer Dependencies
+
 ### query-insights
 - Query Insights Plugin Setup
 


### PR DESCRIPTION
## Summary

Adds documentation for Performance Analyzer dependency updates in v2.16.0.

### Changes
- **Release report**: `docs/releases/v2.16.0/features/performance-analyzer/performance-analyzer-dependencies.md`
- **Feature report update**: Added v2.16.0 entries to Change History and References

### Key Updates in v2.16.0
- BouncyCastle upgrade (1.74 → 1.78.1) - addresses security vulnerabilities
- PA Commons library update (1.4.0 → 1.5.0) - release compatibility

### Related PRs
- [#656](https://github.com/opensearch-project/performance-analyzer/pull/656) - Bump bouncycastle
- [#698](https://github.com/opensearch-project/performance-analyzer/pull/698) - Bump PA commons

Closes #2217