### PR TITLE
docs: add ML Inference Processors report for v2.16.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -11,6 +11,7 @@ Cumulative feature documentation across all versions.
 
 - Batch Prediction Mode
 - Conversation Memory
+- ML Inference Processor
 
 ## neural-search
 

--- a/docs/features/ml-commons/ml-commons-ml-inference-processor.md
+++ b/docs/features/ml-commons/ml-commons-ml-inference-processor.md
@@ -276,7 +276,9 @@ POST _plugins/_ml/agents/_register
 | v3.3.0 | [#4093](https://github.com/opensearch-project/ml-commons/pull/4093) | Add processor chain framework |   |
 | v3.3.0 | [#4260](https://github.com/opensearch-project/ml-commons/pull/4260) | Refactor processor chain with additional processors |   |
 | v2.17.0 | [#2801](https://github.com/opensearch-project/ml-commons/pull/2801) | Support one_to_one in ML Inference Search Response Processor | [#2173](https://github.com/opensearch-project/ml-commons/issues/2173) |
-| v2.16.0 | - | ML Inference Search Request/Response Processors |   |
+| v2.16.0 | [#2688](https://github.com/opensearch-project/ml-commons/pull/2688) | Add initial MLInferenceSearchResponseProcessor | [#2173](https://github.com/opensearch-project/ml-commons/issues/2173), [#2444](https://github.com/opensearch-project/ml-commons/issues/2444) |
+| v2.16.0 | [#2616](https://github.com/opensearch-project/ml-commons/pull/2616) | Add initial search request inference processor | [#2173](https://github.com/opensearch-project/ml-commons/issues/2173), [#2444](https://github.com/opensearch-project/ml-commons/issues/2444) |
+| v2.16.0 | [#2610](https://github.com/opensearch-project/ml-commons/pull/2610) | Add model input validation for local models | [#2601](https://github.com/opensearch-project/ml-commons/issues/2601) |
 | v2.14.0 | - | Initial ML Inference Ingest Processor |   |
 
 ### Issues (Design / RFC)

--- a/docs/releases/v2.16.0/features/ml-commons/ml-inference-processors.md
+++ b/docs/releases/v2.16.0/features/ml-commons/ml-inference-processors.md
@@ -1,0 +1,128 @@
+---
+tags:
+  - ml-commons
+---
+# ML Inference Processors
+
+## Summary
+
+OpenSearch v2.16.0 introduces ML Inference Search Request and Search Response Processors, extending the ML inference capabilities from ingest pipelines to search pipelines. These processors enable ML model predictions to be applied during search operations, supporting use cases like query embedding for semantic search and search result enrichment.
+
+## Details
+
+### What's New in v2.16.0
+
+#### ML Inference Search Request Processor
+A new search request processor that transforms search queries using ML models before execution. Key capabilities:
+- Converts text queries to vector embeddings for semantic search
+- Supports query template transformation with model predictions
+- Works with both remote and local ML models
+
+#### ML Inference Search Response Processor
+A new search response processor that enriches search results with ML model predictions. Key capabilities:
+- Adds ML-generated fields to search hits (e.g., embeddings, classifications)
+- Supports many-to-one prediction mode (batch processing multiple documents)
+- Configurable input/output field mappings
+
+#### Model Input Validation for Local Models
+Added validation for model input when using local models in ML processors, ensuring proper configuration and preventing runtime errors.
+
+### Technical Changes
+
+#### New Classes
+- `MLInferenceSearchRequestProcessor`: Implements `SearchRequestProcessor` interface
+- `MLInferenceSearchResponseProcessor`: Implements `SearchResponseProcessor` interface
+- `MapUtils`: Utility class for counter management in batch processing
+- `SearchResponseUtil`: Utility for replacing search hits in responses
+
+#### Configuration Parameters
+
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `model_id` | ID of the ML model to invoke | Required |
+| `function_name` | Function name (`remote`, `text_embedding`, etc.) | `remote` |
+| `input_map` | Maps query/document fields to model input | Optional |
+| `output_map` | Maps model output to new fields | Optional |
+| `model_config` | Additional model configuration | Optional |
+| `model_input` | Template for model input format | Auto-generated for remote |
+| `full_response_path` | Use JSON path for output extraction | `false` (remote) |
+| `ignore_missing` | Skip documents with missing input fields | `false` |
+| `ignore_failure` | Continue on prediction failures | `false` |
+| `max_prediction_tasks` | Maximum concurrent model invocations | `10` |
+| `one_to_one` | Invoke model per document (response only) | `false` |
+
+### Usage Examples
+
+#### Search Request Pipeline - Query Embedding
+
+```json
+PUT /_search/pipeline/semantic_search_pipeline
+{
+  "request_processors": [
+    {
+      "ml_inference": {
+        "model_id": "<embedding_model_id>",
+        "query_template": "{\"query\":{\"knn\":{\"embedding\":{\"vector\":${modelPredictionOutcome},\"k\":10}}}}",
+        "input_map": [
+          {
+            "inputText": "query.match.text.query"
+          }
+        ],
+        "output_map": [
+          {
+            "modelPredictionOutcome": "embedding"
+          }
+        ]
+      }
+    }
+  ]
+}
+```
+
+#### Search Response Pipeline - Result Enrichment
+
+```json
+PUT /_search/pipeline/enrichment_pipeline
+{
+  "response_processors": [
+    {
+      "ml_inference": {
+        "model_id": "<embedding_model_id>",
+        "input_map": [
+          {
+            "input": "text_field"
+          }
+        ],
+        "output_map": [
+          {
+            "text_embedding": "data[*].embedding"
+          }
+        ],
+        "ignore_missing": false,
+        "ignore_failure": false
+      }
+    }
+  ]
+}
+```
+
+## Limitations
+
+- `one_to_one` mode for per-document inference in search response processor is not yet supported (throws exception)
+- Local models require explicit `function_name` and `model_input` configuration
+- Model must be deployed and accessible before pipeline execution
+- Complex nested field mappings require JSON path syntax
+
+## References
+
+### Documentation
+- [ML Inference Search Request Processor](https://docs.opensearch.org/2.16/search-plugins/search-pipelines/ml-inference-search-request/)
+- [ML Inference Search Response Processor](https://docs.opensearch.org/2.16/search-plugins/search-pipelines/ml-inference-search-response/)
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#2688](https://github.com/opensearch-project/ml-commons/pull/2688) | Add initial MLInferenceSearchResponseProcessor | [#2173](https://github.com/opensearch-project/ml-commons/issues/2173), [#2444](https://github.com/opensearch-project/ml-commons/issues/2444) |
+| [#2616](https://github.com/opensearch-project/ml-commons/pull/2616) | Add initial search request inference processor | [#2173](https://github.com/opensearch-project/ml-commons/issues/2173), [#2444](https://github.com/opensearch-project/ml-commons/issues/2444) |
+| [#2731](https://github.com/opensearch-project/ml-commons/pull/2731) | Backport search request processor to 2.16 | - |
+| [#2610](https://github.com/opensearch-project/ml-commons/pull/2610) | Add model input validation for local models in ml processor | [#2601](https://github.com/opensearch-project/ml-commons/issues/2601) |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -54,6 +54,7 @@
 - Connector & Model Fixes
 - Bedrock Runtime Agent
 - Conversation Memory
+- ML Inference Processors
 
 ### multi-plugin
 - MDS Version Decoupling (Plugins)


### PR DESCRIPTION
## Summary

This PR adds documentation for the ML Inference Processors feature introduced in OpenSearch v2.16.0.

## Changes

### Release Report
- Created `docs/releases/v2.16.0/features/ml-commons/ml-inference-processors.md`
- Documents the new ML Inference Search Request and Search Response Processors
- Includes configuration parameters, usage examples, and limitations

### Feature Report Update
- Updated `docs/features/ml-commons/ml-commons-ml-inference-processor.md`
- Added v2.16.0 PR details to the Pull Requests table

### Index Updates
- Added "ML Inference Processors" to `docs/releases/v2.16.0/index.md`
- Added "ML Inference Processor" to `docs/features/index.md`

## Key Changes in v2.16.0
- ML Inference Search Request Processor for query transformation
- ML Inference Search Response Processor for result enrichment
- Model input validation for local models

## Related PRs
- [#2688](https://github.com/opensearch-project/ml-commons/pull/2688) - MLInferenceSearchResponseProcessor
- [#2616](https://github.com/opensearch-project/ml-commons/pull/2616) - Search request inference processor
- [#2610](https://github.com/opensearch-project/ml-commons/pull/2610) - Model input validation

Closes #2172