### PR TITLE
docs: add geospatial-validation report for v3.5.0

### DIFF
--- a/docs/features/geospatial/geospatial-validation.md
+++ b/docs/features/geospatial/geospatial-validation.md
@@ -1,0 +1,99 @@
+---
+tags:
+  - geospatial
+---
+# Geospatial Validation
+
+## Summary
+
+The geospatial plugin provides geometric complexity validation for GeoJSON uploads to prevent system instability. When uploading GeoJSON data via the `POST /_plugins/geospatial/geojson/_upload` endpoint, the plugin validates that geometries do not exceed configurable complexity limits, protecting against Out-of-Memory errors and node crashes.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph "GeoJSON Upload Flow"
+        A[REST API Request] --> B[UploadGeoJSONRequestContent]
+        B --> C[Feature Count Validation]
+        C --> D[Geometric Complexity Validation]
+        D --> E[Index Documents]
+    end
+    
+    subgraph "Settings"
+        F[GeospatialSettings] --> G[GeospatialSettingsAccessor]
+        G --> D
+    end
+```
+
+### Configuration
+
+All settings are dynamically configurable via the cluster settings API:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.geospatial.geojson.max_coordinates_per_geo` | Maximum coordinates per geometry | 10,000 |
+| `plugins.geospatial.geojson.max_holes_per_polygon` | Maximum holes in a Polygon | 1,000 |
+| `plugins.geospatial.geojson.max_multi_gemoetries` | Maximum geometries in Multi* types | 100 |
+| `plugins.geospatial.geojson.max_geometry_collection_nested_depth` | Maximum GeometryCollection nesting | 5 |
+
+### Usage Example
+
+Update validation limits dynamically:
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "plugins.geospatial.geojson.max_coordinates_per_geo": 5000,
+    "plugins.geospatial.geojson.max_holes_per_polygon": 500
+  }
+}
+```
+
+When validation fails, the API returns an error:
+
+```json
+{
+  "error": {
+    "type": "illegal_argument_exception",
+    "reason": "LineString has 15000 coordinates, exceeds limit of 10000"
+  },
+  "status": 400
+}
+```
+
+### Validated Geometry Types
+
+| Geometry Type | Validation Rules |
+|---------------|------------------|
+| LineString | Coordinate count ≤ max_coordinates_per_geo |
+| Polygon | Holes ≤ max_holes_per_polygon, each ring ≤ max_coordinates_per_geo |
+| MultiLineString | Count ≤ max_multi_gemoetries, each LineString validated |
+| MultiPolygon | Count ≤ max_multi_gemoetries, each Polygon validated |
+| GeometryCollection | Count ≤ max_multi_gemoetries, depth ≤ max_geometry_collection_nested_depth |
+
+## Limitations
+
+- Validation only applies to the GeoJSON upload API (`/_plugins/geospatial/geojson/_upload`)
+- Point and MultiPoint geometries are not validated
+- Settings are node-scoped (apply to all nodes in the cluster)
+
+## Change History
+
+- **v3.5.0** (2026-01): Initial implementation of geometric complexity validation
+
+## References
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.5.0 | [#829](https://github.com/opensearch-project/geospatial/pull/829) | Add coordinate limit validation for lines, polygons, and holes |
+
+### Issues
+
+| Issue | Description |
+|-------|-------------|
+| [#828](https://github.com/opensearch-project/geospatial/issues/828) | Enforces geometric complexity limits to ensure system stability |

--- a/docs/features/geospatial/index.md
+++ b/docs/features/geospatial/index.md
@@ -4,3 +4,4 @@
 |----------|-------------|
 | [geospatial-ip2geo](geospatial-ip2geo.md) | IP2Geo Processor |
 | [geospatial-plugin](geospatial-plugin.md) | Geospatial Plugin |
+| [geospatial-validation](geospatial-validation.md) | GeoJSON Upload Validation |

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -7,6 +7,10 @@ Cumulative feature documentation across all versions.
 - Alerting Integration
 - Cross-Cluster & Remote Monitors
 
+## geospatial
+
+- Geospatial Validation
+
 ## ml-commons
 
 - Batch Prediction Mode

--- a/docs/releases/v3.5.0/features/geospatial/geospatial-validation.md
+++ b/docs/releases/v3.5.0/features/geospatial/geospatial-validation.md
@@ -1,0 +1,81 @@
+---
+tags:
+  - geospatial
+---
+# Geospatial Validation
+
+## Summary
+
+OpenSearch v3.5.0 introduces geometric complexity validation for the GeoJSON upload API (`POST /_plugins/geospatial/geojson/_upload`). This feature prevents Out-of-Memory (OOM) errors and node crashes caused by uploading overly complex geometries such as polygons with millions of coordinates or excessive holes.
+
+## Details
+
+### What's New in v3.5.0
+
+The geospatial plugin now validates geometric complexity during GeoJSON upload to ensure system stability. Four new cluster settings control the validation limits:
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.geospatial.geojson.max_coordinates_per_geo` | Maximum coordinates per geometry (LineString, Polygon rings) | 10,000 |
+| `plugins.geospatial.geojson.max_holes_per_polygon` | Maximum holes allowed in a Polygon | 1,000 |
+| `plugins.geospatial.geojson.max_multi_gemoetries` | Maximum geometries in MultiLineString, MultiPolygon, or GeometryCollection | 100 |
+| `plugins.geospatial.geojson.max_geometry_collection_nested_depth` | Maximum nesting depth for GeometryCollections | 5 |
+
+### Technical Changes
+
+The validation is implemented in `UploadGeoJSONRequestContent.java` using an iterative queue-based approach to avoid stack overflow on deeply nested structures:
+
+```mermaid
+flowchart TB
+    A[GeoJSON Upload Request] --> B[Feature Count Validation]
+    B --> C[Geometric Complexity Validation]
+    C --> D{Geometry Type}
+    D -->|LineString| E[Validate Coordinate Count]
+    D -->|Polygon| F[Validate Holes & Ring Coordinates]
+    D -->|MultiLineString| G[Validate LineString Count & Each Line]
+    D -->|MultiPolygon| H[Validate Polygon Count & Each Polygon]
+    D -->|GeometryCollection| I[Validate Size & Nesting Depth]
+    E --> J{Within Limits?}
+    F --> J
+    G --> J
+    H --> J
+    I --> J
+    J -->|Yes| K[Continue Processing]
+    J -->|No| L[Reject with IllegalArgumentException]
+```
+
+Key implementation details:
+- Settings are dynamically configurable at runtime via cluster settings API
+- Validation uses `GeospatialSettingsAccessor` to access current limit values
+- All geometry types are validated: LineString, Polygon, MultiLineString, MultiPolygon, GeometryCollection
+- Nested GeometryCollections are processed iteratively with depth tracking
+
+### Validated Geometry Types
+
+| Geometry Type | Validation |
+|---------------|------------|
+| LineString | Coordinate count ≤ `max_coordinates_per_geo` |
+| Polygon | Holes ≤ `max_holes_per_polygon`, each ring ≤ `max_coordinates_per_geo` |
+| MultiLineString | LineString count ≤ `max_multi_gemoetries`, each line validated |
+| MultiPolygon | Polygon count ≤ `max_multi_gemoetries`, each polygon validated |
+| GeometryCollection | Geometry count ≤ `max_multi_gemoetries`, nesting depth ≤ `max_geometry_collection_nested_depth` |
+
+## Limitations
+
+- Validation only applies to the GeoJSON upload API endpoint
+- Settings are node-scoped but dynamically updatable
+- Point and MultiPoint geometries are not validated (no complexity concerns)
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#829](https://github.com/opensearch-project/geospatial/pull/829) | Add coordinate limit validation for lines, polygons, and holes | [#828](https://github.com/opensearch-project/geospatial/issues/828) |
+
+### Issues
+
+| Issue | Description |
+|-------|-------------|
+| [#828](https://github.com/opensearch-project/geospatial/issues/828) | Enforces geometric complexity limits to ensure system stability |

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -1,5 +1,8 @@
 # OpenSearch v3.5.0 Release
 
+## geospatial
+- Geospatial Validation
+
 ## cross-cluster-replication
 - Cross-Cluster Replication Bug Fixes
 


### PR DESCRIPTION
## Summary

Adds documentation for the Geospatial Validation feature introduced in OpenSearch v3.5.0.

### Reports Created
- Release report: `docs/releases/v3.5.0/features/geospatial/geospatial-validation.md`
- Feature report: `docs/features/geospatial/geospatial-validation.md`

### Key Changes in v3.5.0
- Added geometric complexity validation for GeoJSON upload API
- Four new cluster settings to control validation limits:
  - `plugins.geospatial.geojson.max_coordinates_per_geo` (default: 10,000)
  - `plugins.geospatial.geojson.max_holes_per_polygon` (default: 1,000)
  - `plugins.geospatial.geojson.max_multi_gemoetries` (default: 100)
  - `plugins.geospatial.geojson.max_geometry_collection_nested_depth` (default: 5)
- Prevents OOM errors from overly complex geometries

### Resources Used
- PR: opensearch-project/geospatial#829
- Issue: opensearch-project/geospatial#828

Closes #2516