### PR TITLE
docs: add Security OIDC HTTP Proxy report for v2.16.0

### DIFF
--- a/docs/features/security-dashboards/security-dashboards-plugin.md
+++ b/docs/features/security-dashboards/security-dashboards-plugin.md
@@ -113,7 +113,7 @@ export function validateNextUrl(url: string, basePath: string): string | undefin
 
 - **v2.19.0** (2025-01-21): Fixed OpenID login redirect to preserve query parameters and URL fragments; Fixed tenant defaulting incorrectly based on preferred tenants order instead of default tenant setting
 - **v2.17.0** (2024-09-17): UI/UX enhancements including smaller/compressed components, updated page headers, avatar relocation to left nav, consistency and density improvements; Fixed tenancy app registration, basepath URL validation, page header UX, and navigation titles/descriptions
-- **v2.16.0** (2024-08-06): Enhanced nextUrl validation to incorporate serverBasePath for improved security against open redirect attacks; Security fix for CVE-2024-4068 (braces package ReDoS vulnerability); CI/CD build fixes for Node.js 20 compatibility; Fixed capabilities API to support carrying authentication info; Fixed URL duplication issue when navigating to security plugin
+- **v2.16.0** (2024-08-06): Added HTTP proxy support for OIDC authentication via `proxy-agent` library, enabling OIDC in closed network environments; Enhanced nextUrl validation to incorporate serverBasePath for improved security against open redirect attacks; Security fix for CVE-2024-4068 (braces package ReDoS vulnerability); CI/CD build fixes for Node.js 20 compatibility; Fixed capabilities API to support carrying authentication info; Fixed URL duplication issue when navigating to security plugin
 
 
 ## References
@@ -138,10 +138,12 @@ export function validateNextUrl(url: string, basePath: string): string | undefin
 | v2.16.0 | [#2048](https://github.com/opensearch-project/security-dashboards-plugin/pull/2048) | Update nextUrl validation to incorporate serverBasePath |   |
 | v2.16.0 | [#2039](https://github.com/opensearch-project/security-dashboards-plugin/pull/2039) | Addresses CVE-2024-4068 and updates yarn.lock |   |
 | v2.16.0 | [#2060](https://github.com/opensearch-project/security-dashboards-plugin/pull/2060) | Format package.json and update CI workflows |   |
+| v2.16.0 | [#2024](https://github.com/opensearch-project/security-dashboards-plugin/pull/2024) | HTTP proxy support for OIDC authentication | [#911](https://github.com/opensearch-project/security-dashboards-plugin/issues/911) |
 | v2.16.0 | [#2014](https://github.com/opensearch-project/security-dashboards-plugin/pull/2014) | Fix capabilities API to support carrying authinfo |   |
 | v2.16.0 | [#2004](https://github.com/opensearch-project/security-dashboards-plugin/pull/2004) | Fix URL duplication issue | [#1967](https://github.com/opensearch-project/security-dashboards-plugin/issues/1967) |
 
 ### Issues (Design / RFC)
+- [Issue #911](https://github.com/opensearch-project/security-dashboards-plugin/issues/911): Support httpsProxy in OpenSearch Dashboards for OIDC support
 - [Issue #2056](https://github.com/opensearch-project/security-dashboards-plugin/issues/2056): Tenant link visibility bug
 - [Issue #2097](https://github.com/opensearch-project/security-dashboards-plugin/issues/2097): Basepath nextUrl validation bug
 - [Issue #1823](https://github.com/opensearch-project/security-dashboards-plugin/issues/1823): Auth redirect resets query

--- a/docs/releases/v2.16.0/features/security-dashboards/oidc-http-proxy.md
+++ b/docs/releases/v2.16.0/features/security-dashboards/oidc-http-proxy.md
@@ -1,0 +1,75 @@
+---
+tags:
+  - security-dashboards
+---
+# Security OIDC HTTP Proxy
+
+## Summary
+
+OpenSearch Dashboards v2.16.0 adds HTTP proxy support for OIDC (OpenID Connect) authentication. This enhancement enables organizations operating in closed network environments to use OIDC authentication by routing requests through HTTP/HTTPS proxies.
+
+## Details
+
+### What's New in v2.16.0
+
+The OIDC authentication module now supports HTTP proxy configuration through standard environment variables (`http_proxy`, `https_proxy`, `HTTP_PROXY`, `HTTPS_PROXY`). This allows OpenSearch Dashboards to communicate with external OIDC identity providers through corporate proxy servers.
+
+### Technical Changes
+
+The implementation replaces the standard Node.js HTTP/HTTPS agents with `proxy-agent`, which automatically detects and uses proxy settings from environment variables.
+
+```mermaid
+graph LR
+    subgraph "OpenSearch Dashboards"
+        OIDC[OIDC Auth Module]
+        PA[ProxyAgent]
+    end
+    subgraph "Network"
+        Proxy[HTTP Proxy]
+    end
+    subgraph "External"
+        IDP[OIDC Provider]
+    end
+    
+    OIDC --> PA
+    PA --> Proxy
+    Proxy --> IDP
+```
+
+Key changes in `openid_auth.ts`:
+- Added `proxy-agent` dependency for automatic proxy detection
+- Replaced `HTTP.Agent` and `HTTPS.Agent` with `ProxyAgent`
+- Proxy settings are automatically read from environment variables
+
+### Configuration
+
+No explicit configuration is required in OpenSearch Dashboards. Set standard proxy environment variables before starting the service:
+
+```bash
+export https_proxy=http://proxy.example.com:8080
+export http_proxy=http://proxy.example.com:8080
+```
+
+The `ProxyAgent` automatically detects these environment variables and routes OIDC-related HTTP requests through the configured proxy.
+
+### Use Cases
+
+- Corporate environments requiring all external traffic to pass through a proxy
+- Air-gapped or restricted network deployments with controlled internet access
+- Compliance scenarios where network traffic must be monitored/logged via proxy
+
+## Limitations
+
+- Proxy authentication (username/password) support depends on the `proxy-agent` library capabilities
+- Only affects OIDC authentication flows; other OpenSearch Dashboards HTTP requests may not use the proxy
+- Requires environment variables to be set before OpenSearch Dashboards starts
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#2024](https://github.com/opensearch-project/security-dashboards-plugin/pull/2024) | feat: http proxy support for oidc | [#911](https://github.com/opensearch-project/security-dashboards-plugin/issues/911) |
+
+### Issues
+- [#911](https://github.com/opensearch-project/security-dashboards-plugin/issues/911): Support httpsProxy in OpenSearch Dashboards for OIDC support

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -163,6 +163,7 @@
 - CVE & Build Fixes
 - Security Dashboards Auth Fixes
 - Security nextUrl Validation
+- OIDC HTTP Proxy Support
 
 ### security
 - Dependency Bumps


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security OIDC HTTP Proxy feature introduced in OpenSearch Dashboards v2.16.0.

## Changes

### Release Report
- Created `docs/releases/v2.16.0/features/security-dashboards/oidc-http-proxy.md`
- Documents the HTTP proxy support for OIDC authentication

### Feature Report Update
- Updated `docs/features/security-dashboards/security-dashboards-plugin.md`
- Added v2.16.0 OIDC HTTP proxy enhancement to Change History
- Added PR #2024 to References table
- Added Issue #911 to Issues section

### Release Index Update
- Updated `docs/releases/v2.16.0/index.md`
- Added "OIDC HTTP Proxy Support" under security-dashboards section

## Key Changes in v2.16.0

- Added HTTP proxy support for OIDC authentication via `proxy-agent` library
- Enables OIDC authentication in closed network environments
- Automatically detects proxy settings from environment variables (`http_proxy`, `https_proxy`)

## Resources Used
- PR: [#2024](https://github.com/opensearch-project/security-dashboards-plugin/pull/2024)
- Issue: [#911](https://github.com/opensearch-project/security-dashboards-plugin/issues/911)

Closes #2197