### PR TITLE
docs: add remote-store report for v3.5.0

### DIFF
--- a/docs/features/opensearch-remote-metadata-sdk/opensearch-remote-metadata-sdk-remote-metadata-sdk.md
+++ b/docs/features/opensearch-remote-metadata-sdk/opensearch-remote-metadata-sdk-remote-metadata-sdk.md
@@ -135,6 +135,7 @@ The following plugins support multi-tenancy with remote metadata storage:
 
 ## Change History
 
+- **v3.5.0** (2026-02-11): Add utility methods to `SdkClientUtils` for wrapping async operation completions with ActionListener handling (`wrapPutCompletion`, `wrapGetCompletion`, `wrapUpdateCompletion`, `wrapDeleteCompletion`, `wrapBulkCompletion`, `wrapSearchCompletion`), simplifying migration to SDK (PR #75)
 - **v3.4.0** (2026-01-14): Add CMK support for encrypting/decrypting customer data in DynamoDB backend with STS role assumption for cross-account access (PRs #271, #295); Fix error when updating global model status (PR #291)
 - **v3.3.0** (2025-09-22): Added SeqNo/PrimaryTerm support for Put and Delete requests, RefreshPolicy and timeout configuration for write operations, empty string ID validation fix, and ThreadContextAccess API compatibility fixes (PRs #234, #244, #236, #250, #254)
 - **v3.0.0** (2025-05-06): Update `Client` import path from `org.opensearch.client.Client` to `org.opensearch.transport.client.Client` for JPMS compatibility with OpenSearch 3.0.0 (PR #73)
@@ -157,6 +158,7 @@ The following plugins support multi-tenancy with remote metadata storage:
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v3.5.0 | [#75](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/75) | Add util methods to handle ActionListeners in whenComplete | [#67](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/67) |
 | v3.4.0 | [#271](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/271) | Add CMK support to encrypt/decrypt customer data |   |
 | v3.4.0 | [#295](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/295) | Add assume role for CMK |   |
 | v3.4.0 | [#291](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/291) | Fix error when updating model status |   |

--- a/docs/releases/v3.5.0/features/dashboards/dashboards-dependencies.md
+++ b/docs/releases/v3.5.0/features/dashboards/dashboards-dependencies.md
@@ -1,0 +1,72 @@
+---
+tags:
+  - dashboards
+---
+# Dashboards Dependencies
+
+## Summary
+
+OpenSearch Dashboards v3.5.0 includes a significant set of dependency updates across both the core OpenSearch-Dashboards repository and the dashboards-assistant plugin. The most notable changes are the Node.js upgrade from v20 to v22 (22.21.1 → 22.22.0), the replacement of `handlebars` with `kbn-handlebars` to eliminate CSP `unsafe-eval` violations, and security-driven bumps to lodash, axios, and other packages.
+
+## Details
+
+### What's New in v3.5.0
+
+#### Node.js Upgrade to v22
+
+The runtime was upgraded from Node.js 20.18.3 to 22.21.1 ([#11076](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11076)), then further to 22.22.0 ([#11218](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11218)). This aligns OpenSearch Dashboards with the latest LTS Node.js version. Key compatibility changes include:
+
+- Updated stream `destroy()` method signatures for Node.js 22 semantics
+- Suppressed new deprecation warnings (`MODULE_TYPELESS_PACKAGE_JSON`, `fs.Stats constructor`)
+- Updated test snapshots for Node.js 22 output changes
+- Widened engine requirement in `package.json` from `<21` to `<23`
+
+#### Handlebars → kbn-handlebars (CSP Security Fix)
+
+Replaced the `handlebars` package with `kbn-handlebars` ([#11084](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11084)) to eliminate CSP `unsafe-eval` violations. The standard `handlebars.compile()` uses `new Function()` internally, which requires `unsafe-eval` in CSP. The replacement uses `compileAST()` which interprets the template AST directly without generating JavaScript code. A follow-up PR ([#11105](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11105)) temporarily added back the original handlebars to fix backward compatibility tests.
+
+#### Security-Driven Library Updates
+
+| Package | From | To | PR | Motivation |
+|---------|------|----|-----|------------|
+| lodash | 4.17.21 | 4.17.23 | [#11254](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11254), [#840](https://github.com/opensearch-project/dashboards-assistant/pull/840) | CVE fix |
+| lodash-es | 4.17.21 | 4.17.23 | [#11254](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11254), [#838](https://github.com/opensearch-project/dashboards-assistant/pull/838) | CVE fix |
+| axios | — | 1.13.3 | [#11233](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11233) | Removed monkey-patch workaround |
+| less | — | 4.1.3 | [#11250](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11250) | Use `disablePluginRule` in Markdown panel |
+| @modelcontextprotocol/sdk | — | 1.24.0 → 1.25.2 | [#11086](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11086), [#11151](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11151) | Feature update |
+| qs | — | 6.14.1 | [#11151](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11151) | Security update |
+| caniuse-lite | — | latest | [#11195](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11195) | Browser compatibility data |
+
+#### UI Framework Update
+
+OUI (OpenSearch UI) was upgraded from 1.21.0 to 1.22.1 ([#11042](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11042)), incorporating the latest UI component improvements across the entire application stack.
+
+#### Version Increment
+
+The dashboards-assistant plugin version was incremented to 3.5.0.0 ([#783](https://github.com/opensearch-project/dashboards-assistant/pull/783)).
+
+## Limitations
+
+- The `kbn-handlebars` `compileAST()` method uses AST interpretation instead of compiled JavaScript, which may be slower for dashboards with many TSVB visualizations or large datasets.
+- The Node.js 22 upgrade required suppressing certain deprecation warnings that may need to be addressed in future versions.
+
+## References
+
+### Pull Requests
+
+| PR | Description | Repository |
+|----|-------------|------------|
+| [#11076](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11076) | Update Node.js to 22.21.1 | OpenSearch-Dashboards |
+| [#11218](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11218) | Bump Node.js to v22.22.0 | OpenSearch-Dashboards |
+| [#11084](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11084) | Replace handlebars with kbn-handlebars | OpenSearch-Dashboards |
+| [#11105](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11105) | Add back handlebars to fix bwc tests | OpenSearch-Dashboards |
+| [#11254](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11254) | Update lodash and lodash-es to 4.17.23 | OpenSearch-Dashboards |
+| [#11233](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11233) | Bump axios to 1.13.3 | OpenSearch-Dashboards |
+| [#11250](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11250) | Bump less to 4.1.3 | OpenSearch-Dashboards |
+| [#11042](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11042) | Upgrade OUI to 1.22 | OpenSearch-Dashboards |
+| [#11151](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11151) | Bump @modelcontextprotocol/sdk to 1.25.2 and qs to 6.14.1 | OpenSearch-Dashboards |
+| [#11086](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11086) | Update @modelcontextprotocol/sdk to v1.24.0 | OpenSearch-Dashboards |
+| [#11195](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11195) | Update caniuse-lite | OpenSearch-Dashboards |
+| [#840](https://github.com/opensearch-project/dashboards-assistant/pull/840) | Bump lodash to 4.17.23 | dashboards-assistant |
+| [#838](https://github.com/opensearch-project/dashboards-assistant/pull/838) | Bump lodash-es to 4.17.23 | dashboards-assistant |
+| [#783](https://github.com/opensearch-project/dashboards-assistant/pull/783) | Increment version to 3.5.0.0 | dashboards-assistant |

--- a/docs/releases/v3.5.0/features/remote/remote-store.md
+++ b/docs/releases/v3.5.0/features/remote/remote-store.md
@@ -1,0 +1,72 @@
+---
+tags:
+  - remote
+---
+# Remote Store
+
+## Summary
+
+This release adds utility methods to the OpenSearch Remote Metadata SDK that simplify ActionListener handling when using async operations with CompletableFuture's `whenComplete` method. These wrapper methods handle response parsing and exception unwrapping automatically, significantly reducing boilerplate code for plugin developers migrating to the SDK.
+
+## Details
+
+### What's New in v3.5.0
+
+#### ActionListener Completion Wrappers
+
+New utility methods in `SdkClientUtils` wrap async operation completions into ActionListener-compatible format:
+
+| Method | Description |
+|--------|-------------|
+| `wrapPutCompletion()` | Wraps PUT operation completion, parses `IndexResponse` |
+| `wrapGetCompletion()` | Wraps GET operation completion, parses `GetResponse` |
+| `wrapUpdateCompletion()` | Wraps UPDATE operation completion, parses `UpdateResponse` |
+| `wrapDeleteCompletion()` | Wraps DELETE operation completion, parses `DeleteResponse` |
+| `wrapBulkCompletion()` | Wraps BULK operation completion, parses `BulkResponse` |
+| `wrapSearchCompletion()` | Wraps SEARCH operation completion, parses `SearchResponse` |
+
+#### Migration Example
+
+Before (manual handling):
+```java
+sdkClient.getDataObjectAsync(getRequest).whenComplete((response, throwable) -> {
+    if (throwable == null) {
+        try {
+            GetResponse getResponse = response.parser() == null 
+                ? null 
+                : GetResponse.fromXContent(response.parser());
+            listener.onResponse(getResponse);
+        } catch (IOException e) {
+            listener.onFailure(new OpenSearchStatusException("Failed to parse", INTERNAL_SERVER_ERROR));
+        }
+    } else {
+        listener.onFailure(unwrapException(throwable));
+    }
+});
+```
+
+After (using wrapper):
+```java
+sdkClient.getDataObjectAsync(getRequest).whenComplete(SdkClientUtils.wrapGetCompletion(listener));
+```
+
+#### Exception Handling
+
+The wrapper methods automatically unwrap exceptions, defaulting to unwrap both `CompletionException` (typical for CompletableFuture) and `OpenSearchStatusException` (current wrapper for client implementations). Callers can optionally override this with custom exception types via vararg parameters.
+
+### Infrastructure Updates
+
+- Updated `aws-actions/configure-aws-credentials` GitHub Action from v4.0.3 to v4.1.0 for snapshot publishing workflow
+
+## Limitations
+
+- Wrapper methods return `null` response when parser is `null`
+- Parse failures result in `OpenSearchStatusException` with `INTERNAL_SERVER_ERROR` status
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#75](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/75) | Add util methods to handle ActionListeners in whenComplete | [#67](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/67) |
+| [#76](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/76) | Update aws-actions/configure-aws-credentials action to v4.1.0 | - |

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -36,3 +36,6 @@
 
 ## reporting
 - Reporting Dependencies
+
+## remote
+- Remote Store


### PR DESCRIPTION
## Summary

Adds release report for Remote Store bugfix item in v3.5.0.

### Changes
- Created release report: `docs/releases/v3.5.0/features/remote/remote-store.md`
- Updated feature report: `docs/features/opensearch-remote-metadata-sdk/opensearch-remote-metadata-sdk-remote-metadata-sdk.md`
- Updated release index

### Key Changes in v3.5.0
- Added utility methods to `SdkClientUtils` for wrapping async operation completions with ActionListener handling
- Methods: `wrapPutCompletion`, `wrapGetCompletion`, `wrapUpdateCompletion`, `wrapDeleteCompletion`, `wrapBulkCompletion`, `wrapSearchCompletion`
- Updated `aws-actions/configure-aws-credentials` GitHub Action to v4.1.0

### PRs Investigated
- [#75](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/75) - Add util methods to handle ActionListeners in whenComplete
- [#76](https://github.com/opensearch-project/opensearch-remote-metadata-sdk/pull/76) - Update aws-actions/configure-aws-credentials action to v4.1.0

Closes #2530