### PR TITLE
docs: add k-NN binary vector support report for v2.16.0

### DIFF
--- a/docs/features/k-nn/index.md
+++ b/docs/features/k-nn/index.md
@@ -3,6 +3,7 @@
 | Document | Description |
 |----------|-------------|
 | [k-nn-avx512-support](k-nn-avx512-support.md) | k-NN AVX512 SIMD Support |
+| [k-nn-binary-vector-support](k-nn-binary-vector-support.md) | k-NN Binary Vector Support |
 | [k-nn-build](k-nn-build.md) | k-NN Build Infrastructure |
 | [k-nn-byte-vector-support](k-nn-byte-vector-support.md) | k-NN Byte Vector Support |
 | [k-nn-derived-source-codec-refactoring](k-nn-derived-source-codec-refactoring.md) | k-NN Derived Source & Codec Refactoring |

--- a/docs/features/k-nn/k-nn-binary-vector-support.md
+++ b/docs/features/k-nn/k-nn-binary-vector-support.md
@@ -1,0 +1,199 @@
+---
+tags:
+  - k-nn
+---
+# k-NN Binary Vector Support
+
+## Summary
+
+Binary vector support in OpenSearch k-NN enables efficient storage and search of binary embeddings using Hamming distance. This feature reduces memory requirements by up to 32x compared to float32 vectors, making large-scale vector search more economical while maintaining high recall performance.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph Input
+        BV[Binary Vector<br/>0,1,1,0,1,1,0,0]
+        PB[Packed Bytes<br/>108, -116]
+    end
+    subgraph "k-NN Plugin"
+        FE[Faiss Engine]
+        HNSW[HNSW Index]
+        IVF[IVF Index]
+    end
+    subgraph Search
+        HD[Hamming Distance]
+        SS[Script Score]
+        PL[Painless Script]
+    end
+    BV --> PB
+    PB --> FE
+    FE --> HNSW
+    FE --> IVF
+    HNSW --> HD
+    IVF --> HD
+    PB --> SS
+    PB --> PL
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Binary Data Type | New `data_type: binary` for knn_vector fields |
+| Hamming Space Type | Distance metric counting differing bits between vectors |
+| Faiss Binary Index | Native support for binary HNSW and IVF indexes |
+| Script Scoring | `hammingbit` space type for exact binary search |
+| Painless Extensions | Hamming distance function for custom scoring |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `data_type` | Vector data type (`float`, `byte`, `binary`) | `float` |
+| `space_type` | Distance metric (must be `hamming` for binary) | `l2` |
+| `dimension` | Vector dimension (must be multiple of 8 for binary) | Required |
+
+### Usage Example
+
+#### Create Index with Binary Vectors
+
+```json
+PUT /binary-index
+{
+  "settings": {
+    "index": { "knn": true }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 768,
+        "data_type": "binary",
+        "method": {
+          "name": "hnsw",
+          "space_type": "hamming",
+          "engine": "faiss",
+          "parameters": {
+            "ef_construction": 128,
+            "m": 24
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+#### Ingest Binary Vectors
+
+Binary vectors must be packed into int8 bytes. Each byte represents 8 bits:
+
+```python
+import numpy as np
+
+bit_array = [0, 1, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0]
+bit_array_np = np.array(bit_array, dtype=np.uint8)
+byte_array = np.packbits(bit_array_np).astype(np.int8).tolist()
+# Result: [108, -116]
+```
+
+```json
+PUT /binary-index/_doc/1
+{
+  "my_vector": [108, -116]
+}
+```
+
+#### Search Binary Vectors
+
+```json
+GET /binary-index/_search
+{
+  "query": {
+    "knn": {
+      "my_vector": {
+        "vector": [108, -116],
+        "k": 10
+      }
+    }
+  }
+}
+```
+
+### IVF with Training
+
+For IVF method, a training step is required:
+
+```json
+POST _plugins/_knn/models/binary-model/_train
+{
+  "training_index": "train-index",
+  "training_field": "train-field",
+  "dimension": 768,
+  "data_type": "binary",
+  "method": {
+    "name": "ivf",
+    "engine": "faiss",
+    "space_type": "hamming",
+    "parameters": {
+      "nlist": 4,
+      "nprobes": 2
+    }
+  }
+}
+```
+
+### Performance Characteristics
+
+| Metric | Float32 vs Binary |
+|--------|-------------------|
+| Memory Usage | ~32x reduction |
+| Storage | ~97% reduction |
+| Indexing Speed | Comparable |
+| Query Latency | Comparable |
+| Recall | ~97% (depends on data) |
+
+## Limitations
+
+- Only supported with Faiss engine
+- Only Hamming distance space type is available
+- Dimension must be a multiple of 8
+- Not supported with Nmslib or Lucene engines
+- Converting float vectors to binary requires quantization, which may affect recall
+- Radial search with binary vectors requires additional configuration
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Initial implementation
+  - Binary format support with HNSW method in Faiss
+  - Binary format support with IVF method in Faiss
+  - Script scoring support for binary vectors
+  - Painless script support for Hamming distance
+
+## References
+
+### Documentation
+
+- [k-NN vector field type - Binary vectors](https://docs.opensearch.org/latest/field-types/supported-field-types/knn-vector/#binary-k-nn-vectors)
+- [Exact k-NN with scoring script](https://docs.opensearch.org/latest/search-plugins/knn/knn-score-script/)
+- [k-NN Painless extensions](https://docs.opensearch.org/latest/search-plugins/knn/painless-functions/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#1781](https://github.com/opensearch-project/k-NN/pull/1781) | Add binary format support with HNSW method in Faiss Engine |
+| v2.16.0 | [#1784](https://github.com/opensearch-project/k-NN/pull/1784) | Add binary format support with IVF method in Faiss Engine |
+| v2.16.0 | [#1826](https://github.com/opensearch-project/k-NN/pull/1826) | Add script scoring support for knn field with binary data type |
+| v2.16.0 | [#1839](https://github.com/opensearch-project/k-NN/pull/1839) | Add painless script support for hamming with binary vector data type |
+
+### Related Issues
+
+- [#1767](https://github.com/opensearch-project/k-NN/issues/1767) - [RFC] Binary vector support
+
+### Blog Posts
+
+- [Optimize your OpenSearch costs using binary vectors](https://opensearch.org/blog/lower-your-cost-on-opensearch-using-binary-vectors/)

--- a/docs/releases/v2.16.0/features/k-nn/k-nn-binary-vector-support.md
+++ b/docs/releases/v2.16.0/features/k-nn/k-nn-binary-vector-support.md
@@ -1,0 +1,130 @@
+---
+tags:
+  - k-nn
+---
+# k-NN Binary Vector Support
+
+## Summary
+
+OpenSearch 2.16.0 introduces binary vector support for the k-NN plugin, enabling significant memory and storage savings for large-scale vector search applications. Binary vectors use Hamming distance for similarity calculations and can reduce memory requirements by a factor of 32 compared to float32 vectors.
+
+## Details
+
+### What's New in v2.16.0
+
+Binary vector support adds a new `data_type: binary` option for k-NN vector fields, allowing vectors to be stored as packed bytes instead of floating-point numbers. This feature is available exclusively with the Faiss engine.
+
+### Supported Methods
+
+| Method | Engine | Space Type | Description |
+|--------|--------|------------|-------------|
+| HNSW | Faiss | hamming | Approximate nearest neighbor search using HNSW algorithm |
+| IVF | Faiss | hamming | Inverted file index with training-based approach |
+
+### Configuration
+
+Binary vectors require:
+- `data_type`: Must be set to `binary`
+- `space_type`: Must be set to `hamming`
+- `dimension`: Must be a multiple of 8
+
+### Index Mapping Example
+
+```json
+PUT /test-binary-hnsw
+{
+  "settings": {
+    "index": {
+      "knn": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "my_vector": {
+        "type": "knn_vector",
+        "dimension": 8,
+        "data_type": "binary",
+        "method": {
+          "name": "hnsw",
+          "space_type": "hamming",
+          "engine": "faiss",
+          "parameters": {
+            "ef_construction": 128,
+            "m": 24
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Data Format
+
+Binary data must be converted to 8-bit signed integers (int8) in the [-128, 127] range. Each byte represents 8 binary bits packed together.
+
+Example conversion:
+- Binary: `0, 1, 1, 0, 1, 1, 0, 0` → Byte: `108`
+- Binary: `1, 0, 0, 0, 1, 1, 0, 0` → Byte: `-116`
+
+### Search Types Supported
+
+1. **Approximate k-NN**: Using HNSW or IVF algorithms with Faiss engine
+2. **Script Score k-NN**: Using `hammingbit` space type for exact search
+3. **Painless Extensions**: Hamming distance calculations in custom scripts
+
+### Script Scoring Example
+
+```json
+POST /my-knn-index/_search
+{
+  "query": {
+    "script_score": {
+      "query": { "match_all": {} },
+      "script": {
+        "source": "knn_score",
+        "lang": "knn",
+        "params": {
+          "field": "my_vector",
+          "query_value": [13],
+          "space_type": "hammingbit"
+        }
+      }
+    }
+  }
+}
+```
+
+### Performance Benefits
+
+Based on benchmarking with 100 million 768-dimensional vectors:
+- Memory reduction: ~92%
+- Storage reduction: ~97%
+- Comparable indexing speeds and query times on 8x smaller hardware
+
+## Limitations
+
+- Only supported with Faiss engine (not Nmslib or Lucene)
+- Only Hamming distance space type is supported
+- Dimension must be a multiple of 8
+- Converting float vectors to binary may result in some recall loss (depends on quantization technique)
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#1781](https://github.com/opensearch-project/k-NN/pull/1781) | Add binary format support with HNSW method in Faiss Engine | [#1767](https://github.com/opensearch-project/k-NN/issues/1767) |
+| [#1784](https://github.com/opensearch-project/k-NN/pull/1784) | Add binary format support with IVF method in Faiss Engine | [#1767](https://github.com/opensearch-project/k-NN/issues/1767) |
+| [#1826](https://github.com/opensearch-project/k-NN/pull/1826) | Add script scoring support for knn field with binary data type | - |
+| [#1839](https://github.com/opensearch-project/k-NN/pull/1839) | Add painless script support for hamming with binary vector data type | - |
+
+### Documentation
+
+- [Binary k-NN vectors](https://docs.opensearch.org/2.16/field-types/supported-field-types/knn-vector/#binary-k-nn-vectors)
+- [Exact k-NN with scoring script](https://docs.opensearch.org/2.16/search-plugins/knn/knn-score-script/)
+
+### Blog Posts
+
+- [Optimize your OpenSearch costs using binary vectors](https://opensearch.org/blog/lower-your-cost-on-opensearch-using-binary-vectors/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -38,6 +38,7 @@
 - Job Scheduler Lock Index Protection
 
 ### k-nn
+- k-NN Binary Vector Support
 - Faiss Updates
 - k-NN Build & Patches
 - k-NN Serialization


### PR DESCRIPTION
## Summary

This PR adds documentation for the k-NN Binary Vector Support feature introduced in OpenSearch v2.16.0.

## Reports Created

- Release report: `docs/releases/v2.16.0/features/k-nn/k-nn-binary-vector-support.md`
- Feature report: `docs/features/k-nn/k-nn-binary-vector-support.md`

## Key Changes in v2.16.0

- Binary format support with HNSW method in Faiss Engine
- Binary format support with IVF method in Faiss Engine
- Script scoring support for knn field with binary data type
- Painless script support for Hamming distance with binary vectors

## Related PRs

- [#1781](https://github.com/opensearch-project/k-NN/pull/1781) - Add binary format support with HNSW method
- [#1784](https://github.com/opensearch-project/k-NN/pull/1784) - Add binary format support with IVF method
- [#1826](https://github.com/opensearch-project/k-NN/pull/1826) - Add script scoring support
- [#1839](https://github.com/opensearch-project/k-NN/pull/1839) - Add painless script support

Closes #2180