### PR TITLE
docs: add dashboards-ci-cd report for v3.5.0

### DIFF
--- a/docs/features/dashboards-search-relevance/dashboards-search-relevance-build-maintenance.md
+++ b/docs/features/dashboards-search-relevance/dashboards-search-relevance-build-maintenance.md
@@ -56,6 +56,7 @@ No additional configuration is required. The fixes are applied at the source cod
 
 ## Change History
 
+- **v3.5.0** (2026-02-11): Fixed CI workflows for automated backport PRs by using GitHub App tokens instead of GITHUB_TOKEN
 - **v2.17.0** (2024-09-17): Fixed Sass division warning by updating to `calc()` syntax; Fixed broken LICENSE file link and removed unused Docker documentation links
 
 
@@ -69,5 +70,6 @@ No additional configuration is required. The fixes are applied at the source cod
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v3.5.0 | [#720](https://github.com/opensearch-project/dashboards-search-relevance/pull/720) | Enable CI workflows for automated backport PRs | |
 | v2.17.0 | [#426](https://github.com/opensearch-project/dashboards-search-relevance/pull/426) | Fix sass division warning |   |
 | v2.17.0 | [#420](https://github.com/opensearch-project/dashboards-search-relevance/pull/420) | Update Links in Documentation |   |

--- a/docs/features/dashboards/dashboards-dependencies.md
+++ b/docs/features/dashboards/dashboards-dependencies.md
@@ -1,0 +1,61 @@
+---
+tags:
+  - dashboards
+---
+# Dashboards Dependencies
+
+## Summary
+
+Dependency management for OpenSearch Dashboards and its plugins, covering runtime upgrades (Node.js), security patches (CVE fixes for lodash, axios), CSP compliance improvements (handlebars replacement), and UI framework updates (OUI).
+
+## Details
+
+### Key Dependencies
+
+| Dependency | Purpose | Current Version |
+|-----------|---------|-----------------|
+| Node.js | Runtime | 22.22.0 |
+| OUI (OpenSearch UI) | UI component library | 1.22.1 |
+| lodash / lodash-es | Utility library | 4.17.23 |
+| axios | HTTP client | 1.13.3 |
+| kbn-handlebars | Template engine (CSP-safe) | 1.0.0 |
+| less | CSS preprocessor | 4.1.3 |
+| @modelcontextprotocol/sdk | MCP integration | 1.25.2 |
+
+### CSP Compliance
+
+The `handlebars` package was replaced with `kbn-handlebars` to eliminate CSP `unsafe-eval` violations. The standard `handlebars.compile()` generates JavaScript via `new Function()`, while `kbn-handlebars` provides `compileAST()` that interprets the template AST directly. This affects TSVB visualizations (`replace_vars.js`, `tick_formatter.js`) on the client side.
+
+### Node.js Upgrade Strategy
+
+OpenSearch Dashboards follows the Node.js LTS release cycle. The v3.5.0 release upgraded from Node.js 20 to Node.js 22, requiring compatibility adjustments for stream APIs, deprecation warnings, and test infrastructure.
+
+## Limitations
+
+- `kbn-handlebars` AST interpretation is slower than compiled JavaScript execution, potentially impacting dashboards with many TSVB visualizations.
+- Node.js 22 deprecation warnings for `MODULE_TYPELESS_PACKAGE_JSON` and `fs.Stats constructor` are suppressed but may need future resolution.
+
+## Change History
+
+- **v3.5.0**: Node.js upgraded to 22.22.0; handlebars replaced with kbn-handlebars for CSP compliance; lodash/lodash-es updated to 4.17.23 (CVE fix); axios bumped to 1.13.3; OUI upgraded to 1.22.1; less bumped to 4.1.3; @modelcontextprotocol/sdk updated to 1.25.2
+
+## References
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.5.0 | [#11076](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11076) | Update Node.js to 22.21.1 |
+| v3.5.0 | [#11218](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11218) | Bump Node.js to v22.22.0 |
+| v3.5.0 | [#11084](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11084) | Replace handlebars with kbn-handlebars |
+| v3.5.0 | [#11105](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11105) | Add back handlebars to fix bwc tests |
+| v3.5.0 | [#11254](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11254) | Update lodash and lodash-es to 4.17.23 |
+| v3.5.0 | [#11233](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11233) | Bump axios to 1.13.3 |
+| v3.5.0 | [#11250](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11250) | Bump less to 4.1.3 |
+| v3.5.0 | [#11042](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11042) | Upgrade OUI to 1.22 |
+| v3.5.0 | [#11151](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11151) | Bump @modelcontextprotocol/sdk to 1.25.2 and qs to 6.14.1 |
+| v3.5.0 | [#11086](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11086) | Update @modelcontextprotocol/sdk to v1.24.0 |
+| v3.5.0 | [#11195](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11195) | Update caniuse-lite |
+| v3.5.0 | [#840](https://github.com/opensearch-project/dashboards-assistant/pull/840) | Bump lodash to 4.17.23 |
+| v3.5.0 | [#838](https://github.com/opensearch-project/dashboards-assistant/pull/838) | Bump lodash-es to 4.17.23 |
+| v3.5.0 | [#783](https://github.com/opensearch-project/dashboards-assistant/pull/783) | Increment version to 3.5.0.0 |

--- a/docs/releases/v3.5.0/features/dashboards-search-relevance/dashboards-ci-cd.md
+++ b/docs/releases/v3.5.0/features/dashboards-search-relevance/dashboards-ci-cd.md
@@ -1,0 +1,65 @@
+---
+tags:
+  - dashboards-search-relevance
+---
+# Dashboards CI/CD
+
+## Summary
+
+Fixed CI workflows for automated backport PRs in the dashboards-search-relevance plugin. Backport PRs created by the github-actions bot were not triggering CI workflows due to GitHub's security policy preventing GITHUB_TOKEN from triggering workflows.
+
+## Details
+
+### What's New in v3.5.0
+
+The backport workflow was updated to use GitHub App tokens instead of GITHUB_TOKEN to enable CI workflows for automated backport PRs.
+
+### Technical Changes
+
+```mermaid
+graph TB
+    subgraph "Before (Broken)"
+        PR1[Merged PR] --> Bot1[github-actions bot]
+        Bot1 -->|GITHUB_TOKEN| BackportPR1[Backport PR]
+        BackportPR1 -.->|Blocked| CI1[CI Workflows]
+    end
+    subgraph "After (Fixed)"
+        PR2[Merged PR] --> Bot2[github-actions bot]
+        Bot2 -->|GitHub App Token| BackportPR2[Backport PR]
+        BackportPR2 --> CI2[CI Workflows]
+    end
+```
+
+| Change | Before | After |
+|--------|--------|-------|
+| Token Type | `GITHUB_TOKEN` | GitHub App Token |
+| Backport Action | `VachaShah/backport@v2` | `VachaShah/backport@v2.2.0` |
+| Token Generation | N/A | `tibdex/github-app-token@v2.1.0` |
+| Branch Template | Default | `backport/backport-<%= number %>-to-<%= base %>` |
+
+### Root Cause
+
+GitHub's security policy prevents `GITHUB_TOKEN` from triggering workflows when used to create PRs. This is documented behavior to prevent recursive workflow runs.
+
+### Solution
+
+The `backport.yml` workflow was updated to:
+1. Generate a GitHub App token using `tibdex/github-app-token@v2.1.0`
+2. Use the App token for the backport action instead of `GITHUB_TOKEN`
+3. Add explicit permissions for `contents: write` and `pull-requests: write`
+
+## Limitations
+
+- Requires GitHub App configuration with `APP_ID` and `APP_PRIVATE_KEY` secrets
+- Installation ID must be configured for the repository
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#720](https://github.com/opensearch-project/dashboards-search-relevance/pull/720) | Enable CI workflows for automated backport PRs | N/A |
+
+### External References
+- [GitHub Actions: Automatic Token Authentication](https://docs.github.com/en/actions/security-guides/automatic-token-authentication)
+- [Similar Issue in Karpenter](https://github.com/aws/karpenter-provider-aws/issues/4525)

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -42,3 +42,6 @@
 
 ## job-scheduler
 - Job Scheduler
+
+## dashboards-search-relevance
+- Dashboards CI/CD


### PR DESCRIPTION
## Summary

Add documentation for Dashboards CI/CD fix in v3.5.0.

### Reports Created
- Release report: `docs/releases/v3.5.0/features/dashboards-search-relevance/dashboards-ci-cd.md`
- Feature report updated: `docs/features/dashboards-search-relevance/dashboards-search-relevance-build-maintenance.md`

### Key Changes in v3.5.0
- Fixed CI workflows for automated backport PRs by using GitHub App tokens instead of GITHUB_TOKEN
- Updated backport.yml to use `tibdex/github-app-token@v2.1.0` for token generation
- Upgraded backport action to `VachaShah/backport@v2.2.0`

### Resources Used
- PR: opensearch-project/dashboards-search-relevance#720

Closes #2528