### PR TITLE
docs: add dashboards-cve-fixes report for v3.5.0

### DIFF
--- a/docs/features/opensearch-dashboards/opensearch-dashboards-dependency-updates.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-dependency-updates.md
@@ -37,6 +37,7 @@ graph TB
 
 | Dependency | Purpose | Security Impact |
 |------------|---------|-----------------|
+| js-yaml | YAML parsing for config files | CVE-2025-64718 (prototype pollution) |
 | json11 | JSON parsing with extended features | UTF-8 safety in JSON stringification |
 | chokidar | File system watching for development | Development tooling |
 | axios | HTTP client for API requests | CVE-2024-39338 |
@@ -75,6 +76,7 @@ yarn upgrade json11@^2.0.0
 
 ## Change History
 
+- **v3.5.0** (2026-02-11): CVE fixes — js-yaml upgraded to 4.1.1 (CVE-2025-64718 prototype pollution), removed `@modelcontextprotocol/sdk` and `node-forge` as direct dependencies, added Yarn resolution override for js-yaml, eliminated js-yaml v3.x from dependency tree
 - **v3.0.0** (2025-05-13): Security updates for vega (5.32.0), dompurify (3.2.4), markdown-it (13.0.2) addressing CVE-2025-25304 and CVE-2025-26791
 - **v2.18.0** (2024-10-22): JSON11 upgrade to 2.0.0 for UTF-8 safety, chokidar bump to 3.6.0
 - **v2.16.0** (2024-08-06): Multiple CVE fixes - tar (CVE-2024-28863), ejs (CVE-2024-33883), braces (CVE-2024-4067/4068), jimp/phin (GHSA-x565-32qp-m3vf), axios (SNYK-JS-AXIOS-6144788), ws (CVE-2024-37890); Babel dependency fix
@@ -89,6 +91,7 @@ yarn upgrade json11@^2.0.0
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v3.5.0 | [#11048](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11048) | CVE fixes: js-yaml 4.1.1, remove @modelcontextprotocol/sdk and node-forge | - |
 | v3.0.0 | [#9623](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9623) | Bump vega from 5.23.0 to 5.32.0 | [#9400](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/9400) |
 | v3.0.0 | [#9447](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9447) | Bump dompurify from 3.1.6 to 3.2.4 |   |
 | v3.0.0 | [#9412](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/9412) | Bump markdown-it from 12.3.2 to 13.0.2 |   |

--- a/docs/releases/v3.5.0/features/opensearch-dashboards/dashboards-cve-fixes.md
+++ b/docs/releases/v3.5.0/features/opensearch-dashboards/dashboards-cve-fixes.md
@@ -1,0 +1,75 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Dashboards CVE Fixes
+
+## Summary
+
+OpenSearch Dashboards v3.5.0 addresses multiple CVEs by upgrading js-yaml to 4.1.1 across all packages, removing unnecessary direct dependencies (`@modelcontextprotocol/sdk`, `node-forge`), and adding a Yarn resolution override to enforce the patched js-yaml version across the entire dependency tree.
+
+## Details
+
+### What's New in v3.5.0
+
+This release fixes several security vulnerabilities in transitive dependencies through strategic dependency management:
+
+#### CVEs Addressed
+
+| CVE / Advisory | Package | Severity | Resolution |
+|----------------|---------|----------|------------|
+| [GHSA-mh29-5h37-fv8m](https://github.com/advisories/GHSA-mh29-5h37-fv8m) (CVE-2025-64718) | js-yaml | Moderate (CVSS 5.3) | Upgraded from 4.1.0 to 4.1.1 |
+| [GHSA-w48q-cv73-mx4w](https://github.com/advisories/GHSA-w48q-cv73-mx4w) | @modelcontextprotocol/sdk | High | Removed as direct dependency |
+| [GHSA-5gfm-wpxj-wjgq](https://github.com/advisories/GHSA-5gfm-wpxj-wjgq) | node-forge | High | Removed as direct dependency |
+| [GHSA-554w-wpv2-vw27](https://github.com/advisories/GHSA-554w-wpv2-vw27) | node-forge | Medium | Removed as direct dependency |
+| [GHSA-65ch-62r8-g69g](https://github.com/advisories/GHSA-65ch-62r8-g69g) | node-forge | Medium | Removed as direct dependency |
+| [GHSA-wqch-xfxh-vrr4](https://github.com/advisories/GHSA-wqch-xfxh-vrr4) | body-parser | Medium | Resolved through transitive updates |
+| [GHSA-rx8g-88g5-qh64](https://github.com/advisories/GHSA-rx8g-88g5-qh64) | min-document | Low | Resolved through transitive updates |
+
+### Technical Changes
+
+#### js-yaml Upgrade (4.1.0 → 4.1.1)
+
+The primary CVE (CVE-2025-64718) is a prototype pollution vulnerability in js-yaml's YAML merge key (`<<`) handling. An attacker could modify the prototype of parsed YAML documents via `__proto__` keys.
+
+Updated across 5 packages:
+- Root `package.json`
+- `packages/osd-agents/package.json`
+- `packages/osd-apm-config-loader/package.json`
+- `packages/osd-config/package.json`
+- `packages/osd-optimizer/package.json`
+
+A Yarn resolution override (`"**/js-yaml": "^4.1.1"`) forces all transitive instances (including those from eslint, grunt, load-grunt-config, istanbul, and api-documenter) to use the patched version. This also eliminates js-yaml v3.x from the dependency tree entirely — the `yarn.lock` consolidates all js-yaml references to 4.1.1.
+
+The v3 → v4 upgrade is backward compatible because:
+- `load()` became the safe method in v4 (previously unsafe)
+- `safeLoad()` was removed (unnecessary since `load()` is now safe)
+- No code in the dependency tree uses deprecated `safeLoad()` or unsafe `!!js/function` tags
+
+#### Removed Direct Dependencies
+
+- `@modelcontextprotocol/sdk` (`^1.18.0`): Pulled in automatically as a transitive dependency where needed
+- `node-forge` (`^1.3.0`): Only used transitively via `node-forge@^1.2.1`
+
+Removing these eliminates unnecessary version lock-in and simplifies dependency management.
+
+## Limitations
+
+- The Yarn resolution override forces js-yaml 4.x for all packages, including those that originally depended on 3.x — this works for standard YAML parsing but could break packages relying on js-yaml v3-specific APIs
+- Transitive CVEs (body-parser, min-document) are resolved indirectly and may resurface if dependency trees change
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#11048](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11048) | CVE fixes | - |
+
+### Security Advisories
+- [GHSA-mh29-5h37-fv8m](https://github.com/advisories/GHSA-mh29-5h37-fv8m): js-yaml prototype pollution in merge (CVE-2025-64718)
+- [GHSA-w48q-cv73-mx4w](https://github.com/advisories/GHSA-w48q-cv73-mx4w): @modelcontextprotocol/sdk vulnerability
+- [GHSA-5gfm-wpxj-wjgq](https://github.com/advisories/GHSA-5gfm-wpxj-wjgq): node-forge vulnerability
+- [GHSA-554w-wpv2-vw27](https://github.com/advisories/GHSA-554w-wpv2-vw27): node-forge vulnerability
+- [GHSA-65ch-62r8-g69g](https://github.com/advisories/GHSA-65ch-62r8-g69g): node-forge vulnerability
+- [GHSA-wqch-xfxh-vrr4](https://github.com/advisories/GHSA-wqch-xfxh-vrr4): body-parser vulnerability
+- [GHSA-rx8g-88g5-qh64](https://github.com/advisories/GHSA-rx8g-88g5-qh64): min-document vulnerability

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -3,6 +3,7 @@
 ## opensearch-dashboards
 - Dashboards Build (Rspack Migration)
 - Dashboards CSP Security
+- Dashboards CVE Fixes
 - Dashboards Data Plugin
 - Dashboards gzip Support
 - Dashboards Misc Fixes


### PR DESCRIPTION
## Summary

Release report and feature report update for Dashboards CVE Fixes in OpenSearch v3.5.0.

### Changes
- Created release report: `docs/releases/v3.5.0/features/opensearch-dashboards/dashboards-cve-fixes.md`
- Updated feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-dependency-updates.md` (added v3.5.0 Change History entry, js-yaml to Key Dependencies, PR to references)
- Updated release index: `docs/releases/v3.5.0/index.md`

### Key Findings
- PR [#11048](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11048) fixes 7 CVEs
- Primary fix: js-yaml upgraded to 4.1.1 for CVE-2025-64718 (prototype pollution via YAML merge keys)
- Removed `@modelcontextprotocol/sdk` and `node-forge` as unnecessary direct dependencies
- Yarn resolution override eliminates js-yaml v3.x from entire dependency tree

Closes #2543