### PR TITLE
docs: add search-relevance report for v3.5.0

### DIFF
--- a/docs/features/search-relevance/search-relevance-workbench.md
+++ b/docs/features/search-relevance/search-relevance-workbench.md
@@ -151,6 +151,11 @@ The plugin includes test data based on Amazon's ESCI (Shopping Queries Dataset):
 
 ## Change History
 
+- **v3.5.0** (2026-02-11): LLM judgment customization - customizable prompt templates with three rating types (SCORE0_1, SCORE1_5, RELEVANT_IRRELEVANT), enhanced caching with prompt template differentiation
+- **v3.5.0** (2026-02-11): New `_search` API endpoints for Query Sets, Search Configurations, Judgments, and Experiments using OpenSearch DSL
+- **v3.5.0** (2026-02-11): UBI sample dataset and dashboards for understanding user interaction patterns
+- **v3.5.0** (2026-02-11): UI/UX improvements - Search Configuration reuse in comparison workflows, improved Judgment Detail page with structured table view
+- **v3.5.0** (2026-02-11): Infrastructure - version-based index mapping updates with `_meta.schema_version`, description field for Search Configurations
 - **v3.4.0** (2026-01-11): Bug fix - Fix floating-point precision issues in Hybrid Optimizer weight generation by switching to step-based iteration and rounding, ensuring clean weight pairs like 0.4/0.6 instead of 0.39999998/0.60000002
 - **v3.4.0** (2026-01-11): Bug fix - Fix hybrid optimizer experiments stuck in PROCESSING after judgment deletion by correcting failure handling to properly transition to ERROR state
 - **v3.4.0** (2026-01-11): Bug fix - Fix query serialization for plugins (e.g., Learning to Rank) that extend OpenSearch's DSL, enabling LTR rescore queries in experiments
@@ -177,6 +182,22 @@ The plugin includes test data based on Amazon's ESCI (Shopping Queries Dataset):
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v3.5.0 | [#667](https://github.com/opensearch-project/dashboards-search-relevance/pull/667) | Add FrontEnd Support for LLM Judgement Template Prompt |   |
+| v3.5.0 | [#727](https://github.com/opensearch-project/dashboards-search-relevance/pull/727) | Reuse Search Configurations with Single Query Comparison UI | [#695](https://github.com/opensearch-project/dashboards-search-relevance/issues/695) |
+| v3.5.0 | [#729](https://github.com/opensearch-project/dashboards-search-relevance/pull/729) | Add UBI sample dataset and dashboards | [#730](https://github.com/opensearch-project/dashboards-search-relevance/issues/730) |
+| v3.5.0 | [#674](https://github.com/opensearch-project/dashboards-search-relevance/pull/674) | Add optional status=COMPLETED parameter for filtering judgments | [#266](https://github.com/opensearch-project/search-relevance/issues/266) |
+| v3.5.0 | [#699](https://github.com/opensearch-project/dashboards-search-relevance/pull/699) | Add Search Pipeline to Search Configuration Detail page |   |
+| v3.5.0 | [#713](https://github.com/opensearch-project/dashboards-search-relevance/pull/713) | Improve UX of the Judgment Detail page | [#691](https://github.com/opensearch-project/dashboards-search-relevance/issues/691) |
+| v3.5.0 | [#344](https://github.com/opensearch-project/search-relevance/pull/344) | Version-based index mapping update support | [#310](https://github.com/opensearch-project/search-relevance/issues/310) |
+| v3.5.0 | [#264](https://github.com/opensearch-project/search-relevance/pull/264) | LLM Judgement Customized Prompt Template Implementation |   |
+| v3.5.0 | [#372](https://github.com/opensearch-project/search-relevance/pull/372) | Add `_search` endpoint for Search Configurations | [#351](https://github.com/opensearch-project/search-relevance/issues/351) |
+| v3.5.0 | [#371](https://github.com/opensearch-project/search-relevance/pull/371) | Add `_search` endpoint for Judgments | [#351](https://github.com/opensearch-project/search-relevance/issues/351) |
+| v3.5.0 | [#362](https://github.com/opensearch-project/search-relevance/pull/362) | Add `_search` endpoint for Query Sets | [#351](https://github.com/opensearch-project/search-relevance/issues/351) |
+| v3.5.0 | [#369](https://github.com/opensearch-project/search-relevance/pull/369) | Add `_search` endpoint for Experiments | [#351](https://github.com/opensearch-project/search-relevance/issues/351) |
+| v3.5.0 | [#354](https://github.com/opensearch-project/search-relevance/pull/354) | Better ESCI demo dataset with images |   |
+| v3.5.0 | [#364](https://github.com/opensearch-project/search-relevance/pull/364) | Support for parsing custom UBI indexes |   |
+| v3.5.0 | [#370](https://github.com/opensearch-project/search-relevance/pull/370) | Add description support in Search Configuration | [#281](https://github.com/opensearch-project/search-relevance/issues/281) |
+| v3.5.0 | [#349](https://github.com/opensearch-project/search-relevance/pull/349) | Add BWC and Integration tests for index mapping update |   |
 | v3.2.0 | [#570](https://github.com/opensearch-project/dashboards-search-relevance/pull/570) | Dashboard visualization for evaluation and hybrid experiments |   |
 | v3.2.0 | [#577](https://github.com/opensearch-project/dashboards-search-relevance/pull/577) | AutoPopulated fields in Query Compare page via URL parameters |   |
 | v3.2.0 | [#594](https://github.com/opensearch-project/dashboards-search-relevance/pull/594) | Polling mechanism for experiment and judgment listing |   |

--- a/docs/releases/v3.5.0/features/dashboards/search-relevance.md
+++ b/docs/releases/v3.5.0/features/dashboards/search-relevance.md
@@ -1,0 +1,107 @@
+---
+tags:
+  - dashboards-search-relevance
+---
+# Search Relevance
+
+## Summary
+
+OpenSearch v3.5.0 brings significant enhancements to the Search Relevance Workbench, including LLM judgment customization with dynamic prompt templates, new `_search` API endpoints for all entities, UBI sample datasets, improved UI/UX for judgment details and search configuration reuse, and version-based index mapping updates for seamless upgrades.
+
+## Details
+
+### What's New in v3.5.0
+
+#### LLM Judgment Customization
+- Customizable prompt templates for LLM-based relevance judgments
+- Three rating types: `SCORE0_1` (0-1 scale), `SCORE1_5` (1-5 scale), `RELEVANT_IRRELEVANT` (binary)
+- Enhanced caching system with prompt template differentiation
+- `overwriteCache` parameter for forced cache refresh
+
+#### New `_search` API Endpoints
+Added OpenSearch DSL-based search endpoints for all Search Relevance entities:
+- `POST _plugins/_search_relevance/query_sets/_search` - Search Query Sets
+- `POST _plugins/_search_relevance/search_configurations/_search` - Search Search Configurations
+- `POST _plugins/_search_relevance/judgments/_search` - Search Judgments (filters out ratings)
+- `POST _plugins/_search_relevance/experiments/_search` - Search Experiments
+
+#### UBI Sample Dataset
+- Added User Behavior Insights (UBI) sample dataset for understanding user interaction patterns
+- Pre-built UBI dashboards for visualization
+- Integration with Search Relevance Workbench playground
+
+#### UI/UX Improvements
+- Search Configuration reuse in Single Query and Query Compare workflows
+- Improved Judgment Detail page with structured table view (Query, Doc ID, Rating)
+- Search/filter capability and pagination for judgment ratings
+- Search Pipeline display in Search Configuration Detail page
+- Optional `status=COMPLETED` filter for judgment dropdowns
+
+#### Infrastructure Improvements
+- Version-based index mapping updates with `_meta.schema_version` field
+- Automatic mapping updates on API calls when schema version changes
+- Description field support for Search Configurations
+
+### Technical Changes
+
+#### API Enhancements
+
+| Endpoint | Change |
+|----------|--------|
+| `PUT _plugins/_search_relevance/judgments` | Added `promptTemplate`, `llmJudgmentRatingType`, `overwriteCache` parameters |
+| `PUT _plugins/_search_relevance/search_configurations` | Added `description` field support |
+| `*/_search` | New endpoints for all entity types |
+
+#### Index Mapping Version System
+
+```json
+{
+  "_meta": {
+    "schema_version": 0
+  }
+}
+```
+
+Version comparison logic:
+- Version -1: Error reading from cluster state → skip update
+- Version 0: Legacy index or initial version
+- Version 1+: Future versions when mappings are updated
+
+## Limitations
+
+- LLM judgment customization requires ML Commons connector configuration
+- `_search` endpoints target system-protected indexes
+- Index mapping updates are forward-only (no downgrade support)
+
+## References
+
+### Pull Requests
+
+| PR | Description | Repository |
+|----|-------------|------------|
+| [#667](https://github.com/opensearch-project/dashboards-search-relevance/pull/667) | Add FrontEnd Support for LLM Judgement Template Prompt | dashboards-search-relevance |
+| [#727](https://github.com/opensearch-project/dashboards-search-relevance/pull/727) | Reuse Search Configurations with Single Query Comparison UI | dashboards-search-relevance |
+| [#729](https://github.com/opensearch-project/dashboards-search-relevance/pull/729) | Add UBI sample dataset and dashboards | dashboards-search-relevance |
+| [#674](https://github.com/opensearch-project/dashboards-search-relevance/pull/674) | Add optional status=COMPLETED parameter for filtering judgments | dashboards-search-relevance |
+| [#699](https://github.com/opensearch-project/dashboards-search-relevance/pull/699) | Add Search Pipeline to Search Configuration Detail page | dashboards-search-relevance |
+| [#713](https://github.com/opensearch-project/dashboards-search-relevance/pull/713) | Improve UX of the Judgment Detail page | dashboards-search-relevance |
+| [#344](https://github.com/opensearch-project/search-relevance/pull/344) | Version-based index mapping update support | search-relevance |
+| [#264](https://github.com/opensearch-project/search-relevance/pull/264) | LLM Judgement Customized Prompt Template Implementation | search-relevance |
+| [#372](https://github.com/opensearch-project/search-relevance/pull/372) | Add `_search` endpoint for Search Configurations | search-relevance |
+| [#371](https://github.com/opensearch-project/search-relevance/pull/371) | Add `_search` endpoint for Judgments | search-relevance |
+| [#362](https://github.com/opensearch-project/search-relevance/pull/362) | Add `_search` endpoint for Query Sets | search-relevance |
+| [#369](https://github.com/opensearch-project/search-relevance/pull/369) | Add `_search` endpoint for Experiments | search-relevance |
+| [#354](https://github.com/opensearch-project/search-relevance/pull/354) | Better ESCI demo dataset with images | search-relevance |
+| [#364](https://github.com/opensearch-project/search-relevance/pull/364) | Support for parsing custom UBI indexes | search-relevance |
+| [#370](https://github.com/opensearch-project/search-relevance/pull/370) | Add description support in Search Configuration | search-relevance |
+| [#349](https://github.com/opensearch-project/search-relevance/pull/349) | Add BWC and Integration tests for index mapping update | search-relevance |
+| [#374](https://github.com/opensearch-project/search-relevance/pull/374) | Fix jackson annotations version | search-relevance |
+
+### Issues
+- [#695](https://github.com/opensearch-project/dashboards-search-relevance/issues/695): Search Configuration reuse in comparison UI
+- [#691](https://github.com/opensearch-project/dashboards-search-relevance/issues/691): Judgment Detail page UX improvements
+- [#730](https://github.com/opensearch-project/dashboards-search-relevance/issues/730): UBI sample dataset
+- [#310](https://github.com/opensearch-project/search-relevance/issues/310): Index mapping update with version
+- [#351](https://github.com/opensearch-project/search-relevance/issues/351): `_search` endpoints for entities
+- [#281](https://github.com/opensearch-project/search-relevance/issues/281): Description field for Search Configuration
+- [#266](https://github.com/opensearch-project/search-relevance/issues/266): Filter completed judgments in dropdown

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -18,6 +18,7 @@
 ## dashboards-search-relevance
 - Agentic Search
 - Dashboards CI/CD
+- Search Relevance
 
 ## job-scheduler
 - Job Scheduler


### PR DESCRIPTION
## Summary

This PR adds documentation for Search Relevance enhancements in OpenSearch v3.5.0.

### Changes
- Created release report: `docs/releases/v3.5.0/features/dashboards/search-relevance.md`
- Updated feature report: `docs/features/search-relevance/search-relevance-workbench.md`
- Updated release index: `docs/releases/v3.5.0/index.md`

### Key Features in v3.5.0
- LLM judgment customization with dynamic prompt templates and multiple rating types
- New `_search` API endpoints for Query Sets, Search Configurations, Judgments, and Experiments
- UBI sample dataset and dashboards
- UI/UX improvements for Judgment Detail page and Search Configuration reuse
- Version-based index mapping updates for seamless upgrades

Closes #2515