### PR TITLE
docs: add Job Scheduler report for v3.5.0

### DIFF
--- a/docs/features/job-scheduler/job-scheduler.md
+++ b/docs/features/job-scheduler/job-scheduler.md
@@ -204,6 +204,7 @@ Job Scheduler supports two schedule formats:
 
 ## Change History
 
+- **v3.5.0** (2026): CI/CD maintenance - Added integTest retry for sample-extension-plugin to reduce flakiness; Renamed CHANGELOG to CHANGELOG.md for changelog_verifier workflow compatibility; Updated GitHub Actions (upload-artifact v5→v6, download-artifact v6→v7) to Node.js 24 runtime
 - **v3.3.0** (2025): Added Job History Service for tracking job execution history; Refactored LockService to interface with LockServiceImpl; Implemented IdentityAwarePlugin for improved security integration; Added remote metadata storage support via SdkClient (DynamoDB, remote OpenSearch); Added multi-tenancy support
 - **v3.2.0** (2025): Added REST APIs for listing scheduled jobs and locks; Added support for second-level interval scheduling; Made LockService non-final for better extensibility; Fixed date serialization in transport actions
 - **v3.1.0** (2025): Added CHANGELOG and changelog_verifier workflow for iterative release note assembly; Removed Guava dependency to reduce jar hell and dependency conflicts in extending plugins
@@ -225,6 +226,10 @@ Job Scheduler supports two schedule formats:
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v3.5.0 | [#872](https://github.com/opensearch-project/job-scheduler/pull/872) | Add integTest retry for sample-extension-plugin | |
+| v3.5.0 | [#843](https://github.com/opensearch-project/job-scheduler/pull/843) | Rename CHANGELOG to CHANGELOG.md for changelog_verifier workflow | |
+| v3.5.0 | [#868](https://github.com/opensearch-project/job-scheduler/pull/868) | Dependabot: bump actions/download-artifact from 6 to 7 | |
+| v3.5.0 | [#867](https://github.com/opensearch-project/job-scheduler/pull/867) | Dependabot: bump actions/upload-artifact from 5 to 6 | |
 | v3.3.0 | [#814](https://github.com/opensearch-project/job-scheduler/pull/814) | Job History Service - creates history index recording job execution times | [#808](https://github.com/opensearch-project/job-scheduler/issues/808) |
 | v3.3.0 | [#714](https://github.com/opensearch-project/job-scheduler/pull/714) | Make LockService an interface and replace usages of ThreadContext.stashContext | [#238](https://github.com/opensearch-project/job-scheduler/issues/238) |
 | v3.3.0 | [#833](https://github.com/opensearch-project/job-scheduler/pull/833) | Create Guice module to bind LockService interface from SPI to LockServiceImpl |   |

--- a/docs/releases/v3.5.0/features/job-scheduler/job-scheduler.md
+++ b/docs/releases/v3.5.0/features/job-scheduler/job-scheduler.md
@@ -1,0 +1,49 @@
+---
+tags:
+  - job-scheduler
+---
+# Job Scheduler
+
+## Summary
+
+Job Scheduler v3.5.0 includes CI/CD maintenance improvements focused on test reliability and workflow compatibility. The changes address flaky integration tests in the sample-extension-plugin and update GitHub Actions dependencies to Node.js 24.
+
+## Details
+
+### What's New in v3.5.0
+
+#### Integration Test Retry Mechanism
+Added retry logic (up to 3 attempts) for integration tests in the sample-extension-plugin to reduce CI flakiness. This addresses intermittent failures in multi-node integration tests without modifying the underlying test logic.
+
+#### Changelog Workflow Fix
+Renamed `CHANGELOG` to `CHANGELOG.md` to ensure the `changelog_verifier` workflow functions correctly. This aligns with the standard markdown file extension expected by the verification tooling.
+
+#### GitHub Actions Updates
+Updated GitHub Actions dependencies to support Node.js 24:
+- `actions/upload-artifact`: v5 → v6
+- `actions/download-artifact`: v6 → v7
+
+These updates require Actions Runner version 2.327.1 or later for self-hosted runners.
+
+### Technical Changes
+
+| Change | Description |
+|--------|-------------|
+| Test retry | Added `maxRetries: 3` configuration for sample-extension-plugin integTest |
+| File rename | `CHANGELOG` → `CHANGELOG.md` for workflow compatibility |
+| Dependency bump | GitHub Actions artifact actions updated to Node.js 24 runtime |
+
+## Limitations
+
+- The test retry mechanism is a workaround; root causes of flaky tests in multi-node integration tests remain unaddressed
+- Self-hosted runners must be updated to version 2.327.1+ before upgrading to the new GitHub Actions versions
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#872](https://github.com/opensearch-project/job-scheduler/pull/872) | Add integTest retry for sample-extension-plugin | [Flaky test example](https://github.com/opensearch-project/job-scheduler/actions/runs/20444634620/job/58745294299) |
+| [#843](https://github.com/opensearch-project/job-scheduler/pull/843) | Rename CHANGELOG to CHANGELOG.md to ensure changelog_verifier workflow works | |
+| [#868](https://github.com/opensearch-project/job-scheduler/pull/868) | Dependabot: bump actions/download-artifact from 6 to 7 | |
+| [#867](https://github.com/opensearch-project/job-scheduler/pull/867) | Dependabot: bump actions/upload-artifact from 5 to 6 | |

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -39,3 +39,6 @@
 
 ## remote
 - Remote Store
+
+## job-scheduler
+- Job Scheduler


### PR DESCRIPTION
## Summary
Add Job Scheduler documentation for v3.5.0 release.

## Changes
- Created release report: `docs/releases/v3.5.0/features/job-scheduler/job-scheduler.md`
- Updated feature report: `docs/features/job-scheduler/job-scheduler.md` (Change History and References)
- Updated release index: `docs/releases/v3.5.0/index.md`

## Key Changes in v3.5.0
- Added integTest retry for sample-extension-plugin to reduce CI flakiness
- Renamed CHANGELOG to CHANGELOG.md for changelog_verifier workflow compatibility
- Updated GitHub Actions (upload-artifact v5→v6, download-artifact v6→v7) to Node.js 24 runtime

## PRs Investigated
- [#872](https://github.com/opensearch-project/job-scheduler/pull/872) - Add integTest retry for sample-extension-plugin
- [#843](https://github.com/opensearch-project/job-scheduler/pull/843) - Rename CHANGELOG to CHANGELOG.md
- [#868](https://github.com/opensearch-project/job-scheduler/pull/868) - Bump actions/download-artifact from 6 to 7
- [#867](https://github.com/opensearch-project/job-scheduler/pull/867) - Bump actions/upload-artifact from 5 to 6

Closes #2529