### PR TITLE
docs: add Mattermost notifications report for v3.5.0

### DIFF
--- a/docs/features/notifications/index.md
+++ b/docs/features/notifications/index.md
@@ -3,3 +3,4 @@
 | Document | Description |
 |----------|-------------|
 | [notifications-plugin](notifications-plugin.md) | Notifications Plugin |
+| [notifications-mattermost](notifications-mattermost.md) | Mattermost Notifications |

--- a/docs/features/notifications/notifications-mattermost.md
+++ b/docs/features/notifications/notifications-mattermost.md
@@ -1,0 +1,132 @@
+---
+tags:
+  - notifications
+---
+# Mattermost Notifications
+
+## Summary
+
+Mattermost notification channel support enables OpenSearch to send notifications directly to Mattermost servers via incoming webhooks. This feature provides native integration for organizations using Mattermost as their team communication platform, allowing alerts, reports, and other notifications to be delivered to Mattermost channels.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    subgraph "OpenSearch Cluster"
+        A[Alerting Plugin] --> N[Notifications Plugin]
+        B[Reporting Plugin] --> N
+        C[Index Management] --> N
+    end
+    
+    subgraph "Notifications Core"
+        N --> T[Transport Layer]
+        T --> WH[Webhook Client]
+    end
+    
+    subgraph "Mattermost"
+        WH -->|POST {"text": "..."}| MW[Mattermost Webhook]
+        MW --> MC[Mattermost Channel]
+    end
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `ConfigType.MATTERMOST` | Enum value identifying Mattermost channel type |
+| `MattermostSettings` | Dashboards UI component for configuration |
+| `Slack` (reused) | Data model for webhook URL storage |
+| `sendSlackMessage` (reused) | Message delivery function |
+
+### Configuration
+
+| Setting | Description | Example |
+|---------|-------------|---------|
+| `config_type` | Must be `"mattermost"` | `"mattermost"` |
+| `mattermost.url` | Mattermost incoming webhook URL | `https://mattermost.example.com/hooks/xxx` |
+
+### URL Validation
+
+Mattermost webhook URLs must match the pattern:
+```
+https?://.*/hooks/.*
+```
+
+This is more flexible than Slack's validation (`https://hooks\.(?:gov-)?slack\.com/services`) to accommodate self-hosted Mattermost instances.
+
+### Usage Example
+
+#### Create Mattermost Channel via API
+
+```json
+POST _plugins/_notifications/configs
+{
+  "config_id": "mattermost-alerts",
+  "config": {
+    "name": "Mattermost Alerts",
+    "description": "Send alerts to Mattermost",
+    "config_type": "mattermost",
+    "is_enabled": true,
+    "mattermost": {
+      "url": "https://your-mattermost-server.com/hooks/xxx-generatedkey-xxx"
+    }
+  }
+}
+```
+
+#### Use in Alerting Monitor
+
+```json
+{
+  "trigger": {
+    "name": "High CPU Alert",
+    "actions": [
+      {
+        "name": "Notify Mattermost",
+        "destination_id": "mattermost-alerts",
+        "message_template": {
+          "source": "CPU usage exceeded threshold: {{ctx.results.0.hits.total.value}} events"
+        }
+      }
+    ]
+  }
+}
+```
+
+### Message Format
+
+Mattermost receives messages in the same format as Slack:
+
+```json
+{
+  "text": "Your notification message here"
+}
+```
+
+## Limitations
+
+- **Payload format**: Only supports the basic `{"text": "..."}` format; Mattermost-specific features like attachments, buttons, or custom fields are not supported
+- **URL pattern**: Must contain `/hooks/` in the path
+- **HTTPS recommended**: While HTTP is technically supported, HTTPS is strongly recommended for security
+
+## Change History
+
+- **v3.5.0** (2026-01-27): Initial implementation - Added Mattermost as a native notification channel type
+
+## References
+
+### Documentation
+- [Mattermost Incoming Webhooks](https://developers.mattermost.com/integrate/webhooks/incoming/)
+- [OpenSearch Notifications Plugin](https://github.com/opensearch-project/notifications)
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.5.0 | [notifications#1055](https://github.com/opensearch-project/notifications/pull/1055) | Add Mattermost as ConfigType for notifications channel |
+| v3.5.0 | [common-utils#853](https://github.com/opensearch-project/common-utils/pull/853) | Add Mattermost as ConfigType for notifications channel |
+| v3.5.0 | [dashboards-notifications#416](https://github.com/opensearch-project/dashboards-notifications/pull/416) | Add Mattermost as a notification channel destination |
+
+### Related Issues
+- [notifications#1048](https://github.com/opensearch-project/notifications/issues/1048) - Feature request for Mattermost support

--- a/docs/releases/v3.5.0/features/notifications/mattermost-notifications.md
+++ b/docs/releases/v3.5.0/features/notifications/mattermost-notifications.md
@@ -1,0 +1,101 @@
+---
+tags:
+  - notifications
+---
+# Mattermost Notifications
+
+## Summary
+
+OpenSearch v3.5.0 adds native support for Mattermost as a notification channel destination. This feature addresses a regression introduced in OpenSearch 3.0.0 where URL validation for Slack channels prevented users from using Slack-compatible platforms like Mattermost, Discord, RocketChat, and Zulip.
+
+## Details
+
+### What's New in v3.5.0
+
+The Mattermost notification channel type provides:
+
+- **New ConfigType**: `MATTERMOST` added to the notifications ConfigType enum
+- **Slack-compatible payload**: Uses the same `{"text": "message"}` format as Slack
+- **Flexible URL validation**: Accepts webhook URLs matching `https://.*/hooks/.*` pattern
+- **Full Dashboards integration**: New UI component for configuring Mattermost channels
+
+### Technical Changes
+
+#### Backend Changes (notifications plugin)
+
+The implementation reuses the existing Slack infrastructure since Mattermost accepts the same payload format:
+
+```kotlin
+// ConfigIndexingActions.kt - URL validation
+private fun validateMattermostConfig(slack: Slack, user: User?) {
+    require(slack.url.contains(Regex("https?://.*/hooks/.*"))) {
+        "Wrong webhook url. Should match \"https://.*/hooks/.*\""
+    }
+}
+
+// SendMessageActionHelper.kt - Message sending
+ConfigType.MATTERMOST -> sendSlackMessage(configData as Slack, message, eventStatus, eventSource.referenceId)
+```
+
+#### Common-utils Changes
+
+Added `MATTERMOST` to the ConfigType enum and mapped it to use the existing `Slack` reader/parser:
+
+```kotlin
+// ConfigType.kt
+MATTERMOST("mattermost") {
+    override fun toString(): String {
+        return tag
+    }
+}
+
+// ConfigDataProperties.kt
+Pair(ConfigType.MATTERMOST, ConfigProperty(Slack.reader, Slack.xParser))
+```
+
+#### Dashboards Changes (dashboards-notifications)
+
+New `MattermostSettings` component added with webhook URL input field:
+
+| File | Change |
+|------|--------|
+| `common/constants.ts` | Added `MATTERMOST: 'mattermost'` to `BACKEND_CHANNEL_TYPE` |
+| `models/interfaces.ts` | Added `mattermost?: { url: string }` to `ChannelItemType` |
+| `CreateChannel.tsx` | Added Mattermost webhook state and validation |
+| `MattermostSettings.tsx` | New component for Mattermost configuration UI |
+
+### Configuration Example
+
+```json
+POST _plugins/_notifications/configs
+{
+  "config_id": "my-mattermost-channel",
+  "config": {
+    "name": "Mattermost Channel",
+    "description": "Send notifications to Mattermost",
+    "config_type": "mattermost",
+    "is_enabled": true,
+    "mattermost": {
+      "url": "https://your-mattermost-server.com/hooks/xxx-generatedkey-xxx"
+    }
+  }
+}
+```
+
+## Limitations
+
+- URL must match the pattern `https://.*/hooks/.*`
+- Uses the same payload format as Slack (`{"text": "message"}`)
+- No support for Mattermost-specific features like attachments or custom fields beyond what Slack webhooks support
+
+## References
+
+### Pull Requests
+| PR | Repository | Description | Related Issue |
+|----|------------|-------------|---------------|
+| [#1055](https://github.com/opensearch-project/notifications/pull/1055) | notifications | Add Mattermost as ConfigType for notifications channel | [#1048](https://github.com/opensearch-project/notifications/issues/1048) |
+| [#853](https://github.com/opensearch-project/common-utils/pull/853) | common-utils | Add Mattermost as ConfigType for notifications channel | [#1048](https://github.com/opensearch-project/notifications/issues/1048) |
+| [#416](https://github.com/opensearch-project/dashboards-notifications/pull/416) | dashboards-notifications | Add Mattermost as a notification channel destination | [#1048](https://github.com/opensearch-project/notifications/issues/1048) |
+
+### Related Issues
+- [notifications#1048](https://github.com/opensearch-project/notifications/issues/1048) - [FEATURE] Add support for Mattermost channel as destination

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -31,6 +31,7 @@
 - SEISMIC (Sparse ANN) Enhancements
 
 ## notifications
+- Mattermost Notifications
 - Notifications Maintenance
 
 ## observability


### PR DESCRIPTION
## Summary

Adds documentation for the new Mattermost notification channel feature in OpenSearch v3.5.0.

## Reports Created
- Release report: `docs/releases/v3.5.0/features/notifications/mattermost-notifications.md`
- Feature report: `docs/features/notifications/notifications-mattermost.md`

## Key Changes in v3.5.0
- Added `MATTERMOST` ConfigType to notifications plugin
- New Dashboards UI component for Mattermost channel configuration
- Flexible URL validation pattern (`https://.*/hooks/.*`) for self-hosted instances
- Reuses Slack message format for compatibility

## Related PRs
- opensearch-project/notifications#1055
- opensearch-project/common-utils#853
- opensearch-project/dashboards-notifications#416

Closes #2512