### PR TITLE
docs: add security-dashboards-auth-fixes report for v2.16.0

### DIFF
--- a/docs/features/security-dashboards/security-dashboards-plugin.md
+++ b/docs/features/security-dashboards/security-dashboards-plugin.md
@@ -113,7 +113,7 @@ export function validateNextUrl(url: string, basePath: string): string | undefin
 
 - **v2.19.0** (2025-01-21): Fixed OpenID login redirect to preserve query parameters and URL fragments; Fixed tenant defaulting incorrectly based on preferred tenants order instead of default tenant setting
 - **v2.17.0** (2024-09-17): UI/UX enhancements including smaller/compressed components, updated page headers, avatar relocation to left nav, consistency and density improvements; Fixed tenancy app registration, basepath URL validation, page header UX, and navigation titles/descriptions
-- **v2.16.0** (2024-08-06): Security fix for CVE-2024-4068 (braces package ReDoS vulnerability); CI/CD build fixes for Node.js 20 compatibility
+- **v2.16.0** (2024-08-06): Security fix for CVE-2024-4068 (braces package ReDoS vulnerability); CI/CD build fixes for Node.js 20 compatibility; Fixed capabilities API to support carrying authentication info; Fixed URL duplication issue when navigating to security plugin
 
 
 ## References
@@ -137,9 +137,12 @@ export function validateNextUrl(url: string, basePath: string): string | undefin
 | v2.17.0 | [#2084](https://github.com/opensearch-project/security-dashboards-plugin/pull/2084) | Update titles and descriptions |   |
 | v2.16.0 | [#2039](https://github.com/opensearch-project/security-dashboards-plugin/pull/2039) | Addresses CVE-2024-4068 and updates yarn.lock |   |
 | v2.16.0 | [#2060](https://github.com/opensearch-project/security-dashboards-plugin/pull/2060) | Format package.json and update CI workflows |   |
+| v2.16.0 | [#2014](https://github.com/opensearch-project/security-dashboards-plugin/pull/2014) | Fix capabilities API to support carrying authinfo |   |
+| v2.16.0 | [#2004](https://github.com/opensearch-project/security-dashboards-plugin/pull/2004) | Fix URL duplication issue | [#1967](https://github.com/opensearch-project/security-dashboards-plugin/issues/1967) |
 
 ### Issues (Design / RFC)
 - [Issue #2056](https://github.com/opensearch-project/security-dashboards-plugin/issues/2056): Tenant link visibility bug
 - [Issue #2097](https://github.com/opensearch-project/security-dashboards-plugin/issues/2097): Basepath nextUrl validation bug
 - [Issue #1823](https://github.com/opensearch-project/security-dashboards-plugin/issues/1823): Auth redirect resets query
 - [Issue #2019](https://github.com/opensearch-project/security-dashboards-plugin/issues/2019): Tenant defaulting incorrectly based on preferred tenants order
+- [Issue #1967](https://github.com/opensearch-project/security-dashboards-plugin/issues/1967): Duplicate URL fragment when clicking on security plugin

--- a/docs/releases/v2.16.0/features/security-dashboards/security-dashboards-auth-fixes.md
+++ b/docs/releases/v2.16.0/features/security-dashboards/security-dashboards-auth-fixes.md
@@ -1,0 +1,75 @@
+---
+tags:
+  - security-dashboards
+---
+# Security Dashboards Auth Fixes
+
+## Summary
+
+OpenSearch v2.16.0 includes two bug fixes for the Security Dashboards Plugin addressing authentication and URL handling issues: fixing the capabilities API to support carrying authentication information, and resolving a URL duplication issue when navigating to the security plugin.
+
+## Details
+
+### What's New in v2.16.0
+
+#### Capabilities API Authentication Support
+
+The capabilities API (`/api/core/capabilities`) was previously excluded from authentication handling, which prevented plugins from accessing user authentication information when using `core.capabilities.registerSwitcher`. This fix introduces optional authentication for the capabilities endpoint.
+
+**Technical Changes:**
+- Moved `/api/core/capabilities` from `ROUTES_TO_IGNORE` to new `ROUTES_AUTH_OPTIONAL` list
+- Added `authOptional()` method to check if a route allows optional authentication
+- When authentication is optional and credentials are provided, the auth info is now included in the request state
+
+```typescript
+// Before: Capabilities API was completely ignored
+protected static readonly ROUTES_TO_IGNORE: string[] = [
+  '/api/core/capabilities', // FIXME: need to figure out how to bypass this API call
+  '/app/login',
+];
+
+// After: Capabilities API allows optional authentication
+protected static readonly ROUTES_TO_IGNORE: string[] = ['/app/login'];
+protected static readonly ROUTES_AUTH_OPTIONAL: string[] = ['/api/core/capabilities'];
+```
+
+**Files Changed:**
+- `server/auth/types/authentication_type.ts`: Added `ROUTES_AUTH_OPTIONAL` and `authOptional()` method
+- `server/auth/types/authentication_type.test.ts`: Added test coverage for capabilities API auth info
+
+#### URL Duplication Fix
+
+Fixed a bug where navigating to the Security Dashboards Plugin would cause the URL fragment to appear twice (e.g., `/app/security-dashboards-plugin#/app/security-dashboards-plugin/getstarted` instead of `/app/security-dashboards-plugin#/getstarted`).
+
+**Root Cause:**
+The `HashRouter` component was incorrectly configured with `basename={props.params.appBasePath}`, which caused the base path to be duplicated in the URL hash.
+
+**Fix:**
+Removed the `basename` prop from the `HashRouter` component.
+
+```typescript
+// Before
+<Router basename={props.params.appBasePath}>
+
+// After
+<Router>
+```
+
+**Files Changed:**
+- `public/apps/configuration/app-router.tsx`: Removed basename prop from HashRouter
+
+## Limitations
+
+- The capabilities API authentication is optional - unauthenticated requests will still succeed but without auth info in the state
+- These fixes are specific to the Security Dashboards Plugin and do not affect the core Security Plugin
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#2014](https://github.com/opensearch-project/security-dashboards-plugin/pull/2014) | Fix the bug of capabilities request not supporting carrying authinfo | - |
+| [#2004](https://github.com/opensearch-project/security-dashboards-plugin/pull/2004) | Fix URL duplication issue | [#1967](https://github.com/opensearch-project/security-dashboards-plugin/issues/1967) |
+
+### Issues
+- [#1967](https://github.com/opensearch-project/security-dashboards-plugin/issues/1967): Duplicate URL fragment when clicking on security plugin

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -139,6 +139,7 @@
 
 ### security-dashboards
 - CVE & Build Fixes
+- Security Dashboards Auth Fixes
 
 ### security
 - Dependency Bumps


### PR DESCRIPTION
## Summary

This PR adds the release report for Security Dashboards Auth Fixes in v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/security-dashboards/security-dashboards-auth-fixes.md`
- Feature report: `docs/features/security-dashboards/security-dashboards-plugin.md` (updated)

### Key Changes in v2.16.0
- Fixed capabilities API (`/api/core/capabilities`) to support carrying authentication info
- Fixed URL duplication issue when navigating to the security plugin

### Pull Requests Investigated
| PR | Description |
|----|-------------|
| [#2014](https://github.com/opensearch-project/security-dashboards-plugin/pull/2014) | Fix capabilities request not supporting carrying authinfo |
| [#2004](https://github.com/opensearch-project/security-dashboards-plugin/pull/2004) | Fix URL duplication issue |

Closes #2213