### PR TITLE
docs: add observability-traces report for v3.5.0

### DIFF
--- a/docs/features/dashboards-observability/dashboards-observability-trace-analytics.md
+++ b/docs/features/dashboards-observability/dashboards-observability-trace-analytics.md
@@ -89,6 +89,8 @@ flowchart TB
 | Multi-Data Source Support | Connect to multiple OpenSearch clusters |
 | Application Analytics | Integrated traces/spans view within app analytics |
 | Custom Index Flyout | Configuration panel for custom span/service indices |
+| RED Metrics Charts | Request, Error, Latency charts in Discover:Traces via PPL queries |
+| Dynamic Feature Flags | DynamicConfigService-based flags for Traces and Metrics features |
 | Data Schema Picker | Mode selector for Jaeger, Data Prepper, or Custom source |
 
 ### Configuration
@@ -105,6 +107,8 @@ flowchart TB
 | `observability:traceAnalyticsServiceMapMaxNodes` | Maximum nodes in service map queries | 500 |
 | `observability:traceAnalyticsServiceMapMaxEdges` | Maximum edges in service map queries | 1000 |
 | `TRACE_CUSTOM_MODE_DEFAULT_SETTING` | Enable custom source as default landing page | `false` |
+| `explore.discoverTraces.enabled` | Enable Discover:Traces feature via DynamicConfigService | `false` |
+| `explore.discoverMetrics.enabled` | Enable Discover:Metrics feature via DynamicConfigService | `false` |
 
 ### Usage Example
 
@@ -145,6 +149,7 @@ http://host:port/app/observability-traces#/services
 
 ## Change History
 
+- **v3.5.0**: Added RED metrics charts (Rate, Errors, Duration) for Discover:Traces, dynamic configuration flags for Traces/Metrics via DynamicConfigService, dataset UI and observability workspace with trace automation, bug fixes for trace auto-detection, redirection, naming conventions, correlation type naming, OTel sample data index naming, and correlations saved object search
 - **v3.2.0** (2026-02-18): User-configurable service map max nodes and max edges settings, bug fixes for traces error display (nested status.code handling) and metrics visualization rendering in local cluster instances
 - **v3.1.0** (2026-01-21): Merged custom source mode into default Data Prepper mode, span flyout support for new Data Prepper format with nested field flattening, unified experience with cross-cluster search, custom indices, data grid, and dynamic filters
 - **v3.0.0** (2025-02-25): Custom logs correlation, data grid migration, OTEL attributes support, service view optimizations, Amazon Network Firewall integration, trace-to-logs correlation improvements
@@ -164,6 +169,16 @@ http://host:port/app/observability-traces#/services
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v3.5.0 | [#11030](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11030) | Add RED metrics charts for Discover:Traces |   |
+| v3.5.0 | [#11096](https://github.com/opensearch-project/dashboards-observability/pull/11096) | Dataset UI and observability workspace + Trace automation |   |
+| v3.5.0 | [#11063](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11063) | Fix RED metric query for Discover:Traces |   |
+| v3.5.0 | [#11068](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11068) | Discover:Traces redirection fix + testing improvement |   |
+| v3.5.0 | [#11220](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11220) | Add dynamic setting flag for Explore Traces + Metrics |   |
+| v3.5.0 | [#11174](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11174) | Fix trace automation naming convention |   |
+| v3.5.0 | [#11191](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11191) | Fix Traces: Auto detect bug |   |
+| v3.5.0 | [#11208](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11208) | Update the OTel sample data index names |   |
+| v3.5.0 | [#11215](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11215) | Update correlationType for trace-to-logs objects | [#2545](https://github.com/opensearch-project/dashboards-observability/issues/2545) |
+| v3.5.0 | [#11256](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11256) | Add title field to correlations saved object | [#11133](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11133) |
 | v3.2.0 | [#2472](https://github.com/opensearch-project/dashboards-observability/pull/2472) | [Traces] Make service map max nodes and max edges values user-configurable |   |
 | v3.2.0 | [#2475](https://github.com/opensearch-project/dashboards-observability/pull/2475) | [Bug] Traces error display - fix nested status.code handling |   |
 | v3.2.0 | [#2478](https://github.com/opensearch-project/dashboards-observability/pull/2478) | [Bug] Fixed metrics viz not showing up in local cluster |   |

--- a/docs/releases/v3.5.0/features/opensearch-dashboards/observability-traces.md
+++ b/docs/releases/v3.5.0/features/opensearch-dashboards/observability-traces.md
@@ -1,0 +1,62 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Observability Traces
+
+## Summary
+
+OpenSearch Dashboards v3.5.0 introduces RED metrics charts (Rate, Errors, Duration) for the Discover:Traces experience, adds dynamic configuration flags for Traces and Metrics features via the DynamicConfigService, implements dataset UI and observability workspace with trace automation in the observability plugin, and delivers multiple bug fixes for trace auto-detection, redirection, naming conventions, correlation types, sample data index naming, and correlations saved object search.
+
+## Details
+
+### What's New in v3.5.0
+
+#### RED Metrics Charts for Discover:Traces
+PR [#11030](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11030) adds RED metrics (Request, Error, Latency) charts to the Discover:Traces experience. Three PPL query calls generate the visualizations with per-chart headers, per-chart cache keys, improved interval options, and configurable bucket targeting. Currently compatible with the Data Prepper schema. PR [#11063](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11063) follows up by fixing the RED metric query to sort after buckets are formed rather than before, improving performance and backward compatibility with older PPL versions.
+
+#### Dynamic Setting Flags for Explore Traces + Metrics
+PR [#11220](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11220) refactors the Explore plugin to use `DynamicConfigService` for managing feature flags (`discoverTraces.enabled` and `discoverMetrics.enabled`). This enables dynamic configuration without restarts. Feature flags are exposed as capabilities that other plugins can consume via `request.getCapabilities()` on the server side or `useCapabilities()` on the browser side. Configuration in `opensearch_dashboards.yml`:
+
+```yaml
+explore:
+  discoverTraces:
+    enabled: true
+  discoverMetrics:
+    enabled: false
+```
+
+#### Dataset UI and Observability Workspace + Trace Automation
+PR [#11096](https://github.com/opensearch-project/dashboards-observability/pull/11096) adds dataset UI and observability workspace integration with trace automation support.
+
+### Bug Fixes
+
+| Fix | PR | Description |
+|-----|-----|-------------|
+| Traces redirection | [#11068](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11068) | Fixed URL redirection bug based on timestamp, improved field-resolution fallbacks for trace details and span durations, added caching for histogram config lookups |
+| Trace automation naming | [#11174](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11174) | Fixed mis-named field in auto-creation that prevented UI from picking up registered timefield; corrected to use "timestamp" field name |
+| Auto detect bug | [#11191](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11191) | Stopped trace auto-detection from running when a trace dataset already exists; removed creation flow from log page; added empty state for datasource select |
+| OTel sample data index names | [#11208](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11208) | Updated OTEL sample data index naming to avoid conflicts with Data Prepper production data |
+| Correlation type naming | [#11215](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11215) | Changed correlationType from static `APM-Correlation` to dynamic `trace-to-logs-<trace-dataset-title>` for unique identification in Assets page |
+| Correlations saved object search | [#11256](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11256) | Added `title` field (text type) to correlations saved object for search support; fixed broken search in Saved Objects Management UI caused by keyword-type `correlationType` field |
+
+## Limitations
+
+- RED metrics charts are currently only compatible with the Data Prepper schema
+- Dynamic feature flags for Traces and Metrics default to `false` (disabled)
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#11030](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11030) | Add RED metrics charts for Discover:Traces |  |
+| [#11096](https://github.com/opensearch-project/dashboards-observability/pull/11096) | Dataset UI and observability workspace + Trace automation |  |
+| [#11063](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11063) | Fix RED metric query for Discover:Traces |  |
+| [#11068](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11068) | Discover:Traces redirection fix + testing improvement |  |
+| [#11220](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11220) | Add dynamic setting flag for Explore Traces + Metrics |  |
+| [#11174](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11174) | Fix trace automation naming convention |  |
+| [#11191](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11191) | Fix Traces: Auto detect bug |  |
+| [#11208](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11208) | Update the OTel sample data index names |  |
+| [#11215](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11215) | Update correlationType for trace-to-logs objects | [#2545](https://github.com/opensearch-project/dashboards-observability/issues/2545) |
+| [#11256](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11256) | Add title field to correlations saved object | [#11133](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11133) |

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -15,3 +15,4 @@
 - Sample Data
 - Table Visualization Rewrite
 - TSVB Enhancements
+- Observability Traces


### PR DESCRIPTION
## Investigation: [bugfix] Observability Traces (v3.5.0)

Closes #2540

### Reports
- Release report: `docs/releases/v3.5.0/features/opensearch-dashboards/observability-traces.md`
- Feature report: `docs/features/dashboards-observability/dashboards-observability-trace-analytics.md` (updated)

### Summary
Investigated 10 PRs across opensearch-dashboards and observability repositories. Key changes include:
- RED metrics charts (Rate, Errors, Duration) for Discover:Traces
- Dynamic configuration flags for Traces/Metrics via DynamicConfigService
- Dataset UI and observability workspace with trace automation
- Multiple bug fixes for trace auto-detection, redirection, naming, correlation types, sample data index naming, and correlations saved object search