### PR TITLE
docs: add performance-analyzer report for v3.5.0

### DIFF
--- a/docs/features/performance-analyzer/performance-analyzer.md
+++ b/docs/features/performance-analyzer/performance-analyzer.md
@@ -117,6 +117,7 @@ GET localhost:9600/_plugins/_performanceanalyzer/rca?name=HighHeapUsageClusterRC
 
 ## Change History
 
+- **v3.5.0** (2026-02-11): PA Commons dependency bump 2.0.0 → 2.1.0 with JDK 21 compatibility; Fixed Jackson annotations version mismatch in build configuration
 - **v3.4.0** (2026-01-11): Build configuration update - restore Java 21 minimum compatibility, remove Java 24 from CI matrix, simplify build.gradle version selection
 - **v3.3.0** (2026-01-11): Transport channel wrapper improvements - delegate getProfileName(), getChannelType(), getVersion(), and get() to wrapped channel; removed getInnerChannel() method for better security plugin compatibility
 - **v3.2.0** (2025-07-18): Build infrastructure update - SpotBugs 6.2.2, Checkstyle 10.26.1; Removed CVE-2025-27820 workaround
@@ -135,6 +136,8 @@ GET localhost:9600/_plugins/_performanceanalyzer/rca?name=HighHeapUsageClusterRC
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v3.5.0 | [#910](https://github.com/opensearch-project/performance-analyzer/pull/910) | Bump PA Commons to v2.1.1 and fix Jackson annotations version |   |
+| v3.5.0 | [#911](https://github.com/opensearch-project/performance-analyzer/pull/911) | Fix PA Commons version to 2.1.0 |   |
 | v3.4.0 | [#902](https://github.com/opensearch-project/performance-analyzer/pull/902) | Restore java min compatible to 21 and remove 24 |   |
 | v3.3.0 | [#845](https://github.com/opensearch-project/performance-analyzer/pull/845) | Use Subclass method for Version and Channel type for security plugin compatibility |   |
 | v3.3.0 | [#846](https://github.com/opensearch-project/performance-analyzer/pull/846) | Increment to 3.3.0.0 and update SHA files |   |

--- a/docs/releases/v3.5.0/features/performance-analyzer/performance-analyzer.md
+++ b/docs/releases/v3.5.0/features/performance-analyzer/performance-analyzer.md
@@ -1,0 +1,46 @@
+---
+tags:
+  - performance-analyzer
+---
+# Performance Analyzer
+
+## Summary
+
+Maintenance update for the Performance Analyzer plugin in OpenSearch v3.5.0. The PA Commons dependency was bumped to version 2.1.0 with JDK 21 compatibility, and a build fix was applied to resolve a Jackson annotations version mismatch in the OpenSearch 3.5.0 snapshot.
+
+## Details
+
+### What's New in v3.5.0
+
+This release contains dependency version bumps and a build configuration fix:
+
+1. **PA Commons Upgrade (2.0.0 → 2.1.0)**: Updated the `performance-analyzer-commons` library dependency from 2.0.0 to 2.1.0, incorporating upstream changes from the commons repository ([PA Commons #118](https://github.com/opensearch-project/performance-analyzer-commons/pull/118)).
+
+2. **Jackson Annotations Version Fix**: In OpenSearch 3.5.0, `jackson-core` and `jackson-annotations` have different minor versions. Previously, both used the same `jacksonVersion` variable, causing build failures. The fix introduces a separate `jacksonAnnotationsVersion` variable (using `versions.jackson_annotations`) to resolve the version mismatch.
+
+3. **SNAPSHOT Build Fix**: Re-enabled the SNAPSHOT suffix for the PA Commons version during snapshot builds, which had been commented out.
+
+### Technical Changes
+
+| Change | Before | After |
+|--------|--------|-------|
+| PA Commons version | 2.0.0 | 2.1.0 |
+| Jackson annotations version variable | `jacksonVersion` (shared) | `jacksonAnnotationsVersion` (separate) |
+| SNAPSHOT suffix for PA Commons | Disabled (commented out) | Enabled |
+
+## Limitations
+
+No new limitations introduced.
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#910](https://github.com/opensearch-project/performance-analyzer/pull/910) | Bump performance-analyzer-commons to v2.1.1 and fix Jackson annotations version | |
+| [#911](https://github.com/opensearch-project/performance-analyzer/pull/911) | Fix performance-analyzer-commons version to 2.1.0 | |
+
+### Related PRs (PA Commons)
+| PR | Description |
+|----|-------------|
+| [PA Commons #118](https://github.com/opensearch-project/performance-analyzer-commons/pull/118) | Changes consumed in PA Commons 2.1.0 |

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -24,3 +24,6 @@
 
 ## skills
 - Skills Dependencies
+
+## performance-analyzer
+- Performance Analyzer


### PR DESCRIPTION
## Summary\n\nInvestigation of Performance Analyzer bugfix for OpenSearch v3.5.0 (Issue #2535).\n\n### Changes\n- Created release report: `docs/releases/v3.5.0/features/performance-analyzer/performance-analyzer.md`\n- Updated feature report: `docs/features/performance-analyzer/performance-analyzer.md` (added v3.5.0 Change History and PRs)\n- Updated release index: `docs/releases/v3.5.0/index.md`\n\n### Key Findings\n- PA Commons dependency bumped from 2.0.0 to 2.1.0 with JDK 21 compatibility\n- Fixed Jackson annotations version mismatch in build configuration (separate variable for `jackson-annotations`)\n- Re-enabled SNAPSHOT suffix for PA Commons version during snapshot builds\n\n### PRs Investigated\n- opensearch-project/performance-analyzer#910 - Bump PA Commons to v2.1.1\n- opensearch-project/performance-analyzer#911 - Fix PA Commons version to 2.1.0