### PR TITLE
docs: add dashboards-gzip-support report for v3.5.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -30,6 +30,7 @@ Cumulative feature documentation across all versions.
 
 ## opensearch-dashboards
 
+- Dashboards gzip Support
 - Dashboards Misc Fixes
 - Navigation & NavGroups
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-gzip-support.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-gzip-support.md
@@ -1,0 +1,119 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Dashboards gzip Support
+
+## Summary
+
+OpenSearch Dashboards supports optional gzip/deflate HTTP response compression for requests to OpenSearch clusters. When enabled, Dashboards sends `Accept-Encoding: gzip, deflate` headers, allowing OpenSearch to return compressed responses. This dramatically reduces payload sizes and improves query latency, especially for large result sets in Discover/Explore workloads.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Configuration"
+        YML["opensearch_dashboards.yml<br/>opensearch.requestCompression"]
+    end
+    subgraph "OpenSearch Dashboards Server"
+        subgraph "Core"
+            DH["getDefaultHeaders()"]
+            CC["ClusterClient"]
+        end
+        subgraph "Data Source Plugin (MDS)"
+            MC["Modern Client"]
+            LC["Legacy Client"]
+            AWS["HttpAmazonESConnector<br/>Sigv4 Auth"]
+        end
+        subgraph "Query Enhancements Plugin"
+            Facet["Facet Class"]
+            PPL["PPL Strategies"]
+        end
+    end
+    subgraph "OpenSearch Cluster"
+        OS["OpenSearch"]
+    end
+    YML --> DH --> CC
+    YML --> MC
+    YML --> LC --> AWS
+    Facet --> PPL
+    CC -->|"accept-encoding: gzip, deflate"| OS
+    MC -->|"accept-encoding: gzip, deflate"| OS
+    AWS -->|"accept-encoding: gzip, deflate"| OS
+    PPL -->|"accept-encoding: gzip, deflate"| OS
+    OS -->|"content-encoding: gzip"| CC
+    OS -->|"content-encoding: gzip"| MC
+    OS -->|"content-encoding: gzip"| AWS
+    OS -->|"content-encoding: gzip"| PPL
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `getDefaultHeaders()` | Function in `default_headers.ts` that conditionally includes `accept-encoding` header based on `requestCompression` config |
+| `OpenSearchConfig.requestCompression` | Boolean config property propagated from `opensearch_dashboards.yml` |
+| `HttpAmazonESConnector` | Custom HTTP connector for IAM Sigv4 auth that decompresses gzip/deflate responses via `zlib` |
+| `Facet` class | Utility in `query_enhancements` plugin with per-request `requestCompression` option for PPL queries |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `opensearch.requestCompression` | Request compressed responses from OpenSearch to reduce payload size | `false` |
+
+```yaml
+# opensearch_dashboards.yml
+opensearch.requestCompression: true
+```
+
+### Client Paths
+
+The compression setting affects multiple client paths:
+
+| Client Path | Mechanism | Controlled By |
+|-------------|-----------|---------------|
+| Core OpenSearch client | `accept-encoding` header via `getDefaultHeaders()` | `opensearch.requestCompression` |
+| MDS modern client | `accept-encoding` header in client options | `opensearch.requestCompression` |
+| MDS legacy client | `suggestCompression` option | `opensearch.requestCompression` |
+| MDS Sigv4 connector | Decompression via `zlib` in `streamToString()` | Always active (handles compressed responses) |
+| PPL search strategies | `requestCompression` option on `Facet` class | Hardcoded `true` per strategy |
+
+### Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/core/server/opensearch/default_headers.ts` | `getDefaultHeaders()` function |
+| `src/core/server/opensearch/opensearch_config.ts` | `requestCompression` schema definition |
+| `src/core/server/opensearch/client/client_config.ts` | Core client header injection |
+| `src/plugins/data_source/server/client/client_config.ts` | MDS modern client config |
+| `src/plugins/data_source/server/legacy/client_config.ts` | MDS legacy client config |
+| `src/plugins/data_source/server/legacy/http_aws_es/connector.js` | Sigv4 connector with decompression |
+| `src/plugins/query_enhancements/server/utils/facet.ts` | Facet class with per-request compression |
+| `config/opensearch_dashboards.yml` | User-facing configuration |
+
+## Limitations
+
+- Disabled by default to avoid breaking clients that do not handle compressed responses
+- PPL query compression operates independently from the global `opensearch.requestCompression` flag
+- SQL queries do not have compression enabled in the `query_enhancements` plugin
+- Custom plugins making direct OpenSearch API calls need to handle compression independently
+
+## Change History
+
+- **v3.5.0** (2026-02-11): Initial implementation with global `opensearch.requestCompression` flag (default: `false`) and independent PPL query compression
+
+## References
+
+### Documentation
+- [RFC: Enable HTTP Response Compression](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11130)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.5.0 | [#11135](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11135) | Initial gzip support for OpenSearch responses |
+| v3.5.0 | [#11158](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11158) | Fix decompression in HttpAmazonESConnector for Sigv4 auth |
+| v3.5.0 | [#11205](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11205) | Add `opensearch.requestCompression` feature flag (disabled by default) |
+| v3.5.0 | [#11240](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11240) | Add gzip compression for PPL queries via Facet class |

--- a/docs/releases/v3.5.0/features/opensearch-dashboards/dashboards-gzip-support.md
+++ b/docs/releases/v3.5.0/features/opensearch-dashboards/dashboards-gzip-support.md
@@ -1,0 +1,112 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Dashboards gzip Support
+
+## Summary
+
+OpenSearch Dashboards v3.5.0 adds optional gzip/deflate HTTP response compression for communication between Dashboards and OpenSearch clusters. This reduces response payload sizes by up to 98% and can improve end-to-end query latency by up to 81%, particularly for large result sets in Discover/Explore workloads. The feature is controlled by a new `opensearch.requestCompression` configuration flag, which defaults to `false`.
+
+## Details
+
+### What's New in v3.5.0
+
+#### Core Compression Support (PR #11135)
+
+The initial implementation added `accept-encoding: gzip, deflate` to the `DEFAULT_HEADERS` in `src/core/server/opensearch/default_headers.ts`, enabling compression by default for all OpenSearch requests from Dashboards. This applied to:
+
+- The default OpenSearch client (core server)
+- The Multi-Data Source (MDS) modern client (`data_source/server/client/client_config.ts`)
+- The MDS legacy client (`data_source/server/legacy/client_config.ts`) via `suggestCompression: true`
+
+#### IAM Sigv4 Decompression Fix (PR #11158)
+
+The `HttpAmazonESConnector` used for IAM Sigv4 authentication in MDS did not handle compressed responses, causing garbled data. This fix updated `streamToString()` in `connector.js` to detect `content-encoding` headers and decompress gzip/deflate responses using Node.js `zlib` (`createGunzip`, `createInflate`).
+
+#### Feature Flag Introduction (PR #11205)
+
+After discovering that some internal clients (e.g., ml-commons chat client) did not support gzip responses, compression was moved behind a configurable flag:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `opensearch.requestCompression` | Request compressed responses from OpenSearch | `false` |
+
+The `DEFAULT_HEADERS` no longer includes `accept-encoding` by default. Instead, a new `getDefaultHeaders(requestCompression)` function conditionally adds the header. The flag is propagated through:
+
+- `OpenSearchConfig` → core client config
+- `SharedGlobalConfigKeys` → plugin initializer context
+- `DataSourcePluginConfigType` → MDS client configs
+
+Configuration in `opensearch_dashboards.yml`:
+
+```yaml
+# Request compressed responses from OpenSearch
+opensearch.requestCompression: true
+```
+
+#### PPL Query Compression (PR #11240)
+
+Added independent gzip compression support for PPL queries in the `query_enhancements` plugin. The `Facet` class gained a `requestCompression` option that adds `accept-encoding: gzip, deflate` headers to individual requests. This is enabled for PPL search strategies only:
+
+- `ppl_search_strategy.ts`
+- `ppl_async_search_strategy.ts`
+- `ppl_raw_search_strategy.ts`
+
+SQL queries and other plugins are not affected.
+
+### Technical Changes
+
+```mermaid
+graph TB
+    subgraph "opensearch_dashboards.yml"
+        Flag["opensearch.requestCompression: true/false"]
+    end
+    subgraph "Core Client"
+        DH["getDefaultHeaders(requestCompression)"]
+        CC["ClusterClient"]
+    end
+    subgraph "MDS Plugin"
+        MC["Modern Client<br/>accept-encoding header"]
+        LC["Legacy Client<br/>suggestCompression"]
+        AWS["HttpAmazonESConnector<br/>gzip/deflate decompression"]
+    end
+    subgraph "Query Enhancements Plugin"
+        F["Facet class<br/>requestCompression option"]
+        PPL["PPL Search Strategies"]
+    end
+    Flag --> DH --> CC
+    Flag --> MC
+    Flag --> LC
+    LC --> AWS
+    F --> PPL
+```
+
+### Performance Impact
+
+Benchmarked with 40,000 documents (~54 MB, 100+ fields, 10,000 row result set):
+
+| Metric | Before | After | Improvement |
+|--------|--------|-------|-------------|
+| End-to-End Query Time | 9,625 ms | 1,835 ms | -81% |
+| Response Payload Size | 15.8 MB | 355 KB | -98% |
+
+## Limitations
+
+- Compression is disabled by default (`opensearch.requestCompression: false`) to avoid compatibility issues with clients that do not handle compressed responses
+- PPL query compression via the `Facet` class operates independently from the global flag
+- SQL queries in the `query_enhancements` plugin do not have compression enabled
+- Custom plugins making direct OpenSearch calls may need their own compression handling
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#11135](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11135) | Support gzip for OpenSearch responses | [#11130](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11130) |
+| [#11158](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11158) | Fix decompression in HttpAmazonESConnector | [#11135](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11135) |
+| [#11205](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11205) | Add opensearch.requestCompression flag | [#11158](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11158) |
+| [#11240](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11240) | Add gzip compression for PPL queries | [#11130](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11130) |
+
+### Issues
+- [#11130](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11130) - [RFC] Enable HTTP Response Compression for OpenSearch Clients in Dashboards

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -2,6 +2,7 @@
 
 ## opensearch-dashboards
 - Dashboards Build (Rspack Migration)
+- Dashboards gzip Support
 - Dashboards Misc Fixes
 - Dashboards Plugin Compatibility
 - Data Importer


### PR DESCRIPTION
## Summary

Adds release report and feature report for Dashboards gzip Support in OpenSearch v3.5.0.

### Reports Created
- Release report: `docs/releases/v3.5.0/features/opensearch-dashboards/dashboards-gzip-support.md`
- Feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-gzip-support.md`

### Key Changes in v3.5.0
- Initial gzip/deflate response compression support for all OpenSearch client paths
- `opensearch.requestCompression` feature flag (default: `false`)
- IAM Sigv4 connector decompression fix
- Independent PPL query compression via Facet class

### PRs Investigated
- #11135 - Support gzip for OpenSearch responses
- #11158 - Fix decompression in HttpAmazonESConnector
- #11205 - Add opensearch.requestCompression flag
- #11240 - Add gzip compression for PPL queries

Closes #2549