### PR TITLE
docs: add index-management-datasource-persistence report for v2.16.0

### DIFF
--- a/docs/features/index-management-dashboards/index-management-dashboards.md
+++ b/docs/features/index-management-dashboards/index-management-dashboards.md
@@ -118,6 +118,7 @@ graph TB
 
 - **v2.19.0** (2025-02-18): Performance improvement using Cat Snapshot API for repository page, bug fixes for snapshot restore alias handling, snapshot policy schedule editing, and index expression display
 - **v2.17.0** (2024-09-17): Comprehensive UI/UX improvements implementing "Look and Feel" and "Fit and Finish" design guidelines across all pages, navigation redesign, notification modal, MDS support for Shrink page, history navigation bug fixes
+- **v2.16.0** (2024-08-06): Fixed data source persistence across sub-applications when new navigation UX is enabled
 
 
 ## References
@@ -148,3 +149,4 @@ graph TB
 | v2.17.0 | [#1157](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1157) | Snapshot Management pages styling |   |
 | v2.17.0 | [#1164](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1164) | Job count in titles |   |
 | v2.17.0 | [#1166](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1166) | History navigation bug fixes |   |
+| v2.16.0 | [#1088](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1088) | Data source persistence across sub-applications | [OpenSearch-Dashboards#7027](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7027) |

--- a/docs/releases/v2.16.0/features/index-management-dashboards/index-management-datasource-persistence.md
+++ b/docs/releases/v2.16.0/features/index-management-dashboards/index-management-datasource-persistence.md
@@ -1,0 +1,85 @@
+---
+tags:
+  - index-management-dashboards
+---
+# Index Management DataSource Persistence
+
+## Summary
+
+Fixed an issue where the selected data source was not persisted when navigating between Index Management sub-applications (Indexes, Policies, Rollups, etc.) under the new navigation UX introduced in OpenSearch Dashboards 2.16.
+
+## Details
+
+### What's New in v2.16.0
+
+This bug fix ensures that when users select a data source in one Index Management page, that selection is maintained when navigating to other Index Management pages using the new left navigation.
+
+### Problem
+
+When the new navigation UX was enabled in OpenSearch Dashboards 2.16, users experienced data source selection being lost when switching between Index Management sub-applications. For example:
+
+1. User selects a remote cluster data source on the Indexes page
+2. User clicks on "Rollup Jobs" in the left navigation
+3. The data source selection resets to local cluster
+
+### Solution
+
+The fix introduces a `BehaviorSubject` observable (`dataSourceObservable`) that maintains the current data source selection across all Index Management sub-applications:
+
+```mermaid
+graph TB
+    subgraph "Index Management Plugin"
+        DSO[dataSourceObservable<br/>BehaviorSubject]
+        Main[Main.tsx]
+        Plugin[plugin.ts]
+    end
+    
+    subgraph "Sub-Applications"
+        Indexes[Indexes]
+        Policies[Policies]
+        Rollups[Rollups]
+        Transforms[Transforms]
+        Snapshots[Snapshots]
+    end
+    
+    Main -->|updates| DSO
+    DSO -->|subscribes| Plugin
+    Plugin -->|updates defaultPath| Indexes
+    Plugin -->|updates defaultPath| Policies
+    Plugin -->|updates defaultPath| Rollups
+    Plugin -->|updates defaultPath| Transforms
+    Plugin -->|updates defaultPath| Snapshots
+```
+
+### Technical Changes
+
+| Component | Change |
+|-----------|--------|
+| `Main.tsx` | Added `dataSourceObservable` BehaviorSubject to track data source selection |
+| `Main.tsx` | Updated constructor to emit data source on initialization if present in URL |
+| `Main.tsx` | Updated `setDataSourceId` to emit changes to observable |
+| `plugin.ts` | Added `AppUpdater` that updates `defaultPath` with current `dataSourceId` |
+| `plugin.ts` | Added `updater$` to all sub-application registrations |
+| `plugin.ts` | Added subscription to `dataSourceObservable` to trigger app updates |
+
+### Implementation Details
+
+The fix uses the OpenSearch Dashboards `AppUpdater` pattern:
+
+1. When a data source is selected, `dataSourceObservable.next()` emits the new value
+2. The plugin subscribes to this observable
+3. On each emission, `appStateUpdater.next()` triggers an update
+4. Each sub-application's `defaultPath` is updated to include `dataSourceId` query parameter
+5. When navigating, the new navigation uses the updated `defaultPath`
+
+## Limitations
+
+- Only applies when the new navigation UX is enabled
+- Requires Multi-Data Source (MDS) feature to be enabled in OpenSearch Dashboards
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#1088](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1088) | Persist dataSourceId across applications under new Nav change | [OpenSearch-Dashboards#7027](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7027) |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -12,6 +12,9 @@
 ### index-management
 - Index Management Build Fixes
 
+### index-management-dashboards
+- Index Management DataSource Persistence
+
 ### job-scheduler
 - Job Scheduler Fixes
 


### PR DESCRIPTION
## Summary

Add documentation for the Index Management DataSource Persistence bug fix in v2.16.0.

## Changes

- Created release report: `docs/releases/v2.16.0/features/index-management-dashboards/index-management-datasource-persistence.md`
- Updated feature report: `docs/features/index-management-dashboards/index-management-dashboards.md`
- Updated release index: `docs/releases/v2.16.0/index.md`

## Bug Fix Details

Fixed an issue where the selected data source was not persisted when navigating between Index Management sub-applications under the new navigation UX.

### Related PR
- [opensearch-project/index-management-dashboards-plugin#1088](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1088)

### Related Issue
- [opensearch-project/OpenSearch-Dashboards#7027](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7027)

Closes #2208