### PR TITLE
docs: add Observability UI Fixes report for v2.16.0

### DIFF
--- a/docs/features/dashboards-observability/dashboards-observability-observability-ui.md
+++ b/docs/features/dashboards-observability/dashboards-observability-observability-ui.md
@@ -102,6 +102,7 @@ The Observability plugin uses OpenSearch Dashboards saved objects for persistenc
 
 - **v2.18.0** (2024-10-22): Services data picker fix, header control styling updates, custom traces table with filtering (All Spans, Traces, Service Entry, Trace Root), overview page typography, Getting Started workflow restructure (Logs/Metrics/Traces), CI build cache optimization, navigation fixes, x-axis label rotation, and trace-to-logs redirection improvements
 - **v2.17.0** (2024-09-17): UI updates for Traces, Services, Logs, and Dashboards views to align with new header design patterns
+- **v2.16.0** (2024-08-06): Bug fixes including Getting Started toast notifications, Trace Analytics navigation breadcrumb fix, scroll bar reset after fly-out close, Query Assist UI improvements (label rename, auto-focus, placeholder text), datasource unregistration from nav groups, Notebooks MDS UX copy changes, and saved objects URL redirection fix
 
 
 ## References
@@ -132,3 +133,9 @@ The Observability plugin uses OpenSearch Dashboards saved objects for persistenc
 | v2.17.0 | [#2078](https://github.com/opensearch-project/dashboards-observability/pull/2078) | Traces/Services UI update |   |
 | v2.17.0 | [#2090](https://github.com/opensearch-project/dashboards-observability/pull/2090) | Observability dashboards UI update |   |
 | v2.17.0 | [#2092](https://github.com/opensearch-project/dashboards-observability/pull/2092) | Logs UI update |   |
+| v2.16.0 | [#1977](https://github.com/opensearch-project/dashboards-observability/pull/1977) | Add toast message for getting started / Fix Nav Bug for Traces |   |
+| v2.16.0 | [#1972](https://github.com/opensearch-project/dashboards-observability/pull/1972) | Unregister observability datasource from old and new nav group | [OSD #7323](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7323) |
+| v2.16.0 | [#1971](https://github.com/opensearch-project/dashboards-observability/pull/1971) | UX copy changes for Notebooks with MDS |   |
+| v2.16.0 | [#1939](https://github.com/opensearch-project/dashboards-observability/pull/1939) | Fix minor issues in query assist UI |   |
+| v2.16.0 | [#1917](https://github.com/opensearch-project/dashboards-observability/pull/1917) | Trace analytics scroll bar reset | [#1916](https://github.com/opensearch-project/dashboards-observability/issues/1916) |
+| v2.16.0 | [#1998](https://github.com/opensearch-project/dashboards-observability/pull/1998) | Fix redirection URL in saved objects management page for notebooks |   |

--- a/docs/releases/v2.16.0/features/dashboards-observability/observability-ui-fixes.md
+++ b/docs/releases/v2.16.0/features/dashboards-observability/observability-ui-fixes.md
@@ -1,0 +1,74 @@
+---
+tags:
+  - dashboards-observability
+---
+# Observability UI Fixes
+
+## Summary
+
+OpenSearch Dashboards Observability v2.16.0 includes several bug fixes addressing navigation issues, toast notifications, scroll bar behavior, Query Assist UI improvements, datasource registration, notebook UX copy changes, and saved objects redirection.
+
+## Details
+
+### What's New in v2.16.0
+
+This release focuses on UI/UX bug fixes across multiple Observability components:
+
+| Fix | Description |
+|-----|-------------|
+| Getting Started Toast | Added toast message and error handling for getting started asset creation |
+| Trace Analytics Navigation | Fixed breadcrumb navigation bug when new nav changes are active |
+| Scroll Bar Reset | Fixed scroll bar position reset after closing fly-out in Trace Analytics |
+| Query Assist UI | Updated label from "PPL Query" to "Query Assist", auto-focus on form field, updated placeholder text and icon size |
+| Datasource Unregistration | Unregistered observability datasource from old and new nav groups |
+| Notebooks MDS Copy | UX copy changes for migrate notebook functionality with MDS |
+| Saved Objects Redirection | Fixed URL redirection for notebooks in Saved Objects Management page |
+
+### Technical Changes
+
+#### Getting Started Toast Message (PR #1977)
+- Added toast notification for successful/failed asset creation in Getting Started workflow
+- Improved error handling with user-visible error messages
+
+#### Trace Analytics Navigation Fix (PR #1977)
+- Fixed breadcrumb display issue when new navigation mode is enabled
+- Ensures consistent navigation experience across old and new nav modes
+
+#### Scroll Bar Reset (PR #1917)
+- Resets scroll bar to original position after closing trace detail fly-out
+- Resolves issue [#1916](https://github.com/opensearch-project/dashboards-observability/issues/1916)
+
+#### Query Assist UI Improvements (PR #1939)
+- Renamed "PPL Query" label to "Query Assist" for clarity
+- Auto-focuses Query Assist form field on page load
+- Updated get started and placeholder text
+- Adjusted icon sizing for consistency
+
+#### Datasource Navigation Group (PR #1972)
+- Unregistered observability datasource from both old and new navigation groups
+- Related to OpenSearch Dashboards [#7323](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7323)
+
+#### Notebooks MDS UX (PR #1971)
+- Updated UX copy for notebook migration workflow
+- Improved user guidance for MDS-enabled environments
+
+#### Saved Objects URL Fix (PR #1998)
+- Fixed incorrect URL redirection when clicking notebooks in Saved Objects Management
+- Ensures proper navigation to notebook detail pages
+
+## Limitations
+
+- These fixes are specific to the Observability plugin UI and do not affect backend functionality
+- Some fixes (PR #1972) depend on corresponding changes in OpenSearch Dashboards core
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#1977](https://github.com/opensearch-project/dashboards-observability/pull/1977) | Add toast message for getting started / Fix Nav Bug for Traces | |
+| [#1972](https://github.com/opensearch-project/dashboards-observability/pull/1972) | Unregister observability datasource from old and new nav group | [OSD #7323](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/7323) |
+| [#1971](https://github.com/opensearch-project/dashboards-observability/pull/1971) | UX copy changes for Notebooks with MDS | |
+| [#1939](https://github.com/opensearch-project/dashboards-observability/pull/1939) | Fix minor issues in query assist UI | |
+| [#1917](https://github.com/opensearch-project/dashboards-observability/pull/1917) | Trace analytics scroll bar reset | [#1916](https://github.com/opensearch-project/dashboards-observability/issues/1916) |
+| [#1998](https://github.com/opensearch-project/dashboards-observability/pull/1998) | Fix redirection URL in saved objects management page for notebooks | |


### PR DESCRIPTION
## Summary

Adds release report and updates feature report for Observability UI Fixes in v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/dashboards-observability/observability-ui-fixes.md`
- Feature report updated: `docs/features/dashboards-observability/dashboards-observability-observability-ui.md`

### Key Changes in v2.16.0
- Getting Started toast notifications for asset creation
- Trace Analytics navigation breadcrumb fix
- Scroll bar reset after fly-out close
- Query Assist UI improvements (label rename, auto-focus, placeholder text)
- Datasource unregistration from nav groups
- Notebooks MDS UX copy changes
- Saved objects URL redirection fix

### PRs Investigated
- #1977 - Add toast message for getting started / Fix Nav Bug for Traces
- #1972 - Unregister observability datasource from old and new nav group
- #1971 - UX copy changes for Notebooks with MDS
- #1939 - Fix minor issues in query assist UI
- #1917 - Trace analytics scroll bar reset
- #1998 - Fix redirection URL in saved objects management page for notebooks

Closes #2203