### PR TITLE
docs: add star-tree report for v3.3.1

### DIFF
--- a/docs/features/opensearch/opensearch-star-tree-index.md
+++ b/docs/features/opensearch/opensearch-star-tree-index.md
@@ -206,6 +206,7 @@ POST /logs/_search
 
 ## Change History
 
+- **v3.3.1** (2026-02-11): Fixed ClassCastException when running star-tree aggregation queries with `profile=true`; sub-aggregators wrapped in ProfilingAggregator are now properly unwrapped before casting to StarTreePreComputeCollector
 - **v3.3.0** (2025-10-28): Added multi-terms aggregation support (up to 40x performance improvement), search query failure statistics (query_failed, startree_query_failed)
 - **v3.2.0** (2025-09-16): Added DLS/FLS/Field Masking security integration (disables star-tree for restricted users), IP field search support, star-tree search statistics (query count, time, current)
 - **v3.1.0** (2025-06-10): Production-ready status, removed feature flag, added index-level setting, date range query support, nested bucket aggregations
@@ -226,6 +227,7 @@ POST /logs/_search
 ### Pull Requests
 | Version | PR | Description | Related Issue |
 |---------|-----|-------------|---------------|
+| v3.3.1 | [#19652](https://github.com/opensearch-project/OpenSearch/pull/19652) | Fix sub-aggregator casting for search with profile=true | [#19649](https://github.com/opensearch-project/OpenSearch/issues/19649) |
 | v3.3.0 | [#19284](https://github.com/opensearch-project/OpenSearch/pull/19284) | Support for multi-terms aggregations | [#18398](https://github.com/opensearch-project/OpenSearch/issues/18398) |
 | v3.3.0 | [#19209](https://github.com/opensearch-project/OpenSearch/pull/19209) | Add search & star-tree search query failure count metrics | [#19210](https://github.com/opensearch-project/OpenSearch/issues/19210) |
 | v3.2.0 | [security#5492](https://github.com/opensearch-project/security/pull/5492) | Restrict star-tree for users with DLS/FLS/Field Masking |   |
@@ -246,6 +248,7 @@ POST /logs/_search
 | v2.18.0 | [#15289](https://github.com/opensearch-project/OpenSearch/pull/15289) | Initial metric aggregations with/without term query | [#15257](https://github.com/opensearch-project/OpenSearch/issues/15257) |
 
 ### Issues (Design / RFC)
+- [Issue #19649](https://github.com/opensearch-project/OpenSearch/issues/19649): ProfilingAggregator casting bug with star-tree sub-aggregations
 - [Issue #18398](https://github.com/opensearch-project/OpenSearch/issues/18398): Multi-terms aggregation feature request
 - [Issue #19210](https://github.com/opensearch-project/OpenSearch/issues/19210): Query failure stats feature request
 - [Issue #17443](https://github.com/opensearch-project/OpenSearch/issues/17443): Date range query support

--- a/docs/releases/v3.3.1/features/opensearch/star-tree.md
+++ b/docs/releases/v3.3.1/features/opensearch/star-tree.md
@@ -1,0 +1,46 @@
+---
+tags:
+  - opensearch
+---
+# Star Tree Bug Fix: Sub-Aggregator Casting with Profile
+
+## Summary
+
+Fixed a `ClassCastException` that occurred when running star-tree aggregation queries with `profile=true`. The bug was caused by sub-aggregators being wrapped in `ProfilingAggregator`, which could not be directly cast to `StarTreePreComputeCollector`. The fix introduces an `unwrapAggregator()` method on the base `Aggregator` class to safely unwrap profiling wrappers before casting.
+
+## Details
+
+### What's New in v3.3.1
+
+When search profiling is enabled (`"profile": true`), OpenSearch wraps aggregators in `ProfilingAggregator` to collect timing metrics. Star-tree bucket aggregators (terms, date histogram, range, multi-terms) cast their sub-aggregators to `StarTreePreComputeCollector` to set up star-tree bucket collectors. This cast failed when the sub-aggregator was wrapped in `ProfilingAggregator`.
+
+### Technical Changes
+
+A new `unwrapAggregator()` method was added to the base `Aggregator` class. By default it returns `this`, but `ProfilingAggregator` overrides it to return the delegate aggregator. This replaces the previous static `ProfilingAggregator.unwrap()` utility method with a polymorphic approach.
+
+Affected aggregators updated to use `aggregator.unwrapAggregator()` before casting:
+- `DateHistogramAggregator`
+- `RangeAggregator`
+- `GlobalOrdinalsStringTermsAggregator`
+- `NumericTermsAggregator`
+- `MultiTermsAggregator`
+
+Additionally, `AggregationPath.resolveTopmostAggregator()` and `FlushModeResolver.getChildren()` were refactored to use the new `unwrapAggregator()` method instead of the removed static utility.
+
+### Error Before Fix
+
+```json
+{
+  "reason": {
+    "type": "class_cast_exception",
+    "reason": "class org.opensearch.search.profile.aggregation.ProfilingAggregator cannot be cast to class org.opensearch.search.aggregations.StarTreePreComputeCollector"
+  }
+}
+```
+
+## References
+
+### Pull Requests
+| PR | Description | Related Issue |
+|----|-------------|---------------|
+| [#19652](https://github.com/opensearch-project/OpenSearch/pull/19652) | Fix sub-aggregator casting for search with profile=true | [#19649](https://github.com/opensearch-project/OpenSearch/issues/19649) |

--- a/docs/releases/v3.3.1/index.md
+++ b/docs/releases/v3.3.1/index.md
@@ -5,3 +5,4 @@
 ### opensearch
 - BWC Timestamp Upgrade Fix
 - Core Version Update Fix
+- Star Tree Bug Fix: Sub-Aggregator Casting with Profile


### PR DESCRIPTION
## Star Tree Bug Fix Report for v3.3.1

Fixes #2603

### Reports
- Release report: `docs/releases/v3.3.1/features/opensearch/star-tree.md`
- Feature report updated: `docs/features/opensearch/opensearch-star-tree-index.md`

### Summary
Fixed `ClassCastException` when running star-tree aggregation queries with `profile=true`. Sub-aggregators wrapped in `ProfilingAggregator` are now properly unwrapped via a new polymorphic `unwrapAggregator()` method before casting to `StarTreePreComputeCollector`.

### Source PR
- opensearch-project/OpenSearch#19652 (resolves opensearch-project/OpenSearch#19649)