### PR TITLE
docs: add observability-integration report for v3.5.0

### DIFF
--- a/docs/features/observability/observability-integrations.md
+++ b/docs/features/observability/observability-integrations.md
@@ -112,9 +112,11 @@ curl -O https://github.com/opensearch-project/opensearch-catalog/releases/downlo
 - Integration assets must conform to the supported schema
 - Custom integrations require manual import through Saved Objects
 - Data must be ingested using compatible pipelines (Data Prepper, OpenTelemetry Collector, Fluent Bit)
+- Initial Data Range feature requires `@timestamp` field in MV schema
 
 ## Change History
 
+- **v3.5.0** (2026-02-11): Added Initial Data Range feature for MV creation with date picker UI
 - **v3.4.0** (2026-01-14): Improved static file serving with image type validation and SVG sanitization
 - **v3.0.0** (2025-05-06): Improved error handling and test result quality for integration configuration parsing
 - **v2.19.0** (2025-01-09): Added comprehensive SOP documentation for Integration and Vended Dashboards Setup
@@ -130,6 +132,8 @@ curl -O https://github.com/opensearch-project/opensearch-catalog/releases/downlo
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v3.5.0 | [#2546](https://github.com/opensearch-project/dashboards-observability/pull/2546) | Implement 1st MV Refresh Window For Integration | [#2506](https://github.com/opensearch-project/dashboards-observability/issues/2506) |
+| v3.5.0 | [#11226](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11226) | Implement 1st MV Refresh Window For Integration Creation (OSD) | [#11227](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11227) |
 | v3.4.0 | [#2530](https://github.com/opensearch-project/dashboards-observability/pull/2530) | Clean up interface for integrations static serving |   |
 | v3.0.0 | [#2387](https://github.com/opensearch-project/dashboards-observability/pull/2387) | Improve error handling when setting up and reading a new integration |   |
 | v3.0.0 | [#2376](https://github.com/opensearch-project/dashboards-observability/pull/2376) | Improve the test results for Integrations internals |   |

--- a/docs/releases/v3.5.0/features/observability/observability-integration.md
+++ b/docs/releases/v3.5.0/features/observability/observability-integration.md
@@ -1,0 +1,80 @@
+---
+tags:
+  - observability
+---
+# Observability Integration
+
+## Summary
+
+OpenSearch v3.5.0 introduces the Initial Data Range feature for Integrations, allowing users to control the time window for initial data loading when creating materialized views (MVs). This enhancement provides flexibility to limit data fetching during integration setup, improving performance and resource utilization.
+
+## Details
+
+### What's New in v3.5.0
+
+#### Initial Data Range for MV Creation
+
+The integration creation flow now includes a date picker UI component that allows users to specify the initial data range for materialized view creation:
+
+- **No Limit Mode**: Fetches all historical data from the beginning (original behavior)
+- **Custom Date Mode**: Users can select a past date to limit the initial data fetch range
+
+```mermaid
+flowchart TB
+    A[User Creates Integration] --> B{Select Data Range}
+    B -->|No Limit| C[Fetch All Historical Data]
+    B -->|Custom Date| D[Select Start Date]
+    D --> E[Generate WHERE Clause]
+    E --> F[Filter by @timestamp]
+    F --> G[Create MV with Limited Data]
+    C --> H[Create MV with All Data]
+```
+
+#### Technical Implementation
+
+The feature introduces a universal timestamp filter strategy that works across all integration types:
+
+| Component | Description |
+|-----------|-------------|
+| `refreshRangeDays` | Configuration parameter for days to look back (0 = no limit) |
+| `generateTimestampFilter()` | Generates SQL WHERE clause for `@timestamp` filtering |
+| `{refresh_range_filter}` | Template placeholder replaced in MV creation queries |
+
+The timestamp filter uses the standardized `@timestamp` field that all MV SQL files transform to, ensuring consistent filtering regardless of the source data format.
+
+#### UI Changes
+
+The integration setup form now includes:
+- A toggle switch for "Load all data (no time limit)"
+- A date picker (when custom range is selected) to choose the start date
+- Default value of 7 days for new integrations
+
+### Additional Enhancements
+
+#### Correlation Object Updates (PR #2570)
+
+- Added echarts dependency (^6.0.0) to the observability plugin
+- Updated correlations object type check
+- Changed default UI setting to true
+
+#### Test Utilities Improvements (PR #11138)
+
+- Switched workspace, dataset, and datasource creation to use APIs instead of UI interactions
+- Navigation now uses URLs instead of UI navigation
+- Removed usage of `cy.reload()` to reduce test flakiness in authenticated environments
+
+## Limitations
+
+- The timestamp filter relies on the `@timestamp` field being present in the MV schema
+- Custom date selection is limited to past dates only (cannot select future dates)
+- The feature is only available for S3-based integrations that use materialized views
+
+## References
+
+### Pull Requests
+| PR | Repository | Description | Related Issue |
+|----|------------|-------------|---------------|
+| [#2546](https://github.com/opensearch-project/dashboards-observability/pull/2546) | dashboards-observability | Implement 1st MV Refresh Window For Integration | [#2506](https://github.com/opensearch-project/dashboards-observability/issues/2506) |
+| [#2570](https://github.com/opensearch-project/dashboards-observability/pull/2570) | dashboards-observability | Update correlation object client, settings check | [#2545](https://github.com/opensearch-project/dashboards-observability/issues/2545) |
+| [#11226](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11226) | OpenSearch-Dashboards | Implement 1st MV Refresh Window For Integration Creation | [#11227](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11227) |
+| [#11138](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11138) | OpenSearch-Dashboards | Improve the Integration Utils | - |

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -33,6 +33,7 @@
 
 ## observability
 - Observability Dependencies
+- Observability Integration
 
 ## notifications
 - Notifications Maintenance


### PR DESCRIPTION
## Summary

This PR adds documentation for the Observability Integration enhancement in OpenSearch v3.5.0.

### Reports Created
- Release report: `docs/releases/v3.5.0/features/observability/observability-integration.md`
- Feature report updated: `docs/features/observability/observability-integrations.md`

### Key Changes in v3.5.0
- Added Initial Data Range feature for MV creation with date picker UI
- Users can now limit data fetching during integration setup
- Added echarts dependency and correlation object updates

### PRs Investigated
- dashboards-observability#2546: Implement 1st MV Refresh Window For Integration
- dashboards-observability#2570: Update correlation object client, settings check
- OpenSearch-Dashboards#11226: Implement 1st MV Refresh Window For Integration Creation
- OpenSearch-Dashboards#11138: Improve the Integration Utils

Closes #2525