### PR TITLE
docs: add observability-dependencies report for v3.5.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -27,6 +27,7 @@ Cumulative feature documentation across all versions.
 - Observability MDS & System Index
 - Observability Release Maintenance
 - Observability Security Maintenance
+- Observability Dependencies
 
 ## opensearch-dashboards
 

--- a/docs/features/observability/observability-dependencies.md
+++ b/docs/features/observability/observability-dependencies.md
@@ -1,0 +1,46 @@
+---
+tags:
+  - observability
+---
+# Observability Dependencies
+
+## Summary
+
+Tracks dependency management, security patches, and build tooling updates for the OpenSearch Observability plugin ecosystem, covering both the backend plugin (`observability`) and the frontend Dashboards plugin (`dashboards-observability`).
+
+## Details
+
+### Components
+
+| Component | Repository | Language |
+|-----------|-----------|----------|
+| Backend plugin | opensearch-project/observability | Kotlin/Java |
+| Frontend plugin | opensearch-project/dashboards-observability | TypeScript/JavaScript |
+
+### Key Dependencies
+
+| Dependency | Purpose | Component |
+|-----------|---------|-----------|
+| lodash | Utility library | dashboards-observability |
+| cypress-parallel | Parallel test execution | dashboards-observability |
+| ktlint-cli | Kotlin code linting | observability |
+| Jackson | JSON serialization | observability |
+
+## Limitations
+
+- Dependency updates are typically maintenance-only and do not change plugin functionality.
+- CVE fixes in transitive dependencies may require upgrading parent packages.
+
+## Change History
+
+- **v3.5.0**: Bumped lodash to 4.17.23 (prototype pollution fix), upgraded cypress-parallel for js-yaml CVE-2025-64718, upgraded ktlint-cli to 1.8.0, decoupled jackson-annotations version
+
+## References
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.5.0 | [#2569](https://github.com/opensearch-project/dashboards-observability/pull/2569) | Bump lodash from 4.17.21 to 4.17.23 |
+| v3.5.0 | [#2577](https://github.com/opensearch-project/dashboards-observability/pull/2577) | Upgrade cypress-parallel for js-yaml CVE-2025-64718 fix |
+| v3.5.0 | [#1962](https://github.com/opensearch-project/observability/pull/1962) | Upgrade to ktlint-cli 1.8.0 |
+| v3.5.0 | [#1968](https://github.com/opensearch-project/observability/pull/1968) | Decouple jackson annotation version |

--- a/docs/releases/v3.5.0/features/observability/observability-dependencies.md
+++ b/docs/releases/v3.5.0/features/observability/observability-dependencies.md
@@ -1,0 +1,46 @@
+---
+tags:
+  - observability
+---
+# Observability Dependencies
+
+## Summary
+
+Dependency updates and security fixes for the Observability plugin in OpenSearch v3.5.0. These changes address CVE vulnerabilities, upgrade build tooling, and fix dependency version mismatches across both the backend (observability) and frontend (dashboards-observability) components.
+
+## Details
+
+### What's New in v3.5.0
+
+#### Security Fixes
+- **lodash 4.17.21 → 4.17.23**: Fixes prototype pollution vulnerability in `baseUnset` function. Applied to the dashboards-observability frontend.
+- **js-yaml CVE-2025-64718**: Resolved by upgrading `cypress-parallel`, which pulls in a patched version of `mocha` → `js-yaml` transitive dependency chain.
+
+#### Build Tooling
+- **ktlint-cli 0.47.1 → 1.8.0**: Upgraded the Kotlin linter from the legacy `com.pinterest:ktlint` artifact to the new `com.pinterest.ktlint:ktlint-cli` artifact. This also triggered a comprehensive Kotlin code style reformatting across the backend plugin source (trailing commas, expression body functions, multi-line parameter formatting).
+
+#### Dependency Version Alignment
+- **Jackson annotations decoupling**: Changed `jackson-annotations` dependency from `${versions.jackson}` to `${versions.jackson_annotations}` in `build.gradle`. This aligns with the upstream OpenSearch build tools change ([OpenSearch#20343](https://github.com/opensearch-project/OpenSearch/pull/20343)) that introduced separate versioning for `jackson-annotations` (2.20) vs other Jackson artifacts (2.20.1). Resolves [observability#1967](https://github.com/opensearch-project/observability/issues/1967).
+
+### Technical Changes
+
+| Change | From | To | Component |
+|--------|------|----|-----------|
+| lodash | 4.17.21 | 4.17.23 | dashboards-observability |
+| cypress-parallel (js-yaml) | vulnerable | patched | dashboards-observability |
+| ktlint-cli | 0.47.1 | 1.8.0 | observability (backend) |
+| jackson-annotations | `${versions.jackson}` | `${versions.jackson_annotations}` | observability (backend) |
+
+## Limitations
+
+- The ktlint upgrade caused widespread code formatting changes that are purely cosmetic (trailing commas, expression bodies). No functional behavior changed.
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#2569](https://github.com/opensearch-project/dashboards-observability/pull/2569) | Bump lodash from 4.17.21 to 4.17.23 | - |
+| [#2577](https://github.com/opensearch-project/dashboards-observability/pull/2577) | Upgrade cypress-parallel for js-yaml CVE-2025-64718 fix | - |
+| [#1962](https://github.com/opensearch-project/observability/pull/1962) | Upgrade to ktlint-cli 1.8.0 | - |
+| [#1968](https://github.com/opensearch-project/observability/pull/1968) | Decouple jackson annotation version | [#1967](https://github.com/opensearch-project/observability/issues/1967) |

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -28,5 +28,8 @@
 ## performance-analyzer
 - Performance Analyzer
 
+## observability
+- Observability Dependencies
+
 ## reporting
 - Reporting Dependencies


### PR DESCRIPTION
## Summary
Adds release and feature reports for Observability Dependencies in v3.5.0.

### Changes
- **Release report**: `docs/releases/v3.5.0/features/observability/observability-dependencies.md`
- **Feature report**: `docs/features/observability/observability-dependencies.md`
- Updated release index and features index

### PRs Investigated
| PR | Description | Repository |
|----|-------------|-----------|
| #2569 | Bump lodash 4.17.21 → 4.17.23 (prototype pollution fix) | dashboards-observability |
| #2577 | Upgrade cypress-parallel for js-yaml CVE-2025-64718 | dashboards-observability |
| #1962 | Upgrade ktlint-cli to 1.8.0 | observability |
| #1968 | Decouple jackson-annotations version | observability |

Closes #2533