### PR TITLE
docs: add threshold-visualization report for v3.5.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -38,6 +38,7 @@ Cumulative feature documentation across all versions.
 - Navigation & NavGroups
 - Prometheus Metrics in Explore
 - Table Visualization
+- Threshold Visualization
 
 ## opensearch
 

--- a/docs/features/opensearch-dashboards/opensearch-dashboards-threshold-visualization.md
+++ b/docs/features/opensearch-dashboards/opensearch-dashboards-threshold-visualization.md
@@ -1,0 +1,81 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Threshold Visualization
+
+## Summary
+
+Threshold visualization in OpenSearch Dashboards allows users to define value-based color boundaries on charts, enabling data-driven visual highlighting. When enabled, chart elements (bars, scatter points, gauge segments, metrics) are colored according to user-defined threshold ranges, making it easy to identify values that exceed or fall below critical boundaries.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "Explore Vis Plugin"
+        TS[Threshold Settings Panel]
+        TU[Threshold Utilities]
+        subgraph "Chart Renderers"
+            BAR[Bar Chart]
+            SCATTER[Scatter Chart]
+            GAUGE[Gauge/Metric]
+        end
+    end
+    TS -->|threshold config| TU
+    TU -->|processed thresholds| BAR
+    TU -->|processed thresholds| SCATTER
+    TU -->|processed thresholds| GAUGE
+    BAR -->|visualMap / series colors| ECharts
+    SCATTER -->|visualMap| ECharts
+    GAUGE -->|color ranges| ECharts
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| Threshold Settings Panel | UI for defining threshold values and colors |
+| Threshold Utilities | Core logic for generation, filtering, range handling, deduplication |
+| Bar Chart Renderer | Applies threshold colors to regular and stacked bar charts via data pivoting |
+| Scatter Chart Renderer | Uses ECharts `visualMap` for threshold-based point coloring |
+| Gauge/Metric Renderer | Applies threshold color ranges to gauge and metric visualizations |
+
+### Supported Chart Types
+
+| Chart Type | Threshold Support | Method |
+|------------|-------------------|--------|
+| Bar (regular) | ✅ | Series color mapping |
+| Bar (stacked) | ✅ | Series color mapping with data pivoting |
+| Scatter | ✅ | ECharts `visualMap` component |
+| Gauge | ✅ | Color ranges |
+| Metric | ✅ | Color ranges |
+
+### Usage
+
+1. Open a visualization in the Explore Vis editor
+2. Navigate to the chart settings panel
+3. Toggle "Use threshold colors" to enable
+4. Define threshold values and assign colors
+5. Chart elements will be colored based on their metric values relative to the defined thresholds
+
+## Limitations
+
+- Threshold visualization is available only within the Explore Vis framework (experimental)
+- Not available in legacy Visualize or VisBuilder chart types
+- Data pivoting for 2-dimension bar charts may have performance implications with very large datasets
+
+## Change History
+
+- **v3.5.0**: Simplified threshold logic for gauge/metric; added threshold colors for bar charts (regular and stacked); added threshold visual map for scatter charts; ensured dark/light mode color consistency; fixed flaky threshold tests
+
+## References
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.5.0 | [#10909](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10909) | Simplify threshold logic |
+| v3.5.0 | [#11106](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11106) | Data processing for applying threshold colors |
+| v3.5.0 | [#11045](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11045) | Fix flaky test for global threshold custom value |
+| v3.5.0 | [#11268](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11268) | Add thresholds visual map for scatter |

--- a/docs/releases/v3.5.0/features/opensearch-dashboards/threshold-visualization.md
+++ b/docs/releases/v3.5.0/features/opensearch-dashboards/threshold-visualization.md
@@ -1,0 +1,60 @@
+---
+tags:
+  - opensearch-dashboards
+---
+# Threshold Visualization
+
+## Summary
+
+OpenSearch Dashboards v3.5.0 introduces improved threshold visualization capabilities in the Explore Vis framework. The changes simplify threshold logic for gauge and metric visualizations, add threshold color support for bar charts (regular and stacked), and extend threshold visual maps to scatter charts. These improvements provide users with more consistent and flexible data-driven color coding across chart types.
+
+## Details
+
+### What's New in v3.5.0
+
+#### Simplified Threshold Logic (PR #10909)
+The threshold processing pipeline was refactored to improve consistency across gauge and metric visualizations. Key changes include:
+- Enhanced threshold generation, filtering, range handling, and deduplication
+- Improved support for undefined values and edge cases
+- Better color consistency across threshold boundaries
+- Comprehensive unit tests added for threshold utility functions
+
+#### Threshold Colors for Bar Charts (PR #11106)
+Threshold color functionality was extended to bar chart visualizations:
+- Data processing layer added to pivot data for 2-dimension scenarios
+- "Use threshold colors" option is now always accessible in bar chart settings (previously conditionally hidden)
+- Supports both regular bar charts and stacked bar charts
+- Colors are applied based on metric values crossing threshold boundaries
+
+#### Scatter Chart Threshold Visual Map (PR #11268)
+Threshold colors were extended to scatter chart visualizations:
+- Added ECharts `visualMap` component for scatter charts to enable threshold-based coloring
+- Ensured color consistency between dark mode and light mode
+- Scatter points are colored based on their Y-axis values relative to defined thresholds
+
+### Technical Changes
+
+The changes primarily affect the Explore Vis plugin within OpenSearch Dashboards, specifically:
+
+| Component | Change |
+|-----------|--------|
+| Threshold utilities | Refactored generation, filtering, range handling, deduplication |
+| Bar chart renderer | Added threshold color data processing with data pivoting |
+| Bar chart settings | "Use threshold colors" toggle always visible |
+| Scatter chart renderer | Added `visualMap` for threshold-based point coloring |
+| Theme handling | Consistent threshold colors across dark/light modes |
+
+## Limitations
+
+- Threshold color support is part of the Explore Vis framework (experimental); not available in legacy visualization types
+- Data pivoting for 2-dimension bar charts may have performance implications with very large datasets
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#10909](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/10909) | Simplify threshold logic | - |
+| [#11106](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11106) | Data processing for applying threshold colors | - |
+| [#11045](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11045) | Fix flaky test for global threshold custom value | - |
+| [#11268](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11268) | Add thresholds visual map for scatter | - |

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -14,6 +14,7 @@
 - Prometheus Metrics in Explore
 - Sample Data
 - Table Visualization Rewrite
+- Threshold Visualization
 - TSVB Enhancements
 - Observability Traces
 - Dashboards Chat/AI


### PR DESCRIPTION
## Summary

Investigation of GitHub Issue #2538: Threshold Visualization for OpenSearch Dashboards v3.5.0.

### Reports Created
- Release report: `docs/releases/v3.5.0/features/opensearch-dashboards/threshold-visualization.md`
- Feature report: `docs/features/opensearch-dashboards/opensearch-dashboards-threshold-visualization.md`

### Key Changes in v3.5.0
- Simplified threshold logic for gauge/metric visualizations with better edge case handling
- Added threshold color support for bar charts (regular and stacked) with data pivoting
- Extended threshold visual maps to scatter charts via ECharts `visualMap`
- Ensured dark/light mode color consistency
- Fixed flaky threshold tests

### PRs Investigated
- #10909 - Simplify threshold logic
- #11106 - Data processing for applying threshold colors
- #11045 - Fix flaky test for global threshold custom value
- #11268 - Add thresholds visual map for scatter