### PR TITLE
docs: add core-version-update-fix report for v3.3.1

### DIFF
--- a/docs/features/index.md
+++ b/docs/features/index.md
@@ -53,6 +53,7 @@ Cumulative feature documentation across all versions.
 - Append Only Indices
 - CAT API
 - Cluster Shard Limits
+- Core Version Update Fix
 - Date Field Sorting
 - Dependency Management
 - Fingerprint Ingest Processor

--- a/docs/features/opensearch/opensearch-core-version-update-fix.md
+++ b/docs/features/opensearch/opensearch-core-version-update-fix.md
@@ -1,0 +1,55 @@
+---
+tags:
+  - opensearch
+---
+# Core Version Update Fix
+
+## Summary
+
+Fix for the Gradle build system that prevented version-bumping OpenSearch core to a patch release (e.g., 3.3.1). The `GlobalBuildInfoPlugin` was including legacy Elasticsearch version numbers during backward compatibility version parsing, causing a validation failure when both minor and patch numbers were non-zero.
+
+## Details
+
+### Architecture
+
+```mermaid
+graph TB
+    A[GlobalBuildInfoPlugin] -->|reads| B[Version.java]
+    A -.->|previously read| C[LegacyESVersion.java]
+    B --> D[BwcVersions]
+    C -.->|removed| D
+    D --> E[assertNoOlderThanTwoMajors]
+    E -->|"minor != 0 && patch != 0"| F{majors == 2?}
+    F -->|Yes| G[Build proceeds]
+    F -->|No| H[Build fails]
+```
+
+### Components
+
+| Component | Description |
+|-----------|-------------|
+| `GlobalBuildInfoPlugin.resolveBwcVersions()` | Reads version source files and constructs `BwcVersions` |
+| `BwcVersions.assertNoOlderThanTwoMajors()` | Validates that only 2 major versions exist in parsed versions |
+| `Version.java` | OpenSearch version constants (2.x, 3.x) |
+| `LegacyESVersion.java` | Legacy Elasticsearch version constants (6.x, 7.x) — no longer read |
+
+### Root Cause
+
+The `resolveBwcVersions()` method concatenated lines from both `Version.java` and `LegacyESVersion.java`. The `BwcVersions` constructor parsed all `V_X_Y_Z` patterns (including `LegacyESVersion` patterns), resulting in major versions `[2, 3, 6, 7]`. The `assertNoOlderThanTwoMajors()` check only triggers when `minor != 0 && patch != 0`, so the bug was invisible during regular minor releases (x.y.0).
+
+## Limitations
+
+- The fix only addresses the `resolveBwcVersions()` code path. The `DEFAULT_LEGACY_VERSION_JAVA_FILE_PATH` constant remains defined in the class.
+
+## Change History
+- **v3.3.1**: Removed `LegacyESVersion.java` reading from `resolveBwcVersions()` to fix patch release builds
+
+## References
+
+### Pull Requests
+| Version | PR | Description |
+|---------|-----|-------------|
+| v3.3.1 | [opensearch-project/OpenSearch#19377](https://github.com/opensearch-project/OpenSearch/pull/19377) | Fix issue with updating core with a patch number other than 0 |
+
+### Related Issues
+- [opensearch-build#5720](https://github.com/opensearch-project/opensearch-build/issues/5720) — Discussion: Patch releases currently take a lot of effort

--- a/docs/releases/v3.3.1/features/opensearch/core-version-update-fix.md
+++ b/docs/releases/v3.3.1/features/opensearch/core-version-update-fix.md
@@ -1,0 +1,59 @@
+---
+tags:
+  - opensearch
+---
+# Core Version Update Fix
+
+## Summary
+
+Fixed a build failure that occurred when bumping the OpenSearch core version to a patch number other than 0 (e.g., 3.3.1). The `GlobalBuildInfoPlugin` was reading legacy Elasticsearch version definitions from `LegacyESVersion.java`, which introduced version numbers from more than two major versions ago. The `BwcVersions` validation then rejected the build because it found more than 2 major versions.
+
+## Details
+
+### What's New in v3.3.1
+
+When attempting to version-bump the core to 3.3.1 and run `./gradlew localDistro`, the build failed with:
+
+```
+Expected exactly 2 majors in parsed versions but found: [2, 3, 6, 7]
+```
+
+The root cause was in `GlobalBuildInfoPlugin.resolveBwcVersions()`, which concatenated version lines from both `Version.java` and `LegacyESVersion.java`. The legacy file contained Elasticsearch 6.x and 7.x version constants. When `BwcVersions.assertNoOlderThanTwoMajors()` ran — a check only triggered when both minor and patch are non-zero — it found 4 major versions instead of the expected 2.
+
+The fix removes the legacy version file reading entirely from `resolveBwcVersions()`, so only `Version.java` (containing OpenSearch 2.x and 3.x versions) is parsed. This is safe because the legacy ES versions are more than two major versions behind and are no longer relevant for backward compatibility testing.
+
+### Technical Changes
+
+| File | Change |
+|------|--------|
+| `buildSrc/.../GlobalBuildInfoPlugin.java` | Removed `LegacyESVersion.java` file reading from `resolveBwcVersions()` |
+
+The `DEFAULT_LEGACY_VERSION_JAVA_FILE_PATH` constant remains in the class but is no longer used in `resolveBwcVersions()`.
+
+### Trigger Condition
+
+The bug only manifested when both `minor != 0` and `patch != 0` (e.g., 3.3.1), because `BwcVersions.assertNoOlderThanTwoMajors()` skips the check when either is zero:
+
+```java
+if (majors.size() != numSupportedMajors
+    && currentVersion.getMinor() != 0
+    && currentVersion.getRevision() != 0) {
+    throw new IllegalStateException(...);
+}
+```
+
+This is why the issue was never encountered during regular minor releases (e.g., 3.3.0).
+
+## Limitations
+
+- The `DEFAULT_LEGACY_VERSION_JAVA_FILE_PATH` constant is still defined in the class but unused by `resolveBwcVersions()`. It may be referenced elsewhere.
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [opensearch-project/OpenSearch#19377](https://github.com/opensearch-project/OpenSearch/pull/19377) | Fix issue with updating core with a patch number other than 0 | [opensearch-build#5720](https://github.com/opensearch-project/opensearch-build/issues/5720) |
+
+### Related Issues
+- [opensearch-build#5720](https://github.com/opensearch-project/opensearch-build/issues/5720) — Discussion: Patch releases currently take a lot of effort

--- a/docs/releases/v3.3.1/index.md
+++ b/docs/releases/v3.3.1/index.md
@@ -4,3 +4,4 @@
 
 ### opensearch
 - BWC Timestamp Upgrade Fix
+- Core Version Update Fix


### PR DESCRIPTION
## Summary\n\nInvestigation report for Issue #2604: Core Version Update Fix (v3.3.1 bugfix).\n\nFixes a Gradle build failure when bumping OpenSearch core to a patch version (e.g., 3.3.1). The `GlobalBuildInfoPlugin.resolveBwcVersions()` was reading legacy Elasticsearch version numbers from `LegacyESVersion.java`, causing `BwcVersions.assertNoOlderThanTwoMajors()` to fail with 4 major versions instead of 2.\n\n### Reports Created\n- Release report: `docs/releases/v3.3.1/features/opensearch/core-version-update-fix.md`\n- Feature report: `docs/features/opensearch/opensearch-core-version-update-fix.md`\n\n### Source PR\n- opensearch-project/OpenSearch#19377\n\nCloses #2604