### PR TITLE
docs: add echarts-migration report for v3.5.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -33,6 +33,7 @@ Cumulative feature documentation across all versions.
 - Dashboards Data Plugin
 - Dashboards gzip Support
 - Dashboards Misc Fixes
+- ECharts Migration
 - Navigation & NavGroups
 
 ## opensearch

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-echarts-migration.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-echarts-migration.md
@@ -1,0 +1,102 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# ECharts Migration
+
+## Summary
+
+The ECharts Migration replaces the Vega-Lite rendering engine in OpenSearch Dashboards' Explore (Discover) visualization plugin with Apache ECharts. This provides a unified spec-based chart pipeline with better performance, richer interactivity, theme support, and faceted multi-grid rendering across all chart types.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Explore Visualization Plugin"
+        DataSource[Data Source] --> Transform[Data Transformation]
+        Transform --> Flatten[Flatten Function]
+        Flatten --> SpecBuilder[ECharts Spec Builder]
+        SpecBuilder --> Theme[Theme Config]
+        Theme --> Renderer[ECharts Renderer]
+        Renderer --> Embeddable[Explore Embeddable]
+    end
+    subgraph "Chart Spec Generators"
+        SpecBuilder --> Bar[Bar / Histogram]
+        SpecBuilder --> Line[Line / Area]
+        SpecBuilder --> Pie[Pie]
+        SpecBuilder --> Gauge[Gauge / Bar Gauge]
+        SpecBuilder --> Heatmap[Heatmap]
+        SpecBuilder --> Timeline[State Timeline]
+        SpecBuilder --> Metric[Metric]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| ECharts Renderer | Core rendering component with auto-resize, fixed grid margins, theme integration |
+| Spec Builder Pipeline | Unified pipeline that assembles ECharts option specs from data and configuration |
+| Data Transformation | Flatten function for data normalization, null-to-zero replacement, interval-to-tick mapping |
+| Theme Config | ECharts theme configuration integrated with OpenSearch Dashboards theming |
+| Explore Embeddable | Dashboard embeddable component updated to support ECharts rendering path |
+
+### Supported Chart Types
+
+| Chart Type | Features |
+|---|---|
+| Bar chart | Standard bar, stacked bar, faceted bar with multi-grid rendering |
+| Line chart | Single/multi-series, faceted, time-series with hover-only dots |
+| Area chart | Simple, multi-series, faceted, category-based, stacked (0.5 opacity) |
+| Pie chart | Dynamic titles, legend positioning (left/right/bottom), truncation control |
+| Gauge | Threshold-based coloring, value display, title toggle |
+| Bar gauge | Horizontal bars, unfilled area toggle, label positioning, invalid value handling |
+| Heatmap | Threshold color mode, color schema mode |
+| State timeline | 4 subtypes (time-category, time-numerical, time-category-category, time-category-numerical), value/range mapping, threshold color switching |
+| Metric | Threshold-driven colors, sparklines, percentage-change display, dynamic font sizing |
+| Histogram | Numeric data binning with aggregation (SUM, MEAN, MAX, MIN, COUNT) |
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `__DEVELOPMENT__.discover.vis.render` | Rendering engine selector | `echarts` |
+| Area opacity | Opacity for area chart fill | `0.5` |
+| Legend display | Show legend for multi-series charts only | Auto (hidden for single series) |
+| Line dots | Show data points on line charts | Hover only |
+
+## Limitations
+
+- Migration is scoped to the Explore (Discover) visualization plugin; legacy Visualize editor is not affected
+- Heatmap color scale may not be visually obvious when data is centered around a narrow range
+- State timeline value mapping takes priority over range mapping when both are configured
+- Responsive grid sizing adjusts based on legend and visualMap to avoid overlap, but extreme cases may still require manual adjustment
+
+## Change History
+
+- **v3.5.0** (2026-02-11): Complete migration from Vega-Lite to ECharts for all 10 chart types in Explore visualization. Added theme support, embeddable rendering, data transformation refactoring, and multiple bug fixes for axes, layout, and UX.
+
+## References
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.5.0 | [#11077](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11077) | Introducing ECharts to discover visualization |
+| v3.5.0 | [#11111](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11111) | Migrate explore area chart from vega-lite to echarts |
+| v3.5.0 | [#11113](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11113) | Migrate line and facet bar chart to echart |
+| v3.5.0 | [#11116](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11116) | Migrate pie chart |
+| v3.5.0 | [#11136](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11136) | Migrate state timeline |
+| v3.5.0 | [#11155](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11155) | Add echarts implementation of metric visualization |
+| v3.5.0 | [#11163](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11163) | Migrate bar gauge |
+| v3.5.0 | [#11164](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11164) | Echarts implementation of histogram visualization |
+| v3.5.0 | [#11170](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11170) | Migrate gauge to ECharts |
+| v3.5.0 | [#11184](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11184) | Add theme config for echarts / embeddable fix |
+| v3.5.0 | [#11192](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11192) | Migrate heatmap to echarts |
+| v3.5.0 | [#11230](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11230) | Discover visualization fix and UX improvements |
+| v3.5.0 | [#11244](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11244) | Address bugs for echarts migration |
+| v3.5.0 | [#11257](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11257) | Bug y_two axis not working |
+| v3.5.0 | [#11298](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11298) | Histogram x-axis incorrectly have type 'category' |
+| v3.5.0 | [#10935](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10935) | Axes panel of line & area chart to use StandardAxes |
+| v3.5.0 | [#11124](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11124) | Discover vis data transformation refactor with flatten function |

--- a/docs/releases/v3.5.0/features/opensearch-dashboards/echarts-migration.md
+++ b/docs/releases/v3.5.0/features/opensearch-dashboards/echarts-migration.md
@@ -1,0 +1,100 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# ECharts Migration
+
+## Summary
+
+OpenSearch Dashboards v3.5.0 completes a comprehensive migration of the Explore (Discover) visualization layer from Vega-Lite to Apache ECharts. This effort spans 17 PRs covering 10 chart types (bar, line, area, pie, heatmap, gauge, bar gauge, metric, histogram, and state timeline), along with infrastructure work (theme support, embeddable rendering) and multiple bug fixes for axis handling, layout, and UX polish.
+
+## Details
+
+### What's New in v3.5.0
+
+The visualization rendering engine in the Explore plugin has been replaced. Previously, charts were rendered using Vega-Lite specifications. In v3.5.0, all chart types now use ECharts, providing better performance, richer interactivity, and a unified spec-based chart pipeline.
+
+### Chart Types Migrated
+
+| Chart Type | PR | Description |
+|---|---|---|
+| Bar chart | [#11077](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11077) | Initial ECharts setup with bar chart refactor from Vega |
+| Line chart | [#11113](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11113) | Line and faceted bar chart with multi-grid rendering |
+| Area chart | [#11111](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11111) | Simple, multi-series, faceted, category-based, and stacked area |
+| Pie chart | [#11116](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11116) | Pie with dynamic titles, legend positioning, truncation control |
+| Gauge | [#11170](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11170) | Threshold-based coloring, improved value display |
+| Heatmap | [#11192](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11192) | Threshold color and color schema support |
+| State timeline | [#11136](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11136) | 4 chart subtypes, value/range mapping, threshold color switching |
+| Bar gauge | [#11163](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11163) | Horizontal bar gauge with unfilled area toggle, invalid value handling |
+| Metric | [#11155](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11155) | Threshold-driven colors, sparklines, percentage-change display |
+| Histogram | [#11164](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11164) | Numeric data binning with aggregation (SUM, MEAN, MAX, MIN, COUNT) |
+
+### Infrastructure Changes
+
+| Change | PR | Description |
+|---|---|---|
+| ECharts initialization | [#11077](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11077) | Added `__DEVELOPMENT__.discover.vis.render` flag for vega/echarts switching, unified spec-based chart pipeline |
+| Theme support | [#11184](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11184) | ECharts theme configuration, explore_embeddable support for ECharts rendering |
+| Axes panel refactor | [#10935](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10935) | StandardAxes component for line & area chart axes panel |
+| Data transformation | [#11124](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11124) | Discover vis data transformation refactor with flatten function |
+
+### Bug Fixes
+
+| Fix | PR | Description |
+|---|---|---|
+| Embeddable rendering | [#11184](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11184) | Explore embeddable not able to render ECharts |
+| UX improvements | [#11230](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11230) | Responsive grid sizing, legend overlap fix, gauge title switch, table crash fix, area opacity, single-series legend removal, hover-only line dots |
+| ECharts bugs | [#11244](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11244) | Address various bugs for ECharts migration |
+| Dual Y-axis | [#11257](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11257) | Y_two axis not working |
+| Histogram x-axis | [#11298](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11298) | Histogram x-axis incorrectly using type 'category' |
+
+### Technical Architecture
+
+```mermaid
+graph TB
+    subgraph "Explore Plugin"
+        Data[Data Source] --> Transform[Data Transformation Pipeline]
+        Transform --> SpecBuilder[ECharts Spec Builder]
+        SpecBuilder --> Renderer[ECharts Renderer]
+        Renderer --> Chart[Rendered Chart]
+    end
+    subgraph "Spec Pipeline"
+        SpecBuilder --> BarSpec[Bar/Histogram Spec]
+        SpecBuilder --> LineSpec[Line/Area Spec]
+        SpecBuilder --> PieSpec[Pie Spec]
+        SpecBuilder --> GaugeSpec[Gauge/Bar Gauge Spec]
+        SpecBuilder --> HeatmapSpec[Heatmap Spec]
+        SpecBuilder --> TimelineSpec[State Timeline Spec]
+        SpecBuilder --> MetricSpec[Metric Spec]
+    end
+    Theme[ECharts Theme Config] --> Renderer
+```
+
+## Limitations
+
+- The migration is scoped to the Explore (Discover) visualization plugin; legacy Visualize editor charts are not affected
+- Heatmap color scale may not be visually obvious when data is centered around a narrow range
+- State timeline value mapping takes priority over range mapping when both are configured
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#11077](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11077) | Introducing ECharts to discover visualization | - |
+| [#11111](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11111) | Migrate explore area chart from vega-lite to echarts | - |
+| [#11113](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11113) | Migrate line and facet bar chart to echart | - |
+| [#11116](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11116) | Migrate pie chart | - |
+| [#11170](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11170) | Migrate gauge to ECharts | - |
+| [#11192](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11192) | Migrate heatmap to echarts | - |
+| [#11136](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11136) | Migrate state timeline | - |
+| [#11163](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11163) | Migrate bar gauge | - |
+| [#11184](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11184) | Add theme config for echarts / embeddable fix | - |
+| [#11230](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11230) | Discover visualization fix and UX improvements | - |
+| [#11244](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11244) | Address bugs for echarts migration | - |
+| [#11257](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11257) | Bug y_two axis not working | - |
+| [#11298](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11298) | Histogram x-axis incorrectly have type 'category' | - |
+| [#10935](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10935) | Axes panel of line & area chart to use StandardAxes | - |
+| [#11124](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11124) | Discover vis data transformation refactor with flatten function | - |
+| [#11155](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11155) | Add echarts implementation of metric visualization | - |
+| [#11164](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11164) | Echarts implementation of histogram visualization | - |

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -7,5 +7,6 @@
 - Dashboards Misc Fixes
 - Dashboards Plugin Compatibility
 - Data Importer
+- ECharts Migration
 - Sample Data
 - TSVB Enhancements


### PR DESCRIPTION
## Summary\n\nInvestigation of ECharts Migration for OpenSearch Dashboards v3.5.0 (Issue #2546).\n\nThis release completes a comprehensive migration of the Explore (Discover) visualization layer from Vega-Lite to Apache ECharts, spanning 17 PRs covering 10 chart types.\n\n### Reports Created\n- Release report: `docs/releases/v3.5.0/features/opensearch-dashboards/echarts-migration.md`\n- Feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-echarts-migration.md`\n\n### Key Changes\n- Migrated bar, line, area, pie, heatmap, gauge, bar gauge, metric, histogram, and state timeline charts to ECharts\n- Added ECharts theme configuration and embeddable rendering support\n- Refactored data transformation pipeline with flatten function\n- Fixed multiple bugs: dual Y-axis, histogram x-axis type, responsive grid sizing, legend overlap