### PR TITLE
docs: add notifications-maintenance report for v3.5.0

### DIFF
--- a/docs/features/notifications/notifications-plugin.md
+++ b/docs/features/notifications/notifications-plugin.md
@@ -99,6 +99,7 @@ POST _plugins/_notifications/configs
 
 ## Change History
 
+- **v3.5.0** (2026-02-11): Maintainer update - added Dennis Toepker (toepkerd) to MAINTAINERS.md and CODEOWNERS
 - **v3.3.0** (2026-01-11): Build infrastructure fixes - Gradle 9 compatibility for environment variable syntax, SLF4J version conflict resolution for Maven snapshot publication
 - **v3.2.0** (2026-01-11): Infrastructure updates - Gradle 8.14, JaCoCo 0.8.13, nebula.ospackage 12.0.0, JDK 24 CI support
 - **v3.1.0** (2026-01-10): Migrated from javax.mail to jakarta.mail APIs to avoid version conflicts; updated greenmail test dependency to 2.0.1
@@ -114,6 +115,7 @@ POST _plugins/_notifications/configs
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v3.5.0 | [#1076](https://github.com/opensearch-project/notifications/pull/1076) | Adding toepkerd to MAINTAINERS.md | [.github#395](https://github.com/opensearch-project/.github/issues/395) |
 | v3.3.0 | [#1074](https://github.com/opensearch-project/notifications/pull/1074) | Fix issue publishing maven snapshots by forcing slf4j version |   |
 | v3.3.0 | [#1069](https://github.com/opensearch-project/notifications/pull/1069) | Fix: Update System.env syntax for Gradle 9 compatibility |   |
 | v3.2.0 | [#1057](https://github.com/opensearch-project/notifications/pull/1057) | Updated gradle, jdk and other dependencies |   |

--- a/docs/releases/v3.5.0/features/notifications/notifications-maintenance.md
+++ b/docs/releases/v3.5.0/features/notifications/notifications-maintenance.md
@@ -1,0 +1,34 @@
+---
+tags:
+  - notifications
+---
+# Notifications Maintenance
+
+## Summary
+
+Maintenance updates for the OpenSearch Notifications plugin in v3.5.0, including adding a new maintainer and a version bump PR (not merged).
+
+## Details
+
+### What's New in v3.5.0
+
+- **New Maintainer**: Dennis Toepker (`toepkerd`) was added to MAINTAINERS.md and CODEOWNERS, expanding the notifications plugin maintainer team.
+
+### Technical Changes
+
+- **MAINTAINERS.md**: Added Dennis Toepker as a maintainer with Amazon affiliation.
+- **CODEOWNERS**: Added `@toepkerd` to the global code owners list for the notifications repository.
+
+Note: PR #414 ("Increment OpenSearch Dashboards version to 2.0.0-rc1") was listed in the release notes but was closed without being merged (from 2022). It has no impact on v3.5.0.
+
+## Limitations
+
+None. These are governance/maintenance changes only.
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#1076](https://github.com/opensearch-project/notifications/pull/1076) | Adding toepkerd to MAINTAINERS.md | [.github#395](https://github.com/opensearch-project/.github/issues/395) |
+| [#414](https://github.com/opensearch-project/notifications/pull/414) | Increment OpenSearch Dashboards version to 2.0.0-rc1 (closed, not merged) | - |

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -31,5 +31,8 @@
 ## observability
 - Observability Dependencies
 
+## notifications
+- Notifications Maintenance
+
 ## reporting
 - Reporting Dependencies


### PR DESCRIPTION
## Summary\n\nInvestigation report for [#2532](https://github.com/tkykenmt/opensearch-feature-explorer/issues/2532) - Notifications Maintenance in v3.5.0.\n\n### Changes\n- Created release report: `docs/releases/v3.5.0/features/notifications/notifications-maintenance.md`\n- Updated feature report: `docs/features/notifications/notifications-plugin.md` (change history + references)\n- Updated release index: `docs/releases/v3.5.0/index.md`\n\n### Findings\n- PR #1076: Added Dennis Toepker (toepkerd) as maintainer to MAINTAINERS.md and CODEOWNERS\n- PR #414: Closed without merge (2022 version bump), no impact on v3.5.0