### PR TITLE
docs: add Security DLS/FLS & Privilege Evaluation report for v2.16.0

### DIFF
--- a/docs/features/security/security-plugin.md
+++ b/docs/features/security/security-plugin.md
@@ -179,7 +179,7 @@ config:
 - **v2.19.0** (2025-02-11): Bugfixes - Netty4HttpRequestHeaderVerifier now handles HTTP upgrade requests by accepting HttpRequest instead of DefaultHttpRequest; Infrastructure - JaCoCo report generation for integTestRemote task, RestHelper TLS configuration updated to use DefaultClientTlsStrategy
 - **v2.18.0** (2024-11-05): Enhancements - datastream support for audit logs, auto-convert V6 to V7 configuration, circuit breaker override for security APIs, improved certificate error messages, JWT in MultipleAuthentication, remote index permissions for AD; Bugfixes - header serialization for rolling upgrades, PBKDF2 password hashing, SSL exception handler; Maintenance - cache endpoint deprecation warning, undeprecate securityadmin script, ASN1 refactoring for FIPS compatibility, CVE-2024-47554 fix
 - **v2.17.0** (2024-09-17): Bugfixes - demo certificate validation, auth token endpoint, audit config null handling, certificate SAN ordering, TermsAggregationEvaluator permissions; Refactoring - security provider instantiation for FIPS support, Log4j utility removal
-- **v2.16.0** (2024-08-06): Bugfixes - fixed NPE when getting metaFields from mapperService on close index request with FLS enabled; Maintenance - removed unused Apache CXF dependency, Gradle 8.8→8.9 updates, code cleanup (unnecessary return statements), test framework modernization (Hamcrest matchers), ML roles refactoring, Security Analytics threat intel action support
+- **v2.16.0** (2024-08-06): Refactoring - separated DLS/FLS privilege evaluation from action privilege evaluation (preparation for optimized privilege evaluation #3870), new FlattenedActionGroups algorithm for action group resolution (handles loops gracefully, pre-computes results), replaced SecurityRoles with Set<String> mappedRoles where full functionality not needed, removed do_not_fail_on_forbidden special handling for cluster actions; Bugfixes - fixed system index permission check to only apply to system indexes (#4429), fixed NPE when getting metaFields from mapperService on close index request with FLS enabled; Maintenance - removed unused Apache CXF dependency, Gradle 8.8→8.9 updates, code cleanup (unnecessary return statements), test framework modernization (Hamcrest matchers), ML roles refactoring, Security Analytics threat intel action support
 
 
 ## References
@@ -261,6 +261,11 @@ config:
 | v2.17.0 | [#4653](https://github.com/opensearch-project/security/pull/4653) | Remove Log4j Strings utility usage |   |
 | v2.17.0 | [#4694](https://github.com/opensearch-project/security/pull/4694) | PluginSubject build fix |   |
 | v2.16.0 | [#4497](https://github.com/opensearch-project/security/pull/4497) | Fix NPE getting metaFields on close index request | [#4475](https://github.com/opensearch-project/security/issues/4475) |
+| v2.16.0 | [#4490](https://github.com/opensearch-project/security/pull/4490) | Separated DLS/FLS privilege evaluation from action privilege evaluation | [#3870](https://github.com/opensearch-project/security/issues/3870) |
+| v2.16.0 | [#4486](https://github.com/opensearch-project/security/pull/4486) | Remove do_not_fail_on_forbidden special handling for cluster actions | [#4485](https://github.com/opensearch-project/security/issues/4485) |
+| v2.16.0 | [#4448](https://github.com/opensearch-project/security/pull/4448) | New FlattenedActionGroups algorithm for action group resolution | [#4380](https://github.com/opensearch-project/security/pull/4380) |
+| v2.16.0 | [#4432](https://github.com/opensearch-project/security/pull/4432) | Replace SecurityRoles with Set<String> mappedRoles | [#4380](https://github.com/opensearch-project/security/pull/4380) |
+| v2.16.0 | [#4430](https://github.com/opensearch-project/security/pull/4430) | Fix system index permission check to only apply to system indexes | [#4429](https://github.com/opensearch-project/security/issues/4429) |
 | v2.16.0 | [#4580](https://github.com/opensearch-project/security/pull/4580) | Remove unused Apache CXF dependency |   |
 | v2.16.0 | [#4558](https://github.com/opensearch-project/security/pull/4558) | Remove unnecessary return statements |   |
 | v2.16.0 | [#4553](https://github.com/opensearch-project/security/pull/4553) | Update Gradle to 8.9 |   |
@@ -292,3 +297,5 @@ config:
 - [Issue #4627](https://github.com/opensearch-project/security/issues/4627): Auth token endpoint issue (v2.17.0)
 - [Issue #4480](https://github.com/opensearch-project/security/issues/4480): Certificate SAN ordering issue (v2.17.0)
 - [Issue #4583](https://github.com/opensearch-project/security/issues/4583): Security provider refactoring (v2.17.0)
+- [Issue #4485](https://github.com/opensearch-project/security/issues/4485): do_not_fail_on_forbidden mode inconsistencies (v2.16.0)
+- [Issue #4429](https://github.com/opensearch-project/security/issues/4429): System index permission check bug (v2.16.0)

--- a/docs/releases/v2.16.0/features/security/security-dls-fls-privilege-evaluation.md
+++ b/docs/releases/v2.16.0/features/security/security-dls-fls-privilege-evaluation.md
@@ -1,0 +1,87 @@
+---
+tags:
+  - security
+---
+# Security DLS/FLS & Privilege Evaluation
+
+## Summary
+
+OpenSearch v2.16.0 includes foundational refactoring work for the Security plugin's privilege evaluation system. These changes separate DLS/FLS (Document-Level Security/Field-Level Security) privilege evaluation from action privilege evaluation, introduce a new action group resolution algorithm, fix system index permission checks, and simplify role handling. This work is part of a larger effort to optimize privilege evaluation performance (Issue #3870).
+
+## Details
+
+### What's New in v2.16.0
+
+#### Separated DLS/FLS Privilege Evaluation
+The `PrivilegesEvaluator.evaluate()` method was refactored to separate DLS/FLS privilege computation from action privilege evaluation. Key improvements:
+- Better separation of concerns and modularization
+- DLS/FLS computations now occur directly in the DLS/FLS valve code
+- If DLS/FLS valve is disabled, no DLS/FLS privileges are computed (performance improvement)
+- New `PrivilegesEvaluationContext` class combines commonly needed information for privilege evaluation
+
+#### Removed do_not_fail_on_forbidden Special Handling
+The special handling for `do_not_fail_on_forbidden` on cluster actions was removed. This eliminates inconsistent behavior where:
+- Multi-part requests (`mget`, `msearch`, `mtv`, `scroll`) required permissions in both `cluster_permissions` and `index_permissions`
+- `_mget` gained invalid index pattern support in `do_not_fail_on_forbidden` mode
+- `indices:data/read/scroll` required index privileges but any index would satisfy the check
+
+After this change, both clusters with `do_not_fail_on_forbidden` set to `true` or `false` require the same set of privileges.
+
+#### New Action Group Resolution Algorithm
+A new `FlattenedActionGroups` class replaces the previous action group resolution in `ConfigModelV7`:
+- Independent class enhancing testability and reusability
+- Handles action group configurations containing loops gracefully (previously caused StackOverflowErrors)
+- Pre-computes resolved action groups for better performance
+
+#### System Index Permission Check Fix
+Fixed a bug where documents in normal indexes could not be queried when `plugins.security.system_indices.permission.enabled` was enabled. The `SecurityIndexSearcherWrapper` was incorrectly checking for `system:admin/system_index` permission for all indexes, not just system indexes.
+
+#### SecurityRoles Simplification
+Replaced uses of `SecurityRoles` with `Set<String> mappedRoles` where the full `SecurityRoles` functionality is not needed. This reduces coupling and prepares for future privilege evaluation optimizations.
+
+### Technical Changes
+
+```mermaid
+graph TB
+    subgraph "Before v2.16.0"
+        PE1[PrivilegesEvaluator.evaluate]
+        PE1 --> Action1[Action Privileges]
+        PE1 --> DLS1[DLS/FLS Privileges]
+        PE1 --> Special[do_not_fail_on_forbidden handling]
+    end
+    
+    subgraph "After v2.16.0"
+        PE2[PrivilegesEvaluator.evaluate]
+        PE2 --> Action2[Action Privileges]
+        Valve[DLS/FLS Valve] --> DLS2[DLS/FLS Privileges]
+        Context[PrivilegesEvaluationContext]
+        PE2 --> Context
+        Valve --> Context
+    end
+```
+
+## Limitations
+
+- These changes are preparatory refactoring for the larger Optimized Privilege Evaluation effort (Issue #3870)
+- Full performance improvements will be realized in future versions when the complete optimization is merged
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#4490](https://github.com/opensearch-project/security/pull/4490) | Separated DLS/FLS privilege evaluation from action privilege evaluation | [#3870](https://github.com/opensearch-project/security/issues/3870) |
+| [#4486](https://github.com/opensearch-project/security/pull/4486) | Remove special handling for do_not_fail_on_forbidden on cluster actions | [#4485](https://github.com/opensearch-project/security/issues/4485) |
+| [#4448](https://github.com/opensearch-project/security/pull/4448) | New algorithm for resolving action groups | [#4380](https://github.com/opensearch-project/security/pull/4380) |
+| [#4430](https://github.com/opensearch-project/security/pull/4430) | Check block request only if system index | [#4429](https://github.com/opensearch-project/security/issues/4429) |
+| [#4432](https://github.com/opensearch-project/security/pull/4432) | Replaced uses of SecurityRoles by Set<String> mappedRoles | [#4380](https://github.com/opensearch-project/security/pull/4380) |
+
+### Related Issues
+- [#3870](https://github.com/opensearch-project/security/issues/3870): Optimized Privilege Evaluation (parent issue)
+- [#4485](https://github.com/opensearch-project/security/issues/4485): do_not_fail_on_forbidden mode introduces inconsistencies
+- [#4429](https://github.com/opensearch-project/security/issues/4429): System index permission check bug
+
+### Documentation
+- [Document-Level Security](https://docs.opensearch.org/2.16/security/access-control/document-level-security/)
+- [Field-Level Security](https://docs.opensearch.org/2.16/security/access-control/field-level-security/)
+- [Security Settings](https://docs.opensearch.org/2.16/install-and-configure/configuring-opensearch/security-settings/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -171,6 +171,7 @@
 - Security Index Request Fixes
 - Security Build & Test Improvements
 - Security REST API Improvements
+- Security DLS/FLS & Privilege Evaluation
 
 ### security-analytics
 - Security Analytics Integration Tests


### PR DESCRIPTION
## Summary

This PR adds documentation for the Security DLS/FLS & Privilege Evaluation enhancements in OpenSearch v2.16.0.

## Changes

### Release Report Created
- `docs/releases/v2.16.0/features/security/security-dls-fls-privilege-evaluation.md`

### Feature Report Updated
- `docs/features/security/security-plugin.md` - Added v2.16.0 changes to Change History and References

### Release Index Updated
- `docs/releases/v2.16.0/index.md` - Added new feature entry

## Key Changes in v2.16.0

- **Separated DLS/FLS privilege evaluation** from action privilege evaluation (preparation for optimized privilege evaluation #3870)
- **New FlattenedActionGroups algorithm** for action group resolution (handles loops gracefully, pre-computes results)
- **Replaced SecurityRoles with Set<String> mappedRoles** where full functionality not needed
- **Removed do_not_fail_on_forbidden special handling** for cluster actions
- **Fixed system index permission check** to only apply to system indexes (#4429)

## Related PRs
- [#4490](https://github.com/opensearch-project/security/pull/4490) - Separated DLS/FLS privilege evaluation
- [#4486](https://github.com/opensearch-project/security/pull/4486) - Remove do_not_fail_on_forbidden special handling
- [#4448](https://github.com/opensearch-project/security/pull/4448) - New action group resolution algorithm
- [#4430](https://github.com/opensearch-project/security/pull/4430) - System index permission check fix
- [#4432](https://github.com/opensearch-project/security/pull/4432) - SecurityRoles simplification

Closes #2194