### PR TITLE
docs: add reporting-dependencies report for v3.5.0

### DIFF
--- a/docs/features/reporting/reporting-plugin.md
+++ b/docs/features/reporting/reporting-plugin.md
@@ -110,6 +110,7 @@ The Reporting plugin integrates with OpenSearch Security:
 
 ## Change History
 
+- **v3.5.0**: Updated mockito-core test dependency to align with OpenSearch core version, resolving build conflicts
 - **v3.3.0** (2026-01-11): Security fix for CVE-2025-7783
 - **v3.2.0** (2026-01-11): Fixed system index creation permissions and tenant URL parsing
 - **v3.1.0** (2025-06-13): Version increment and release notes maintenance
@@ -130,6 +131,7 @@ The Reporting plugin integrates with OpenSearch Security:
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v3.5.0 | [#678](https://github.com/opensearch-project/reporting/pull/678) | Bump mockito-core version to align with OpenSearch core | Build conflict |
 | v3.3.0 | [#640](https://github.com/opensearch-project/reporting/pull/640) | Fixing CVE-2025-7783 |   |
 | v3.2.0 | [#1108](https://github.com/opensearch-project/reporting/pull/1108) | Create report indices in system context to avoid permission issues | [#998](https://github.com/opensearch-project/reporting/issues/998) |
 | v3.2.0 | [#599](https://github.com/opensearch-project/dashboards-reporting/pull/599) | Fix tenant URL parsing when generating reports from Discover | [#535](https://github.com/opensearch-project/dashboards-reporting/issues/535) |

--- a/docs/releases/v3.5.0/features/reporting/reporting-dependencies.md
+++ b/docs/releases/v3.5.0/features/reporting/reporting-dependencies.md
@@ -1,0 +1,31 @@
+---
+tags:
+  - reporting
+---
+# Reporting Dependencies
+
+## Summary
+
+In v3.5.0, the Reporting plugin updated its mockito-core test dependency to align with the version provided by the OpenSearch core framework, resolving a build conflict that caused compilation failures.
+
+## Details
+
+### What's New in v3.5.0
+
+The `mockito-core` dependency was updated to use `${versions.mockito}` from the OpenSearch version catalog instead of a hardcoded version. This resolved a version conflict between mockito-core 5.2.0 (from OpenSearch core) and 5.1.0 (previously pinned in the reporting plugin), which caused `compileTestKotlin` task failures.
+
+### Technical Changes
+
+- Replaced hardcoded mockito-core version with `${versions.mockito}` to fetch the version from OpenSearch core
+- Resolved `testCompileClasspath` dependency conflict between mockito-core 5.2.0 and 5.1.0
+
+## Limitations
+
+- This is a test-only dependency change with no runtime impact
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#678](https://github.com/opensearch-project/reporting/pull/678) | Bump mockito-core version to align with OpenSearch core | Build failure due to version conflict |

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -27,3 +27,6 @@
 
 ## performance-analyzer
 - Performance Analyzer
+
+## reporting
+- Reporting Dependencies


### PR DESCRIPTION
## Summary\nRelease report for [bugfix] Reporting Dependencies (v3.5.0).\n\nUpdated mockito-core test dependency in the Reporting plugin to align with OpenSearch core version, resolving build compilation conflicts.\n\n### Reports\n- Release report: `docs/releases/v3.5.0/features/reporting/reporting-dependencies.md`\n- Feature report updated: `docs/features/reporting/reporting-plugin.md` (Change History + References)\n- Release index updated: `docs/releases/v3.5.0/index.md`\n\nCloses #2534