### PR TITLE
docs: add neural-search-bugfixes report for v2.16.0

### DIFF
--- a/docs/features/neural-search/neural-search-batch-ingestion.md
+++ b/docs/features/neural-search/neural-search-batch-ingestion.md
@@ -128,7 +128,7 @@ PUT /_ingest/pipeline/sparse-pipeline
   - Removed batch_size from Bulk API test parameters
   - Updated BWC test infrastructure with cleaner version checks
   - Added batch_size parameter to pipeline configuration in tests
-- **v2.16.0**: Batch size configuration moved from Bulk API to processor level
+- **v2.16.0** (2024-08-06): Batch size configuration moved from Bulk API to processor level; Added BWC tests for batch ingestion feature
 - **v2.14.0**: Initial batch ingestion feature introduced
 
  - Different feature: batch processing in ingest pipelines
@@ -147,7 +147,7 @@ PUT /_ingest/pipeline/sparse-pipeline
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
 | v2.17.0 | [#852](https://github.com/opensearch-project/neural-search/pull/852) | Update tests to use batch_size in processor | [#14283](https://github.com/opensearch-project/neural-search/issues/14283) |
-| v2.16.0 | - | Batch size moved from Bulk API to processor configuration |   |
+| v2.16.0 | [#769](https://github.com/opensearch-project/neural-search/pull/769) | Add BWC for batch ingestion | [#763](https://github.com/opensearch-project/neural-search/issues/763) |
 | v2.14.0 | - | Initial batch ingestion support |   |
 
 ### Issues (Design / RFC)

--- a/docs/features/neural-search/neural-search-hybrid-query.md
+++ b/docs/features/neural-search/neural-search-hybrid-query.md
@@ -217,6 +217,7 @@ GET /_plugins/_neural/stats/text_embedding_executions
 - **v2.19.0** (2025-02-18): Pagination support with `pagination_depth` parameter, Reciprocal Rank Fusion (RRF) via `score-ranker-processor`, explainability with `explain` flag and `explanation_response_processor`; Bug fixes for inconsistent scoring with two-phase iterators and sorted hybrid query field mismatch
 - **v2.18.0** (2024-11-05): Fixed incorrect document order for nested aggregations in hybrid query
 - **v2.17.0** (2024-09-17): Fixed pagination error handling and multi-shard merge logic
+- **v2.16.0** (2024-08-06): Fixed missing results when concurrent segment search is enabled on shards with 6+ segments
 - **v2.11.0** (2023-10-16): Initial implementation of hybrid search
 
 
@@ -271,6 +272,7 @@ GET /_plugins/_neural/stats/text_embedding_executions
 | v2.18.0 | [#956](https://github.com/opensearch-project/neural-search/pull/956) | Fixed incorrect document order for nested aggregations in hybrid query | [#955](https://github.com/opensearch-project/neural-search/issues/955) |
 | v2.17.0 | [#867](https://github.com/opensearch-project/neural-search/pull/867) | Removed misleading pagination code, added clear error |   |
 | v2.17.0 | [#877](https://github.com/opensearch-project/neural-search/pull/877) | Fixed merge logic for empty shard results | [#875](https://github.com/opensearch-project/neural-search/issues/875) |
+| v2.16.0 | [#800](https://github.com/opensearch-project/neural-search/pull/800) | Fix for missing HybridQuery results when concurrent segment search is enabled | [#799](https://github.com/opensearch-project/neural-search/issues/799) |
 | v2.11.0 | - | Initial implementation of hybrid search |   |
 
 ### Issues (Design / RFC)

--- a/docs/features/neural-search/neural-search-neural-sparse-search.md
+++ b/docs/features/neural-search/neural-search-neural-sparse-search.md
@@ -246,6 +246,7 @@ GET /my-sparse-index/_search
 - **v3.1.0**: Added validation to prevent specifying both model_id and analyzer simultaneously
 - **v3.0.0** (2025-03-11): Added analyzer-based neural sparse query support, enabling tokenization without ML Commons models
 - **v2.19.0** (2025-01-14): Added pruning support for sparse vectors with four strategies (`top_k`, `max_ratio`, `alpha_mass`, `abs_value`) in both ingestion and two-phase search
+- **v2.16.0** (2024-08-06): Added BWC tests for neural sparse query two-phase search processor
 - **v2.11.0**: Initial implementation of neural sparse query with model-based and raw token support
 
 
@@ -263,6 +264,7 @@ GET /my-sparse-index/_search
 | v3.1.0 | [#1359](https://github.com/opensearch-project/neural-search/pull/1359) | Validate model_id and analyzer mutual exclusivity |   |
 | v3.0.0 | [#1088](https://github.com/opensearch-project/neural-search/pull/1088) | Implement analyzer-based neural sparse query |   |
 | v2.19.0 | [#988](https://github.com/opensearch-project/neural-search/pull/988) | Implement pruning for neural sparse ingestion and two-phase search | [#946](https://github.com/opensearch-project/neural-search/issues/946) |
+| v2.16.0 | [#777](https://github.com/opensearch-project/neural-search/pull/777) | Add backward test cases for neural sparse two phase processor | [#646](https://github.com/opensearch-project/neural-search/issues/646) |
 | v2.11.0 | - | Initial neural sparse query implementation |   |
 
 ### Issues (Design / RFC)

--- a/docs/releases/v2.16.0/features/neural-search/neural-search-bugfixes.md
+++ b/docs/releases/v2.16.0/features/neural-search/neural-search-bugfixes.md
@@ -1,0 +1,52 @@
+---
+tags:
+  - neural-search
+---
+# Neural Search Bugfixes
+
+## Summary
+
+OpenSearch v2.16.0 includes several bug fixes and infrastructure improvements for the neural-search plugin. The most significant fix addresses missing results in hybrid queries when concurrent segment search is enabled on shards with 6 or more segments. Additional changes include backward compatibility (BWC) test improvements for batch ingestion and neural sparse two-phase processor, along with CI/build fixes for JDK 21 compatibility.
+
+## Details
+
+### What's New in v2.16.0
+
+#### HybridQuery Concurrent Segment Search Fix
+
+Fixed a critical bug where hybrid queries could return incomplete results when concurrent segment search was enabled on shards with 6 or more segments.
+
+**Root Cause**: The collector manager incorrectly assumed only one hybrid query result collector would exist in the reduce phase. Lucene's `IndexSearcher` creates multiple collectors when processing more than 5 segments (or 250,000 docs per slice), each containing a portion of results.
+
+**Solution**: Implemented proper merging logic at the shard level to combine results from multiple collectors. The merge process:
+1. Identifies results from each sub-query across collectors
+2. Merges sub-query results separately
+3. Wraps merged results back into hybrid query format
+
+#### BWC Test Infrastructure
+
+- Added backward compatibility tests for batch ingestion feature
+- Added BWC tests for neural sparse query two-phase search processor
+- Improved test infrastructure with cleaner version checks
+
+#### CI/Build Fixes
+
+- Fixed CI errors caused by JDK version mismatch between ml-commons and neural-search
+- Updated JDK version to 21 in maven publish workflow
+- Corrected gradle file function names and comments
+
+## Limitations
+
+- Concurrent segment search results may still vary due to non-deterministic merge order (documented behavior)
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#800](https://github.com/opensearch-project/neural-search/pull/800) | Fix for missing HybridQuery results when concurrent segment search is enabled | [#799](https://github.com/opensearch-project/neural-search/issues/799) |
+| [#769](https://github.com/opensearch-project/neural-search/pull/769) | Add BWC for batch ingestion | [#763](https://github.com/opensearch-project/neural-search/issues/763) |
+| [#777](https://github.com/opensearch-project/neural-search/pull/777) | Add backward test cases for neural sparse two phase processor | [#646](https://github.com/opensearch-project/neural-search/issues/646) |
+| [#795](https://github.com/opensearch-project/neural-search/pull/795) | Fix function names and comments in the gradle file for BWC tests | - |
+| [#835](https://github.com/opensearch-project/neural-search/pull/835) | Fix CI for JDK upgrade towards 21 | - |
+| [#837](https://github.com/opensearch-project/neural-search/pull/837) | Maven publishing workflow by upgrade jdk to 21 | - |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -29,6 +29,9 @@
 - MDS Version Decoupling (Plugins)
 - Version Bumps & Release Notes
 
+### neural-search
+- Neural Search Bugfixes
+
 ### opensearch
 - Fingerprint Ingest Processor
 - Aggregation Optimizations


### PR DESCRIPTION
## Summary

Adds release report for Neural Search bugfixes in v2.16.0 and updates related feature reports.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/neural-search/neural-search-bugfixes.md`

### Feature Reports Updated
- `docs/features/neural-search/neural-search-hybrid-query.md` - Added v2.16.0 concurrent segment search fix
- `docs/features/neural-search/neural-search-batch-ingestion.md` - Added v2.16.0 BWC tests
- `docs/features/neural-search/neural-search-neural-sparse-search.md` - Added v2.16.0 BWC tests

### Key Changes in v2.16.0
- Fixed missing HybridQuery results when concurrent segment search is enabled on shards with 6+ segments
- Added BWC tests for batch ingestion feature
- Added BWC tests for neural sparse two-phase processor
- CI/build fixes for JDK 21 compatibility

### PRs Investigated
- [#800](https://github.com/opensearch-project/neural-search/pull/800) - HybridQuery concurrent segment search fix
- [#769](https://github.com/opensearch-project/neural-search/pull/769) - BWC for batch ingestion
- [#777](https://github.com/opensearch-project/neural-search/pull/777) - BWC for neural sparse two-phase processor
- [#795](https://github.com/opensearch-project/neural-search/pull/795) - Gradle file fixes
- [#835](https://github.com/opensearch-project/neural-search/pull/835) - CI JDK 21 fix
- [#837](https://github.com/opensearch-project/neural-search/pull/837) - Maven publish JDK 21 fix

Closes #2210