### PR TITLE
docs: add user-plugin-maintenance report for v3.5.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -67,3 +67,7 @@ Cumulative feature documentation across all versions.
 ## sql
 
 - SQL/PPL Engine
+
+## user
+
+- User Plugin Maintenance

--- a/docs/features/user/user-plugin-maintenance.md
+++ b/docs/features/user/user-plugin-maintenance.md
@@ -1,0 +1,38 @@
+---
+tags:
+  - user
+---
+# User Plugin Maintenance
+
+## Summary
+
+Tracks maintenance activities for the User Behavior Insights (UBI) plugin, including version bumps, dependency upgrades, and code modernization. The UBI plugin enables capturing and analyzing user search behavior within OpenSearch.
+
+## Details
+
+### Overview
+
+The User Behavior Insights plugin provides the ability to capture user queries and click-through events, enabling search relevance analysis. Maintenance activities ensure the plugin stays compatible with each OpenSearch release and follows current best practices.
+
+### Key Maintenance Areas
+
+| Area | Description |
+|------|-------------|
+| Version management | Automated version bumps to align with OpenSearch releases |
+| Dependency upgrades | Jackson and other library updates for compatibility and security |
+| Code modernization | Removal of deprecated APIs (e.g., `AccessController`) |
+
+## Limitations
+
+None.
+
+## Change History
+
+- **v3.5.0**: Version bump to 3.5.0-SNAPSHOT, Jackson upgrade (annotations 2.18.2→2.20, databind 2.18.2→2.20.1), removed deprecated `AccessController.doPrivileged` usage
+
+## References
+
+### Pull Requests
+| Version | PR | Description |
+|---------|----|-------------|
+| v3.5.0 | [#156](https://github.com/opensearch-project/user-behavior-insights/pull/156) | Increment version to 3.5.0-SNAPSHOT |

--- a/docs/releases/v3.5.0/features/user/user-plugin-maintenance.md
+++ b/docs/releases/v3.5.0/features/user/user-plugin-maintenance.md
@@ -1,0 +1,34 @@
+---
+tags:
+  - user
+---
+# User Plugin Maintenance
+
+## Summary
+
+Routine maintenance for the User Behavior Insights (UBI) plugin in OpenSearch v3.5.0. This update increments the plugin version to 3.5.0-SNAPSHOT, upgrades Jackson dependencies, and removes the deprecated `java.security.AccessController` usage that is no longer applicable in OpenSearch 3.x.
+
+## Details
+
+### What's New in v3.5.0
+
+- Version bumped from 3.4.0-SNAPSHOT to 3.5.0-SNAPSHOT
+- Jackson annotations upgraded from 2.18.2 to 2.20
+- Jackson databind upgraded from 2.18.2 to 2.20.1
+- Decoupled `jackson-annotations` version from `jackson-core` by using `versions.jackson_annotations` instead of `versions.jackson`
+- Removed deprecated `AccessController.doPrivileged` wrapper in `QueryRequest.java`, replacing it with a direct `ObjectMapper.writeValueAsString()` call
+
+### Technical Changes
+
+The `QueryRequest.toString()` method previously wrapped JSON serialization in `AccessController.doPrivileged()`, which was a Java Security Manager pattern. Since Java Security Manager is deprecated and removed in OpenSearch 3.x, this code was simplified to a direct try-catch block.
+
+## Limitations
+
+None specific to this maintenance update.
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#156](https://github.com/opensearch-project/user-behavior-insights/pull/156) | Increment version to 3.5.0-SNAPSHOT | - |

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -18,3 +18,6 @@
 - TSVB Enhancements
 - Observability Traces
 - Dashboards Chat/AI
+
+## user
+- User Plugin Maintenance


### PR DESCRIPTION
## Summary\n\nAdds release and feature reports for the User Behavior Insights (UBI) plugin maintenance in v3.5.0.\n\n### Changes\n- Release report: `docs/releases/v3.5.0/features/user/user-plugin-maintenance.md`\n- Feature report: `docs/features/user/user-plugin-maintenance.md`\n- Updated release index and features index\n\n### Key Findings\n- PR #156 in opensearch-project/user-behavior-insights: automated version bump to 3.5.0-SNAPSHOT\n- Jackson annotations upgraded 2.18.2→2.20, Jackson databind 2.18.2→2.20.1\n- Removed deprecated `AccessController.doPrivileged` usage\n\nCloses #2537