### PR TITLE
docs: add dashboards-plugin-compatibility report for v3.5.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-plugin-compatibility.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-plugin-compatibility.md
@@ -6,7 +6,7 @@ tags:
 
 ## Summary
 
-OpenSearch Dashboards plugin compatibility controls how plugins are validated against the Dashboards version during installation. The system ensures plugins are compatible with the running Dashboards instance, preventing runtime errors from version mismatches. Starting in v3.3.0, administrators can configure the validation strictness using the `--single-version` CLI flag.
+OpenSearch Dashboards plugin compatibility controls how plugins are validated against the Dashboards version during installation and server startup. The system ensures plugins are compatible with the running Dashboards instance, preventing runtime errors from version mismatches. Starting in v3.3.0, administrators can configure the validation strictness using the `--single-version` CLI flag. In v3.5.0, the default was changed from `strict` to `ignore`, and the server-side manifest parser was relaxed to warn instead of error on version mismatches.
 
 ## Details
 
@@ -31,26 +31,19 @@ graph TB
         IgnoreCheck --> Success
     end
     
+    subgraph "Server Startup"
+        Boot[OSD Server Start] --> Discover[Plugin Discovery]
+        Discover --> ParseManifest[parseManifest]
+        ParseManifest --> VersionCheck{Version Match?}
+        VersionCheck -->|match| Load[Load Plugin]
+        VersionCheck -->|mismatch| Warn[Log Warning]
+        Warn --> Load
+    end
+    
     subgraph "Installation Complete"
         Success --> Rename[Rename to Plugin Dir]
         Rename --> Done[Installation Complete]
     end
-```
-
-### Data Flow
-
-```mermaid
-flowchart TB
-    A[Plugin Archive] --> B[Extract]
-    B --> C[Read Manifest]
-    C --> D[Get opensearchDashboardsVersion]
-    D --> E[cleanVersion]
-    E --> F[semver.parse]
-    F --> G{Mode Check}
-    G -->|strict| H[Exact Match]
-    G -->|ignore| I[Major Version Check]
-    H --> J[Install/Reject]
-    I --> K[Install with Warning]
 ```
 
 ### Components
@@ -60,55 +53,41 @@ flowchart TB
 | CLI Plugin Install | `src/cli_plugin/install/index.js` | Command-line interface for plugin installation |
 | Settings Parser | `src/cli_plugin/install/settings.js` | Parses CLI options including `singleVersion` |
 | Version Validator | `src/cli_plugin/install/opensearch_dashboards.js` | `assertVersion()` function for compatibility checks |
-| Manifest Parser | `src/core/server/plugins/discovery/plugin_manifest_parser.ts` | Server-side plugin manifest validation |
+| Manifest Parser | `src/core/server/plugins/discovery/plugin_manifest_parser.ts` | Server-side plugin manifest validation (warns on mismatch since v3.5.0) |
+| OpenSearch Config | `src/core/server/opensearch/opensearch_config.ts` | `ignoreVersionMismatch` setting |
+| Dependency Validator | `packages/osd-pm/src/utils/validate_dependencies.ts` | `singleVersionResolution` for dependency validation |
 
 ### Configuration
 
-| Setting | Description | Default | Values |
-|---------|-------------|---------|--------|
-| `--single-version` | Version validation mode for plugin installation | `strict` | `strict`, `ignore` |
+| Setting | Description | Default (v3.3.0) | Default (v3.5.0+) | Values |
+|---------|-------------|-------------------|---------------------|--------|
+| `--single-version` | Version validation mode for plugin installation | `strict` | `ignore` | `strict`, `ignore` |
+| `opensearch.ignoreVersionMismatch` | Ignore OSD-OpenSearch version mismatch | `false` | `true` | `true`, `false` |
 
 ### Usage Example
 
 ```bash
-# Install plugin with strict version matching (default)
-bin/opensearch-dashboards-plugin install https://example.com/plugin-3.3.0.zip
+# Install plugin with default mode (ignore since v3.5.0)
+bin/opensearch-dashboards-plugin install https://example.com/plugin-3.4.0.zip
 
-# Install plugin ignoring version mismatch (for development/testing)
-bin/opensearch-dashboards-plugin install --single-version ignore https://example.com/plugin-3.2.0.zip
-```
-
-### Version Validation Logic
-
-```javascript
-// Strict mode: exact version match required
-if (mode === 'strict') {
-  if (!semver.eq(actualVersion, expectedVersion)) {
-    throw new Error(`Plugin incompatible with OpenSearch Dashboards`);
-  }
-}
-
-// Ignore mode: warn on major version difference only
-if (mode === 'ignore') {
-  if (actualVersion.major !== expectedVersion.major) {
-    logger.log('WARNING: Major version differs');
-  }
-}
+# Install plugin with strict version matching (opt-in since v3.5.0)
+bin/opensearch-dashboards-plugin install --single-version strict https://example.com/plugin-3.5.0.zip
 ```
 
 ### Special Cases
 
 - **Development override**: Plugins with `opensearchDashboardsVersion: "opensearchDashboards"` bypass all version checks
-- **Invalid versions**: Both plugin and Dashboards versions must be valid semver; invalid formats throw errors
+- **Invalid versions**: Both plugin and Dashboards versions must be valid semver; invalid formats now produce warnings instead of errors (since v3.5.0)
 
 ## Limitations
 
-- Server-side manifest parsing (`plugin_manifest_parser.ts`) still requires exact version match
 - The `ignore` mode does not guarantee plugin functionality with mismatched versions
-- Only CLI installation supports the `--single-version` flag; programmatic installation uses strict mode
+- Users should verify plugin compatibility manually when using `ignore` mode
+- Plugins can still explicitly opt into strict mode via `--single-version strict`
 
 ## Change History
 
+- **v3.5.0**: Changed default `--single-version` from `strict` to `ignore`; server-side manifest parser now warns instead of throwing errors on version mismatch; `ignoreVersionMismatch` defaults to `true`
 - **v3.3.0** (2026-01-11): Added `--single-version` CLI flag with `strict` and `ignore` modes for flexible version validation
 
 
@@ -124,4 +103,6 @@ if (mode === 'ignore') {
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v3.5.0 | [#11179](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11179) | Allow external plugins to be a different version from OSD (warn instead of error) | - |
+| v3.5.0 | [#11183](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11183) | Make single-version=ignore as default | Follow-up to #11179 |
 | v3.3.0 | [#10273](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10273) | Add `--single-version` flag with strict/ignore modes | [#10294](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10294) |

--- a/docs/releases/v3.5.0/features/opensearch-dashboards/dashboards-plugin-compatibility.md
+++ b/docs/releases/v3.5.0/features/opensearch-dashboards/dashboards-plugin-compatibility.md
@@ -1,0 +1,53 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Dashboards Plugin Compatibility
+
+## Summary
+
+In v3.5.0, OpenSearch Dashboards relaxes plugin version compatibility enforcement. Previously, plugins with a version mismatch would cause errors that prevented server startup or plugin installation. Now, version mismatches produce warnings instead of errors, and the default validation mode is changed from `strict` to `ignore` across all components.
+
+## Details
+
+### What's New in v3.5.0
+
+Two complementary changes make plugin version compatibility more permissive:
+
+1. **Server-side manifest parser now warns instead of errors** (PR #11179): The `plugin_manifest_parser.ts` no longer throws a `PluginDiscoveryError.incompatibleVersion` when a plugin's version doesn't match the OSD version. Instead, it logs a warning and allows the plugin to load. This means OSD can run with older plugin versions without being blocked at startup.
+
+2. **Default validation mode changed to `ignore`** (PR #11183): The default value of `--single-version` is changed from `strict` to `ignore` across multiple components:
+
+| Component | Setting | Before | After |
+|-----------|---------|--------|-------|
+| CLI plugin install (`index.js`) | `--single-version` default | `strict` | `ignore` |
+| Settings parser (`settings.js`) | `singleVersion` fallback | `strict` | `ignore` |
+| OpenSearch config (`opensearch_config.ts`) | `ignoreVersionMismatch` | `false` | `true` |
+| Dependency validator (`validate_dependencies.ts`) | `singleVersionResolution` | `STRICT` | `IGNORE` |
+
+### Technical Changes
+
+In `plugin_manifest_parser.ts`, the version check was changed from:
+```typescript
+throw PluginDiscoveryError.incompatibleVersion(manifestPath, new Error(...));
+```
+to:
+```typescript
+log.warn(`Plugin "${manifest.id}" is version "${expectedVersion}", but used OpenSearch Dashboards version is "${packageInfo.version}".`);
+```
+
+This allows incompatible plugins to be discovered and loaded, with a warning logged to the console for debugging purposes.
+
+## Limitations
+
+- Version mismatch warnings do not guarantee that the plugin will function correctly with a different OSD version
+- Plugins with `opensearchDashboardsVersion: "opensearchDashboards"` continue to bypass all version checks
+- Users can still enforce strict mode by explicitly passing `--single-version strict`
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#11179](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11179) | Allow external plugins to be a different version from OSD (warn instead of error) | - |
+| [#11183](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11183) | Make single-version=ignore as default | Follow-up to #11179 |

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -2,3 +2,4 @@
 
 ## opensearch-dashboards
 - Dashboards Build (Rspack Migration)
+- Dashboards Plugin Compatibility


### PR DESCRIPTION
## Summary\n\nInvestigation report for Issue #2553: [bugfix] Dashboards Plugin Compatibility (v3.5.0)\n\n### Changes\n- Created release report: `docs/releases/v3.5.0/features/opensearch-dashboards/dashboards-plugin-compatibility.md`\n- Updated feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-plugin-compatibility.md`\n- Updated release index\n\n### Key Changes in v3.5.0\n- Server-side manifest parser now warns instead of throwing errors on plugin version mismatch (PR #11179)\n- Default `--single-version` mode changed from `strict` to `ignore` across all components (PR #11183)\n- `ignoreVersionMismatch` config default changed from `false` to `true`\n\nCloses #2553