### PR TITLE
docs: add Job Scheduler lock index protection report for v2.16.0

### DIFF
--- a/docs/features/job-scheduler/job-scheduler.md
+++ b/docs/features/job-scheduler/job-scheduler.md
@@ -210,7 +210,7 @@ Job Scheduler supports two schedule formats:
 - **v3.0.0** (2025): CI/CD improvements, JPMS compatibility fixes, conditional demo certificate downloads
 - **v2.18.0** (2024-11-05): Return LockService from createComponents for Guice injection, enabling shared lock service across plugins
 - **v2.17.0** (2024-09-17): Fixed system index compatibility with v1 templates in LockService and JobDetailsService
-- **v2.16.0** (2024-08-06): Fixed CI workflow GLIBC compatibility issue by enabling Node16 fallback for GitHub Actions
+- **v2.16.0** (2024-08-06): Wrapped all lock index interactions with `ThreadContext.stashContext()` to enable system index protection compatibility; Fixed CI workflow GLIBC compatibility issue by enabling Node16 fallback for GitHub Actions
 
 
 ## References
@@ -246,6 +246,7 @@ Job Scheduler supports two schedule formats:
 | v3.0.0 | [#737](https://github.com/opensearch-project/job-scheduler/pull/737) | Only download demo certs when integTest run with -Dsecurity.enabled=true |   |
 | v2.18.0 | [#670](https://github.com/opensearch-project/job-scheduler/pull/670) | Return LockService from createComponents for Guice injection | [#238](https://github.com/opensearch-project/opensearch-plugins/issues/238) |
 | v2.17.0 | [#658](https://github.com/opensearch-project/job-scheduler/pull/658) | Fix system index compatibility with v1 templates | [#14984](https://github.com/opensearch-project/OpenSearch/issues/14984) |
+| v2.16.0 | [#347](https://github.com/opensearch-project/job-scheduler/pull/347) | Wrap lock index interactions with ThreadContext.stashContext | [#305](https://github.com/opensearch-project/job-scheduler/issues/305) |
 | v2.16.0 | [#650](https://github.com/opensearch-project/job-scheduler/pull/650) | Fix checkout action failure (GLIBC compatibility) | [actions/checkout#1809](https://github.com/actions/checkout/issues/1809) |
 
 ### Issues (Design / RFC)

--- a/docs/releases/v2.16.0/features/job-scheduler/job-scheduler-lock-index-protection.md
+++ b/docs/releases/v2.16.0/features/job-scheduler/job-scheduler-lock-index-protection.md
@@ -1,0 +1,61 @@
+---
+tags:
+  - job-scheduler
+---
+# Job Scheduler Lock Index Protection
+
+## Summary
+
+Enhanced the Job Scheduler plugin to wrap all interactions with the `.opendistro-job-scheduler-lock` system index inside `ThreadContext.stashContext()`. This ensures the plugin can properly read and write to the lock index even when system index protections are enabled.
+
+## Details
+
+### What's New in v2.16.0
+
+The Job Scheduler plugin uses a lock index (`.opendistro-job-scheduler-lock`) to prevent concurrent job execution across cluster nodes. With enhanced system index protections in OpenSearch, direct access to system indices can be blocked even for plugins.
+
+This enhancement wraps all lock index operations with `ThreadContext.stashContext()`, which temporarily clears the thread context to allow privileged access to system indices.
+
+### Technical Changes
+
+The `LockService` class was modified to wrap the following operations:
+
+| Method | Operation |
+|--------|-----------|
+| `createLockIndex()` | Creating the lock index |
+| `createLock()` | Creating a new lock document |
+| `updateLock()` | Updating an existing lock |
+| `findLock()` | Finding a lock by ID |
+| `deleteLock()` | Deleting a lock |
+
+Each method now uses the pattern:
+
+```java
+try (ThreadContext.StoredContext ignore = client.threadPool().getThreadContext().stashContext()) {
+    // Lock index operation
+} catch (Exception e) {
+    logger.error(e);
+    listener.onFailure(e);
+}
+```
+
+### Why This Matters
+
+System indices have special protections that prevent inadvertent modification by users, including admin users. Without this change, the Job Scheduler plugin could fail to acquire or release locks when system index protections are enforced, causing scheduled jobs to fail or run concurrently.
+
+## Limitations
+
+- This is a preparatory change for full system index registration (completed separately in PR #474)
+- The lock index itself is not yet registered as a system index in this PR
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#347](https://github.com/opensearch-project/job-scheduler/pull/347) | Wrap interactions with `.opendistro-job-scheduler-lock` in ThreadContext.stashContext | [#305](https://github.com/opensearch-project/job-scheduler/issues/305) |
+
+### Related Issues
+| Issue | Description |
+|-------|-------------|
+| [#305](https://github.com/opensearch-project/job-scheduler/issues/305) | Make the job scheduler lock index a system index |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -32,6 +32,7 @@
 
 ### job-scheduler
 - Job Scheduler Fixes
+- Job Scheduler Lock Index Protection
 
 ### k-nn
 - Faiss Updates


### PR DESCRIPTION
## Summary

Added release report for Job Scheduler lock index protection enhancement in v2.16.0.

### Changes
- Created release report: `docs/releases/v2.16.0/features/job-scheduler/job-scheduler-lock-index-protection.md`
- Updated feature report: `docs/features/job-scheduler/job-scheduler.md` (Change History and PR references)
- Updated release index: `docs/releases/v2.16.0/index.md`

### Key Changes in v2.16.0
- Wrapped all lock index interactions with `ThreadContext.stashContext()` to enable system index protection compatibility
- This allows the Job Scheduler plugin to properly read/write to the `.opendistro-job-scheduler-lock` system index

### Related
- PR: [opensearch-project/job-scheduler#347](https://github.com/opensearch-project/job-scheduler/pull/347)
- Issue: [opensearch-project/job-scheduler#305](https://github.com/opensearch-project/job-scheduler/issues/305)

Closes #2187