### PR TITLE
docs: add text-to-visualization report for v2.16.0

### DIFF
--- a/docs/features/dashboards-assistant/dashboards-assistant-text-to-visualization.md
+++ b/docs/features/dashboards-assistant/dashboards-assistant-text-to-visualization.md
@@ -206,7 +206,8 @@ interface VisNLQSavedObject {
 - **v3.2.0**: Added support for natural language visualization in new dashboard ingress (Explore UI); restructured alias registration for better integration
 - **v3.1.0**: Added error handling for PPL queries with no results
 - **v3.0.0**: Added metrics collection for t2viz usage
-- **v2.18.0**: Initial implementation with Text2Vega, Text2PPL, and Data2Summary APIs
+- **v2.18.0**: Added Data2Summary API, enhanced implementation
+- **v2.16.0**: Initial implementation with Text2Vega and Text2PPL APIs
 
 
 ## References
@@ -219,7 +220,8 @@ interface VisNLQSavedObject {
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
-| v2.18.0 | [#264](https://github.com/opensearch-project/dashboards-assistant/pull/264) | Initial implementation of text to visualization |   |
+| v2.16.0 | [#218](https://github.com/opensearch-project/dashboards-assistant/pull/218) | Initial implementation of text to visualization | |
+| v2.18.0 | [#264](https://github.com/opensearch-project/dashboards-assistant/pull/264) | Enhanced text to visualization implementation |   |
 | v2.18.0 | [#295](https://github.com/opensearch-project/dashboards-assistant/pull/295) | Add discovery summary API |   |
 | v2.18.0 | [#349](https://github.com/opensearch-project/dashboards-assistant/pull/349) | Integration with Discover page |   |
 | v3.0.0 | [#510](https://github.com/opensearch-project/dashboards-assistant/pull/510) | Add metrics collection for t2viz |   |

--- a/docs/releases/v2.16.0/features/dashboards-assistant/text-to-visualization.md
+++ b/docs/releases/v2.16.0/features/dashboards-assistant/text-to-visualization.md
@@ -1,0 +1,80 @@
+---
+tags:
+  - dashboards-assistant
+---
+# Text to Visualization
+
+## Summary
+
+Text to Visualization (t2viz) is a new experimental feature that enables users to create data visualizations using natural language queries. Users can describe their visualization needs in plain English, and the system automatically generates Vega-Lite specifications through ML Commons agents connected to LLM providers.
+
+## Details
+
+### What's New in v2.16.0
+
+This release introduces the initial implementation of the Text to Visualization feature:
+
+- **Text2Viz Page**: New dedicated page for creating visualizations from natural language
+- **Text2Vega Service**: Coordinates the pipeline from natural language to Vega-Lite specification
+- **Text2PPL API**: Converts natural language questions to PPL queries
+- **Text2Vega API**: Generates Vega-Lite specs from PPL results and user input
+- **Source Selector**: Index pattern selection for data source
+- **Visualization Alias**: Registered as experimental visualization type in the visualize app
+
+### Technical Changes
+
+#### New APIs
+
+| API | Method | Path | Description |
+|-----|--------|------|-------------|
+| Text2PPL | POST | `/api/assistant/text2ppl` | Convert question to PPL query |
+| Text2Vega | POST | `/api/assistant/text2vega` | Generate Vega-Lite from PPL and sample data |
+
+#### New Components
+
+| Component | Description |
+|-----------|-------------|
+| `Text2Viz` | Main page component |
+| `Text2Vega` | Service class using RxJS for reactive pipeline |
+| `SourceSelector` | Data source selection component |
+| `Text2VizEmpty` | Empty state component |
+| `Text2VizLoading` | Loading state component |
+
+#### Configuration
+
+The feature is controlled by the `assistant.next.enabled` configuration flag (disabled by default).
+
+#### ML Agents Required
+
+- `text2vega`: Agent for generating Vega-Lite specifications
+- `text2ppl`: Agent for generating PPL queries from natural language
+
+### Data Flow
+
+```mermaid
+flowchart TB
+    A[User Input] --> B[Text2PPL Agent]
+    B --> C[Generate PPL Query]
+    C --> D[Execute PPL]
+    D --> E[Get Sample Data + Schema]
+    E --> F[Text2Vega Agent]
+    F --> G[Generate Vega-Lite Spec]
+    G --> H[Render Visualization]
+    H --> I[Save as visualization]
+```
+
+## Limitations
+
+- Experimental feature, not recommended for production
+- Requires external LLM provider configuration
+- Requires ML Commons agents to be set up
+- Only generates Vega-Lite visualizations
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#218](https://github.com/opensearch-project/dashboards-assistant/pull/218) | Initial implementation of text to visualization | |
+| [#223](https://github.com/opensearch-project/dashboards-assistant/pull/223) | Backport to 2.16 branch | |

--- a/docs/releases/v2.16.0/index.md
+++ b/docs/releases/v2.16.0/index.md
@@ -14,6 +14,9 @@
 - Anomaly Detection JDK21 Upgrade
 - PR Template Updates
 
+### dashboards-assistant
+- Text to Visualization
+
 ### dashboards-maps
 - Dashboards Maps WMS Fix
 


### PR DESCRIPTION
## Summary

Add release report for Text to Visualization feature in v2.16.0.

### Changes
- Created release report: `docs/releases/v2.16.0/features/dashboards-assistant/text-to-visualization.md`
- Updated feature report: `docs/features/dashboards-assistant/dashboards-assistant-text-to-visualization.md`
  - Added v2.16.0 as initial implementation in Change History
  - Added PR #218 to Pull Requests table
- Updated release index: `docs/releases/v2.16.0/index.md`

### Key Findings
- PR #218 introduced the initial Text to Visualization feature for v2.16.0
- The feature enables natural language to Vega-Lite visualization generation
- Requires ML Commons agents (text2vega, text2ppl) and LLM provider configuration
- Experimental feature controlled by `assistant.next.enabled` flag

Closes #2165