### PR TITLE
docs: add nexturl-validation report for v2.16.0

### DIFF
--- a/docs/features/security-dashboards/security-dashboards-plugin.md
+++ b/docs/features/security-dashboards/security-dashboards-plugin.md
@@ -113,7 +113,7 @@ export function validateNextUrl(url: string, basePath: string): string | undefin
 
 - **v2.19.0** (2025-01-21): Fixed OpenID login redirect to preserve query parameters and URL fragments; Fixed tenant defaulting incorrectly based on preferred tenants order instead of default tenant setting
 - **v2.17.0** (2024-09-17): UI/UX enhancements including smaller/compressed components, updated page headers, avatar relocation to left nav, consistency and density improvements; Fixed tenancy app registration, basepath URL validation, page header UX, and navigation titles/descriptions
-- **v2.16.0** (2024-08-06): Security fix for CVE-2024-4068 (braces package ReDoS vulnerability); CI/CD build fixes for Node.js 20 compatibility; Fixed capabilities API to support carrying authentication info; Fixed URL duplication issue when navigating to security plugin
+- **v2.16.0** (2024-08-06): Enhanced nextUrl validation to incorporate serverBasePath for improved security against open redirect attacks; Security fix for CVE-2024-4068 (braces package ReDoS vulnerability); CI/CD build fixes for Node.js 20 compatibility; Fixed capabilities API to support carrying authentication info; Fixed URL duplication issue when navigating to security plugin
 
 
 ## References
@@ -135,6 +135,7 @@ export function validateNextUrl(url: string, basePath: string): string | undefin
 | v2.17.0 | [#2096](https://github.com/opensearch-project/security-dashboards-plugin/pull/2096) | Fix basepath nextUrl validation |   |
 | v2.17.0 | [#2108](https://github.com/opensearch-project/security-dashboards-plugin/pull/2108) | UX fixes for page header |   |
 | v2.17.0 | [#2084](https://github.com/opensearch-project/security-dashboards-plugin/pull/2084) | Update titles and descriptions |   |
+| v2.16.0 | [#2048](https://github.com/opensearch-project/security-dashboards-plugin/pull/2048) | Update nextUrl validation to incorporate serverBasePath |   |
 | v2.16.0 | [#2039](https://github.com/opensearch-project/security-dashboards-plugin/pull/2039) | Addresses CVE-2024-4068 and updates yarn.lock |   |
 | v2.16.0 | [#2060](https://github.com/opensearch-project/security-dashboards-plugin/pull/2060) | Format package.json and update CI workflows |   |
 | v2.16.0 | [#2014](https://github.com/opensearch-project/security-dashboards-plugin/pull/2014) | Fix capabilities API to support carrying authinfo |   |

--- a/docs/releases/v2.16.0/features/security-dashboards/nexturl-validation.md
+++ b/docs/releases/v2.16.0/features/security-dashboards/nexturl-validation.md
@@ -1,0 +1,91 @@
+---
+tags:
+  - security-dashboards
+---
+# Security nextUrl Validation
+
+## Summary
+
+Enhanced the `nextUrl` parameter validation in OpenSearch Security Dashboards Plugin to incorporate the `serverBasePath`. This security enhancement ensures that all redirect URLs after authentication must be prefixed with the configured base path, preventing potential open redirect vulnerabilities.
+
+## Details
+
+### What's New in v2.16.0
+
+The `validateNextUrl` function was updated to require that the `nextUrl` parameter starts with the configured `serverBasePath`. This change affects all authentication types:
+
+- Basic authentication
+- OpenID Connect (OIDC)
+- SAML
+- Proxy authentication
+
+### Technical Changes
+
+#### Updated Validation Logic
+
+The validation function signature changed to accept the base path:
+
+```typescript
+// Before
+export const validateNextUrl = (url: string | undefined): string | void
+
+// After  
+export function validateNextUrl(
+  url: string | undefined,
+  basePath: string | undefined
+): string | void
+```
+
+#### New Validation Criteria
+
+The updated validation checks:
+1. `nextUrl` must start with the configured `basePath` (or `/` if no basePath is set)
+2. If the path (minus basePath) is longer than 2 characters, the second character must be alphabetical or underscore
+3. Following characters must be alphanumeric, dash, or underscore
+
+```typescript
+// server/utils/next_url.ts
+const path = url.split(/\?|#/)[0];
+const bp = basePath || '';
+if (!path.startsWith(bp)) {
+  return INVALID_NEXT_URL_PARAMETER_MESSAGE;
+}
+const pathMinusBase = path.replace(bp, '');
+if (
+  !pathMinusBase.startsWith('/') ||
+  (pathMinusBase.length >= 2 && !/^\/[a-zA-Z_][\/a-zA-Z0-9-_]+$/.test(pathMinusBase))
+) {
+  return INVALID_NEXT_URL_PARAMETER_MESSAGE;
+}
+```
+
+#### Files Modified
+
+| File | Change |
+|------|--------|
+| `server/auth/types/basic/routes.ts` | Added validation with serverBasePath to login page route |
+| `server/auth/types/openid/routes.ts` | Updated validation calls to include serverBasePath |
+| `server/auth/types/proxy/routes.ts` | Updated validation calls to include serverBasePath |
+| `server/auth/types/saml/routes.ts` | Updated validation calls to include serverBasePath |
+| `server/utils/next_url.ts` | Enhanced validation logic with basePath support |
+| `server/utils/next_url.test.ts` | Added tests for basePath validation |
+
+### Security Improvements
+
+This enhancement provides additional protection against:
+- Open redirect attacks via manipulated `nextUrl` parameters
+- URL injection attempts that bypass basePath configuration
+- JavaScript protocol injection attempts
+
+## Limitations
+
+- The validation is stricter than before, which may affect custom integrations that relied on the previous behavior
+- URLs with special characters in the path (beyond alphanumeric, dash, underscore) will be rejected
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#2048](https://github.com/opensearch-project/security-dashboards-plugin/pull/2048) | Update nextUrl validation to incorporate serverBasePath | - |
+| [#2050](https://github.com/opensearch-project/security-dashboards-plugin/pull/2050) | Backport to 2.16 branch | - |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -162,6 +162,7 @@
 ### security-dashboards
 - CVE & Build Fixes
 - Security Dashboards Auth Fixes
+- Security nextUrl Validation
 
 ### security
 - Dependency Bumps


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security nextUrl Validation enhancement in OpenSearch v2.16.0.

### Changes
- Created release report: `docs/releases/v2.16.0/features/security-dashboards/nexturl-validation.md`
- Updated feature report: `docs/features/security-dashboards/security-dashboards-plugin.md`
- Updated release index: `docs/releases/v2.16.0/index.md`

### Key Changes in v2.16.0
- Enhanced `validateNextUrl` function to incorporate `serverBasePath`
- All redirect URLs after authentication must now be prefixed with the configured base path
- Improved protection against open redirect attacks

### Source
- PR: [#2048](https://github.com/opensearch-project/security-dashboards-plugin/pull/2048)

Closes #2198