### PR TITLE
docs: add bwc-timestamp-upgrade-fix report for v3.3.1

### DIFF
--- a/docs/features/opensearch/opensearch-skip-list.md
+++ b/docs/features/opensearch/opensearch-skip-list.md
@@ -156,7 +156,7 @@ PUT /logs
 }
 ```
 
-Note: `@timestamp` fields automatically have skip list enabled in v3.3.0+.
+Note: `@timestamp` fields automatically have skip list enabled for indices created on v3.3.0+. Indices created on earlier versions retain `skip_list=false` even after upgrading (fixed in v3.3.1).
 
 Index documents:
 
@@ -255,10 +255,12 @@ GET /logs/_search
   - Analytics workloads with numeric/date filtering
 - Date histogram skip list optimization requires single-valued fields
 - Hard bounds in date histogram disable skip list optimization
+- Auto-enablement of skip list for `@timestamp` and index sort fields only applies to indices created on v3.3.0+ (v3.3.1 fix). Indices upgraded from pre-3.3.0 must reindex to enable skip list on those fields.
 - Requires reindexing to enable on existing fields
 
 ## Change History
 
+- **v3.3.1**: BWC fix - Added version check to `isSkiplistDefaultEnabled()` so auto-enablement of skip list for `@timestamp` and index sort fields only applies to indices created on v3.3.0+, fixing upgrade failures from pre-3.3.0 versions
 - **v3.3.0** (2025-10-01): Extended skip list support - Added date histogram aggregation optimization, extended to date/scaled_float/token_count fields, added sub-aggregation support, auto-enabled for @timestamp and index sort fields
 - **v3.2.0** (2025-08-19): Initial implementation - Added `skip_list` parameter to all numeric field mappers
 
@@ -274,6 +276,7 @@ GET /logs/_search
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v3.3.1 | [#19671](https://github.com/opensearch-project/OpenSearch/pull/19671) | Fix bwc @timestamp upgrade issue by adding a version check on skip_list param | [#19660](https://github.com/opensearch-project/OpenSearch/issues/19660) |
 | v3.3.0 | [#19130](https://github.com/opensearch-project/OpenSearch/pull/19130) | Adding logic for histogram aggregation using skiplist |   |
 | v3.3.0 | [#19142](https://github.com/opensearch-project/OpenSearch/pull/19142) | Add skip_list param for date, scaled float and token count fields | [#19123](https://github.com/opensearch-project/OpenSearch/issues/19123) |
 | v3.3.0 | [#19438](https://github.com/opensearch-project/OpenSearch/pull/19438) | Add sub aggregation support for histogram aggregation using skiplist |   |
@@ -284,4 +287,5 @@ GET /logs/_search
 - [Issue #17965](https://github.com/opensearch-project/OpenSearch/issues/17965): [SparseIndex] Modify FieldMappers to enable SkipList
 - [Issue #17283](https://github.com/opensearch-project/OpenSearch/issues/17283): Support for sub-aggregations
 - [Issue #19123](https://github.com/opensearch-project/OpenSearch/issues/19123): Enable skip_list by default in 3.3
+- [Issue #19660](https://github.com/opensearch-project/OpenSearch/issues/19660): Upgrade from 2.19.2 to 3.3.0 failed (BWC bug)
 - [Documentation Issue #11166](https://github.com/opensearch-project/documentation-website/issues/11166): Public documentation for skip_list

--- a/docs/releases/v3.3.1/features/opensearch/bwc-timestamp-upgrade-fix.md
+++ b/docs/releases/v3.3.1/features/opensearch/bwc-timestamp-upgrade-fix.md
@@ -1,0 +1,56 @@
+---
+tags:
+  - opensearch
+---
+# BWC Timestamp Upgrade Fix
+
+## Summary
+
+Fixes a backward compatibility (BWC) issue where upgrading from pre-3.3.0 versions (e.g., 2.19.x) to 3.3.0 caused shard allocation failures on indices with `@timestamp` date fields. The root cause was that v3.3.0 unconditionally enabled `skip_list` (via `docValuesSkipIndexType=RANGE`) for `@timestamp` fields, but Lucene does not allow changing the skip index type on existing index segments. The fix adds a version check so that `skip_list` auto-enablement only applies to indices created on v3.3.0 or later.
+
+## Details
+
+### What's New in v3.3.1
+
+In v3.3.0, the `isSkiplistDefaultEnabled()` method in `DateFieldMapper` was introduced to automatically enable skip list for `@timestamp` fields and index sort date fields. However, this applied to all indices regardless of when they were created. When a pre-3.3.0 index (with `docValuesSkipIndexType=NONE`) was opened on a 3.3.0 node and new documents were ingested, Lucene rejected the change with:
+
+```
+IllegalArgumentException: cannot change field "@timestamp" from docValuesSkipIndexType=NONE to inconsistent docValuesSkipIndexType=RANGE
+```
+
+The fix wraps the auto-enable logic in a version check (`indexCreatedVersion.onOrAfter(Version.V_3_3_0)`), ensuring only indices created on 3.3.0+ get automatic skip list enablement. Older indices retain `skip_list=false` for `@timestamp` and index sort fields, avoiding the Lucene incompatibility.
+
+### Technical Changes
+
+The change is in `DateFieldMapper.isSkiplistDefaultEnabled()`:
+
+```java
+boolean isSkiplistDefaultEnabled(IndexSortConfig indexSortConfig, String fieldName) {
+    if (this.indexCreatedVersion.onOrAfter(Version.V_3_3_0)) {
+        if (!isSkiplistConfigured) {
+            if (indexSortConfig.hasPrimarySortOnField(fieldName)) {
+                return true;
+            }
+            if (DataStreamFieldMapper.Defaults.TIMESTAMP_FIELD.getName().equals(fieldName)) {
+                return true;
+            }
+        }
+    }
+    return false;
+}
+```
+
+Tests were updated to verify that indices created with v3.2.0 do not get skip list auto-enabled, while v3.3.0+ indices continue to benefit from the optimization.
+
+## Limitations
+
+- Indices created before v3.3.0 will not automatically benefit from skip list on `@timestamp` fields, even after upgrading to v3.3.1. Users must reindex to enable skip list on those fields.
+- The `skip_list` mapping parameter is not updatable after index creation.
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#19671](https://github.com/opensearch-project/OpenSearch/pull/19671) | Fix bwc @timestamp upgrade issue by adding a version check on skip_list param | [#19660](https://github.com/opensearch-project/OpenSearch/issues/19660) |
+| [#19661](https://github.com/opensearch-project/OpenSearch/pull/19661) | Revert attempt (closed, not merged) — superseded by #19671 | [#19660](https://github.com/opensearch-project/OpenSearch/issues/19660) |

--- a/docs/releases/v3.3.1/index.md
+++ b/docs/releases/v3.3.1/index.md
@@ -1,0 +1,6 @@
+# OpenSearch v3.3.1 Release
+
+## Features
+
+### opensearch
+- BWC Timestamp Upgrade Fix


### PR DESCRIPTION
## BWC Timestamp Upgrade Fix - v3.3.1

Fixes a backward compatibility issue where upgrading from pre-3.3.0 to 3.3.0 caused shard allocation failures on indices with `@timestamp` date fields due to unconditional skip_list auto-enablement.

### Reports
- Release report: `docs/releases/v3.3.1/features/opensearch/bwc-timestamp-upgrade-fix.md`
- Feature report updated: `docs/features/opensearch/opensearch-skip-list.md`

### Source
- PR: opensearch-project/OpenSearch#19671
- Issue: opensearch-project/OpenSearch#19660

Closes #2605