### PR TITLE
docs: add batch-prediction-mode report for v2.16.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -9,6 +9,7 @@ Cumulative feature documentation across all versions.
 
 ## ml-commons
 
+- Batch Prediction Mode
 - Conversation Memory
 
 ## neural-search

--- a/docs/features/ml-commons/ml-commons-batch-prediction-mode.md
+++ b/docs/features/ml-commons/ml-commons-batch-prediction-mode.md
@@ -1,0 +1,270 @@
+---
+tags:
+  - ml-commons
+---
+# ML Commons Batch Prediction Mode
+
+## Summary
+
+Batch Prediction Mode enables offline batch inference through the ML Commons Connector Framework. Unlike real-time prediction that processes requests synchronously, batch prediction submits jobs to external ML services (Amazon SageMaker, OpenAI, Cohere) for asynchronous processing of large datasets. This is ideal for generating embeddings at scale, where processing millions of documents in real-time would be impractical.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch ML Commons"
+        A[Batch Predict API] --> B[Connector Framework]
+        B --> C[Remote Model]
+        C --> D[ML Task Manager]
+    end
+    
+    subgraph "External ML Services"
+        E[Amazon SageMaker]
+        F[OpenAI Batch API]
+        G[Cohere]
+    end
+    
+    subgraph "Storage"
+        H[S3 Input]
+        I[S3 Output]
+    end
+    
+    B --> E
+    B --> F
+    B --> G
+    H --> E
+    E --> I
+    H --> F
+    F --> I
+```
+
+### Data Flow
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant OpenSearch
+    participant MLCommons
+    participant ExternalML
+    participant S3
+    
+    User->>OpenSearch: POST /_plugins/_ml/models/{id}/_batch_predict
+    OpenSearch->>MLCommons: Create batch prediction task
+    MLCommons->>ExternalML: Submit batch job (e.g., CreateTransformJob)
+    ExternalML-->>MLCommons: Job ID / Status
+    MLCommons-->>User: Return task_id
+    
+    Note over ExternalML,S3: Async processing
+    ExternalML->>S3: Read input data
+    ExternalML->>ExternalML: Process batch
+    ExternalML->>S3: Write output data
+    
+    User->>OpenSearch: GET /_plugins/_ml/tasks/{task_id}
+    OpenSearch->>MLCommons: Get task status
+    MLCommons->>ExternalML: Check job status
+    ExternalML-->>MLCommons: Job status
+    MLCommons-->>User: Return status (RUNNING/COMPLETED)
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ConnectorAction.ActionType.BATCH_PREDICT` | New action type for batch prediction operations |
+| `RestMLPredictionAction` | REST handler supporting `/_batch_predict` endpoint |
+| `RemoteInferenceInputDataSet` | Input data set with action type support |
+| `MLPredictTaskRunner` | Task runner with batch prediction action tracking |
+| `ActionName.BATCH_PREDICT` | Statistics tracking for batch operations |
+
+### Configuration
+
+#### Connector Actions
+
+| Action Type | Description | Use Case |
+|-------------|-------------|----------|
+| `predict` | Real-time synchronous inference | Single document embedding |
+| `batch_predict` | Asynchronous batch inference | Large-scale embedding generation |
+| `batch_predict_status` | Check batch job status | Job monitoring |
+| `cancel_batch_predict` | Cancel running batch job | Job management |
+
+#### Supported Services
+
+| Service | Batch API | Status |
+|---------|-----------|--------|
+| Amazon SageMaker | CreateTransformJob | Supported |
+| OpenAI | Batch API | Supported |
+| Cohere | Batch API | Supported |
+| Amazon Bedrock | Batch Inference | Preview |
+
+### Usage Examples
+
+#### Amazon SageMaker Batch Transform
+
+Create connector with batch_predict action:
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "SageMaker Batch Connector",
+  "protocol": "aws_sigv4",
+  "credential": {
+    "access_key": "<ACCESS_KEY>",
+    "secret_key": "<SECRET_KEY>"
+  },
+  "parameters": {
+    "region": "us-east-1",
+    "service_name": "sagemaker",
+    "ModelName": "DJL-Text-Embedding-Model",
+    "TransformInput": {
+      "ContentType": "application/json",
+      "DataSource": {
+        "S3DataSource": {
+          "S3DataType": "S3Prefix",
+          "S3Uri": "s3://bucket/input/"
+        }
+      },
+      "SplitType": "Line"
+    },
+    "TransformOutput": {
+      "S3OutputPath": "s3://bucket/output/"
+    },
+    "TransformResources": {
+      "InstanceCount": 10,
+      "InstanceType": "ml.m4.xlarge"
+    }
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://runtime.sagemaker.us-east-1.amazonaws.com/endpoints/<endpoint>/invocations",
+      "request_body": "${parameters.input}"
+    },
+    {
+      "action_type": "batch_predict",
+      "method": "POST",
+      "url": "https://api.sagemaker.us-east-1.amazonaws.com/CreateTransformJob",
+      "request_body": "{ \"BatchStrategy\": \"${parameters.BatchStrategy}\", \"ModelName\": \"${parameters.ModelName}\", \"TransformInput\": ${parameters.TransformInput}, \"TransformJobName\": \"${parameters.TransformJobName}\", \"TransformOutput\": ${parameters.TransformOutput}, \"TransformResources\": ${parameters.TransformResources} }"
+    }
+  ]
+}
+```
+
+Invoke batch prediction:
+
+```json
+POST /_plugins/_ml/models/{model_id}/_batch_predict
+{
+  "parameters": {
+    "TransformJobName": "my-batch-job-001",
+    "BatchStrategy": "SingleRecord"
+  }
+}
+```
+
+Response:
+
+```json
+{
+  "task_id": "oSWbv5EB_tT1A82ZnO8k",
+  "status": "CREATED"
+}
+```
+
+#### OpenAI Batch API
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "OpenAI Batch Connector",
+  "protocol": "http",
+  "parameters": {
+    "model": "text-embedding-ada-002",
+    "input_file_id": "<file_id>",
+    "endpoint": "/v1/embeddings"
+  },
+  "credential": {
+    "openAI_key": "<API_KEY>"
+  },
+  "actions": [
+    {
+      "action_type": "batch_predict",
+      "method": "POST",
+      "url": "https://api.openai.com/v1/batches",
+      "headers": {
+        "Authorization": "Bearer ${credential.openAI_key}"
+      },
+      "request_body": "{ \"input_file_id\": \"${parameters.input_file_id}\", \"endpoint\": \"${parameters.endpoint}\", \"completion_window\": \"24h\" }"
+    }
+  ]
+}
+```
+
+#### Checking Job Status
+
+```json
+GET /_plugins/_ml/tasks/{task_id}
+```
+
+Response when running:
+
+```json
+{
+  "model_id": "nyWbv5EB_tT1A82ZCu-e",
+  "task_type": "BATCH_PREDICTION",
+  "function_name": "REMOTE",
+  "state": "RUNNING",
+  "create_time": 1725496527958,
+  "last_update_time": 1725496527958,
+  "remote_job": {
+    "TransformJobStatus": "InProgress",
+    "TransformJobName": "my-batch-job-001"
+  }
+}
+```
+
+### Integration with Batch Ingestion
+
+Batch Prediction Mode works together with Batch Ingestion for end-to-end offline ML workflows:
+
+1. **Batch Predict**: Generate embeddings for large datasets asynchronously
+2. **Batch Ingest**: Import the generated embeddings into OpenSearch indexes
+
+See ML Commons Batch Ingestion documentation for details on ingesting batch prediction results.
+
+## Limitations
+
+- Experimental feature - not recommended for production use
+- Supported external services: Amazon SageMaker, OpenAI, Cohere
+- Amazon Bedrock batch inference is in preview
+- Requires proper IAM/API credentials for external service access
+- Results stored in external storage (S3, OpenAI Files) - not directly returned
+- No automatic retry for failed batch jobs
+- Job cancellation depends on external service support
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Initial implementation with SageMaker and OpenAI support
+
+## References
+
+### Documentation
+- [Batch Predict API](https://docs.opensearch.org/latest/ml-commons-plugin/api/model-apis/batch-predict/): Official API documentation
+- [Connecting to externally hosted models](https://docs.opensearch.org/latest/ml-commons-plugin/remote-models/index/): Remote model setup guide
+
+### Blog Posts
+- [Scaling Vector Generation: Batch ML Inference](https://opensearch.org/blog/scaling-vector-generation-batch-ml-inference-with-opensearch-ingestion-and-ml-commons/): End-to-end batch inference workflow with OpenSearch Ingestion
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [#2661](https://github.com/opensearch-project/ml-commons/pull/2661) | Add Batch Prediction Mode in the Connector Framework |
+
+### Issues (Design / RFC)
+- [Issue #2488](https://github.com/opensearch-project/ml-commons/issues/2488): Integrate new Action Type of Batch Transform in Connectors
+
+### Connector Blueprints
+- [Amazon SageMaker batch predict connector blueprint](https://github.com/opensearch-project/ml-commons/blob/main/docs/remote_inference_blueprints/batch_inference_sagemaker_connector_blueprint.md)
+- [OpenAI batch predict connector blueprint](https://github.com/opensearch-project/ml-commons/blob/main/docs/remote_inference_blueprints/batch_inference_openAI_connector_blueprint.md)

--- a/docs/releases/v2.16.0/features/ml-commons/batch-prediction-mode.md
+++ b/docs/releases/v2.16.0/features/ml-commons/batch-prediction-mode.md
@@ -1,0 +1,156 @@
+---
+tags:
+  - ml-commons
+---
+# Batch Prediction Mode
+
+## Summary
+
+Batch Prediction Mode adds a new `BATCH_PREDICT` action type to the ML Commons Connector Framework, enabling offline batch inference for large-scale ML workloads. This feature allows users to submit batch prediction jobs to external ML services (Amazon SageMaker, OpenAI, Cohere) through OpenSearch connectors and track job status via ML Tasks APIs.
+
+## Details
+
+### What's New in v2.16.0
+
+This release introduces the foundational batch prediction capability in ML Commons:
+
+- New `BATCH_PREDICT` action type in `ConnectorAction.ActionType` enum
+- New REST endpoint: `POST /_plugins/_ml/models/{model_id}/_batch_predict`
+- Action type detection from REST request path (no need to specify in request body)
+- Support for Amazon SageMaker batch transform jobs
+- Support for OpenAI batch API
+- Task-based job tracking through ML Tasks APIs
+- Added `api.sagemaker.*.amazonaws.com` to default trusted URL regex for batch operations
+
+### Technical Changes
+
+#### New Action Type
+
+The `ConnectorAction.ActionType` enum now includes `BATCH_PREDICT`:
+
+```java
+public enum ActionType {
+    PREDICT,
+    EXECUTE,
+    BATCH_PREDICT;
+}
+```
+
+#### REST API Endpoint
+
+New endpoint for batch prediction:
+
+```
+POST /_plugins/_ml/models/{model_id}/_batch_predict
+```
+
+The action type is automatically determined from the URL path, eliminating the need to specify it in the request body.
+
+#### Connector Configuration
+
+Connectors can now define a `batch_predict` action alongside the standard `predict` action:
+
+```json
+{
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://runtime.sagemaker.<region>.amazonaws.com/endpoints/<endpoint>/invocations",
+      "request_body": "${parameters.input}"
+    },
+    {
+      "action_type": "batch_predict",
+      "method": "POST",
+      "url": "https://api.sagemaker.<region>.amazonaws.com/CreateTransformJob",
+      "request_body": "{ \"BatchStrategy\": \"${parameters.BatchStrategy}\", ... }"
+    }
+  ]
+}
+```
+
+#### Input Data Set Enhancement
+
+`RemoteInferenceInputDataSet` now includes an `actionType` field to specify the action type for remote inference operations.
+
+#### Statistics Tracking
+
+New `BATCH_PREDICT` action name added to `ActionName` enum for tracking batch prediction statistics separately from real-time predictions.
+
+### Usage Example
+
+1. Create a connector with batch_predict action:
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "SageMaker Batch Connector",
+  "protocol": "aws_sigv4",
+  "parameters": {
+    "region": "us-east-1",
+    "service_name": "sagemaker",
+    "ModelName": "my-embedding-model",
+    "TransformInput": {
+      "DataSource": {
+        "S3DataSource": {
+          "S3Uri": "s3://bucket/input/"
+        }
+      }
+    },
+    "TransformOutput": {
+      "S3OutputPath": "s3://bucket/output/"
+    }
+  },
+  "actions": [
+    {
+      "action_type": "batch_predict",
+      "method": "POST",
+      "url": "https://api.sagemaker.us-east-1.amazonaws.com/CreateTransformJob",
+      "request_body": "..."
+    }
+  ]
+}
+```
+
+2. Register and deploy a model with the connector
+
+3. Invoke batch prediction:
+
+```json
+POST /_plugins/_ml/models/{model_id}/_batch_predict
+{
+  "parameters": {
+    "TransformJobName": "my-batch-job"
+  }
+}
+```
+
+4. Check job status via Tasks API:
+
+```json
+GET /_plugins/_ml/tasks/{task_id}
+```
+
+## Limitations
+
+- Experimental feature - not recommended for production use
+- Supported external services: Amazon SageMaker, OpenAI, Cohere only
+- Requires proper IAM permissions for external service access
+- Batch job results must be retrieved from the external service's output location
+
+## References
+
+### Documentation
+- [Batch Predict API](https://docs.opensearch.org/2.16/ml-commons-plugin/api/model-apis/batch-predict/): Official API documentation
+
+### Blog Posts
+- [Scaling Vector Generation: Batch ML Inference](https://opensearch.org/blog/scaling-vector-generation-batch-ml-inference-with-opensearch-ingestion-and-ml-commons/): End-to-end batch inference workflow
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#2661](https://github.com/opensearch-project/ml-commons/pull/2661) | Add Batch Prediction Mode in the Connector Framework for batch inference | [#2488](https://github.com/opensearch-project/ml-commons/issues/2488) |
+
+### Connector Blueprints
+- [Amazon SageMaker batch predict connector blueprint](https://github.com/opensearch-project/ml-commons/blob/main/docs/remote_inference_blueprints/batch_inference_sagemaker_connector_blueprint.md)
+- [OpenAI batch predict connector blueprint](https://github.com/opensearch-project/ml-commons/blob/main/docs/remote_inference_blueprints/batch_inference_openAI_connector_blueprint.md)

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -47,6 +47,7 @@
 - Lucene Scalar Quantizer
 
 ### ml-commons
+- Batch Prediction Mode
 - Model & Connector Enhancements
 - System Index & Dependencies
 - ML Commons Blueprints & Tutorials


### PR DESCRIPTION
## Summary

This PR adds documentation for the Batch Prediction Mode feature introduced in OpenSearch v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/ml-commons/batch-prediction-mode.md`
- Feature report: `docs/features/ml-commons/ml-commons-batch-prediction-mode.md`

### Key Changes in v2.16.0
- New `BATCH_PREDICT` action type in Connector Framework
- New REST endpoint: `POST /_plugins/_ml/models/{model_id}/_batch_predict`
- Support for Amazon SageMaker batch transform jobs
- Support for OpenAI batch API
- Task-based job tracking through ML Tasks APIs

### Resources Used
- PR: [#2661](https://github.com/opensearch-project/ml-commons/pull/2661)
- Issue: [#2488](https://github.com/opensearch-project/ml-commons/issues/2488)
- Docs: https://docs.opensearch.org/2.16/ml-commons-plugin/api/model-apis/batch-predict/
- Blog: https://opensearch.org/blog/scaling-vector-generation-batch-ml-inference-with-opensearch-ingestion-and-ml-commons/

Related to #2173