### PR TITLE
docs: add Flow Framework Bugfixes report for v2.16.0

### DIFF
--- a/docs/features/flow-framework/flow-framework.md
+++ b/docs/features/flow-framework/flow-framework.md
@@ -200,6 +200,7 @@ POST /_plugins/_flow_framework/workflow/<id>/_deprovision
 - **v2.19.0** (2025-02-18): Multi-tenancy support with remote metadata storage (DynamoDB, remote OpenSearch); Synchronous provisioning with `wait_for_completion_timeout` parameter for provision and reprovision APIs; Fixed RBAC access control when workflow template is deleted by reading user info from workflow state; Improved logging with Log4j ParameterizedMessage
 - **v2.18.0** (2024-11-05): Added optional config field to tool step for static tool parameters; Incremental resource removal during deprovisioning for better reliability; Removed Painless scripts for workflow state updates with optimistic locking; Fixed template update location in ReprovisionWorkflowTransportAction
 - **v2.17.0** (2024-10-01): Initial Reprovision API implementation supporting updates to search pipelines, ingest pipelines, and index settings
+- **v2.16.0** (2024-08-06): Bug fixes for deprovision error handling (NOT_FOUND exceptions treated as successful deletions for models/agents), system index mapping _doc wrapper, and FlowFrameworkException status code recognition by ExceptionsHelper
 
 
 ## References
@@ -246,6 +247,9 @@ POST /_plugins/_flow_framework/workflow/<id>/_deprovision
 | v2.18.0 | [#918](https://github.com/opensearch-project/flow-framework/pull/918) | Fixed template update location and improved logger statements in ReprovisionWorkflowTransportAction | [#870](https://github.com/opensearch-project/flow-framework/issues/870) |
 | v2.18.0 | [#894](https://github.com/opensearch-project/flow-framework/pull/894) | Update workflow state without using painless script | [#779](https://github.com/opensearch-project/flow-framework/issues/779) |
 | v2.17.0 | [#804](https://github.com/opensearch-project/flow-framework/pull/804) | Adds reprovision API to support updating search pipelines, ingest pipelines, index settings | [#717](https://github.com/opensearch-project/flow-framework/issues/717) |
+| v2.16.0 | [#805](https://github.com/opensearch-project/flow-framework/pull/805) | Handle Not Found deprovision exceptions as successful deletions | [#803](https://github.com/opensearch-project/flow-framework/issues/803) |
+| v2.16.0 | [#809](https://github.com/opensearch-project/flow-framework/pull/809) | Wrap CreateIndexRequest mappings in _doc key as required | [#798](https://github.com/opensearch-project/flow-framework/issues/798) |
+| v2.16.0 | [#811](https://github.com/opensearch-project/flow-framework/pull/811) | Have FlowFrameworkException status recognized by ExceptionsHelper | [#810](https://github.com/opensearch-project/flow-framework/issues/810) |
 
 ### Issues (Design / RFC)
 - [Issue #1254](https://github.com/opensearch-project/flow-framework/issues/1254): Incorrect field map output dimensions in semantic search with local model template
@@ -262,5 +266,8 @@ POST /_plugins/_flow_framework/workflow/<id>/_deprovision
 - [Issue #986](https://github.com/opensearch-project/flow-framework/issues/986): Can't get or delete workflow state without template if filtering by user
 - [Issue #905](https://github.com/opensearch-project/flow-framework/issues/905): Replace String concatenation with Log4j ParameterizedMessage
 - [Issue #878](https://github.com/opensearch-project/flow-framework/issues/878): ML-commons config field in MLToolSpec
+- [Issue #810](https://github.com/opensearch-project/flow-framework/issues/810): Deprovision workflow returns 500 error when workflow ID not found
+- [Issue #803](https://github.com/opensearch-project/flow-framework/issues/803): DeleteModelStep and DeleteAgentStep don't handle NOT_FOUND exceptions
+- [Issue #798](https://github.com/opensearch-project/flow-framework/issues/798): System index mapping does not use required _doc wrapper
 - [Issue #780](https://github.com/opensearch-project/flow-framework/issues/780): Update WorkflowState resources during deprovisioning
 - [Issue #691](https://github.com/opensearch-project/flow-framework/issues/691): Handle deprovision with workflow state update failure

--- a/docs/releases/v2.16.0/features/flow-framework/flow-framework-bugfixes.md
+++ b/docs/releases/v2.16.0/features/flow-framework/flow-framework-bugfixes.md
@@ -1,0 +1,38 @@
+---
+tags:
+  - flow-framework
+---
+# Flow Framework Bugfixes
+
+## Summary
+
+OpenSearch 2.16.0 includes three bug fixes for the Flow Framework plugin that improve error handling during deprovisioning and index creation operations.
+
+## Details
+
+### What's New in v2.16.0
+
+#### NOT_FOUND Exception Handling for Deprovision
+
+When deprovisioning workflows, the `DeleteModelStep` and `DeleteAgentStep` now handle `NOT_FOUND` exceptions as successful deletions. Previously, if a model or agent was manually deleted before deprovisioning, the workflow would fail because ML Commons throws an exception when the resource doesn't exist. This fix treats missing resources as already deleted, allowing deprovisioning to complete successfully.
+
+#### Index Mapping _doc Wrapper Fix
+
+The `FlowFrameworkIndicesHandler` now correctly wraps index mappings in the required `_doc` key when creating system indices. This aligns with the `CreateIndexRequest` javadoc requirements and ensures proper index initialization with the specified mapping rather than inferring mappings from documents.
+
+#### FlowFrameworkException Status Code Fix
+
+The `FlowFrameworkException` class now properly extends `OpenSearchException` and overrides the `status()` method. This ensures that `ExceptionsHelper.status()` returns the correct HTTP status code instead of defaulting to 500 (INTERNAL_SERVER_ERROR). For example, a workflow ID not found error now correctly returns a 404 status.
+
+## Limitations
+
+- These fixes are specific to error handling scenarios and do not change normal workflow behavior
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#805](https://github.com/opensearch-project/flow-framework/pull/805) | Handle Not Found deprovision exceptions as successful deletions | [#803](https://github.com/opensearch-project/flow-framework/issues/803) |
+| [#809](https://github.com/opensearch-project/flow-framework/pull/809) | Wrap CreateIndexRequest mappings in _doc key as required | [#798](https://github.com/opensearch-project/flow-framework/issues/798) |
+| [#811](https://github.com/opensearch-project/flow-framework/pull/811) | Have FlowFrameworkException status recognized by ExceptionsHelper | [#810](https://github.com/opensearch-project/flow-framework/issues/810) |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -9,6 +9,9 @@
 ### dashboards-observability
 - Observability Getting Started & Dashboards
 
+### flow-framework
+- Flow Framework Bugfixes
+
 ### index-management
 - Index Management Build Fixes
 


### PR DESCRIPTION
## Summary
Add release report for Flow Framework Bugfixes in v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/flow-framework/flow-framework-bugfixes.md`
- Feature report: `docs/features/flow-framework/flow-framework.md` (updated)

### Key Changes in v2.16.0
- Handle NOT_FOUND deprovision exceptions as successful deletions for models/agents
- Wrap CreateIndexRequest mappings in _doc key as required
- Have FlowFrameworkException status recognized by ExceptionsHelper

### PRs Investigated
- [#805](https://github.com/opensearch-project/flow-framework/pull/805)
- [#809](https://github.com/opensearch-project/flow-framework/pull/809)
- [#811](https://github.com/opensearch-project/flow-framework/pull/811)