### PR TITLE
docs: add Navigation & NavGroups report for v2.16.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -28,6 +28,10 @@ Cumulative feature documentation across all versions.
 - Observability Release Maintenance
 - Observability Security Maintenance
 
+## opensearch-dashboards
+
+- Navigation & NavGroups
+
 ## opensearch
 
 - Application-Based Configuration (ABC) Templates

--- a/docs/features/opensearch-dashboards/navigation-navgroups.md
+++ b/docs/features/opensearch-dashboards/navigation-navgroups.md
@@ -1,0 +1,136 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Navigation & NavGroups
+
+## Summary
+
+NavGroups is a navigation architecture in OpenSearch Dashboards that provides hierarchical grouping of applications into use cases (groups) and categories. It addresses the challenge of managing an increasingly crowded left navigation menu as the number of plugins grows.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Navigation Hierarchy"
+        ROOT[Left Navigation]
+        ROOT --> GROUPS[Use Cases / Groups]
+        
+        GROUPS --> OBS[Observability]
+        GROUPS --> SA[Security Analytics]
+        GROUPS --> AN[Analytics]
+        GROUPS --> DA[Data Administration]
+        
+        OBS --> OBS_CAT[Categories]
+        OBS_CAT --> OBS_INV[Investigate]
+        OBS_CAT --> OBS_DR[Dashboards & Report]
+        OBS_CAT --> OBS_DET[Detect]
+        
+        OBS_INV --> TRACES[Traces]
+        OBS_INV --> METRICS[Metrics]
+        OBS_DR --> NOTEBOOKS[Notebooks]
+        OBS_DET --> AD[Anomaly Detection]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| NavGroup | Top-level grouping representing a use case (e.g., Observability, Security Analytics) |
+| NavCategory | Second-level grouping within a NavGroup (e.g., Investigate, Dashboards & Report) |
+| NavLink | Individual application link registered to one or more NavGroups |
+| Chrome Service | Core service providing `navGroup.addNavLinksToGroup()` API |
+
+### Configuration
+
+Plugins register their applications to NavGroups during setup:
+
+```typescript
+// In plugin setup
+public setup(core: CoreSetup) {
+    // Standard application registration
+    core.application.register({
+        id: 'myPlugin',
+        title: 'My Plugin',
+        category: DEFAULT_APP_CATEGORIES.opensearchDashboards,
+    });
+
+    // Register to NavGroups
+    core.chrome.navGroup.addNavLinksToGroup(
+        DEFAULT_USE_CASES.observability,
+        [{
+            id: 'myPlugin',
+            order: 100,
+            category: DEFAULT_APP_CATEGORIES.investigate
+        }]
+    );
+
+    // Can register to multiple groups
+    core.chrome.navGroup.addNavLinksToGroup(
+        DEFAULT_USE_CASES.securityAnalytics,
+        [{
+            id: 'myPlugin',
+            order: 200,
+            category: DEFAULT_APP_CATEGORIES.dashboardAndReport
+        }]
+    );
+}
+```
+
+### Default Use Cases
+
+| Use Case | Description |
+|----------|-------------|
+| `observability` | Log analysis, metrics, traces, and application monitoring |
+| `securityAnalytics` | Security event detection, alerts, and threat intelligence |
+| `analytics` | Data visualization, dashboards, and reporting |
+| `dataAdministration` | Index management, security configuration, and system settings |
+
+### Default Categories
+
+| Category | Typical Use |
+|----------|-------------|
+| `investigate` | Tools for exploring and analyzing data (Traces, Metrics) |
+| `dashboardAndReport` | Visualization and reporting tools (Notebooks, Dashboards) |
+| `detect` | Alerting and anomaly detection tools |
+| `machineLearning` | ML models and AI-related features |
+| `dataManagement` | Index and data lifecycle management |
+
+## Limitations
+
+- Applications can appear in multiple NavGroups, which may cause initial user confusion
+- Feature flag must be enabled to use the new navigation
+- Legacy deep links continue to work but may not reflect the new navigation structure
+- Custom plugins must be updated to register with NavGroups for proper placement
+
+## Change History
+
+- **v2.16.0** (2024-08-06): Initial implementation of NavGroups across all major dashboard plugins
+
+## References
+
+### Documentation
+
+- OpenSearch Dashboards quickstart guide
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v2.16.0 | [dashboards-observability#1926](https://github.com/opensearch-project/dashboards-observability/pull/1926) | Register all plugins to NavGroups |
+| v2.16.0 | [dashboards-observability#1950](https://github.com/opensearch-project/dashboards-observability/pull/1950) | Remove integrations from new NavGroups |
+| v2.16.0 | [alerting-dashboards-plugin#1007](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1007) | Side nav changes for alerting |
+| v2.16.0 | [anomaly-detection-dashboards-plugin#810](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/810) | AD side navigation redesign |
+| v2.16.0 | [ml-commons-dashboards#343](https://github.com/opensearch-project/ml-commons-dashboards/pull/343) | Update category to Machine learning |
+| v2.16.0 | [dashboards-notifications#222](https://github.com/opensearch-project/dashboards-notifications/pull/222) | Side navigation changes for notifications |
+| v2.16.0 | [index-management-dashboards-plugin#1085](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1085) | New Navigation UX change |
+| v2.16.0 | [security-dashboards-plugin#2022](https://github.com/opensearch-project/security-dashboards-plugin/pull/2022) | Conform to Navigation changes from OSD core |
+
+### Related Issues
+
+| Issue | Description |
+|-------|-------------|
+| [OpenSearch-Dashboards#7029](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7029) | RFC: Introduce `group` in chrome service to group applications and categories |

--- a/docs/releases/v2.16.0/features/opensearch-dashboards/navigation-navgroups.md
+++ b/docs/releases/v2.16.0/features/opensearch-dashboards/navigation-navgroups.md
@@ -1,0 +1,110 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Navigation & NavGroups
+
+## Summary
+
+OpenSearch Dashboards v2.16.0 introduces NavGroups, a new navigation architecture that groups related applications and categories into higher-level use cases. This addresses the growing complexity of the left navigation menu as the number of plugins increases. All major dashboard plugins have been updated to register their applications to appropriate NavGroups.
+
+## Details
+
+### What's New in v2.16.0
+
+The NavGroups feature introduces a hierarchical navigation structure:
+
+```mermaid
+graph TB
+    subgraph "New Navigation Structure"
+        UC[Use Cases/Groups]
+        UC --> OBS[Observability]
+        UC --> SA[Security Analytics]
+        UC --> AN[Analytics]
+        UC --> DA[Data Administration]
+        
+        OBS --> OBS_CAT[Categories]
+        OBS_CAT --> INV[Investigate]
+        OBS_CAT --> DR[Dashboards & Report]
+        
+        SA --> SA_CAT[Categories]
+        SA_CAT --> SA_DR[Dashboards & Report]
+    end
+```
+
+### Key Changes
+
+1. **Chrome Service Extension**: New `navGroup.addNavLinksToGroup()` API allows plugins to register applications to multiple groups with different categories
+2. **Decoupled Applications and Categories**: Applications can now belong to multiple categories under different groups
+3. **Feature Flag Control**: Navigation changes are controlled by a feature flag, maintaining backward compatibility
+4. **Plugin Registration**: All major plugins updated to register with appropriate NavGroups
+
+### Plugin Registration Summary
+
+| Plugin | Group | Category |
+|--------|-------|----------|
+| Notebooks | Observability, Security Analytics, Analytics | Dashboards and Report |
+| Integrations | Observability | Dashboards and Report |
+| Metrics | Observability | Investigate |
+| Applications | Observability | Dashboards and Report |
+| Traces | Observability | Investigate |
+| Alerting | Observability, Security Analytics | Detect |
+| Anomaly Detection | Observability | Detect |
+| Index Management | Data Administration | Data Management |
+| Security | Data Administration | Security |
+| ML Commons | Analytics | Machine Learning |
+| Notifications | Observability, Security Analytics | Notifications |
+
+### Technical Implementation
+
+Plugins register to NavGroups using the chrome service API:
+
+```typescript
+// Register application (unchanged)
+coreSetup.application.register({
+    id: 'myApp',
+    title: 'My Application',
+    category: DEFAULT_APP_CATEGORIES.opensearchDashboards,
+});
+
+// Register to NavGroup (new in v2.16.0)
+coreSetup.chrome.navGroup.addNavLinksToGroup(
+    DEFAULT_USE_CASES.observability, 
+    [{
+        id: 'myApp',
+        category: DEFAULT_APP_CATEGORIES.investigate
+    }]
+);
+```
+
+## Limitations
+
+- Feature is controlled by a feature flag and may not be enabled by default
+- Deep links using old URL patterns (`app/${applicationId}`) continue to work for backward compatibility
+- Some plugins may appear in multiple navigation groups, which could cause initial user confusion
+
+## References
+
+### Pull Requests
+
+| PR | Repository | Description |
+|----|------------|-------------|
+| [#1926](https://github.com/opensearch-project/dashboards-observability/pull/1926) | dashboards-observability | Register all plugins to NavGroups |
+| [#1950](https://github.com/opensearch-project/dashboards-observability/pull/1950) | dashboards-observability | Remove integrations from new NavGroups |
+| [#1007](https://github.com/opensearch-project/alerting-dashboards-plugin/pull/1007) | alerting-dashboards-plugin | Side nav changes for alerting |
+| [#810](https://github.com/opensearch-project/anomaly-detection-dashboards-plugin/pull/810) | anomaly-detection-dashboards-plugin | AD side navigation redesign |
+| [#635](https://github.com/opensearch-project/dashboards-maps/pull/635) | dashboards-maps | Add support new navigation for maps |
+| [#406](https://github.com/opensearch-project/dashboards-maps/pull/406) | dashboards-maps | Register all plugins to NavGroups |
+| [#343](https://github.com/opensearch-project/ml-commons-dashboards/pull/343) | ml-commons-dashboards | Update category to Machine learning |
+| [#337](https://github.com/opensearch-project/ml-commons-dashboards/pull/337) | ml-commons-dashboards | Register admin UI as AI models |
+| [#222](https://github.com/opensearch-project/dashboards-notifications/pull/222) | dashboards-notifications | Side navigation changes for notifications |
+| [#369](https://github.com/opensearch-project/dashboards-reporting/pull/369) | dashboards-reporting | Register all plugins to NavGroups |
+| [#1085](https://github.com/opensearch-project/index-management-dashboards-plugin/pull/1085) | index-management-dashboards-plugin | New Navigation UX change |
+| [#2022](https://github.com/opensearch-project/security-dashboards-plugin/pull/2022) | security-dashboards-plugin | Conform to Navigation changes from OSD core |
+| [#1084](https://github.com/opensearch-project/security-dashboards-plugin/pull/1084) | security-dashboards-plugin | Side nav changes for SA |
+
+### Related Issues
+
+| Issue | Repository | Description |
+|-------|------------|-------------|
+| [#7029](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/7029) | OpenSearch-Dashboards | RFC: Introduce `group` in chrome service |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -20,6 +20,9 @@
 ### dashboards-observability
 - Observability Getting Started & Dashboards
 
+### opensearch-dashboards
+- Navigation & NavGroups
+
 ### dashboards-query-workbench
 - Query Workbench Dev Tools Migration
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the Navigation & NavGroups feature introduced in OpenSearch Dashboards v2.16.0.

## Changes

- **Release Report**: `docs/releases/v2.16.0/features/opensearch-dashboards/navigation-navgroups.md`
- **Feature Report**: `docs/features/opensearch-dashboards/navigation-navgroups.md`
- Updated release and feature indexes

## Feature Overview

NavGroups introduces a hierarchical navigation structure that groups applications into use cases (Observability, Security Analytics, Analytics, Data Administration) and categories. This addresses the growing complexity of the left navigation menu.

### Key PRs Investigated

- dashboards-observability#1926, #1950
- alerting-dashboards-plugin#1007
- anomaly-detection-dashboards-plugin#810
- ml-commons-dashboards#343
- dashboards-notifications#222
- index-management-dashboards-plugin#1085
- security-dashboards-plugin#2022

Closes #2168