### PR TITLE
docs: add skills-dependencies report for v3.5.0

### DIFF
--- a/docs/features/skills/skills-plugin-dependencies.md
+++ b/docs/features/skills/skills-plugin-dependencies.md
@@ -70,6 +70,7 @@ The Skills plugin follows automated dependency management using Mend (formerly W
 - Test fixes may be needed when dependent plugins change their APIs
 
 ## Change History
+- **v3.5.0**: Fixed jackson dependency version mismatches — `jackson-annotations` now uses `${versions.jackson_annotations}`, `jackson-module-scala_3` uses centralized `${versions.jackson}` instead of hardcoded `2.18.2`; added `core` jar to SQL dependency includes
 - **v2.19.0** (2024-12-10): Critical security fix for CVE-2022-36944 (scala-library 2.13.9), ByteBuddy 1.15.10 for module conflict resolution
 - **v2.18.0** (2024-10-29): Updated Mockito to 5.14.2, JUnit5 to 5.11.2, ByteBuddy to 1.15.4, Gradle to 8.10.2, Lombok plugin to 8.10.2; Fixed test failures from AnomalyDetector API changes
 
@@ -85,6 +86,7 @@ The Skills plugin follows automated dependency management using Mend (formerly W
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v3.5.0 | [#683](https://github.com/opensearch-project/skills/pull/683) | Fix jackson version references in build.gradle |   |
 | v2.19.0 | [#496](https://github.com/opensearch-project/skills/pull/496) | Update scala-library to v2.13.9 (CVE-2022-36944) | [#495](https://github.com/opensearch-project/skills/issues/495) |
 | v2.19.0 | [#466](https://github.com/opensearch-project/skills/pull/466) | Bump byte-buddy 1.15.4 → 1.15.10 |   |
 | v2.18.0 | [#427](https://github.com/opensearch-project/skills/pull/427) | Fix test failure due to external change |   |

--- a/docs/releases/v3.5.0/features/skills/skills-dependencies.md
+++ b/docs/releases/v3.5.0/features/skills/skills-dependencies.md
@@ -1,0 +1,38 @@
+---
+tags:
+  - skills
+---
+# Skills Dependencies
+
+## Summary
+Fixed jackson dependency version mismatches in the Skills plugin's `build.gradle`. The `jackson-annotations` artifact was referencing the wrong version variable (`versions.jackson` instead of `versions.jackson_annotations`), and `jackson-module-scala_3` was using a hardcoded version (`2.18.2`) instead of the centralized `${versions.jackson}` variable. Additionally, the `core-${opensearch_build}.jar` was added to the SQL dependency file tree.
+
+## Details
+
+### What's New in v3.5.0
+
+This bugfix corrects dependency version management in the Skills plugin build configuration:
+
+1. `jackson-annotations` dependency changed from `${versions.jackson}` to `${versions.jackson_annotations}`, ensuring the correct version is resolved for the annotations artifact
+2. `jackson-module-scala_3` changed from hardcoded `2.18.2` to `${versions.jackson}`, aligning it with centralized version management
+3. Added `core-${opensearch_build}.jar` to the SQL plugin dependency file tree inclusion pattern
+
+### Technical Changes
+
+| Change | Before | After |
+|--------|--------|-------|
+| `jackson-annotations` version variable | `${versions.jackson}` | `${versions.jackson_annotations}` |
+| `jackson-module-scala_3` version | Hardcoded `2.18.2` | `${versions.jackson}` |
+| SQL dependency jars | `opensearch-sql-thin`, `ppl`, `protocol` | Added `core` jar |
+
+These changes ensure that jackson library versions are consistently managed through OpenSearch's centralized version properties, preventing potential classpath conflicts from version mismatches.
+
+## Limitations
+- The PR was bundled with the version increment to 3.5.0-SNAPSHOT, so the jackson fix is not isolated in a separate commit
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#683](https://github.com/opensearch-project/skills/pull/683) | Fix jackson version (included in version increment PR) | - |

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -21,3 +21,6 @@
 
 ## user
 - User Plugin Maintenance
+
+## skills
+- Skills Dependencies


### PR DESCRIPTION
## Summary\nRelease report and feature report update for Skills Dependencies bugfix in v3.5.0.\n\n### Changes\n- Created release report: `docs/releases/v3.5.0/features/skills/skills-dependencies.md`\n- Updated feature report: `docs/features/skills/skills-plugin-dependencies.md` (added v3.5.0 change history and PR reference)\n- Updated release index: `docs/releases/v3.5.0/index.md`\n\n### Key Findings\nPR #683 fixed jackson dependency version mismatches in the Skills plugin build.gradle:\n- `jackson-annotations` was using wrong version variable (`versions.jackson` → `versions.jackson_annotations`)\n- `jackson-module-scala_3` was hardcoded to `2.18.2` instead of using `${versions.jackson}`\n- Added `core` jar to SQL dependency includes\n\nCloses #2536"