### PR TITLE
docs: add lucene-scalar-quantizer report for v2.16.0

### DIFF
--- a/docs/features/k-nn/index.md
+++ b/docs/features/k-nn/index.md
@@ -12,6 +12,7 @@
 | [k-nn-iterative-graph-build](k-nn-iterative-graph-build.md) | k-NN Iterative Graph Build |
 | [k-nn-late-interaction](k-nn-late-interaction.md) | Late Interaction |
 | [k-nn-lucene-on-faiss](k-nn-lucene-on-faiss.md) | Lucene On Faiss (Memory Optimized Search) |
+| [k-nn-lucene-scalar-quantizer](k-nn-lucene-scalar-quantizer.md) | Lucene Scalar Quantizer |
 | [k-nn-lucene-vector-integration](k-nn-lucene-vector-integration.md) | k-NN Lucene Vector Integration |
 | [k-nn-maximal-marginal-relevance-mmr](k-nn-maximal-marginal-relevance-mmr.md) | Maximal Marginal Relevance (MMR) |
 | [k-nn-memory-optimized-warmup](k-nn-memory-optimized-warmup.md) | k-NN Memory Optimized Warmup |

--- a/docs/features/k-nn/k-nn-lucene-scalar-quantizer.md
+++ b/docs/features/k-nn/k-nn-lucene-scalar-quantizer.md
@@ -1,0 +1,135 @@
+---
+tags:
+  - k-nn
+---
+# Lucene Scalar Quantizer
+
+## Summary
+
+The Lucene Scalar Quantizer is a built-in vector quantization feature in the k-NN plugin that automatically compresses 32-bit floating-point vectors to 7-bit integers during ingestion. This reduces memory footprint by approximately 75% while maintaining acceptable search recall, without requiring pre-quantization of vectors before indexing.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph Ingestion
+        A[fp32 Vector] --> B[Lucene SQ Encoder]
+        B --> C[Compute Quantiles]
+        C --> D[7-bit Quantized Vector]
+        D --> E[Store in Segment]
+    end
+    
+    subgraph Search
+        F[Query Vector] --> G[Load Segment Quantiles]
+        G --> H[Quantize Query]
+        H --> I[Distance Computation]
+        I --> J[Results]
+    end
+```
+
+### How It Works
+
+1. **Ingestion**: Input fp32 vectors are quantized to 7-bit integers using min/max quantiles computed from the data
+2. **Per-segment quantization**: Each Lucene segment maintains its own quantile values
+3. **Search**: Query vectors are quantized using segment-specific quantiles for distance computation
+4. **Storage**: Both raw vectors and quantized vectors are stored (slight disk overhead)
+
+### Configuration
+
+| Parameter | Description | Default | Valid Values |
+|-----------|-------------|---------|--------------|
+| `bits` | Quantization bit depth | `7` | `7` only |
+| `confidence_interval` | Controls quantile computation | Dimension-based | `0` or `0.9`-`1.0` |
+
+### Confidence Interval
+
+The `confidence_interval` parameter determines how min/max quantiles are computed:
+
+| Value | Behavior |
+|-------|----------|
+| `0.9` - `1.0` | Static: Uses middle N% of vector values |
+| `0` | Dynamic: Oversampling with additional computation |
+| Not set | Computed as `max(0.9, 1 - 1/(1 + dimension))` |
+
+### Usage Example
+
+```json
+PUT /my-index
+{
+  "settings": {
+    "index": { "knn": true }
+  },
+  "mappings": {
+    "properties": {
+      "embedding": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "method": {
+          "name": "hnsw",
+          "engine": "lucene",
+          "space_type": "l2",
+          "parameters": {
+            "encoder": {
+              "name": "sq",
+              "parameters": {
+                "confidence_interval": 0.95
+              }
+            },
+            "m": 16,
+            "ef_construction": 100
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Memory Estimation
+
+HNSW with scalar quantization: `1.1 * (dimension + 8 * M)` bytes/vector
+
+| Vectors | Dimension | M | Memory (SQ) | Memory (fp32) | Savings |
+|---------|-----------|---|-------------|---------------|---------|
+| 1M | 256 | 16 | ~0.4 GB | ~1.6 GB | 75% |
+| 1M | 768 | 16 | ~1.0 GB | ~3.5 GB | 71% |
+| 10M | 256 | 16 | ~4.0 GB | ~16 GB | 75% |
+
+### Comparison with Other Quantization Methods
+
+| Method | Engine | Compression | Pre-quantization Required | Recall Impact |
+|--------|--------|-------------|---------------------------|---------------|
+| Lucene SQ | Lucene | ~75% | No | Low |
+| Lucene Byte Vector | Lucene | 75% | Yes | Low |
+| Faiss SQfp16 | Faiss | 50% | No | Minimal |
+| Faiss PQ | Faiss | Configurable | Training required | Variable |
+
+## Limitations
+
+- Only 7-bit quantization supported (8-bit disabled due to recall degradation)
+- Requires `float` data type (incompatible with `byte` or `binary` vectors)
+- Increases disk usage (stores both raw and quantized vectors)
+- Some recall loss compared to unquantized vectors
+- Only available with Lucene engine
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Initial implementation with 7-bit quantization and confidence_interval parameter
+
+## References
+
+### Documentation
+
+- [k-NN vector quantization](https://docs.opensearch.org/latest/search-plugins/knn/knn-vector-quantization/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#1848](https://github.com/opensearch-project/k-NN/pull/1848) | Add support for Lucene inbuilt Scalar Quantizer |
+
+### Issues
+
+- [#1277](https://github.com/opensearch-project/k-NN/issues/1277) - Feature request for Lucene inbuilt scalar quantizer

--- a/docs/releases/v2.16.0/features/k-nn/lucene-scalar-quantizer.md
+++ b/docs/releases/v2.16.0/features/k-nn/lucene-scalar-quantizer.md
@@ -1,0 +1,114 @@
+---
+tags:
+  - k-nn
+---
+# Lucene Scalar Quantizer
+
+## Summary
+
+OpenSearch 2.16.0 introduces built-in scalar quantization for the Lucene engine in the k-NN plugin. This feature automatically quantizes 32-bit floating-point vectors to 7-bit integers during ingestion, reducing memory footprint by approximately 75% while maintaining search quality.
+
+## Details
+
+### What's New in v2.16.0
+
+The Lucene scalar quantizer provides automatic vector compression without requiring pre-quantization before ingestion:
+
+- **Automatic quantization**: Converts fp32 vectors to 7-bit integers during document indexing
+- **Dynamic quantile computation**: Calculates min/max quantiles per segment based on `confidence_interval`
+- **Query-time dequantization**: Quantizes query vectors using segment-specific quantiles for distance computation
+- **Consistent API**: Uses the `sq` encoder under `parameters` field, similar to Faiss
+
+### Configuration
+
+The `sq` encoder for Lucene supports the following parameters:
+
+| Parameter | Description | Default | Valid Values |
+|-----------|-------------|---------|--------------|
+| `bits` | Number of bits for quantization | `7` | `7` only (8-bit not supported due to recall issues) |
+| `confidence_interval` | Controls quantile computation for min/max values | Computed as `1 - 1/(1 + dimension)` | `0` (dynamic), or `0.9` to `1.0` |
+
+### Usage Example
+
+```json
+PUT /test-index
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 128,
+        "method": {
+          "name": "hnsw",
+          "space_type": "l2",
+          "engine": "lucene",
+          "parameters": {
+            "encoder": {
+              "name": "sq",
+              "parameters": {
+                "bits": 7,
+                "confidence_interval": 1.0
+              }
+            },
+            "ef_construction": 128,
+            "m": 24
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Confidence Interval Behavior
+
+- `0.9` to `1.0`: Static quantile calculation (e.g., `0.9` uses middle 90% of values)
+- `0`: Dynamic computation with oversampling
+- Not set: Computed from dimension as `max(0.9, 1 - 1/(1 + d))`
+
+### Technical Changes
+
+Key implementation components:
+
+| Component | Description |
+|-----------|-------------|
+| `KNNScalarQuantizedVectorsFormatParams` | New class for SQ encoder parameters |
+| `KNNVectorsFormatParams` | Base class for vector format parameters |
+| `KNN990PerFieldKnnVectorsFormat` | Updated to support `Lucene99HnswScalarQuantizedVectorsFormat` |
+| `Lucene.java` | Added `sq` encoder definition with parameter validation |
+| `Parameter.DoubleParameter` | New parameter type for confidence_interval validation |
+
+### Memory Estimation
+
+HNSW memory with scalar quantization: `1.1 * (dimension + 8 * M)` bytes/vector
+
+Example: 1M vectors, dimension=256, M=16:
+```
+1.1 * (256 + 8 * 16) * 1,000,000 ≈ 0.4 GB
+```
+
+Compared to fp32 vectors (~1.6 GB), this represents ~75% memory reduction.
+
+## Limitations
+
+- Only 7-bit quantization is supported (8-bit disabled due to recall issues)
+- Only works with `float` data type vectors (not `byte` or `binary`)
+- Slightly increases disk usage (stores both raw and quantized vectors)
+- Some recall loss compared to unquantized vectors
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#1848](https://github.com/opensearch-project/k-NN/pull/1848) | Add support for Lucene inbuilt Scalar Quantizer | [#1277](https://github.com/opensearch-project/k-NN/issues/1277) |
+
+### Documentation
+
+- [k-NN vector quantization](https://docs.opensearch.org/2.16/search-plugins/knn/knn-vector-quantization/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -42,6 +42,7 @@
 - k-NN Build & Patches
 - k-NN Serialization
 - k-NN Vector Streaming & Memory Bug Fixes
+- Lucene Scalar Quantizer
 
 ### ml-commons
 - Model & Connector Enhancements


### PR DESCRIPTION
## Summary

Adds documentation for the Lucene Scalar Quantizer feature introduced in OpenSearch v2.16.0.

## Changes

- **Release report**: `docs/releases/v2.16.0/features/k-nn/lucene-scalar-quantizer.md`
- **Feature report**: `docs/features/k-nn/k-nn-lucene-scalar-quantizer.md`
- Updated release and feature indexes

## Feature Overview

The Lucene Scalar Quantizer provides built-in vector quantization that:
- Automatically compresses fp32 vectors to 7-bit integers during ingestion
- Reduces memory footprint by ~75%
- Requires no pre-quantization of vectors
- Supports configurable confidence_interval for quantile computation

## References

- PR: opensearch-project/k-NN#1848
- Issue: opensearch-project/k-NN#1277
- Closes #2181