### PR TITLE
docs: add bedrock-runtime-agent report for v2.16.0

### DIFF
--- a/docs/features/ml-commons/ml-commons-agent-framework.md
+++ b/docs/features/ml-commons/ml-commons-agent-framework.md
@@ -239,6 +239,7 @@ PUT /_plugins/_ml/agents/{agent_id}
 - **v3.2.0** (2025-09-16): Execute Tool API, AI-oriented memory container system (create, add, search, update, delete, get), QueryPlanningTool for agentic search, date/time injection for agents, message history limit for PER Agent, output filter support, SearchIndexTool improvements, feature flags for agentic search/memory, multiple bug fixes (class cast exception, connector URL exposure, async status, max iterations handling)
 - **v3.1.0** (2025-07-15): Update Agent API, MCP tools persistence, function calling for LLM interfaces, custom SSE endpoint, metrics framework integration, PlanExecuteReflect memory tracking, error handling improvements, multiple bug fixes (private IP validation, circuit breaker bypass, Python MCP client)
 - **v3.0.0** (2025-05-13): Plan-Execute-Reflect agent type, MCP server integration
+- **v2.16.0** (2024-08-06): Bedrock Runtime Agent support for Amazon Bedrock Knowledge Base, enhanced tool parameter passing with chat_history
 - **v2.13.0** (2024-03-26): Initial agent framework with flow and conversational agents
 
 
@@ -277,6 +278,8 @@ PUT /_plugins/_ml/agents/{agent_id}
 | v3.1.0 | [#3862](https://github.com/opensearch-project/ml-commons/pull/3862) | Fix connector private IP validation when executing agent | [#3839](https://github.com/opensearch-project/ml-commons/issues/3839) |
 | v3.1.0 | [#3814](https://github.com/opensearch-project/ml-commons/pull/3814) | Exclude circuit breaker for Agent |   |
 | v3.1.0 | [#3822](https://github.com/opensearch-project/ml-commons/pull/3822) | Fix Python client MCP server connection |   |
+| v2.16.0 | [#2651](https://github.com/opensearch-project/ml-commons/pull/2651) | Add bedrock runtime agent for knowledge base |   |
+| v2.16.0 | [#2714](https://github.com/opensearch-project/ml-commons/pull/2714) | Pass all parameters including chat_history to run tools |   |
 
 ### Issues (Design / RFC)
 - [Issue #4197](https://github.com/opensearch-project/ml-commons/issues/4197): Failure message update feature request

--- a/docs/releases/v2.16.0/features/ml-commons/bedrock-runtime-agent.md
+++ b/docs/releases/v2.16.0/features/ml-commons/bedrock-runtime-agent.md
@@ -1,0 +1,110 @@
+---
+tags:
+  - ml-commons
+---
+# Bedrock Runtime Agent
+
+## Summary
+
+OpenSearch v2.16.0 adds support for Amazon Bedrock Runtime Agent, enabling integration with Amazon Bedrock Knowledge Base. This enhancement also improves agent tool execution by passing all parameters including chat history to tools.
+
+## Details
+
+### What's New in v2.16.0
+
+1. **Bedrock Agent Runtime URL Support**: Added `bedrock-agent-runtime` to the allowed connector URL patterns, enabling connections to Amazon Bedrock Knowledge Base service.
+
+2. **Enhanced Tool Parameter Passing**: Modified `MLChatAgentRunner` to pass all parameters (including `chat_history`) to tools during execution, enabling tools to access full conversation context.
+
+### Technical Changes
+
+**Connector URL Allowlist Update**
+
+The `plugins.ml_commons.trusted_connector_endpoints_regex` setting now includes:
+```
+^https://bedrock-agent-runtime\..*[a-z0-9-]\.amazonaws\.com/.*$
+```
+
+This allows connectors to call Amazon Bedrock Agent Runtime APIs for knowledge base retrieval.
+
+**Tool Parameter Enhancement**
+
+In `MLChatAgentRunner.runTool()`, tool execution now receives merged parameters:
+```java
+Map<String, String> parameters = new HashMap<>();
+parameters.putAll(tmpParameters);  // Includes chat_history
+parameters.putAll(toolParams);
+tools.get(action).run(parameters, toolListener);
+```
+
+### Usage Example
+
+**Create a Bedrock Knowledge Base Connector:**
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "Amazon Bedrock Connector: knowledge",
+  "description": "The connector to the Bedrock knowledge base",
+  "version": 1,
+  "protocol": "aws_sigv4",
+  "parameters": {
+    "region": "<YOUR_AWS_REGION>",
+    "service_name": "bedrock"
+  },
+  "credential": {
+    "access_key": "<YOUR_ACCESS_KEY>",
+    "secret_key": "<YOUR_SECRET_KEY>"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://bedrock-agent-runtime.<region>.amazonaws.com/knowledgebases/<kb_id>/retrieve",
+      "headers": {
+        "content-type": "application/json",
+        "x-amz-content-sha256": "required"
+      },
+      "request_body": "{\"retrievalQuery\": {\"text\": \"${parameters.text}\"}}"
+    }
+  ]
+}
+```
+
+**Register a model using the connector:**
+```json
+POST /_plugins/_ml/models/_register?deploy=true
+{
+  "name": "bedrock: knowledge base",
+  "function_name": "remote",
+  "description": "Connector for bedrock knowledge base",
+  "connector_id": "<connector_id>"
+}
+```
+
+**Query the knowledge base:**
+```json
+POST /_plugins/_ml/models/<model_id>/_predict
+{
+  "parameters": {
+    "text": "your search query"
+  }
+}
+```
+
+## Limitations
+
+- Requires valid AWS credentials with appropriate Bedrock permissions
+- Knowledge base must be pre-configured in Amazon Bedrock
+- AWS SigV4 authentication is required for Bedrock Agent Runtime APIs
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#2651](https://github.com/opensearch-project/ml-commons/pull/2651) | Add bedrock runtime agent for knowledge base | - |
+| [#2714](https://github.com/opensearch-project/ml-commons/pull/2714) | Pass all parameters including chat_history to run tools | - |
+
+### Documentation
+- [Connectors](https://docs.opensearch.org/2.16/ml-commons-plugin/remote-models/connectors/)
+- [Connector Blueprints](https://docs.opensearch.org/2.16/ml-commons-plugin/remote-models/blueprints/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -44,6 +44,7 @@
 - System Index & Dependencies
 - ML Commons Blueprints & Tutorials
 - Connector & Model Fixes
+- Bedrock Runtime Agent
 
 ### multi-plugin
 - MDS Version Decoupling (Plugins)


### PR DESCRIPTION
## Summary

Adds documentation for Bedrock Runtime Agent feature in OpenSearch v2.16.0.

### Changes
- Created release report: `docs/releases/v2.16.0/features/ml-commons/bedrock-runtime-agent.md`
- Updated feature report: `docs/features/ml-commons/ml-commons-agent-framework.md` (added v2.16.0 to Change History and References)
- Updated release index: `docs/releases/v2.16.0/index.md`

### Key Features in v2.16.0
- Added `bedrock-agent-runtime` URL pattern to allowed connector endpoints
- Enhanced tool parameter passing to include `chat_history` for conversation context

### Related PRs
- [ml-commons#2651](https://github.com/opensearch-project/ml-commons/pull/2651): Add bedrock runtime agent for knowledge base
- [ml-commons#2714](https://github.com/opensearch-project/ml-commons/pull/2714): Pass all parameters including chat_history to run tools

Closes #2190