### PR TITLE
docs: add Conversation Memory report for v2.16.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -6,6 +6,10 @@ Cumulative feature documentation across all versions.
 
 - Alerting Integration
 
+## ml-commons
+
+- Conversation Memory
+
 ## neural-search
 
 - Batch Ingestion

--- a/docs/features/ml-commons/ml-commons-conversation-memory.md
+++ b/docs/features/ml-commons/ml-commons-conversation-memory.md
@@ -1,0 +1,132 @@
+---
+tags:
+  - ml-commons
+---
+# Conversation Memory
+
+## Summary
+
+Conversation Memory is a feature in OpenSearch ML Commons that enables AI agents and conversational search applications to maintain context across multiple interactions. It provides a persistent storage mechanism for conversation history, allowing LLMs to understand follow-up questions and provide contextually relevant responses. The feature supports creating, retrieving, updating, and deleting both conversations (memories) and individual messages (interactions).
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Conversation Memory"
+        MEM[Memory<br/>Conversation container]
+        MEM --> |contains| MSG1[Message 1<br/>Q&A pair]
+        MEM --> |contains| MSG2[Message 2<br/>Q&A pair]
+        MEM --> |contains| MSGN[Message N<br/>Q&A pair]
+    end
+    
+    subgraph "Integration Points"
+        RAG[RAG Pipeline]
+        AGENT[Conversational Agent]
+    end
+    
+    RAG --> |stores/retrieves| MEM
+    AGENT --> |stores/retrieves| MEM
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Memory | A container that holds all messages for a single conversation |
+| Message (Interaction) | A question/answer pair within a conversation |
+| Memory APIs | REST APIs for CRUD operations on memories and messages |
+| ConversationalMemoryHandler | Internal handler for memory operations |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.ml_commons.memory_feature_enabled` | Enable/disable the Conversation Memory feature | `true` |
+| `plugins.ml_commons.rag_pipeline_feature_enabled` | Enable/disable RAG pipeline (uses memory) | `false` |
+
+### API Endpoints
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/_plugins/_ml/memory/` | POST | Create a new memory |
+| `/_plugins/_ml/memory/{memory_id}` | GET | Get a memory by ID |
+| `/_plugins/_ml/memory/{memory_id}` | PUT | Update a memory |
+| `/_plugins/_ml/memory/{memory_id}` | DELETE | Delete a memory |
+| `/_plugins/_ml/memory/_search` | GET/POST | Search memories |
+| `/_plugins/_ml/memory/{memory_id}/messages` | POST | Create a message |
+| `/_plugins/_ml/memory/{memory_id}/messages` | GET | Get messages in a memory |
+| `/_plugins/_ml/memory/{memory_id}/messages/_search` | GET/POST | Search messages |
+
+### Usage Example
+
+**Create a Conversation Memory**
+```json
+POST /_plugins/_ml/memory/
+{
+  "name": "Customer Support Conversation"
+}
+```
+
+Response:
+```json
+{
+  "memory_id": "znCqcI0BfUsSoeNTntd7"
+}
+```
+
+**Add a Message to the Conversation**
+```json
+POST /_plugins/_ml/memory/znCqcI0BfUsSoeNTntd7/messages
+{
+  "input": "What is the population of NYC?",
+  "prompt_template": "You are a helpful assistant",
+  "response": "The population of NYC metro area is approximately 18.9 million.",
+  "origin": "retrieval_augmented_generation",
+  "additional_info": {}
+}
+```
+
+**Use with RAG Pipeline**
+```json
+GET /my_index/_search
+{
+  "query": {
+    "match": { "text": "What was it in 2022" }
+  },
+  "ext": {
+    "generative_qa_parameters": {
+      "llm_model": "gpt-3.5-turbo",
+      "llm_question": "What was it in 2022",
+      "memory_id": "znCqcI0BfUsSoeNTntd7",
+      "context_size": 5,
+      "message_size": 5
+    }
+  }
+}
+```
+
+## Limitations
+
+- When the Security plugin is enabled, all memories exist in a private security mode - only the user who created a memory can interact with it
+- Memory names cannot be updated after creation
+- The feature requires explicit enablement via cluster settings
+- Token limits of LLMs constrain the amount of conversation history that can be sent as context
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Promoted from experimental to GA; removed "experimental" label from all error messages
+- **v2.12.0** (2024-02-20): Initial experimental release with Memory APIs for conversational search
+
+## References
+
+### Documentation
+- [Memory APIs](https://docs.opensearch.org/latest/ml-commons-plugin/api/memory-apis/index/)
+- [Conversational Search](https://docs.opensearch.org/latest/search-plugins/conversational-search/)
+- [RAG Chatbot Tutorial](https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/rag-chatbot/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#2592](https://github.com/opensearch-project/ml-commons/pull/2592) | Removing experimental from the Conversation memory feature |

--- a/docs/releases/v2.16.0/features/ml-commons/conversation-memory.md
+++ b/docs/releases/v2.16.0/features/ml-commons/conversation-memory.md
@@ -1,0 +1,65 @@
+---
+tags:
+  - ml-commons
+---
+# Conversation Memory
+
+## Summary
+
+In OpenSearch 2.16.0, the Conversation Memory feature has been promoted from experimental to generally available (GA). This change removes the "experimental" designation from all Conversation Memory APIs and error messages, signaling that the feature is now production-ready and stable.
+
+## Details
+
+### What's New in v2.16.0
+
+The Conversation Memory feature, which was introduced as experimental in v2.12.0, is now officially GA. The primary change involves:
+
+- Removing the "experimental" label from error messages across all Conversation Memory transport actions
+- Centralizing the disabled feature message into a constant (`ML_COMMONS_MEMORY_FEATURE_DISABLED_MESSAGE`)
+- Code cleanup including method reference improvements and logging format updates
+
+### Technical Changes
+
+The following transport actions were updated to use the new standardized error message:
+
+| Transport Action | Description |
+|-----------------|-------------|
+| `CreateConversationTransportAction` | Creates a new conversation memory |
+| `CreateInteractionTransportAction` | Creates a message within a conversation |
+| `DeleteConversationTransportAction` | Deletes a conversation memory |
+| `GetConversationTransportAction` | Retrieves a single conversation |
+| `GetConversationsTransportAction` | Lists all conversations |
+| `GetInteractionTransportAction` | Retrieves a single message |
+| `GetInteractionsTransportAction` | Lists messages in a conversation |
+| `SearchConversationsTransportAction` | Searches conversations |
+| `SearchInteractionsTransportAction` | Searches messages |
+| `UpdateConversationTransportAction` | Updates conversation metadata |
+| `UpdateInteractionTransportAction` | Updates message metadata |
+
+### Error Message Change
+
+Before v2.16.0:
+```
+The experimental Conversation Memory feature is not enabled. To enable, please update the setting plugins.ml_commons.memory_feature_enabled
+```
+
+After v2.16.0:
+```
+The Conversation Memory feature is not enabled. To enable, please update the setting plugins.ml_commons.memory_feature_enabled
+```
+
+## Limitations
+
+- The feature must still be explicitly enabled via the `plugins.ml_commons.memory_feature_enabled` setting (default: `true`)
+- When the Security plugin is enabled, all memories exist in a private security mode - only the user who created a memory can interact with it
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#2592](https://github.com/opensearch-project/ml-commons/pull/2592) | Removing experimental from the Conversation memory feature | - |
+
+### Documentation
+- [Memory APIs](https://docs.opensearch.org/2.16/ml-commons-plugin/api/memory-apis/index/)
+- [Conversational Search](https://docs.opensearch.org/2.16/search-plugins/conversational-search/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -45,6 +45,7 @@
 - ML Commons Blueprints & Tutorials
 - Connector & Model Fixes
 - Bedrock Runtime Agent
+- Conversation Memory
 
 ### multi-plugin
 - MDS Version Decoupling (Plugins)


### PR DESCRIPTION
## Summary

This PR adds documentation for the Conversation Memory feature promotion to GA in OpenSearch v2.16.0.

## Changes

### Release Report
- `docs/releases/v2.16.0/features/ml-commons/conversation-memory.md`
  - Documents the removal of "experimental" label from Conversation Memory
  - Lists all affected transport actions
  - Shows the error message change

### Feature Report
- `docs/features/ml-commons/ml-commons-conversation-memory.md`
  - Comprehensive documentation of the Conversation Memory feature
  - Architecture diagram
  - API endpoints and usage examples
  - Configuration settings
  - Change history tracking v2.12.0 (experimental) → v2.16.0 (GA)

### Index Updates
- Updated `docs/features/index.md` to include Conversation Memory under ml-commons
- Updated `docs/releases/v2.16.0/index.md` to include Conversation Memory

## Related Issue
Closes #2189