### PR TITLE
docs: add cross-cluster-replication report for v3.5.0

### DIFF
--- a/docs/features/cross-cluster-replication/cross-cluster-replication.md
+++ b/docs/features/cross-cluster-replication/cross-cluster-replication.md
@@ -152,6 +152,7 @@ POST _plugins/_replication/follower-index/_stop
 
 ## Change History
 
+- **v3.5.0** (2026-02-11): Test stability improvements - fixed multi-node synonym file handling, improved test cleanup error handling, thread-safe batch size management
 - **v3.4.0** (2026-01-14): Made pause replication API request body optional, defaulting to "User initiated" reason
 - **v3.3.0** (2025-11-18): Fixed 2GB limit breach for large document replication with dynamic batch size adjustment and new index-level batch size setting
 - **v3.2.0** (2025-08-06): Build fix - added missing `getLowPriorityRemoteDownloadThrottleTimeInNanos()` method to RemoteClusterRepository
@@ -175,6 +176,8 @@ POST _plugins/_replication/follower-index/_stop
 ### Pull Requests
 | Version | PR | Repository | Description | Related Issue |
 |---------|-----|------------|-------------|---------------|
+| v3.5.0 | [#1621](https://github.com/opensearch-project/cross-cluster-replication/pull/1621) | cross-cluster-replication | Fix replication tests and increment version to 3.5.0 | [#1617](https://github.com/opensearch-project/cross-cluster-replication/pull/1617) |
+| v3.5.0 | [#1630](https://github.com/opensearch-project/cross-cluster-replication/pull/1630) | cross-cluster-replication | Fix flaky test by allowing 500 error on stopAllReplication | - |
 | v3.4.0 | [#1603](https://github.com/opensearch-project/cross-cluster-replication/pull/1603) | cross-cluster-replication | Fix the requirement of empty request body in pause replication | [#1468](https://github.com/opensearch-project/cross-cluster-replication/issues/1468) |
 | v3.3.0 | [#1580](https://github.com/opensearch-project/cross-cluster-replication/pull/1580) | cross-cluster-replication | Fix: Replication of large documents breaches the size limit (2GB) of ReleasableBytesStreamOutput | [#1568](https://github.com/opensearch-project/cross-cluster-replication/issues/1568) |
 | v3.2.0 | [#1564](https://github.com/opensearch-project/cross-cluster-replication/pull/1564) | cross-cluster-replication | Add missing method for RemoteClusterRepository class |   |

--- a/docs/releases/v3.5.0/features/cross-cluster-replication/cross-cluster-replication.md
+++ b/docs/releases/v3.5.0/features/cross-cluster-replication/cross-cluster-replication.md
@@ -1,0 +1,81 @@
+---
+tags:
+  - cross-cluster-replication
+---
+# Cross-Cluster Replication Bug Fixes
+
+## Summary
+
+OpenSearch v3.5.0 includes test stability improvements for the Cross-Cluster Replication (CCR) plugin. These changes fix flaky integration tests related to multi-node cluster configurations and improve error handling during test cleanup.
+
+## Details
+
+### What's New in v3.5.0
+
+#### Test Infrastructure Improvements
+
+1. **Multi-Node Test Support**: Fixed integration tests to properly handle multi-node cluster configurations by copying synonym files to all cluster nodes instead of just the first node.
+
+2. **Flaky Test Fix**: Improved test cleanup reliability by allowing HTTP 500 errors during `stopAllReplication` operations. This addresses race conditions where synonym files may be deleted before replication is fully stopped.
+
+3. **Connection Manager Fix**: Added proper cleanup of HTTP connection managers in test infrastructure to prevent resource leaks.
+
+4. **Thread Safety Improvement**: Changed `BatchSizeSettings` to use `AtomicInteger` for thread-safe batch size adjustments.
+
+5. **API Compatibility**: Updated `RemoteClusterRepository.snapshotShard()` method signature to include new `IndexMetadata` parameter for OpenSearch 3.5.0 compatibility.
+
+### Technical Changes
+
+#### Multi-Node Synonym File Handling
+
+Tests now iterate over all cluster nodes when copying synonym files:
+
+```kotlin
+for (i in 0 until clusterNodes(LEADER)) {
+    val config = PathUtils.get(buildDir, leaderClusterPath + i, "config")
+    val synonymPath = config.resolve("synonyms.txt")
+    Files.copy(javaClass.getResourceAsStream("/analyzers/synonyms.txt"), synonymPath)
+}
+```
+
+#### Improved Error Handling in Test Cleanup
+
+The `stopAllReplicationJobs` method now tolerates HTTP 500 errors during cleanup:
+
+```kotlin
+catch (e: ResponseException) {
+    // 400 = index not being replicated, 500 = internal error (e.g., missing synonym files)
+    // Both are acceptable during cleanup
+    if (e.response.statusLine.statusCode != 400 && e.response.statusLine.statusCode != 500) {
+        throw e
+    }
+}
+```
+
+#### Thread-Safe Batch Size Management
+
+Changed from volatile variable to `AtomicInteger` for concurrent access:
+
+```kotlin
+private val dynamicBatchSize = AtomicInteger(-1)
+
+fun reduceBatchSize() {
+    dynamicBatchSize.updateAndGet { current ->
+        val effectiveSize = if (current > 0) current else getBatchSize()
+        maxOf(effectiveSize / 2, MIN_OPS_BATCH_SIZE)
+    }
+}
+```
+
+## Limitations
+
+- These are test-only changes with no impact on production functionality
+- The synonym file handling fix is specific to the test infrastructure
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#1621](https://github.com/opensearch-project/cross-cluster-replication/pull/1621) | Fix replication tests and increment version to 3.5.0 | [#1617](https://github.com/opensearch-project/cross-cluster-replication/pull/1617) |
+| [#1630](https://github.com/opensearch-project/cross-cluster-replication/pull/1630) | Fix flaky test by allowing 500 error on stopAllReplication for MultiNode tests | - |

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -45,3 +45,6 @@
 
 ## dashboards-search-relevance
 - Dashboards CI/CD
+
+## cross-cluster-replication
+- Cross-Cluster Replication Bug Fixes


### PR DESCRIPTION
## Summary

Adds release report for Cross-Cluster Replication bug fixes in v3.5.0.

### Changes in v3.5.0
- Test stability improvements for multi-node cluster configurations
- Fixed flaky tests by allowing HTTP 500 errors during test cleanup
- Thread-safe batch size management using AtomicInteger
- API compatibility update for RemoteClusterRepository.snapshotShard()

### Reports
- Release report: `docs/releases/v3.5.0/features/cross-cluster-replication/cross-cluster-replication.md`
- Feature report: `docs/features/cross-cluster-replication/cross-cluster-replication.md` (updated)

### PRs Investigated
- [#1621](https://github.com/opensearch-project/cross-cluster-replication/pull/1621) - Fix replication tests and increment version to 3.5.0
- [#1630](https://github.com/opensearch-project/cross-cluster-replication/pull/1630) - Fix flaky test by allowing 500 error on stopAllReplication

Closes #2527"