### PR TITLE
docs: add security-analytics-integration-tests report for v2.16.0

### DIFF
--- a/docs/features/security-analytics/security-analytics-correlation-engine.md
+++ b/docs/features/security-analytics/security-analytics-correlation-engine.md
@@ -167,6 +167,7 @@ The correlation graph in OpenSearch Dashboards displays:
 ## Change History
 
 - **v3.0.0** (2024-12): Removed incomplete events-correlation-engine plugin from OpenSearch core; correlation functionality remains available through Security Analytics plugin
+- **v2.16.0**: Bug fix - CorrelationAlertService now returns empty response instead of error when correlation alerts index doesn't exist
 - **v2.9.0**: Correlation engine enhancements in Security Analytics
 - **v2.6.0**: Initial correlation engine release in Security Analytics plugin
 
@@ -186,4 +187,5 @@ The correlation graph in OpenSearch Dashboards displays:
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
 | v3.0.0 | [#16885](https://github.com/opensearch-project/OpenSearch/pull/16885) | Removed incomplete events-correlation-engine from core | [#6779](https://github.com/opensearch-project/OpenSearch/issues/6779) |
+| v2.16.0 | [#1125](https://github.com/opensearch-project/security-analytics/pull/1125) | Set blank response when indexNotFound exception | - |
 | v2.x | Various | Security Analytics correlation engine implementation |   |

--- a/docs/releases/v2.16.0/features/security-analytics/security-analytics-integration-tests.md
+++ b/docs/releases/v2.16.0/features/security-analytics/security-analytics-integration-tests.md
@@ -1,0 +1,60 @@
+---
+tags:
+  - security-analytics
+---
+# Security Analytics Integration Tests
+
+## Summary
+
+Bug fixes for Security Analytics integration tests and error handling improvements in v2.16.0. These changes improve test stability and provide better error handling when correlation alert indices don't exist.
+
+## Details
+
+### What's New in v2.16.0
+
+#### Integration Test Fixes (PR #1082)
+
+Fixed flaky integration tests by removing unnecessary explicit refresh calls that were causing timing issues. The changes affect multiple test files:
+
+- `SecurityAnalyticsRestTestCase.java`
+- `AlertsIT.java`
+- `SecureAlertsRestApiIT.java`
+- `FindingIT.java`
+- `SecureFindingRestApiIT.java`
+- `MapperRestApiIT.java`
+
+#### IndexNotFoundException Handling (PR #1125)
+
+Improved error handling in `CorrelationAlertService` to gracefully handle cases where the correlation alerts index doesn't exist yet. Instead of throwing an exception, the service now returns an empty response.
+
+```java
+// Before: Exception thrown when index not found
+listener.onFailure(e);
+
+// After: Return empty response for IndexNotFoundException
+if (e instanceof IndexNotFoundException) {
+    listener.onResponse(new GetCorrelationAlertsResponse(Collections.emptyList(), 0));
+} else {
+    listener.onFailure(e);
+}
+```
+
+### Technical Changes
+
+| Change | Description |
+|--------|-------------|
+| Test refresh removal | Commented out explicit `_refresh` API calls in integration tests |
+| IndexNotFoundException handling | Return empty array instead of error when correlation alerts index doesn't exist |
+
+## Limitations
+
+- These are internal bug fixes with no user-facing API changes
+- The IndexNotFoundException fix only applies to correlation alerts queries
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#1082](https://github.com/opensearch-project/security-analytics/pull/1082) | Pass integ tests | - |
+| [#1125](https://github.com/opensearch-project/security-analytics/pull/1125) | Set blank response when indexNotFound exception | - |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -144,6 +144,9 @@
 - Dependency Bumps
 - Security Plugin Maintenance
 
+### security-analytics
+- Security Analytics Integration Tests
+
 ### observability
 - Observability CVE Fixes
 


### PR DESCRIPTION
## Summary

Investigation of GitHub Issue #2214 - Security Analytics Integration Tests bug fixes for v2.16.0.

## Reports Created
- Release report: `docs/releases/v2.16.0/features/security-analytics/security-analytics-integration-tests.md`
- Feature report updated: `docs/features/security-analytics/security-analytics-correlation-engine.md`

## Key Changes in v2.16.0
- Fixed flaky integration tests by removing unnecessary explicit refresh calls (PR #1082)
- Improved error handling in CorrelationAlertService to return empty response instead of error when correlation alerts index doesn't exist (PR #1125)

## PRs Investigated
- [#1082](https://github.com/opensearch-project/security-analytics/pull/1082) - Pass integ tests
- [#1125](https://github.com/opensearch-project/security-analytics/pull/1125) - Set blank response when indexNotFound exception

Closes #2214