### PR TITLE
docs: add alerting-build-fixes report for v2.16.0

### DIFF
--- a/docs/features/alerting/alerting.md
+++ b/docs/features/alerting/alerting.md
@@ -164,6 +164,7 @@ POST _plugins/_alerting/monitors
 - **v3.0.0** (2025): Bug fixes for bucket selector aggregation, Java Agent migration, and dashboard subfield selection
 - **v2.18.0** (2024-11-05): Doc-level monitor improvements including dynamic query index deletion (`delete_query_index_in_every_run` flag), query index lifecycle optimization, bucket-level monitor performance optimization for time-series indices, dashboard UX fit-and-finish updates, MDS compatibility fixes
 - **v2.17.0** (2024-09-17): Monitor lock renewal fix, distribution build fixes, workspace navigation fix, trigger name validation fix, alerts card rendering fix, cypress and unit test fixes
+- **v2.16.0** (2024-08-06): Build script fixes to re-enable plugin zip publishing and ensure only alerting plugin (not sample remote monitor plugin) is included in release artifacts
 
 
 ## References
@@ -220,6 +221,8 @@ POST _plugins/_alerting/monitors
 | v2.17.0 | [#1040](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1040) | Fix failed UT of AddAlertingMonitor.test.js |   |
 | v2.17.0 | [#794](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/794) | Fix trigger name validation | [#671](https://github.com/opensearch-project/alerting-dashboards-plugin/issues/671) |
 | v2.17.0 | [#1073](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1073) | Fix alerts card in all-use case overview page |   |
+| v2.16.0 | [#1604](https://github.com/opensearch-project/alerting/pull/1604) | Fix pluginzippublish issue - re-enable publishing zip to staging repo | [#1599](https://github.com/opensearch-project/alerting/issues/1599) |
+| v2.16.0 | [#1605](https://github.com/opensearch-project/alerting/pull/1605) | Fixing build script to only publish alerting zip | [#1599](https://github.com/opensearch-project/alerting/issues/1599) |
 
 ### Issues (Design / RFC)
 - [Issue #1829](https://github.com/opensearch-project/alerting/issues/1829): Alerting does not work with DLS parameter substitution
@@ -227,4 +230,5 @@ POST _plugins/_alerting/monitors
 - [Issue #1853](https://github.com/opensearch-project/alerting/issues/1853): Timebox doc level monitor to avoid duplicate executions
 - [Issue #1859](https://github.com/opensearch-project/alerting/issues/1859): Change publish findings to accept a list of findings
 - [Issue #1617](https://github.com/opensearch-project/alerting/issues/1617): Distribution build issue
+- [Issue #1599](https://github.com/opensearch-project/alerting/issues/1599): Build failure due to missing staging repo directory
 - [Issue #671](https://github.com/opensearch-project/alerting-dashboards-plugin/issues/671): Trigger name validation issue

--- a/docs/releases/v2.16.0/features/alerting/alerting-build-fixes.md
+++ b/docs/releases/v2.16.0/features/alerting/alerting-build-fixes.md
@@ -1,0 +1,54 @@
+---
+tags:
+  - alerting
+---
+# Alerting Build Fixes
+
+## Summary
+
+Fixed build script issues in the Alerting plugin that prevented proper publishing of the alerting zip artifact to the staging repository. The fixes ensure only the main alerting plugin zip is published, excluding the sample remote monitor plugin from release artifacts.
+
+## Details
+
+### What's New in v2.16.0
+
+Two related PRs addressed build script issues that were causing build failures:
+
+1. **PR #1604**: Re-enabled publishing of the alerting zip to the staging repository by removing the exclusion of `publishPluginZipPublicationToMavenLocal` and `publishPluginZipPublicationToZipStagingRepository` tasks from `settings.gradle`. This fixed the error where the build script couldn't find the local staging repo directory.
+
+2. **PR #1605**: Fixed a side-effect from PR #1604 where the sample remote monitor plugin zip was also being published to the artifacts folder. The build script was modified to explicitly copy only the alerting plugin zip (`./alerting/build/distributions/*.zip`) instead of using a wildcard find that matched all zip files.
+
+### Technical Changes
+
+**settings.gradle change (PR #1604)**:
+- Removed: `startParameter.excludedTaskNames=["publishPluginZipPublicationToMavenLocal", "publishPluginZipPublicationToZipStagingRepository"]`
+- This re-enabled the Gradle tasks needed for publishing the plugin zip
+
+**build.sh change (PR #1605)**:
+- Changed from wildcard zip discovery to explicit path
+- Before: `zipPath=$(find . -path \*build/distributions/*.zip)` followed by `cp ${distributions}/*.zip`
+- After: `cp ./alerting/build/distributions/*.zip $OUTPUT/plugins`
+- This ensures only the main alerting plugin is included in release artifacts
+
+### Build Error Fixed
+
+The original error that was occurring:
+```
+cp: cannot stat './build/local-staging-repo/org/opensearch/.': No such file or directory
+ERROR: Command 'bash /tmp/tmp3bqjkb5d/alerting/scripts/build.sh -v 3.0.0 -p linux -a x64 -s false -o builds' returned non-zero exit status 1.
+```
+
+## Limitations
+
+None - these are build infrastructure fixes only.
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#1604](https://github.com/opensearch-project/alerting/pull/1604) | Fix pluginzippublish issue - re-enable publishing zip to staging repo | [#1599](https://github.com/opensearch-project/alerting/issues/1599) |
+| [#1605](https://github.com/opensearch-project/alerting/pull/1605) | Fixing build script to only publish alerting zip | [#1599](https://github.com/opensearch-project/alerting/issues/1599) |
+
+### Issues
+- [#1599](https://github.com/opensearch-project/alerting/issues/1599): Build failure due to missing staging repo directory

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -2,6 +2,9 @@
 
 ## Features
 
+### alerting
+- Alerting Build Fixes
+
 ### anomaly-detection
 - Anomaly Detection JDK21 Upgrade
 - PR Template Updates


### PR DESCRIPTION
## Summary

This PR adds documentation for the Alerting Build Fixes in OpenSearch v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/alerting/alerting-build-fixes.md`
- Feature report: `docs/features/alerting/alerting.md` (updated Change History and References)

### Key Changes in v2.16.0
- Fixed build script to re-enable plugin zip publishing to staging repository
- Ensured only the main alerting plugin zip is published, excluding sample remote monitor plugin

### PRs Investigated
- [#1604](https://github.com/opensearch-project/alerting/pull/1604): Fix pluginzippublish issue
- [#1605](https://github.com/opensearch-project/alerting/pull/1605): Fixing build script to only publish alerting zip

Closes #2204