### PR TITLE
docs: add alerting-access-control report for v3.5.0

### DIFF
--- a/docs/features/alerting/alerting-access-control.md
+++ b/docs/features/alerting/alerting-access-control.md
@@ -1,0 +1,95 @@
+---
+tags:
+  - alerting
+---
+# Alerting Access Control
+
+## Summary
+
+The Alerting plugin provides role-based access control mechanisms to restrict which users can access monitor results in notification templates. This security feature prevents potential exposure of sensitive data through alert notifications by allowing administrators to specify which user roles are permitted to include query results in notification message templates.
+
+## Details
+
+### Architecture
+
+```mermaid
+flowchart TB
+    subgraph "Monitor Execution"
+        A[Monitor Trigger] --> B[TriggerExecutionContext]
+        B --> C{Check Access Control}
+    end
+    
+    subgraph "Access Control Check"
+        C --> D{Setting Configured?}
+        D -->|No| E[Return full results]
+        D -->|Yes| F{Monitor roles ∩<br/>Allowed roles?}
+        F -->|Yes| E
+        F -->|No| G[Return empty results]
+    end
+    
+    subgraph "Notification"
+        E --> H[Template with results]
+        G --> I[Template without results]
+        H --> J[Send Notification]
+        I --> J
+    end
+```
+
+### Configuration
+
+| Setting | Description | Default | Scope |
+|---------|-------------|---------|-------|
+| `plugins.alerting.notification_context_results_allowed_roles` | List of user roles allowed to include results in notification templates | `[]` (empty - all roles allowed) | Cluster |
+
+### Behavior Matrix
+
+| Setting State | Monitor User Roles | Result Access |
+|---------------|-------------------|---------------|
+| Not configured | Any | Full results |
+| Configured with `["admin"]` | `["admin", "user"]` | Full results |
+| Configured with `["admin"]` | `["user"]` | Empty results |
+| Configured with `["admin", "analyst"]` | `["analyst"]` | Full results |
+
+### Usage Example
+
+Configure allowed roles:
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "plugins.alerting.notification_context_results_allowed_roles": ["admin", "security_analyst"]
+  }
+}
+```
+
+In notification templates, `{{ctx.results}}` will:
+- Return query results for monitors owned by users with `admin` or `security_analyst` roles
+- Return an empty list for monitors owned by users without these roles
+
+## Limitations
+
+- Cluster-wide setting only; cannot be configured per-monitor
+- Affects all existing monitors immediately when changed
+- Only controls `results` field in templates; other context fields remain accessible
+- Document-level monitors always return empty results in templates by design
+
+## Change History
+
+- **v3.5.0** (2026-01-26): Initial implementation - Added `NOTIFICATION_CONTEXT_RESULTS_ALLOWED_ROLES` setting for role-based access control of trigger execution context results
+
+## References
+
+### Documentation
+
+- [Alerting Security](https://opensearch.org/docs/latest/observing-your-data/alerting/security/) - Official documentation on alerting security and access control
+
+### Pull Requests
+
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.5.0 | [#1991](https://github.com/opensearch-project/alerting/pull/1991) | Access control for results in trigger execution context |
+
+### Related Issues
+
+- [#1986](https://github.com/opensearch-project/alerting/issues/1986) - Feature request: Access control for using monitor results in email template

--- a/docs/features/alerting/index.md
+++ b/docs/features/alerting/index.md
@@ -2,6 +2,7 @@
 
 | Document | Description |
 |----------|-------------|
+| [alerting-access-control](alerting-access-control.md) | Alerting Access Control |
 | [alerting-integration](alerting-integration.md) | Alerting Integration |
 | [alerting-ppl-alerting](alerting-ppl-alerting.md) | PPL Alerting |
 | [alerting](alerting.md) | Alerting |

--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -4,6 +4,7 @@ Cumulative feature documentation across all versions.
 
 ## alerting
 
+- Alerting Access Control
 - Alerting Integration
 - Cross-Cluster & Remote Monitors
 

--- a/docs/releases/v3.5.0/features/alerting/alerting-access-control.md
+++ b/docs/releases/v3.5.0/features/alerting/alerting-access-control.md
@@ -1,0 +1,84 @@
+---
+tags:
+  - alerting
+---
+# Alerting Access Control
+
+## Summary
+
+OpenSearch v3.5.0 introduces role-based access control for trigger execution context results in the Alerting plugin. A new cluster setting `plugins.alerting.notification_context_results_allowed_roles` allows administrators to restrict which user roles can include query results in notification message templates, preventing potential exposure of sensitive data through alert notifications.
+
+## Details
+
+### What's New in v3.5.0
+
+This release adds a security enhancement to control access to monitor results in notification templates. When configuring alerting actions, users can include `ctx.results` in message templates to interpolate query results that triggered the alert. While useful, this could expose sensitive data through unencrypted notifications like email.
+
+### New Configuration Setting
+
+| Setting | Description | Default |
+|---------|-------------|---------|
+| `plugins.alerting.notification_context_results_allowed_roles` | List of user roles allowed to include results in notification templates | `[]` (empty - all roles allowed) |
+
+### Behavior
+
+```mermaid
+flowchart TB
+    A[Trigger Execution] --> B{Setting Configured?}
+    B -->|No| C[Include results in template context]
+    B -->|Yes| D{Monitor roles intersect<br/>allowed roles?}
+    D -->|Yes| C
+    D -->|No| E[Return empty results in template context]
+    C --> F[Notification sent with results]
+    E --> G[Notification sent without results]
+```
+
+- **Setting not configured (default)**: Original behavior preserved - all monitors can include results in notification templates
+- **Setting configured with roles**: Only monitors owned by users with at least one matching role can access results in templates
+- **No role intersection**: The `results` field in the template context returns an empty list
+
+### Technical Changes
+
+The implementation modifies the `TriggerExecutionContext` class hierarchy:
+
+| Class | Change |
+|-------|--------|
+| `TriggerExecutionContext` | Added `templateResults` property with role-based filtering logic |
+| `QueryLevelTriggerExecutionContext` | Updated to pass `ClusterSettings` and use `templateResults` |
+| `BucketLevelTriggerExecutionContext` | Updated to pass `ClusterSettings` and use `templateResults` |
+| `DocumentLevelTriggerExecutionContext` | Updated to pass `ClusterSettings` and use `templateResults` |
+| `AlertingSettings` | Added `NOTIFICATION_CONTEXT_RESULTS_ALLOWED_ROLES` setting |
+
+### Usage Example
+
+To restrict results access to only `admin` and `security_analyst` roles:
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "plugins.alerting.notification_context_results_allowed_roles": ["admin", "security_analyst"]
+  }
+}
+```
+
+With this setting, monitors created by users without these roles will have empty `results` in their notification templates, even if they use `{{ctx.results}}` in the message body.
+
+## Limitations
+
+- The setting applies cluster-wide and cannot be configured per-monitor
+- Existing monitors are affected immediately when the setting is changed
+- The setting only affects the `results` field in notification templates; other context fields remain accessible
+- Document-level monitors always return empty results in templates (by design, as they don't populate results in the execution context)
+
+## References
+
+### Pull Requests
+
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#1991](https://github.com/opensearch-project/alerting/pull/1991) | Access control for results in trigger execution context | [#1986](https://github.com/opensearch-project/alerting/issues/1986) |
+
+### Related Issues
+
+- [#1986](https://github.com/opensearch-project/alerting/issues/1986) - Feature request: Access control for using monitor results in email template

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -1,5 +1,8 @@
 # OpenSearch v3.5.0 Release
 
+## alerting
+- Alerting Access Control
+
 ## anomaly-detection
 - Anomaly Detection Correlation
 


### PR DESCRIPTION
## Summary

Adds documentation for the Alerting Access Control feature introduced in OpenSearch v3.5.0.

### Feature Overview

This feature adds role-based access control for trigger execution context results in the Alerting plugin. A new cluster setting `plugins.alerting.notification_context_results_allowed_roles` allows administrators to restrict which user roles can include query results in notification message templates.

### Reports Created

- Release report: `docs/releases/v3.5.0/features/alerting/alerting-access-control.md`
- Feature report: `docs/features/alerting/alerting-access-control.md`

### Key Changes in v3.5.0

- Added `NOTIFICATION_CONTEXT_RESULTS_ALLOWED_ROLES` setting
- Modified `TriggerExecutionContext` to conditionally filter results based on user roles
- Updated all trigger execution context classes to support the new access control

### References

- PR: [opensearch-project/alerting#1991](https://github.com/opensearch-project/alerting/pull/1991)
- Issue: [opensearch-project/alerting#1986](https://github.com/opensearch-project/alerting/issues/1986)

Closes #2510