### PR TITLE
docs: add k-NN vector streaming & memory bug fixes report for v2.16.0

### DIFF
--- a/docs/features/k-nn/k-nn-vector-search-k-nn.md
+++ b/docs/features/k-nn/k-nn-vector-search-k-nn.md
@@ -235,6 +235,7 @@ PUT /_cluster/settings
 - **v3.0.0** (2025-05-06): Breaking changes removing deprecated index settings; node-level circuit breakers; filter function in KNNQueryBuilder; concurrency optimizations for graph loading; Remote Native Index Build foundation
 - **v2.18.0** (2024-11-05): Lucene 9.12 codec compatibility (KNN9120Codec); force merge performance optimization for non-quantization cases (~20% improvement); removed deprecated benchmarks folder; code refactoring improvements
 - **v2.17.0** (2024-09-17): Memory overflow fix for cache behavior; improved filter handling for non-existent fields; script_fields context support; field name validation for snapshots; graph merge stats fix; binary vector IVF training fix; Windows build improvements
+- **v2.16.0** (2024-08-06): Bug fixes for vector streaming arithmetic in Java-JNI layer; LeafReader casting errors with segment replication and deleted docs; memory release for array types in native code; nested field file suffix matching causing zero recall
 
 
 ## References
@@ -319,6 +320,10 @@ PUT /_cluster/settings
 | v2.17.0 | [#2086](https://github.com/opensearch-project/k-NN/pull/2086) | Use correct type for binary vector in IVF training |   |
 | v2.17.0 | [#2090](https://github.com/opensearch-project/k-NN/pull/2090) | Switch MINGW32 to MINGW64 for Windows builds |   |
 | v2.17.0 | [#2006](https://github.com/opensearch-project/k-NN/pull/2006) | Parallelize make to reduce build time |   |
+| v2.16.0 | [#1804](https://github.com/opensearch-project/k-NN/pull/1804) | Fix vector streaming count arithmetic |   |
+| v2.16.0 | [#1808](https://github.com/opensearch-project/k-NN/pull/1808) | Fix LeafReader casting for segment replication | [#1807](https://github.com/opensearch-project/k-NN/issues/1807) |
+| v2.16.0 | [#1820](https://github.com/opensearch-project/k-NN/pull/1820) | Fix memory release for array types |   |
+| v2.16.0 | [#1802](https://github.com/opensearch-project/k-NN/pull/1802) | Fix nested field suffix matching | [#1803](https://github.com/opensearch-project/k-NN/issues/1803) |
 
 ### Issues (Design / RFC)
 - [Issue #1827](https://github.com/opensearch-project/k-NN/issues/1827): Remove double converting for script scoring with binary vector
@@ -340,3 +345,5 @@ PUT /_cluster/settings
 - [Issue #1857](https://github.com/opensearch-project/k-NN/issues/1857): Binary index support for Lucene engine
 - [Issue #2377](https://github.com/opensearch-project/k-NN/issues/2377): Derived vector source design
 - [Issue #1581](https://github.com/opensearch-project/k-NN/issues/1581): Concurrent graph creation for Lucene
+- [Issue #1803](https://github.com/opensearch-project/k-NN/issues/1803): Same suffix causes recall drop to zero
+- [Issue #1807](https://github.com/opensearch-project/k-NN/issues/1807): k-NN queries fail with segment replication and deleted docs

--- a/docs/releases/v2.16.0/features/k-nn/k-nn-vector-streaming-memory.md
+++ b/docs/releases/v2.16.0/features/k-nn/k-nn-vector-streaming-memory.md
@@ -1,0 +1,64 @@
+---
+tags:
+  - k-nn
+---
+# k-NN Vector Streaming & Memory Bug Fixes
+
+## Summary
+
+OpenSearch 2.16.0 includes several critical bug fixes for the k-NN plugin addressing vector streaming arithmetic, segment replication compatibility, memory management, and nested field file matching issues.
+
+## Details
+
+### What's New in v2.16.0
+
+This release addresses four bug fixes that improve k-NN plugin stability and correctness:
+
+#### 1. Vector Streaming Arithmetic Fix
+Fixed incorrect arithmetic when calculating the number of vectors to stream from Java to JNI layer. The calculation error could affect vector data transfer during index operations.
+
+#### 2. Segment Replication LeafReader Casting Fix
+Fixed `ClassCastException` when searching on replicas with segment replication enabled and deleted documents present. The issue occurred because:
+- Segment replication opens IndexReaders via directory path (not IndexWriter)
+- Soft deletes handling wraps SegmentReader in `SoftDeletesFilterCodecReader` or `SoftDeletesFilterLeafReader`
+- The k-NN plugin incorrectly cast these wrapped readers directly to `SegmentReader`
+
+The fix properly unwraps readers through `FilterLeafReader` and `FilterCodecReader` layers using OpenSearch Core helper functions.
+
+#### 3. Memory Release for Array Types
+Fixed improper memory deallocation for array types in native code. Changed `delete` to `delete[]` for `heap_group_ids` array allocation. While no immediate user impact existed (single query execution path), this follows C++ best practices for array memory management.
+
+#### 4. Nested Field File Suffix Matching Fix
+Fixed a bug where nested k-NN fields with similar suffixes caused incorrect index file selection, resulting in zero recall. For example, with fields:
+- `MultipleMatrix.Vector` → `_3_2011_MultipleMatrix.Vector.hnsw`
+- `PersonMultipleMatrix.Vector` → `_3_2011_PersonMultipleMatrix.Vector.hnsw`
+
+The filter `.endsWith(engineSuffix)` incorrectly matched both files when searching `MultipleMatrix.Vector`. The fix uses underscore prefix (`_MultipleMatrix.Vector.hnsw`) to distinguish field boundaries.
+
+### Technical Changes
+
+| Component | Change |
+|-----------|--------|
+| `KNNWeight.java` | Proper LeafReader unwrapping for segment replication |
+| JNI Layer | Corrected vector count arithmetic for streaming |
+| Native Memory | Use `delete[]` for array type deallocation |
+| File Matching | Underscore-prefixed suffix matching for nested fields |
+
+## Limitations
+
+- Segment replication fix requires proper unwrapping through multiple reader wrapper layers
+- The nested field fix changes file matching behavior; existing indices are unaffected
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#1804](https://github.com/opensearch-project/k-NN/pull/1804) | Fix vector streaming count arithmetic | - |
+| [#1808](https://github.com/opensearch-project/k-NN/pull/1808) | Fix LeafReader casting for segment replication | [#1807](https://github.com/opensearch-project/k-NN/issues/1807) |
+| [#1820](https://github.com/opensearch-project/k-NN/pull/1820) | Fix memory release for array types | - |
+| [#1802](https://github.com/opensearch-project/k-NN/pull/1802) | Fix nested field suffix matching | [#1803](https://github.com/opensearch-project/k-NN/issues/1803) |
+
+### Issues
+- [#1803](https://github.com/opensearch-project/k-NN/issues/1803): Same suffix causes recall drop to zero
+- [#1807](https://github.com/opensearch-project/k-NN/issues/1807): k-NN queries fail with segment replication and deleted docs

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -18,6 +18,7 @@
 ### k-nn
 - Faiss Updates
 - k-NN Build & Patches
+- k-NN Vector Streaming & Memory Bug Fixes
 
 ### ml-commons
 - Model & Connector Enhancements


### PR DESCRIPTION
## Summary

Investigation of k-NN Vector Streaming & Memory bug fixes for OpenSearch v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/k-nn/k-nn-vector-streaming-memory.md`
- Feature report updated: `docs/features/k-nn/k-nn-vector-search-k-nn.md`

### Key Changes in v2.16.0
- Fixed vector streaming count arithmetic in Java-JNI layer
- Fixed LeafReader casting errors with segment replication and deleted docs
- Fixed memory release for array types in native code
- Fixed nested field file suffix matching causing zero recall

### PRs Investigated
- [#1804](https://github.com/opensearch-project/k-NN/pull/1804): Fix vector streaming count arithmetic
- [#1808](https://github.com/opensearch-project/k-NN/pull/1808): Fix LeafReader casting for segment replication
- [#1820](https://github.com/opensearch-project/k-NN/pull/1820): Fix memory release for array types
- [#1802](https://github.com/opensearch-project/k-NN/pull/1802): Fix nested field suffix matching

Closes #2212