### PR TITLE
docs: add k-NN vector search report for v3.5.0

### DIFF
--- a/docs/features/k-nn/k-nn-vector-search-k-nn.md
+++ b/docs/features/k-nn/k-nn-vector-search-k-nn.md
@@ -92,6 +92,7 @@ flowchart TB
 |---------|-------------|---------|
 | `index.knn` | Enable k-NN for the index | `false` |
 | `index.knn.algo_param.ef_search` | Size of dynamic candidate list during search | `100` |
+| `index.knn.faiss.efficient_filter.disable_exact_search` | Disable exact search fallback after ANN with efficient filters (v3.5.0+) | `false` |
 
 #### Cluster Settings
 
@@ -368,8 +369,13 @@ Response:
 
 ## Change History
 
-- **v2.19.0** (2025-02-18): Cosine similarity support for FAISS engine; AVX-512 SPR build mode for Intel Sapphire Rapids; binary vector support for Lucene engine; derived source for vector fields (experimental); multi-value innerHit for nested k-NN fields; concurrent graph creation for Lucene engine; expand_nested_docs parameter for NMSLIB; NMSLIB engine deprecation; numerous bug fixes including C++17 upgrade, byte vector filter fix, mapping validation, query vector memory release, filter rewrite logic fix
+- **v3.5.0** (2026-02-11): Index setting to disable exact search fallback after ANN with Faiss efficient filters; Bulk SIMD V2 implementation with 15-31% throughput improvement; Lucene engine ef_search parameter correction for improved recall; nested k-NN query filter improvements for parent-scope filtering; derived source regex support and field exclusion handling; AdditionalCodecs integration for custom codec registration; bug fixes for MOS reentrant search in byte index, warmup integer overflow for large files (>2GB), nested docs query with missing vector fields, BinaryCagra score conversion; improved validation for k > total results; Gradle build enhancements and comprehensive IT/BWC tests
 - **v3.4.0** (2026-01-11): Bug fixes for memory optimized search on old indices (NPE), totalHits inconsistency, race condition in KNNQueryBuilder with cosine similarity, Faiss inner product score-to-distance calculation, disk-based vector search BWC for segment merge
+- **v3.3.0** (2026-01-11): Bug fixes for MDC check NPE with byte vectors, derived source deserialization on invalid documents, cosine score range in LuceneOnFaiss, filter k nullable, integer overflow in distance computation, AVX2 detection on non-Linux/Mac/Windows platforms, radial search for byte vectors with FAISS, MMR doc ID issue, JNI local reference leak, nested exact search rescoring
+- **v3.2.0** (2025-10-01): GPU indexing support for FP16, Byte, and Binary vectors via Cagra2; Asymmetric Distance Computation (ADC) for improved recall on binary quantized indices; random rotation feature for binary encoder; gRPC support for k-NN queries; nested search support for IndexBinaryHNSWCagra; dynamic index thread quantity defaults (4 threads for 32+ core machines); NativeMemoryCacheKeyHelper @ collision fix
+- **v3.1.0** (2025-07-15): Memory-optimized search (LuceneOnFaiss) integration into KNNWeight with layered architecture; rescore support for Lucene engine; 4x compression rescore context optimization; derived source indexing optimization; script scoring performance improvement for binary vectors; TopDocs refactoring for search results; Bug fixes for quantization cache scale/thread safety, rescoring for dimensions > 1000, native memory cache race conditions, nested vector query with efficient filter, mode/compression backward compatibility for pre-2.17.0 indices
+- **v3.0.0** (2025-05-06): Breaking changes removing deprecated index settings; node-level circuit breakers; filter function in KNNQueryBuilder; concurrency optimizations for graph loading; Remote Native Index Build foundation
+- **v2.19.0** (2025-02-18): Cosine similarity support for FAISS engine; AVX-512 SPR build mode for Intel Sapphire Rapids; binary vector support for Lucene engine; derived source for vector fields (experimental); multi-value innerHit for nested k-NN fields; concurrent graph creation for Lucene engine; expand_nested_docs parameter for NMSLIB; NMSLIB engine deprecation; numerous bug fixes including C++17 upgrade, byte vector filter fix, mapping validation, query vector memory release, filter rewrite logic fix
 - **v3.3.0** (2026-01-11): Bug fixes for MDC check NPE with byte vectors, derived source deserialization on invalid documents, cosine score range in LuceneOnFaiss, filter k nullable, integer overflow in distance computation, AVX2 detection on non-Linux/Mac/Windows platforms, radial search for byte vectors with FAISS, MMR doc ID issue, JNI local reference leak, nested exact search rescoring
 - **v3.2.0** (2025-10-01): GPU indexing support for FP16, Byte, and Binary vectors via Cagra2; Asymmetric Distance Computation (ADC) for improved recall on binary quantized indices; random rotation feature for binary encoder; gRPC support for k-NN queries; nested search support for IndexBinaryHNSWCagra; dynamic index thread quantity defaults (4 threads for 32+ core machines); NativeMemoryCacheKeyHelper @ collision fix
 - **v3.1.0** (2025-07-15): Memory-optimized search (LuceneOnFaiss) integration into KNNWeight with layered architecture; rescore support for Lucene engine; 4x compression rescore context optimization; derived source indexing optimization; script scoring performance improvement for binary vectors; TopDocs refactoring for search results; Bug fixes for quantization cache scale/thread safety, rescoring for dimensions > 1000, native memory cache race conditions, nested vector query with efficient filter, mode/compression backward compatibility for pre-2.17.0 indices
@@ -397,6 +403,22 @@ Response:
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v3.5.0 | [#3022](https://github.com/opensearch-project/k-NN/pull/3022) | Index setting to disable exact search after ANN with Faiss efficient filters | [#2936](https://github.com/opensearch-project/k-NN/issues/2936) |
+| v3.5.0 | [#3075](https://github.com/opensearch-project/k-NN/pull/3075) | Bulk SIMD V2 Implementation | [#2875](https://github.com/opensearch-project/k-NN/issues/2875) |
+| v3.5.0 | [#3037](https://github.com/opensearch-project/k-NN/pull/3037) | Correct ef_search parameter for Lucene engine | [#2940](https://github.com/opensearch-project/k-NN/issues/2940) |
+| v3.5.0 | [#3049](https://github.com/opensearch-project/k-NN/pull/3049) | Field exclusion in source indexing handling | [#3034](https://github.com/opensearch-project/k-NN/issues/3034) |
+| v3.5.0 | [#2990](https://github.com/opensearch-project/k-NN/pull/2990) | Join filter clauses of nested k-NN queries to root-parent scope | [#2222](https://github.com/opensearch-project/k-NN/issues/2222) |
+| v3.5.0 | [#3031](https://github.com/opensearch-project/k-NN/pull/3031) | Regex for derived source support | [#3029](https://github.com/opensearch-project/k-NN/issues/3029) |
+| v3.5.0 | [#3038](https://github.com/opensearch-project/k-NN/pull/3038) | Update validation for k > total results | [#3017](https://github.com/opensearch-project/k-NN/issues/3017) |
+| v3.5.0 | [#3085](https://github.com/opensearch-project/k-NN/pull/3085) | AdditionalCodecs and EnginePlugin::getAdditionalCodecs hook |   |
+| v3.5.0 | [#3067](https://github.com/opensearch-project/k-NN/pull/3067) | Fix: Warmup seek overflow for large files | [#3066](https://github.com/opensearch-project/k-NN/issues/3066) |
+| v3.5.0 | [#3071](https://github.com/opensearch-project/k-NN/pull/3071) | Fix: MOS reentrant search bug in byte index | [#3069](https://github.com/opensearch-project/k-NN/issues/3069) |
+| v3.5.0 | [#3051](https://github.com/opensearch-project/k-NN/pull/3051) | Fix: Nested docs query with missing vector fields | [#3026](https://github.com/opensearch-project/k-NN/issues/3026) |
+| v3.5.0 | [#2983](https://github.com/opensearch-project/k-NN/pull/2983) | Fix: BinaryCagra score conversion |   |
+| v3.5.0 | [#3064](https://github.com/opensearch-project/k-NN/pull/3064) | Add IT and BWC tests for mixed vector/non-vector docs | [#2284](https://github.com/opensearch-project/k-NN/issues/2284) |
+| v3.5.0 | [#3033](https://github.com/opensearch-project/k-NN/pull/3033) | Gradle ban System.loadLibrary | [#3005](https://github.com/opensearch-project/k-NN/issues/3005) |
+| v3.5.0 | [#3032](https://github.com/opensearch-project/k-NN/pull/3032) | Create build graph |   |
+| v3.5.0 | [#3070](https://github.com/opensearch-project/k-NN/pull/3070) | Add exception type for expected warmup behavior |   |
 | v3.4.0 | [#2918](https://github.com/opensearch-project/k-NN/pull/2918) | Fix: Block memory optimized search for old indices created before 2.18 | [#2917](https://github.com/opensearch-project/k-NN/issues/2917) |
 | v3.4.0 | [#2965](https://github.com/opensearch-project/k-NN/pull/2965) | Fix: NativeEngineKnnQuery to return correct totalHits | [#2962](https://github.com/opensearch-project/k-NN/issues/2962) |
 | v3.4.0 | [#2974](https://github.com/opensearch-project/k-NN/pull/2974) | Fix: Race condition on transforming vector in KNNQueryBuilder |   |

--- a/docs/releases/v3.5.0/features/k-nn/k-nn-vector-search.md
+++ b/docs/releases/v3.5.0/features/k-nn/k-nn-vector-search.md
@@ -1,0 +1,129 @@
+---
+tags:
+  - k-nn
+---
+# k-NN Vector Search
+
+## Summary
+
+OpenSearch v3.5.0 brings significant improvements to the k-NN plugin including new features for efficient filtering, SIMD performance optimizations, codec architecture enhancements, and numerous bug fixes for nested queries, memory-optimized search, and warmup operations.
+
+## Details
+
+### What's New in v3.5.0
+
+#### New Features
+
+**Index Setting to Disable Exact Search After ANN with Faiss Efficient Filters**
+
+A new dynamic index setting `index.knn.faiss.efficient_filter.disable_exact_search` allows users to disable the fallback mechanism to exact search after ANN search when using Faiss efficient filters. This provides more control over search behavior and can improve performance in scenarios where exact search fallback is not desired.
+
+**Bulk SIMD V2 Implementation**
+
+A major performance optimization for FP16 vector distance computation using SIMD instructions. The new implementation combines prefetching with a multi-register strategy, calculating distances between a query and multiple vectors simultaneously (4-8 vectors at a time depending on the chip).
+
+Performance improvements:
+- 15-31% throughput improvement
+- 11-25% latency improvement
+- 31-44% reduction in p99 tail latency
+
+#### Enhancements
+
+**Lucene Engine ef_search Parameter Correction**
+
+Fixed recall degradation issues in k-NN search (especially with small k values) by implementing dynamic ef_search resolution for the Lucene engine:
+1. Use ef_search from method parameters if specified in query
+2. Fall back to index setting (`knn.algo_param.ef_search`)
+3. Use default ef_search value based on index version
+4. Calculate effective Lucene k as `max(k, luceneK)`
+5. Override `mergeLeafResults` to return top K results
+
+**Nested k-NN Query Filter Improvements**
+
+Fixed parent document efficient filtering for nested k-NN queries by ensuring the efficient filter query always operates in parent context and joins down to children. This resolves issues where filter clauses were not correctly scoped to root-parent level.
+
+**Derived Source Enhancements**
+
+- Added regex support for derived source transformer exclusion
+- Improved field exclusion handling in source indexing - fields excluded from source now skip derived source logic
+- Better handling of non-included fields
+
+**Validation for k Greater Than Total Results**
+
+Updated validation to handle scenarios where a segment has fewer results than k. The system now finds the minimum score from available results rather than failing.
+
+**AdditionalCodecs Integration**
+
+Integrated `AdditionalCodecs` and `EnginePlugin::getAdditionalCodecs` hook to allow additional Codec registration, enabling custom codecs to be used with k-NN, neural-search, and other plugins.
+
+#### Bug Fixes
+
+**Memory-Optimized Search (MOS) Reentrant Search Bug**
+
+Fixed reentrant search when memory-optimized search is enabled for byte index. The fix ensures byte[] query is passed correctly and ByteVectorValues are created properly.
+
+**Warmup Integer Overflow**
+
+Fixed an integer overflow bug in the memory-optimized search warmup functionality that prevented proper warmup of large index files (>2GB). Changed warmup seek to use `long` instead of `int`.
+
+**Warmup Exception Handling**
+
+Added new exception type `WarmupExpectedException` to signify expected warmup behavior, improving error handling and debugging.
+
+**Nested Docs Query with Missing Vector Fields**
+
+Fixed nested docs query when some child documents have no vector field present. The fix creates an Intersection Iterator using VectorValuesIterator and MatchedDocsDISI to ensure only docs with vectors are scored. This resolves EOF exceptions on `.vec` files during:
+- expand_nested_docs = true scenarios
+- on_disk mode with rescoring
+- Filtering cases with exact search fallback
+
+**BinaryCagra Score Conversion**
+
+Fixed a bug in the HNSW Cagra binary path where float-typed Hamming distances were incorrectly interpreted as integers. The patch now correctly converts float values back to integers after search, fixing score calculation while preserving correct ranking.
+
+#### Build and Testing Improvements
+
+**Gradle Build Enhancements**
+
+- Added `validateLibraryUsage` task to prevent `System.loadLibrary` calls outside of `KNNLibraryLoader`
+- Added task to generate Gradle task dependency graph for better build visualization
+
+**Integration and BWC Tests**
+
+Added comprehensive tests for indices containing both vector and non-vector documents:
+- Tests for deleted doc segments in mixed-field indices
+- Tests for segments that never had vector data
+- Tests for documents updated to remove vector fields
+
+### Configuration
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `index.knn.faiss.efficient_filter.disable_exact_search` | Disable exact search fallback after ANN with efficient filters | `false` |
+
+## Limitations
+
+- Bulk SIMD V2 ARM Neon L2 implementation has ~2% score error (under investigation)
+- BinaryCagra score bug affected score values but not ranking (fixed in this release)
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#3022](https://github.com/opensearch-project/k-NN/pull/3022) | Index setting to disable exact search after ANN Search with Faiss efficient filters | [#2936](https://github.com/opensearch-project/k-NN/issues/2936) |
+| [#3075](https://github.com/opensearch-project/k-NN/pull/3075) | Bulk SIMD V2 Implementation | [#2875](https://github.com/opensearch-project/k-NN/issues/2875) |
+| [#3037](https://github.com/opensearch-project/k-NN/pull/3037) | Correct ef_search parameter for Lucene engine and reduce to top K | [#2940](https://github.com/opensearch-project/k-NN/issues/2940) |
+| [#3049](https://github.com/opensearch-project/k-NN/pull/3049) | Field exclusion in source indexing handling | [#3034](https://github.com/opensearch-project/k-NN/issues/3034) |
+| [#2990](https://github.com/opensearch-project/k-NN/pull/2990) | Join filter clauses of nested k-NN queries to root-parent scope | [#2222](https://github.com/opensearch-project/k-NN/issues/2222) |
+| [#3031](https://github.com/opensearch-project/k-NN/pull/3031) | Regex for derived source support | [#3029](https://github.com/opensearch-project/k-NN/issues/3029) |
+| [#3038](https://github.com/opensearch-project/k-NN/pull/3038) | Update validation for cases when k is greater than total results | [#3017](https://github.com/opensearch-project/k-NN/issues/3017) |
+| [#3085](https://github.com/opensearch-project/k-NN/pull/3085) | Include AdditionalCodecs and EnginePlugin::getAdditionalCodecs hook | [OpenSearch#20411](https://github.com/opensearch-project/OpenSearch/pull/20411) |
+| [#3067](https://github.com/opensearch-project/k-NN/pull/3067) | Changed warmup seek to use long instead of int to avoid overflow | [#3066](https://github.com/opensearch-project/k-NN/issues/3066) |
+| [#3071](https://github.com/opensearch-project/k-NN/pull/3071) | Fix MOS reentrant search bug in byte index | [#3069](https://github.com/opensearch-project/k-NN/issues/3069) |
+| [#3051](https://github.com/opensearch-project/k-NN/pull/3051) | Fix nested docs query when some child docs has no vector field present | [#3026](https://github.com/opensearch-project/k-NN/issues/3026) |
+| [#2983](https://github.com/opensearch-project/k-NN/pull/2983) | Fix patch to have a valid score conversion for BinaryCagra | - |
+| [#3064](https://github.com/opensearch-project/k-NN/pull/3064) | Add IT and bwc test with indices containing both vector and non-vector docs | [#2284](https://github.com/opensearch-project/k-NN/issues/2284) |
+| [#3033](https://github.com/opensearch-project/k-NN/pull/3033) | Gradle ban System.loadLibrary | [#3005](https://github.com/opensearch-project/k-NN/issues/3005) |
+| [#3032](https://github.com/opensearch-project/k-NN/pull/3032) | Create build graph | - |
+| [#3070](https://github.com/opensearch-project/k-NN/pull/3070) | Added new exception type to signify expected warmup behavior | - |

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -1,10 +1,33 @@
 # OpenSearch v3.5.0 Release
 
+## cross-cluster-replication
+- Cross-Cluster Replication Bug Fixes
+
+## dashboards
+- Dashboards Dependencies
+
 ## dashboards-flow-framework
 - Dashboards ML Agents
 
+## dashboards-search-relevance
+- Agentic Search
+- Dashboards CI/CD
+
+## job-scheduler
+- Job Scheduler
+
+## k-nn
+- k-NN Vector Search
+
 ## neural-search
 - SEISMIC (Sparse ANN) Enhancements
+
+## notifications
+- Notifications Maintenance
+
+## observability
+- Observability Dependencies
+- Observability Integration
 
 ## opensearch-dashboards
 - Dashboards Build (Rspack Migration)
@@ -25,37 +48,20 @@
 - Observability Traces
 - Dashboards Chat/AI
 
-## user
-- User Plugin Maintenance
-
-## skills
-- Skills Dependencies
-
 ## performance-analyzer
 - Performance Analyzer
-
-## observability
-- Observability Dependencies
-- Observability Integration
-
-## notifications
-- Notifications Maintenance
-
-## reporting
-- Reporting Dependencies
 
 ## remote
 - Remote Store
 
-## job-scheduler
-- Job Scheduler
+## reporting
+- Reporting Dependencies
 
-## dashboards-search-relevance
-- Agentic Search
-- Dashboards CI/CD
-
-## cross-cluster-replication
-- Cross-Cluster Replication Bug Fixes
+## skills
+- Skills Dependencies
 
 ## sql
 - SQL/PPL Engine
+
+## user
+- User Plugin Maintenance


### PR DESCRIPTION
## Summary

This PR adds documentation for k-NN Vector Search changes in OpenSearch v3.5.0.

### Reports Created
- Release report: `docs/releases/v3.5.0/features/k-nn/k-nn-vector-search.md`
- Feature report: `docs/features/k-nn/k-nn-vector-search-k-nn.md` (updated)

### Key Changes in v3.5.0

**New Features:**
- Index setting to disable exact search fallback after ANN with Faiss efficient filters (`index.knn.faiss.efficient_filter.disable_exact_search`)
- Bulk SIMD V2 implementation with 15-31% throughput improvement

**Enhancements:**
- Lucene engine ef_search parameter correction for improved recall
- Nested k-NN query filter improvements for parent-scope filtering
- Derived source regex support and field exclusion handling
- AdditionalCodecs integration for custom codec registration
- Improved validation for k > total results

**Bug Fixes:**
- MOS reentrant search bug in byte index
- Warmup integer overflow for large files (>2GB)
- Nested docs query with missing vector fields
- BinaryCagra score conversion

**Build/Testing:**
- Gradle build enhancements (ban System.loadLibrary, build graph)
- Comprehensive IT/BWC tests for mixed vector/non-vector docs

### PRs Investigated
16 PRs from the k-NN repository

Closes #2521