### PR TITLE
docs: add dashboards-build-rspack-migration report for v3.5.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-webpack-and-build-performance.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-webpack-and-build-performance.md
@@ -175,6 +175,7 @@ module.exports = {
 
 ## Change History
 
+- **v3.5.0**: Migrated entire build toolchain from Webpack 4 to Rspack 1.6.4. Replaced Babel with SWC for transpilation. Upgraded Storybook to Webpack 5. Replaced `BundleRefsPlugin` with `VirtualModulesPlugin`. Added `BundleDepsCheckPlugin` for dependency validation. Updated sass-embedded to 1.93.3 with async compiler pooling. Bundle size limits recalibrated for Rspack output.
 - **v3.0.0** (2025-03-20): Initial implementation with bundle analyzer and Lighthouse CI workflows
 
 
@@ -185,9 +186,11 @@ module.exports = {
 - [PR #9304](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9304): Lighthouse CI implementation
 - [Lighthouse CI](https://github.com/GoogleChrome/lighthouse-ci): Google's Lighthouse CI tool
 - [Webpack Bundle Analyzer](https://www.npmjs.com/package/webpack-bundle-analyzer): Bundle analysis tool
+- [Rspack](https://rspack.dev/): High-performance Rust-based bundler
 
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v3.5.0 | [#11102](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11102) | Migrate OSD build from Webpack4 to Rspack | |
 | v3.0.0 | [#9320](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9320) | Webpack bundle analyser limit check |   |
 | v3.0.0 | [#9304](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9304) | Lighthouse Page Performance Metrics CI workflow |   |

--- a/docs/releases/v3.5.0/features/opensearch-dashboards/dashboards-build-rspack-migration.md
+++ b/docs/releases/v3.5.0/features/opensearch-dashboards/dashboards-build-rspack-migration.md
@@ -1,0 +1,69 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Dashboards Build (Rspack Migration)
+
+## Summary
+
+OpenSearch Dashboards v3.5.0 migrates the entire build toolchain from Webpack 4 to [Rspack](https://rspack.dev/) (v1.6.4), a high-performance Rust-based bundler with Webpack-compatible APIs. This also replaces Babel with SWC for JavaScript/TypeScript transpilation and upgrades Storybook to Webpack 5. The migration improves build speed while maintaining full compatibility with the existing plugin ecosystem.
+
+## Details
+
+### What's New in v3.5.0
+
+The core build system (`osd-optimizer`) and all supporting packages have been migrated from Webpack 4 (a custom fork `@amoo-miki/webpack@4.46.0-xxhash.1`) to `@rspack/core@1.6.4`.
+
+### Technical Changes
+
+| Area | Before (Webpack 4) | After (Rspack 1.6.4) |
+|------|--------------------|-----------------------|
+| Bundler | `webpack` (custom fork) | `@rspack/core` |
+| Transpiler | Babel (`babel-loader`) | SWC (built-in to Rspack via `getSwcLoaderConfig`) |
+| Sass | `@amoo-miki/sass-loader` + `sass-embedded@1.66.1` | `sass-loader@16.0.5` + `sass-embedded@1.93.3` |
+| PostCSS | `postcss-loader@4.x` | `postcss-loader@8.x` |
+| Compression | `@amoo-miki/compression-webpack-plugin@4.0.1-rc.1` | `compression-webpack-plugin@11.x` |
+| Merge | `webpack-merge@4.x` | `webpack-merge@5.x` |
+| Minifier | `terser-webpack-plugin` | `rspack.SwcJsMinimizerRspackPlugin` + `LightningCssMinimizerRspackPlugin` |
+| Bundle refs | `BundleRefsPlugin` + `BundleRefModule` (custom webpack Module) | `VirtualModulesPlugin` + `BundleDepsCheckPlugin` |
+| Hash function | `Xxh64` | `xxhash64` |
+| Storybook | Webpack 4 | Webpack 5 |
+| Asset handling | `url-loader`, `file-loader`, `raw-loader` | Rspack native `asset`, `asset/resource`, `asset/source` types |
+
+#### Key Architectural Changes
+
+1. `BundleRefsPlugin` and `BundleRefModule` (which intercepted webpack's module factory to replace cross-bundle imports with custom Module instances) are removed. Replaced by `rspack.experiments.VirtualModulesPlugin` which creates virtual files that resolve to `__osdBundles__.get(exportId)`.
+
+2. `BundleDepsCheckPlugin` is a new plugin that validates bundle dependency declarations at build time by inspecting `NormalModule` instances in `finishModules` hook.
+
+3. Entry point creator changed from `__osdBundles__.define(id, __webpack_require__, require.resolve(path))` to `__osdBundles__.define(id, () => { return require(path) })` — a lazy factory pattern.
+
+4. Sass compilation uses a pool of 3 async `sass-embedded` compilers for parallel SCSS processing, with proper disposal on build completion.
+
+5. CI cypress workflow switched from `--dev` to `--dist` (production) builds to address disk space constraints on GitHub Actions runners.
+
+#### Modified Packages
+
+| Package | Changes |
+|---------|---------|
+| `osd-optimizer` | Core migration: Rspack config, SWC loader, VirtualModulesPlugin, BundleDepsCheckPlugin |
+| `osd-monaco` | Build script uses `rspack` CLI, SWC replaces Babel, native asset types |
+| `osd-pm` | Build script uses `rspack` CLI, SWC replaces Babel |
+| `osd-ui-shared-deps` | Webpack config migrated to Rspack |
+| `osd-ui-framework` | Build config migrated to Rspack |
+| `osd-std` | Updated `json11` dependency to `^2.0.2` |
+
+## Limitations
+
+- Rspack produces slightly larger assets in development mode compared to Webpack 4
+- Chunk file naming changed (e.g., `chunk.1.js` → `chunk.0.js`), which may affect plugins that reference chunk files by name
+- Compression for async chunks in tests may behave differently (`.gz` files not created for chunks in test environment, but work correctly in actual builds)
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#11102](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11102) | Migrate OSD build from Webpack4 to Rspack | |
+| [#11107](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11107) | Webpack 5 migration of Storybook (combined into #11102) | |
+| [#11125](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11125) | RFC: Rspack migration | |

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -1,0 +1,4 @@
+# OpenSearch v3.5.0 Release
+
+## opensearch-dashboards
+- Dashboards Build (Rspack Migration)


### PR DESCRIPTION
## Summary

Adds release report and updates feature report for the Webpack 4 → Rspack migration in OpenSearch Dashboards v3.5.0.

### Reports
- Release report: `docs/releases/v3.5.0/features/opensearch-dashboards/dashboards-build-rspack-migration.md`
- Feature report updated: `docs/features/opensearch-dashboards/opensearch-dashboards-webpack-and-build-performance.md`

### Key Changes
- Build toolchain migrated from Webpack 4 to Rspack 1.6.4
- Babel replaced with SWC for transpilation
- Storybook upgraded to Webpack 5
- BundleRefsPlugin replaced with VirtualModulesPlugin
- New BundleDepsCheckPlugin for dependency validation

Closes #2554