### PR TITLE
docs: add Threat Intel IOC & Source Config report for v2.16.0

### DIFF
--- a/docs/features/security-analytics/security-analytics-threat-intelligence.md
+++ b/docs/features/security-analytics/security-analytics-threat-intelligence.md
@@ -185,6 +185,7 @@ POST _plugins/_security_analytics/threat_intel/sources/
 - **v2.19.0** (2025-02-18): Added source config validation requiring valid name, type, format, source, and ioc_type; Source configs with null values can still be read and deleted
 - **v2.18.0** (2024-11-05): Bug fixes - IOC scan null check for multi-indicator types, ListIOCs API count limits removed (total IOCs and findings per IOC no longer capped at 10,000), IOC index exists check to prevent race conditions, notification listener leak fix, duplicate findings prevention, source config validation, improved error handling for partial failures
 - **v2.17.0** (2024-09-17): Bug fixes for security (user validation, context stashing), stability (multi-node race conditions, event-driven lock release), and integration with standard detectors
+- **v2.16.0** (2024-08-06): List IOC API filter to fetch only from AVAILABLE/REFRESHING sources, null check for IOC index aliases, store config model changes (unique ioc_types, partial IOC downloads), URL_DOWNLOAD source type added
 - **v2.15.0**: Initial threat intelligence feature with S3, IOC_UPLOAD, and URL_DOWNLOAD source types
 
 
@@ -217,6 +218,9 @@ POST _plugins/_security_analytics/threat_intel/sources/
 | v2.17.0 | [#1254](https://github.com/opensearch-project/security-analytics/pull/1254) | Event-driven lock release for source config | [#1224](https://github.com/opensearch-project/security-analytics/issues/1224) |
 | v2.17.0 | [#1274](https://github.com/opensearch-project/security-analytics/pull/1274) | Fix threat intel multinode tests |   |
 | v2.17.0 | [#1278](https://github.com/opensearch-project/security-analytics/pull/1278) | Stash context for List IOCs API |   |
+| v2.16.0 | [#1131](https://github.com/opensearch-project/security-analytics/pull/1131) | Add filter to list IOC API for available/refreshing sources |   |
+| v2.16.0 | [#1133](https://github.com/opensearch-project/security-analytics/pull/1133) | Changes threat intel default store config model |   |
+| v2.16.0 | [#1142](https://github.com/opensearch-project/security-analytics/pull/1142) | Adds new TIF source config type - URL download |   |
 
 ### Issues (Design / RFC)
 - [Issue #1191](https://github.com/opensearch-project/security-analytics/issues/1191): ListIOCsAPI total hits and findings count per IOC are incorrect

--- a/docs/releases/v2.16.0/features/security-analytics/threat-intel-ioc-source-config.md
+++ b/docs/releases/v2.16.0/features/security-analytics/threat-intel-ioc-source-config.md
@@ -1,0 +1,75 @@
+---
+tags:
+  - security-analytics
+---
+# Threat Intel IOC & Source Config
+
+## Summary
+
+OpenSearch v2.16.0 includes enhancements to the Threat Intelligence feature in Security Analytics, focusing on List IOC API improvements, source config model changes, and the addition of URL download as a new threat intel source type.
+
+## Details
+
+### What's New in v2.16.0
+
+#### List IOC API Filter Enhancement
+Added a filter to the List IOC API to fetch IOCs only from sources in `AVAILABLE` and `REFRESHING` states. This ensures users only see IOCs from active, valid sources and prevents errors when querying IOCs from sources that are still being created or have failed.
+
+- Added null check for alias of IOC indices to prevent NPE errors
+- IOCs from sources in `CREATING`, `FAILED`, or `DELETING` states are now excluded from results
+
+#### Default Store Config Model Changes
+Updated the threat intel default store config model to:
+- Ensure no duplicates in `ioc_types` field
+- Allow partial IOC downloads based on specified `ioc_types`
+- Fail source creation if no IOC types are present
+
+#### URL Download Source Type
+Added `URL_DOWNLOAD` as a new threat intel source config type, enabling users to download IOCs directly from a URL endpoint. This complements the existing `S3_CUSTOM` and `IOC_UPLOAD` source types.
+
+```json
+POST _plugins/_security_analytics/threat_intel/sources/
+{
+  "type": "URL_DOWNLOAD",
+  "name": "external-threat-feed",
+  "format": "STIX2",
+  "enabled": true,
+  "schedule": {
+    "interval": {
+      "start_time": 1717097122,
+      "period": "1",
+      "unit": "DAYS"
+    }
+  },
+  "source": {
+    "url": {
+      "url": "https://example.com/threat-feed.json"
+    }
+  },
+  "ioc_types": ["ipv4-addr", "domain-name"]
+}
+```
+
+### Technical Changes
+
+| Change | Description |
+|--------|-------------|
+| List IOC API filter | Only returns IOCs from AVAILABLE/REFRESHING sources |
+| Null check for aliases | Prevents NPE when IOC index alias is null |
+| Store config validation | Ensures unique ioc_types and fails on empty list |
+| URL_DOWNLOAD type | New source type for downloading IOCs from URLs |
+
+## Limitations
+
+- URL_DOWNLOAD sources require the URL to be accessible from the OpenSearch cluster
+- URL endpoints must return data in a supported format (e.g., STIX2)
+- Schedule-based refresh is required for URL_DOWNLOAD sources
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#1131](https://github.com/opensearch-project/security-analytics/pull/1131) | Add filter to list IOC API for available/refreshing sources |  |
+| [#1133](https://github.com/opensearch-project/security-analytics/pull/1133) | Changes threat intel default store config model |  |
+| [#1142](https://github.com/opensearch-project/security-analytics/pull/1142) | Adds new TIF source config type - URL download |  |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -173,6 +173,7 @@
 
 ### security-analytics
 - Security Analytics Integration Tests
+- Threat Intel IOC & Source Config
 
 ### observability
 - Observability CVE Fixes


### PR DESCRIPTION
## Summary

Adds documentation for Threat Intel IOC & Source Config enhancements in OpenSearch v2.16.0.

## Changes

### Release Report Created
- `docs/releases/v2.16.0/features/security-analytics/threat-intel-ioc-source-config.md`

### Feature Report Updated
- `docs/features/security-analytics/security-analytics-threat-intelligence.md`
  - Added v2.16.0 entry to Change History
  - Added v2.16.0 PRs to References section

### Release Index Updated
- `docs/releases/v2.16.0/index.md`

## Key Changes in v2.16.0

- **List IOC API Filter**: Added filter to fetch IOCs only from AVAILABLE/REFRESHING sources
- **Store Config Model**: Ensures unique ioc_types, allows partial IOC downloads
- **URL_DOWNLOAD Source Type**: New source type for downloading IOCs from URLs
- **Null Check**: Added null check for IOC index aliases

## Related Issue
Closes #2196