### PR TITLE
docs: add dashboards-data-plugin report for v3.5.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -30,6 +30,7 @@ Cumulative feature documentation across all versions.
 
 ## opensearch-dashboards
 
+- Dashboards Data Plugin
 - Dashboards gzip Support
 - Dashboards Misc Fixes
 - Navigation & NavGroups

--- a/docs/features/opensearch-dashboards/index.md
+++ b/docs/features/opensearch-dashboards/index.md
@@ -24,6 +24,7 @@
 | [opensearch-dashboards-data-connections](opensearch-dashboards-data-connections.md) | Data Connections |
 | [opensearch-dashboards-data-explorer](opensearch-dashboards-data-explorer.md) | Data Explorer |
 | [opensearch-dashboards-data-importer](opensearch-dashboards-data-importer.md) | Data Importer |
+| [opensearch-dashboards-data-plugin](opensearch-dashboards-data-plugin.md) | Data Plugin |
 | [opensearch-dashboards-data-source-permissions](opensearch-dashboards-data-source-permissions.md) | Data Source Permissions |
 | [opensearch-dashboards-data-source-selector](opensearch-dashboards-data-source-selector.md) | Data Source Selector |
 | [opensearch-dashboards-dataset-explorer](opensearch-dashboards-dataset-explorer.md) | Dataset Explorer |

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-data-plugin.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-data-plugin.md
@@ -1,0 +1,83 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Dashboards Data Plugin
+
+## Summary
+
+The OpenSearch Dashboards Data plugin provides core data access functionality including index pattern management, field type mapping, search, and query capabilities. It serves as the foundation for how Dashboards understands and interacts with OpenSearch field types, translating OpenSearch-native types into OSD field types used throughout the UI.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Cluster"
+        OS_TYPES["OpenSearch Field Types<br/>(text, keyword, flat_object, ...)"]
+    end
+    subgraph "Data Plugin (osd_field_types)"
+        ENUM["OPENSEARCH_FIELD_TYPES enum"]
+        FACTORY["OsdFieldType Factory"]
+        OSD_TYPES["OSD Field Types<br/>(string, number, date, ...)"]
+    end
+    subgraph "Dashboards UI"
+        IP["Index Patterns"]
+        DISCOVER["Discover"]
+        VIS["Visualizations"]
+    end
+    OS_TYPES --> ENUM --> FACTORY --> OSD_TYPES
+    OSD_TYPES --> IP
+    OSD_TYPES --> DISCOVER
+    OSD_TYPES --> VIS
+```
+
+### Field Type Mapping
+
+The Data plugin maps OpenSearch field types to a smaller set of OSD field types. Each OSD type defines sortability and filterability.
+
+| OSD Type | OpenSearch Types | Sortable | Filterable |
+|----------|-----------------|----------|------------|
+| `string` | `string`, `text`, `match_only_text`, `wildcard`, `keyword`, `flat_object`, `_type`, `_id` | Yes | Yes |
+| `number` | `float`, `half_float`, `scaled_float`, `double`, `integer`, `long`, `unsigned_long`, `short`, `byte`, `token_count` | Yes | Yes |
+| `date` | `date`, `date_nanos` | Yes | Yes |
+| `ip` | `ip` | Yes | Yes |
+| `boolean` | `boolean` | Yes | Yes |
+| `object` | `object` | No | No |
+| `nested` | `nested` | No | No |
+| `geo_point` | `geo_point` | No | No |
+| `geo_shape` | `geo_shape` | No | No |
+| `histogram` | `histogram` | No | Yes |
+
+### Key Components
+
+| Component | Path | Description |
+|-----------|------|-------------|
+| `OPENSEARCH_FIELD_TYPES` | `src/plugins/data/common/osd_field_types/types.ts` | Enum of all recognized OpenSearch field types |
+| `OSD_FIELD_TYPES` | `src/plugins/data/common/osd_field_types/types.ts` | Enum of OSD-level field types |
+| `createOsdFieldTypes` | `src/plugins/data/common/osd_field_types/osd_field_types_factory.ts` | Factory that creates the mapping between OpenSearch and OSD types |
+
+## Limitations
+
+- `flat_object` fields appear as `string` type in Dashboards; individual subfields are not surfaced as separate fields in index patterns
+- Aggregations on `flat_object` subfields via dot notation are not supported by the OpenSearch engine
+
+## Change History
+
+- **v3.5.0**: Added `flat_object` field type support, mapping it to OSD `string` type
+
+## References
+
+### Documentation
+- [Flat object field type](https://docs.opensearch.org/latest/mappings/supported-field-types/flat-object/)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|----|-------------|
+| v3.5.0 | [#11085](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11085) | Support flat_object field type |
+
+### Related Issues
+| Issue | Description |
+|-------|-------------|
+| [#9348](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9348) | RFC: Add support for new field types flat_object, match_only_text, wildcard |

--- a/docs/releases/v3.5.0/features/opensearch-dashboards/dashboards-data-plugin.md
+++ b/docs/releases/v3.5.0/features/opensearch-dashboards/dashboards-data-plugin.md
@@ -1,0 +1,47 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Dashboards Data Plugin
+
+## Summary
+
+OpenSearch Dashboards v3.5.0 adds support for the `flat_object` field type in the Data plugin. Previously, fields mapped as `flat_object` in OpenSearch were not recognized by Dashboards, causing them to be displayed as unknown type in index patterns. With this change, `flat_object` fields are properly mapped to the OSD `string` field type, enabling correct display in index pattern management and search functionality in Discover.
+
+## Details
+
+### What's New in v3.5.0
+
+The `flat_object` field type (introduced in OpenSearch 2.7) stores entire JSON objects as a single field without indexing subfields individually. This is useful for preventing mapping explosions when dealing with documents containing many dynamic keys. However, OpenSearch Dashboards did not recognize this field type, treating it as unknown.
+
+This change registers `flat_object` as a recognized OpenSearch field type and maps it to the OSD `string` type, consistent with how other text-like types (`text`, `keyword`, `match_only_text`, `wildcard`) are handled.
+
+### Technical Changes
+
+Three files in the Data plugin's `osd_field_types` module were modified:
+
+| File | Change |
+|------|--------|
+| `types.ts` | Added `FLAT_OBJECT = 'flat_object'` to the `OPENSEARCH_FIELD_TYPES` enum |
+| `osd_field_types_factory.ts` | Added `OPENSEARCH_FIELD_TYPES.FLAT_OBJECT` to the `string` OSD field type's `esTypes` array |
+| `osd_field_types.test.ts` | Added test verifying `flat_object` maps to `string` |
+
+The mapping means `flat_object` fields are:
+- **Sortable**: Yes (inherits from string type)
+- **Filterable**: Yes (inherits from string type)
+- **Displayed as**: `string` in index pattern field lists
+
+## Limitations
+
+- The `flat_object` type is mapped as a plain `string` in Dashboards. Subfield dot-path notation (e.g., `issue.labels.version`) is not surfaced as separate fields in index patterns.
+- Aggregations on `flat_object` subfields using dot notation are not supported by the underlying OpenSearch engine, so Dashboards visualizations based on subfield aggregations are not available.
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#11085](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11085) | feat: support flat_object field type | [#9348](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9348) |
+
+### Documentation
+- [Flat object field type](https://docs.opensearch.org/latest/mappings/supported-field-types/flat-object/)

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -2,6 +2,7 @@
 
 ## opensearch-dashboards
 - Dashboards Build (Rspack Migration)
+- Dashboards Data Plugin
 - Dashboards gzip Support
 - Dashboards Misc Fixes
 - Dashboards Plugin Compatibility


### PR DESCRIPTION
Adds release and feature reports for the Dashboards Data Plugin flat_object field type support in v3.5.0.\n\n- Release report: `docs/releases/v3.5.0/features/opensearch-dashboards/dashboards-data-plugin.md`\n- Feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-data-plugin.md`\n\nResolves investigation for Issue #2547.