### PR TITLE
docs: add APM (Application Performance Monitoring) report for v3.5.0

### DIFF
--- a/docs/features/observability/index.md
+++ b/docs/features/observability/index.md
@@ -2,6 +2,7 @@
 
 | Document | Description |
 |----------|-------------|
+| [observability-apm](observability-apm.md) | Application Performance Monitoring (APM) |
 | [observability-cypress-updates](observability-cypress-updates.md) | Observability Cypress Test Dependencies |
 | [observability-infrastructure](observability-infrastructure.md) | Observability Infrastructure |
 | [observability-integrations](observability-integrations.md) | Observability Integrations |

--- a/docs/features/observability/observability-apm.md
+++ b/docs/features/observability/observability-apm.md
@@ -1,0 +1,140 @@
+---
+tags:
+  - observability
+---
+# Application Performance Monitoring (APM)
+
+## Summary
+
+OpenSearch APM (Application Performance Monitoring) provides comprehensive observability capabilities for distributed systems built on open-source technologies. It enables monitoring of service health, performance metrics, and dependencies through an integrated dashboard experience in OpenSearch Dashboards.
+
+## Details
+
+### Architecture
+
+APM employs a hybrid architecture leveraging different storage systems for optimal performance:
+
+```mermaid
+graph TB
+    subgraph "Data Collection"
+        App[Application] --> OTel[OTel SDK]
+        OTel --> Collector[OTel Collector]
+        Collector --> DataPrepper[Data Prepper]
+    end
+    
+    subgraph "Storage Layer"
+        DataPrepper --> OS[OpenSearch<br/>Topology & Traces]
+        DataPrepper --> Prom[Prometheus<br/>RED Metrics]
+    end
+    
+    subgraph "Visualization"
+        OS --> Dashboard[OpenSearch Dashboards]
+        Prom --> Dashboard
+    end
+    
+    subgraph "APM Features"
+        Dashboard --> Services[Services Home]
+        Dashboard --> Map[Application Map]
+        Dashboard --> Details[Service Details]
+        Dashboard --> Correlations[Correlations]
+    end
+```
+
+### Key Capabilities
+
+| Capability | Description |
+|------------|-------------|
+| RED Metrics | Rate, Errors, and Duration metrics for services and operations |
+| Service Maps | Interactive topology visualization showing service dependencies |
+| Service-Level Monitoring | Detailed performance metrics at service and operation levels |
+| Trace Exploration | Deep dive into distributed traces with log correlation |
+
+### Components
+
+#### Services Home Page
+
+Interactive landing page displaying all monitored services with:
+- Services table with columns: Service Name, Environment, Latency (P95), Throughput, Failure Ratio
+- Sparkline visualizations for metric trends
+- Resizable filter sidebar with environment, latency, throughput, and failure ratio filters
+- Top Services by Fault Rate widget
+- Top Dependencies by Fault Rate widget
+
+#### Application Map
+
+Interactive service topology visualization featuring:
+- CelestialMap-based graph visualization
+- Group By functionality (environment, deployment, namespace)
+- Service Details Panel with RED metrics on node click
+- Edge Metrics Flyout for dependency metrics
+- Sidebar navigation with service list and search
+
+#### Service Details Pages
+
+Comprehensive drill-down views with three tabs:
+- **Overview Tab**: Key metric cards (Requests, Faults, Errors, Availability, P99 Latency) and time-series charts
+- **Operations Tab**: All operations with sortable/filterable metrics and expandable detail charts
+- **Dependencies Tab**: Outbound service dependencies with metrics
+
+#### Correlations Flyout
+
+Quick view panel for:
+- Correlated spans with status code filtering
+- Associated logs with log level filtering
+- Expandable rows showing raw logs and spans
+- Navigation links to Explore traces and logs
+
+### Configuration
+
+APM configuration is stored as a saved object containing:
+
+| Setting | Description |
+|---------|-------------|
+| Trace Dataset | OpenSearch index pattern for trace data |
+| Service Map Dataset | OpenSearch index pattern for service topology |
+| Prometheus Connection | Saved object reference for Prometheus data source |
+
+### Query Languages
+
+| Language | Use Case |
+|----------|----------|
+| PPL | Querying OpenSearch for topology, operations, and trace data |
+| PromQL | Querying Prometheus for RED metrics and time-series data |
+
+### Data Flow
+
+1. Applications instrumented with OpenTelemetry SDK emit traces and metrics
+2. OTel Collector receives and processes telemetry data
+3. Data Prepper routes data to appropriate backends:
+   - Topology and trace data → OpenSearch
+   - Time-series metrics → Prometheus
+4. APM UI queries both backends to display unified observability views
+
+## Limitations
+
+- Requires hybrid backend setup (OpenSearch + Prometheus)
+- Service map visualization depends on CelestialMap library
+- Metrics accuracy depends on proper OpenTelemetry instrumentation
+- High-cardinality data may impact Prometheus performance
+
+## Change History
+
+- **v3.5.0** (2026-02): Initial implementation with Services Home, Application Map, Service Details, and Correlations Flyout
+
+## References
+
+### Documentation
+
+- [RFC: OpenSearch Application Performance Monitoring](https://github.com/opensearch-project/dashboards-observability/issues/2545)
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.5.0 | [#2556](https://github.com/opensearch-project/dashboards-observability/pull/2556) | APM Configuration page and server components |
+| v3.5.0 | [#2557](https://github.com/opensearch-project/dashboards-observability/pull/2557) | APM config and context provider |
+| v3.5.0 | [#2558](https://github.com/opensearch-project/dashboards-observability/pull/2558) | Services landing page |
+| v3.5.0 | [#2561](https://github.com/opensearch-project/dashboards-observability/pull/2561) | Correlations flyout support |
+| v3.5.0 | [#2565](https://github.com/opensearch-project/dashboards-observability/pull/2565) | Service details hooks and utilities |
+| v3.5.0 | [#2566](https://github.com/opensearch-project/dashboards-observability/pull/2566) | Service details pages |
+| v3.5.0 | [#2574](https://github.com/opensearch-project/dashboards-observability/pull/2574) | Application Map with topology visualization |

--- a/docs/releases/v3.5.0/features/observability/apm-application-performance-monitoring.md
+++ b/docs/releases/v3.5.0/features/observability/apm-application-performance-monitoring.md
@@ -1,0 +1,111 @@
+---
+tags:
+  - observability
+---
+# APM (Application Performance Monitoring)
+
+## Summary
+
+OpenSearch v3.5.0 introduces Application Performance Monitoring (APM) capabilities to the Observability plugin, providing comprehensive service monitoring with RED metrics (Rate, Errors, Duration), interactive service topology visualization, and detailed service-level analytics.
+
+## Details
+
+### What's New in v3.5.0
+
+APM is a new feature that enables users to monitor distributed systems through:
+
+- **Services Landing Page**: Interactive table displaying all services with metrics including latency (P95), throughput, failure ratio, and sparkline visualizations
+- **Application Map**: Interactive topology visualization showing service dependencies using CelestialMap library with group-by functionality
+- **Service Details Pages**: Comprehensive drill-down views with Overview, Operations, and Dependencies tabs
+- **Correlations Flyout**: Quick view of correlated spans and associated logs with filtering capabilities
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "APM Data Flow"
+        OTel[OTel SDK] --> Collector[OTel Collector]
+        Collector --> DataPrepper[Data Prepper]
+        DataPrepper --> OS[OpenSearch<br/>Topology/Traces]
+        DataPrepper --> Prom[Prometheus<br/>RED Metrics]
+    end
+    
+    subgraph "APM UI Components"
+        Config[APM Configuration]
+        Services[Services Home]
+        Map[Application Map]
+        Details[Service Details]
+        Correlations[Correlations Flyout]
+    end
+    
+    OS --> Services
+    OS --> Map
+    Prom --> Services
+    Prom --> Details
+    Config --> Services
+    Config --> Map
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| APM Configuration Page | Stores trace dataset, service map dataset, and Prometheus saved object |
+| APM Context Provider | Provides resolved configuration to all APM pages |
+| Services Home Page | Landing page with services table, filters, and fault rate widgets |
+| Application Map Page | Interactive service topology visualization with CelestialMap |
+| Service Details Page | Detailed metrics with Overview, Operations, Dependencies tabs |
+| Correlations Flyout | View correlated spans and logs with filtering |
+
+### New Hooks
+
+| Hook | Purpose |
+|------|---------|
+| `useServiceMap` | Fetches service topology from OpenSearch |
+| `useServiceMapMetrics` | Batch fetches RED metrics for all services |
+| `useEdgeMetrics` | Fetches metrics for service dependencies |
+| `useOperations` | Fetches service operations with call counts |
+| `useDependencies` | Fetches service dependencies with grouping |
+| `useOperationMetrics` | Fetches RED metrics per operation |
+| `useDependencyMetrics` | Fetches RED metrics per dependency |
+| `usePromQLChartData` | Transforms PromQL responses for time-series charts |
+| `useCorrelatedLogsByTrace` | Fetches logs correlated via traceIds |
+
+### Query Services
+
+- **PPL Search Service**: Queries OpenSearch span/service data for topology and operations
+- **PromQL Search Service**: Queries Prometheus for RED metrics (latency, throughput, error rate)
+
+### Visibility Control
+
+APM visibility is controlled by the `explore.discoverTracesEnabled` capability:
+
+| UI Setting | Traces Capability | Result |
+|------------|-------------------|--------|
+| Enabled | Enabled | APM visible, Trace Analytics hidden |
+| Enabled | Disabled | APM hidden, Trace Analytics visible |
+| Disabled | Any | Trace Analytics visible (fallback) |
+
+## Limitations
+
+- Requires both OpenSearch and Prometheus backends configured
+- Service map visualization depends on CelestialMap library
+- Metrics accuracy depends on proper OpenTelemetry instrumentation
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#2556](https://github.com/opensearch-project/dashboards-observability/pull/2556) | Add APM Configuration page and server components | [#2545](https://github.com/opensearch-project/dashboards-observability/issues/2545) |
+| [#2557](https://github.com/opensearch-project/dashboards-observability/pull/2557) | Add APM config and context provider | [#2545](https://github.com/opensearch-project/dashboards-observability/issues/2545) |
+| [#2558](https://github.com/opensearch-project/dashboards-observability/pull/2558) | Add Services landing page | [#2545](https://github.com/opensearch-project/dashboards-observability/issues/2545) |
+| [#2561](https://github.com/opensearch-project/dashboards-observability/pull/2561) | Add support for correlations flyout in services pages | [#2545](https://github.com/opensearch-project/dashboards-observability/issues/2545) |
+| [#2565](https://github.com/opensearch-project/dashboards-observability/pull/2565) | Add hooks and utility functions for service details | [#2545](https://github.com/opensearch-project/dashboards-observability/issues/2545) |
+| [#2566](https://github.com/opensearch-project/dashboards-observability/pull/2566) | Add service details pages for APM | [#2545](https://github.com/opensearch-project/dashboards-observability/issues/2545) |
+| [#2574](https://github.com/opensearch-project/dashboards-observability/pull/2574) | Add Application Map page for APM with topology visualization | [#2545](https://github.com/opensearch-project/dashboards-observability/issues/2545) |
+
+### Related Issues
+
+- [#2545](https://github.com/opensearch-project/dashboards-observability/issues/2545) - [RFC] OpenSearch Application Performance Monitoring

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -34,6 +34,7 @@
 - Notifications Maintenance
 
 ## observability
+- APM (Application Performance Monitoring)
 - Observability Dependencies
 - Observability Integration
 


### PR DESCRIPTION
## Summary

This PR adds documentation for the APM (Application Performance Monitoring) feature introduced in OpenSearch v3.5.0.

## Reports Created

- **Release report**: `docs/releases/v3.5.0/features/observability/apm-application-performance-monitoring.md`
- **Feature report**: `docs/features/observability/observability-apm.md`

## Key Changes in v3.5.0

- Services Home Page with interactive services table and fault rate widgets
- Application Map with CelestialMap-based topology visualization
- Service Details Pages with Overview, Operations, and Dependencies tabs
- Correlations Flyout for viewing correlated spans and logs
- Hybrid architecture using OpenSearch for topology/traces and Prometheus for RED metrics

## Related PRs

- opensearch-project/dashboards-observability#2556 - APM Configuration page
- opensearch-project/dashboards-observability#2557 - APM config and context provider
- opensearch-project/dashboards-observability#2558 - Services landing page
- opensearch-project/dashboards-observability#2561 - Correlations flyout
- opensearch-project/dashboards-observability#2565 - Service details hooks
- opensearch-project/dashboards-observability#2566 - Service details pages
- opensearch-project/dashboards-observability#2574 - Application Map

Closes #2513