### PR TITLE
docs: add Anomaly Detection date_nanos Support report for v2.16.0

### DIFF
--- a/docs/features/anomaly-detection/anomaly-detection-date-nanos-support.md
+++ b/docs/features/anomaly-detection/anomaly-detection-date-nanos-support.md
@@ -1,0 +1,142 @@
+---
+tags:
+  - anomaly-detection
+---
+# Anomaly Detection date_nanos Support
+
+## Summary
+
+The Anomaly Detection plugin supports the `date_nanos` field type as a valid timestamp field for creating anomaly detectors. This allows users with nanosecond-precision timestamps to use Anomaly Detection without needing to create a separate `date` type field.
+
+## Details
+
+### Overview
+
+OpenSearch provides two date field types:
+- `date`: Millisecond precision (default)
+- `date_nanos`: Nanosecond precision
+
+The Anomaly Detection plugin validates the timestamp field type when creating detectors. With `date_nanos` support, both field types are accepted as valid timestamp fields.
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph "Detector Creation"
+        UI[OpenSearch Dashboards UI]
+        API[Anomaly Detection API]
+        Validator[Time Field Validator]
+    end
+    
+    subgraph "Index Mapping"
+        DateField["date field"]
+        DateNanosField["date_nanos field"]
+    end
+    
+    UI --> API
+    API --> Validator
+    Validator --> DateField
+    Validator --> DateNanosField
+    
+    DateField -->|Valid| Detector[Anomaly Detector]
+    DateNanosField -->|Valid| Detector
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `AbstractTimeSeriesActionHandler` | Validates timestamp field type during detector creation |
+| `CommonName.DATE_NANOS_TYPE` | Constant for `date_nanos` type string |
+| `Timestamp.tsx` | UI component for timestamp field selection |
+| `DataTypes` interface | Redux state interface including `date_nanos` fields |
+
+### Configuration
+
+No additional configuration is required. The `date_nanos` field type is automatically recognized when:
+1. Creating a detector via the REST API
+2. Selecting a timestamp field in OpenSearch Dashboards
+
+### Usage Example
+
+#### Index Mapping with date_nanos
+
+```json
+PUT /high-frequency-data
+{
+  "mappings": {
+    "properties": {
+      "timestamp": {
+        "type": "date_nanos",
+        "format": "strict_date_optional_time_nanos||epoch_millis"
+      },
+      "cpu_usage": {
+        "type": "double"
+      },
+      "host": {
+        "type": "keyword"
+      }
+    }
+  }
+}
+```
+
+#### Creating a Detector
+
+```json
+POST /_plugins/_anomaly_detection/detectors
+{
+  "name": "cpu-anomaly-detector",
+  "description": "Detect CPU usage anomalies",
+  "time_field": "timestamp",
+  "indices": ["high-frequency-data"],
+  "feature_attributes": [
+    {
+      "feature_name": "cpu_avg",
+      "feature_enabled": true,
+      "aggregation_query": {
+        "cpu_avg": {
+          "avg": {
+            "field": "cpu_usage"
+          }
+        }
+      }
+    }
+  ],
+  "detection_interval": {
+    "period": {
+      "interval": 1,
+      "unit": "Minutes"
+    }
+  }
+}
+```
+
+## Limitations
+
+- Internal anomaly detection processing uses millisecond precision for detection intervals
+- The nanosecond precision is preserved in the source data but aggregated to the detection interval
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Added support for `date_nanos` field type as a valid timestamp field
+
+## References
+
+### Documentation
+
+- [Date nanoseconds field type](https://docs.opensearch.org/latest/field-types/supported-field-types/date-nanos/)
+- [Anomaly Detection](https://docs.opensearch.org/latest/observing-your-data/ad/index/)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [anomaly-detection#1238](https://github.com/opensearch-project/anomaly-detection/pull/1238) | Adding support for date_nanos to Anomaly Detection |
+| v2.16.0 | [anomaly-detection-dashboards-plugin#795](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/795) | Allow date_nanos dates in timestamp selection |
+
+### Related Issues
+
+| Issue | Description |
+|-------|-------------|
+| [anomaly-detection#1226](https://github.com/opensearch-project/anomaly-detection/issues/1226) | Feature request: Support date_nanos as a date field |

--- a/docs/features/anomaly-detection/index.md
+++ b/docs/features/anomaly-detection/index.md
@@ -3,6 +3,7 @@
 | Document | Description |
 |----------|-------------|
 | [anomaly-detection-admin-backend-role-bypass](anomaly-detection-admin-backend-role-bypass.md) | Anomaly Detection Admin Backend Role Bypass |
+| [anomaly-detection-date-nanos-support](anomaly-detection-date-nanos-support.md) | Anomaly Detection date_nanos Support |
 | [anomaly-detection-dependencies](anomaly-detection-dependencies.md) | Anomaly Detection Dependencies |
 | [anomaly-detection-dual-cluster-development](anomaly-detection-dual-cluster-development.md) | Dual Cluster Development Environment |
 | [anomaly-detection-forecasting](anomaly-detection-forecasting.md) | Anomaly Detection Forecasting |

--- a/docs/releases/v2.16.0/features/anomaly-detection/anomaly-detection-date-nanos-support.md
+++ b/docs/releases/v2.16.0/features/anomaly-detection/anomaly-detection-date-nanos-support.md
@@ -1,0 +1,139 @@
+---
+tags:
+  - anomaly-detection
+---
+# Anomaly Detection date_nanos Support
+
+## Summary
+
+OpenSearch 2.16.0 adds support for the `date_nanos` field type as a valid timestamp field in Anomaly Detection. Previously, only the `date` field type was accepted for the time field when creating anomaly detectors. This enhancement allows users with nanosecond-precision timestamps to use Anomaly Detection without needing to create a separate `date` type field.
+
+## Details
+
+### What's New in v2.16.0
+
+The `date_nanos` field type provides nanosecond precision for timestamps, which is useful for high-frequency data ingestion scenarios. Prior to this release, Anomaly Detection only validated `date` type fields as valid timestamp fields, causing a validation exception when users attempted to create detectors with `date_nanos` fields.
+
+### Technical Changes
+
+#### Backend Plugin (anomaly-detection)
+
+The validation logic in `AbstractTimeSeriesActionHandler.validateTimeField()` was updated to accept both `date` and `date_nanos` field types:
+
+```java
+// Before: Only date type was accepted
+if (!typeName.equals(CommonName.DATE_TYPE)) {
+    // throw ValidationException
+}
+
+// After: Both date and date_nanos are accepted
+if (!typeName.equals(CommonName.DATE_TYPE) && !typeName.equals(CommonName.DATE_NANOS_TYPE)) {
+    // throw ValidationException
+}
+```
+
+A new constant `DATE_NANOS_TYPE` was added to `CommonName.java`:
+
+```java
+public static final String DATE_NANOS_TYPE = "date_nanos";
+```
+
+#### Dashboards Plugin (anomaly-detection-dashboards-plugin)
+
+The timestamp field selector in the detector creation UI was updated to include `date_nanos` fields in the dropdown:
+
+```typescript
+// Timestamp.tsx
+const dateNanoFields = Array.from(
+  get(opensearchState, 'dataTypes.date_nanos', []) as string[]
+);
+
+const allDateFields = dateFields.concat(dateNanoFields);
+
+const timeStampFieldOptions = isEmpty(allDateFields)
+  ? []
+  : allDateFields.map((dateField) => ({ label: dateField }));
+```
+
+The `DataTypes` interface in the Redux reducer was extended to include `date_nanos`:
+
+```typescript
+export interface DataTypes {
+  // ... existing types
+  date?: string[];
+  date_nanos?: string[];  // Added
+  // ...
+}
+```
+
+### Usage Example
+
+Create an index with a `date_nanos` timestamp field:
+
+```json
+PUT /my-index
+{
+  "mappings": {
+    "properties": {
+      "timestamp": {
+        "type": "date_nanos",
+        "format": "epoch_millis||yyyy-MM-dd HH:mm:ss.SSS||yyyy-MM-dd HH:mm:ss.SSSSSS"
+      },
+      "value": {
+        "type": "double"
+      }
+    }
+  }
+}
+```
+
+Create an anomaly detector using the `date_nanos` field as the timestamp:
+
+```json
+POST /_plugins/_anomaly_detection/detectors
+{
+  "name": "my-detector",
+  "description": "Detector with date_nanos timestamp",
+  "time_field": "timestamp",
+  "indices": ["my-index"],
+  "feature_attributes": [
+    {
+      "feature_name": "value_avg",
+      "feature_enabled": true,
+      "aggregation_query": {
+        "value_avg": {
+          "avg": {
+            "field": "value"
+          }
+        }
+      }
+    }
+  ],
+  "detection_interval": {
+    "period": {
+      "interval": 10,
+      "unit": "Minutes"
+    }
+  }
+}
+```
+
+## Limitations
+
+- The internal processing still uses millisecond precision for anomaly detection intervals
+- No changes to the anomaly detection algorithm itself; only the timestamp field validation was updated
+
+## References
+
+### Pull Requests
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#1238](https://github.com/opensearch-project/anomaly-detection/pull/1238) | anomaly-detection | Adding support for date_nanos to Anomaly Detection |
+| [#795](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/795) | anomaly-detection-dashboards-plugin | Allow date_nanos dates in timestamp selection |
+
+### Related Issues
+
+| Issue | Repository | Description |
+|-------|------------|-------------|
+| [#1226](https://github.com/opensearch-project/anomaly-detection/issues/1226) | anomaly-detection | Support date_nanos as a date field in Anomaly Detection |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -7,6 +7,7 @@
 - Cross-Cluster & Remote Monitors
 
 ### anomaly-detection
+- Anomaly Detection date_nanos Support
 - Anomaly Detection JDK21 Upgrade
 - PR Template Updates
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Anomaly Detection date_nanos Support feature introduced in OpenSearch v2.16.0.

### Reports Created
- Release report: `docs/releases/v2.16.0/features/anomaly-detection/anomaly-detection-date-nanos-support.md`
- Feature report: `docs/features/anomaly-detection/anomaly-detection-date-nanos-support.md`

### Key Changes in v2.16.0
- Added support for `date_nanos` field type as a valid timestamp field in Anomaly Detection
- Updated backend validation to accept both `date` and `date_nanos` types
- Updated Dashboards UI to show `date_nanos` fields in timestamp selector

### Resources Used
- PR: [anomaly-detection#1238](https://github.com/opensearch-project/anomaly-detection/pull/1238)
- PR: [anomaly-detection-dashboards-plugin#795](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/795)
- Issue: [anomaly-detection#1226](https://github.com/opensearch-project/anomaly-detection/issues/1226)

Closes #2171