### PR TITLE
docs: add security-index-request-fixes report for v2.16.0

### DIFF
--- a/docs/features/security/security-plugin.md
+++ b/docs/features/security/security-plugin.md
@@ -179,7 +179,7 @@ config:
 - **v2.19.0** (2025-02-11): Bugfixes - Netty4HttpRequestHeaderVerifier now handles HTTP upgrade requests by accepting HttpRequest instead of DefaultHttpRequest; Infrastructure - JaCoCo report generation for integTestRemote task, RestHelper TLS configuration updated to use DefaultClientTlsStrategy
 - **v2.18.0** (2024-11-05): Enhancements - datastream support for audit logs, auto-convert V6 to V7 configuration, circuit breaker override for security APIs, improved certificate error messages, JWT in MultipleAuthentication, remote index permissions for AD; Bugfixes - header serialization for rolling upgrades, PBKDF2 password hashing, SSL exception handler; Maintenance - cache endpoint deprecation warning, undeprecate securityadmin script, ASN1 refactoring for FIPS compatibility, CVE-2024-47554 fix
 - **v2.17.0** (2024-09-17): Bugfixes - demo certificate validation, auth token endpoint, audit config null handling, certificate SAN ordering, TermsAggregationEvaluator permissions; Refactoring - security provider instantiation for FIPS support, Log4j utility removal
-- **v2.16.0** (2024-08-06): Maintenance - removed unused Apache CXF dependency, Gradle 8.8→8.9 updates, code cleanup (unnecessary return statements), test framework modernization (Hamcrest matchers), ML roles refactoring, Security Analytics threat intel action support
+- **v2.16.0** (2024-08-06): Bugfixes - fixed NPE when getting metaFields from mapperService on close index request with FLS enabled; Maintenance - removed unused Apache CXF dependency, Gradle 8.8→8.9 updates, code cleanup (unnecessary return statements), test framework modernization (Hamcrest matchers), ML roles refactoring, Security Analytics threat intel action support
 
 
 ## References
@@ -260,6 +260,7 @@ config:
 | v2.17.0 | [#4611](https://github.com/opensearch-project/security/pull/4611) | Refactor security provider instantiation |   |
 | v2.17.0 | [#4653](https://github.com/opensearch-project/security/pull/4653) | Remove Log4j Strings utility usage |   |
 | v2.17.0 | [#4694](https://github.com/opensearch-project/security/pull/4694) | PluginSubject build fix |   |
+| v2.16.0 | [#4497](https://github.com/opensearch-project/security/pull/4497) | Fix NPE getting metaFields on close index request | [#4475](https://github.com/opensearch-project/security/issues/4475) |
 | v2.16.0 | [#4580](https://github.com/opensearch-project/security/pull/4580) | Remove unused Apache CXF dependency |   |
 | v2.16.0 | [#4558](https://github.com/opensearch-project/security/pull/4558) | Remove unnecessary return statements |   |
 | v2.16.0 | [#4553](https://github.com/opensearch-project/security/pull/4553) | Update Gradle to 8.9 |   |

--- a/docs/releases/v2.16.0/features/security/security-index-request-fixes.md
+++ b/docs/releases/v2.16.0/features/security/security-index-request-fixes.md
@@ -1,0 +1,74 @@
+---
+tags:
+  - security
+---
+# Security Index Request Fixes
+
+## Summary
+
+OpenSearch v2.16.0 fixes a NullPointerException (NPE) that occurred in the Security plugin when handling close index requests with Field-Level Security (FLS) enabled. The issue was caused by attempting to retrieve metadata fields from a closed index's mapper service, which returns null.
+
+## Details
+
+### What's New in v2.16.0
+
+#### Bug Fix: NPE on Close Index Request
+
+A NullPointerException was thrown when the Security plugin's `SecurityFlsDlsIndexSearcherWrapper` attempted to get metadata fields from a closed index:
+
+```
+java.lang.NullPointerException: Cannot invoke "org.opensearch.index.mapper.MapperService.getMetadataFields()" 
+because the return value of "org.opensearch.index.IndexService.mapperService()" is null
+```
+
+This occurred because:
+1. PR [#4370](https://github.com/opensearch-project/security/pull/4370) changed the FLS implementation to dynamically retrieve metadata fields from the mapper service
+2. For closed indices, `indexService.mapperService()` returns null since `needsMapperService` returns false for closed indices
+3. The fix adds a check for the index state before attempting to retrieve metadata fields
+
+#### Technical Implementation
+
+The fix modifies `SecurityFlsDlsIndexSearcherWrapper` to:
+1. Check if the index state is `CLOSE` using `indexService.getMetadata().getState()`
+2. If closed, set `metadataFields` to an empty set (closed indices are not searchable anyway)
+3. Log a debug message indicating the index was closed
+
+```java
+if (indexService.getMetadata().getState() == IndexMetadata.State.CLOSE) {
+    log.debug("{} was closed. Setting metadataFields to empty. Closed index is not searchable.",
+        indexService.index().getName());
+    metadataFieldsCopy = Collections.emptySet();
+} else {
+    metadataFieldsCopy = new HashSet<>(indexService.mapperService().getMetadataFields());
+    // ... add additional metadata fields
+}
+```
+
+### Background
+
+This bug was discovered during OpenSearch 2.15 RC generation when ISM (Index State Management) integration tests failed. A revert PR ([#4474](https://github.com/opensearch-project/security/pull/4474)) was introduced to unblock 2.15, and this fix was implemented for 2.16.0.
+
+### Impact
+
+- Affects clusters using Field-Level Security (FLS) with indices that are closed and reopened
+- Without this fix, close/open index operations would fail with NPE when FLS is configured
+- The fix ensures FLS works correctly with index lifecycle operations
+
+## Limitations
+
+- Closed indices remain unsearchable (expected behavior)
+- The fix sets metadata fields to empty for closed indices, which is safe since closed indices cannot be searched
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#4497](https://github.com/opensearch-project/security/pull/4497) | Fix NPE getting metaFields from mapperService on a close index request | [#4475](https://github.com/opensearch-project/security/issues/4475) |
+| [#4474](https://github.com/opensearch-project/security/pull/4474) | Revert PR (for 2.15 unblock) | [#4475](https://github.com/opensearch-project/security/issues/4475) |
+| [#4370](https://github.com/opensearch-project/security/pull/4370) | Original change that introduced the regression | [#4349](https://github.com/opensearch-project/security/issues/4349) |
+
+### Issues
+| Issue | Description |
+|-------|-------------|
+| [#4475](https://github.com/opensearch-project/security/issues/4475) | Investigate ISM failures caused during 2.15 RC generation |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -166,6 +166,7 @@
 ### security
 - Dependency Bumps
 - Security Plugin Maintenance
+- Security Index Request Fixes
 
 ### security-analytics
 - Security Analytics Integration Tests


### PR DESCRIPTION
## Summary

Adds release report for Security Index Request Fixes in OpenSearch v2.16.0.

## Changes

- Created release report: `docs/releases/v2.16.0/features/security/security-index-request-fixes.md`
- Updated feature report: `docs/features/security/security-plugin.md` (Change History and PR table)
- Updated release index: `docs/releases/v2.16.0/index.md`

## Key Findings

This bugfix resolves a NullPointerException that occurred when using Field-Level Security (FLS) with close/open index operations. The issue was introduced in PR #4370 and caused ISM integration test failures during 2.15 RC generation.

### Technical Details
- `SecurityFlsDlsIndexSearcherWrapper` now checks if an index is closed before attempting to retrieve metadata fields from the mapper service
- For closed indices, metadata fields are set to an empty set (safe since closed indices are not searchable)

### Related
- PR: [opensearch-project/security#4497](https://github.com/opensearch-project/security/pull/4497)
- Issue: [opensearch-project/security#4475](https://github.com/opensearch-project/security/issues/4475)

Closes #2200"