### PR TITLE
docs: add job-scheduler-fixes report for v2.16.0

### DIFF
--- a/docs/features/job-scheduler/job-scheduler.md
+++ b/docs/features/job-scheduler/job-scheduler.md
@@ -210,6 +210,7 @@ Job Scheduler supports two schedule formats:
 - **v3.0.0** (2025): CI/CD improvements, JPMS compatibility fixes, conditional demo certificate downloads
 - **v2.18.0** (2024-11-05): Return LockService from createComponents for Guice injection, enabling shared lock service across plugins
 - **v2.17.0** (2024-09-17): Fixed system index compatibility with v1 templates in LockService and JobDetailsService
+- **v2.16.0** (2024-08-06): Fixed CI workflow GLIBC compatibility issue by enabling Node16 fallback for GitHub Actions
 
 
 ## References
@@ -245,6 +246,7 @@ Job Scheduler supports two schedule formats:
 | v3.0.0 | [#737](https://github.com/opensearch-project/job-scheduler/pull/737) | Only download demo certs when integTest run with -Dsecurity.enabled=true |   |
 | v2.18.0 | [#670](https://github.com/opensearch-project/job-scheduler/pull/670) | Return LockService from createComponents for Guice injection | [#238](https://github.com/opensearch-project/opensearch-plugins/issues/238) |
 | v2.17.0 | [#658](https://github.com/opensearch-project/job-scheduler/pull/658) | Fix system index compatibility with v1 templates | [#14984](https://github.com/opensearch-project/OpenSearch/issues/14984) |
+| v2.16.0 | [#650](https://github.com/opensearch-project/job-scheduler/pull/650) | Fix checkout action failure (GLIBC compatibility) | [actions/checkout#1809](https://github.com/actions/checkout/issues/1809) |
 
 ### Issues (Design / RFC)
 - [Issue #808](https://github.com/opensearch-project/job-scheduler/issues/808): Feature request for Job execution History index

--- a/docs/releases/v2.16.0/features/job-scheduler/job-scheduler-fixes.md
+++ b/docs/releases/v2.16.0/features/job-scheduler/job-scheduler-fixes.md
@@ -1,0 +1,38 @@
+---
+tags:
+  - job-scheduler
+---
+# Job Scheduler Fixes
+
+## Summary
+
+Fixed GitHub Actions CI workflow failure caused by GLIBC version incompatibility on older runner images by enabling Node16 fallback.
+
+## Details
+
+### What's New in v2.16.0
+
+The CI workflow was failing with GLIBC version errors when running the checkout action:
+
+```
+/__e/node20/bin/node: /lib64/libm.so.6: version `GLIBC_2.27' not found (required by /__e/node20/bin/node)
+/__e/node20/bin/node: /lib64/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)
+```
+
+### Technical Changes
+
+Added `ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true` environment variable to the CI workflow to allow using Node16 actions instead of Node20, which requires newer GLIBC versions not available on the runner image.
+
+```yaml
+env:
+  ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION: true
+```
+
+This is a temporary workaround until the runner images are updated with newer GLIBC versions.
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#650](https://github.com/opensearch-project/job-scheduler/pull/650) | Fix checkout action failure | [actions/checkout#1809](https://github.com/actions/checkout/issues/1809) |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -11,6 +11,9 @@
 ### index-management
 - Index Management Build Fixes
 
+### job-scheduler
+- Job Scheduler Fixes
+
 ### k-nn
 - Faiss Updates
 - k-NN Build & Patches


### PR DESCRIPTION
## Summary

Added release report for Job Scheduler CI fix in v2.16.0.

### Changes
- Created release report: `docs/releases/v2.16.0/features/job-scheduler/job-scheduler-fixes.md`
- Updated feature report: `docs/features/job-scheduler/job-scheduler.md` (added v2.16.0 to Change History and References)
- Updated release index: `docs/releases/v2.16.0/index.md`

### PR Investigated
- [opensearch-project/job-scheduler#650](https://github.com/opensearch-project/job-scheduler/pull/650) - Fix checkout action failure

Closes #2216