### PR TITLE
docs: add observability-notebooks report for v3.5.0

### DIFF
--- a/docs/features/dashboards-observability/dashboards-observability-observability-notebooks.md
+++ b/docs/features/dashboards-observability/dashboards-observability-observability-notebooks.md
@@ -132,6 +132,7 @@ Notebooks are stored as saved objects in the `.kibana` index. Each notebook cont
 
 ## Change History
 
+- **v3.5.0** (2026-02-11): Added capability-based visibility control; Notebook nav link hidden when Investigation capability is enabled
 - **v3.0.0** (2025-05-06): Removed legacy notebooks support; only `.kibana` storage supported
 - **v2.19.0** (2025-02-11): Deprecated legacy notebooks with migration notice
 - **v2.17.0** (2024-09-17): UI improvements (badge counter in breadcrumbs, simplified delete workflow); fixed sample notebooks for MDS environments
@@ -150,6 +151,7 @@ Notebooks are stored as saved objects in the `.kibana` index. Each notebook cont
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v3.5.0 | [#2512](https://github.com/opensearch-project/dashboards-observability/pull/2512) | Use capabilities to show notebook | [#2442](https://github.com/opensearch-project/dashboards-observability/issues/2442) |
 | v3.0.0 | [#2406](https://github.com/opensearch-project/dashboards-observability/pull/2406) | Remove support for legacy notebooks | [#2350](https://github.com/opensearch-project/dashboards-observability/issues/2350) |
 | v2.17.0 | [#2110](https://github.com/opensearch-project/dashboards-observability/pull/2110) | UI update: badge counter in breadcrumbs, simplified delete workflow |   |
 | v2.17.0 | [#2108](https://github.com/opensearch-project/dashboards-observability/pull/2108) | Fix sample notebooks for MDS environments |   |

--- a/docs/releases/v3.5.0/features/dashboards-observability/observability-notebooks.md
+++ b/docs/releases/v3.5.0/features/dashboards-observability/observability-notebooks.md
@@ -1,0 +1,86 @@
+---
+tags:
+  - dashboards-observability
+---
+# Observability Notebooks
+
+## Summary
+
+In v3.5.0, the Observability Notebooks feature introduces capability-based visibility control. The Notebook navigation entry can now be dynamically shown or hidden based on the `investigation` capability, enabling better integration with the Investigation plugin and supporting the ongoing migration of Notebooks to OpenSearch Dashboards core.
+
+## Details
+
+### What's New in v3.5.0
+
+The primary change is the introduction of capability-based visibility for the Notebooks navigation entry:
+
+- **Dynamic Configuration**: Instead of checking for the presence of the `investigationDashboards` plugin at setup time, the visibility is now controlled at runtime using OpenSearch Dashboards capabilities
+- **Investigation Integration**: When `capabilities.investigation.enabled` is `true`, the Notebook navigation link is automatically hidden to avoid duplication with the Investigation plugin's notebook functionality
+- **Backward Compatibility**: The Notebook application is always registered; only the navigation visibility changes based on capabilities
+
+### Technical Changes
+
+The implementation uses `BehaviorSubject` and `AppUpdater` to dynamically update the application's navigation status:
+
+```typescript
+// Application registration with updater$
+core.application.register({
+  id: observabilityNotebookID,
+  title: observabilityNotebookTitle,
+  category: OBSERVABILITY_APP_CATEGORIES.observability,
+  order: observabilityNotebookPluginOrder,
+  mount: appMountWithStartPage('notebooks'),
+  updater$: this.appUpdater$,
+});
+
+// Runtime visibility control based on capabilities
+if (core.application.capabilities.investigation?.enabled) {
+  this.appUpdater$.next(() => ({
+    navLinkStatus: AppNavLinkStatus.hidden,
+  }));
+}
+```
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph "Plugin Setup"
+        REG[Register Notebook App]
+        NAV[Add Nav Links to Groups]
+    end
+    
+    subgraph "Plugin Start"
+        CAP{Check Capabilities}
+        SHOW[Show Nav Link]
+        HIDE[Hide Nav Link]
+    end
+    
+    REG --> NAV
+    NAV --> CAP
+    CAP -->|investigation.enabled = false| SHOW
+    CAP -->|investigation.enabled = true| HIDE
+```
+
+### Benefits
+
+| Aspect | Before | After |
+|--------|--------|-------|
+| Visibility Control | Static plugin dependency check | Dynamic capability-based |
+| Configuration | Requires plugin presence | Configurable via capabilities |
+| Integration | Hard dependency on investigationDashboards | Flexible integration |
+
+## Limitations
+
+- The capability check occurs at plugin start time; changes to capabilities require a page refresh
+- The Notebook application is still registered even when hidden, consuming minimal resources
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#2512](https://github.com/opensearch-project/dashboards-observability/pull/2512) | Use capabilities to show notebook | - |
+
+### Issues (Design / RFC)
+- [Issue #2442](https://github.com/opensearch-project/dashboards-observability/issues/2442): RFC for moving Notebook from Observability to OpenSearch Dashboards Core

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -37,6 +37,9 @@
 - Observability Dependencies
 - Observability Integration
 
+## dashboards-observability
+- Observability Notebooks
+
 ## opensearch-dashboards
 - Dashboards Build (Rspack Migration)
 - Dashboards CSP Security


### PR DESCRIPTION
## Summary

Add documentation for Observability Notebooks feature in v3.5.0.

### Changes
- **Release report**: `docs/releases/v3.5.0/features/dashboards-observability/observability-notebooks.md`
- **Feature report update**: Added v3.5.0 entry to `docs/features/dashboards-observability/dashboards-observability-observability-notebooks.md`
- **Release index update**: Added entry to `docs/releases/v3.5.0/index.md`

### Key Changes in v3.5.0
- Added capability-based visibility control for Notebooks navigation
- Notebook nav link is hidden when Investigation capability is enabled
- Supports the ongoing migration of Notebooks to OpenSearch Dashboards core

### References
- PR: [#2512](https://github.com/opensearch-project/dashboards-observability/pull/2512)
- RFC: [#2442](https://github.com/opensearch-project/dashboards-observability/issues/2442)

Closes #2514