### PR TITLE
docs: add k-NN Dynamic Query Parameters report for v2.16.0

### DIFF
--- a/docs/features/k-nn/index.md
+++ b/docs/features/k-nn/index.md
@@ -8,6 +8,7 @@
 | [k-nn-byte-vector-support](k-nn-byte-vector-support.md) | k-NN Byte Vector Support |
 | [k-nn-derived-source-codec-refactoring](k-nn-derived-source-codec-refactoring.md) | k-NN Derived Source & Codec Refactoring |
 | [k-nn-disk-based-vector-search](k-nn-disk-based-vector-search.md) | Disk-Based Vector Search |
+| [k-nn-dynamic-query-parameters](k-nn-dynamic-query-parameters.md) | k-NN Dynamic Query Parameters |
 | [k-nn-engine-enhancements](k-nn-engine-enhancements.md) | k-NN Engine Enhancements |
 | [k-nn-explain-api](k-nn-explain-api.md) | k-NN Explain API |
 | [k-nn-iterative-graph-build](k-nn-iterative-graph-build.md) | k-NN Iterative Graph Build |

--- a/docs/features/k-nn/k-nn-dynamic-query-parameters.md
+++ b/docs/features/k-nn/k-nn-dynamic-query-parameters.md
@@ -1,0 +1,158 @@
+---
+tags:
+  - k-nn
+---
+# k-NN Dynamic Query Parameters
+
+## Summary
+
+Dynamic query parameters allow users to specify search algorithm parameters like `ef_search` and `nprobes` at query time rather than only at index creation. This enables per-query tuning of the accuracy vs. latency trade-off without modifying index settings.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Query Time"
+        Q[k-NN Query] --> MP[method_parameters]
+        MP --> EF[ef_search]
+        MP --> NP[nprobes]
+    end
+    
+    subgraph "Index Time"
+        IS[Index Settings] --> IEF[index.knn.algo_param.ef_search]
+        IM[Index Mapping] --> INP[nprobes in method]
+    end
+    
+    subgraph "Resolution"
+        EF --> |Override| IEF
+        NP --> |Override| INP
+        IEF --> Engine
+        INP --> Engine
+    end
+```
+
+### Parameters
+
+| Parameter | Method | Description | Default |
+|-----------|--------|-------------|---------|
+| `ef_search` | HNSW | Number of vectors to examine for finding top k neighbors. Higher values improve recall at cost of latency. | Index setting or engine default |
+| `nprobes` | IVF | Number of buckets to examine for finding top k neighbors. Higher values improve recall at cost of latency. | Value set at index creation |
+
+### Engine Support Matrix
+
+| Engine | ef_search | nprobes | Radial Query with ef_search |
+|--------|-----------|---------|----------------------------|
+| Lucene | ✓ | - | No |
+| FAISS | ✓ | ✓ | Yes |
+| NMSLIB | ✓ | - | No |
+
+### Usage Examples
+
+#### Basic k-NN Query with ef_search
+
+```json
+GET my-knn-index/_search
+{
+  "size": 10,
+  "query": {
+    "knn": {
+      "my_vector": {
+        "vector": [1.5, 2.5, 3.5],
+        "k": 10,
+        "method_parameters": {
+          "ef_search": 200
+        }
+      }
+    }
+  }
+}
+```
+
+#### IVF Query with nprobes
+
+```json
+GET my-ivf-index/_search
+{
+  "size": 10,
+  "query": {
+    "knn": {
+      "my_vector": {
+        "vector": [1.5, 2.5, 3.5],
+        "k": 10,
+        "method_parameters": {
+          "nprobes": 10
+        }
+      }
+    }
+  }
+}
+```
+
+#### Neural Search with method_parameters
+
+```json
+GET my-neural-index/_search
+{
+  "query": {
+    "neural": {
+      "passage_embedding": {
+        "query_text": "example query",
+        "model_id": "my-model-id",
+        "k": 10,
+        "method_parameters": {
+          "ef_search": 150
+        }
+      }
+    }
+  }
+}
+```
+
+### Engine-Specific Behavior
+
+#### Lucene
+- Uses `max(k, ef_search)` as the effective ef_search value
+- If `ef_search > k`, use the `size` parameter to limit final results
+
+#### FAISS
+- Query-time `ef_search` overrides `index.knn.algo_param.ef_search`
+- Query-time `nprobes` overrides the value set during index creation
+- Supports radial search with `ef_search`
+
+#### NMSLIB
+- Query-time `ef_search` overrides `index.knn.algo_param.ef_search`
+- Does not support radial search with `ef_search`
+
+## Limitations
+
+- `ef_search` only works with HNSW method
+- `nprobes` only works with IVF method
+- Radial search with `ef_search` is only supported on FAISS engine
+- Values must be positive integers
+- Higher values increase search latency
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Initial implementation of dynamic query parameters (`ef_search`, `nprobes`) for k-NN and neural search queries
+
+## References
+
+### Documentation
+
+- [Approximate k-NN search](https://docs.opensearch.org/latest/search-plugins/knn/approximate-knn/)
+- [k-NN index](https://docs.opensearch.org/latest/search-plugins/knn/knn-index/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [k-NN#1783](https://github.com/opensearch-project/k-NN/pull/1783) | Adds ef_search as query parameter for Lucene, FAISS, and NMSLIB |
+| v2.16.0 | [k-NN#1790](https://github.com/opensearch-project/k-NN/pull/1790) | Support ef_search parameter in radial search FAISS engine |
+| v2.16.0 | [k-NN#1792](https://github.com/opensearch-project/k-NN/pull/1792) | Adds nprobes as query parameter |
+| v2.16.0 | [neural-search#814](https://github.com/opensearch-project/neural-search/pull/814) | Adds method_parameters in neural search query |
+
+### Related Issues
+
+- [k-NN#1537](https://github.com/opensearch-project/k-NN/issues/1537) - Feature request: Enable setting ef_search parameter as part of k-NN Query

--- a/docs/releases/v2.16.0/features/k-nn/k-nn-dynamic-query-parameters.md
+++ b/docs/releases/v2.16.0/features/k-nn/k-nn-dynamic-query-parameters.md
@@ -1,0 +1,85 @@
+---
+tags:
+  - k-nn
+---
+# k-NN Dynamic Query Parameters
+
+## Summary
+
+OpenSearch 2.16.0 introduces the ability to specify `ef_search` and `nprobes` parameters at query time in k-NN searches. Previously, these parameters could only be set at index level. This feature allows users to dynamically tune search accuracy and latency trade-offs per query without modifying index settings.
+
+## Details
+
+### What's New in v2.16.0
+
+The `method_parameters` field is now supported in k-NN queries, enabling query-time configuration of search parameters:
+
+```json
+GET my-knn-index/_search
+{
+  "size": 2,
+  "query": {
+    "knn": {
+      "target-field": {
+        "vector": [2, 3, 5, 6],
+        "k": 2,
+        "method_parameters": {
+          "ef_search": 100
+        }
+      }
+    }
+  }
+}
+```
+
+### Supported Parameters
+
+| Parameter | Method | Description |
+|-----------|--------|-------------|
+| `ef_search` | HNSW | Number of vectors to examine for finding top k neighbors |
+| `nprobes` | IVF | Number of buckets to examine for finding top k neighbors |
+
+### Engine Support
+
+| Engine | ef_search | nprobes | Radial Query Support |
+|--------|-----------|---------|---------------------|
+| Lucene | ✓ | - | No |
+| FAISS | ✓ | ✓ | Yes |
+| NMSLIB | ✓ | - | No |
+
+### Behavior by Engine
+
+- **FAISS/NMSLIB**: Query-time `ef_search` overrides the `index.knn.algo_param.ef_search` index setting
+- **Lucene**: Uses the larger of `k` and `ef_search` as the effective ef_search value. Use `size` parameter to limit final results if `ef_search > k`
+- **FAISS (IVF)**: Query-time `nprobes` overrides the value set during index creation
+
+### Neural Search Integration
+
+The neural-search plugin also supports these parameters via the `method_parameters` field, enabling the same query-time tuning for neural search queries.
+
+## Limitations
+
+- Parameters are method-specific: `ef_search` only works with HNSW, `nprobes` only with IVF
+- Radial search with `ef_search` is only supported on FAISS engine
+- Higher values improve recall but increase search latency
+
+## References
+
+### Pull Requests
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#1783](https://github.com/opensearch-project/k-NN/pull/1783) | k-NN | Adds ef_search as query parameter for Lucene, FAISS, and NMSLIB |
+| [#1790](https://github.com/opensearch-project/k-NN/pull/1790) | k-NN | Support ef_search parameter in radial search FAISS engine |
+| [#1792](https://github.com/opensearch-project/k-NN/pull/1792) | k-NN | Adds nprobes as query parameter |
+| [#814](https://github.com/opensearch-project/neural-search/pull/814) | neural-search | Adds method_parameters in neural search query |
+
+### Related Issues
+
+| Issue | Description |
+|-------|-------------|
+| [#1537](https://github.com/opensearch-project/k-NN/issues/1537) | Feature request: Enable setting ef_search parameter as part of k-NN Query |
+
+### Documentation
+
+- [Approximate k-NN search](https://docs.opensearch.org/2.16/search-plugins/knn/approximate-knn/)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -39,6 +39,7 @@
 
 ### k-nn
 - k-NN Binary Vector Support
+- k-NN Dynamic Query Parameters
 - Faiss Updates
 - k-NN Build & Patches
 - k-NN Serialization


### PR DESCRIPTION
## Summary

Adds documentation for k-NN Dynamic Query Parameters feature introduced in OpenSearch v2.16.0.

## Changes

- Created release report: `docs/releases/v2.16.0/features/k-nn/k-nn-dynamic-query-parameters.md`
- Created feature report: `docs/features/k-nn/k-nn-dynamic-query-parameters.md`
- Updated release index and features index

## Feature Overview

This feature allows users to specify `ef_search` and `nprobes` parameters at query time in k-NN searches, enabling per-query tuning of accuracy vs. latency trade-offs without modifying index settings.

## Related PRs

- k-NN#1783: Adds ef_search as query parameter
- k-NN#1790: Support ef_search in radial search FAISS
- k-NN#1792: Adds nprobes as query parameter
- neural-search#814: Adds method_parameters in neural search

Closes #2179