### PR TITLE
docs: add performance-metrics report for v2.16.0

### DIFF
--- a/docs/features/performance-analyzer/performance-analyzer.md
+++ b/docs/features/performance-analyzer/performance-analyzer.md
@@ -121,7 +121,7 @@ GET localhost:9600/_plugins/_performanceanalyzer/rca?name=HighHeapUsageClusterRC
 - **v3.3.0** (2026-01-11): Transport channel wrapper improvements - delegate getProfileName(), getChannelType(), getVersion(), and get() to wrapped channel; removed getInnerChannel() method for better security plugin compatibility
 - **v3.2.0** (2025-07-18): Build infrastructure update - SpotBugs 6.2.2, Checkstyle 10.26.1; Removed CVE-2025-27820 workaround
 - **v2.17.0** (2024-09-17): Added RTFCacheConfigMetricsCollector for cache configuration telemetry; Updated PA Commons dependency to 1.6.0
-- **v2.16.0** (2024-08-06): Security dependency updates - BouncyCastle 1.74 → 1.78.1 (CVE fixes); PA Commons 1.4.0 → 1.5.0
+- **v2.16.0** (2024-08-06): Added index_uuid tag to shard metrics; Added RTFPerformanceAnalyzerSearchListener for CPU/heap metrics on search operations; Added RTFPerformanceAnalyzerTransportInterceptor for bulk operation metrics; Security dependency updates - BouncyCastle 1.74 → 1.78.1 (CVE fixes); PA Commons 1.4.0 → 1.5.0
 
 
 ## References
@@ -141,5 +141,7 @@ GET localhost:9600/_plugins/_performanceanalyzer/rca?name=HighHeapUsageClusterRC
 | v3.2.0 | [#826](https://github.com/opensearch-project/performance-analyzer/pull/826) | Bump SpotBugs to 6.2.2 and Checkstyle to 10.26.1 |   |
 | v2.17.0 | [#690](https://github.com/opensearch-project/performance-analyzer/pull/690) | Added CacheConfig Telemetry collectors |   |
 | v2.17.0 | [#712](https://github.com/opensearch-project/performance-analyzer/pull/712) | Bump PA to use 1.6.0 PA commons lib |   |
+| v2.16.0 | [#680](https://github.com/opensearch-project/performance-analyzer/pull/680) | Adds index_uuid as a tag in node stats all shard metrics |   |
+| v2.16.0 | [#687](https://github.com/opensearch-project/performance-analyzer/pull/687) | Adds the listener for resource utilization metrics |   |
 | v2.16.0 | [#656](https://github.com/opensearch-project/performance-analyzer/pull/656) | Bump bouncycastle from 1.74 to 1.78.1 | Security advisories |
 | v2.16.0 | [#698](https://github.com/opensearch-project/performance-analyzer/pull/698) | Bump PA to use 1.5.0 PA commons lib |   |

--- a/docs/releases/v2.16.0/features/performance-analyzer/performance-metrics.md
+++ b/docs/releases/v2.16.0/features/performance-analyzer/performance-metrics.md
@@ -1,0 +1,90 @@
+---
+tags:
+  - performance-analyzer
+---
+# Performance Metrics
+
+## Summary
+
+Enhanced Performance Analyzer metrics collection in v2.16.0 with index UUID tagging for shard metrics and new resource utilization listeners for search and bulk operations.
+
+## Details
+
+### What's New in v2.16.0
+
+Two key enhancements to the Performance Analyzer metrics framework:
+
+1. **Index UUID Tag for Shard Metrics**: Added `index_uuid` as a dimension tag in node stats all shard metrics, enabling more precise metric identification
+2. **Resource Utilization Listeners**: New RTF (Real-Time Framework) listeners for capturing CPU utilization and heap usage metrics at the task level
+
+### Technical Changes
+
+#### Index UUID Tag (PR #680)
+
+Added `index_uuid` as a tag dimension in the `RTFNodeStatsAllShardsMetricsCollector` for metrics emitted by the RTF collector. This enables correlation of metrics with specific index instances.
+
+Example metric output with new tag:
+```
+metric: ImmutableMetricData{
+  name=cache_field_data_eviction,
+  attributes={
+    index_name="your-index",
+    index_uuid="TxGu9noCSQKt8OE8ioR1-A",
+    shard_id="0"
+  },
+  value=0.0
+}
+```
+
+#### Resource Utilization Listeners (PR #687)
+
+New components for capturing resource utilization metrics:
+
+| Component | Description |
+|-----------|-------------|
+| `RTFPerformanceAnalyzerSearchListener` | Emits CPU_Utilization and Heap_used metrics for query and fetch phases |
+| `RTFPerformanceAnalyzerTransportInterceptor` | Emits CPU_Utilization metric for BulkShardRequest operations |
+| `RTFPerformanceAnalyzerTransportChannel` | Transport channel wrapper for bulk shard operations |
+| `RTFPerformanceAnalyzerTransportRequestHandler` | Request handler for intercepting bulk shard requests |
+
+##### Metrics Emitted
+
+| Metric | Description | Unit |
+|--------|-------------|------|
+| `cpu_utilization` | CPU utilization per shard for search/bulk operations | rate |
+| `heap_allocated` | Heap memory used per shard for search phases | bytes |
+
+##### Metric Tags
+
+| Tag | Description |
+|-----|-------------|
+| `index_name` | Name of the index |
+| `index_uuid` | UUID of the index |
+| `shard_id` | Shard identifier |
+| `operation` | Operation type (shard_query, shard_fetch, shardbulk) |
+| `failed` | Whether the operation failed |
+| `shard_role` | Primary or replica (for bulk operations) |
+
+##### Collector Mode Support
+
+The listeners respect the collector run mode configuration:
+
+| Mode | Search Listener | Transport Handler |
+|------|-----------------|-------------------|
+| RCA | Disabled | Enabled |
+| TELEMETRY | Enabled | Enabled |
+| DUAL | Enabled | Enabled |
+
+## Limitations
+
+- Resource tracking requires OpenSearch's task resource tracking to be enabled
+- CPU utilization calculation uses share factor when query and fetch phases run in the same task
+- Metrics are only emitted when Performance Analyzer is enabled
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#680](https://github.com/opensearch-project/performance-analyzer/pull/680) | Adds index_uuid as a tag in node stats all shard metrics | - |
+| [#687](https://github.com/opensearch-project/performance-analyzer/pull/687) | Adds the listener for resource utilization metrics | - |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -165,6 +165,7 @@
 
 ### performance-analyzer
 - Performance Analyzer Dependencies
+- Performance Metrics
 
 ### query-insights
 - Query Insights Plugin Setup


### PR DESCRIPTION
## Summary

Adds documentation for Performance Metrics enhancements in OpenSearch v2.16.0.

### Changes
- Created release report: `docs/releases/v2.16.0/features/performance-analyzer/performance-metrics.md`
- Updated feature report: `docs/features/performance-analyzer/performance-analyzer.md`
- Updated release index

### Key Features Documented
1. **Index UUID Tag (PR #680)**: Added `index_uuid` as a dimension tag in node stats all shard metrics
2. **Resource Utilization Listeners (PR #687)**: New RTF listeners for CPU utilization and heap usage metrics

### Related Issue
Closes #2175