### PR TITLE
docs: add reporting-dependency-updates report for v2.16.0

### DIFF
--- a/docs/features/dashboards-reporting/dashboards-reporting.md
+++ b/docs/features/dashboards-reporting/dashboards-reporting.md
@@ -122,6 +122,7 @@ opensearch-reporting-cli \
 - **v3.0.0** (2025-05-20): Fixed date range handling in report generation, made time parameters optional, fixed popover UI positioning
 - **v2.19.0** (2025-02-18): Sanitize markdown in header/footer preview, fixed CSV nested fields parsing, hide reporting button when MDS enabled in notebooks
 - **v2.18.0** (2024-11-12): Fixed missing EUI component imports in report_settings component
+- **v2.16.0** (2024-08-06): Security dependency updates - jsdom v18 (CVE-2024-37890), ws v7.5.10 (CVE-2024-37890), braces v3.0.3 (CVE-2024-4068)
 
 
 ## References
@@ -143,6 +144,9 @@ opensearch-reporting-cli \
 | v2.19.0 | [#502](https://github.com/opensearch-project/dashboards-reporting/pull/502) | CSV report generation had missing nested fields | [#375](https://github.com/opensearch-project/dashboards-reporting/issues/375) |
 | v2.19.0 | [dashboards-observability#2278](https://github.com/opensearch-project/dashboards-observability/pull/2278) | Updated notebooks reporting button render |   |
 | v2.18.0 | [#464](https://github.com/opensearch-project/dashboards-reporting/pull/464) | Fix missing imports in report_settings |   |
+| v2.16.0 | [#381](https://github.com/opensearch-project/dashboards-reporting/pull/381) | Update dependency jsdom to v18 | [#377](https://github.com/opensearch-project/dashboards-reporting/issues/377) |
+| v2.16.0 | [#385](https://github.com/opensearch-project/dashboards-reporting/pull/385) | Update dependency ws to v7.5.10 | [#377](https://github.com/opensearch-project/dashboards-reporting/issues/377) |
+| v2.16.0 | [#388](https://github.com/opensearch-project/dashboards-reporting/pull/388) | Add braces v3.0.3 to resolution | CVE-2024-4068 |
 
 ### Issues (Design / RFC)
 - [Issue #308](https://github.com/opensearch-project/dashboards-reporting/issues/308): Undefined date throws error while creating CSV

--- a/docs/releases/v2.16.0/features/dashboards-reporting/reporting-dependency-updates.md
+++ b/docs/releases/v2.16.0/features/dashboards-reporting/reporting-dependency-updates.md
@@ -1,0 +1,57 @@
+---
+tags:
+  - dashboards-reporting
+---
+# Reporting Dependency Updates
+
+## Summary
+
+OpenSearch Dashboards Reporting v2.16.0 includes critical security updates for three npm dependencies to address known CVEs. These updates fix vulnerabilities in jsdom, ws (WebSocket), and braces packages.
+
+## Details
+
+### What's New in v2.16.0
+
+Three dependency updates were merged to address security vulnerabilities:
+
+| Dependency | Update | CVE Fixed | Severity |
+|------------|--------|-----------|----------|
+| jsdom | 17.0.0 → 18.0.0 | CVE-2024-37890 | High (7.5) |
+| ws | Resolution to v7.5.10 | CVE-2024-37890 | High |
+| braces | Resolution to v3.0.3 | CVE-2024-4068 | - |
+
+### Technical Changes
+
+#### jsdom Update (PR #381)
+
+The jsdom library was updated from v17.0.0 to v18.0.0. Key changes include:
+
+- Fixed SSL certificate checking for WebSocket connections (previously invalid SSL certificates were always accepted)
+- Changed the global context for Promise and TypeError instances to the jsdom global instead of Node.js global
+- Fixed element tagName cache reset when moving elements between HTML and XML documents
+- Fixed form submission to not happen when the form is invalid
+
+#### ws WebSocket Update (PR #385)
+
+Added resolution for ws package to v7.5.10 to address CVE-2024-37890, a high-severity vulnerability in the WebSocket library.
+
+#### braces Update (PR #388)
+
+Added braces v3.0.3 to package resolutions to address CVE-2024-4068, a vulnerability in the braces package used for brace expansion.
+
+## Limitations
+
+- The jsdom update changes the global context for Promise instances, which could affect code using `instanceof` checks
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#381](https://github.com/opensearch-project/dashboards-reporting/pull/381) | Update dependency jsdom to v18 | [#377](https://github.com/opensearch-project/dashboards-reporting/issues/377) |
+| [#385](https://github.com/opensearch-project/dashboards-reporting/pull/385) | Update dependency ws to v7.5.10 | [#377](https://github.com/opensearch-project/dashboards-reporting/issues/377) |
+| [#388](https://github.com/opensearch-project/dashboards-reporting/pull/388) | Add braces v3.0.3 to resolution | CVE-2024-4068 |
+
+### CVE References
+- [CVE-2024-37890](https://nvd.nist.gov/vuln/detail/CVE-2024-37890): WebSocket vulnerability
+- [CVE-2024-4068](https://nvd.nist.gov/vuln/detail/CVE-2024-4068): braces vulnerability

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -9,6 +9,9 @@
 ### dashboards-observability
 - Observability Getting Started & Dashboards
 
+### dashboards-reporting
+- Reporting Dependency Updates
+
 ### flow-framework
 - Flow Framework Bugfixes
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Dashboards Reporting dependency updates in OpenSearch v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/dashboards-reporting/reporting-dependency-updates.md`
- Feature report: `docs/features/dashboards-reporting/dashboards-reporting.md` (updated)

### Key Changes in v2.16.0
- Updated jsdom from v17.0.0 to v18.0.0 (CVE-2024-37890)
- Added ws v7.5.10 resolution (CVE-2024-37890)
- Added braces v3.0.3 resolution (CVE-2024-4068)

### Resources Used
- PR: #381 (jsdom update)
- PR: #385 (ws update)
- PR: #388 (braces update)

Closes #2206