### PR TITLE
docs: add AG-UI (Agent-User Interaction) protocol report for v3.5.0

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -14,6 +14,7 @@ Cumulative feature documentation across all versions.
 
 ## ml-commons
 
+- AG-UI (Agent-User Interaction) Protocol
 - Batch Prediction Mode
 - Conversation Memory
 - ML Inference Processor

--- a/docs/features/ml-commons/ml-commons-ag-ui-protocol.md
+++ b/docs/features/ml-commons/ml-commons-ag-ui-protocol.md
@@ -1,0 +1,133 @@
+---
+tags:
+  - ml-commons
+---
+
+# AG-UI (Agent-User Interaction) Protocol
+
+## Summary
+
+AG-UI (Agent-User Interaction) is an open, event-based protocol that standardizes how AI agents connect to user-facing frontend applications. OpenSearch ml-commons implements AG-UI protocol support in its Agent Framework, enabling real-time streaming communication between conversational AI frontends and OpenSearch agents. This allows any AG-UI compatible frontend — including OpenSearch Dashboards — to interact with OpenSearch agents through standardized streaming events and hybrid tool execution.
+
+AG-UI is positioned as a complementary protocol in the agentic ecosystem:
+- **MCP (Model Context Protocol)**: Gives agents backend tools
+- **A2A (Agent-to-Agent Protocol)**: Allows agents to communicate with other agents
+- **AG-UI**: Brings agents into user-facing applications with frontend interaction tools
+
+## Details
+
+### Agent Type and Registration
+
+AG-UI agents are registered with `"type": "AG_UI"` and use the `MLAGUIAgentRunner` class. This runner acts as a preprocessing layer that transforms AG-UI protocol requests into ml-commons compatible format, then delegates to `MLChatAgentRunner` for actual ReAct loop execution.
+
+Key registration parameters:
+- `type`: `"AG_UI"`
+- `llm.model_id`: Reference to a deployed remote model (e.g., Bedrock Claude)
+- `parameters._llm_interface`: LLM provider interface (e.g., `bedrock/converse/claude`)
+- `tools[]`: Backend tools available to the agent
+- `memory.type`: `"conversation_index"` for conversation persistence
+
+### AG-UI Protocol Request Format
+
+The AG-UI execute stream endpoint accepts:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `threadId` | string | Conversation thread identifier |
+| `runId` | string | Execution run identifier |
+| `messages` | array | Conversation messages with roles: `user`, `assistant`, `tool` |
+| `tools` | array | Frontend tool definitions with name, description, and JSON Schema parameters |
+| `context` | array | Application context items (e.g., current page state, time range) |
+| `state` | object | Shared state between agent and UI |
+| `forwardedProps` | object | Additional forwarded properties |
+
+### AG-UI Event Types
+
+Responses are streamed as Server-Sent Events (SSE):
+
+| Event Type | Description |
+|------------|-------------|
+| `RUN_STARTED` | Agent execution begins; includes threadId and runId |
+| `TEXT_MESSAGE_START` | Start of assistant text response |
+| `TEXT_MESSAGE_CONTENT` | Incremental text content delta |
+| `TEXT_MESSAGE_END` | End of text response |
+| `TOOL_CALL_START` | Agent requests tool execution; includes toolCallId and toolCallName |
+| `TOOL_CALL_ARGS` | Tool call arguments as JSON delta |
+| `TOOL_CALL_END` | Tool call definition complete |
+| `TOOL_CALL_RESULT` | Backend tool execution result |
+| `RUN_FINISHED` | Agent execution complete |
+| `RUN_ERROR` | Error during execution |
+| `MESSAGES_SNAPSHOT` | Reserved for memory integration |
+
+### Hybrid Tool Execution
+
+The AG-UI implementation supports a hybrid tool model within the ReAct loop:
+
+1. **Backend tools** (e.g., `ListIndexTool`, `SearchIndexTool`, MCP tools): Execute server-side within the ReAct loop. Results feed back into the next LLM iteration.
+2. **Frontend tools** (defined in request `tools[]`): When the LLM selects a frontend tool, the ReAct loop pauses and returns `TOOL_CALL_*` events to the client. The frontend executes the tool (e.g., updating a query bar, changing time range) and sends results back in a follow-up request with `tool` role messages.
+
+The LLM sees all tools (backend + frontend) in a unified view, enabling seamless multi-tool reasoning across server and client boundaries.
+
+### Frontend Integration
+
+AG-UI compatible frontends can connect using the AG-UI client SDK:
+
+```javascript
+import { HttpAgent } from '@ag-ui/client';
+
+const agent = new HttpAgent({
+  url: 'https://your-opensearch-cluster/_plugins/_ml/agents/{agent_id}/_execute/stream'
+});
+```
+
+OpenSearch Dashboards integrates AG-UI through its chat plugin, context provider framework, and page tools architecture, enabling context-aware chatbot experiences within the Explore application and other pages.
+
+### Configuration
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `plugins.ml_commons.ag_ui_enabled` | `false` | Enable AG-UI agent feature |
+| `plugins.ml_commons.stream_enabled` | `false` | Enable streaming responses |
+
+### Supported LLM Providers
+
+| Provider | `_llm_interface` Value |
+|----------|----------------------|
+| Amazon Bedrock (Claude) | `bedrock/converse/claude` |
+| OpenAI-compatible APIs | `openai` (via HttpStreamingHandler) |
+
+## Limitations
+
+- AG-UI agent requires explicit feature flag enablement (`plugins.ml_commons.ag_ui_enabled`)
+- Streaming with the unified agent interface is only supported for AG-UI agents; conversational agents registered via the new interface do not yet support `/_execute/stream`
+- Multi-modal content (images) in streaming is supported but multi-modal content storage in `conversation_index` memory is limited
+- The `MESSAGES_SNAPSHOT` event type is reserved but not yet fully integrated with memory
+
+## Change History
+
+### v3.5.0
+- Initial AG-UI protocol support in Agent Framework (PR #4549, PR #4347)
+- New `AG_UI` agent type with `MLAGUIAgentRunner`
+- SSE streaming with 11 AG-UI event types
+- Hybrid backend/frontend tool execution model
+- `AGUIInputConverter` for protocol format detection and conversion
+- Support for Bedrock Converse and OpenAI-compatible streaming handlers
+- Feature flag `plugins.ml_commons.ag_ui_enabled`
+- Tool message support in agent revamp for both Bedrock and OpenAI providers (PR #4596)
+- Image support in streaming responses
+
+## References
+
+- PR: https://github.com/opensearch-project/ml-commons/pull/4549
+- PR: https://github.com/opensearch-project/ml-commons/pull/4347
+- PR: https://github.com/opensearch-project/ml-commons/pull/4596
+- RFC: https://github.com/opensearch-project/ml-commons/issues/4409
+- Issue: https://github.com/opensearch-project/ml-commons/issues/4211
+- Issue: https://github.com/opensearch-project/ml-commons/issues/4548
+- Issue: https://github.com/opensearch-project/ml-commons/issues/4604
+- RFC: https://github.com/opensearch-project/ml-commons/issues/4552
+- OSD RFC (AI Assistant Framework): https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10585
+- OSD RFC (Context & Page Tools): https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10571
+- OSD RFC (AI Toolkit): https://github.com/opensearch-project/OpenSearch-Dashboards/issues/10561
+- AG-UI Protocol: https://github.com/ag-ui-protocol/ag-ui
+- Docs Issue: https://github.com/opensearch-project/documentation-website/issues/11799

--- a/docs/releases/v3.5.0/features/ml-commons/ag-ui-agent-user-interaction.md
+++ b/docs/releases/v3.5.0/features/ml-commons/ag-ui-agent-user-interaction.md
@@ -1,0 +1,143 @@
+---
+tags:
+  - ml-commons
+---
+
+# AG-UI (Agent-User Interaction) Protocol Support
+
+## Summary
+
+OpenSearch v3.5.0 introduces AG-UI (Agent-User Interaction) protocol support in the ml-commons Agent Framework. AG-UI is an open, lightweight, event-based protocol that standardizes how AI agents connect to user-facing frontend applications. This implementation adds a new `AG_UI` agent type that enables real-time streaming interactions between OpenSearch agents and any AG-UI compatible frontend, including OpenSearch Dashboards' new chat interface.
+
+## Key Changes
+
+### New AG_UI Agent Type
+- New `MLAGUIAgentRunner` class that processes AG-UI protocol requests and delegates to the existing `MLChatAgentRunner` for execution
+- Agent registration with `"type": "AG_UI"` to create AG-UI compatible agents
+- Feature flag `plugins.ml_commons.ag_ui_enabled` to control availability
+
+### AG-UI Protocol Input Format
+- Accepts AG-UI standard request format with `threadId`, `runId`, `messages[]`, `tools[]`, `context[]`, `state`, and `forwardedProps`
+- `AGUIInputConverter` automatically detects and converts AG-UI requests to ml-commons `AgentMLInput` format
+- Supports message roles: `user`, `assistant`, and `tool` (for frontend tool results)
+
+### Server-Sent Events (SSE) Streaming Output
+- Streaming via `/_plugins/_ml/agents/{agent_id}/_execute/stream` endpoint
+- AG-UI event types emitted during streaming:
+  - Run lifecycle: `RUN_STARTED`, `RUN_FINISHED`, `RUN_ERROR`
+  - Text streaming: `TEXT_MESSAGE_START`, `TEXT_MESSAGE_CONTENT`, `TEXT_MESSAGE_END`
+  - Tool calls: `TOOL_CALL_START`, `TOOL_CALL_ARGS`, `TOOL_CALL_END`, `TOOL_CALL_RESULT`
+  - State: `MESSAGES_SNAPSHOT` (reserved for memory integration)
+
+### Hybrid Tool Execution Model
+- Backend tools (e.g., `ListIndexTool`, `SearchIndexTool`) execute server-side within the ReAct loop
+- Frontend tools (defined in the request `tools[]` array) are delegated back to the client via `TOOL_CALL_*` events
+- The frontend executes the tool and sends results back in a follow-up request with `tool` role messages
+- LLM sees both backend and frontend tools in a unified view, enabling seamless multi-tool reasoning
+
+### Tool Message Support in Agent Revamp
+- Support for `tool` role messages in the unified agent interface for both Bedrock and OpenAI model providers
+- Tool message processing logic moved from AG-UI agent to the agent revamp layer for reuse
+- Image support in streaming responses
+
+### Multi-LLM Provider Support
+- `_llm_interface` parameter supports `bedrock/converse/claude` and OpenAI-compatible APIs
+- `FunctionCalling` interface handles provider-specific tool call formatting
+- `BedrockStreamingHandler` and `HttpStreamingHandler` generate AG-UI events from respective provider streams
+
+## Configuration
+
+### Enable AG-UI
+```json
+POST /_cluster/settings
+{
+    "persistent": {
+        "plugins.ml_commons.stream_enabled": true,
+        "plugins.ml_commons.ag_ui_enabled": true
+    }
+}
+```
+
+### Register AG-UI Agent
+```json
+POST /_plugins/_ml/agents/_register
+{
+    "name": "AG-UI chat agent",
+    "type": "AG_UI",
+    "llm": {
+        "model_id": "{{model_id}}",
+        "parameters": {
+            "max_iteration": 50,
+            "system_prompt": "You are a helpful assistant.",
+            "prompt": "Context:${parameters.context}\nQuestion:${parameters.question}"
+        }
+    },
+    "memory": { "type": "conversation_index" },
+    "parameters": { "_llm_interface": "bedrock/converse/claude" },
+    "tools": [{ "type": "ListIndexTool", "name": "ListIndexTool" }]
+}
+```
+
+### Execute with Streaming
+```json
+POST /_plugins/_ml/agents/{{agent_id}}/_execute/stream
+{
+    "threadId": "thread-123",
+    "runId": "run-456",
+    "messages": [
+        { "id": "msg-1", "role": "user", "content": "list my indices" }
+    ],
+    "tools": [],
+    "context": [],
+    "state": {},
+    "forwardedProps": {}
+}
+```
+
+## Architecture
+
+```mermaid
+graph TB
+    subgraph Frontend["Frontend (AG-UI Client)"]
+        A[AG-UI Request] --> B[SSE Stream]
+        B --> C{Tool Call Event?}
+        C -->|Frontend Tool| D[Execute in Browser]
+        D --> E[Send Tool Result Back]
+        C -->|No| F[Render Text/Events]
+    end
+
+    subgraph Backend["ml-commons Agent Framework"]
+        G[RestMLExecuteStreamAction] --> H[AGUIInputConverter]
+        H --> I[MLAGUIAgentRunner]
+        I --> J[MLChatAgentRunner / ReAct Loop]
+        J --> K{Tool Type?}
+        K -->|Backend| L[Execute Server-side]
+        K -->|Frontend| M[Return TOOL_CALL Events]
+        L --> N[StreamingHandler]
+        N --> O[AG-UI Events via SSE]
+    end
+
+    E --> G
+    A --> G
+    O --> B
+```
+
+## Limitations
+
+- AG-UI agent requires `plugins.ml_commons.ag_ui_enabled` feature flag to be explicitly enabled
+- Conversational agents registered via the new unified interface do not yet work with `/_execute/stream` (only AG-UI agents support streaming with the unified format)
+- The `MLAGUIAgentRunner` previously hard-coded to include only the latest tool result; multi-tool support improvements are tracked in Issue #4548
+- System role messages were initially ignored in AG-UI agent execution; fix tracked in Issue #4548
+
+## References
+
+- PR: https://github.com/opensearch-project/ml-commons/pull/4549 (AG-UI support in Agent Framework, merged v3.5.0)
+- PR: https://github.com/opensearch-project/ml-commons/pull/4347 (Initial AG-UI support, merged to feature branch)
+- PR: https://github.com/opensearch-project/ml-commons/pull/4596 (Tool messages in agent revamp)
+- RFC: https://github.com/opensearch-project/ml-commons/issues/4409 (AG-UI Support in Agent Framework)
+- Issue: https://github.com/opensearch-project/ml-commons/issues/4211 (Feature request)
+- Issue: https://github.com/opensearch-project/ml-commons/issues/4548 (Improve AG-UI Agent Features)
+- Issue: https://github.com/opensearch-project/ml-commons/issues/4604 (Unified interface + agent execute stream)
+- RFC: https://github.com/opensearch-project/ml-commons/issues/4552 (Simplify agent creation and standardize agent input)
+- AG-UI Protocol: https://github.com/ag-ui-protocol/ag-ui
+- Docs Issue: https://github.com/opensearch-project/documentation-website/issues/11799

--- a/docs/releases/v3.5.0/index.md
+++ b/docs/releases/v3.5.0/index.md
@@ -39,6 +39,9 @@
 ### k-nn
 - k-NN Vector Search
 
+### ml-commons
+- AG-UI (Agent-User Interaction) Protocol Support
+
 ### neural-search
 - Neural Search
 - SEISMIC (Sparse ANN) Enhancements


### PR DESCRIPTION
## Summary\n\nAdds release report and feature report for the AG-UI (Agent-User Interaction) protocol support introduced in OpenSearch v3.5.0 via ml-commons.\n\n### Reports Created\n- Release report: `docs/releases/v3.5.0/features/ml-commons/ag-ui-agent-user-interaction.md`\n- Feature report: `docs/features/ml-commons/ml-commons-ag-ui-protocol.md`\n\n### Key Changes in v3.5.0\n- New `AG_UI` agent type with `MLAGUIAgentRunner` for AG-UI protocol compatibility\n- SSE streaming with 11 AG-UI event types (RUN_STARTED, TEXT_MESSAGE_CONTENT, TOOL_CALL_START, etc.)\n- Hybrid backend/frontend tool execution model within the ReAct loop\n- `AGUIInputConverter` for automatic protocol format detection and conversion\n- Support for Bedrock Converse and OpenAI-compatible streaming handlers\n- Feature flag `plugins.ml_commons.ag_ui_enabled`\n- Tool message support in agent revamp for both Bedrock and OpenAI providers\n\n### Sources\n- RFC: opensearch-project/ml-commons#4409\n- Main PR: opensearch-project/ml-commons#4549\n- Tool messages PR: opensearch-project/ml-commons#4596\n- OSD AI Assistant RFC: opensearch-project/OpenSearch-Dashboards#10585